### PR TITLE
Add mode to strip type prefix for SourceCodePrinter

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -94,9 +94,11 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def showExtractors: String =
           Extractors.showTree(using QuotesImpl.this)(self)
         def show: String =
-          SourceCode.showTree(using QuotesImpl.this)(self)(SyntaxHighlight.plain)
+          SourceCode.showTree(using QuotesImpl.this)(self)(SyntaxHighlight.plain, fullNames = true)
+        def showShort: String =
+          SourceCode.showTree(using QuotesImpl.this)(self)(SyntaxHighlight.plain, fullNames = false)
         def showAnsiColored: String =
-          SourceCode.showTree(using QuotesImpl.this)(self)(SyntaxHighlight.ANSI)
+          SourceCode.showTree(using QuotesImpl.this)(self)(SyntaxHighlight.ANSI, fullNames = true)
         def isExpr: Boolean =
           self match
             case TermTypeTest(self) =>
@@ -1590,10 +1592,13 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           Extractors.showType(using QuotesImpl.this)(self)
 
         def show: String =
-          SourceCode.showType(using QuotesImpl.this)(self)(SyntaxHighlight.plain)
+          SourceCode.showType(using QuotesImpl.this)(self)(SyntaxHighlight.plain, fullNames = true)
+
+        def showShort: String =
+          SourceCode.showType(using QuotesImpl.this)(self)(SyntaxHighlight.plain, fullNames = false)
 
         def showAnsiColored: String =
-          SourceCode.showType(using QuotesImpl.this)(self)(SyntaxHighlight.ANSI)
+          SourceCode.showType(using QuotesImpl.this)(self)(SyntaxHighlight.ANSI, fullNames = true)
 
         def seal: scala.quoted.Type[_] = self.asType
 
@@ -2154,9 +2159,11 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def showExtractors: String =
           Extractors.showConstant(using QuotesImpl.this)(self)
         def show: String =
-          SourceCode.showConstant(using QuotesImpl.this)(self)(SyntaxHighlight.plain)
+          SourceCode.showConstant(using QuotesImpl.this)(self)(SyntaxHighlight.plain, fullNames = true)
+        def showShort: String =
+          SourceCode.showConstant(using QuotesImpl.this)(self)(SyntaxHighlight.plain, fullNames = false)
         def showAnsiColored: String =
-          SourceCode.showConstant(using QuotesImpl.this)(self)(SyntaxHighlight.ANSI)
+          SourceCode.showConstant(using QuotesImpl.this)(self)(SyntaxHighlight.ANSI, fullNames = true)
       end extension
     end ConstantMethodsImpl
 

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -210,6 +210,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** Shows the tree as fully typed source code */
         def show: String
 
+        /** Shows the tree as without package prefix*/
+        def showShort: String
+
         /** Shows the tree as fully typed source code colored with ANSI */
         def showAnsiColored: String
 
@@ -1865,6 +1868,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** Shows the tree as fully typed source code */
         def show: String
 
+        /** Shows the tree as without package prefix*/
+        def showShort: String
+
         /** Shows the tree as fully typed source code colored with ANSI */
         def showAnsiColored: String
 
@@ -2607,6 +2613,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
         /** Shows the tree as extractors */
         def showExtractors: String
+
+        /** Shows the tree as without package prefix*/
+        def showShort: String
 
         /** Shows the tree as fully typed source code */
         def show: String

--- a/library/src/scala/quoted/Type.scala
+++ b/library/src/scala/quoted/Type.scala
@@ -15,6 +15,10 @@ object Type:
   def show[T](using Type[T])(using Quotes): String =
     quotes.reflect.TypeTree.of[T].show
 
+  /** Show a source code like representation of this type without syntax highlight */
+  def showShort[T](using Type[T])(using Quotes): String =
+    quotes.reflect.TypeTree.of[T].showShort
+
   /** Shows the tree as fully typed source code colored with ANSI */
   def showAnsiColored[T](using Type[T])(using Quotes): String =
     quotes.reflect.TypeTree.of[T].showAnsiColored


### PR DESCRIPTION
This is a proposal to help with https://github.com/lampepfl/dotty/issues/9716

I see this is already an issue both in mdoc and in munit. It most likely also help with pprint's TypePrinter.

What do you think? I can add some tests if the solution is sensible.
