### PR TITLE
Migrate dokka site

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1465,7 +1465,7 @@ object Build {
 
       def joinProducts(products: Seq[java.io.File]): String =
         products.iterator.map(_.getAbsolutePath.toString).mkString(java.io.File.pathSeparator)
-      
+
       val dokkaVersion = "1.4.10.2"
 
       project.settings(commonBootstrappedSettings).

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1465,6 +1465,8 @@ object Build {
 
       def joinProducts(products: Seq[java.io.File]): String =
         products.iterator.map(_.getAbsolutePath.toString).mkString(java.io.File.pathSeparator)
+      
+      val dokkaVersion = "1.4.10.2"
 
       project.settings(commonBootstrappedSettings).
         dependsOn(`scala3-compiler-bootstrapped`).
@@ -1472,15 +1474,15 @@ object Build {
         settings(
           // Needed to download dokka and its dependencies
           resolvers += Resolver.jcenterRepo,
-          // Needed to download dokka-site
-          resolvers += Resolver.bintrayRepo("virtuslab", "dokka"),
           libraryDependencies ++= Seq(
-            "com.virtuslab.dokka" % "dokka-site" % "0.1.9",
+            "org.jetbrains.dokka" % "dokka-core" % dokkaVersion,
+            "org.jetbrains.dokka" % "dokka-base" % dokkaVersion,
+            "org.jetbrains.kotlinx" % "kotlinx-html-jvm" % "0.7.2", // Needs update when dokka version changes
             "com.vladsch.flexmark" % "flexmark-all" % "0.42.12",
             "nl.big-o" % "liqp" % "0.6.7",
             "args4j" % "args4j" % "2.33",
 
-            "org.jetbrains.dokka" % "dokka-test-api" % "1.4.10.2" % "test",
+            "org.jetbrains.dokka" % "dokka-test-api" % dokkaVersion % "test",
             "com.novocode" % "junit-interface" % "0.11" % "test",
           ),
           Test / test := (Test / test).dependsOn(compile.in(Compile).in(`scala3doc-testcases`)).value,

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -358,10 +358,7 @@ object DottyPlugin extends AutoPlugin {
       }.value,
 
       // Configuration for the doctool
-      resolvers ++= (if(!useScala3doc.value) Nil else Seq(
-        Resolver.jcenterRepo,
-        Resolver.bintrayRepo("virtuslab", "dokka"),
-      )),
+      resolvers ++= (if(!useScala3doc.value) Nil else Seq(Resolver.jcenterRepo)),
       useScala3doc := false,
       scala3docOptions := Nil,
       Compile / doc / scalacOptions := {

--- a/scala3doc/dotty-docs/docs/index.html
+++ b/scala3doc/dotty-docs/docs/index.html
@@ -49,158 +49,31 @@ extraCSS:
         </div>
     </div>
 </section>
-
-
 <section class="page bg-blue bg-dark">
-    <div class="container">
+  <div class="container">
 
-        <h1 id="getting-started">Try Dotty</h1>
-        <p>If you are a Mac user, you can install Dotty with <a href="https://brew.sh/">brew</a>:</p>
-        <pre><code>brew install lampepfl/brew/dotty</code></pre>
+      <h1 id="getting-started">Try Dotty</h1>
+      <p>If you are a Mac user, you can install Dotty with <a href="https://brew.sh/">brew</a>:</p>
+      <pre><code>brew install lampepfl/brew/dotty</code></pre>
 
-        <p>If you are a Linux or Windows user, download the <a href="https://github.com/lampepfl/dotty/releases">latest release</a>. Optionally add path of the folder <code>bin/</code> to the system environment variable <code>PATH</code>. </p>
+      <p>If you are a Linux or Windows user, download the <a href="https://github.com/lampepfl/dotty/releases">latest release</a>. Optionally add path of the folder <code>bin/</code> to the system environment variable <code>PATH</code>. </p>
 
-        <p>Now you can compile Scala source code:</p>
-        <pre><code>dotc hello.scala</code></pre>
+      <p>Now you can compile Scala source code:</p>
+      <pre><code>scalac hello.scala</code></pre>
 
-        <p>To start the REPL, run: <code>dotr</code>.</p>
+      <p>To start the REPL, run: <code>scala</code>.</p>
 
-        <p>Or, you can try Dotty in your browser with <a href="https://scastie.scala-lang.org/?target=dotty">Scastie</a>.</p>
+      <p>Or, you can try Dotty in your browser with <a href="https://scastie.scala-lang.org/?target=dotty">Scastie</a>.</p>
 
-        <h1 id="getting-started-with-a-project">Create a Dotty Project</h1>
-        <p>The fastest way to create a new project in Dotty is using <a href="http://www.scala-sbt.org/">sbt (1.1.4+)</a>.</p>
+      <h1 id="getting-started-with-a-project">Create a Dotty Project</h1>
+      <p>The fastest way to create a new project in Dotty is using <a href="http://www.scala-sbt.org/">sbt (1.1.4+)</a>.</p>
 
-        <p>Create a Dotty project:</p>
-        <pre><code>sbt new <a href="https://github.com/lampepfl/dotty.g8">lampepfl/dotty.g8</a></code></pre>
+      <p>Create a Dotty project:</p>
+      <pre><code>sbt new <a href="https://github.com/lampepfl/dotty.g8">lampepfl/dotty.g8</a></code></pre>
 
-        <p>Or a Dotty project that cross compiles with Scala 2:</p>
-        <pre><code>sbt new <a href="https://github.com/lampepfl/dotty-cross.g8">lampepfl/dotty-cross.g8</a></code></pre>
+      <p>Or a Dotty project that cross compiles with Scala 2:</p>
+      <pre><code>sbt new <a href="https://github.com/lampepfl/dotty-cross.g8">lampepfl/dotty-cross.g8</a></code></pre>
 
-        <p>For documentation see the <a href="https://github.com/lampepfl/dotty-example-project">Dotty Example Project</a>.</p>
-    </div>
+      <p>For documentation see the <a href="https://github.com/lampepfl/dotty-example-project">Dotty Example Project</a>.</p>
+  </div>
 </section>
-
-<section class="page bg-teal bg-dark">
-    <div class="container">
-        <h1 id="so-features">So, features?</h1>
-        <div class="centered-table">
-            <table>
-                <colgroup>
-                    <col width="82%" />
-                    <col width="17%" />
-                </colgroup>
-                <tbody>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html">Intersection Types</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/new-types/union-types.html">Union Types</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/new-types/type-lambdas.html">Type lambdas</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/implicit-function-types.html">Context query</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/other-new-features/trait-parameters.html">Trait parameters</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/delegates.html">Implied Instances</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/given-clauses.html">Inferable parameters</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/extension-methods.html">Extension Methods</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/other-new-features/opaques.html">Opaque Type Aliases</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/dropped-features/package-objects.html">Toplevel definitions</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/other-new-features/export.html">Export clauses</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/changed-features/vararg-patterns.html">Vararg patterns</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/other-new-features/creator-applications.html">Creator applications</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/scala/scala.github.com/pull/491">@static methods and fields</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/#getting-started">SBT incremental build</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/changed-features/pattern-matching.html">Option-less pattern matching</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/contextual/multiversal-equality.html">Multiversal equality</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://dotty.epfl.ch/docs/reference/metaprogramming/erased-terms.html">Erased Terms</a></td>
-                        <td>Implemented</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/dotty-linker/dotty">Auto-Specialization</a></td>
-                        <td>In progress</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/lampepfl/dotty/pull/1840">Whole program optimizer</a></td>
-                        <td>In progress</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/lampepfl/dotty/pull/2199">HList &amp; HMaps/Record types</a></td>
-                        <td>In progress</td>
-                    </tr>
-                    <tr>
-                        <td></td>
-                        <td></td>
-                    </tr>
-                    <tr>
-                        <td>Effects</td>
-                        <td>Considered</td>
-                    </tr>
-                    <tr>
-                        <td>…and many more, check the <a href="https://dotty.epfl.ch/docs/reference/overview.html">overview page</a> for a comprehensive list</td>
-                        <td></td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <h1 id="talks-on-dotty">Talks on Dotty?</h1>
-        <ul>
-            <li><a href="https://www.youtube.com/watch?v=GHzWqJKFCk4">Scala's Road Ahead</a> by Martin Odersky (<a href="http://www.slideshare.net/Odersky/scala-days-nyc-2016">slides</a>)</li>
-            <li><a href="https://www.youtube.com/watch?v=WxyyJyB_Ssc">Compilers are Databases</a> by Martin Odersky (<a href="http://www.slideshare.net/Odersky/compilers-are-databases">slides</a>)</li>
-            <li><a href="https://www.youtube.com/watch?v=aftdOFuVU1o">Exploring the future of Scala</a> by Dmitry Petrashko (<a href="https://d-d.me/scalaworld2015/#/">slides</a>)</li>
-            <li><a href="https://dotty.epfl.ch/docs/resources/talks.html">Deep Dive with Dotty</a></li>
-        </ul>
-        <h1 id="i-have-more-questions">I have more questions!</h1>
-        <div class="text-center">
-            <p>That’s great! We have more details on the <a href="{{ site.baseurl }}/docs">docs</a> and please join our <a href="https://gitter.im/lampepfl/dotty">Gitter channel</a>!</p>
-        </div>
-        <br/>
-    </div>
-</section>
-

--- a/scala3doc/src/dotty/dokka/DottyDokkaConfig.scala
+++ b/scala3doc/src/dotty/dokka/DottyDokkaConfig.scala
@@ -4,6 +4,7 @@ import org.jetbrains.dokka._
 import org.jetbrains.dokka.DokkaSourceSetImpl
 import java.io.File
 import collection.JavaConverters._
+import dotty.dokka.site.StaticSiteContext
 
 case class DottyDokkaConfig(docConfiguration: DocConfiguration) extends DokkaConfiguration:
   override def getOutputDir: File = docConfiguration.args.output
@@ -16,15 +17,11 @@ case class DottyDokkaConfig(docConfiguration: DocConfiguration) extends DokkaCon
   override def getModuleName(): String = "ModuleName"
   override def getModuleVersion(): String = ""
 
-  private object OurConfig extends DokkaConfiguration.PluginConfiguration:
-    override def getFqPluginName = "ExternalDocsTooKey"
-    override def getSerializationFormat: DokkaConfiguration$SerializationFormat =
-      DokkaConfiguration$SerializationFormat.JSON.asInstanceOf[DokkaConfiguration$SerializationFormat]
-    override def getValues: String = docConfiguration.args.docsRoot.getOrElse("")
+  lazy val staticSiteContext = docConfiguration.args.docsRoot.map(path => StaticSiteContext(File(path).getAbsoluteFile(), Set(mkSourceSet.asInstanceOf[SourceSetWrapper])))
 
-  override def getPluginsConfiguration: JList[DokkaConfiguration.PluginConfiguration] = JList(OurConfig)
+  override def getPluginsConfiguration: JList[DokkaConfiguration.PluginConfiguration] = JList()
 
-  def mkSourceSet: DokkaSourceSet =
+  lazy val mkSourceSet: DokkaSourceSet =
     val sourceLinks:Set[SourceLinkDefinitionImpl] = docConfiguration.args.sourceLinks.map(SourceLinkDefinitionImpl.Companion.parseSourceLinkDefinition(_)).toSet
     new DokkaSourceSetImpl(
       /*displayName=*/ docConfiguration.args.name,

--- a/scala3doc/src/dotty/dokka/DottyDokkaConfig.scala
+++ b/scala3doc/src/dotty/dokka/DottyDokkaConfig.scala
@@ -3,7 +3,6 @@ package dotty.dokka
 import org.jetbrains.dokka._
 import org.jetbrains.dokka.DokkaSourceSetImpl
 import java.io.File
-import java.util.{ List => JList, Map => JMap}
 import collection.JavaConverters._
 
 case class DottyDokkaConfig(docConfiguration: DocConfiguration) extends DokkaConfiguration:
@@ -11,9 +10,9 @@ case class DottyDokkaConfig(docConfiguration: DocConfiguration) extends DokkaCon
   override def getCacheRoot: File = null
   override def getOfflineMode: Boolean = false
   override def getFailOnWarning: Boolean = false
-  override def getSourceSets: JList[DokkaConfiguration.DokkaSourceSet] = List(mkSourceSet).asJava
-  override def getModules: JList[DokkaConfiguration.DokkaModuleDescription] = List().asJava
-  override def getPluginsClasspath: JList[File] = Nil.asJava
+  override def getSourceSets: JList[DokkaSourceSet] = JList(mkSourceSet)
+  override def getModules: JList[DokkaConfiguration.DokkaModuleDescription] = JList()
+  override def getPluginsClasspath: JList[File] = JList()
   override def getModuleName(): String = "ModuleName"
   override def getModuleVersion(): String = ""
 
@@ -23,31 +22,31 @@ case class DottyDokkaConfig(docConfiguration: DocConfiguration) extends DokkaCon
       DokkaConfiguration$SerializationFormat.JSON.asInstanceOf[DokkaConfiguration$SerializationFormat]
     override def getValues: String = docConfiguration.args.docsRoot.getOrElse("")
 
-  override def getPluginsConfiguration: JList[DokkaConfiguration.PluginConfiguration] = List(OurConfig).asJava
+  override def getPluginsConfiguration: JList[DokkaConfiguration.PluginConfiguration] = JList(OurConfig)
 
-  def mkSourceSet: DokkaConfiguration.DokkaSourceSet =
+  def mkSourceSet: DokkaSourceSet =
     val sourceLinks:Set[SourceLinkDefinitionImpl] = docConfiguration.args.sourceLinks.map(SourceLinkDefinitionImpl.Companion.parseSourceLinkDefinition(_)).toSet
     new DokkaSourceSetImpl(
       /*displayName=*/ docConfiguration.args.name,
       /*sourceSetID=*/ new DokkaSourceSetID(docConfiguration.args.name, "main"),
-      /*classpath=*/ Nil.asJava,
-      /*sourceRoots=*/ Set().asJava,
-      /*dependentSourceSets=*/ Set().asJava,
-      /*samples=*/ Set().asJava,
-      /*includes=*/ Set().asJava,
+      /*classpath=*/ JList(),
+      /*sourceRoots=*/ JSet(),
+      /*dependentSourceSets=*/ JSet(),
+      /*samples=*/ JSet(),
+      /*includes=*/ JSet(),
       /*includeNonPublic=*/ true,
       /*reportUndocumented=*/ false, /* changed because of exception in reportUndocumentedTransformer - there's 'when' which doesnt match because it contains only KotlinVisbility cases */
       /*skipEmptyPackages=*/ false, // Now all our packages are empty from dokka perspective
       /*skipDeprecated=*/ true,
       /*jdkVersion=*/ 8,
       /*sourceLinks=*/ sourceLinks.asJava,
-      /*perPackageOptions=*/ Nil.asJava,
-      /*externalDocumentationLinks=*/ Set().asJava,
+      /*perPackageOptions=*/ JList(),
+      /*externalDocumentationLinks=*/ JSet(),
       /*languageVersion=*/ null,
       /*apiVersion=*/ null,
       /*noStdlibLink=*/ true,
       /*noJdkLink=*/  true,
-      /*suppressedFiles=*/  Set().asJava,
+      /*suppressedFiles=*/  JSet(),
       /*suppressedFiles=*/  Platform.jvm
-    ).asInstanceOf[DokkaConfiguration.DokkaSourceSet] // Why I do need to cast here? Kotlin magic?
+    ).asInstanceOf[DokkaSourceSet] // Why I do need to cast here? Kotlin magic?
 

--- a/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
+++ b/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
@@ -149,7 +149,7 @@ class DottyDokkaPlugin extends DokkaJavaPlugin:
           dokkaBase.getNavigationPageInstaller,
           dokkaBase.getScriptsInstaller,
           dokkaBase.getStylesInstaller,
-          dokkaBase.getPackageListCreator,  
+          dokkaBase.getPackageListCreator,
         ),
         after = Seq(dokkaBase.getRootCreator)
       )
@@ -184,7 +184,7 @@ class DottyDokkaPlugin extends DokkaJavaPlugin:
   )
 
   extension (ctx: DokkaContext):
-    def siteContext: Option[StaticSiteContext] = ctx.getConfiguration match 
+    def siteContext: Option[StaticSiteContext] = ctx.getConfiguration match
       case d: DottyDokkaConfig => d.staticSiteContext
       case _ => None
 
@@ -194,7 +194,7 @@ extension [T]  (builder: ExtensionBuilder[T]):
     val byDsl = new OrderingKind.ByDsl(dsl => {
       dsl.after(after:_*)
       dsl.before(before:_*)
-      kotlin.Unit.INSTANCE // TODO why U does not work here? 
+      kotlin.Unit.INSTANCE // TODO why U does not work here?
     })
     // Does not compile but compiles in scala 2
     // ExtensionBuilder.copy$default(builder, null, null, null, byDsl, null, null, 55, null)
@@ -206,5 +206,5 @@ extension [T]  (builder: ExtensionBuilder[T]):
 
 
   def before(exts: Extension[_, _, _]*):  ExtensionBuilder[T] = ordered(exts, Nil)
-    
+
   def after(exts: Extension[_, _, _]*):  ExtensionBuilder[T] = ordered(Nil, exts)

--- a/scala3doc/src/dotty/dokka/Main.scala
+++ b/scala3doc/src/dotty/dokka/Main.scala
@@ -8,7 +8,6 @@ import java.io.File
 import java.util.jar._
 import collection.JavaConverters._
 import collection.immutable.ArraySeq
-import java.util.{List => JList}
 
 import scala.tasty.Reflection
 import scala.tasty.inspector.TastyInspector

--- a/scala3doc/src/dotty/dokka/compat.scala
+++ b/scala3doc/src/dotty/dokka/compat.scala
@@ -36,15 +36,15 @@ extension [T] (wrapper: DokkaSourceSet):
     // when named `toSet` fails in runtime -- TODO: create a minimal!
     // def toSet: JSet[DokkaConfiguration$DokkaSourceSet] = JSet(wrapper.asInstanceOf[SourceSetWrapper])
     def asSet: JSet[DokkaConfiguration$DokkaSourceSet] = JSet(wrapper.asInstanceOf[SourceSetWrapper])
-    def asMap(value: T): JMap[DokkaConfiguration$DokkaSourceSet, T] = JMap(wrapper.asInstanceOf[SourceSetWrapper] -> value)    
+    def asMap(value: T): JMap[DokkaConfiguration$DokkaSourceSet, T] = JMap(wrapper.asInstanceOf[SourceSetWrapper] -> value)
 
 extension (sourceSets: JList[DokkaSourceSet]):
   def asDokka: JSet[SourceSetWrapper] = sourceSets.asScala.toSet.asJava.asInstanceOf[JSet[SourceSetWrapper]]
-  def toDisplaySourceSet = sourceSets.asScala.map(ss => DisplaySourceSet(ss.asInstanceOf[SourceSetWrapper])).toSet.asJava 
+  def toDisplaySourceSet = sourceSets.asScala.map(ss => DisplaySourceSet(ss.asInstanceOf[SourceSetWrapper])).toSet.asJava
 
 extension (sourceSets: Set[SourceSetWrapper]):
-  def toDisplay = sourceSets.map(DisplaySourceSet(_)).asJava    
-  
+  def toDisplay = sourceSets.map(DisplaySourceSet(_)).asJava
+
 extension [V] (a: WithExtraProperties[_]):
   def get(key: ExtraProperty.Key[_, V]): V = a.getExtra().getMap().get(key).asInstanceOf[V]
 
@@ -55,5 +55,5 @@ extension [V] (map: JMap[SourceSetWrapper, V]):
   def defaultValue: V = map.values.asScala.head
 
 extension [V](jlist: JList[V]):
-  def ++ (other: JList[V]): JList[V] = 
+  def ++ (other: JList[V]): JList[V] =
     Stream.of(jlist, other).flatMap(_.stream).collect(Collectors.toList())

--- a/scala3doc/src/dotty/dokka/compat.scala
+++ b/scala3doc/src/dotty/dokka/compat.scala
@@ -1,0 +1,59 @@
+package dotty.dokka
+
+import org.jetbrains.dokka.links.{DRI, PointingToDeclaration}
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.DokkaConfiguration$DokkaSourceSet
+import collection.JavaConverters._
+import org.jetbrains.dokka.model.DisplaySourceSet
+import org.jetbrains.dokka.model.properties.WithExtraProperties
+// TODO reproduction! - comment line below to broke compiler!
+import org.jetbrains.dokka.model.properties.ExtraProperty
+// import java.util.Stream // TODO reproduction uncomment
+import java.util.stream.Stream // comment out - wrong error!
+import java.util.stream.Collectors
+
+def mkDRI(classNames: String = null, extra: String = null) = new DRI(null, classNames, null, PointingToDeclaration.INSTANCE, extra)
+
+val U: kotlin.Unit = kotlin.Unit.INSTANCE
+
+def JList[T](e: T*): JList[T] = e.asJava
+def JSet[T](e: T*): JSet[T] = e.toSet.asJava
+def JMap[K, V](e: (K, V)*): JMap[K, V] = e.toMap.asJava
+def JMap2[K, V](): JMap[K, V] = ??? // e.toMap.asJava
+
+type JList[T] = java.util.List[T]
+type JSet[T] = java.util.Set[T]
+type JMap[K, V] = java.util.Map[K, V]
+
+type SourceSetWrapper = DokkaConfiguration$DokkaSourceSet
+type DokkaSourceSet = DokkaConfiguration.DokkaSourceSet
+
+extension [T] (wrapper: SourceSetWrapper):
+    def toSet: JSet[DokkaConfiguration$DokkaSourceSet] = JSet(wrapper)
+    def toMap(value: T): JMap[DokkaConfiguration$DokkaSourceSet, T] = JMap(wrapper -> value)
+
+extension [T] (wrapper: DokkaSourceSet):
+    // when named `toSet` fails in runtime -- TODO: create a minimal!
+    // def toSet: JSet[DokkaConfiguration$DokkaSourceSet] = JSet(wrapper.asInstanceOf[SourceSetWrapper])
+    def asSet: JSet[DokkaConfiguration$DokkaSourceSet] = JSet(wrapper.asInstanceOf[SourceSetWrapper])
+    def asMap(value: T): JMap[DokkaConfiguration$DokkaSourceSet, T] = JMap(wrapper.asInstanceOf[SourceSetWrapper] -> value)    
+
+extension (sourceSets: JList[DokkaSourceSet]):
+  def asDokka: JSet[SourceSetWrapper] = sourceSets.asScala.toSet.asJava.asInstanceOf[JSet[SourceSetWrapper]]
+  def toDisplaySourceSet = sourceSets.asScala.map(ss => DisplaySourceSet(ss.asInstanceOf[SourceSetWrapper])).toSet.asJava 
+
+extension (sourceSets: Set[SourceSetWrapper]):
+  def toDisplay = sourceSets.map(DisplaySourceSet(_)).asJava    
+  
+extension [V] (a: WithExtraProperties[_]):
+  def get(key: ExtraProperty.Key[_, V]): V = a.getExtra().getMap().get(key).asInstanceOf[V]
+
+extension [E <: WithExtraProperties[E]] (a: E):
+  def put(value: ExtraProperty[_ >: E]): E = a.withNewExtras(a.getExtra plus value)
+
+extension [V] (map: JMap[SourceSetWrapper, V]):
+  def defaultValue: V = map.values.asScala.head
+
+extension [V](jlist: JList[V]):
+  def ++ (other: JList[V]): JList[V] = 
+    Stream.of(jlist, other).flatMap(_.stream).collect(Collectors.toList())  

--- a/scala3doc/src/dotty/dokka/compat.scala
+++ b/scala3doc/src/dotty/dokka/compat.scala
@@ -12,7 +12,7 @@ import org.jetbrains.dokka.model.properties.ExtraProperty
 import java.util.stream.Stream // comment out - wrong error!
 import java.util.stream.Collectors
 
-def mkDRI(classNames: String = null, extra: String = null) = new DRI(null, classNames, null, PointingToDeclaration.INSTANCE, extra)
+def mkDRI(packageName: String = null, extra: String = null) = new DRI(packageName, null, null, PointingToDeclaration.INSTANCE, extra)
 
 val U: kotlin.Unit = kotlin.Unit.INSTANCE
 
@@ -56,4 +56,4 @@ extension [V] (map: JMap[SourceSetWrapper, V]):
 
 extension [V](jlist: JList[V]):
   def ++ (other: JList[V]): JList[V] = 
-    Stream.of(jlist, other).flatMap(_.stream).collect(Collectors.toList())  
+    Stream.of(jlist, other).flatMap(_.stream).collect(Collectors.toList())

--- a/scala3doc/src/dotty/dokka/model/api/api.scala
+++ b/scala3doc/src/dotty/dokka/model/api/api.scala
@@ -10,8 +10,6 @@ import org.jetbrains.dokka.links._
 import org.jetbrains.dokka.model.doc._
 import org.jetbrains.dokka.model.properties._
 import org.jetbrains.dokka.pages._
-import java.util.{List => JList, Set => JSet}
-
 
 enum Visibility(val name: String):
   case Unrestricted extends Visibility("")

--- a/scala3doc/src/dotty/dokka/model/api/api.scala
+++ b/scala3doc/src/dotty/dokka/model/api/api.scala
@@ -87,7 +87,7 @@ object Annotation:
 
 // TODO (longterm) properly represent signatures
 case class Link(name: String, dri: DRI)
-type Signature = Seq[String | Link]// TODO migrate tupes to Links
+type Signature = Seq[String | Link]
 
 object Signature:
   def apply(names: (String | Link)*): Signature = names // TO batter dotty shortcommings in union types

--- a/scala3doc/src/dotty/dokka/model/api/internalExtensions.scala
+++ b/scala3doc/src/dotty/dokka/model/api/internalExtensions.scala
@@ -21,9 +21,6 @@ import collection.JavaConverters._
 import org.jetbrains.dokka.links._
 import org.jetbrains.dokka.model.doc.DocumentationNode
 import org.jetbrains.dokka.model.properties._
-import java.util.{List => JList, Set => JSet}
-
-import com.virtuslab.dokka.site.SourceSetWrapper
 
 private [model] case class MemberExtension(
   visibility: Visibility,

--- a/scala3doc/src/dotty/dokka/model/extras.scala
+++ b/scala3doc/src/dotty/dokka/model/extras.scala
@@ -9,7 +9,6 @@ import collection.JavaConverters._
 import org.jetbrains.dokka.links._
 import org.jetbrains.dokka.model.doc._
 import org.jetbrains.dokka.model.properties._
-import java.util.{List => JList, Set => JSet}
 import dotty.dokka.model.api._
 
 case class ModuleExtension(driMap: Map[DRI, Member]) extends ExtraProperty[DModule]:

--- a/scala3doc/src/dotty/dokka/model/scalaModel.scala
+++ b/scala3doc/src/dotty/dokka/model/scalaModel.scala
@@ -8,7 +8,6 @@ import org.jetbrains.dokka.links._
 import org.jetbrains.dokka.model.doc._
 import org.jetbrains.dokka.model.properties._
 import org.jetbrains.dokka.pages._
-import java.util.{List => JList, Set => JSet}
 import dotty.dokka.model.api.Signature
 import dotty.dokka.model.api.HierarchyGraph
 
@@ -33,7 +32,7 @@ case class HtmlContentNode(
   override def getStyle = style.asJava
   override def hasAnyContent = !body.isEmpty
   def withSourceSets(sourceSets: JSet[DisplaySourceSet]) = copy(sourceSets = sourceSets.asScala.toSet)
-  override def getChildren: JList[ContentNode] = Nil.asJava
+  override def getChildren: JList[ContentNode] = JList()
   override def getExtra = extra
   override def withNewExtras(p: PropertyContainer[ContentNode]) = copy(extra = p)
 
@@ -70,7 +69,7 @@ case class HierarchyGraphContentNode(
   override def getStyle = style.asJava
   override def hasAnyContent = !diagram.edges.isEmpty
   def withSourceSets(sourceSets: JSet[DisplaySourceSet]) = copy(sourceSets = sourceSets.asScala.toSet)
-  override def getChildren: JList[ContentNode] = Nil.asJava
+  override def getChildren: JList[ContentNode] = JList()
   override def getExtra = extra
   override def withNewExtras(p: PropertyContainer[ContentNode]) = copy(extra = p)
 
@@ -91,7 +90,7 @@ abstract class ScalaContentNode(params: ContentNodeParams) extends ContentNode:
   override def hasAnyContent = true
   def withSourceSets(sourceSets: JSet[DisplaySourceSet]) =
     newInstance(params.copy(sourceSets = sourceSets))
-  override def getChildren: JList[ContentNode] = Nil.asJava
+  override def getChildren: JList[ContentNode] = JList()
   override def getExtra = params.extra
   override def withNewExtras(p: PropertyContainer[ContentNode]) = newInstance(params.copy(extra = p))
 

--- a/scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala
+++ b/scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala
@@ -6,14 +6,15 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.pages.{ContentNode, DCI, Style}
 
 case class PartiallyRenderedContent(
-    page: PreResolvedPage,
+    template: TemplateFile,
+    context: StaticSiteContext,
     override val getChildren: JList[ContentNode],
     override val getDci: DCI,
     override val getSourceSets: JSet[DisplaySourceSet],
     override val getStyle: JSet[Style] = JSet(),
     override val getExtra: PropertyContainer[ContentNode] = new PropertyContainer(JMap())
 ) extends ContentNode:
-    override def hasAnyContent(): Boolean = getChildren.stream().filter(_.hasAnyContent()).count() > 0
+    override def hasAnyContent(): Boolean = true
 
     override def withNewExtras(newExtras: PropertyContainer[ContentNode]): ContentNode =
         copy(getExtra = newExtras)
@@ -21,4 +22,4 @@ case class PartiallyRenderedContent(
     override def withSourceSets(sourceSets: JSet[DisplaySourceSet]): ContentNode =
         copy(getSourceSets = sourceSets)
 
-    val allResources: List[String] = page.render("").resources
+    lazy val resolved = template.resolveToHtml(context)

--- a/scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala
+++ b/scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala
@@ -6,20 +6,20 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.pages.{ContentNode, DCI, Style}
 
 case class PartiallyRenderedContent(
-    template: TemplateFile,
-    context: StaticSiteContext,
-    override val getChildren: JList[ContentNode],
-    override val getDci: DCI,
-    override val getSourceSets: JSet[DisplaySourceSet],
-    override val getStyle: JSet[Style] = JSet(),
-    override val getExtra: PropertyContainer[ContentNode] = new PropertyContainer(JMap())
+  template: TemplateFile,
+  context: StaticSiteContext,
+  override val getChildren: JList[ContentNode],
+  override val getDci: DCI,
+  override val getSourceSets: JSet[DisplaySourceSet],
+  override val getStyle: JSet[Style] = JSet(),
+  override val getExtra: PropertyContainer[ContentNode] = new PropertyContainer(JMap())
 ) extends ContentNode:
-    override def hasAnyContent(): Boolean = true
+  override def hasAnyContent(): Boolean = true
 
-    override def withNewExtras(newExtras: PropertyContainer[ContentNode]): ContentNode =
-        copy(getExtra = newExtras)
+  override def withNewExtras(newExtras: PropertyContainer[ContentNode]): ContentNode =
+    copy(getExtra = newExtras)
 
-    override def withSourceSets(sourceSets: JSet[DisplaySourceSet]): ContentNode =
-        copy(getSourceSets = sourceSets)
+  override def withSourceSets(sourceSets: JSet[DisplaySourceSet]): ContentNode =
+    copy(getSourceSets = sourceSets)
 
-    lazy val resolved = template.resolveToHtml(context)
+  lazy val resolved = template.resolveToHtml(context)

--- a/scala3doc/src/dotty/dokka/site/StaticPageNode.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticPageNode.scala
@@ -1,0 +1,39 @@
+package dotty.dokka
+package site
+
+import java.io.File
+import java.nio.file.Files
+
+import org.jetbrains.dokka.base.renderers.html.{NavigationNode, NavigationPage}
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.pages._
+import org.jetbrains.dokka.transformers.pages.PageTransformer
+
+case class LoadedTemplate(templateFile: TemplateFile, children: List[LoadedTemplate], file: File) {
+    def relativePath(root: File): String =
+        root.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '.')
+}
+
+case class StaticPageNode(
+                           template: TemplateFile,
+                           override val getName: String,
+                           override val getContent: ContentNode,
+                           override val getDri: JSet[DRI],
+                           override val getEmbeddedResources: JList[String],
+                           override val getChildren: JList[PageNode],
+                         ) extends ContentPage:
+    override def getDocumentable: Documentable = null
+
+    def title(): String = template.title()
+    def hasFrame(): Boolean = template.hasFrame()
+
+    override def modified(name: String, content: ContentNode, dri: JSet[DRI], embeddedResources: JList[String], children: JList[_ <: PageNode]): ContentPage =
+        copy(template, name, content, dri, embeddedResources, children.asInstanceOf[JList[PageNode]])
+
+    override def modified(name: String, children: JList[_ <: PageNode]): PageNode =
+        copy(getName = name, getChildren = children.asInstanceOf[JList[PageNode]])
+
+    def resources(): List[String] = getContent match 
+        case p: PartiallyRenderedContent => p.resolved.resources
+        case _ => Nil

--- a/scala3doc/src/dotty/dokka/site/StaticPageNode.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticPageNode.scala
@@ -11,8 +11,8 @@ import org.jetbrains.dokka.pages._
 import org.jetbrains.dokka.transformers.pages.PageTransformer
 
 case class LoadedTemplate(templateFile: TemplateFile, children: List[LoadedTemplate], file: File) {
-    def relativePath(root: File): String =
-        root.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '.')
+  def relativePath(root: File): String =
+    root.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '.')
 }
 
 case class StaticPageNode(
@@ -23,17 +23,22 @@ case class StaticPageNode(
                            override val getEmbeddedResources: JList[String],
                            override val getChildren: JList[PageNode],
                          ) extends ContentPage:
-    override def getDocumentable: Documentable = null
+  override def getDocumentable: Documentable = null
 
-    def title(): String = template.title()
-    def hasFrame(): Boolean = template.hasFrame()
+  def title(): String = template.title()
+  def hasFrame(): Boolean = template.hasFrame()
 
-    override def modified(name: String, content: ContentNode, dri: JSet[DRI], embeddedResources: JList[String], children: JList[_ <: PageNode]): ContentPage =
-        copy(template, name, content, dri, embeddedResources, children.asInstanceOf[JList[PageNode]])
+  override def modified(
+    name: String,
+    content: ContentNode,
+    dri: JSet[DRI],
+    embeddedResources: JList[String],
+    children: JList[_ <: PageNode]): ContentPage =
+      copy(template, name, content, dri, embeddedResources, children.asInstanceOf[JList[PageNode]])
 
-    override def modified(name: String, children: JList[_ <: PageNode]): PageNode =
-        copy(getName = name, getChildren = children.asInstanceOf[JList[PageNode]])
+  override def modified(name: String, children: JList[_ <: PageNode]): PageNode =
+    copy(getName = name, getChildren = children.asInstanceOf[JList[PageNode]])
 
-    def resources(): List[String] = getContent match 
-        case p: PartiallyRenderedContent => p.resolved.resources
-        case _ => Nil
+  def resources(): List[String] = getContent match
+    case p: PartiallyRenderedContent => p.resolved.resources
+    case _ => Nil

--- a/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
@@ -5,7 +5,6 @@ import java.io.File
 
 import org.jetbrains.dokka.base.parsers.MarkdownParser
 import org.jetbrains.dokka.base.transformers.pages.comments.DocTagToContentConverter
-import org.jetbrains.dokka.DokkaConfiguration$DokkaSourceSet
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.doc.{DocTag, Text}
@@ -13,19 +12,19 @@ import org.jetbrains.dokka.model.properties.PropertyContainer
 import org.jetbrains.dokka.pages.{ContentKind, ContentNode, DCI, PageNode}
 import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.pages.Style
+import org.jetbrains.dokka.model.DisplaySourceSet
 
 import scala.collection.JavaConverters._
 
-class StaticSiteContext(val root: File, cxt: DokkaContext):
-
+class StaticSiteContext(val root: File, sourceSets: Set[SourceSetWrapper]):
     val docsFile = new File(root, "docs")
 
     def indexPage():Option[StaticPageNode] = 
       val files = List(new File(root, "index.html"), new File(root, "index.md")).filter { _.exists() }
-      if (files.size > 1) println("ERROR: Multiple root index pages found: ${files.map { it.absolutePath }}") // TODO (#14): provide proper error handling
+      if (files.size > 1) println(s"ERROR: Multiple root index pages found: ${files.map(_.getAbsolutePath)}") // TODO (#14): provide proper error handling
       loadFiles(files).headOption
 
-    private lazy val layouts: Map[String, TemplateFile] =
+    lazy val layouts: Map[String, TemplateFile] =
       val layoutRoot = new File(root, "_layouts")
       val dirs: Array[File] = Option(layoutRoot.listFiles()).getOrElse(Array())
       dirs.map { it => loadTemplateFile(it) }.map { it => it.name() -> it }.toMap
@@ -39,16 +38,16 @@ class StaticSiteContext(val root: File, cxt: DokkaContext):
     private def loadTemplate(from: File): Option[LoadedTemplate] =
       if (!isValidTemplate(from)) None else 
         try
-          val (indexes, children) = Option(from.listFiles()).toSeq.flatten.flatMap(loadTemplate).partition(_.isIndexPage())
+          val (indexes, children) = Option(from.listFiles()).toSeq.flatten.flatMap(loadTemplate).partition(_.templateFile.isIndexPage())
           if (indexes.size > 1)
-              println("ERROR: Multiple index pages for $from found in ${indexes.map { it.file }}") // TODO (#14): provide proper error handling
+              println(s"ERROR: Multiple index pages for $from found in ${indexes.map(_.file)}") // TODO (#14): provide proper error handling
 
           def loadIndexPage(): TemplateFile = {
               val indexFiles = from.listFiles { file =>file.getName == "index.md" || file.getName == "index.html" }
               indexFiles.size match {
                   case 0 => emptyTemplate(from)
                   case 1 => loadTemplateFile(indexFiles.head).copy(file = from)
-                  case _ =>  throw new java.lang.RuntimeException("ERROR: Multiple index pages found under ${from.path}")
+                  case _ =>  throw new java.lang.RuntimeException(s"ERROR: Multiple index pages found under ${from.toPath}")
               }
           }
 
@@ -60,40 +59,10 @@ class StaticSiteContext(val root: File, cxt: DokkaContext):
             e.printStackTrace() // TODO (#14): provide proper error handling
             None
 
-    private def parseMarkdown(page: PreResolvedPage, dri: DRI, allDRIs: Map[String, DRI]): ContentNode =
-      val nodes: JList[ContentNode] = if (!page.hasMarkdown) JList() else 
-        val parser = new MarkdownParser ( link => {
-          val driKey = 
-            if (link.startsWith("/")) then
-              // handle root related links
-              link.replace('/', '.').stripPrefix(".")
-            else 
-              val unSuffixedDri = dri.getPackageName.stripSuffix(".html").stripSuffix(".md")
-              val parentDri = unSuffixedDri.take(unSuffixedDri.lastIndexOf('.')).stripPrefix("_.")
-              "${parentDri}.${link.replace('/', '.')}"
-          
-          allDRIs.get(driKey).orNull
-        })
-        val docTag = try parser.parseStringToDocNode(page.code) catch
-          case (e: Throwable) =>
-            val msg = "Error rendering (dri = $dri): ${e.message}"
-            println("ERROR: $msg") // TODO (#14): provide proper error handling
-            new Text()
-
-        asContent(docTag, dri)
-
-      new PartiallyRenderedContent(
-          page,
-          nodes,
-          new DCI(Set(dri).asJava, ContentKind.Empty),
-          cxt.getConfiguration.getSourceSets.toDisplaySourceSet,
-          JSet()
-      )
-
     def asContent(d: DocTag, dri: DRI) = new DocTagToContentConverter().buildContent(
         d,
         new DCI(Set(dri).asJava, ContentKind.Empty),
-        cxt.getConfiguration.getSourceSets.asDokka,
+        sourceSets.asJava,
         JSet(),
         new PropertyContainer(JMap())
     )
@@ -106,31 +75,27 @@ class StaticSiteContext(val root: File, cxt: DokkaContext):
       def flatten(it: LoadedTemplate): List[String] =
         List(it.relativePath(root)) ++ it.children.flatMap(flatten)
 
-      def pathTomkDRI(path: String) = mkDRI("_.$path")
+      def pathToDRI(path: String) = mkDRI(s"_.$path")
 
-      val driMap = all.flatMap { it => flatten(it) }.map { it =>  it -> pathTomkDRI(it) }.toMap
+      val driMap = all.flatMap { it => flatten(it) }.map { it =>  it -> pathToDRI(it) }.toMap
 
       def templateToPage(myTemplate: LoadedTemplate): StaticPageNode = 
-        val dri = pathTomkDRI(myTemplate.relativePath(root))
-        val page = try {
-          val properties = myTemplate.templateFile.layout()
-            .map(c => Map("content" -> myTemplate.templateFile.rawCode)).getOrElse(Map.empty)
-
-          myTemplate.templateFile.resolveMarkdown(RenderingContext(properties, layouts))
-        } catch  { case e: Throwable =>
-          val msg = "Error rendering $myTemplate: ${e.message}"
-          println("ERROR: $msg") // TODO (#14): provide proper error handling
-          PreResolvedPage("", None, true)
-        }
-        val content = parseMarkdown(page, dri, driMap)
-        val children = myTemplate.children.map(templateToPage)
+        val dri = pathToDRI(myTemplate.relativePath(root))
+        val content = new PartiallyRenderedContent(
+          myTemplate.templateFile,
+          this,
+          JList(),
+          new DCI(Set(dri).asJava, ContentKind.Empty),
+          sourceSets.toDisplay,
+          JSet()
+        )
         StaticPageNode(
-          myTemplate,
+          myTemplate.templateFile,
           myTemplate.templateFile.title(),
           content,
           JSet(dri),
           JList(),
-          (children ++ customChildren).asJava
+          (myTemplate.children.map(templateToPage) ++ customChildren).asJava
         )
 
       all.map(templateToPage)

--- a/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
@@ -1,0 +1,136 @@
+package dotty.dokka
+package site
+
+import java.io.File
+
+import org.jetbrains.dokka.base.parsers.MarkdownParser
+import org.jetbrains.dokka.base.transformers.pages.comments.DocTagToContentConverter
+import org.jetbrains.dokka.DokkaConfiguration$DokkaSourceSet
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.doc.{DocTag, Text}
+import org.jetbrains.dokka.model.properties.PropertyContainer
+import org.jetbrains.dokka.pages.{ContentKind, ContentNode, DCI, PageNode}
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.pages.Style
+
+import scala.collection.JavaConverters._
+
+class StaticSiteContext(val root: File, cxt: DokkaContext):
+
+    val docsFile = new File(root, "docs")
+
+    def indexPage():Option[StaticPageNode] = 
+      val files = List(new File(root, "index.html"), new File(root, "index.md")).filter { _.exists() }
+      if (files.size > 1) println("ERROR: Multiple root index pages found: ${files.map { it.absolutePath }}") // TODO (#14): provide proper error handling
+      loadFiles(files).headOption
+
+    private lazy val layouts: Map[String, TemplateFile] =
+      val layoutRoot = new File(root, "_layouts")
+      val dirs: Array[File] = Option(layoutRoot.listFiles()).getOrElse(Array())
+      dirs.map { it => loadTemplateFile(it) }.map { it => it.name() -> it }.toMap
+
+    private def isValidTemplate(file: File): Boolean =
+      (file.isDirectory && !file.getName.startsWith("_")) ||
+        file.getName.endsWith(".md") ||
+        file.getName.endsWith(".html")
+
+
+    private def loadTemplate(from: File): Option[LoadedTemplate] =
+      if (!isValidTemplate(from)) None else 
+        try
+          val (indexes, children) = Option(from.listFiles()).toSeq.flatten.flatMap(loadTemplate).partition(_.isIndexPage())
+          if (indexes.size > 1)
+              println("ERROR: Multiple index pages for $from found in ${indexes.map { it.file }}") // TODO (#14): provide proper error handling
+
+          def loadIndexPage(): TemplateFile = {
+              val indexFiles = from.listFiles { file =>file.getName == "index.md" || file.getName == "index.html" }
+              indexFiles.size match {
+                  case 0 => emptyTemplate(from)
+                  case 1 => loadTemplateFile(indexFiles.head).copy(file = from)
+                  case _ =>  throw new java.lang.RuntimeException("ERROR: Multiple index pages found under ${from.path}")
+              }
+          }
+
+          val templateFile = if (from.isDirectory) loadIndexPage() else loadTemplateFile(from)
+
+          Some(LoadedTemplate(templateFile, children.toList, from))
+        catch
+          case e: RuntimeException =>
+            e.printStackTrace() // TODO (#14): provide proper error handling
+            None
+
+    private def parseMarkdown(page: PreResolvedPage, dri: DRI, allDRIs: Map[String, DRI]): ContentNode =
+      val nodes: JList[ContentNode] = if (!page.hasMarkdown) JList() else 
+        val parser = new MarkdownParser ( link => {
+          val driKey = 
+            if (link.startsWith("/")) then
+              // handle root related links
+              link.replace('/', '.').stripPrefix(".")
+            else 
+              val unSuffixedDri = dri.getPackageName.stripSuffix(".html").stripSuffix(".md")
+              val parentDri = unSuffixedDri.take(unSuffixedDri.lastIndexOf('.')).stripPrefix("_.")
+              "${parentDri}.${link.replace('/', '.')}"
+          
+          allDRIs.get(driKey).orNull
+        })
+        val docTag = try parser.parseStringToDocNode(page.code) catch
+          case (e: Throwable) =>
+            val msg = "Error rendering (dri = $dri): ${e.message}"
+            println("ERROR: $msg") // TODO (#14): provide proper error handling
+            new Text()
+
+        asContent(docTag, dri)
+
+      new PartiallyRenderedContent(
+          page,
+          nodes,
+          new DCI(Set(dri).asJava, ContentKind.Empty),
+          cxt.getConfiguration.getSourceSets.toDisplaySourceSet,
+          JSet()
+      )
+
+    def asContent(d: DocTag, dri: DRI) = new DocTagToContentConverter().buildContent(
+        d,
+        new DCI(Set(dri).asJava, ContentKind.Empty),
+        cxt.getConfiguration.getSourceSets.asDokka,
+        JSet(),
+        new PropertyContainer(JMap())
+    )
+
+    def loadFiles(
+        files: List[File],
+        customChildren: List[PageNode] = Nil
+    ): List[StaticPageNode] =
+      val all = files.flatMap(loadTemplate)
+      def flatten(it: LoadedTemplate): List[String] =
+        List(it.relativePath(root)) ++ it.children.flatMap(flatten)
+
+      def pathTomkDRI(path: String) = mkDRI("_.$path")
+
+      val driMap = all.flatMap { it => flatten(it) }.map { it =>  it -> pathTomkDRI(it) }.toMap
+
+      def templateToPage(myTemplate: LoadedTemplate): StaticPageNode = 
+        val dri = pathTomkDRI(myTemplate.relativePath(root))
+        val page = try {
+          val properties = myTemplate.templateFile.layout()
+            .map(c => Map("content" -> myTemplate.templateFile.rawCode)).getOrElse(Map.empty)
+
+          myTemplate.templateFile.resolveMarkdown(RenderingContext(properties, layouts))
+        } catch  { case e: Throwable =>
+          val msg = "Error rendering $myTemplate: ${e.message}"
+          println("ERROR: $msg") // TODO (#14): provide proper error handling
+          PreResolvedPage("", None, true)
+        }
+        val content = parseMarkdown(page, dri, driMap)
+        val children = myTemplate.children.map(templateToPage)
+        StaticPageNode(
+          myTemplate,
+          myTemplate.templateFile.title(),
+          content,
+          JSet(dri),
+          JList(),
+          (children ++ customChildren).asJava
+        )
+
+      all.map(templateToPage)

--- a/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
@@ -17,85 +17,82 @@ import org.jetbrains.dokka.model.DisplaySourceSet
 import scala.collection.JavaConverters._
 
 class StaticSiteContext(val root: File, sourceSets: Set[SourceSetWrapper]):
-    val docsFile = new File(root, "docs")
+  val docsFile = new File(root, "docs")
 
-    def indexPage():Option[StaticPageNode] = 
-      val files = List(new File(root, "index.html"), new File(root, "index.md")).filter { _.exists() }
-      if (files.size > 1) println(s"ERROR: Multiple root index pages found: ${files.map(_.getAbsolutePath)}") // TODO (#14): provide proper error handling
-      loadFiles(files).headOption
+  def indexPage():Option[StaticPageNode] =
+    val files = List(new File(root, "index.html"), new File(root, "index.md")).filter { _.exists() }
+    if (files.size > 1) println(s"ERROR: Multiple root index pages found: ${files.map(_.getAbsolutePath)}") // TODO (#14): provide proper error handling
+    loadFiles(files).headOption
 
-    lazy val layouts: Map[String, TemplateFile] =
-      val layoutRoot = new File(root, "_layouts")
-      val dirs: Array[File] = Option(layoutRoot.listFiles()).getOrElse(Array())
-      dirs.map { it => loadTemplateFile(it) }.map { it => it.name() -> it }.toMap
+  lazy val layouts: Map[String, TemplateFile] =
+    val layoutRoot = new File(root, "_layouts")
+    val dirs: Array[File] = Option(layoutRoot.listFiles()).getOrElse(Array())
+    dirs.map { it => loadTemplateFile(it) }.map { it => it.name() -> it }.toMap
 
-    private def isValidTemplate(file: File): Boolean =
-      (file.isDirectory && !file.getName.startsWith("_")) ||
-        file.getName.endsWith(".md") ||
-        file.getName.endsWith(".html")
+  private def isValidTemplate(file: File): Boolean =
+    (file.isDirectory && !file.getName.startsWith("_")) ||
+      file.getName.endsWith(".md") ||
+      file.getName.endsWith(".html")
 
 
-    private def loadTemplate(from: File): Option[LoadedTemplate] =
-      if (!isValidTemplate(from)) None else 
-        try
-          val (indexes, children) = Option(from.listFiles()).toSeq.flatten.flatMap(loadTemplate).partition(_.templateFile.isIndexPage())
-          if (indexes.size > 1)
-              println(s"ERROR: Multiple index pages for $from found in ${indexes.map(_.file)}") // TODO (#14): provide proper error handling
+  private def loadTemplate(from: File): Option[LoadedTemplate] =
+    if (!isValidTemplate(from)) None else
+      try
+        val (indexes, children) = Option(from.listFiles()).toSeq.flatten.flatMap(loadTemplate).partition(_.templateFile.isIndexPage())
+        if (indexes.size > 1)
+          println(s"ERROR: Multiple index pages for $from found in ${indexes.map(_.file)}") // TODO (#14): provide proper error handling
 
-          def loadIndexPage(): TemplateFile = {
-              val indexFiles = from.listFiles { file =>file.getName == "index.md" || file.getName == "index.html" }
-              indexFiles.size match {
-                  case 0 => emptyTemplate(from)
-                  case 1 => loadTemplateFile(indexFiles.head).copy(file = from)
-                  case _ =>  throw new java.lang.RuntimeException(s"ERROR: Multiple index pages found under ${from.toPath}")
-              }
-          }
+        def loadIndexPage(): TemplateFile =
+          val indexFiles = from.listFiles { file =>file.getName == "index.md" || file.getName == "index.html" }
+          indexFiles.size match
+            case 0 => emptyTemplate(from)
+            case 1 => loadTemplateFile(indexFiles.head).copy(file = from)
+            case _ =>
+              val msg = s"ERROR: Multiple index pages found under ${from.toPath}"
+              throw new java.lang.RuntimeException(msg)
 
-          val templateFile = if (from.isDirectory) loadIndexPage() else loadTemplateFile(from)
+        val templateFile = if (from.isDirectory) loadIndexPage() else loadTemplateFile(from)
 
-          Some(LoadedTemplate(templateFile, children.toList, from))
-        catch
+        Some(LoadedTemplate(templateFile, children.toList, from))
+      catch
           case e: RuntimeException =>
             e.printStackTrace() // TODO (#14): provide proper error handling
             None
 
-    def asContent(d: DocTag, dri: DRI) = new DocTagToContentConverter().buildContent(
-        d,
+  def asContent(doctag: DocTag, dri: DRI) = new DocTagToContentConverter().buildContent(
+    doctag,
+    new DCI(Set(dri).asJava, ContentKind.Empty),
+    sourceSets.asJava,
+    JSet(),
+    new PropertyContainer(JMap())
+  )
+
+  def loadFiles(files: List[File], customChildren: List[PageNode] = Nil): List[StaticPageNode] =
+    val all = files.flatMap(loadTemplate)
+    def flatten(it: LoadedTemplate): List[String] =
+      List(it.relativePath(root)) ++ it.children.flatMap(flatten)
+
+    def pathToDRI(path: String) = mkDRI(s"_.$path")
+
+    val driMap = all.flatMap(flatten).map(it => it -> pathToDRI(it)).toMap
+
+    def templateToPage(myTemplate: LoadedTemplate): StaticPageNode =
+      val dri = pathToDRI(myTemplate.relativePath(root))
+      val content = new PartiallyRenderedContent(
+        myTemplate.templateFile,
+        this,
+        JList(),
         new DCI(Set(dri).asJava, ContentKind.Empty),
-        sourceSets.asJava,
-        JSet(),
-        new PropertyContainer(JMap())
-    )
+        sourceSets.toDisplay,
+        JSet()
+      )
+      StaticPageNode(
+        myTemplate.templateFile,
+        myTemplate.templateFile.title(),
+        content,
+        JSet(dri),
+        JList(),
+        (myTemplate.children.map(templateToPage) ++ customChildren).asJava
+      )
 
-    def loadFiles(
-        files: List[File],
-        customChildren: List[PageNode] = Nil
-    ): List[StaticPageNode] =
-      val all = files.flatMap(loadTemplate)
-      def flatten(it: LoadedTemplate): List[String] =
-        List(it.relativePath(root)) ++ it.children.flatMap(flatten)
-
-      def pathToDRI(path: String) = mkDRI(s"_.$path")
-
-      val driMap = all.flatMap { it => flatten(it) }.map { it =>  it -> pathToDRI(it) }.toMap
-
-      def templateToPage(myTemplate: LoadedTemplate): StaticPageNode = 
-        val dri = pathToDRI(myTemplate.relativePath(root))
-        val content = new PartiallyRenderedContent(
-          myTemplate.templateFile,
-          this,
-          JList(),
-          new DCI(Set(dri).asJava, ContentKind.Empty),
-          sourceSets.toDisplay,
-          JSet()
-        )
-        StaticPageNode(
-          myTemplate.templateFile,
-          myTemplate.templateFile.title(),
-          content,
-          JSet(dri),
-          JList(),
-          (myTemplate.children.map(templateToPage) ++ customChildren).asJava
-        )
-
-      all.map(templateToPage)
+    all.map(templateToPage)

--- a/scala3doc/src/dotty/dokka/site/StaticSiteLocationProvider.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticSiteLocationProvider.scala
@@ -12,13 +12,13 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import scala.collection.JavaConverters._
 
 class StaticSiteLocationProviderFactory(private val ctx: DokkaContext) extends LocationProviderFactory:
-    override def getLocationProvider(pageNode: RootPageNode): LocationProvider =
-      new StaticSiteLocationProvider(ctx, pageNode)
+  override def getLocationProvider(pageNode: RootPageNode): LocationProvider =
+    new StaticSiteLocationProvider(ctx, pageNode)
 
-class StaticSiteLocationProvider(ctx: DokkaContext, pageNode: RootPageNode) 
+class StaticSiteLocationProvider(ctx: DokkaContext, pageNode: RootPageNode)
   extends DokkaLocationProvider(pageNode, ctx, ".html"):
     private def updatePageEntry(page: PageNode, jpath: JList[String]): JList[String] =
-      page match 
+      page match
         case page: StaticPageNode =>
           if (page.getDri.contains(docsRootDRI)) JList("index")
           else {

--- a/scala3doc/src/dotty/dokka/site/StaticSiteLocationProvider.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticSiteLocationProvider.scala
@@ -24,7 +24,7 @@ class StaticSiteLocationProvider(ctx: DokkaContext, pageNode: RootPageNode)
           else {
             val path = jpath.asScala.toList
             val start = if (path.head == "--root--") List("docs") else path.take(1)
-            val pageName = page.loadedTemplate.file.getName
+            val pageName = page.template.file.getName
             val dotIndex = pageName.lastIndexOf('.')
             val newName = if (dotIndex < 0) pageName else pageName.substring(0, dotIndex)
             (start ++ path.drop(1).dropRight(1) ++ List(newName)).asJava

--- a/scala3doc/src/dotty/dokka/site/common.scala
+++ b/scala3doc/src/dotty/dokka/site/common.scala
@@ -18,11 +18,9 @@ import org.jetbrains.dokka.model.doc.Text
 
 import scala.collection.JavaConverters._
 
-val ExternalDocsTooKey = "ExternalDocsTooKey"
 val docsRootDRI: DRI = mkDRI(extra = "_top_level_index")
 val docsDRI: DRI = mkDRI(extra = "_docs_level_index")
-val apiPageDRI: DRI = mkDRI(classNames = "api", extra = "__api__")
-
+val apiPageDRI: DRI = mkDRI(packageName = "api", extra = "__api__")
 
 val defaultMarkdownOptions: DataHolder =
   new MutableDataSet()

--- a/scala3doc/src/dotty/dokka/site/common.scala
+++ b/scala3doc/src/dotty/dokka/site/common.scala
@@ -1,0 +1,74 @@
+package dotty.dokka
+package site
+
+import java.io.File
+import java.nio.file.Files
+
+import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension
+import com.vladsch.flexmark.ext.emoji.EmojiExtension
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension
+import com.vladsch.flexmark.ext.tables.TablesExtension
+import com.vladsch.flexmark.ext.yaml.front.matter.{AbstractYamlFrontMatterVisitor, YamlFrontMatterExtension}
+import com.vladsch.flexmark.parser.{Parser, ParserEmulationProfile}
+import com.vladsch.flexmark.util.options.{DataHolder, MutableDataSet}
+import org.jetbrains.dokka.links.{DRI, PointingToDeclaration}
+import org.jetbrains.dokka.model.doc.Text
+
+import scala.collection.JavaConverters._
+
+val ExternalDocsTooKey = "ExternalDocsTooKey"
+val docsRootDRI: DRI = mkDRI(extra = "_top_level_index")
+val docsDRI: DRI = mkDRI(extra = "_docs_level_index")
+val apiPageDRI: DRI = mkDRI(classNames = "api", extra = "__api__")
+
+
+val defaultMarkdownOptions: DataHolder =
+  new MutableDataSet()
+    .setFrom(ParserEmulationProfile.KRAMDOWN.getOptions)
+    .set(
+      Parser.EXTENSIONS, List(
+        TablesExtension.create(),
+        TaskListExtension.create(),
+        AutolinkExtension.create(),
+        AnchorLinkExtension.create(),
+        EmojiExtension.create(),
+        YamlFrontMatterExtension.create(),
+        StrikethroughExtension.create()
+      ).asJava)
+    .set(
+      EmojiExtension.ROOT_IMAGE_PATH,
+      "https://github.global.ssl.fastly.net/images/icons/emoji/"
+    )
+
+def emptyTemplate(file: File): TemplateFile = TemplateFile(file, isHtml = true, "", Map())
+
+final val ConfigSeparator = "---"
+final val LineSeparator = "\n"
+
+val yamlParser: Parser = Parser.builder(defaultMarkdownOptions).build()
+
+def loadTemplateFile(file: File): TemplateFile = {
+  val lines = Files.readAllLines(file.toPath).asScala.toList
+
+  val (config, content) = if (lines.head == ConfigSeparator) {
+    // Taking the second occurrence of ConfigSeparator.
+    // The rest may appear within the content.
+    val index = lines.drop(1).indexOf(ConfigSeparator) + 2
+    (lines.take(index), lines.drop(index))
+  } else (Nil, lines)
+
+  val configParsed = yamlParser.parse(config.mkString(LineSeparator))
+  val yamlCollector = new AbstractYamlFrontMatterVisitor()
+  yamlCollector.visit(configParsed)
+
+  TemplateFile(
+    file = file,
+    file.getName.endsWith(".html"),
+    rawCode = content.mkString(LineSeparator),
+    settings = yamlCollector.getData.asScala.toMap.transform((_, v) => v.asScala.toList)
+  )
+}
+
+def Text(msg: String = "") = new Text(msg, JList(), JMap())

--- a/scala3doc/src/dotty/dokka/site/contentNodes.scala
+++ b/scala3doc/src/dotty/dokka/site/contentNodes.scala
@@ -1,0 +1,24 @@
+package dotty.dokka
+package site
+
+import org.jetbrains.dokka.model.DisplaySourceSet
+import org.jetbrains.dokka.model.properties.PropertyContainer
+import org.jetbrains.dokka.pages.{ContentNode, DCI, Style}
+
+case class PartiallyRenderedContent(
+    page: PreResolvedPage,
+    override val getChildren: JList[ContentNode],
+    override val getDci: DCI,
+    override val getSourceSets: JSet[DisplaySourceSet],
+    override val getStyle: JSet[Style] = JSet(),
+    override val getExtra: PropertyContainer[ContentNode] = new PropertyContainer(JMap())
+) extends ContentNode:
+    override def hasAnyContent(): Boolean = getChildren.stream().filter(_.hasAnyContent()).count() > 0
+
+    override def withNewExtras(newExtras: PropertyContainer[ContentNode]): ContentNode =
+        copy(getExtra = newExtras)
+
+    override def withSourceSets(sourceSets: JSet[DisplaySourceSet]): ContentNode =
+        copy(getSourceSets = sourceSets)
+
+    val allResources: List[String] = page.render("").resources

--- a/scala3doc/src/dotty/dokka/site/locationProvider.scala
+++ b/scala3doc/src/dotty/dokka/site/locationProvider.scala
@@ -1,0 +1,42 @@
+package dotty.dokka
+package site
+
+import org.jetbrains.dokka.base.resolvers.local.DokkaLocationProvider
+import org.jetbrains.dokka.base.resolvers.local.LocationProvider
+import org.jetbrains.dokka.base.resolvers.local.LocationProviderFactory
+import org.jetbrains.dokka.pages.ContentPage
+import org.jetbrains.dokka.pages.PageNode
+import org.jetbrains.dokka.pages.RootPageNode
+import org.jetbrains.dokka.plugability.DokkaContext
+
+import scala.collection.JavaConverters._
+
+class StaticSiteLocationProviderFactory(private val ctx: DokkaContext) extends LocationProviderFactory:
+    override def getLocationProvider(pageNode: RootPageNode): LocationProvider =
+      new StaticSiteLocationProvider(ctx, pageNode)
+
+class StaticSiteLocationProvider(ctx: DokkaContext, pageNode: RootPageNode) 
+  extends DokkaLocationProvider(pageNode, ctx, ".html"):
+    private def updatePageEntry(page: PageNode, jpath: JList[String]): JList[String] =
+      page match 
+        case page: StaticPageNode =>
+          if (page.getDri.contains(docsRootDRI)) JList("index")
+          else {
+            val path = jpath.asScala.toList
+            val start = if (path.head == "--root--") List("docs") else path.take(1)
+            val pageName = page.loadedTemplate.file.getName
+            val dotIndex = pageName.lastIndexOf('.')
+            val newName = if (dotIndex < 0) pageName else pageName.substring(0, dotIndex)
+            (start ++ path.drop(1).dropRight(1) ++ List(newName)).asJava
+          }
+        case page: ContentPage if page.getDri.contains(docsDRI) =>
+           JList("docs")
+        case page: ContentPage if page.getDri.contains(apiPageDRI) =>
+          JList("api", "index")
+        case _ if jpath.size() > 1 && jpath.get(0) ==   "--root--" && jpath.get(1) == "-a-p-i" =>
+          (List("api") ++ jpath.asScala.drop(2)).asJava
+        case _ =>
+          jpath
+
+    override val getPathsIndex: JMap[PageNode, JList[String]] =
+      super.getPathsIndex.asScala.mapValuesInPlace(updatePageEntry).asJava

--- a/scala3doc/src/dotty/dokka/site/processors.scala
+++ b/scala3doc/src/dotty/dokka/site/processors.scala
@@ -13,123 +13,121 @@ import org.jetbrains.dokka.transformers.pages.PageTransformer
 import scala.collection.JavaConverters._
 
 abstract class BaseStaticSiteProcessor(staticSiteContext: Option[StaticSiteContext]) extends PageTransformer:
-    final override def invoke(input: RootPageNode): RootPageNode = staticSiteContext.fold(input)(transform(input, _))
+  final override def invoke(input: RootPageNode): RootPageNode = staticSiteContext.fold(input)(transform(input, _))
 
-    protected def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode
+  protected def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode
 
 class SiteResourceManager(ctx: Option[StaticSiteContext]) extends BaseStaticSiteProcessor(ctx):
+  private def listResources(nodes: Seq[PageNode]): Set[String] =
+    nodes.flatMap {
+      case it: StaticPageNode => listResources(it.getChildren.asScala.toList) ++ it.resources()
+      case _ => Seq.empty
+    }.toSet
 
-    private def listResources(nodes: Seq[PageNode]): Set[String] =
-        nodes.flatMap {
-            case it: StaticPageNode => listResources(it.getChildren.asScala.toList) ++ it.resources()
-            case _ => Seq.empty
-        }.toSet
+  override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
+    val imgPath = ctx.root.toPath().resolve("images")
+    val images =
+      if !Files.exists(imgPath) then Nil
+      else
+        val stream = Files.walk(imgPath)filter(p => Files.isRegularFile(p) && p.getFileName().toString().endsWith(".svg"))
+        stream.iterator().asScala.toList.map(_.toString)
 
-    override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
-        val imgPath = ctx.root.toPath().resolve("images")
-        val images = 
-          if !Files.exists(imgPath) then Nil 
-          else 
-            val stream = Files.walk(imgPath)filter(p => Files.isRegularFile(p) && p.getFileName().toString().endsWith(".svg"))
-            stream.iterator().asScala.toList.map(_.toString)
+    val resources = listResources(input.getChildren.asScala.toList) ++ images
+    val resourcePages = resources.map { path =>
+      val content = Files.readString(ctx.root.toPath.resolve(path))
+      new RendererSpecificResourcePage(path, JList(), new RenderingStrategy.Write(content))
+    }.toList
 
-        val resources = listResources(input.getChildren.asScala.toList) ++ images
-        val resourcePages = resources.map { path =>
-            val content = Files.readString(ctx.root.toPath.resolve(path))
-            new RendererSpecificResourcePage(path, JList(), new RenderingStrategy.Write(content))
-        }.toList
-
-        val modified = input.transformContentPagesTree {
-            case it: StaticPageNode =>
-                it.copy(getEmbeddedResources = 
-                  if it.template.hasFrame() then it.getEmbeddedResources ++ it.resources().asJava
-                  else it.resources().asJava
-                )
-            case it => it
-        }
-        modified.modified(modified.getName, (resourcePages ++ modified.getChildren.asScala).asJava)
+    val modified = input.transformContentPagesTree {
+      case it: StaticPageNode =>
+        it.copy(getEmbeddedResources =
+          if it.template.hasFrame() then it.getEmbeddedResources ++ it.resources().asJava
+          else it.resources().asJava
+        )
+      case it => it
+    }
+    modified.modified(modified.getName, (resourcePages ++ modified.getChildren.asScala).asJava)
 
 case class AContentPage(
-    override val getName: String,
-    override val getChildren: JList[PageNode],
-    override val getContent: ContentNode,
-    override val getDri: JSet[DRI],
-    override val getEmbeddedResources: JList[String] = JList(),
+  override val getName: String,
+  override val getChildren: JList[PageNode],
+  override val getContent: ContentNode,
+  override val getDri: JSet[DRI],
+  override val getEmbeddedResources: JList[String] = JList(),
 ) extends ContentPage:
-    override def getDocumentable: Documentable = null
+  override def getDocumentable: Documentable = null
 
-    override def modified(
-        name: String,
-        content: ContentNode,
-        dri: JSet[DRI],
-        embeddedResources: JList[String],
-        children: JList[_ <: PageNode]
-    ): ContentPage = copy(name, children.asInstanceOf[JList[PageNode]], content, dri, embeddedResources)
+  override def modified(
+    name: String,
+    content: ContentNode,
+    dri: JSet[DRI],
+    embeddedResources: JList[String],
+    children: JList[_ <: PageNode]
+  ): ContentPage = copy(name, children.asInstanceOf[JList[PageNode]], content, dri, embeddedResources)
 
-    override def modified(name: String, children: JList[_ <: PageNode]): PageNode = copy(name, getChildren = children.asInstanceOf[JList[PageNode]])
+  override def modified(name: String, children: JList[_ <: PageNode]): PageNode =
+    copy(name, getChildren = children.asInstanceOf[JList[PageNode]])
 
 class SitePagesCreator(ctx: Option[StaticSiteContext]) extends BaseStaticSiteProcessor(ctx):
+  private def processRootPage(input: RootPageNode, children: List[PageNode] = Nil): AContentPage = input match
+    case input: ContentPage =>
+      AContentPage(
+        input.getName,
+        children.asJava,
+        input.getContent,
+        JSet(apiPageDRI),
+        input.getEmbeddedResources
+      )
+    case _: RendererSpecificRootPage =>
+      children.filter(_.isInstanceOf[RootPageNode]) match
+          case List(nestedRoot: RootPageNode) =>
+            processRootPage(nestedRoot, children.filter { _ != nestedRoot } ++ nestedRoot.getChildren.asScala)
+          case other =>
+            throw new RuntimeException(s"Expected single nested roor but get: $other")
 
-    private def processRootPage(input: RootPageNode, children: List[PageNode] = Nil): AContentPage = input match
-      case input: ContentPage =>
-        AContentPage(
-            input.getName,
-            children.asJava,
-            input.getContent,
-            JSet(apiPageDRI),
-            input.getEmbeddedResources
-        )
-      case _: RendererSpecificRootPage =>
-        children.filter(_.isInstanceOf[RootPageNode]) match {
-            case List(nestedRoot: RootPageNode) =>
-                processRootPage(
-                    nestedRoot,
-                    children.filter { _ != nestedRoot } ++ nestedRoot.getChildren.asScala)
-            case other => 
-              throw new RuntimeException(s"Expected single nested roor but get: $other")
-        }
-      case _ => throw new RuntimeException(s"UNSUPPORTED! ${input.getClass.getName}")
+    case _ => throw new RuntimeException(s"UNSUPPORTED! ${input.getClass.getName}")
 
-    override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
-        val (contentPage, others) = input.getChildren.asScala.toList.partition { _.isInstanceOf[ContentPage] }
-        val modifiedModuleRoot = processRootPage(input, contentPage)
-        val allFiles = Option(ctx.docsFile.listFiles()).toList.flatten
-        val (indexes, children) = ctx.loadFiles(allFiles).partition(_.template.isIndexPage())
-        if (indexes.size > 1) println("ERROR: Multiple index pages found $indexes}") // TODO (#14): provide proper error handling
+  override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
+    val (contentPage, others) = input.getChildren.asScala.toList.partition { _.isInstanceOf[ContentPage] }
+    val modifiedModuleRoot = processRootPage(input, contentPage)
+    val allFiles = Option(ctx.docsFile.listFiles()).toList.flatten
+    val (indexes, children) = ctx.loadFiles(allFiles).partition(_.template.isIndexPage())
+      // TODO (#14): provide proper error handling
+    if (indexes.size > 1) println("ERROR: Multiple index pages found $indexes}")
 
-        val rootContent = indexes.headOption.fold(ctx.asContent(Text(), mkDRI(extra = "root_content")).get(0))(_.getContent)
+    val rootContent = indexes.headOption.fold(ctx.asContent(Text(), mkDRI(extra = "root_content")).get(0))(_.getContent)
 
-        val root = AContentPage(
-            input.getName,
-            (List(modifiedModuleRoot.modified("API", modifiedModuleRoot.getChildren)) ++ children).asJava,
-            rootContent,
-            JSet(docsDRI),
-            JList()
-        )
+    val root = AContentPage(
+      input.getName,
+      (List(modifiedModuleRoot.modified("API", modifiedModuleRoot.getChildren)) ++ children).asJava,
+      rootContent,
+      JSet(docsDRI),
+      JList()
+    )
 
-        new RendererSpecificRootPage(
-            modifiedModuleRoot.getName,
-            (List(root) ++ others).asJava,
-            RenderingStrategy.DoNothing.INSTANCE
-        )
+    new RendererSpecificRootPage(
+      modifiedModuleRoot.getName,
+      (List(root) ++ others).asJava,
+      RenderingStrategy.DoNothing.INSTANCE
+    )
 
 class RootIndexPageCreator(ctx: Option[StaticSiteContext]) extends BaseStaticSiteProcessor(ctx):
-    override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
-      ctx.indexPage().fold(input){ it =>
-          val (contentNodes, nonContent) = input.getChildren.asScala.partition { _.isInstanceOf[ContentNode] }
-          val (navigations, rest) = nonContent.partition { _.isInstanceOf[NavigationPage] }
-          val modifiedNavigation = navigations.map { it =>
-              val root = it.asInstanceOf[NavigationPage].getRoot
-              val (api, rest) = root.getChildren.asScala.partition { _.getDri == apiPageDRI }
-              new NavigationPage(
-                  new NavigationNode(
-                      input.getName,
-                      docsRootDRI,
-                      root.getSourceSets,
-                      (rest ++ api).asJava
-                  )
-              )
-          }
-          val newRoot = it.copy(getDri =  JSet(docsRootDRI), getChildren = contentNodes.asJava)
-          input.modified(input.getName, (List(newRoot) ++ rest ++ modifiedNavigation).asJava)
+  override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
+    ctx.indexPage().fold(input){ it =>
+      val (contentNodes, nonContent) = input.getChildren.asScala.partition { _.isInstanceOf[ContentNode] }
+      val (navigations, rest) = nonContent.partition { _.isInstanceOf[NavigationPage] }
+      val modifiedNavigation = navigations.map { it =>
+        val root = it.asInstanceOf[NavigationPage].getRoot
+        val (api, rest) = root.getChildren.asScala.partition { _.getDri == apiPageDRI }
+        new NavigationPage(
+          new NavigationNode(
+            input.getName,
+            docsRootDRI,
+            root.getSourceSets,
+            (rest ++ api).asJava
+          )
+        )
       }
+      val newRoot = it.copy(getDri =  JSet(docsRootDRI), getChildren = contentNodes.asJava)
+      input.modified(input.getName, (List(newRoot) ++ rest ++ modifiedNavigation).asJava)
+    }

--- a/scala3doc/src/dotty/dokka/site/processors.scala
+++ b/scala3doc/src/dotty/dokka/site/processors.scala
@@ -1,0 +1,161 @@
+package dotty.dokka
+package site
+
+import java.io.File
+import java.nio.file.Files
+
+import org.jetbrains.dokka.base.renderers.html.{NavigationNode, NavigationPage}
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.Documentable
+import org.jetbrains.dokka.pages._
+import org.jetbrains.dokka.transformers.pages.PageTransformer
+
+import scala.collection.JavaConverters._
+
+case class LoadedTemplate(templateFile: TemplateFile, children: List[LoadedTemplate], file: File) {
+    def isIndexPage() = file.isFile && (file.getName == "index.md" || file.getName == "index.html")
+    def relativePath(root: File): String =
+        root.toPath().relativize(file.toPath()).toString().replace(File.separatorChar, '.')
+}
+
+case class StaticPageNode(
+                           loadedTemplate: LoadedTemplate,
+                           override val getName: String,
+                           override val getContent: ContentNode,
+                           override val getDri: JSet[DRI],
+                           override val getEmbeddedResources: JList[String],
+                           override val getChildren: JList[PageNode],
+                         ) extends ContentPage:
+    override def getDocumentable: Documentable = null
+
+    def title(): String = loadedTemplate.templateFile.title()
+    def hasFrame(): Boolean = loadedTemplate.templateFile.hasFrame()
+
+    override def modified(name: String, content: ContentNode, dri: JSet[DRI], embeddedResources: JList[String], children: JList[_ <: PageNode]): ContentPage =
+        copy(loadedTemplate, name, content, dri, embeddedResources, children.asInstanceOf[JList[PageNode]])
+
+    override def modified(name: String, children: JList[_ <: PageNode]): PageNode =
+        copy(getName = name, getChildren = children.asInstanceOf[JList[PageNode]])
+
+    def resources(): List[String] = getContent match 
+        case p: PartiallyRenderedContent => p.allResources
+        case _ => Nil
+
+
+abstract class BaseStaticSiteProcessor(staticSiteContext: Option[StaticSiteContext]) extends PageTransformer:
+    final override def invoke(input: RootPageNode): RootPageNode = staticSiteContext.fold(input)(transform(input, _))
+
+    protected def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode
+
+class SiteResourceManager(ctx: Option[StaticSiteContext]) extends BaseStaticSiteProcessor(ctx):
+
+    private def listResources(nodes: Seq[PageNode]): Set[String] =
+        nodes.flatMap {
+            case it: StaticPageNode => listResources(it.getChildren.asScala.toList) ++ it.resources()
+            case _ => Seq.empty
+        }.toSet
+
+    override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
+        val imgPath = ctx.root.toPath().resolve("images")
+        val allImgPaths = Files.walk(imgPath).filter(Files.isRegularFile(_))
+        val images = allImgPaths.iterator().asScala.toList.map(_.toString)
+
+        val resources = listResources(input.getChildren.asScala.toList) ++ images
+        val resourcePages = resources.map { path =>
+            val content = Files.readString(ctx.root.toPath.resolve(path))
+            new RendererSpecificResourcePage(path, JList(), new RenderingStrategy.Write(content))
+        }.toList
+        val modified = input.transformContentPagesTree {
+            case it: StaticPageNode =>
+                val newRes = JList[String]()
+                newRes.addAll(it.getEmbeddedResources)
+                newRes.addAll(it.resources().asJava)
+                it.copy(getEmbeddedResources = newRes)
+            case it => it
+        }
+        modified.modified(modified.getName, (resourcePages ++ modified.getChildren.asScala).asJava)
+
+case class AContentPage(
+    override val getName: String,
+    override val getChildren: JList[PageNode],
+    override val getContent: ContentNode,
+    override val getDri: JSet[DRI],
+    override val getEmbeddedResources: JList[String] = JList(),
+) extends ContentPage:
+    override def getDocumentable: Documentable = null
+
+    override def modified(
+        name: String,
+        content: ContentNode,
+        dri: JSet[DRI],
+        embeddedResources: JList[String],
+        children: JList[_ <: PageNode]
+    ): ContentPage = copy(name, children.asInstanceOf[JList[PageNode]], content, dri, embeddedResources)
+
+    override def modified(name: String, children: JList[_ <: PageNode]): PageNode = copy(name, getChildren = children.asInstanceOf[JList[PageNode]])
+
+class SitePagesCreator(ctx: Option[StaticSiteContext]) extends BaseStaticSiteProcessor(ctx):
+
+    private def processRootPage(input: RootPageNode, children: List[PageNode] = Nil): AContentPage = input match
+      case input: ContentPage =>
+        AContentPage(
+            input.getName,
+            children.asJava,
+            input.getContent,
+            JSet(apiPageDRI),
+            input.getEmbeddedResources
+        )
+      case _: RendererSpecificRootPage =>
+        children.filter(_.isInstanceOf[RootPageNode]) match {
+            case List(nestedRoot: RootPageNode) =>
+                processRootPage(
+                    nestedRoot,
+                    children.filter { _ != nestedRoot } ++ nestedRoot.getChildren.asScala)
+            case other => 
+              throw new RuntimeException(s"Expected single nested roor but get: $other")
+        }
+      case _ => throw new RuntimeException(s"UNSUPPORTED! ${input.getClass.getName}")
+
+    override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
+        val (contentPage, others) = input.getChildren.asScala.toList.partition { _.isInstanceOf[ContentPage] }
+        val modifiedModuleRoot = processRootPage(input, contentPage)
+        val allFiles = Option(ctx.docsFile.listFiles()).toList.flatten
+        val (indexes, children) = ctx.loadFiles(allFiles).partition(_.loadedTemplate.isIndexPage())
+        if (indexes.size > 1) println("ERROR: Multiple index pages found $indexes}") // TODO (#14): provide proper error handling
+
+        val rootContent = indexes.headOption.fold(ctx.asContent(Text(), mkDRI(extra = "root_content")).get(0))(_.getContent)
+
+        val root = AContentPage(
+            input.getName,
+            (List(modifiedModuleRoot.modified("API", modifiedModuleRoot.getChildren)) ++ children).asJava,
+            rootContent,
+            JSet(docsDRI),
+            JList()
+        )
+
+        new RendererSpecificRootPage(
+            modifiedModuleRoot.getName,
+            (List(root) ++ others).asJava,
+            RenderingStrategy.DoNothing.INSTANCE
+        )
+
+class RootIndexPageCreator(ctx: Option[StaticSiteContext]) extends BaseStaticSiteProcessor(ctx):
+    override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
+      ctx.indexPage().fold(input){ it =>
+          val (contentNodes, nonContent) = input.getChildren.asScala.partition { _.isInstanceOf[ContentNode] }
+          val (navigations, rest) = nonContent.partition { _.isInstanceOf[NavigationPage] }
+          val modifiedNavigation = navigations.map { it =>
+              val root = it.asInstanceOf[NavigationPage].getRoot
+              val (api, rest) = root.getChildren.asScala.partition { _.getDri == apiPageDRI }
+              new NavigationPage(
+                  new NavigationNode(
+                      input.getName,
+                      docsRootDRI,
+                      root.getSourceSets,
+                      (rest ++ api).asJava
+                  )
+              )
+          }
+          val newRoot = it.copy(getDri =  JSet(docsRootDRI), getChildren = contentNodes.asJava)
+          input.modified(input.getName, (List(newRoot) ++ rest ++ modifiedNavigation).asJava)
+      }

--- a/scala3doc/src/dotty/dokka/site/processors.scala
+++ b/scala3doc/src/dotty/dokka/site/processors.scala
@@ -27,9 +27,11 @@ class SiteResourceManager(ctx: Option[StaticSiteContext]) extends BaseStaticSite
 
     override def transform(input: RootPageNode, ctx: StaticSiteContext): RootPageNode =
         val imgPath = ctx.root.toPath().resolve("images")
-        val allImgPaths = Files.walk(imgPath)
-          .filter(p => Files.isRegularFile(p) && p.getFileName().toString().endsWith(".svg"))
-        val images = allImgPaths.iterator().asScala.toList.map(_.toString)
+        val images = 
+          if !Files.exists(imgPath) then Nil 
+          else 
+            val stream = Files.walk(imgPath)filter(p => Files.isRegularFile(p) && p.getFileName().toString().endsWith(".svg"))
+            stream.iterator().asScala.toList.map(_.toString)
 
         val resources = listResources(input.getChildren.asScala.toList) ++ images
         val resourcePages = resources.map { path =>

--- a/scala3doc/src/dotty/dokka/site/processors.scala
+++ b/scala3doc/src/dotty/dokka/site/processors.scala
@@ -34,7 +34,7 @@ class SiteResourceManager(ctx: Option[StaticSiteContext]) extends BaseStaticSite
 
     val resources = listResources(input.getChildren.asScala.toList) ++ images
     val resourcePages = resources.map { path =>
-      val content = Files.readString(ctx.root.toPath.resolve(path))
+      val content = Files.readAllLines(ctx.root.toPath.resolve(path)).asScala.mkString("\n")
       new RendererSpecificResourcePage(path, JList(), new RenderingStrategy.Write(content))
     }.toList
 

--- a/scala3doc/src/dotty/dokka/site/templates.scala
+++ b/scala3doc/src/dotty/dokka/site/templates.scala
@@ -33,10 +33,7 @@ case class RenderingContext(
       resources = this.resources ++ resources
     )
 
-case class ResolvedPage(
-                         val code: String,
-                         val resources: List[String] = Nil
-                       )
+case class ResolvedPage(val code: String, val resources: List[String] = Nil)
 
 /**
  * case class for the template files.
@@ -84,13 +81,13 @@ case class TemplateFile(
 
     // Library requires mutable maps..
     val mutableProperties = new java.util.HashMap[String, Object](ctx.properties.asJava)
-    val rendered = Template.parse(this.rawCode).render(mutableProperties) 
+    val rendered = Template.parse(this.rawCode).render(mutableProperties)
     val code = if (!isHtml) rendered else
       val parser: Parser = Parser.builder().build()
       HtmlRenderer.builder(ctx.markdownOptions).build().render(parser.parse(rendered))
-    
+
     val resources = listSetting("extraCSS") ++ listSetting("extraJS")
-    layoutTemplate match 
+    layoutTemplate match
       case None => ResolvedPage(code, resources ++ ctx.resources)
       case Some(layoutTemplate) =>
         layoutTemplate.resolveInner(ctx.nest(code, file, resources))

--- a/scala3doc/src/dotty/dokka/site/templates.scala
+++ b/scala3doc/src/dotty/dokka/site/templates.scala
@@ -1,0 +1,126 @@
+package dotty.dokka.site
+
+import java.io.File
+import java.nio.file.Files
+
+import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension
+import com.vladsch.flexmark.ext.emoji.EmojiExtension
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension
+import com.vladsch.flexmark.ext.tables.TablesExtension
+import com.vladsch.flexmark.ext.yaml.front.matter.{AbstractYamlFrontMatterVisitor, YamlFrontMatterExtension}
+import com.vladsch.flexmark.parser.{Parser, ParserEmulationProfile}
+import com.vladsch.flexmark.util.options.{DataHolder, MutableDataSet}
+import com.vladsch.flexmark.html.HtmlRenderer
+import liqp.Template
+
+import scala.collection.JavaConverters._
+import scala.io.Source
+
+case class RenderingContext(
+                             properties: Map[String, Object],
+                             layouts: Map[String, TemplateFile] = Map(),
+                             resolving: Set[String] = Set(),
+                             markdownOptions: DataHolder = defaultMarkdownOptions,
+                             resources: List[String] = Nil
+                           ):
+
+  def nest(code: String, file: File, resources: List[String]) =
+    copy(
+      resolving = resolving + file.getAbsolutePath,
+      properties = properties + ("content" -> code),
+      resources = this.resources ++ resources
+    )
+
+case class LayoutInfo(htmlTemple: TemplateFile, ctx: RenderingContext)
+
+case class PreResolvedPage(
+                            code: String,
+                            nextLayoutInfo: Option[LayoutInfo],
+                            hasMarkdown: Boolean,
+                            resources: List[String] = Nil
+                          ):
+  def render(renderedMarkdown: String): ResolvedPage = nextLayoutInfo match
+    case None => ResolvedPage(renderedMarkdown, hasMarkdown, resources)
+    case Some(nextLayoutInfo) =>
+      val newCtx =
+        nextLayoutInfo.ctx.copy(properties = nextLayoutInfo.ctx.properties + ("content" -> renderedMarkdown))
+      val res = nextLayoutInfo.htmlTemple.resolveToHtml(newCtx, hasMarkdown)
+      ResolvedPage(res.code, hasMarkdown, res.resources)
+
+case class ResolvedPage(
+                         val code: String,
+                         val hasMarkdown: Boolean,
+                         val resources: List[String] = Nil
+                       )
+
+/**
+ * case class for the template files.
+ * Template file is a file `.md` or `.html` handling settings.
+ *
+ * @param file     The Actual file defining the template.
+ * @param rawCode  The content, what is to be shown, everything but settings.
+ * @param settings The config defined in the begging of the file, between the pair of `---` (e.g. layout: basic).
+ */
+case class TemplateFile(
+                         val file: File,
+                         val isHtml: Boolean,
+                         val rawCode: String,
+                         private val settings: Map[String, List[String]]
+                       ):
+
+  private def stringSetting(name: String): Option[String] =
+    settings.get(name) map {
+      case List(single) => single.stripPrefix("\"").stripSuffix("\"")
+      case nonSingle =>
+        throw new RuntimeException(s"Setting $name is a not a singlel-ement list but $nonSingle")
+    }
+
+
+  private def listSetting(name: String): List[String] = settings.getOrElse(name, Nil)
+
+  def name(): String = stringSetting("name").getOrElse(file.getName.stripSuffix(if (isHtml) ".html" else ".md"))
+
+  def title(): String = stringSetting("title").getOrElse(name())
+
+  def layout(): Option[String] = stringSetting("layout")
+
+  def hasFrame(): Boolean = !stringSetting("hasFrame").contains("false")
+
+
+  def resolveMarkdown(ctx: RenderingContext): PreResolvedPage =
+    resolveInner(
+      ctx = ctx.copy(properties = ctx.properties + ("page" -> Map("title" -> title()))),
+      stopAtHtml = true,
+      !isHtml // This is top level template
+    )
+
+  def resolveToHtml(ctx: RenderingContext, hasMarkdown: Boolean): PreResolvedPage =
+    resolveInner(ctx, stopAtHtml = false, hasMarkdown)
+
+  private def resolveInner(ctx: RenderingContext, stopAtHtml: Boolean, hasMarkdown: Boolean): PreResolvedPage =
+    if (ctx.resolving.contains(file.getAbsolutePath))
+      throw new RuntimeException("Cycle in templates involving $file: ${ctx.resolving}")
+
+    val layoutTemplate = layout().map(name =>
+      ctx.layouts.getOrElse(name, throw new RuntimeException(s"No layouts named $name in ${ctx.layouts}")))
+
+    if (!stopAtHtml && !isHtml)
+      throw new java.lang.RuntimeException(
+        "Markdown layout cannot be applied after .html. Rendering $file after: ${ctx.resolving}"
+      )
+
+    if stopAtHtml && isHtml then
+      PreResolvedPage(ctx.properties.getOrElse("content", "").toString, Some(LayoutInfo(this, ctx)), hasMarkdown)
+    else 
+      val rendered = Template.parse(this.rawCode).render(ctx.properties.asJava) // Library requires mutable maps..
+      val code = if (!isHtml) rendered else
+        val parser: Parser = Parser.builder().build()
+        HtmlRenderer.builder(ctx.markdownOptions).build().render(parser.parse(rendered))
+      
+      val resources = listSetting("extraCSS") ++ listSetting("extraJS")
+      layoutTemplate match 
+        case None => PreResolvedPage(code, None, hasMarkdown, resources ++ ctx.resources)
+        case Some(layoutTemplate) =>
+          layoutTemplate.resolveInner(ctx.nest(code, file, resources), stopAtHtml, hasMarkdown)

--- a/scala3doc/src/dotty/dokka/site/templates.scala
+++ b/scala3doc/src/dotty/dokka/site/templates.scala
@@ -75,7 +75,7 @@ case class TemplateFile(
 
   def resolveToHtml(ctx: StaticSiteContext): ResolvedPage = resolveInner(RenderingContext(Map(), ctx.layouts))
 
-  private def resolveInner(ctx: RenderingContext): ResolvedPage =
+  private[site] def resolveInner(ctx: RenderingContext): ResolvedPage =
     if (ctx.resolving.contains(file.getAbsolutePath))
       throw new RuntimeException(s"Cycle in templates involving $file: ${ctx.resolving}")
 

--- a/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
@@ -35,14 +35,14 @@ trait BasicSupport:
   extension (sym: Symbol):
     def documentation(using cxt: Context) = sym.documentation match
       case Some(comment) =>
-          Map(sourceSet.getSourceSet -> parseComment(comment, sym.tree))
+          Map(sourceSet -> parseComment(comment, sym.tree))
       case None =>
           Map.empty
 
     def source(using ctx: Context) =
       val path = Some(sym.pos.sourceFile.jpath).filter(_ != null).map(_.toAbsolutePath).map(_.toString)
       path match{
-        case Some(p) => Map(sourceSet.getSourceSet -> TastyDocumentableSource(p, sym.pos.startLine))
+        case Some(p) => Map(sourceSet -> TastyDocumentableSource(p, sym.pos.startLine))
         case None => Map.empty
       }
 

--- a/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -18,8 +18,8 @@ trait ClassLikeSupport:
   self: TastyParser =>
   import qctx.reflect._
 
-  private val placeholderVisibility = Map(sourceSet.getSourceSet -> KotlinVisibility.Public.INSTANCE).asJava
-  private val placeholderModifier = Map(sourceSet.getSourceSet -> KotlinModifier.Empty.INSTANCE).asJava
+  private val placeholderVisibility = JMap(sourceSet -> KotlinVisibility.Public.INSTANCE)
+  private val placeholderModifier = JMap(sourceSet -> KotlinModifier.Empty.INSTANCE)
 
   private def kindForClasslike(sym: Symbol): Kind =
         if sym.flags.is(Flags.Object) then Kind.Object
@@ -79,9 +79,9 @@ trait ClassLikeSupport:
           dri,
           name,
           (if(signatureOnly) Nil else classDef.getConstructors.map(parseMethod(_))).asJava,
-          Nil.asJava,
-          Nil.asJava,
-          Nil.asJava,
+          JList(),
+          JList(),
+          JList(),
           classDef.symbol.source.asJava,
           placeholderVisibility,
           null,
@@ -250,7 +250,7 @@ trait ClassLikeSupport:
       /*generics =*/ genericTypes.map(parseTypeArgument).asJava,
       /*receiver =*/ null, // Not used
       /*modifier =*/ placeholderModifier,
-      sourceSet.toSet(),
+      sourceSet.toSet,
        /*isExpectActual =*/ false,
       PropertyContainer.Companion.empty()
         plus MethodExtension(paramLists.map(_.size))
@@ -270,7 +270,7 @@ trait ClassLikeSupport:
       argument.symbol.documentation.asJava,
       null,
       argument.tpt.dokkaType,
-      sourceSet.toSet(),
+      sourceSet.toSet,
       PropertyContainer.Companion.empty()
         .plus(ParameterExtension(isExtendedSymbol, isGrouped))
         .plus(MemberExtension.empty.copy(annotations = argument.symbol.getAnnotations()))
@@ -287,8 +287,8 @@ trait ClassLikeSupport:
       Invariance(TypeParameter(argument.symbol.dri, variancePrefix + argument.symbol.name, null)),
       argument.symbol.documentation.asJava,
       null,
-      List(argument.rhs.dokkaType).asJava,
-      sourceSet.toSet(),
+      JList(argument.rhs.dokkaType),
+      sourceSet.toSet,
       PropertyContainer.Companion.empty()
     )
 
@@ -317,7 +317,7 @@ trait ClassLikeSupport:
       /*setter =*/ null,
       /*getter =*/ null,
       /*modifier =*/ placeholderModifier,
-      sourceSet.toSet(),
+      sourceSet.toSet,
       /*generics =*/ generics.asJava, // TODO
        /*isExpectActual =*/ false,
       PropertyContainer.Companion.empty() plus MemberExtension(
@@ -355,8 +355,8 @@ trait ClassLikeSupport:
       /*setter =*/ null,
       /*getter =*/ null,
       /*modifier =*/ placeholderModifier,
-      sourceSet.toSet(),
-      /*generics =*/ Nil.asJava,
+      sourceSet.toSet,
+      /*generics =*/ JList(),
        /*isExpectActual =*/ false,
       PropertyContainer.Companion.empty().plus(MemberExtension(
           valDef.symbol.getVisibility(),

--- a/scala3doc/src/dotty/dokka/tasty/PackageSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/PackageSupport.scala
@@ -1,4 +1,5 @@
-package dotty.dokka.tasty
+package dotty.dokka
+package tasty
 
 import org.jetbrains.dokka.model._
 import org.jetbrains.dokka.links._
@@ -18,10 +19,10 @@ trait PackageSupport:
         val documentation = pck.symbol.documentation
         DPackage(
           new DRI(name, null, null, PointingToDeclaration.INSTANCE, null),
-          Nil.asJava,
-          Nil.asJava,
-          Nil.asJava,
-          Nil.asJava,
+          JList(),
+          JList(),
+          JList(),
+          JList(),
           documentation.asJava,
           null,
           sourceSet.toSet,
@@ -36,8 +37,8 @@ trait PackageSupport:
               new DRI(pckObj.symbol.dri.getPackageName, null, null, PointingToDeclaration.INSTANCE, null),
               clazz.getFunctions,
               clazz.getProperties,
-              Nil.asJava,
-              Nil.asJava,
+              JList(),
+              JList(),
               pckObj.symbol.documentation.asJava,
               null,
               sourceSet.toSet,

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -113,7 +113,7 @@ class SymOps[R <: Reflection](val r: R):
         new DRI(
           sym.packageName,
           sym.topLevelEntryName.orNull, // TODO do we need any of this fields?
-          method.map(s => new org.jetbrains.dokka.links.Callable(s.name, null, Nil.asJava)).orNull,
+          method.map(s => new org.jetbrains.dokka.links.Callable(s.name, null, JList())).orNull,
           pointsTo, // TODO different targets?
           s"${sym.show}/${sym.signature.resultSig}/[${sym.signature.paramSigs.mkString("/")}]"
         )

--- a/scala3doc/src/dotty/dokka/tasty/TastyParser.scala
+++ b/scala3doc/src/dotty/dokka/tasty/TastyParser.scala
@@ -135,7 +135,7 @@ trait DokkaBaseTastyInspector:
     }.toList
 
   extension (self: DPackage) def mergeWith(other: DPackage): DPackage =
-    def nodes(p: DPackage): JList[TagWrapper] = p.getDocumentation.get(sourceSet) match 
+    def nodes(p: DPackage): JList[TagWrapper] = p.getDocumentation.get(sourceSet) match
       case null => JList[TagWrapper]()
       case node => node.getChildren
 

--- a/scala3doc/src/dotty/dokka/tasty/comments/MarkdownConverter.scala
+++ b/scala3doc/src/dotty/dokka/tasty/comments/MarkdownConverter.scala
@@ -1,4 +1,5 @@
-package dotty.dokka.tasty.comments
+package dotty.dokka
+package tasty.comments
 
 import scala.jdk.CollectionConverters._
 import scala.tasty.Reflection
@@ -40,7 +41,8 @@ class MarkdownConverter(val repr: Repr) extends BaseConverter {
       emit(dkkd.P(convertChildren(n).asJava, kt.emptyMap))
 
     case n: mda.Heading => emit(n.getLevel match {
-        case 1 => dkkd.H1(List(dkk.text(n.getText().toString)).asJava, kt.emptyMap)
+        case 1 => dkkd.H1(List(dkk.text(n.getText().toString)).asJava, JMap())
+        // case -1 => dkkd.H1(List(dkk.text(n.getText().toString)).asJava, JMap()) // This does not compile but should!
         case 2 => dkkd.H2(List(dkk.text(n.getText().toString)).asJava, kt.emptyMap)
         case 3 => dkkd.H3(List(dkk.text(n.getText().toString)).asJava, kt.emptyMap)
         case 4 => dkkd.H4(List(dkk.text(n.getText().toString)).asJava, kt.emptyMap)

--- a/scala3doc/src/dotty/dokka/tasty/comments/package.scala
+++ b/scala3doc/src/dotty/dokka/tasty/comments/package.scala
@@ -1,4 +1,5 @@
-package dotty.dokka.tasty.comments
+package dotty.dokka
+package tasty.comments
 
 import scala.jdk.CollectionConverters._
 
@@ -17,7 +18,7 @@ object dkk:
   def p(params: (String, String)*)(children: dkkd.DocTag*) =
     dkkd.P(children.asJava, params.toMap.asJava)
 
-  def text(str: String) = dkkd.Text(str, Nil.asJava, Map.empty.asJava)
+  def text(str: String) = dkkd.Text(str, JList(), Map.empty.asJava)
 
   def a(children: dkkd.DocTag*) =
     dkkd.A(children.asJava, Map.empty.asJava)

--- a/scala3doc/src/dotty/dokka/transformers/ScalaSourceLinksTransformer.scala
+++ b/scala3doc/src/dotty/dokka/transformers/ScalaSourceLinksTransformer.scala
@@ -24,10 +24,10 @@ class ScalaSourceLinksTransformer(
   val sourceLinks = ctx.getConfiguration.getSourceSets.asScala.flatMap(s => s.getSourceLinks.asScala.map(l => SourceLink(l, s)))
   val pageBuilder = ScalaPageContentBuilder(commentsToContentConverter, signatureProvider, logger)
 
-  case class SourceLink(val path: String, val url: String, val lineSuffix: Option[String], val sourceSetData: DokkaConfiguration.DokkaSourceSet)
+  case class SourceLink(val path: String, val url: String, val lineSuffix: Option[String], val sourceSetData: DokkaSourceSet)
 
   object SourceLink {
-    def apply(sourceLinkDef: DokkaConfiguration$SourceLinkDefinition, sourceSetData: DokkaConfiguration.DokkaSourceSet): SourceLink =
+    def apply(sourceLinkDef: DokkaConfiguration$SourceLinkDefinition, sourceSetData: DokkaSourceSet): SourceLink =
       SourceLink(sourceLinkDef.getLocalDirectory, sourceLinkDef.getRemoteUrl.toString, Option(sourceLinkDef.getRemoteLineSuffix), sourceSetData)
   }
 

--- a/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
@@ -370,7 +370,7 @@ class ScalaPageContentBuilder(
         address,
         DCI(mainDRI.asJava, kind),
         sourceSets.toDisplay,
-        Set().asJava,
+        JSet(),
         PropertyContainer.Companion.empty()
       )
     )
@@ -388,7 +388,7 @@ class ScalaPageContentBuilder(
         address,
         DCI(mainDRI.asJava, kind),
         sourceSets.toDisplay,
-        Set().asJava,
+        JSet(),
         PropertyContainer.Companion.empty()
       )
     )
@@ -407,7 +407,7 @@ class ScalaPageContentBuilder(
         address,
         DCI(mainDRI.asJava, kind),
         sourceSets.toDisplay,
-        Set().asJava,
+        JSet(),
         PropertyContainer.Companion.empty()
       )
     )
@@ -434,7 +434,7 @@ class ScalaPageContentBuilder(
           docTag,
           DCI(mainDRI.asJava, kind),
           sourceSets.asJava,
-          Set().asJava,
+          JSet(),
           PropertyContainer.Companion.empty()
         ).asScala.toSeq
 

--- a/scala3doc/src/dotty/dokka/utils.scala
+++ b/scala3doc/src/dotty/dokka/utils.scala
@@ -13,23 +13,9 @@ import org.jetbrains.dokka.base.translators.documentables._
 import org.jetbrains.dokka.model.properties.PropertyContainer
 import java.util.function.Consumer
 import kotlin.jvm.functions.Function2
-import java.util.{List => JList, Set => JSet, Map => JMap}
 import org.jetbrains.dokka.DokkaConfiguration$DokkaSourceSet
 import org.jetbrains.dokka.plugability._
 import kotlin.jvm.JvmClassMappingKt.getKotlinClass
-
-extension [V] (a: WithExtraProperties[_]):
-  def get(key: ExtraProperty.Key[_, V]): V = a.getExtra().getMap().get(key).asInstanceOf[V]
-
-extension [E <: WithExtraProperties[E]] (a: E):
-  def put(value: ExtraProperty[_ >: E]): E = // TODO remove some of the InstanceOf
-  a.withNewExtras(a.getExtra plus value).asInstanceOf[E]
-
-extension [V] (map: JMap[DokkaConfiguration$DokkaSourceSet, V]):
-  def defaultValue: V = map.values.asScala.toSeq(0)
-
-extension (sourceSets: Set[DokkaConfiguration$DokkaSourceSet]):
-  def toDisplay = sourceSets.map(DisplaySourceSet(_)).asJava
 
 class BaseKey[T, V] extends ExtraProperty.Key[T, V]:
   override def mergeStrategyFor(left: V, right: V): MergeStrategy[T] =
@@ -50,14 +36,6 @@ def getFromExtra[V](e: WithExtraProperties[_], k: ExtraProperty.Key[_, V]): Opti
 
 extension (f: DFunction):
   def isRightAssociative(): Boolean = f.getName.endsWith(":")
-
-object JList:
-  def apply[T](elem: T): JList[T] = List(elem).asJava
-  def apply[T]() = List[T]().asJava
-
-object JSet:
-  def apply[T](elem: T): JSet[T] = Set(elem).asJava
-  def apply[T]() = Set[T]().asJava
 
 def modifyContentGroup(originalContentNodeWithParents: Seq[ContentGroup], modifiedContentNode: ContentGroup): ContentGroup =
   originalContentNodeWithParents match {

--- a/scala3doc/src/dotty/renderers/ScalaHtmlRenderer.scala
+++ b/scala3doc/src/dotty/renderers/ScalaHtmlRenderer.scala
@@ -50,14 +50,14 @@ class ScalaHtmlRenderer(ctx: DokkaContext) extends HtmlRenderer(ctx) {
       })
     case _ =>
       val div = new DIV(JMap(), context.getConsumer())
-      try 
+      try
         div.getConsumer().onTagStart(div)
         withHtml(div, content)
       catch
         case e: Throwable =>
           div.getConsumer.onTagError(div, e)
       finally
-        div.getConsumer.onTagEnd(div)    
+        div.getConsumer.onTagEnd(div)
   }
 
   lazy val sourceSets = ctx.getConfiguration.getSourceSets.asScala
@@ -189,7 +189,7 @@ class ScalaHtmlRenderer(ctx: DokkaContext) extends HtmlRenderer(ctx) {
   ): Unit = {
     import kotlinx.html.{Gen_consumer_tagsKt => dsl}
     val c = f.getConsumer
-    
+
     dsl.a(c, node.getAddress, /*target*/ null, /*classes*/ null, { e =>
       import ScalaCommentToContentConverter._
       // node.getExtra.getMap.asScala.get(LinkAttributesKey)
@@ -233,7 +233,7 @@ class ScalaHtmlRenderer(ctx: DokkaContext) extends HtmlRenderer(ctx) {
       ).toString()
     )
 
-  override def buildPageContent(context: FlowContent, page: ContentPage): Unit = 
+  override def buildPageContent(context: FlowContent, page: ContentPage): Unit =
     page match
       case s: StaticPageNode if !s.hasFrame() =>
       case _ => buildNavigation(context, page)
@@ -243,7 +243,7 @@ class ScalaHtmlRenderer(ctx: DokkaContext) extends HtmlRenderer(ctx) {
         withHtml(context, prc.resolved.code)
       case content =>
         build(content, context, page, /*sourceSetRestriction=*/null)
-  
+
 
   override def buildHtml(page: PageNode, resources: JList[String], kotlinxContent: FlowContentConsumer): String =
     val (pageTitle, noFrame) = page match

--- a/scala3doc/test/dotty/dokka/DottyTestRunner.scala
+++ b/scala3doc/test/dotty/dokka/DottyTestRunner.scala
@@ -66,7 +66,7 @@ abstract class DottyAbstractCoreTest extends AbstractCoreTest:
       config,
       new TestLogger(DokkaConsoleLogger.INSTANCE),
       tests.build(),
-      Nil.asJava
+      JList()
     ).generate()
 
     signatures

--- a/scala3doc/test/dotty/dokka/site/TemplateFileTests.scala
+++ b/scala3doc/test/dotty/dokka/site/TemplateFileTests.scala
@@ -1,0 +1,218 @@
+package dotty.dokka.site
+
+import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.parser.Parser
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.file.Files
+
+class TemplateFileTests:
+  private def testTemplate(code: String, ext: String = "html")(op: TemplateFile => Unit): Unit =
+    val tmpFile = Files.createTempFile("headerTests", s".${ext}").toFile()
+    try 
+      Files.writeString(tmpFile.toPath, code)
+      op(loadTemplateFile(tmpFile))
+    finally tmpFile.delete()
+    
+
+  private def testTemplates(
+                             props: Map[String, String],
+                             template: List[(String, String)])(
+                             op: RenderingContext => Unit
+                           ) =
+    def rec(cxt: RenderingContext, remaining: List[(String, String)]): Unit =
+      if (remaining.isEmpty) op(cxt)
+      else
+        val (code, ext) = remaining.head
+        testTemplate(code, ext) { template =>
+          val newCtx = cxt.copy(layouts = cxt.layouts + (template.name() -> template))
+          rec(newCtx, remaining.drop(1))
+        }
+  
+    rec(RenderingContext(props), template)
+
+  private def fullRender(template: TemplateFile, ctx: RenderingContext): String = template.resolveInner(ctx).code.trim()
+
+  @Test
+  def testParsingHeaders(): Unit =
+    testTemplate(
+      """---
+        |title: myTitle
+        |---
+        |code""".stripMargin
+    ) { t =>
+      assertEquals(t.rawCode, "code")
+      assertEquals(t.title(), "myTitle")
+    }
+  
+
+  @Test
+  def testLinks(): Unit =
+    val base =
+      """---
+        |title: myTitle
+        |name: base
+        |---
+        |Ala {{ content }}. {{p2}} with [link](link/target.md)!
+        |""".stripMargin
+
+    val content =
+      """---
+        |layout: base
+        |name: content
+        |---
+        |ma kota w **{{ p1 }}** from [here](link/here.md)
+        |""".stripMargin
+
+
+    val expected = """<p>Ala ma kota w <strong>paski</strong> from <a href="link/here.md">here</a>. Hej with <a href="link/target.md">link</a>!</p>"""
+
+    testTemplates(
+      Map("p1" -> "paski", "p2" -> "Hej"),
+      List(base -> "html", content -> "md")
+    ) { it =>
+      assertEquals(
+        expected,
+        fullRender(it.layouts("content"), it)
+      )
+    }
+
+  @Test
+  def layout(): Unit =
+    val base =
+      """---
+        |title: myTitle
+        |name: base
+        |---
+        |Ala {{ content }}. {{p2}}!
+        |""".stripMargin
+
+    val content =
+      """---
+        |layout: base
+        |name: content
+        |---
+        |ma kota w **{{ p1 }}**
+        |""".stripMargin
+
+
+    val expected = """<p>Ala ma kota w <strong>paski</strong>. Hej!</p>""".stripMargin
+
+    testTemplates(
+      Map("p1" -> "paski", "p2" -> "Hej"),
+      List(base -> "html", content -> "md")
+    ) { it =>
+      assertEquals(
+        expected,
+        fullRender(it.layouts("content"), it)
+      )
+    }
+
+  @Test
+  def nestedLayout_htmlMdHtml(): Unit =
+    val toplevel =
+      """---
+        |name: toplevel
+        |---
+        |[div id="root"]{{ content }}[/div]
+        |""".stripMargin
+
+    val basePage =
+      """---
+        |layout: toplevel
+        |name: basePage
+        |---
+        |# {{ pageName }}
+        |
+        |{{content}}
+        |
+        |## {{ pageName }} end
+        |""".stripMargin
+
+    val content =
+      """---
+        |layout: basePage
+        |name: content
+        |---
+        |Hello {{ name }}!
+        |""".stripMargin
+
+
+    val expected =
+      """[div id="root"][h1]Test page[/h1]
+        |[p]Hello world!![/p]
+        |[h2]Test page end[/h2]
+        |[/div]""".stripMargin
+
+    testTemplates(
+      Map("pageName" -> "Test page", "name" -> "world!"),
+      List(
+        toplevel -> "html",
+        basePage -> "md",
+        content -> "md"
+      )
+    ) (it => fullRender(it.layouts("content"), it))
+
+  @Test
+  def nestedLayout_mdHtmlMd(): Unit =
+    val toplevel =
+      """---
+        |name: toplevel
+        |---
+        |<h1>The Page</h1>
+        |{{ content }}
+        |""".stripMargin
+
+    val basePage =
+      """---
+        |layout: toplevel
+        |name: basePage
+        |---
+        |<h2>{{ pageName }}</h2>
+        |
+        |{{content}}
+        |
+        |<h3>{{ pageName }} end</h3>
+        |""".stripMargin
+
+    val content =
+      """---
+        |layout: basePage
+        |name: content
+        |---
+        |Hello {{ name }}!
+        |""".stripMargin
+
+
+    val expected =
+      """<h1>The Page</h1>
+        |<h2>Test page</h2>
+        |<p>Hello world!!</p>
+        |<h3>Test page end</h3>""".stripMargin
+
+    testTemplates(
+      Map("pageName" -> "Test page", "name" -> "world!"),
+      List(
+        toplevel -> "html",
+        basePage -> "html",
+        content -> "md"
+      )
+    ) { ctx => assertEquals(expected, fullRender(ctx.layouts("content"), ctx)) }
+
+  @Test
+  def markdown(): Unit =
+    testTemplate(
+      """# Hello {{ msg }}!""",
+      ext = "md"
+    ) { t =>
+      assertEquals("# Hello there!", t.resolveInner(RenderingContext(Map("msg" -> "there"))).code.trim())
+    }
+
+  @Test
+  def mixedTemplates() : Unit =
+    testTemplate(
+      """# Hello {{ msg }}!""",
+      ext = "md"
+    ) { t =>
+      assertEquals("# Hello there!", t.resolveInner(RenderingContext(Map("msg" -> "there"))).code.trim())
+    }

--- a/scala3doc/test/dotty/dokka/site/TemplateFileTests.scala
+++ b/scala3doc/test/dotty/dokka/site/TemplateFileTests.scala
@@ -9,11 +9,11 @@ import java.nio.file.Files
 class TemplateFileTests:
   private def testTemplate(code: String, ext: String = "html")(op: TemplateFile => Unit): Unit =
     val tmpFile = Files.createTempFile("headerTests", s".${ext}").toFile()
-    try 
+    try
       Files.writeString(tmpFile.toPath, code)
       op(loadTemplateFile(tmpFile))
     finally tmpFile.delete()
-    
+
 
   private def testTemplates(
                              props: Map[String, String],
@@ -28,7 +28,7 @@ class TemplateFileTests:
           val newCtx = cxt.copy(layouts = cxt.layouts + (template.name() -> template))
           rec(newCtx, remaining.drop(1))
         }
-  
+
     rec(RenderingContext(props), template)
 
   private def fullRender(template: TemplateFile, ctx: RenderingContext): String = template.resolveInner(ctx).code.trim()
@@ -44,7 +44,7 @@ class TemplateFileTests:
       assertEquals(t.rawCode, "code")
       assertEquals(t.title(), "myTitle")
     }
-  
+
 
   @Test
   def testLinks(): Unit =

--- a/scala3doc/test/dotty/dokka/site/TemplateFileTests.scala
+++ b/scala3doc/test/dotty/dokka/site/TemplateFileTests.scala
@@ -10,7 +10,7 @@ class TemplateFileTests:
   private def testTemplate(code: String, ext: String = "html")(op: TemplateFile => Unit): Unit =
     val tmpFile = Files.createTempFile("headerTests", s".${ext}").toFile()
     try
-      Files.writeString(tmpFile.toPath, code)
+      Files.write(tmpFile.toPath, code.getBytes)
       op(loadTemplateFile(tmpFile))
     finally tmpFile.delete()
 


### PR DESCRIPTION
Rewrite [dokka-site](https://github.com/Virtuslab/dokka-site) to Scala (from Kotlin) and pull it into scala3doc codebase.

This remove one external dependency (and its resolver) and will allow us to progress more quickly with static site part of generated documentation.

There is still problem with parsing of index page but this seems to be caused by `flexmark.HtmlRenderer` (or the we way how we are using it)