### PR TITLE
Move let to ValDef and fix signature

### DIFF
--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -7,6 +7,7 @@ object scalatest {
   def assertImpl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
     import util._
+    import ValDef.let
 
     cond.unseal.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>

--- a/tests/pos-macros/i8866/Macro_1.scala
+++ b/tests/pos-macros/i8866/Macro_1.scala
@@ -14,7 +14,7 @@ object Macro {
   def impl(using qctx: QuoteContext): Expr[Int] = {
     import qctx.reflect._
 
-    let(
+    ValDef.let(
       Select.unique(
         '{ OtherMacro }.unseal,
         "apply"

--- a/tests/pos-macros/i8866b/Macro_1.scala
+++ b/tests/pos-macros/i8866b/Macro_1.scala
@@ -9,7 +9,7 @@ object Macro {
   def impl(using qctx: QuoteContext): Expr[Int] = {
     import qctx.reflect._
 
-    let(
+    ValDef.let(
       Select.unique(
         '{ Other }.unseal,
         "apply"

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     cond.unseal.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
-            let(app) { result =>
+            ValDef.let(app) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.seal.cast[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
         if isImplicitMethodType(f.tpe) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
-            let(Apply(app, implicits)) { result =>
+            ValDef.let(Apply(app, implicits)) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     cond.unseal.underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = left.select(sel.symbol).appliedTo(right)
-            let(app) { result =>
+            ValDef.let(app) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.seal.cast[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = qual.appliedTo(left).select(sel.symbol).appliedTo(right)
-            let(Apply(app, implicits)) { result =>
+            ValDef.let(Apply(app, implicits)) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -10,8 +10,8 @@ object scalatest {
 
     cond.unseal.underlyingArgument match {
       case t @ Apply(TypeApply(Select(lhs, op), targs), rhs) =>
-        let(lhs) { left =>
-          lets(rhs) { rs =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { rs =>
             val app = Select.overloaded(left, op, targs.map(_.tpe), rs)
             val b = app.seal.cast[Boolean]
             '{ scala.Predef.assert($b) }.unseal

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     cond.unseal.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
-            let(app) { result =>
+            ValDef.let(app) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.seal.cast[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
-            let(Apply(app, implicits)) { result =>
+            ValDef.let(Apply(app, implicits)) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]

--- a/tests/run-macros/reflect-select-copy-2/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy-2/assert_1.scala
@@ -14,9 +14,9 @@ object scalatest {
 
     cond.unseal.underlyingArgument match {
       case Apply(sel @ Select(lhs, op), rhs :: Nil) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
-            let(Apply(Select.copy(sel)(left, op), right :: Nil)) { result =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
+            ValDef.let(Apply(Select.copy(sel)(left, op), right :: Nil)) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]
@@ -27,9 +27,9 @@ object scalatest {
         }.seal.cast[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
-            let(Apply(Apply(Select.copy(sel)(Apply(qual, left :: Nil), op), right :: Nil), implicits)) { result =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
+            ValDef.let(Apply(Apply(Select.copy(sel)(Apply(qual, left :: Nil), op), right :: Nil), implicits)) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     cond.unseal.underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = Apply(Select(left, sel.symbol), right :: Nil)
-            let(app) { result =>
+            ValDef.let(app) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.seal.cast[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = Apply(Select(Apply(qual, left :: Nil), sel.symbol), right :: Nil)
-            let(Apply(app, implicits)) { result =>
+            ValDef.let(Apply(app, implicits)) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     cond.unseal.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
-            let(app) { result =>
+            ValDef.let(app) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.seal.cast[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        ValDef.let(lhs) { left =>
+          ValDef.let(rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
-            let(Apply(app, implicits)) { result =>
+            ValDef.let(Apply(app, implicits)) { result =>
               val l = left.seal
               val r = right.seal
               val b = result.seal.cast[Boolean]

--- a/tests/run-macros/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-macros/tasty-unsafe-let/quoted_1.scala
@@ -10,8 +10,8 @@ object Macros {
 
     val rhsTerm = rhs.unseal
 
-    import qctx.reflect.{let => letTerm}
-    letTerm(rhsTerm) { rhsId =>
+    import qctx.reflect._
+    ValDef.let(rhsTerm) { rhsId =>
       Expr.betaReduce('{$body(${rhsId.seal.asInstanceOf[Expr[T]]})}).unseal // Dangerous uncheked cast!
     }.seal.cast[Unit]
   }

--- a/tests/run-staging/staged-streams_1.scala
+++ b/tests/run-staging/staged-streams_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.util._
 import language.experimental.namedTypeArguments
 
 /**


### PR DESCRIPTION
Rather than remove it as originally planed, we keep it under ValDef as it creates a block with vals.
Both signatures take an return an Ident now.