### PR TITLE
Fix infinite loop bug in scaladoc after dotty version bump

### DIFF
--- a/scala3doc-testcases/src/tests/inheritanceLoop.scala
+++ b/scala3doc-testcases/src/tests/inheritanceLoop.scala
@@ -1,0 +1,18 @@
+package tests
+package inheritanceLoop
+
+class A
+{
+  type I = Int
+  object X
+  class B extends C
+  {
+    class D extends C
+    {
+      class E extends C
+    }
+  }
+}
+
+
+class C extends A

--- a/scala3doc-testcases/src/tests/inheritedMembers1.scala
+++ b/scala3doc-testcases/src/tests/inheritedMembers1.scala
@@ -1,0 +1,17 @@
+package tests
+package inheritedMembers1
+
+
+class A
+{
+    def A: String
+      = ???
+    val B: Int
+      = ???
+    object X
+    trait Z
+    given B
+    type I = Int
+    /*<-*/extension (a: A) /*->*/def extension: String
+      = ???
+}

--- a/scala3doc-testcases/src/tests/inheritedMembers2.scala
+++ b/scala3doc-testcases/src/tests/inheritedMembers2.scala
@@ -1,0 +1,7 @@
+package tests
+package inheritedMembers2
+
+import tests.inheritedMembers1.A
+
+class F extends A
+

--- a/scala3doc/test/dotty/dokka/SignatureTests.scala
+++ b/scala3doc/test/dotty/dokka/SignatureTests.scala
@@ -50,3 +50,8 @@ class OpaqueTypes extends SingleFileTest("opaqueTypes", SingleFileTest.all)
 // class GivenSignatures extends SingleFileTest("givenSignatures", SingleFileTest.all)
 
 class Annotations extends SingleFileTest("annotations", SingleFileTest.all)
+
+class InheritanceLoop extends SingleFileTest("inheritanceLoop", SingleFileTest.all)
+
+class InheritedMembers extends MultipleFileTest(List("inheritedMembers1", "inheritedMembers2"), List("inheritedMembers2"), MultipleFileTest.all.filter(_ != "class"))
+


### PR DESCRIPTION
closes #10166 

After bump of dotty version there was a problem with infinite loop in member extraction, specifically with extraction of members looking like this:
```Scala
class C extends A
class A:
  class D extends C
```
In new version our code which was used to retrieve inherited methods and fields, returns also classlikes and it led to infinite loop.
This PR fixes this bug by parsing inherited classlikes for signature only (without delving into its members)