### PR TITLE
Keep export clause until first transform, use for incremental compilation

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -361,6 +361,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def Import(expr: Tree, selectors: List[untpd.ImportSelector])(using Context): Import =
     ta.assignType(untpd.Import(expr, selectors), newImportSymbol(ctx.owner, expr))
 
+  def Export(expr: Tree, selectors: List[untpd.ImportSelector])(using Context): Export =
+    ta.assignType(untpd.Export(expr, selectors))
+
   def PackageDef(pid: RefTree, stats: List[Tree])(using Context): PackageDef =
     ta.assignType(untpd.PackageDef(pid, stats), pid)
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4815,11 +4815,6 @@ object Types {
   /** The type of an import clause tree */
   case class ImportType(expr: Tree) extends UncachedGroundType
 
-  /** Sentinal for typed export clauses */
-  @sharable case object ExportType extends CachedGroundType {
-    override def computeHash(bs: Binders): Int = hashSeed
-  }
-
   /** Sentinel for "missing type" */
   @sharable case object NoType extends CachedGroundType {
     override def computeHash(bs: Binders): Int = hashSeed

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4815,6 +4815,11 @@ object Types {
   /** The type of an import clause tree */
   case class ImportType(expr: Tree) extends UncachedGroundType
 
+  /** Sentinal for typed export clauses */
+  @sharable case object ExportType extends CachedGroundType {
+    override def computeHash(bs: Binders): Int = hashSeed
+  }
+
   /** Sentinel for "missing type" */
   @sharable case object NoType extends CachedGroundType {
     override def computeHash(bs: Binders): Int = hashSeed

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -593,6 +593,12 @@ class TreePickler(pickler: TastyPickler) {
             pickleTree(expr)
             pickleSelectors(selectors)
           }
+        case Export(expr, selectors) =>
+          writeByte(EXPORT)
+          withLength {
+            pickleTree(expr)
+            pickleSelectors(selectors)
+          }
         case PackageDef(pid, stats) =>
           writeByte(PACKAGE)
           withLength { pickleType(pid.tpe); pickleStats(stats) }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3747,7 +3747,7 @@ object Parsers {
         else if (in.token == IMPORT)
           stats ++= importClause(IMPORT, mkImport(outermost))
         else if (in.token == EXPORT)
-          stats ++= importClause(EXPORT, Export.apply)
+          stats ++= importClause(EXPORT, Export(_,_))
         else if isIdent(nme.extension) && followingIsExtension() then
           stats += extension()
         else if isDefIntro(modifierTokens) then
@@ -3801,7 +3801,7 @@ object Parsers {
         if (in.token == IMPORT)
           stats ++= importClause(IMPORT, mkImport())
         else if (in.token == EXPORT)
-          stats ++= importClause(EXPORT, Export.apply)
+          stats ++= importClause(EXPORT, Export(_,_))
         else if isIdent(nme.extension) && followingIsExtension() then
           stats += extension()
         else if (isDefIntro(modifierTokensOrCase))

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -152,7 +152,7 @@ class FirstTransform extends MiniPhase with InfoTransformer { thisPhase =>
   }
 
   override def transformOther(tree: Tree)(using Context): Tree = tree match {
-    case tree: Import => EmptyTree
+    case tree: ImportOrExport[_] => EmptyTree
     case tree: NamedArg => transformAllDeep(tree.arg)
     case tree => if (tree.isType) toTypeTree(tree) else tree
   }

--- a/compiler/src/dotty/tools/dotc/transform/TreeMapWithStages.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeMapWithStages.scala
@@ -140,7 +140,7 @@ abstract class TreeMapWithStages(@constructorOnly ictx: Context) extends TreeMap
           tpd.patVars(pat).foreach(markSymbol)
           mapOverTree(last)
 
-        case _: Import =>
+        case (_:Import | _:Export) =>
           tree
 
         case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -945,7 +945,7 @@ class Namer { typer: Typer =>
         val buf = new mutable.ListBuffer[tpd.MemberDef]
         val Export(expr, selectors) = exp
         val path = typedAheadExpr(expr, AnySelectionProto)
-        checkLegalImportPath(path)
+        checkLegalExportPath(path, selectors)
         lazy val wildcardBound = importBound(selectors, isGiven = false)
         lazy val givenBound = importBound(selectors, isGiven = true)
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -511,6 +511,9 @@ trait TypeAssigner {
   def assignType(tree: untpd.Import, sym: Symbol)(using Context): Import =
     tree.withType(sym.termRef)
 
+  def assignType(tree: untpd.Export)(using Context): Export =
+    tree.withType(ExportType)
+
   def assignType(tree: untpd.Annotated, arg: Tree, annot: Tree)(using Context): Annotated = {
     assert(tree.isType) // annotating a term is done via a Typed node, can't use Annotate directly
     tree.withType(AnnotatedType(arg.tpe, Annotation(annot)))

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -512,7 +512,7 @@ trait TypeAssigner {
     tree.withType(sym.termRef)
 
   def assignType(tree: untpd.Export)(using Context): Export =
-    tree.withType(ExportType)
+    tree.withType(defn.UnitType)
 
   def assignType(tree: untpd.Annotated, arg: Tree, annot: Tree)(using Context): Annotated = {
     assert(tree.isType) // annotating a term is done via a Typed node, can't use Annotate directly

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -157,20 +157,40 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ImportTypeTestImpl
 
     object Import extends ImportModule:
-      def apply(expr: Term, selectors: List[ImportSelector]): Import =
+      def apply(expr: Term, selectors: List[Selector]): Import =
         withDefaultPos(tpd.Import(expr, selectors))
-      def copy(original: Tree)(expr: Term, selectors: List[ImportSelector]): Import =
+      def copy(original: Tree)(expr: Term, selectors: List[Selector]): Import =
         tpd.cpy.Import(original)(expr, selectors)
-      def unapply(tree: Import): Option[(Term, List[ImportSelector])] =
+      def unapply(tree: Import): Option[(Term, List[Selector])] =
         Some((tree.expr, tree.selectors))
     end Import
 
     object ImportMethodsImpl extends ImportMethods:
       extension (self: Import):
         def expr: Term = self.expr
-        def selectors: List[ImportSelector] = self.selectors
+        def selectors: List[Selector] = self.selectors
       end extension
     end ImportMethodsImpl
+
+    type Export = tpd.Export
+
+    object ExportTypeTest extends TypeTest[Tree, Export]:
+      def unapply(x: Tree): Option[Export & x.type] = x match
+        case tree: (tpd.Export & x.type) => Some(tree)
+        case _ => None
+    end ExportTypeTest
+
+    object Export extends ExportModule:
+      def unapply(tree: Export): Option[(Term, List[Selector])] =
+        Some((tree.expr, tree.selectors))
+    end Export
+
+    object ExportMethodsImpl extends ExportMethods:
+      extension (self: Export):
+        def expr: Term = self.expr
+        def selectors: List[Selector] = self.selectors
+      end extension
+    end ExportMethodsImpl
 
     type Statement = tpd.Tree
 
@@ -1468,14 +1488,14 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       end extension
     end AlternativesMethodsImpl
 
-    type ImportSelector = untpd.ImportSelector
+    type Selector = untpd.ImportSelector
 
-    object ImportSelector extends ImportSelectorModule
+    object Selector extends SelectorModule
 
     type SimpleSelector = untpd.ImportSelector
 
-    object SimpleSelectorTypeTestImpl extends TypeTest[ImportSelector, SimpleSelector]:
-      def unapply(x: ImportSelector): Option[SimpleSelector & x.type] = x match
+    object SimpleSelectorTypeTestImpl extends TypeTest[Selector, SimpleSelector]:
+      def unapply(x: Selector): Option[SimpleSelector & x.type] = x match
         case x: (untpd.ImportSelector & x.type) if x.renamed.isEmpty && !x.isGiven => Some(x)
         case _ => None // TODO: handle import bounds
     end SimpleSelectorTypeTestImpl
@@ -1483,7 +1503,6 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     object SimpleSelector extends SimpleSelectorModule:
       def unapply(x: SimpleSelector): Option[String] = Some(x.name.toString)
     end SimpleSelector
-
 
     object SimpleSelectorMethodsImpl extends SimpleSelectorMethods:
       extension (self: SimpleSelector):
@@ -1494,8 +1513,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     type RenameSelector = untpd.ImportSelector
 
-    object RenameSelectorTypeTestImpl extends TypeTest[ImportSelector, RenameSelector]:
-      def unapply(x: ImportSelector): Option[RenameSelector & x.type] = x match
+    object RenameSelectorTypeTestImpl extends TypeTest[Selector, RenameSelector]:
+      def unapply(x: Selector): Option[RenameSelector & x.type] = x match
         case x: (untpd.ImportSelector & x.type) if !x.renamed.isEmpty => Some(x)
         case _ => None
     end RenameSelectorTypeTestImpl
@@ -1515,8 +1534,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     type OmitSelector = untpd.ImportSelector
 
-    object OmitSelectorTypeTestImpl extends TypeTest[ImportSelector, OmitSelector]:
-      def unapply(x: ImportSelector): Option[OmitSelector & x.type] = x match {
+    object OmitSelectorTypeTestImpl extends TypeTest[Selector, OmitSelector]:
+      def unapply(x: Selector): Option[OmitSelector & x.type] = x match {
         case self: (untpd.ImportSelector & x.type) =>
           self.renamed match
             case dotc.ast.Trees.Ident(nme.WILDCARD) => Some(self)
@@ -1538,8 +1557,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     type GivenSelector = untpd.ImportSelector
 
-    object GivenSelectorTypeTestImpl extends TypeTest[ImportSelector, GivenSelector]:
-      def unapply(x: ImportSelector): Option[GivenSelector & x.type] = x match {
+    object GivenSelectorTypeTestImpl extends TypeTest[Selector, GivenSelector]:
+      def unapply(x: Selector): Option[GivenSelector & x.type] = x match {
         case self: (untpd.ImportSelector & x.type) if x.isGiven => Some(self)
         case _ => None
       }

--- a/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
@@ -129,6 +129,8 @@ object Extractors {
         this += ", " += self += ", " ++= body += ")"
       case Import(expr, selectors) =>
         this += "Import(" += expr += ", " ++= selectors += ")"
+      case Export(expr, selectors) =>
+        this += "Export(" += expr += ", " ++= selectors += ")"
       case PackageClause(pid, stats) =>
         this += "PackageClause(" += pid += ", " ++= stats += ")"
       case Inferred() =>
@@ -239,7 +241,7 @@ object Extractors {
       this += "Signature(" ++= params.map(_.toString) += ", " += res += ")"
     }
 
-    def visitImportSelector(sel: ImportSelector): this.type = sel match {
+    def visitSelector(sel: Selector): this.type = sel match {
       case SimpleSelector(id) => this += "SimpleSelector(" += id += ")"
       case RenameSelector(id1, id2) => this += "RenameSelector(" += id1 += ", " += id2 += ")"
       case OmitSelector(id) => this += "OmitSelector(" += id += ")"
@@ -291,8 +293,8 @@ object Extractors {
       def +=(x: Option[Signature]): self.type = { visitOption(x, visitSignature); buff }
     }
 
-    private implicit class ImportSelectorOps(buff: self.type) {
-      def ++=(x: List[ImportSelector]): self.type = { visitList(x, visitImportSelector); buff }
+    private implicit class SelectorOps(buff: self.type) {
+      def ++=(x: List[Selector]): self.type = { visitList(x, visitSelector); buff }
     }
 
     private implicit class SymbolOps(buff: self.type) {

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -16,7 +16,7 @@ trait ExprMap:
             transformTerm(tree, TypeRepr.of[Any])(owner)
           case tree: Definition =>
             transformDefinition(tree)(owner)
-          case tree: Import =>
+          case tree @ (_:Import | _:Export) =>
             tree
         }
       }

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -81,8 +81,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *  ```none
    *
    *  +- Tree -+- PackageClause
-   *           +- Import
-   *           +- Statement -+- Definition --+- ClassDef
+   *           |
+   *           +- Statement -+- Import
+   *           |             +- Export
+   *           |             +- Definition --+- ClassDef
    *           |             |               +- TypeDef
    *           |             |               +- DefDef
    *           |             |               +- ValDef
@@ -158,10 +160,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *               +- TypeBounds
    *               +- NoPrefix
    *
-   *  +- ImportSelector -+- SimpleSelector
-   *                     +- RenameSelector
-   *                     +- OmitSelector
-   *                     +- GivenSelector
+   *  +- Selector -+- SimpleSelector
+   *               +- RenameSelector
+   *               +- OmitSelector
+   *               +- GivenSelector
    *
    *  +- Signature
    *
@@ -291,9 +293,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Import` */
     trait ImportModule { this: Import.type =>
-      def apply(expr: Term, selectors: List[ImportSelector]): Import
-      def copy(original: Tree)(expr: Term, selectors: List[ImportSelector]): Import
-      def unapply(tree: Import): Option[(Term, List[ImportSelector])]
+      def apply(expr: Term, selectors: List[Selector]): Import
+      def copy(original: Tree)(expr: Term, selectors: List[Selector]): Import
+      def unapply(tree: Import): Option[(Term, List[Selector])]
     }
 
     /** Makes extension methods on `Import` available without any imports */
@@ -306,9 +308,33 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     trait ImportMethods:
       extension (self: Import):
         def expr: Term
-        def selectors: List[ImportSelector]
+        def selectors: List[Selector]
       end extension
     end ImportMethods
+
+    /** Tree representing an export clause in the source code.
+     *  Export forwarders generated from this clause appear in the same scope.
+     */
+    type Export <: Statement
+
+    given TypeTest[Tree, Export] = ExportTypeTest
+    protected val ExportTypeTest: TypeTest[Tree, Export]
+
+    val Export: ExportModule
+
+    trait ExportModule { this: Export.type =>
+      def unapply(tree: Export): Option[(Term, List[Selector])]
+    }
+
+    given ExportMethods: ExportMethods = ExportMethodsImpl
+    protected val ExportMethodsImpl: ExportMethods
+
+    trait ExportMethods:
+      extension (self: Export):
+        def expr: Term
+        def selectors: List[Selector]
+      end extension
+    end ExportMethods
 
     /** Tree representing a statement in the source code */
     type Statement <: Tree
@@ -2193,31 +2219,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     end AlternativesMethods
 
     //////////////////////
-    // IMPORT SELECTORS //
+    //    SELECTORS     //
     /////////////////////
 
-    /** Import selectors:
+    /** Import/Export selectors:
     *   * SimpleSelector: `.bar` in `import foo.bar`
-    *   * RenameSelector: `.{bar => baz}` in `import foo.{bar => baz}`
+    *   * RenameSelector: `.{bar => baz}` in `export foo.{bar => baz}`
     *   * OmitSelector: `.{bar => _}` in `import foo.{bar => _}`
-    *   * GivneSelector: `.given`/`.{given T}` in `import foo.given`/`import foo.{given T}`
+    *   * GivenSelector: `.given`/`.{given T}` in `export foo.given`/`import foo.{given T}`
     */
-    type ImportSelector <: AnyRef
+    type Selector <: AnyRef
 
-    /** Module object of `type ImportSelector`  */
-    val ImportSelector: ImportSelectorModule
+    /** Module object of `type Selector`  */
+    val Selector: SelectorModule
 
-    /** Methods of the module object `val ImportSelector` */
-    trait ImportSelectorModule { this: ImportSelector.type => }
+    /** Methods of the module object `val Selector` */
+    trait SelectorModule { this: Selector.type => }
 
-    /** Simple import selector: `.bar` in `import foo.bar` */
-    type SimpleSelector <: ImportSelector
+    /** Simple import/export selector: `.bar` in `import foo.bar` */
+    type SimpleSelector <: Selector
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImportSelector` is a `SimpleSelector` */
-    given SimpleSelectorTypeTest: TypeTest[ImportSelector, SimpleSelector] = SimpleSelectorTypeTestImpl
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is a `SimpleSelector` */
+    given SimpleSelectorTypeTest: TypeTest[Selector, SimpleSelector] = SimpleSelectorTypeTestImpl
 
-    /** Implementation of `SimpleSelectorTypeTest` */
-    protected val SimpleSelectorTypeTestImpl: TypeTest[ImportSelector, SimpleSelector]
+    /** Implementation of `TypeTest[Selector, SimpleSelector]` */
+    protected val SimpleSelectorTypeTestImpl: TypeTest[Selector, SimpleSelector]
 
     /** Module object of `type SimpleSelector`  */
     val SimpleSelector: SimpleSelectorModule
@@ -2241,14 +2267,14 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end SimpleSelectorMethods
 
-    /** Rename import selector: `.{bar => baz}` in `import foo.{bar => baz}` */
-    type RenameSelector <: ImportSelector
+    /** Rename import/export selector: `.{bar => baz}` in `import foo.{bar => baz}` */
+    type RenameSelector <: Selector
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImportSelector` is a `RenameSelector` */
-    given RenameSelectorTypeTest: TypeTest[ImportSelector, RenameSelector] = RenameSelectorTypeTestImpl
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is a `RenameSelector` */
+    given RenameSelectorTypeTest: TypeTest[Selector, RenameSelector] = RenameSelectorTypeTestImpl
 
-    /** Implementation of `RenameSelectorTypeTest` */
-    protected val RenameSelectorTypeTestImpl: TypeTest[ImportSelector, RenameSelector]
+    /** Implementation of `TypeTest[Selector, RenameSelector]` */
+    protected val RenameSelectorTypeTestImpl: TypeTest[Selector, RenameSelector]
 
     /** Module object of `type RenameSelector`  */
     val RenameSelector: RenameSelectorModule
@@ -2274,14 +2300,14 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end RenameSelectorMethods
 
-    /** Omit import selector: `.{bar => _}` in `import foo.{bar => _}` */
-    type OmitSelector <: ImportSelector
+    /** Omit import/export selector: `.{bar => _}` in `import foo.{bar => _}` */
+    type OmitSelector <: Selector
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImportSelector` is an `OmitSelector` */
-    given OmitSelectorTypeTest: TypeTest[ImportSelector, OmitSelector] = OmitSelectorTypeTestImpl
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is an `OmitSelector` */
+    given OmitSelectorTypeTest: TypeTest[Selector, OmitSelector] = OmitSelectorTypeTestImpl
 
-    /** Implementation of `OmitSelectorTypeTest` */
-    protected val OmitSelectorTypeTestImpl: TypeTest[ImportSelector, OmitSelector]
+    /** Implementation of `TypeTest[Selector, OmitSelector]` */
+    protected val OmitSelectorTypeTestImpl: TypeTest[Selector, OmitSelector]
 
     /** Module object of `type OmitSelector`  */
     val OmitSelector: OmitSelectorModule
@@ -2304,14 +2330,14 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def namePos: Position
     end OmitSelectorMethods
 
-    /** Omit import selector: `.given`/`.{given T}` in `import foo.given`/`import foo.{given T}` */
-    type GivenSelector <: ImportSelector
+    /** given import/export selector: `.given`/`.{given T}` in `import foo.given`/`export foo.{given T}` */
+    type GivenSelector <: Selector
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImportSelector` is a `GivenSelector` */
-    given GivenSelectorTypeTest: TypeTest[ImportSelector, GivenSelector] = GivenSelectorTypeTestImpl
+    /** `TypeTest` that allows testing at runtime in a pattern match if an `Selector` is a `GivenSelector` */
+    given GivenSelectorTypeTest: TypeTest[Selector, GivenSelector] = GivenSelectorTypeTestImpl
 
-    /** Implementation of `GivenSelectorTypeTest` */
-    protected val GivenSelectorTypeTestImpl: TypeTest[ImportSelector, GivenSelector]
+    /** Implementation of `TypeTest[Selector, GivenSelector]` */
+    protected val GivenSelectorTypeTestImpl: TypeTest[Selector, GivenSelector]
 
     /** Module object of `type GivenSelector`  */
     val GivenSelector: GivenSelectorModule
@@ -4310,6 +4336,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
             foldTrees(foldTrees(foldTrees(foldTrees(foldTree(x, constr)(owner), parents)(owner), derived)(owner), self)(owner), body)(owner)
           case Import(expr, _) =>
             foldTree(x, expr)(owner)
+          case Export(expr, _) =>
+            foldTree(x, expr)(owner)
           case clause @ PackageClause(pid, stats) =>
             foldTrees(foldTree(x, pid)(owner), stats)(clause.symbol)
           case Inferred() => x
@@ -4376,6 +4404,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
             PackageClause.copy(tree)(transformTerm(tree.pid).asInstanceOf[Ref], transformTrees(tree.stats)(tree.symbol))
           case tree: Import =>
             Import.copy(tree)(transformTerm(tree.expr)(owner), tree.selectors)
+          case tree: Export =>
+            tree
           case tree: Statement =>
             transformStatement(tree)(owner)
           case tree: TypeTree => transformTypeTree(tree)(owner)
@@ -4414,6 +4444,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
             ClassDef.copy(tree)(tree.name, tree.constructor, tree.parents, tree.derived, tree.self, tree.body)
           case tree: Import =>
             Import.copy(tree)(transformTerm(tree.expr)(owner), tree.selectors)
+          case tree: Export =>
+            tree
         }
       }
 

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/A.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/A.scala
@@ -1,0 +1,18 @@
+class A {
+
+  private val b: B = new B
+  export b._
+
+  class Inner {
+    private val c: C = new C
+    export c._
+  }
+
+  def local = {
+    class Local {
+      private val d: D = new D
+      export d._
+    }
+  }
+
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/B.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/B.scala
@@ -1,0 +1,3 @@
+class B {
+  val x: Int = 23
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/C.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/C.scala
@@ -1,0 +1,3 @@
+class C {
+  val y: Int = 47
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/D.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/D.scala
@@ -1,0 +1,3 @@
+class D {
+  val z: Int = 113
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/build.sbt
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/build.sbt
@@ -1,0 +1,25 @@
+import sbt.internal.inc.Analysis
+import complete.DefaultParsers._
+
+// Reset compiler iterations, necessary because tests run in batch mode
+val recordPreviousIterations = taskKey[Unit]("Record previous iterations.")
+recordPreviousIterations := {
+  val log = streams.value.log
+  CompileState.previousIterations = {
+    val previousAnalysis = (previousCompile in Compile).value.analysis.asScala
+    previousAnalysis match {
+      case None =>
+        log.info("No previous analysis detected")
+        0
+      case Some(a: Analysis) => a.compilations.allCompilations.size
+    }
+  }
+}
+
+val checkIterations = inputKey[Unit]("Verifies the accumulated number of iterations of incremental compilation.")
+
+checkIterations := {
+  val expected: Int = (Space ~> NatBasic).parsed
+  val actual: Int = ((compile in Compile).value match { case a: Analysis => a.compilations.allCompilations.size }) - CompileState.previousIterations
+  assert(expected == actual, s"Expected $expected compilations, got $actual")
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/changes/B1.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/changes/B1.scala
@@ -1,0 +1,4 @@
+class B {
+  val x: Int = 23
+  val a: Int = 31
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/changes/C1.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/changes/C1.scala
@@ -1,0 +1,4 @@
+class C {
+  val y: Int = 47
+  val b: Int = 93
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/changes/D1.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/changes/D1.scala
@@ -1,0 +1,4 @@
+class D {
+  val z: Int = 113
+  val c: Int = 271
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/project/CompileState.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/project/CompileState.scala
@@ -1,0 +1,4 @@
+// This is necessary because tests are run in batch mode
+object CompileState {
+  @volatile var previousIterations: Int = -1
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/project/DottyInjectedPlugin.scala
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/project/DottyInjectedPlugin.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+    scalacOptions += "-source:3.0-migration"
+  )
+}

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/source-dependencies/export-clauses/test
+++ b/sbt-dotty/sbt-test/source-dependencies/export-clauses/test
@@ -1,0 +1,29 @@
+> recordPreviousIterations
+> compile
+$ copy-file changes/B1.scala B.scala
+> compile
+# This should be 3 because of:
+# 1. the first `compile` call
+# 2. the recompilation of B.scala
+# 3. this recompilation triggering a recompilation of A.scala
+#    because B has a new member and A does a wildcard export
+#    from a value of type B.
+> checkIterations 3
+$ copy-file changes/C1.scala C.scala
+> compile
+# This should be 5 because of:
+# 1. the three prior compilations
+# 2. the recompilation of C.scala
+# 3. this recompilation triggering a recompilation of A.scala
+#    because C has a new member and A.Inner does a wildcard export
+#    from a value of type C.
+> checkIterations 5
+$ copy-file changes/D1.scala D.scala
+> compile
+# This should be 7 because of:
+# 1. the 5 prior compilations
+# 2. the recompilation of D.scala
+# 3. this recompilation triggering a recompilation of A.scala
+#    because D has a new member and A.local().Local does a wildcard export
+#    from a value of type D.
+> checkIterations 7

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -60,6 +60,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   ValOrDefDef
                   TYPEDEF        Length NameRef (type_Term | Template) Modifier*   -- modifiers type name (= type | bounds)  |  modifiers class name template
                   IMPORT         Length qual_Term Selector*                        -- import qual selectors
+                  EXPORT         Length qual_Term Selector*                        -- export qual selectors
   ValOrDefDef   = VALDEF         Length NameRef type_Term rhs_Term? Modifier*      -- modifiers val name : type (= rhs)?
                   DEFDEF         Length NameRef TypeParam* Params* returnType_Term
                                         rhs_Term? Modifier*                        -- modifiers def name [typeparams] paramss : returnType (= rhs)?
@@ -475,6 +476,7 @@ object TastyFormat {
   final val TERMREFin = 174
   final val TYPEREFin = 175
   final val SELECTin = 176
+  final val EXPORT = 177
 
   final val METHODtype = 180
 
@@ -634,6 +636,7 @@ object TastyFormat {
     case DEFDEF => "DEFDEF"
     case TYPEDEF => "TYPEDEF"
     case IMPORT => "IMPORT"
+    case EXPORT => "EXPORT"
     case TYPEPARAM => "TYPEPARAM"
     case PARAM => "PARAM"
     case IMPORTED => "IMPORTED"

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -261,7 +261,7 @@ object TastyFormat {
 
   final val header: Array[Int] = Array(0x5C, 0xA1, 0xAB, 0x1F)
   val MajorVersion: Int = 26
-  val MinorVersion: Int = 0
+  val MinorVersion: Int = 1
 
   final val ASTsSection = "ASTs"
   final val PositionsSection = "Positions"

--- a/tests/neg/package-export/defaults.scala
+++ b/tests/neg/package-export/defaults.scala
@@ -1,0 +1,3 @@
+package defaults
+
+given numerics.Ring[Int] = ???

--- a/tests/neg/package-export/enums.scala
+++ b/tests/neg/package-export/enums.scala
@@ -1,0 +1,5 @@
+package enums
+
+def enumOrdinal[T](t: T): Int = t match
+  case t: reflect.Enum => t.ordinal
+  case t               => -1

--- a/tests/neg/package-export/numerics.scala
+++ b/tests/neg/package-export/numerics.scala
@@ -1,0 +1,3 @@
+package numerics
+
+trait Ring[T]

--- a/tests/neg/package-export/package.scala
+++ b/tests/neg/package-export/package.scala
@@ -1,0 +1,7 @@
+package mylib
+
+export numerics._ // error: package numerics is not a valid prefix for a wildcard export...
+
+export defaults.{given Ring[Int]} // error: package defaults is not a valid prefix for a wildcard export...
+
+export enums.enumOrdinal // ok, enums is a package but export is not wildcard

--- a/tests/run-macros/exports.check
+++ b/tests/run-macros/exports.check
@@ -1,0 +1,16 @@
+visited exports with ExprMap
+visited exports with TreeMap
+extracted with TreeAccumulator: '{export Messages.{logMessage => log}}, '{export Messages.{count}}
+reflection show:
+{
+  lazy val Observer: Observer = new Observer()
+  object Observer {
+    export Messages.{count}
+    final def count: scala.Int = Messages.count
+  }
+  ()
+}
+reflection show extractors:
+Inlined(None, Nil, Block(List(ValDef("Observer", TypeIdent("Observer$"), Some(Apply(Select(New(TypeIdent("Observer$")), "<init>"), Nil))), ClassDef("Observer$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Observer")), None)), List(Export(Ident("Messages"), List(SimpleSelector(count))), DefDef("count", Nil, Nil, Inferred(), Some(Select(Ident("Messages"), "count")))))), Literal(Constant.Unit())))
+visited exports with splice
+visited exports with splice inverted

--- a/tests/run-macros/exports/Logger_1.scala
+++ b/tests/run-macros/exports/Logger_1.scala
@@ -1,0 +1,3 @@
+trait Logger {
+  def log(a: String): Unit
+}

--- a/tests/run-macros/exports/Macro_2.scala
+++ b/tests/run-macros/exports/Macro_2.scala
@@ -1,0 +1,58 @@
+import scala.quoted._
+
+inline def visitExportsTreeAccumulator[T](inline x: T)(inline f: String => Any): Any = ${ traverseExportsImpl('x, 'f) }
+inline def visitExportsTreeMap[T](inline x: T)(inline f: T => Any): Any = ${ visitExportsTreeMapImpl('x, 'f) }
+inline def visitExportsExprMap[T](inline x: T)(inline f: T => Any): Any = ${ visitExportsExprMapImpl('x, 'f) }
+inline def visitExportsShow[T](inline x: T): Any = ${ visitExportsShowImpl('x) }
+inline def visitExportsShowExtract[T](inline x: T): Any = ${ visitExportsShowExtractImpl('x) }
+inline def visitExportsSplice(inline l: Logger): Logger = ${ mixinLoggerImpl('l) }
+inline def visitExportsSpliceInverse(inline op: Logger => Logger): Logger = ${ mixinLoggerInverseImpl('op) }
+
+private def visitExportsExprMapImpl[T: Type](e: Expr[T], f: Expr[T => Any])(using Quotes): Expr[Any] =
+  '{$f(${IdempotentExprMap.transform(e)})}
+
+private def visitExportsTreeMapImpl[T: Type](e: Expr[T], f: Expr[T => Any])(using Quotes): Expr[Any] =
+  import quotes.reflect._
+  object m extends TreeMap
+  '{$f(${m.transformTerm(Term.of(e))(Symbol.spliceOwner).asExprOf})}
+
+private def visitExportsShowImpl[T: Type](e: Expr[T])(using Quotes): Expr[Any] =
+  import quotes.reflect._
+  '{println(${Expr(Term.of(e).show)})}
+
+private def visitExportsShowExtractImpl[T: Type](e: Expr[T])(using Quotes): Expr[Any] =
+  import quotes.reflect._
+  '{println(${Expr(Term.of(e).showExtractors)})}
+
+private object IdempotentExprMap extends ExprMap {
+
+  def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] =
+    transformChildren(e)
+
+}
+
+private def traverseExportsImpl(e: Expr[Any], f: Expr[String => Any])(using Quotes): Expr[Any] = {
+  import quotes.reflect._
+  import collection.mutable
+
+  object ExportAccumulator extends TreeAccumulator[mutable.Buffer[String]] {
+    def foldTree(x: mutable.Buffer[String], tree: Tree)(owner: Symbol): mutable.Buffer[String] = tree match {
+      case tree: Export => foldOverTree(x += s"'{${tree.show}}", tree)(owner)
+      case _            => foldOverTree(x, tree)(owner)
+    }
+  }
+
+  val res =
+    ExportAccumulator.foldTree(mutable.Buffer.empty, Term.of(e))(Symbol.spliceOwner).mkString(", ")
+
+  '{ $f(${Expr(res)}) }
+}
+
+private def mixinLoggerImpl(l: Expr[Logger])(using Quotes): Expr[Logger] =
+  '{ new Logger {
+    private val delegate = $l
+    export delegate._
+   }}
+
+private def mixinLoggerInverseImpl(op: Expr[Logger => Logger])(using Quotes): Expr[Logger] =
+  '{ $op(new Logger { def log(a: String): Unit = println(a) }) }

--- a/tests/run-macros/exports/Test_3.scala
+++ b/tests/run-macros/exports/Test_3.scala
@@ -1,0 +1,31 @@
+object Messages {
+  private var logs: Int = 0
+  def logMessage(a: String): Unit =
+    logs += 1
+    println(a)
+  def count = logs
+}
+
+@main def Test: Unit =
+  assert(Messages.count == 0)
+  visitExportsExprMap(new Logger { export Messages.{logMessage => log} })(
+    _.log("visited exports with ExprMap")
+  )
+  assert(Messages.count == 1)
+  visitExportsTreeMap(new Logger { export Messages.{logMessage => log} })(
+    _.log("visited exports with TreeMap")
+  )
+  assert(Messages.count == 2)
+  visitExportsTreeAccumulator(new Logger { export Messages.{logMessage => log}; export Messages.count })(
+    exportStrings => println(s"extracted with TreeAccumulator: $exportStrings")
+  )
+  println("reflection show:")
+  visitExportsShow({ object Observer { export Messages.count } })
+  println("reflection show extractors:")
+  visitExportsShowExtract({ object Observer { export Messages.count } })
+  val localLogger = new Logger { def log(a: String): Unit = println(a) }
+  visitExportsSplice(localLogger).log("visited exports with splice")
+  visitExportsSpliceInverse(logger => new Logger {
+    private val delegate = logger
+    export delegate._
+  }).log("visited exports with splice inverted")

--- a/tests/semanticdb/expect/exports-example-Codec.expect.scala
+++ b/tests/semanticdb/expect/exports-example-Codec.expect.scala
@@ -1,0 +1,15 @@
+package exports.example
+
+trait Decoder/*<-exports::example::Decoder#*/[+T/*<-exports::example::Decoder#[T]*/] {
+  def decode/*<-exports::example::Decoder#decode().*/(a/*<-exports::example::Decoder#decode().(a)*/: Array/*->scala::Array#*/[Byte/*->scala::Byte#*/]): T/*->exports::example::Decoder#[T]*/
+}
+
+trait Encoder/*<-exports::example::Encoder#*/[-T/*<-exports::example::Encoder#[T]*/] {
+  def encode/*<-exports::example::Encoder#encode().*/(t/*<-exports::example::Encoder#encode().(t)*/: T/*->exports::example::Encoder#[T]*/): Array/*->scala::Array#*/[Byte/*->scala::Byte#*/]
+}
+
+trait Codec/*<-exports::example::Codec#*/[T/*<-exports::example::Codec#[T]*/](decode/*<-exports::example::Codec#decode.*/: Decoder/*->exports::example::Decoder#*/[T/*->exports::example::Codec#[T]*/], encode/*<-exports::example::Codec#encode.*/: Encoder/*->exports::example::Encoder#*/[T/*->exports::example::Codec#[T]*/])
+  extends Decoder/*->exports::example::Decoder#*/[T/*->exports::example::Codec#[T]*/] with Encoder/*->exports::example::Encoder#*/[T/*->exports::example::Codec#[T]*/] {
+  export decode/*->exports::example::Codec#decode.*//*->exports::example::Decoder#decode().*//*->exports::example::Codec#decode().(a)*/./*<-exports::example::Codec#decode().*/_
+  export encode/*->exports::example::Codec#encode.*//*->exports::example::Encoder#encode().*//*->exports::example::Codec#encode().(t)*/./*<-exports::example::Codec#encode().*/_
+}

--- a/tests/semanticdb/expect/exports-example-Codec.scala
+++ b/tests/semanticdb/expect/exports-example-Codec.scala
@@ -1,0 +1,15 @@
+package exports.example
+
+trait Decoder[+T] {
+  def decode(a: Array[Byte]): T
+}
+
+trait Encoder[-T] {
+  def encode(t: T): Array[Byte]
+}
+
+trait Codec[T](decode: Decoder[T], encode: Encoder[T])
+  extends Decoder[T] with Encoder[T] {
+  export decode._
+  export encode._
+}

--- a/tests/semanticdb/expect/exports-package.expect.scala
+++ b/tests/semanticdb/expect/exports-package.expect.scala
@@ -1,0 +1,3 @@
+package exports
+
+/*<-exports::`exports-package$package`.*/export example.{Decoder/*<-exports::`exports-package$package`.Decoder#*/, Encoder/*<-exports::`exports-package$package`.Encoder#*/, Codec/*<-exports::`exports-package$package`.Codec#*/}

--- a/tests/semanticdb/expect/exports-package.scala
+++ b/tests/semanticdb/expect/exports-package.scala
@@ -1,0 +1,3 @@
+package exports
+
+export example.{Decoder, Encoder, Codec}

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3019,6 +3019,106 @@ Occurrences:
 [4:18..4:21): Int -> scala/Int#
 [4:26..4:30): Unit -> scala/Unit#
 
+expect/exports-example-Codec.scala
+----------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => exports-example-Codec.scala
+Text => empty
+Language => Scala
+Symbols => 21 entries
+Occurrences => 39 entries
+
+Symbols:
+exports/example/Codec# => trait Codec
+exports/example/Codec#[T] => typeparam T
+exports/example/Codec#`<init>`(). => primary ctor <init>
+exports/example/Codec#`<init>`().(decode) => param decode
+exports/example/Codec#`<init>`().(encode) => param encode
+exports/example/Codec#decode(). => final method decode
+exports/example/Codec#decode().(a) => param a
+exports/example/Codec#decode. => val method decode
+exports/example/Codec#encode(). => final method encode
+exports/example/Codec#encode().(t) => param t
+exports/example/Codec#encode. => val method encode
+exports/example/Decoder# => trait Decoder
+exports/example/Decoder#[T] => covariant typeparam T
+exports/example/Decoder#`<init>`(). => primary ctor <init>
+exports/example/Decoder#decode(). => abstract method decode
+exports/example/Decoder#decode().(a) => param a
+exports/example/Encoder# => trait Encoder
+exports/example/Encoder#[T] => contravariant typeparam T
+exports/example/Encoder#`<init>`(). => primary ctor <init>
+exports/example/Encoder#encode(). => abstract method encode
+exports/example/Encoder#encode().(t) => param t
+
+Occurrences:
+[0:8..0:15): exports -> exports/
+[0:16..0:23): example <- exports/example/
+[2:6..2:13): Decoder <- exports/example/Decoder#
+[2:13..2:13): <- exports/example/Decoder#`<init>`().
+[2:15..2:16): T <- exports/example/Decoder#[T]
+[3:6..3:12): decode <- exports/example/Decoder#decode().
+[3:13..3:14): a <- exports/example/Decoder#decode().(a)
+[3:16..3:21): Array -> scala/Array#
+[3:22..3:26): Byte -> scala/Byte#
+[3:30..3:31): T -> exports/example/Decoder#[T]
+[6:6..6:13): Encoder <- exports/example/Encoder#
+[6:13..6:13): <- exports/example/Encoder#`<init>`().
+[6:15..6:16): T <- exports/example/Encoder#[T]
+[7:6..7:12): encode <- exports/example/Encoder#encode().
+[7:13..7:14): t <- exports/example/Encoder#encode().(t)
+[7:16..7:17): T -> exports/example/Encoder#[T]
+[7:20..7:25): Array -> scala/Array#
+[7:26..7:30): Byte -> scala/Byte#
+[10:6..10:11): Codec <- exports/example/Codec#
+[10:11..10:11): <- exports/example/Codec#`<init>`().
+[10:12..10:13): T <- exports/example/Codec#[T]
+[10:15..10:21): decode <- exports/example/Codec#decode.
+[10:23..10:30): Decoder -> exports/example/Decoder#
+[10:31..10:32): T -> exports/example/Codec#[T]
+[10:35..10:41): encode <- exports/example/Codec#encode.
+[10:43..10:50): Encoder -> exports/example/Encoder#
+[10:51..10:52): T -> exports/example/Codec#[T]
+[11:10..11:17): Decoder -> exports/example/Decoder#
+[11:18..11:19): T -> exports/example/Codec#[T]
+[11:26..11:33): Encoder -> exports/example/Encoder#
+[11:34..11:35): T -> exports/example/Codec#[T]
+[12:9..12:15): decode -> exports/example/Codec#decode.
+[12:15..12:15): -> exports/example/Decoder#decode().
+[12:15..12:15): -> exports/example/Codec#decode().(a)
+[12:16..12:16): <- exports/example/Codec#decode().
+[13:9..13:15): encode -> exports/example/Codec#encode.
+[13:15..13:15): -> exports/example/Encoder#encode().
+[13:15..13:15): -> exports/example/Codec#encode().(t)
+[13:16..13:16): <- exports/example/Codec#encode().
+
+expect/exports-package.scala
+----------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => exports-package.scala
+Text => empty
+Language => Scala
+Symbols => 4 entries
+Occurrences => 6 entries
+
+Symbols:
+exports/`exports-package$package`. => final package object exports
+exports/`exports-package$package`.Codec# => final type Codec
+exports/`exports-package$package`.Decoder# => final type Decoder
+exports/`exports-package$package`.Encoder# => final type Encoder
+
+Occurrences:
+[0:8..0:15): exports <- exports/
+[2:0..2:0): <- exports/`exports-package$package`.
+[2:7..2:14): example -> exports/example/
+[2:16..2:23): Decoder <- exports/`exports-package$package`.Decoder#
+[2:25..2:32): Encoder <- exports/`exports-package$package`.Encoder#
+[2:34..2:39): Codec <- exports/`exports-package$package`.Codec#
+
 expect/filename with spaces.scala
 ---------------------------------
 


### PR DESCRIPTION
~not sure what else should cause enough indirection for this to fail~

now:

- Keep export clause trees until FirstTransform
- Add Export trees to TASTy format and QuoteContext reflection API
- Use Export trees to record wildcard export as dependencies by inheritance in incremental compilation.
- Restrict wildcard export from a package prefix