### PR TITLE
Fix #10177: Test `@JSType` in `isJSType` instead of using time travel.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
@@ -43,11 +43,8 @@ object JSSymUtils {
 
   extension (sym: Symbol) {
     /** Is this symbol a JavaScript type? */
-    def isJSType(using Context): Boolean = {
-      atPhase(erasurePhase) {
-        sym.derivesFrom(jsdefn.JSAnyClass) || sym == jsdefn.PseudoUnionClass
-      }
-    }
+    def isJSType(using Context): Boolean =
+      sym.hasAnnotation(jsdefn.JSTypeAnnot)
 
     /** Is this symbol a non-native JS class? */
     def isNonNativeJSClass(using Context): Boolean =

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -1,0 +1,24 @@
+package org.scalajs.testsuite.compiler
+
+import org.junit.Assert._
+import org.junit.Test
+
+class RegressionTestScala3 {
+  import RegressionTestScala3._
+
+  @Test def testRegressionDoubleDefinitionOfOuterPointerIssue10177(): Unit = {
+    assertEquals(6, new OuterClassIssue10177().foo(5))
+  }
+}
+
+object RegressionTestScala3 {
+  class OuterClassIssue10177 { // can also be trait
+    trait ParentTrait { // must be trait, can be private
+      def concreteMethod(x: Int): Int = x + 1 // must have a concrete method
+    }
+
+    private class ChildClass extends ParentTrait // must be class *and* private
+
+    def foo(x: Int): Int = new ChildClass().concreteMethod(x)
+  }
+}


### PR DESCRIPTION
The time travel in `isJSType` was causing an issue when used from `ExplicitJSClasses`. It would somehow interfere with `ExplicitOuter`, which would then generate an outer pointer twice.

We now test the presence of the `@JSType` annotation, which is also what Scala 2 does. Historically we used the time travel because we had not implemented `PrepJSInterop`, which is responsible for adding the `@JSType` annotations in the first place.