### PR TITLE
upgrade scalacheck to 1.15, test scala.js too

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -172,7 +172,7 @@ object projects:
 
   lazy val scalacheck = SbtCommunityProject(
     project       = "scalacheck",
-    sbtTestCommand   = "jvm/test",
+    sbtTestCommand   = "jvm/test; js/test",
     sbtPublishCommand = ";set jvm/publishArtifact in (Compile, packageDoc) := false ;jvm/publishLocal"
   )
 


### PR DESCRIPTION
Testing the Scala.js support is a good idea since if we had done it
before we would have caught #10177 sooner.