### PR TITLE
Fix #10178: Put the wildcard demon back in the bottle

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1456,10 +1456,15 @@ object desugar {
 
       /** If `pat` is not an Identifier, a Typed(Ident, _), or a Bind, wrap
        *  it in a Bind with a fresh name. Return the transformed pattern, and the identifier
-       *  that refers to the bound variable for the pattern.
+       *  that refers to the bound variable for the pattern. Wildcard Binds are
+       *  also replaced by Binds with fresh names.
        */
       def makeIdPat(pat: Tree): (Tree, Ident) = pat match {
-        case Bind(name, _) => (pat, Ident(name))
+        case Bind(name, pat1) =>
+          if name == nme.WILDCARD then
+            val name = UniqueName.fresh()
+            (cpy.Bind(pat)(name, pat1), Ident(name))
+          else (pat, Ident(name))
         case id: Ident if isVarPattern(id) && id.name != nme.WILDCARD => (id, id)
         case Typed(id: Ident, _) if isVarPattern(id) && id.name != nme.WILDCARD => (pat, id)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -232,7 +232,7 @@ class Typer extends Namer
                 fail(em"reference to `$name` is ambiguous; it is imported twice")
               found
 
-            if adjustExtension(selector.rename) == termName then
+            if adjustExtension(selector.rename) == termName && selector.rename != nme.WILDCARD then
               val memberName =
                 if selector.name == termName then name
                 else if name.isTypeName then selector.name.toTypeName

--- a/tests/run/i10178.scala
+++ b/tests/run/i10178.scala
@@ -1,0 +1,5 @@
+@main def Test: Unit =
+  for
+    x <- Option(23)
+    given Int = x
+  do assert(summon[Int] == 23)


### PR DESCRIPTION
This was a very interesting bug. Why did `any2stringadd` appear out of the blue?
The first observation was that it was resolved by an import of an identifier with
`_` as its name. Why? Because we have a standard predefined import
```scala
import Predef.{any2stringadd => _, _}
```
This is represented as a "rename" from `anyToStringAdd` to `_`, assuming that
no real identifier could be `_`. But that assumption turned out to be wrong.

How did we end up with an identifier `_` that needed to be resolved? This was a
second bug in Desugar, method `makeIdPat`. Here we needed to create binds for parts
of a pattern. If the pattern was already a Bind, we used that one instead. But the
`Bind` in question was anonymous, using `_` as the pattern variable. So we did not
replace that by a fresh identifier, but used `_` as the identifier instead. However,
`_` is treated specially as a binder; it does not generate a symbol in the enclosing
scope. So resolving the `_` identifier did not see the enclosing bind and searched
further out instead, until it found the "renamed" import. Beautiful! It shows that
treating wildcards as some sort of identifiers is fraught with surprises.