### PR TITLE
Fix #10273: Use Docker bind mounts for CI caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
            startsWith(github.event.ref, 'refs/tags/sbt-dotty-'))"
 
     steps:
-      - name: Set JDK 11 as default
+      - name: Set JDK 14 as default
         run: echo "/usr/lib/jvm/java-14-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Checkout cleanup script
@@ -62,7 +62,7 @@ jobs:
            startsWith(github.event.ref, 'refs/tags/sbt-dotty-'))"
 
     steps:
-      - name: Set JDK 11 as default
+      - name: Set JDK 14 as default
         run: echo "/usr/lib/jvm/java-14-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Checkout cleanup script

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,12 @@ env:
 jobs:
   test:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
     if: "!(github.event_name == 'push' &&
            startsWith(github.event.ref, 'refs/tags/sbt-dotty-'))"
 
@@ -28,27 +33,6 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
-
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
 
       - name: Test
         run: |
@@ -57,7 +41,12 @@ jobs:
 
   test_bootstrapped:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
     if: "!(github.event_name == 'push' &&
            startsWith(github.event.ref, 'refs/tags/sbt-dotty-'))"
 
@@ -73,27 +62,6 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
-
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
 
       - name: Test
         run: |
@@ -135,7 +103,12 @@ jobs:
 
   community_build:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
 
     steps:
       - name: Checkout cleanup script
@@ -147,27 +120,6 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
-
       - name: Test
         run: |
           git submodule sync
@@ -176,7 +128,12 @@ jobs:
 
   test_sbt:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
     if: (
           github.event_name == 'push' &&
           startsWith(github.event.ref, 'refs/tags/')
@@ -193,33 +150,18 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
-
       - name: Test
         run: ./project/scripts/sbt sbt-dotty/scripted
 
   test_java8:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
+
     if: "(
           github.event_name == 'push' &&
           startsWith(github.event.ref, 'refs/tags/') &&
@@ -240,33 +182,17 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
-
       - name: Test
         run: ./project/scripts/sbt ";compile ;test"
 
   publish_nightly:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
     needs: [test, test_bootstrapped, community_build, test_sbt, test_java8]
     if: github.event_name == 'schedule'
     env:
@@ -286,34 +212,18 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
-
       - name: Publish Nightly
         run: |
           ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
 
   nightly_documentation:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
     needs: [publish_nightly]
     if: github.event_name == 'schedule'
     env:
@@ -332,27 +242,6 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
-
       - name: Generate Website
         run: |
           ./project/scripts/genDocs -doc-snapshot
@@ -367,7 +256,12 @@ jobs:
 
   publish_release:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
     needs: [test, test_bootstrapped, community_build, test_sbt, test_java8]
     if: github.event_name == 'push' &&
         startsWith(github.event.ref, 'refs/tags/') &&
@@ -389,27 +283,6 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
-
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
 
       - name: Publish Release
         run: |
@@ -462,7 +335,12 @@ jobs:
 
   release_documentation:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
     needs: [publish_release]
     if: github.event_name == 'push' &&
         startsWith(github.event.ref, 'refs/tags/') &&
@@ -484,27 +362,6 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
-
       - name: Generate Website
         run: |
           ./project/scripts/genDocs -doc-snapshot
@@ -519,7 +376,12 @@ jobs:
 
   publish_sbt_release:
     runs-on: [self-hosted, Linux]
-    container: lampepfl/dotty:2020-09-08
+    container:
+      image: lampepfl/dotty:2020-09-08
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
     needs: [community_build, test_sbt]
     if: github.event_name == 'push' &&
         startsWith(github.event.ref, 'refs/tags/sbt-dotty-')
@@ -540,27 +402,6 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
-
-      - name: Cache Ivy
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-ivy-
-
-      - name: Cache SBT
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-          restore-keys: ${{ runner.os }}-sbt-
-
-      - name: Cache Coursier and Mill
-        uses: actions/cache@v1.1.2
-        with:
-          path: /root/.cache
-          key: ${{ runner.os }}-general-${{ hashFiles('**/build.sbt') }}
-          restore-keys: ${{ runner.os }}-general-
 
       - name: Publish Dotty SBT Plugin Release
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
+
       - name: Test
         run: |
           ./project/scripts/sbt ";compile ;test"
@@ -62,6 +65,9 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
+
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
       - name: Test
         run: |
@@ -120,6 +126,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
+
       - name: Test
         run: |
           git submodule sync
@@ -149,6 +158,9 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
+
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
       - name: Test
         run: ./project/scripts/sbt sbt-dotty/scripted
@@ -182,6 +194,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
+
       - name: Test
         run: ./project/scripts/sbt ";compile ;test"
 
@@ -212,6 +227,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
+
       - name: Publish Nightly
         run: |
           ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
@@ -241,6 +259,9 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
+
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
       - name: Generate Website
         run: |
@@ -283,6 +304,9 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
+
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
       - name: Publish Release
         run: |
@@ -362,6 +386,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
+
       - name: Generate Website
         run: |
           ./project/scripts/genDocs -doc-snapshot
@@ -402,6 +429,9 @@ jobs:
 
       - name: Git Checkout
         uses: actions/checkout@v2
+
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
       - name: Publish Dotty SBT Plugin Release
         run: |

--- a/.github/workflows/repositories
+++ b/.github/workflows/repositories
@@ -1,0 +1,4 @@
+[repositories]
+local
+my-ivy-proxy-releases: https://scala-webapps.epfl.ch/artifactory/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+my-maven-proxy-releases: https://scala-webapps.epfl.ch/artifactory/central/


### PR DESCRIPTION
Issues with GitHub Actions caching are causing intermittent significant slowdown in CI (and also some spurious failures, I believe). Let's see what we can do about that.

---

The issues have been found to be caused by shortcomings in the implementation of the GitHub `actions/cache@v1` action (and its associated backend service), and have been experienced by other users as well.

A number of tickets have been filed on their issue tracker related to the problems we have been experiencing:

* actions/cache#267 Networking issues impacting cache save/restore
* actions/cache#436 actions/cache@v1 jumps from ~24s to ~20m
* actions/cache#381 Very slow cache restoration
* actions/cache#141 Failed restore should fail step
* actions/cache#265 Getting cache sometimes fails badly (networking issue?)
* actions/cache#207 Github action is stuck when trying to restore the cache
* actions/cache#189 Cache download can hang forever when fetched from multiple concurrent jobs

These issues have been mostly mitigated in the newer `actions/cache@v2`, but extensive testing has uncovered that they are not completely eliminated, and occasionally cache restoration will take 20+ minutes.

This investigation also revealed that we did not necessarily realize that `actions/cache` stores its cache data on GitHub servers and must re-download it on every run, even when using self-hosted runners, which is less than ideal for our use case.

The solution proposed here is to drop the usage of `actions/cache` altogether, and instead use per-runner, locally stored, persistent caches, implemented using Docker bind mounts.

Fixes #10273 