### PR TITLE
Fix scala3doc ignoring literal identifiers

### DIFF
--- a/scala3doc-testcases/src/tests/complexNames.scala
+++ b/scala3doc-testcases/src/tests/complexNames.scala
@@ -2,16 +2,23 @@ package tests
 
 package complexNames
 
+import scala.annotation.StaticAnnotation
+
+class `*** Annotation` extends StaticAnnotation
+class `OtherAnnotation` extends StaticAnnotation
+
+class `*** Type`
+class `OtherType`
+
 abstract class A:
   def ++(other: A): A
   def +:(other: Int): A
   def :+(other: Int): A
 
-  // scala3doc has problems with names in backticks
-  // def `multi word name`: Int
-  // def `*** name with arbitrary chars ^%`: Int
-  // def `mischievous(param:Int)`(otherParam: Int): String
-  // def withMischievousParams(`param: String, param2`: String): String
+  def `multi word name`: Int
+  def `*** name with arbitrary chars ^%`: Int
+  def `mischievous(param:Int)`(otherParam: Int): String
+  def withMischievousParams(`param: String, param2`: String): String
 
   def complexName_^*(param: String): A
 
@@ -19,8 +26,16 @@ abstract class A:
   def `+++:`(other: Int): A //expected: def +++:(other: Int): A
   def `:+++`(other: Int): A //expected: def :+++(other: Int): A
 
-  def `abc_^^_&&`: A //expected: def abc_^^_&&: A
+  def `abc_^^_&&`: A
   def `abc_def`: A //expected: def abc_def: A
   def `abc_def_++`: A //expected: def abc_def_++: A
-  // def `++_abc`: A
-  // def `abc_++_--`: A
+  def `++_abc`: A
+  def `abc_++_--`: A
+
+  @`*** Annotation` def withStrangeAnnotation: A
+  @`OtherAnnotation` def withOtherAnnotation: A //expected: @OtherAnnotation def withOtherAnnotation: A
+  @OtherAnnotation def withOtherAnnotation2: A
+
+  def withStrangeType: `*** Type`
+  def withOtherType: `OtherType` //expected: def withOtherType: OtherType
+  def withOtherType2: OtherType

--- a/scala3doc-testcases/src/tests/complexNames.scala
+++ b/scala3doc-testcases/src/tests/complexNames.scala
@@ -39,3 +39,10 @@ abstract class A:
   def withStrangeType: `*** Type`
   def withOtherType: `OtherType` //expected: def withOtherType: OtherType
   def withOtherType2: OtherType
+
+  def `class`: A
+  def `case`: A
+  def `=>`: A
+  def `=>:`(other: A): A //expected: def =>:(other: A): A
+  def `caseclass`: A //expected: def caseclass: A
+  def `Class`: A //expected: def Class: A

--- a/scala3doc/src/dotty/dokka/model/extras.scala
+++ b/scala3doc/src/dotty/dokka/model/extras.scala
@@ -19,7 +19,7 @@ case class MethodExtension(parametersListSizes: Seq[Int]) extends ExtraProperty[
 
 object MethodExtension extends BaseKey[DFunction, MethodExtension]
 
-case class ParameterExtension(isExtendedSymbol: Boolean, isGrouped: Boolean) extends ExtraProperty[DParameter]:
+case class ParameterExtension(isExtendedSymbol: Boolean, isGrouped: Boolean, prefix: String) extends ExtraProperty[DParameter]:
   override def getKey = ParameterExtension
 
 object ParameterExtension extends BaseKey[DParameter, ParameterExtension]

--- a/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -125,9 +125,9 @@ trait ClassLikeSupport:
           .map { _ =>
             parseMethod(dd.symbol, kind = Kind.Given(getGivenInstance(dd).map(_.asSignature), None))
           }
-          
+
       case dd: DefDef if !dd.symbol.isHiddenByVisibility && dd.symbol.isExported =>
-        val exportedTarget = dd.rhs.collect { 
+        val exportedTarget = dd.rhs.collect {
           case a: Apply => a.fun.asInstanceOf[Select]
           case s: Select => s
         }
@@ -137,7 +137,7 @@ trait ClassLikeSupport:
           case Select(qualifier: Ident, _) => qualifier.tpe.typeSymbol.normalizedName
         }.getOrElse("instance")
         val dri = dd.rhs.collect {
-          case s: Select if s.symbol.isDefDef => s.symbol.dri 
+          case s: Select if s.symbol.isDefDef => s.symbol.dri
         }.orElse(exportedTarget.map(_.qualifier.tpe.typeSymbol.dri))
         Some(parseMethod(dd.symbol, kind = Kind.Exported).withOrigin(Origin.ExportedFrom(s"$instanceName.$functionName", dri)))
 
@@ -350,13 +350,13 @@ trait ClassLikeSupport:
   def parseArgument(argument: ValDef, prefix: Symbol => String, isExtendedSymbol: Boolean = false, isGrouped: Boolean = false): DParameter =
     new DParameter(
       argument.symbol.dri,
-      prefix(argument.symbol) + argument.symbol.normalizedName,
+      argument.symbol.normalizedName,
       argument.symbol.documentation.asJava,
       null,
       argument.tpt.dokkaType,
       ctx.sourceSet.toSet,
       PropertyContainer.Companion.empty()
-        .plus(ParameterExtension(isExtendedSymbol, isGrouped))
+        .plus(ParameterExtension(isExtendedSymbol, isGrouped, prefix(argument.symbol)))
         .plus(MemberExtension.empty.copy(annotations = argument.symbol.getAnnotations()))
     )
 

--- a/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
@@ -498,7 +498,7 @@ class ScalaPageContentBuilder(
         DocumentableElement(
           buildAnnotations(documentable),
           signatureBuilder.preName.reverse,
-          documentable.getName,
+          hackEscapedName(documentable.getName),
           signatureBuilder.names.reverse,
           docs.fold(Nil)(d => reset().rawComment(d.getRoot)),
           originInfo,

--- a/scala3doc/src/dotty/dokka/translators/ScalaSignatureUtils.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaSignatureUtils.scala
@@ -7,6 +7,8 @@ import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.pages._
 import collection.JavaConverters._
 import dotty.dokka.model.api.{Kind, _}
+import dotty.tools.dotc.core.StdNames.nme.keywords
+import dotty.tools.dotc.core.Names.termName
 
 case class InlineSignatureBuilder(names: Signature = Nil, preName: Signature = Nil) extends SignatureBuilder:
   override def text(str: String): SignatureBuilder = copy(names = str +: names)
@@ -126,5 +128,6 @@ trait ScalaSignatureUtils:
 private[dokka] def hackEscapedName(name: String) =
   val simpleIdentifierRegex = raw"(?:\w+_[^\[\(\s_]+)|\w+|[^\[\(\s\w_]+".r
   name match
+    case n if keywords(termName(n)) => s"`$n`"
     case simpleIdentifierRegex() => name
-    case _ => s"`$name`"
+    case n => s"`$n`"

--- a/scala3doc/src/dotty/dokka/translators/ScalaSignatureUtils.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaSignatureUtils.scala
@@ -124,10 +124,13 @@ trait ScalaSignatureUtils:
   extension (tokens: Seq[String]) def toSignatureString(): String =
     tokens.filter(_.trim.nonEmpty).mkString(""," "," ")
 
+private[dokka] val ignoredKeywords: Set[String] = Set("this")
+
 // TODO: remove after adding name abstraction to reflection api
 private[dokka] def hackEscapedName(name: String) =
   val simpleIdentifierRegex = raw"(?:\w+_[^\[\(\s_]+)|\w+|[^\[\(\s\w_]+".r
   name match
+    case n if ignoredKeywords(n) => n
     case n if keywords(termName(n)) => s"`$n`"
     case simpleIdentifierRegex() => name
     case n => s"`$n`"

--- a/scala3doc/test/dotty/dokka/ScaladocTest.scala
+++ b/scala3doc/test/dotty/dokka/ScaladocTest.scala
@@ -22,7 +22,7 @@ abstract class ScaladocTest(val name: String):
 
   private def args = Scala3doc.Args(
       name = "test",
-      tastyFiles = tastyFiles(name),
+      tastyFiles = tastyFiles,
       output = getTempDir().getRoot,
       projectVersion = Some("1.0")
     )
@@ -31,9 +31,9 @@ abstract class ScaladocTest(val name: String):
     def listFilesSafe(dir: File) = Option(dir.listFiles).getOrElse {
       throw AssertionError(s"$dir not found. The test name is incorrect or scala3doc-testcases were not recompiled.")
     }
-    def collectFiles(dir: File): List[String] = listFilesSafe(dir).toList.flatMap {
+    def collectFiles(dir: File): List[File] = listFilesSafe(dir).toList.flatMap {
         case f if f.isDirectory => collectFiles(f)
-        case f if f.getName endsWith ".tasty" => f.getAbsolutePath :: Nil
+        case f if f.getName endsWith ".tasty" => f :: Nil
         case _ => Nil
       }
     collectFiles(File(s"${BuildInfo.test_testcasesOutputDir}/tests/$name"))

--- a/scala3doc/test/dotty/dokka/ScaladocTest.scala
+++ b/scala3doc/test/dotty/dokka/ScaladocTest.scala
@@ -27,6 +27,17 @@ abstract class ScaladocTest(val name: String):
       projectVersion = Some("1.0")
     )
 
+  private def tastyFiles =
+    def listFilesSafe(dir: File) = Option(dir.listFiles).getOrElse {
+      throw AssertionError(s"$dir not found. The test name is incorrect or scala3doc-testcases were not recompiled.")
+    }
+    def collectFiles(dir: File): List[String] = listFilesSafe(dir).toList.flatMap {
+        case f if f.isDirectory => collectFiles(f)
+        case f if f.getName endsWith ".tasty" => f.getAbsolutePath :: Nil
+        case _ => Nil
+      }
+    collectFiles(File(s"${BuildInfo.test_testcasesOutputDir}/tests/$name"))
+
   @Rule
   def collector = _collector
   private val _collector = new ErrorCollector();


### PR DESCRIPTION
Fixes https://github.com/lampepfl/scala3doc/issues/235
This PR is a follow-up to #10170 and should be merged after it.

After merging this pr, names that cannot be expressed without backticks in source code will be displayed as literal indentifiers in generated documentation and names that can be expressed without backticks will always be documented without them, even if their declaration in source code uses ones. 

I also sperated prefixes from parameter names  in the model to avoid cases when scala3doc is helpless encountering some mischievous identifiers, like `` val `var a`: Int ``.