### PR TITLE
Fix #10137: Emit a warning if generated main class conflicts

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -84,7 +84,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     nameString(if (ctx.property(XprintMode).isEmpty) sym.initial.name else sym.name)
 
   override def fullNameString(sym: Symbol): String =
-    if (isEmptyPrefix(sym.maybeOwner)) nameString(sym)
+    if !sym.exists || isEmptyPrefix(sym.effectiveOwner) then nameString(sym)
     else super.fullNameString(sym)
 
   override protected def fullNameOwner(sym: Symbol): Symbol = {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2241,11 +2241,12 @@ class Typer extends Namer
     val pkg = pid1.symbol
     pid1 match
       case pid1: RefTree if pkg.is(Package) =>
-        val packageCtx = ctx.packageContext(tree, pkg)
-        var stats1 = typedStats(tree.stats, pkg.moduleClass)(using packageCtx)._1
-        if (!ctx.isAfterTyper)
-          stats1 = stats1 ++ typedBlockStats(MainProxies.mainProxies(stats1))(using packageCtx)._1
-        cpy.PackageDef(tree)(pid1, stats1).withType(pkg.termRef)
+        inContext(ctx.packageContext(tree, pkg)) {
+          var stats1 = typedStats(tree.stats, pkg.moduleClass)._1
+          if (!ctx.isAfterTyper)
+            stats1 = stats1 ++ typedBlockStats(MainProxies.mainProxies(stats1))._1
+          cpy.PackageDef(tree)(pid1, stats1).withType(pkg.termRef)
+        }
       case _ =>
         // Package will not exist if a duplicate type has already been entered, see `tests/neg/1708.scala`
         errorTree(tree,

--- a/tests/neg-custom-args/fatal-warnings/i10137.check
+++ b/tests/neg-custom-args/fatal-warnings/i10137.check
@@ -1,0 +1,10 @@
+-- Error: tests/neg-custom-args/fatal-warnings/i10137.scala:2:12 -------------------------------------------------------
+2 |  @main def main(): Unit = println("Hello, World!") // error
+  |            ^
+  |            The class `foo.main` generated from `@main` will shadow the existing class main in package scala.
+  |            The existing definition might no longer be found on recompile.
+-- Error: tests/neg-custom-args/fatal-warnings/i10137.scala:4:10 -------------------------------------------------------
+4 |@main def List(): Unit = println("List") // error
+  |          ^
+  |          The class `List` generated from `@main` will shadow the existing type List in package scala.
+  |          The existing definition might no longer be found on recompile.

--- a/tests/neg-custom-args/fatal-warnings/i10137.scala
+++ b/tests/neg-custom-args/fatal-warnings/i10137.scala
@@ -1,0 +1,4 @@
+package foo:
+  @main def main(): Unit = println("Hello, World!") // error
+
+@main def List(): Unit = println("List") // error

--- a/tests/pending/pos/i10161.scala
+++ b/tests/pending/pos/i10161.scala
@@ -1,0 +1,18 @@
+object Incompat2 {
+  trait Context { type Out }
+
+  object Context {
+    def foo(implicit ctx: Context): Option[ctx.Out] = ???
+
+    def bar(implicit ctx: Context): (Option[ctx.Out], String) = (foo, "foo")
+  }
+}
+object Incompat3 {
+  trait Context { type Out }
+
+  object Context {
+    given foo(using ctx: Context) as Option[ctx.Out] = ???
+
+    given bar(using ctx: Context) as (Option[ctx.Out], String) = (foo, "foo")
+  }
+}


### PR DESCRIPTION
Emit a warning if generated main class can shadow a type defined
somewhere else.