### PR TITLE
Add `isExprOf` and `toExprOf` to allow safe expression casting

### DIFF
--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -29,13 +29,6 @@ abstract class Expr[+T] private[scala] {
   def isExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): Boolean =
     this.unseal.tpe <:< tp.unseal.tpe
 
-  /** Convert this to an `Some[quoted.Expr[X]]` if this expression is a valid expression of type `X`.
-   *  Otherwise returns None.
-   */
-  def toExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): Option[scala.quoted.Expr[X]] =
-    if isExprOf[X] then Some(this.asInstanceOf[scala.quoted.Expr[X]])
-    else None
-
   /** Convert this to an `quoted.Expr[X]` if this expression is a valid expression of type `X` or throws */
   def asExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): scala.quoted.Expr[X] = {
     if isExprOf[X] then

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -25,17 +25,26 @@ abstract class Expr[+T] private[scala] {
   /** Checked cast to a `quoted.Expr[U]` */
   def cast[U](using tp: scala.quoted.Type[U])(using qctx: QuoteContext): scala.quoted.Expr[U] = asExprOf[U]
 
+  /** Checks is the `quoted.Expr[?]` is valid expression of type `X` */
+  def isExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): Boolean =
+    this.unseal.tpe <:< tp.unseal.tpe
+
+  /** Convert this to an `Some[quoted.Expr[X]]` if this expression is a valid expression of type `X`.
+   *  Otherwise returns None.
+   */
+  def toExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): Option[scala.quoted.Expr[X]] =
+    if isExprOf[X] then Some(this.asInstanceOf[scala.quoted.Expr[X]])
+    else None
+
   /** Convert this to an `quoted.Expr[X]` if this expression is a valid expression of type `X` or throws */
   def asExprOf[X](using tp: scala.quoted.Type[X])(using qctx: QuoteContext): scala.quoted.Expr[X] = {
-    val tree = this.unseal
-    val expectedType = tp.unseal.tpe
-    if (tree.tpe <:< expectedType)
+    if isExprOf[X] then
       this.asInstanceOf[scala.quoted.Expr[X]]
     else
-      throw new scala.tasty.reflect.ExprCastError(
-        s"""Expr: ${tree.show}
-           |of type: ${tree.tpe.show}
-           |did not conform to type: ${expectedType.show}
+      throw new tasty.reflect.ExprCastError(
+        s"""Expr: ${this.show}
+           |of type: ${this.unseal.tpe.show}
+           |did not conform to type: ${tp.unseal.tpe.show}
            |""".stripMargin
       )
   }

--- a/tests/run-staging/staged-streams_1.scala
+++ b/tests/run-staging/staged-streams_1.scala
@@ -1,6 +1,5 @@
 import scala.quoted._
 import scala.quoted.staging._
-import scala.quoted.util._
 import language.experimental.namedTypeArguments
 
 /**


### PR DESCRIPTION
Currently we can only call `asExprOf` but have no simple way to check that
the expression is in fact of some type.