### PR TITLE
Fix #10129: Fix comparisons of applied type aliases

### DIFF
--- a/tests/pos/i10129.scala
+++ b/tests/pos/i10129.scala
@@ -1,0 +1,14 @@
+class Err
+
+type Lifted[A] = Err | A
+
+def point[O](o: O): Lifted[O] = o
+extension [O, U](o: Lifted[O]) def map(f: O => U): Lifted[U] = ???
+
+val error: Err = Err()
+
+def ok: Int | Err =
+  point("a").map(_ => if true then 1 else error)
+
+def fail: Lifted[Int] =
+  point("a").map(_ => if true then 1 else error) // error


### PR DESCRIPTION
Given

    type F[Xs] = ...
    F[As] <: F[Bs]

Do we dealias `F` or check the arguments directly? It turns out that neither choice
is correct in all instances. Checking the arguments directly is necessary for hk
type inference, but may narrow the constraint too much. The solution is to use
an `either` that tries both alternatives.
