### PR TITLE
Move `scala.interal.Chars` to `dotc.util`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -5,7 +5,7 @@ import java.security.MessageDigest
 import scala.io.Codec
 import Int.MaxValue
 import Names._, StdNames._, Contexts._, Symbols._, Flags._, NameKinds._, Types._
-import scala.internal.Chars.{isOperatorPart, digit2int}
+import util.Chars.{isOperatorPart, digit2int}
 import Definitions._
 import nme._
 import Decorators.concat

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -7,7 +7,7 @@ import util.NameTransformer
 import printing.{Showable, Texts, Printer}
 import Texts.Text
 import StdNames.str
-import scala.internal.Chars.isIdentifierStart
+import util.Chars.isIdentifierStart
 import collection.immutable
 import config.Config
 import util.{LinearMap, HashSet}

--- a/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/CharArrayReader.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package parsing
 
-import scala.internal.Chars._
+import util.Chars._
 
 abstract class CharArrayReader { self =>
 

--- a/compiler/src/dotty/tools/dotc/parsing/JavaScanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaScanners.scala
@@ -8,7 +8,7 @@ import Scanners._
 import util.SourceFile
 import JavaTokens._
 import scala.annotation.{ switch, tailrec }
-import scala.internal.Chars._
+import util.Chars._
 
 object JavaScanners {
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -23,7 +23,7 @@ import Constants._
 import Symbols.defn
 import ScriptParsers._
 import Decorators._
-import scala.internal.Chars
+import util.Chars
 import scala.annotation.{tailrec, switch}
 import rewrites.Rewrites.{patch, overlapsPatch}
 import reporting._

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -6,7 +6,7 @@ import core.Names._, core.Contexts._, core.Decorators._, util.Spans._
 import core.StdNames._, core.Comments._
 import util.SourceFile
 import java.lang.Character.isDigit
-import scala.internal.Chars._
+import util.Chars._
 import util.{SourcePosition, CharBuffer}
 import util.Spans.Span
 import config.Config

--- a/compiler/src/dotty/tools/dotc/parsing/package.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/package.scala
@@ -1,6 +1,6 @@
 package dotty.tools.dotc
 
-import scala.internal.Chars._
+import util.Chars._
 import core.Names.Name
 import core.StdNames.nme
 import core.NameOps._

--- a/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParserCommon.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParserCommon.scala
@@ -10,7 +10,7 @@ package parsing
 package xml
 
 import Utility._
-import scala.internal.Chars.SU
+import util.Chars.SU
 
 
 

--- a/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
@@ -6,7 +6,7 @@ package xml
 import scala.collection.mutable
 import mutable.{ Buffer, ArrayBuffer, ListBuffer }
 import scala.util.control.ControlThrowable
-import scala.internal.Chars.SU
+import util.Chars.SU
 import Parsers._
 import util.Spans._
 import core._

--- a/compiler/src/dotty/tools/dotc/parsing/xml/Utility.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/Utility.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
  * @author Burak Emir
  */
 object Utility {
-  import scala.internal.Chars.SU
+  import util.Chars.SU
 
   private val unescMap = Map(
     "lt"    -> '<',

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -20,7 +20,7 @@ import typer.ProtoTypes._
 import Trees._
 import TypeApplications._
 import Decorators._
-import scala.internal.Chars.isOperatorPart
+import util.Chars.isOperatorPart
 import transform.TypeUtils._
 import transform.SymUtils._
 

--- a/compiler/src/dotty/tools/dotc/quoted/printers/SourceCode.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/printers/SourceCode.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc.quoted.printers
+package dotty.tools.dotc
+package quoted.printers
 
 import scala.annotation.switch
 import scala.quoted._
@@ -436,7 +437,7 @@ object SourceCode {
           case _ =>
             inParens {
               printTree(term)
-              this += (if (scala.internal.Chars.isOperatorPart(sb.last)) " : " else ": ")
+              this += (if (util.Chars.isOperatorPart(sb.last)) " : " else ": ")
               def printTypeOrAnnots(tpe: TypeRepr): Unit = tpe match {
                 case AnnotatedType(tp, annot) if tp == term.tpe =>
                   printAnnotation(annot)

--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -10,7 +10,7 @@ import printing.Highlighting.{Blue, Red, Yellow}
 import printing.SyntaxHighlighting
 import Diagnostic._
 import util.SourcePosition
-import scala.internal.Chars.{ LF, CR, FF, SU }
+import util.Chars.{ LF, CR, FF, SU }
 import scala.annotation.switch
 
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -18,7 +18,7 @@ import typer.ErrorReporting._
 import reporting._
 import ast.Trees._
 import ast.{tpd, untpd}
-import scala.internal.Chars._
+import util.Chars._
 import collection.mutable
 import ProtoTypes._
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -38,7 +38,7 @@ import config.SourceVersion._
 
 import collection.mutable
 import reporting._
-import scala.internal.Chars.isOperatorPart
+import util.Chars.isOperatorPart
 
 object Checking {
   import tpd._

--- a/compiler/src/dotty/tools/dotc/util/Chars.scala
+++ b/compiler/src/dotty/tools/dotc/util/Chars.scala
@@ -1,4 +1,4 @@
-package scala.internal
+package dotty.tools.dotc.util
 
 import scala.annotation.switch
 import java.lang.{Character => JCharacter}

--- a/compiler/src/dotty/tools/dotc/util/CommentParsing.scala
+++ b/compiler/src/dotty/tools/dotc/util/CommentParsing.scala
@@ -15,7 +15,7 @@ import scala.collection.mutable
   * handled by dottydoc.
   */
 object CommentParsing {
-  import scala.internal.Chars._
+  import Chars._
 
   /** Returns index of string `str` following `start` skipping longest
    *  sequence of whitespace characters characters (but no newlines)

--- a/compiler/src/dotty/tools/dotc/util/NameTransformer.scala
+++ b/compiler/src/dotty/tools/dotc/util/NameTransformer.scala
@@ -4,7 +4,7 @@ package util
 
 import core.Names._
 import collection.mutable
-import scala.internal.Chars
+import util.Chars
 
 import scala.annotation.internal.sharable
 

--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -7,7 +7,7 @@ import Spans._
 import core.Contexts._
 
 import scala.io.Codec
-import scala.internal.Chars._
+import Chars._
 import scala.annotation.internal.sharable
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer

--- a/library/src/scala/util/FromDigits.scala
+++ b/library/src/scala/util/FromDigits.scala
@@ -79,9 +79,13 @@ object FromDigits {
     }
     if (i == len) throw MalformedNumber()
     while (i < len) {
-      val c = digits(i)
-      val d = digit2int(c, radix)
-      if (d < 0) throw MalformedNumber()
+      val ch = digits(i)
+      val d =
+        if (ch <= '9') ch - '0'
+        else if ('a' <= ch && ch <= 'z') ch - 'a' + 10
+        else if ('A' <= ch && ch <= 'Z') ch - 'A' + 10
+        else -1
+      if (d < 0 || radix <= d) throw MalformedNumber()
       if (value < 0 ||
           limit / (radix / divider) < value ||
           limit - (d / divider) < value * (radix / divider) &&
@@ -90,19 +94,6 @@ object FromDigits {
       i += 1
     }
     if (negated) -value else value
-  }
-
-  /** Convert a character digit to an Int according to given base,
-   *  -1 if no success
-   */
-  private def digit2int(ch: Char, base: Int): Int = {
-    val num = (
-      if (ch <= '9') ch - '0'
-      else if ('a' <= ch && ch <= 'z') ch - 'a' + 10
-      else if ('A' <= ch && ch <= 'Z') ch - 'A' + 10
-      else -1
-      )
-    if (0 <= num && num < base) num else -1
   }
 
   /** Convert digit string to Int number

--- a/library/src/scala/util/FromDigits.scala
+++ b/library/src/scala/util/FromDigits.scala
@@ -1,7 +1,6 @@
 package scala.util
 import scala.math.{BigInt}
 import quoted._
-import internal.Chars.digit2int
 import annotation.internal.sharable
 
 /** A type class for types that admit numeric literals.
@@ -91,6 +90,19 @@ object FromDigits {
       i += 1
     }
     if (negated) -value else value
+  }
+
+  /** Convert a character digit to an Int according to given base,
+   *  -1 if no success
+   */
+  private def digit2int(ch: Char, base: Int): Int = {
+    val num = (
+      if (ch <= '9') ch - '0'
+      else if ('a' <= ch && ch <= 'z') ch - 'a' + 10
+      else if ('A' <= ch && ch <= 'Z') ch - 'A' + 10
+      else -1
+      )
+    if (0 <= num && num < base) num else -1
   }
 
   /** Convert digit string to Int number

--- a/scala3doc/src/dotty/dokka/tasty/TypesSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/TypesSupport.scala
@@ -157,7 +157,7 @@ trait TypesSupport:
         }
       }
       case t @ AppliedType(tpe, typeList) =>
-        import scala.internal.Chars._
+        import util.Chars._
         if !t.typeSymbol.name.forall(isIdentifierPart) && typeList.size == 2 then
           inner(typeList.head)
           ++ texts(" ")

--- a/scala3doc/src/dotty/dokka/tasty/TypesSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/TypesSupport.scala
@@ -157,7 +157,7 @@ trait TypesSupport:
         }
       }
       case t @ AppliedType(tpe, typeList) =>
-        import util.Chars._
+        import dotty.tools.dotc.util.Chars._
         if !t.typeSymbol.name.forall(isIdentifierPart) && typeList.size == 2 then
           inner(typeList.head)
           ++ texts(" ")


### PR DESCRIPTION
This class was there for a single use of `digit2int` in `FromDigits`.
`digit2int` was copied inside of `FromDigit`.