### PR TITLE
sbt reporter: Don't crash with malformed positions

### DIFF
--- a/sbt-bridge/src/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/xsbt/DelegatingReporter.java
@@ -127,7 +127,9 @@ final public class DelegatingReporter extends AbstractReporter {
           String lineContent = this.lineContent();
           int pointer = this.pointer().get();
           StringBuilder result = new StringBuilder();
-          for (int i = 0; i < pointer; i++)
+          // Don't crash if pointer is out-of-bounds (happens with some macros)
+          int fixedPointer = Math.min(pointer, lineContent.length());
+          for (int i = 0; i < fixedPointer; i++)
             result.append(lineContent.charAt(i) == '\t' ? '\t' : ' ');
           return Optional.of(result.toString());
         }


### PR DESCRIPTION
In https://github.com/Sciss/DottyScalaTestAssertCrash we get a crash
when trying to report a warning in RichNumberSuite.scala: the file
contains 284 characters and yet the `pos.point` of the error is at
position 8742, this line calls the scalatest `assert` macro so it seems
that something is wrong with the way we compute positions in macros (or
could the macro have a bug?). It'd be good if we could find the root
cause of the problem but in any case being robust when reporting errors
is better than crashing.

FWIW, after fixing this on top of 3.0.0-M1 and recompiling the
problematic project I see the following the warning:

[warn] -- [E123] Syntax Warning: /home/smarter/opt/DottyScalaTestAssertCrash/src/test/scala/synth/RichNumberSuite.scala:9:6
[warn] 9 |      assert(intInt1.isInstanceOf[Int], "found " + intInt1.getClass)
[warn]   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]   |The highlighted type test will always succeed since the scrutinee type (TermRef(NoPrefix,val x).show) is a subtype of Int
[warn]   | This location contains code that was inlined from RichNumberSuite.scala:12

Which still looks a bit weird (showing a raw TermRef, mentioning that
the code was inlined from `RichNumberSuite.scala:12` even thought that's
just the last line of a file which contains only a `}`.