### PR TITLE
Move quote internal representations to scala.internal

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -810,11 +810,11 @@ class Definitions {
     @tu lazy val LiftableModule_CharLiftable: Symbol = LiftableModule.requiredMethod("CharLiftable")
     @tu lazy val LiftableModule_StringLiftable: Symbol = LiftableModule.requiredMethod("StringLiftable")
 
-  @tu lazy val InternalQuotedModule: Symbol = requiredModule("scala.internal.quoted.CompileTime")
-    @tu lazy val InternalQuoted_exprQuote  : Symbol = InternalQuotedModule.requiredMethod("exprQuote")
-    @tu lazy val InternalQuoted_exprSplice : Symbol = InternalQuotedModule.requiredMethod("exprSplice")
-    @tu lazy val InternalQuoted_exprNestedSplice : Symbol = InternalQuotedModule.requiredMethod("exprNestedSplice")
-    @tu lazy val InternalQuoted_QuoteTypeTagAnnot: ClassSymbol = InternalQuotedModule.requiredClass("quoteTypeTag")
+  @tu lazy val QuotedModule: Symbol = requiredModule("scala.internal.Quoted")
+    @tu lazy val Quoted_exprQuote  : Symbol = QuotedModule.requiredMethod("exprQuote")
+    @tu lazy val Quoted_exprSplice : Symbol = QuotedModule.requiredMethod("exprSplice")
+    @tu lazy val Quoted_exprNestedSplice : Symbol = QuotedModule.requiredMethod("exprNestedSplice")
+    @tu lazy val Quoted_QuoteTypeTagAnnot: ClassSymbol = QuotedModule.requiredClass("quoteTypeTag")
 
   @tu lazy val InternalQuotedPatterns: Symbol = requiredModule("scala.internal.quoted.Patterns")
     @tu lazy val InternalQuotedPatterns_patternHole: Symbol = InternalQuotedPatterns.requiredMethod("patternHole")

--- a/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/DecompilerPrinter.scala
@@ -74,6 +74,6 @@ class DecompilerPrinter(_ctx: Context) extends RefinedPrinter(_ctx) {
   }
 
   override protected def typeApplyText[T >: Untyped](tree: TypeApply[T]): Text =
-    if (tree.symbol eq defn.InternalQuoted_exprQuote) "'"
+    if (tree.symbol eq defn.Quoted_exprQuote) "'"
     else super.typeApplyText(tree)
 }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -389,7 +389,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           changePrec (GlobalPrec) {
             keywordStr("throw ") ~ toText(args.head)
           }
-        else if (!printDebug && fun.hasType && fun.symbol == defn.InternalQuoted_exprQuote)
+        else if (!printDebug && fun.hasType && fun.symbol == defn.Quoted_exprQuote)
           keywordStr("'{") ~ toTextGlobal(args, ", ") ~ keywordStr("}")
         else if (!printDebug && fun.hasType && fun.symbol.isExprSplice)
           keywordStr("${") ~ toTextGlobal(args, ", ") ~ keywordStr("}")

--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -126,10 +126,10 @@ object PickledQuotes {
   /** Replace all type holes generated with the spliced types */
   private def spliceTypes(tree: Tree, pickledQuote: PickledQuote)(using Context): Tree = {
     tree match
-      case Block(stat :: rest, expr1) if stat.symbol.hasAnnotation(defn.InternalQuoted_QuoteTypeTagAnnot) =>
+      case Block(stat :: rest, expr1) if stat.symbol.hasAnnotation(defn.Quoted_QuoteTypeTagAnnot) =>
         val typeSpliceMap = (stat :: rest).iterator.map {
           case tdef: TypeDef =>
-            assert(tdef.symbol.hasAnnotation(defn.InternalQuoted_QuoteTypeTagAnnot))
+            assert(tdef.symbol.hasAnnotation(defn.Quoted_QuoteTypeTagAnnot))
             val tree = tdef.rhs match
               case TypeBoundsTree(_, Hole(_, idx, args), _) =>
                 val quotedType = pickledQuote.typeSplice(idx)(args)
@@ -144,7 +144,7 @@ object PickledQuotes {
               tp.derivedClassInfo(classParents = tp.classParents.map(apply))
             case tp: TypeRef =>
               typeSpliceMap.get(tp.symbol) match
-                case Some(t) if tp.typeSymbol.hasAnnotation(defn.InternalQuoted_QuoteTypeTagAnnot) => mapOver(t)
+                case Some(t) if tp.typeSymbol.hasAnnotation(defn.Quoted_QuoteTypeTagAnnot) => mapOver(t)
                 case _ => mapOver(tp)
             case _ =>
               mapOver(tp)

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -174,7 +174,7 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
       tp match
         case tp: TypeRef =>
           tp.prefix match
-            case NoPrefix if level > levelOf(tp.symbol) && !tp.typeSymbol.hasAnnotation(defn.InternalQuoted_QuoteTypeTagAnnot) =>
+            case NoPrefix if level > levelOf(tp.symbol) && !tp.typeSymbol.hasAnnotation(defn.Quoted_QuoteTypeTagAnnot) =>
               val tp1 = tp.dealias
               if tp1 != tp then apply(tp1)
               else tryHeal(tp.symbol, tp, pos)
@@ -279,7 +279,7 @@ object PCPCheckAndHeal {
         flags = Synthetic,
         info = TypeAlias(splicedTree.tpe.select(tpnme.Underlying)),
         coord = span).asType
-      local.addAnnotation(Annotation(defn.InternalQuoted_QuoteTypeTagAnnot))
+      local.addAnnotation(Annotation(defn.Quoted_QuoteTypeTagAnnot))
       ctx.typeAssigner.assignType(untpd.TypeDef(local.name, alias), local)
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifyQuotes.scala
@@ -78,7 +78,7 @@ class ReifyQuotes extends MacroTransform {
         assert(!tree.symbol.isQuote)
         assert(!tree.symbol.isExprSplice)
       case _ : TypeDef =>
-        assert(!tree.symbol.hasAnnotation(defn.InternalQuoted_QuoteTypeTagAnnot),
+        assert(!tree.symbol.hasAnnotation(defn.Quoted_QuoteTypeTagAnnot),
           s"${tree.symbol} should have been removed by PickledQuotes because it has a @quoteTypeTag")
       case _ =>
     }
@@ -434,7 +434,7 @@ class ReifyQuotes extends MacroTransform {
             if (tree.isType)
               transformSpliceType(body, body.select(tpnme.Underlying))
             else
-              val splice = ref(defn.InternalQuoted_exprSplice).appliedToType(tree.tpe).appliedTo(body)
+              val splice = ref(defn.Quoted_exprSplice).appliedToType(tree.tpe).appliedTo(body)
               transformSplice(body, splice)
 
           case tree: DefDef if tree.symbol.is(Macro) && level == 0 =>

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -143,7 +143,7 @@ object Splicer {
         case Block(Nil, expr) => checkIfValidArgument(expr)
         case Typed(expr, _) => checkIfValidArgument(expr)
 
-        case Apply(Select(Apply(fn, quoted :: Nil), nme.apply), _) if fn.symbol == defn.InternalQuoted_exprQuote =>
+        case Apply(Select(Apply(fn, quoted :: Nil), nme.apply), _) if fn.symbol == defn.Quoted_exprQuote =>
           // OK
 
         case Apply(Select(TypeApply(fn, List(quoted)), nme.apply), _)if fn.symbol == defn.QuotedTypeModule_apply =>
@@ -220,7 +220,7 @@ object Splicer {
       }
 
     def interpretTree(tree: Tree)(implicit env: Env): Object = tree match {
-      case Apply(Select(Apply(TypeApply(fn, _), quoted :: Nil), nme.apply), _) if fn.symbol == defn.InternalQuoted_exprQuote =>
+      case Apply(Select(Apply(TypeApply(fn, _), quoted :: Nil), nme.apply), _) if fn.symbol == defn.Quoted_exprQuote =>
         val quoted1 = quoted match {
           case quoted: Ident if quoted.symbol.isAllOf(InlineByNameProxy) =>
             // inline proxy for by-name parameter

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -49,7 +49,7 @@ class Staging extends MacroTransform {
                 else i"${sym.name}.this"
               val errMsg = s"\nin ${ctx.owner.fullName}"
               assert(
-                ctx.owner.hasAnnotation(defn.InternalQuoted_QuoteTypeTagAnnot) ||
+                ctx.owner.hasAnnotation(defn.Quoted_QuoteTypeTagAnnot) ||
                 (sym.isType && levelOf(sym) > 0),
                 em"""access to $symStr from wrong staging level:
                     | - the definition is at level ${levelOf(sym)},

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -220,11 +220,11 @@ object SymUtils {
 
   /** Is symbol a quote operation? */
   def isQuote(using Context): Boolean =
-    self == defn.InternalQuoted_exprQuote || self == defn.QuotedTypeModule_apply
+    self == defn.Quoted_exprQuote || self == defn.QuotedTypeModule_apply
 
   /** Is symbol a term splice operation? */
   def isExprSplice(using Context): Boolean =
-    self == defn.InternalQuoted_exprSplice || self == defn.InternalQuoted_exprNestedSplice
+    self == defn.Quoted_exprSplice || self == defn.Quoted_exprNestedSplice
 
   /** Is symbol a type splice operation? */
   def isTypeSplice(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -1254,7 +1254,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
 
     override def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree =
       constToLiteral(betaReduce(super.typedApply(tree, pt))) match {
-        case res: Apply if res.symbol == defn.InternalQuoted_exprSplice
+        case res: Apply if res.symbol == defn.Quoted_exprSplice
                         && level == 0
                         && !suppressInline =>
           val expanded = expandMacro(res.args.head, tree.span)

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -65,7 +65,7 @@ trait QuotesAndSplices {
         else report.warning(msg, tree.srcPos)
         typedTypeApply(untpd.TypeApply(untpd.ref(defn.QuotedTypeModule_apply.termRef), tree.quoted :: Nil), pt)(using quoteContext).select(nme.apply).appliedTo(qctx)
       else
-        typedApply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprQuote.termRef), tree.quoted), pt)(using pushQuoteContext(qctx)).select(nme.apply).appliedTo(qctx)
+        typedApply(untpd.Apply(untpd.ref(defn.Quoted_exprQuote.termRef), tree.quoted), pt)(using pushQuoteContext(qctx)).select(nme.apply).appliedTo(qctx)
     tree1.withSpan(tree.span)
   }
 
@@ -86,7 +86,7 @@ trait QuotesAndSplices {
           using spliceContext.retractMode(Mode.QuotedPattern).addMode(Mode.Pattern).withOwner(spliceOwner(ctx)))
         val baseType = pat.tpe.baseType(defn.QuotedExprClass)
         val argType = if baseType != NoType then baseType.argTypesHi.head else defn.NothingType
-        ref(defn.InternalQuoted_exprSplice).appliedToType(argType).appliedTo(pat)
+        ref(defn.Quoted_exprSplice).appliedToType(argType).appliedTo(pat)
       }
       else {
         report.error(i"Type must be fully defined.\nConsider annotating the splice using a type ascription:\n  ($tree: XYZ).", tree.expr.srcPos)
@@ -107,8 +107,8 @@ trait QuotesAndSplices {
 
       val internalSplice =
         outerQctx match
-          case Some(qctxRef) => untpd.Apply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprNestedSplice.termRef), qctxRef), tree.expr)
-          case _ => untpd.Apply(untpd.ref(defn.InternalQuoted_exprSplice.termRef), tree.expr)
+          case Some(qctxRef) => untpd.Apply(untpd.Apply(untpd.ref(defn.Quoted_exprNestedSplice.termRef), qctxRef), tree.expr)
+          case _ => untpd.Apply(untpd.ref(defn.Quoted_exprSplice.termRef), tree.expr)
 
       typedApply(internalSplice, pt)(using ctx1).withSpan(tree.span)
     }
@@ -249,7 +249,7 @@ trait QuotesAndSplices {
         case Typed(Apply(fn, pat :: Nil), tpt) if fn.symbol.isExprSplice && !tpt.tpe.derivesFrom(defn.RepeatedParamClass) =>
           val tpt1 = transform(tpt) // Transform type bindings
           val exprTpt = AppliedTypeTree(TypeTree(defn.QuotedExprClass.typeRef), tpt1 :: Nil)
-          val newSplice = ref(defn.InternalQuoted_exprSplice).appliedToType(tpt1.tpe).appliedTo(Typed(pat, exprTpt))
+          val newSplice = ref(defn.Quoted_exprSplice).appliedToType(tpt1.tpe).appliedTo(Typed(pat, exprTpt))
           transform(newSplice)
         case Apply(TypeApply(fn, targs), Apply(sp, pat :: Nil) :: args :: Nil) if fn.symbol == defn.InternalQuotedPatterns_patternHigherOrderHole =>
           args match // TODO support these patterns. Possibly using scala.quoted.util.Var
@@ -460,7 +460,7 @@ trait QuotesAndSplices {
 
     val quoteClass = if (tree.quoted.isTerm) defn.QuotedExprClass else defn.QuotedTypeClass
     val quotedPattern =
-      if (tree.quoted.isTerm) ref(defn.InternalQuoted_exprQuote.termRef).appliedToType(defn.AnyType).appliedTo(shape).select(nme.apply).appliedTo(qctx)
+      if (tree.quoted.isTerm) ref(defn.Quoted_exprQuote.termRef).appliedToType(defn.AnyType).appliedTo(shape).select(nme.apply).appliedTo(qctx)
       else ref(defn.QuotedTypeModule_apply.termRef).appliedToTypeTree(shape).select(nme.apply).appliedTo(qctx)
 
     val matchModule = if tree.quoted.isTerm then defn.QuoteContextInternalClass_ExprMatch else defn.QuoteContextInternalClass_TypeMatch

--- a/library/src/scala/internal/Quoted.scala
+++ b/library/src/scala/internal/Quoted.scala
@@ -1,10 +1,10 @@
-package scala.internal.quoted
+package scala.internal
 
 import scala.annotation.{Annotation, compileTimeOnly}
 import scala.quoted._
 
 @compileTimeOnly("Illegal reference to `scala.internal.quoted.CompileTime`")
-object CompileTime {
+object Quoted {
 
   /** A term quote is desugared by the compiler into a call to this method */
   @compileTimeOnly("Illegal reference to `scala.internal.quoted.CompileTime.exprQuote`")

--- a/tests/run-staging/multi-staging.check
+++ b/tests/run-staging/multi-staging.check
@@ -1,5 +1,5 @@
 stage1 code: ((qctx1: scala.quoted.QuoteContext) ?=> {
   val x1: scala.Int = 2
-  scala.internal.quoted.CompileTime.exprQuote[scala.Int](1.+(scala.internal.quoted.CompileTime.exprNestedSplice[scala.Int](qctx1)(((evidence$5: qctx1.Nested) ?=> scala.quoted.Expr.apply[scala.Int](x1)(evidence$5, scala.quoted.Liftable.IntLiftable[scala.Int]))))).apply(using qctx1)
+  '{1.+(scala.internal.Quoted.exprNestedSplice[scala.Int](qctx1)(((evidence$5: qctx1.Nested) ?=> scala.quoted.Expr.apply[scala.Int](x1)(evidence$5, scala.quoted.Liftable.IntLiftable[scala.Int]))))}.apply(using qctx1)
 })
 3

--- a/tests/run-staging/quote-nested-1.check
+++ b/tests/run-staging/quote-nested-1.check
@@ -1,1 +1,1 @@
-((qctx: scala.quoted.QuoteContext) ?=> scala.internal.quoted.CompileTime.exprQuote[scala.Int](3).apply(using qctx))
+((qctx: scala.quoted.QuoteContext) ?=> '{3}.apply(using qctx))

--- a/tests/run-staging/quote-nested-2.check
+++ b/tests/run-staging/quote-nested-2.check
@@ -1,4 +1,4 @@
 ((qctx: scala.quoted.QuoteContext) ?=> {
-  val a: scala.quoted.Expr[scala.Int] = scala.internal.quoted.CompileTime.exprQuote[scala.Int](4).apply(using qctx)
+  val a: scala.quoted.Expr[scala.Int] = '{4}.apply(using qctx)
   ((evidence$2: qctx.Nested) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx)
 })

--- a/tests/run-staging/quote-nested-5.check
+++ b/tests/run-staging/quote-nested-5.check
@@ -1,4 +1,4 @@
 ((qctx: scala.quoted.QuoteContext) ?=> {
-  val a: scala.quoted.Expr[scala.Int] = scala.internal.quoted.CompileTime.exprQuote[scala.Int](4).apply(using qctx)
+  val a: scala.quoted.Expr[scala.Int] = '{4}.apply(using qctx)
   ((qctx2: scala.quoted.QuoteContext) ?=> ((evidence$3: qctx2.Nested) ?=> a).asInstanceOf[scala.ContextFunction1[scala.quoted.QuoteContext, scala.quoted.Expr[scala.Int]]].apply(using qctx2)).apply(using qctx)
 })


### PR DESCRIPTION
This object contains the internal representations of quotes and splices used in the compiler.