### PR TITLE
updated version message

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -31,7 +31,7 @@ object CompilerCommand {
 
   def shortUsage: String = s"Usage: $cmdName <options> <source files>"
 
-  def versionMsg: String = s"Dotty compiler $versionString -- $copyrightString"
+  def versionMsg: String = s"Scala compiler $versionString -- $copyrightString"
 
   /** Distill arguments into summary detailing settings, errors and files to compiler */
   def distill(args: Array[String])(using Context): ArgsSummary = {


### PR DESCRIPTION
Prints version message
```
$ c:\opt\scala-3.0.0-M1\bin\scalac -version
Scala compiler version 3.0.0-M2-bin-20201105-c20be38-NIGHTLY-git-c20be38 -- Copyright 2002-2020, LAMP/EPFL
```
instead of
```
$ c:\opt\scala-3.0.0-M1\bin\scalac -version
Dotty compiler version 3.0.0-M2-bin-20201105-c20be38-NIGHTLY-git-c20be38 -- Copyright 2002-2020, LAMP/EPFL
```
