### PR TITLE
Fix 10256: Avoid crashing in LazyRef.ref when checking for cycles

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -41,6 +41,7 @@ object Mode {
    */
   val TypevarsMissContext: Mode = newMode(4, "TypevarsMissContext")
 
+  /** Are we looking for cyclic references? */
   val CheckCyclic: Mode = newMode(5, "CheckCyclic")
 
   /** We are in a pattern alternative */

--- a/tests/neg/i10256.scala
+++ b/tests/neg/i10256.scala
@@ -1,0 +1,7 @@
+trait Foo[T <: Foo[T]] {
+  type I <: Foo[I]
+}
+
+trait Bar[T <: Foo[T]] extends Foo[T] { // error: cyclic
+  self: T =>
+}


### PR DESCRIPTION
Report a cycle instead.
