### PR TITLE
Bump sbt to 1.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules
 .bloop/
 .metals/
 metals.sbt
+.bsp
 
 # Scala-IDE specific
 .scala_dependencies

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.4.2


### PR DESCRIPTION
Add .bsp to git igonre

This will allow use to utilize Metals 0.9.5 and its ablity to use sbt as build server.

From my tesking so far it seems to work (diagnostics, go to definition, find usages etc).