### PR TITLE
Align `quoted.Type` with `reflect.TypeRepr` and `reflect.TypeTree`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -395,7 +395,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     case New(_) | Closure(_, _, _) =>
       Pure
     case TypeApply(fn, _) =>
-      if (fn.symbol.is(Erased) || fn.symbol == defn.QuotedTypeModule_apply || fn.symbol == defn.Predef_classOf) Pure else exprPurity(fn)
+      if (fn.symbol.is(Erased) || fn.symbol == defn.QuotedTypeModule_of || fn.symbol == defn.Predef_classOf) Pure else exprPurity(fn)
     case Apply(fn, args) =>
       def isKnownPureOp(sym: Symbol) =
         sym.owner.isPrimitiveValueClass

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -833,7 +833,7 @@ class Definitions {
     @tu lazy val QuotedType_splice: Symbol = QuotedTypeClass.requiredType(tpnme.Underlying)
 
   @tu lazy val QuotedTypeModule: Symbol = QuotedTypeClass.companionModule
-    @tu lazy val QuotedTypeModule_apply: Symbol = QuotedTypeModule.requiredMethod("apply")
+    @tu lazy val QuotedTypeModule_of: Symbol = QuotedTypeModule.requiredMethod("of")
 
   @tu lazy val TastyReflectionClass: ClassSymbol = requiredClass("scala.tasty.Reflection")
 

--- a/compiler/src/dotty/tools/dotc/quoted/TypeImpl.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/TypeImpl.scala
@@ -24,5 +24,5 @@ final class TypeImpl(val typeTree: tpd.Tree, val scopeId: Int) extends scala.quo
       throw new ScopeException("Cannot call `scala.quoted.staging.run(...)` within a macro or another `run(...)`")
 
   override def hashCode: Int = typeTree.hashCode
-  override def toString: String = "'[ ... ]"
+  override def toString: String = "Type.of[...]"
 }

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -128,7 +128,7 @@ class PickleQuotes extends MacroTransform {
      *  core and splices as arguments.
      */
     override protected def transformQuotation(body: Tree, quote: Tree)(using Context): Tree = {
-      val isType = quote.symbol eq defn.QuotedTypeModule_apply
+      val isType = quote.symbol eq defn.QuotedTypeModule_of
       if (level > 0) {
         val body1 = nested(isQuote = true).transform(body)(using quoteContext)
         super.transformQuotation(body1, quote)
@@ -472,7 +472,7 @@ class PickleQuotes extends MacroTransform {
         transform(tree)(using ctx.withSource(tree.source))
       else reporting.trace(i"Reifier.transform $tree at $level", show = true) {
         tree match {
-          case Apply(Select(TypeApply(fn, (body: RefTree) :: Nil), _), _) if fn.symbol == defn.QuotedTypeModule_apply && isCaptured(body.symbol, level + 1) =>
+          case Apply(Select(TypeApply(fn, (body: RefTree) :: Nil), _), _) if fn.symbol == defn.QuotedTypeModule_of && isCaptured(body.symbol, level + 1) =>
             // Optimization: avoid the full conversion when capturing `x`
             // in '{ x } to '{ ${x$1} } and go directly to `x$1`
             capturers(body.symbol)(body)

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -146,7 +146,7 @@ object Splicer {
         case Apply(Select(Apply(fn, quoted :: Nil), nme.apply), _) if fn.symbol == defn.InternalQuoted_exprQuote =>
           // OK
 
-        case Apply(Select(TypeApply(fn, List(quoted)), nme.apply), _)if fn.symbol == defn.QuotedTypeModule_apply =>
+        case Apply(Select(TypeApply(fn, List(quoted)), nme.apply), _)if fn.symbol == defn.QuotedTypeModule_of =>
           // OK
 
         case Literal(Constant(value)) =>
@@ -230,7 +230,7 @@ object Splicer {
         }
         interpretQuote(quoted1)
 
-      case Apply(Select(TypeApply(fn, quoted :: Nil), _), _) if fn.symbol == defn.QuotedTypeModule_apply =>
+      case Apply(Select(TypeApply(fn, quoted :: Nil), _), _) if fn.symbol == defn.QuotedTypeModule_of =>
         interpretTypeQuote(quoted)
 
       case Literal(Constant(value)) =>

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -223,7 +223,7 @@ object SymUtils:
 
     /** Is symbol a quote operation? */
     def isQuote(using Context): Boolean =
-      self == defn.InternalQuoted_exprQuote || self == defn.QuotedTypeModule_apply
+      self == defn.InternalQuoted_exprQuote || self == defn.QuotedTypeModule_of
 
     /** Is symbol a term splice operation? */
     def isExprSplice(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -524,7 +524,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
       case New(_) | Closure(_, _, _) =>
         true
       case TypeApply(fn, _) =>
-        if (fn.symbol.is(Erased) || fn.symbol == defn.QuotedTypeModule_apply) true else apply(fn)
+        if (fn.symbol.is(Erased) || fn.symbol == defn.QuotedTypeModule_of) true else apply(fn)
       case Apply(fn, args) =>
         def isKnownPureOp(sym: Symbol) =
           sym.owner.isPrimitiveValueClass

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -63,7 +63,7 @@ trait QuotesAndSplices {
         val msg = em"Consider using canonical type constructor scala.quoted.Type[${tree.quoted}] instead"
         if sourceVersion.isAtLeast(`3.1-migration`) then report.error(msg, tree.srcPos)
         else report.warning(msg, tree.srcPos)
-        typedTypeApply(untpd.TypeApply(untpd.ref(defn.QuotedTypeModule_apply.termRef), tree.quoted :: Nil), pt)(using quoteContext).select(nme.apply).appliedTo(qctx)
+        typedTypeApply(untpd.TypeApply(untpd.ref(defn.QuotedTypeModule_of.termRef), tree.quoted :: Nil), pt)(using quoteContext).select(nme.apply).appliedTo(qctx)
       else
         typedApply(untpd.Apply(untpd.ref(defn.InternalQuoted_exprQuote.termRef), tree.quoted), pt)(using pushQuoteContext(qctx)).select(nme.apply).appliedTo(qctx)
     tree1.withSpan(tree.span)
@@ -461,7 +461,7 @@ trait QuotesAndSplices {
     val quoteClass = if (tree.quoted.isTerm) defn.QuotedExprClass else defn.QuotedTypeClass
     val quotedPattern =
       if (tree.quoted.isTerm) ref(defn.InternalQuoted_exprQuote.termRef).appliedToType(defn.AnyType).appliedTo(shape).select(nme.apply).appliedTo(qctx)
-      else ref(defn.QuotedTypeModule_apply.termRef).appliedToTypeTree(shape).select(nme.apply).appliedTo(qctx)
+      else ref(defn.QuotedTypeModule_of.termRef).appliedToTypeTree(shape).select(nme.apply).appliedTo(qctx)
 
     val matchModule = if tree.quoted.isTerm then defn.QuoteMatching_ExprMatch else defn.QuoteMatching_TypeMatch
     val unapplyFun = qctx.asInstance(defn.QuoteMatchingClass.typeRef).select(matchModule).select(nme.unapply)

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -20,7 +20,7 @@ object Type:
     qctx.reflect.TypeTree.of[T].showAnsiColored
 
   /** Return a quoted.Type with the given type */
-  @compileTimeOnly("Reference to `scala.quoted.Type.apply` was not handled by PickleQuotes")
-  given apply[T <: AnyKind] as (QuoteContext ?=> Type[T]) = ???
+  @compileTimeOnly("Reference to `scala.quoted.Type.of` was not handled by PickleQuotes")
+  given of[T <: AnyKind] as (QuoteContext ?=> Type[T]) = ???
 
 end Type

--- a/library/src-non-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Type.scala
@@ -7,4 +7,5 @@ abstract class Type[T <: AnyKind] private[scala]:
 
 object Type:
   @compileTimeOnly("Reference to `scala.quoted.Type.apply` was not handled by PickleQuotes")
+  given of[T <: AnyKind] as (QuoteContext ?=> Type[T]) = ???
   given apply[T <: AnyKind] as (QuoteContext ?=> Type[T]) = ???

--- a/tests/neg-macros/i4493-b.scala
+++ b/tests/neg-macros/i4493-b.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 class Index[K]
 object Index {
   inline def succ[K](x: K): Unit = ${
-    implicit val t: Type[K] = Type[K] // error
+    implicit val t: Type[K] = Type.of[K] // error
     '{new Index[K]} // error
   }
 }

--- a/tests/neg-macros/i4493.scala
+++ b/tests/neg-macros/i4493.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 class Index[K]
 object Index {
   inline def succ[K]: Unit = ${
-    implicit val t: Type[K] = Type[K] // error
+    implicit val t: Type[K] = Type.of[K] // error
     '{new Index[K]} // error
   }
 }

--- a/tests/neg-macros/i7121.scala
+++ b/tests/neg-macros/i7121.scala
@@ -7,7 +7,7 @@ class Test()(implicit qtx: QuoteContext) {
   @annot1('{4}) // error
   def foo(str: String) = ()
 
-  @annot2(4)(using Type[Int]) // error
+  @annot2(4)(using Type.of[Int]) // error
   def foo2(str: String) = ()
 
 }

--- a/tests/neg-macros/quotedPatterns-5.scala
+++ b/tests/neg-macros/quotedPatterns-5.scala
@@ -1,10 +1,10 @@
 import scala.quoted._
 object Test {
   def test(x: quoted.Expr[Int])(using QuoteContext): Unit = x match {
-    case '{ type t; 4 } => Type[t]
+    case '{ type t; 4 } => Type.of[t]
     case '{ type t; poly[t]($x); 4 } => // error: duplicate pattern variable: t
     case '{ type `t`; poly[`t`]($x); 4 } =>
-      Type[t] // error
+      Type.of[t] // error
     case _ =>
   }
 

--- a/tests/patmat/i9489.scala
+++ b/tests/patmat/i9489.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-def summonTypedType[T : Type](using QuoteContext): String = Type[T] match {
+def summonTypedType[T : Type](using QuoteContext): String = Type.of[T] match {
   case '[Boolean] => "Boolean"
   case '[Byte] => "Byte"
   case _ => "Other"

--- a/tests/pos-macros/i10050.scala
+++ b/tests/pos-macros/i10050.scala
@@ -24,6 +24,6 @@ def test[T: Type](x: Expr[Any])(using QuoteContext): Unit =
     case '{ type t; $x: `t` } => // match any `t` and bind it as a type variable
       '{ val y: t = $x; } // use `t` provided by previous match
 
-  Type[T] match
-    case '[List[u]] => Type[u]
-    case '[u] => Type[u]
+  Type.of[T] match
+    case '[List[u]] => Type.of[u]
+    case '[u] => Type.of[u]

--- a/tests/pos-macros/i4539.scala
+++ b/tests/pos-macros/i4539.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 def test(using QuoteContext) = {
-  val q = Type[String]
-  Type[String]
+  val q = Type.of[String]
+  Type.of[String]
 }

--- a/tests/pos-macros/i4539b.scala
+++ b/tests/pos-macros/i4539b.scala
@@ -2,21 +2,21 @@ import scala.quoted._
 def test(using QuoteContext): Unit = {
   def f = {
     {
-      Type[String]
-      Type[String]
+      Type.of[String]
+      Type.of[String]
     }
 
-    Type[String] match { case _ => }
-    try Type[String] catch { case _ => }
+    Type.of[String] match { case _ => }
+    try Type.of[String] catch { case _ => }
 
-    Type[String]
-    Type[String]
+    Type.of[String]
+    Type.of[String]
   }
 
   def bar[T](t: Type[T]) = ???
-  bar(Type[String])
+  bar(Type.of[String])
 
   class Baz[T](t: Type[T])
-  new Baz(Type[String])
+  new Baz(Type.of[String])
 
 }

--- a/tests/pos-macros/i6140.scala
+++ b/tests/pos-macros/i6140.scala
@@ -4,5 +4,5 @@ sealed trait Trait[T] {
 }
 
 object O {
-  def fn[T:Type](t : Trait[T])(using QuoteContext): Type[T] = Type[t.t]
+  def fn[T:Type](t : Trait[T])(using QuoteContext): Type[T] = Type.of[t.t]
 }

--- a/tests/pos-macros/i6142.scala
+++ b/tests/pos-macros/i6142.scala
@@ -4,7 +4,7 @@ object O {
   def foo(using QuoteContext) = {
     type T
     implicit val _: scala.quoted.Type[T] = ???
-    Type[List[T]]
+    Type.of[List[T]]
     ()
   }
 }

--- a/tests/pos-macros/i6210/Macros_1.scala
+++ b/tests/pos-macros/i6210/Macros_1.scala
@@ -5,7 +5,7 @@ object Macro {
     ${ impl[A, B] }
 
   def impl[A : Type, B : Type](using QuoteContext): Expr[Any] = {
-    val t = Type[Map[A, B]]
+    val t = Type.of[Map[A, B]]
     '{
       new Object().asInstanceOf[t.Underlying]
       ???.asInstanceOf[t.Underlying]

--- a/tests/pos-macros/i7048b.scala
+++ b/tests/pos-macros/i7048b.scala
@@ -7,6 +7,6 @@ trait IsExpr {
 val foo: IsExpr = ???
 
 def g()(using QuoteContext): Unit = {
-  val a = Type[foo.Underlying]
+  val a = Type.of[foo.Underlying]
   ()
 }

--- a/tests/pos-macros/i7264.scala
+++ b/tests/pos-macros/i7264.scala
@@ -2,6 +2,6 @@ import scala.quoted._
 class Foo {
   def f[T2](t: Type[T2])(using QuoteContext) = t match {
     case '[ *:[Int, t2] ] =>
-      Type[ *:[Int, t2] ]
+      Type.of[ *:[Int, t2] ]
   }
 }

--- a/tests/pos-macros/i7264b.scala
+++ b/tests/pos-macros/i7264b.scala
@@ -2,6 +2,6 @@ import scala.quoted._
 class Foo {
   def f[T2: Type](e: Expr[T2])(using QuoteContext) = e match {
     case '{ $x: *:[Int, t] } =>
-      Type[ *:[Int, t] ]
+      Type.of[ *:[Int, t] ]
   }
 }

--- a/tests/pos-macros/i7264c.scala
+++ b/tests/pos-macros/i7264c.scala
@@ -2,8 +2,8 @@ import scala.quoted._
 class Foo {
   def f[T2: Type](e: Expr[T2])(using QuoteContext) = e match {
     case '{ $x: t0 } =>
-      Type[t0] match
+      Type.of[t0] match
         case '[ *:[Int, t] ] =>
-          Type[ *:[Int, t] ]
+          Type.of[ *:[Int, t] ]
   }
 }

--- a/tests/pos-macros/i7405.scala
+++ b/tests/pos-macros/i7405.scala
@@ -5,7 +5,7 @@ class Foo {
       type X = Int // Level 1
       val x: X = ???
       ${
-        val t: Type[X] = Type[X] // Level 0
+        val t: Type[X] = Type.of[X] // Level 0
         '{ val y: t.Underlying = x }
       }
     }

--- a/tests/pos-macros/i7405b.scala
+++ b/tests/pos-macros/i7405b.scala
@@ -10,7 +10,7 @@ class Foo {
       val x: X = ???
       type Z = x.Y
       ${
-        val t: Type[Z] = Type[Z]
+        val t: Type[Z] = Type.of[Z]
         '{ val y: Z = x.y }
         '{ val y: t.Underlying = x.y }
       }

--- a/tests/pos-macros/i8100.scala
+++ b/tests/pos-macros/i8100.scala
@@ -10,10 +10,10 @@ def f[T: Type](using QuoteContext) =
       '{
         val m = $mm
         type ME = m.E
-        ${ g[ME](using Type[ME]) }
-        ${ g[m.E](using Type[ME]) }
-        ${ g[ME](using Type[m.E]) }
-        ${ g[m.E](using Type[m.E]) }
+        ${ g[ME](using Type.of[ME]) }
+        ${ g[m.E](using Type.of[ME]) }
+        ${ g[ME](using Type.of[m.E]) }
+        ${ g[m.E](using Type.of[m.E]) }
         // ${ g[ME] } // FIXME: issue seems to be in PickleQuotes
         // ${ g[m.E] } // FIXME: issue seems to be in PickleQuotes
       }

--- a/tests/pos-macros/i8302.scala
+++ b/tests/pos-macros/i8302.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 def foo[T](using qctx: QuoteContext, tpe: Type[T]): Expr[Any] =
   '{ (using qctx: QuoteContext) =>
     type TT = T
-    val t = Type[TT]
+    val t = Type.of[TT]
     ???
   }
 

--- a/tests/pos-macros/i9518/Macro_1.scala
+++ b/tests/pos-macros/i9518/Macro_1.scala
@@ -10,8 +10,8 @@ def shiftTerm(using QuoteContext): Expr[Unit] = {
   val nTree = '{ ??? : CB[Int] }.unseal
   val tp1 = TypeRepr.of[CB[Int]]
   val tp2 = TypeRepr.of[([X] =>> CB[X])[Int]]
-  val ta = Type[[X] =>> CB[X]]
-  val tp3 = TypeRepr.of(using Type[ta.Underlying[Int]])
+  val ta = Type.of[[X] =>> CB[X]]
+  val tp3 = TypeRepr.of(using Type.of[ta.Underlying[Int]])
   val tp4 = TypeRepr.of[CB].appliedTo(TypeRepr.of[Int])
   assert(nTree.tpe <:< tp1)
   assert(nTree.tpe <:< tp2)

--- a/tests/pos-macros/macro-with-type/Macro_1.scala
+++ b/tests/pos-macros/macro-with-type/Macro_1.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Macro {
-  inline def ff: Unit = ${impl(Type[Int])}
+  inline def ff: Unit = ${impl(Type.of[Int])}
   def impl(t: Type[Int])(using QuoteContext): Expr[Unit] = '{}
 }

--- a/tests/pos-macros/quote-1.scala
+++ b/tests/pos-macros/quote-1.scala
@@ -7,9 +7,9 @@ class Test(using QuoteContext) {
     val z = $x
   }
 
-  f('{2})(Type[Int])
-  f('{ true })(Type[Boolean])
+  f('{2})(Type.of[Int])
+  f('{ true })(Type.of[Boolean])
 
   def g(es: Expr[String], t: Type[String]) =
-    f('{ ($es + "!") :: Nil })(Type[List[t.Underlying]])
+    f('{ ($es + "!") :: Nil })(Type.of[List[t.Underlying]])
 }

--- a/tests/run-macros/i8007/Macro_1.scala
+++ b/tests/run-macros/i8007/Macro_1.scala
@@ -5,7 +5,7 @@ import scala.quoted._
 object Macro1 {
 
   def mirrorFields[T: Type](using qctx: QuoteContext): List[String] =
-    Type[T] match {
+    Type.of[T] match {
       case '[field *: fields] => Type.show[field] :: mirrorFields[fields]
       case '[EmptyTuple] => Nil
     }
@@ -19,7 +19,7 @@ object Macro1 {
   def test1Impl[T: Type](value: Expr[T])(using qctx: QuoteContext): Expr[List[String]] = {
     import qctx.reflect._
 
-    val mirrorTpe = Type[Mirror.Of[T]]
+    val mirrorTpe = Type.of[Mirror.Of[T]]
 
     Expr.summon(using mirrorTpe).get match {
       case '{ $m: Mirror.ProductOf[T]{ type MirroredElemLabels = elems } } => {

--- a/tests/run-macros/i8007/Macro_2.scala
+++ b/tests/run-macros/i8007/Macro_2.scala
@@ -45,7 +45,7 @@ object Macro2 {
   def test2Impl[T: Type](value: Expr[T])(using qctx: QuoteContext): Expr[Unit] = {
     import qctx.reflect._
 
-    val mirrorTpe = Type[Mirror.Of[T]]
+    val mirrorTpe = Type.of[Mirror.Of[T]]
     val mirrorExpr = Expr.summon(using mirrorTpe).get
     val derivedInstance = JsonEncoder.derived(mirrorExpr)
 

--- a/tests/run-macros/i8007/Macro_3.scala
+++ b/tests/run-macros/i8007/Macro_3.scala
@@ -35,7 +35,7 @@ object Eq {
   given derived[T: Type](using qctx: QuoteContext) as Expr[Eq[T]] = {
     import qctx.reflect._
 
-    val ev: Expr[Mirror.Of[T]] = Expr.summon(using Type[Mirror.Of[T]]).get
+    val ev: Expr[Mirror.Of[T]] = Expr.summon(using Type.of[Mirror.Of[T]]).get
 
     ev match {
       case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = elementTypes }} =>

--- a/tests/run-macros/quote-indexed-map-by-name/quoted_1.scala
+++ b/tests/run-macros/quote-indexed-map-by-name/quoted_1.scala
@@ -5,7 +5,7 @@ object Index {
 
   implicit def zero[K, T]: Index[K, (K, T)] = new Index(0)
 
-  implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ${succImpl(Type[K], Type[H], Type[T])}
+  implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ${succImpl(Type.of[K], Type.of[H], Type.of[T])}
 
   def succImpl[K, H, T](k: Type[K], h: Type[H], t: Type[T])(using QuoteContext): Expr[Index[K, (H, T)]] = {
     implicit val kk: Type[K] = k

--- a/tests/run-macros/string-context-implicits/Macro_1.scala
+++ b/tests/run-macros/string-context-implicits/Macro_1.scala
@@ -8,7 +8,7 @@ private def showMeExpr(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using 
     case Varargs(argExprs) =>
       val argShowedExprs = argExprs.map {
         case '{ $arg: tp } =>
-          val showTp = Type[Show[tp]]
+          val showTp = Type.of[Show[tp]]
           Expr.summon(using showTp) match {
             case Some(showExpr) => '{ $showExpr.show($arg) }
             case None => report.error(s"could not find implicit for ${Type.show[Show[tp]]}", arg); '{???}

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -41,7 +41,7 @@ object Macros {
       )
 
     assert(x1T =:= TypeRepr.of[1])
-    assert(x2T =:= TypeRepr.of(using Type[1|2]))
+    assert(x2T =:= TypeRepr.of(using Type.of[1|2]))
     assert(x3T =:= TypeRepr.of[3&Any])
     assert(x4T =:= TypeRepr.of[[A,B] =>> B])
     assert(x5T =:= TypeRepr.of[RefineMe { type T = Int }])

--- a/tests/run-macros/tasty-linenumber/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber/quoted_1.scala
@@ -7,7 +7,7 @@ class LineNumber(val value: Int) {
 object LineNumber {
 
   implicit inline def line[T >: Unit <: Unit]: LineNumber =
-    ${lineImpl(Type[T])}
+    ${lineImpl(Type.of[T])}
 
   def lineImpl(x: Type[Unit])(using QuoteContext) : Expr[LineNumber] = {
     import qctx.reflect._

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   inline def fun2(x: =>Any): Unit = ${ impl('x) }
 
-  inline def fun3[T]: Unit = ${ impl2(using Type[T]) }
+  inline def fun3[T]: Unit = ${ impl2(using Type.of[T]) }
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._

--- a/tests/run-staging/i3823-b.scala
+++ b/tests/run-staging/i3823-b.scala
@@ -6,6 +6,6 @@ object Test {
     def f[T](x: Expr[T])(implicit t: Type[T]) = '{
       val z: t.Underlying = $x
     }
-    println(f('{2})(Type[Int]).show)
+    println(f('{2})(Type.of[Int]).show)
   }
 }

--- a/tests/run-staging/i3823-c.scala
+++ b/tests/run-staging/i3823-c.scala
@@ -6,6 +6,6 @@ object Test {
     def f[T](x: Expr[T])(implicit t: Type[T]) = '{
       val z = $x
     }
-    println(f('{2})(Type[Int]).show)
+    println(f('{2})(Type.of[Int]).show)
   }
 }

--- a/tests/run-staging/i3823.scala
+++ b/tests/run-staging/i3823.scala
@@ -6,6 +6,6 @@ object Test {
     def f[T](x: Expr[T])(using t: Type[T]) = '{
       val z: t.Underlying = $x
     }
-    println(f('{2})(using Type[Int]).show)
+    println(f('{2})(using Type.of[Int]).show)
   }
 }

--- a/tests/run-staging/i4044e.scala
+++ b/tests/run-staging/i4044e.scala
@@ -6,7 +6,7 @@ class Foo {
   def foo: Unit = withQuoteContext {
     val e: Expr[Int] = '{3}
     val f: Expr[Int] = '{5}
-    val t: Type[Int] = Type[Int]
+    val t: Type[Int] = Type.of[Int]
     val q = '{ ${ '{ ($e + $f).asInstanceOf[t.Underlying] } } }
     println(q.show)
   }

--- a/tests/run-staging/i5247.scala
+++ b/tests/run-staging/i5247.scala
@@ -8,11 +8,11 @@ object Test {
     println(bar[Object].show)
   }
   def foo[H : Type](using QuoteContext): Expr[H] = {
-    val t = Type[H]
+    val t = Type.of[H]
     '{ null.asInstanceOf[t.Underlying] }
   }
   def bar[H : Type](using QuoteContext): Expr[List[H]] = {
-    val t = Type[List[H]]
+    val t = Type.of[List[H]]
     '{ null.asInstanceOf[t.Underlying] }
   }
 }

--- a/tests/run-staging/i5965.scala
+++ b/tests/run-staging/i5965.scala
@@ -5,7 +5,7 @@ object Test {
 
   given Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
-    withQuoteContext(Type[List])
+    withQuoteContext(Type.of[List])
 
     def list(using QuoteContext) = bound('{List(1, 2, 3)})
     println(withQuoteContext(list.show))

--- a/tests/run-staging/i5965b.scala
+++ b/tests/run-staging/i5965b.scala
@@ -6,7 +6,7 @@ object Test {
   def main(args: Array[String]): Unit = {
     given Toolbox = Toolbox.make(getClass.getClassLoader)
 
-    withQuoteContext(Type[List])
+    withQuoteContext(Type.of[List])
     def list(using QuoteContext) = bound('{List(1, 2, 3)})
     println(withQuoteContext(list.show))
     println(run(list))

--- a/tests/run-staging/quote-nested-4.check
+++ b/tests/run-staging/quote-nested-4.check
@@ -1,5 +1,5 @@
 ((qctx: scala.quoted.QuoteContext) ?=> {
-  val t: scala.quoted.Type[scala.Predef.String] = scala.quoted.Type.apply[scala.Predef.String].apply(using qctx)
+  val t: scala.quoted.Type[scala.Predef.String] = scala.quoted.Type.of[scala.Predef.String].apply(using qctx)
 
   (t: scala.quoted.Type[scala.Predef.String])
 })

--- a/tests/run-staging/quote-nested-4.scala
+++ b/tests/run-staging/quote-nested-4.scala
@@ -6,7 +6,7 @@ object Test {
   def main(args: Array[String]): Unit = withQuoteContext {
 
     val q = '{ (using qctx: QuoteContext) =>
-      val t = Type[String]
+      val t = Type.of[String]
       t
     }
 

--- a/tests/run-staging/quote-owners-2.scala
+++ b/tests/run-staging/quote-owners-2.scala
@@ -5,7 +5,7 @@ import scala.quoted.staging._
 object Test {
   given Toolbox = Toolbox.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
-    val q = f(g(Type[Int]))
+    val q = f(g(Type.of[Int]))
     println(q.show)
     '{ println($q) }
   }
@@ -22,5 +22,5 @@ object Test {
     ff
   }
 
-  def g[T](a: Type[T])(using QuoteContext): Type[List[T]] = Type[List[a.Underlying]]
+  def g[T](a: Type[T])(using QuoteContext): Type[List[T]] = Type.of[List[a.Underlying]]
 }

--- a/tests/run-staging/quote-simple-hole.scala
+++ b/tests/run-staging/quote-simple-hole.scala
@@ -15,8 +15,8 @@ object Test {
     assert(x eq a)
     assert(x eq b)
 
-    val i = Type[Int]
-    val j = Type[i.Underlying]
+    val i = Type.of[Int]
+    val j = Type.of[i.Underlying]
     assert(i eq j)
   }
 }

--- a/tests/run-staging/quote-type-matcher.scala
+++ b/tests/run-staging/quote-type-matcher.scala
@@ -5,20 +5,20 @@ import scala.reflect.ClassTag
 object Test {
   given Toolbox = Toolbox.make(this.getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuoteContext {
-    val '[List[Int]] = Type[List[Int]]
+    val '[List[Int]] = Type.of[List[Int]]
 
-    Type[List[Int]] match
+    Type.of[List[Int]] match
       case '[List[int]] =>
         println(Type.show[int])
         println()
 
-    Type[Int => Double] match
+    Type.of[Int => Double] match
       case  '[Function1[t1, r]] =>
         println(Type.show[t1])
         println(Type.show[r])
         println()
 
-    Type[(Int => Short) => Double] match
+    Type.of[(Int => Short) => Double] match
       case '[Function1[Function1[t1, r0], r]] =>
         println(Type.show[t1])
         println(Type.show[r0])

--- a/tests/run-staging/quote-type-tags.scala
+++ b/tests/run-staging/quote-type-tags.scala
@@ -7,17 +7,17 @@ object Test {
     def asof[T: Type, U](x: Expr[T], t: Type[U]): Expr[U] =
       '{$x.asInstanceOf[t.Underlying]}
 
-    println(asof('{}, Type[Unit]).show)
-    println(asof('{true}, Type[Boolean]).show)
-    println(asof('{0.toByte}, Type[Byte]).show)
-    println(asof('{ 'a' }, Type[Char]).show)
-    println(asof('{1.toShort}, Type[Short]).show)
-    println(asof('{2}, Type[Int]).show)
-    println(asof('{3L}, Type[Long]).show)
-    println(asof('{4f}, Type[Float]).show)
-    println(asof('{5d}, Type[Double]).show)
+    println(asof('{}, Type.of[Unit]).show)
+    println(asof('{true}, Type.of[Boolean]).show)
+    println(asof('{0.toByte}, Type.of[Byte]).show)
+    println(asof('{ 'a' }, Type.of[Char]).show)
+    println(asof('{1.toShort}, Type.of[Short]).show)
+    println(asof('{2}, Type.of[Int]).show)
+    println(asof('{3L}, Type.of[Long]).show)
+    println(asof('{4f}, Type.of[Float]).show)
+    println(asof('{5d}, Type.of[Double]).show)
 
-    println(asof('{5d}, Type[Boolean]).show) // Will clearly fail at runtime but the code can be generated
+    println(asof('{5d}, Type.of[Boolean]).show) // Will clearly fail at runtime but the code can be generated
     '{}
   }
 }


### PR DESCRIPTION
* Rename `Type.apply` to `Type.of` to have the same names as in `TypeRepr` and `TypeTree`


```scala
def f[T: Type](using QuoteContext) = {
  val quotedType = Type.of[T]
  val typeRepr = TypeRepr.of[T]
  val typeTree = TypeTree.of[T]
  ....
}
```