### PR TITLE
Move Reflection to scala.quoted

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/QuoteContextImpl.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteContextImpl.scala
@@ -79,7 +79,7 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext, QuoteUnpickl
     }
   end extension
 
-  object reflect extends scala.tasty.Reflection:
+  object reflect extends scala.quoted.Reflection:
 
     def rootContext: Context = ctx
 

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -66,7 +66,8 @@ trait QuoteContext { self: internal.QuoteUnpickler & internal.QuoteMatching =>
   /** Low-level Typed AST API metaprogramming API.
    *  This API does not have the static type guarantiees that `Expr` and `Type` provide.
    */
-  val reflect: scala.tasty.Reflection
+  val reflect: scala.quoted.Reflection
+  // TODO move Reflcetion definition in here
 
   /** Type of a QuoteContext provided by a splice within a quote that took this context.
    *  It is only required if working with the reflection API.

--- a/library/src/scala/quoted/Reflection.scala
+++ b/library/src/scala/quoted/Reflection.scala
@@ -1,8 +1,8 @@
-package scala.tasty
+package scala.quoted
 
 import scala.tasty.reflect._
 
-/** TASTy Reflect Interface.
+/** AST reflection interface.
  *
  *  Provides all functionality related with AST based metaprogramming.
  *

--- a/scala3doc/src/dotty/dokka/Main.scala
+++ b/scala3doc/src/dotty/dokka/Main.scala
@@ -9,7 +9,6 @@ import java.util.jar._
 import collection.JavaConverters._
 import collection.immutable.ArraySeq
 
-import scala.tasty.Reflection
 import scala.tasty.inspector.TastyInspector
 import java.nio.file.Files
 

--- a/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
@@ -9,7 +9,7 @@ import dotty.dokka.model.api.Annotation
 trait BasicSupport:
   self: TastyParser =>
   import qctx.reflect._
-  object SymOps extends SymOps[qctx.reflect.type](qctx.reflect)
+  object SymOps extends SymOps[qctx.type](qctx)
   export SymOps._
 
   def parseAnnotation(annotTerm: Term): Annotation =

--- a/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -50,7 +50,7 @@ trait ClassLikeSupport:
           }
         )
 
-      val supertypes = getSupertypes(classDef).map {
+      val supertypes = getSupertypes(using qctx)(classDef).map {
         case (symbol, tpe) => LinkToType(tpe.dokkaType.asSignature, symbol.dri, kindForClasslike(symbol))
       }
       val selfSiangture: DSignature = typeForClass(classDef).dokkaType.asSignature

--- a/scala3doc/src/dotty/dokka/tasty/ScalaDocSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ScalaDocSupport.scala
@@ -32,9 +32,9 @@ trait ScaladocSupport { self: TastyParser =>
 
     val parser = commentSyntax match {
       case CommentSyntax.Wiki =>
-        comments.WikiCommentParser(comments.Repr(qctx.reflect)(tree.symbol))
+        comments.WikiCommentParser(comments.Repr(qctx)(tree.symbol))
       case CommentSyntax.Markdown =>
-        comments.MarkdownCommentParser(comments.Repr(qctx.reflect)(tree.symbol))
+        comments.MarkdownCommentParser(comments.Repr(qctx)(tree.symbol))
     }
     val parsed = parser.parse(preparsed)
 

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -7,13 +7,14 @@ import dotty.dokka._
 import dotty.dokka.model.api.Visibility
 import dotty.dokka.model.api.VisibilityScope
 import dotty.dokka.model.api.Modifier
-import scala.tasty.Reflection
 
-class SymOps[R <: Reflection](val r: R):
-  import r._
+import scala.quoted._
 
-  given R = r
-  extension (sym: r.Symbol):
+class SymOps[Q <: QuoteContext](val q: Q):
+  import q.reflect._
+
+  given Q = q
+  extension (sym: Symbol):
     def packageName(using ctx: Context): String =
       if (sym.isPackageDef) sym.fullName
       else sym.maybeOwner.packageName
@@ -49,7 +50,7 @@ class SymOps[R <: Reflection](val r: R):
     // TODO: #49 Remove it after TASTY-Reflect release with published flag Extension
     def hackIsOpen: Boolean = {
       import dotty.tools.dotc
-      given dotc.core.Contexts.Context = r.rootContext.asInstanceOf
+      given dotc.core.Contexts.Context = qctx.reflect.rootContext.asInstanceOf
       val symbol = sym.asInstanceOf[dotc.core.Symbols.Symbol]
       symbol.is(dotc.core.Flags.Open)
     }

--- a/scala3doc/src/dotty/dokka/tasty/comments/Comments.scala
+++ b/scala3doc/src/dotty/dokka/tasty/comments/Comments.scala
@@ -8,8 +8,9 @@ import com.vladsch.flexmark.util.{ast => mdu}
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.util.options.MutableDataSet
 
-import scala.tasty.Reflection
-class Repr(val r: Reflection)(val sym: r.Symbol)
+import scala.quoted._
+
+class Repr(val qctx: QuoteContext)(val sym: qctx.reflect.Symbol)
 
 case class Comment (
   body:                    dkkd.DocTag,

--- a/scala3doc/src/dotty/dokka/tasty/comments/MarkdownConverter.scala
+++ b/scala3doc/src/dotty/dokka/tasty/comments/MarkdownConverter.scala
@@ -2,7 +2,6 @@ package dotty.dokka
 package tasty.comments
 
 import scala.jdk.CollectionConverters._
-import scala.tasty.Reflection
 
 import org.jetbrains.dokka.model.{doc => dkkd}
 import com.vladsch.flexmark.{ast => mda}
@@ -17,10 +16,10 @@ class MarkdownConverter(val repr: Repr) extends BaseConverter {
 
   // makeshift support for not passing an owner
   // see same in wiki.Converter
-  val r: repr.r.type = if repr == null then null else repr.r
-  val owner: r.Symbol = if repr == null then null.asInstanceOf[r.Symbol] else repr.sym
+  val qctx: repr.qctx.type = if repr == null then null else repr.qctx
+  val owner: qctx.reflect.Symbol = if repr == null then null.asInstanceOf[qctx.reflect.Symbol] else repr.sym
 
-  object SymOps extends SymOps[r.type](r)
+  object SymOps extends SymOps[qctx.type](qctx)
   import SymOps._
 
   def convertDocument(doc: mdu.Document): dkkd.DocTag = {
@@ -178,7 +177,7 @@ class MarkdownConverter(val repr: Repr) extends BaseConverter {
       List(dkk.text(resolved)).asJava
 
     withParsedQuery(queryStr) { query =>
-      MemberLookup.lookup(using r)(query, owner) match {
+      MemberLookup.lookup(using qctx)(query, owner) match {
         case Some((sym, targetText)) =>
           dkkd.DocumentationLink(sym.dri, resolveBody(default = targetText), kt.emptyMap)
         case None =>

--- a/scala3doc/src/dotty/dokka/tasty/comments/wiki/Converter.scala
+++ b/scala3doc/src/dotty/dokka/tasty/comments/wiki/Converter.scala
@@ -2,7 +2,6 @@ package dotty.dokka.tasty.comments
 package wiki
 
 import scala.jdk.CollectionConverters._
-import scala.tasty.Reflection
 
 import org.jetbrains.dokka.model.{doc => dkkd}
 
@@ -13,10 +12,10 @@ class Converter(val repr: Repr) extends BaseConverter {
 
   // makeshift support for not passing an owner
   // see same in MarkdownConverter
-  val r: repr.r.type = if repr == null then null else repr.r
-  val owner: r.Symbol = if repr == null then null.asInstanceOf[r.Symbol] else repr.sym
+  val qctx: repr.qctx.type = if repr == null then null else repr.qctx
+  val owner: qctx.reflect.Symbol = if repr == null then null.asInstanceOf[qctx.reflect.Symbol] else repr.sym
 
-  object SymOps extends SymOps[r.type](r)
+  object SymOps extends SymOps[qctx.type](qctx)
   import SymOps._
 
   def convertBody(body: Body): dkkd.DocTag = {
@@ -131,7 +130,7 @@ class Converter(val repr: Repr) extends BaseConverter {
       }
 
     withParsedQuery(queryStr) { query =>
-      MemberLookup.lookup(using r)(query, owner) match {
+      MemberLookup.lookup(using qctx)(query, owner) match {
         case Some((sym, targetText)) =>
           dkkd.DocumentationLink(sym.dri, resolveBody(default = targetText), kt.emptyMap)
         case None =>

--- a/tests/neg-macros/i6324.scala
+++ b/tests/neg-macros/i6324.scala
@@ -1,5 +1,5 @@
 class Test {
-  def res(x: quoted.Expr[Int])(using tasty.Reflection): quoted.Expr[Int] = x match {
+  def res(x: quoted.Expr[Int])(using quoted.Reflection): quoted.Expr[Int] = x match {
     case '{ 1 + $b } => // error: Type must be fully defined. Consider annotating the splice using a type ascription: (${b}: XYZ).
       b // error: Not found: b
   }

--- a/tests/neg-macros/i6325.scala
+++ b/tests/neg-macros/i6325.scala
@@ -1,5 +1,5 @@
 object Test {
-  def res(x: quoted.Expr[Int])(using tasty.Reflection): quoted.Expr[Int] = x match {
+  def res(x: quoted.Expr[Int])(using quoted.Reflection): quoted.Expr[Int] = x match {
     case '{ 1 + (${Bind(b)}: Int) } => ??? // error: Not found: Bind
     case _ => ???
   }

--- a/tests/pos-special/fatal-warnings/tasty-parent-unapply.scala
+++ b/tests/pos-special/fatal-warnings/tasty-parent-unapply.scala
@@ -1,12 +1,10 @@
 import scala.quoted._
 
-import scala.tasty.Reflection
-
 object Macros {
 
 
-  def impl(reflect: Reflection): Unit = {
-    import reflect.{_, given}
+  def impl(using QuoteContext): Unit = {
+    import qctx.reflect._
 
     def foo(tree: Tree, term: Term, typeTree: TypeTree, parent: Tree) = {
 

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
@@ -2,7 +2,6 @@ package scala.tasty.interpreter
 
 import scala.quoted._
 import scala.tasty.interpreter.jvm.JVMReflection
-import scala.tasty.Reflection
 
 abstract class TreeInterpreter[QCtx <: QuoteContext & Singleton](using val qctx: QCtx) {
   import qctx.reflect._
@@ -196,7 +195,7 @@ abstract class TreeInterpreter[QCtx <: QuoteContext & Singleton](using val qctx:
   private def isNumericPrimitive(tpe: TypeRepr): Boolean =
     isIntegralPrimitive(tpe) || isFractionalPrimitive(tpe)
 
-  private def isIntegralPrimitive(tpe: TypeRepr): Boolean ={ 
+  private def isIntegralPrimitive(tpe: TypeRepr): Boolean = {
     tpe <:< TypeRepr.of[Byte] ||
     tpe <:< TypeRepr.of[Char] ||
     tpe <:< TypeRepr.of[Short] ||

--- a/tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
@@ -3,7 +3,6 @@ package jvm
 
 import scala.quoted._
 import scala.tasty.interpreter.jvm.JVMReflection
-import scala.tasty.Reflection
 
 class Interpreter[QCtx <: QuoteContext & Singleton](using qctx0: QCtx) extends TreeInterpreter[QCtx] {
   import qctx.reflect._

--- a/tests/run-custom-args/tasty-interpreter/interpreter/jvm/JVMReflection.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/jvm/JVMReflection.scala
@@ -1,7 +1,6 @@
 package scala.tasty.interpreter.jvm
 
 import scala.quoted._
-import scala.tasty.Reflection
 
 class JVMReflection[QCtx <: QuoteContext & Singleton](using val tasty: QCtx) {
   import qctx.reflect._


### PR DESCRIPTION
In theory it should be inside of the QuoteContext but this is blocked by #10253.
We take this first step to cleanup the `scala.tasty` package.