### PR TITLE
Move QuoteContext implementation to scala.quoted.internal.impl

### DIFF
--- a/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
@@ -9,8 +9,9 @@ import scala.io.Codec
 import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.tasty.TastyPrinter
-import dotty.tools.dotc.quoted.QuoteContextImpl
 import dotty.tools.io.File
+
+import scala.quoted.internal.impl.QuoteContextImpl
 
 /** Phase that prints the trees in all loaded compilation units.
  *

--- a/compiler/src/dotty/tools/dotc/decompiler/IDEDecompilerDriver.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/IDEDecompilerDriver.scala
@@ -6,7 +6,8 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core._
 import dotty.tools.dotc.core.tasty.TastyHTMLPrinter
 import dotty.tools.dotc.reporting._
-import dotty.tools.dotc.quoted.QuoteContextImpl
+
+import scala.quoted.internal.impl.QuoteContextImpl
 
 /**
   * Decompiler to be used with IDEs

--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -20,6 +20,8 @@ import dotty.tools.dotc.report
 import scala.reflect.ClassTag
 
 import scala.quoted.QuoteContext
+import scala.quoted.internal.impl._
+
 import scala.collection.mutable
 
 import QuoteUtils._
@@ -38,14 +40,14 @@ object PickledQuotes {
 
   /** Transform the expression into its fully spliced Tree */
   def quotedExprToTree[T](expr: quoted.Expr[T])(using Context): Tree = {
-    val expr1 = expr.asInstanceOf[dotty.tools.dotc.quoted.ExprImpl]
+    val expr1 = expr.asInstanceOf[ExprImpl]
     expr1.checkScopeId(QuoteContextImpl.scopeId)
     changeOwnerOfTree(expr1.tree, ctx.owner)
   }
 
   /** Transform the expression into its fully spliced TypeTree */
   def quotedTypeToTree(tpe: quoted.Type[?])(using Context): Tree = {
-    val tpe1 = tpe.asInstanceOf[dotty.tools.dotc.quoted.TypeImpl]
+    val tpe1 = tpe.asInstanceOf[TypeImpl]
     tpe1.checkScopeId(QuoteContextImpl.scopeId)
     changeOwnerOfTree(tpe1.typeTree, ctx.owner)
   }
@@ -72,11 +74,11 @@ object PickledQuotes {
       override def transform(tree: tpd.Tree)(using Context): tpd.Tree = tree match {
         case Hole(isTerm, idx, args) =>
           val reifiedArgs = args.map { arg =>
-            if (arg.isTerm) (using qctx: QuoteContext) => new dotty.tools.dotc.quoted.ExprImpl(arg, QuoteContextImpl.scopeId)
-            else new dotty.tools.dotc.quoted.TypeImpl(arg, QuoteContextImpl.scopeId)
+            if (arg.isTerm) (using qctx: QuoteContext) => new ExprImpl(arg, QuoteContextImpl.scopeId)
+            else new TypeImpl(arg, QuoteContextImpl.scopeId)
           }
           if isTerm then
-            val quotedExpr = termHole(idx, reifiedArgs, dotty.tools.dotc.quoted.QuoteContextImpl())
+            val quotedExpr = termHole(idx, reifiedArgs, QuoteContextImpl())
             val filled = PickledQuotes.quotedExprToTree(quotedExpr)
 
             // We need to make sure a hole is created with the source file of the surrounding context, even if

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -24,8 +24,10 @@ import dotty.tools.repl.AbstractFileClassLoader
 
 import scala.reflect.ClassTag
 
-import dotty.tools.dotc.quoted._
+import dotty.tools.dotc.quoted.{PickledQuotes, QuoteUtils}
+
 import scala.quoted.QuoteContext
+import scala.quoted.internal.impl._
 
 /** Utility class to splice quoted expressions */
 object Splicer {
@@ -323,10 +325,10 @@ object Splicer {
     }
 
     private def interpretQuote(tree: Tree)(implicit env: Env): Object =
-      new dotty.tools.dotc.quoted.ExprImpl(Inlined(EmptyTree, Nil, QuoteUtils.changeOwnerOfTree(tree, ctx.owner)).withSpan(tree.span), QuoteContextImpl.scopeId)
+      new ExprImpl(Inlined(EmptyTree, Nil, QuoteUtils.changeOwnerOfTree(tree, ctx.owner)).withSpan(tree.span), QuoteContextImpl.scopeId)
 
     private def interpretTypeQuote(tree: Tree)(implicit env: Env): Object =
-      new dotty.tools.dotc.quoted.TypeImpl(QuoteUtils.changeOwnerOfTree(tree, ctx.owner), QuoteContextImpl.scopeId)
+      new TypeImpl(QuoteUtils.changeOwnerOfTree(tree, ctx.owner), QuoteContextImpl.scopeId)
 
     private def interpretLiteral(value: Any)(implicit env: Env): Object =
       value.asInstanceOf[Object]

--- a/compiler/src/scala/quoted/internal/impl/ExprImpl.scala
+++ b/compiler/src/scala/quoted/internal/impl/ExprImpl.scala
@@ -1,6 +1,5 @@
-package dotty.tools.dotc.quoted
-
-import scala.quoted._
+package scala.quoted
+package internal.impl
 
 import dotty.tools.dotc.ast.tpd
 
@@ -11,7 +10,7 @@ import dotty.tools.dotc.ast.tpd
  *
  *  May contain references to code defined outside this Expr instance.
  */
-final class ExprImpl(val tree: tpd.Tree, val scopeId: Int) extends scala.quoted.internal.Expr[Any] {
+final class ExprImpl(val tree: tpd.Tree, val scopeId: Int) extends Expr[Any] {
   override def equals(that: Any): Boolean = that match {
     case that: ExprImpl =>
       // Expr are wrappers around trees, therefore they are equals if their trees are equal.

--- a/compiler/src/scala/quoted/internal/impl/Matcher.scala
+++ b/compiler/src/scala/quoted/internal/impl/Matcher.scala
@@ -1,9 +1,8 @@
-package dotty.tools.dotc.quoted
+package scala.quoted
+package internal.impl
 
 import scala.annotation.internal.sharable
 import scala.annotation.{Annotation, compileTimeOnly}
-
-import scala.quoted._
 
 /** Matches a quoted tree against a quoted pattern tree.
  *  A quoted pattern tree may have type and term holes in addition to normal terms.

--- a/compiler/src/scala/quoted/internal/impl/QuoteContextImpl.scala
+++ b/compiler/src/scala/quoted/internal/impl/QuoteContextImpl.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc.quoted
+package scala.quoted
+package internal.impl
 
 import dotty.tools.dotc
 import dotty.tools.dotc.ast.tpd
@@ -13,9 +14,11 @@ import dotty.tools.dotc.quoted.reflect._
 import dotty.tools.dotc.quoted.QuoteUtils._
 import dotty.tools.dotc.core.Decorators._
 
-import scala.quoted.QuoteContext
+import dotty.tools.dotc.quoted.{MacroExpansion, PickledQuotes, QuoteUtils}
+
 import scala.quoted.internal.{QuoteUnpickler, QuoteMatching}
-import dotty.tools.dotc.quoted.printers.{Extractors, SourceCode, SyntaxHighlight}
+import scala.quoted.internal.impl.printers._
+
 
 import scala.tasty.reflect._
 
@@ -36,7 +39,7 @@ object QuoteContextImpl {
 
   // TODO Explore more fine grained scope ids.
   //      This id can only differentiate scope extrusion from one compiler instance to another.
-  private[dotty] def scopeId(using Context): ScopeId =
+  def scopeId(using Context): ScopeId =
     ctx.outersIterator.toList.last.hashCode()
 
 }
@@ -2708,7 +2711,7 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext, QuoteUnpickl
         ctx1.gadt.addToConstraint(typeHoles)
         ctx1
 
-    val qctx1 = dotty.tools.dotc.quoted.QuoteContextImpl()(using ctx1)
+    val qctx1 = QuoteContextImpl()(using ctx1)
 
     val matcher = new Matcher.QuoteMatcher[qctx1.type](qctx1) {
       def patternHoleSymbol: qctx1.reflect.Symbol = dotc.core.Symbols.defn.InternalQuotedPatterns_patternHole.asInstanceOf

--- a/compiler/src/scala/quoted/internal/impl/ScopeException.scala
+++ b/compiler/src/scala/quoted/internal/impl/ScopeException.scala
@@ -1,3 +1,3 @@
-package dotty.tools.dotc.quoted
+package scala.quoted.internal.impl
 
 class ScopeException(msg: String) extends Exception(msg)

--- a/compiler/src/scala/quoted/internal/impl/TypeImpl.scala
+++ b/compiler/src/scala/quoted/internal/impl/TypeImpl.scala
@@ -1,11 +1,10 @@
-package dotty.tools.dotc.quoted
-
-import scala.quoted._
+package scala.quoted
+package internal.impl
 
 import dotty.tools.dotc.ast.tpd
 
 /** Quoted type (or kind) `T` backed by a tree */
-final class TypeImpl(val typeTree: tpd.Tree, val scopeId: Int) extends scala.quoted.internal.Type[?] {
+final class TypeImpl(val typeTree: tpd.Tree, val scopeId: Int) extends Type[?] {
   override def equals(that: Any): Boolean = that match {
     case that: TypeImpl => typeTree ==
       // TastyTreeExpr are wrappers around trees, therfore they are equals if their trees are equal.

--- a/compiler/src/scala/quoted/internal/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/internal/impl/printers/Extractors.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc.quoted.printers
+package scala.quoted
+package internal.impl.printers
 
 import scala.quoted._
 

--- a/compiler/src/scala/quoted/internal/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/internal/impl/printers/SourceCode.scala
@@ -1,8 +1,7 @@
-package dotty.tools.dotc
-package quoted.printers
+package scala.quoted
+package internal.impl.printers
 
 import scala.annotation.switch
-import scala.quoted._
 
 /** Printer for fully elaborated representation of the source code */
 object SourceCode {
@@ -437,7 +436,7 @@ object SourceCode {
           case _ =>
             inParens {
               printTree(term)
-              this += (if (util.Chars.isOperatorPart(sb.last)) " : " else ": ")
+              this += (if (dotty.tools.dotc.util.Chars.isOperatorPart(sb.last)) " : " else ": ")
               def printTypeOrAnnots(tpe: TypeRepr): Unit = tpe match {
                 case AnnotatedType(tp, annot) if tp == term.tpe =>
                   printAnnotation(annot)

--- a/compiler/src/scala/quoted/internal/impl/printers/SyntaxHighlight.scala
+++ b/compiler/src/scala/quoted/internal/impl/printers/SyntaxHighlight.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc.quoted.printers
+package scala.quoted
+package internal.impl.printers
 
 trait SyntaxHighlight {
   def highlightKeyword(str: String): String

--- a/library/src/scala/quoted/internal/Expr.scala
+++ b/library/src/scala/quoted/internal/Expr.scala
@@ -3,9 +3,6 @@ package internal
 
 import scala.annotation.{Annotation, compileTimeOnly}
 
-/** Implementation of scala.quoted.Expr that sould only be extended by the implementation of `QuoteContext` */
-abstract class Expr[+T] extends scala.quoted.Expr[T]
-
 @compileTimeOnly("Illegal reference to `scala.quoted.internal.Expr`")
 object Expr:
 

--- a/library/src/scala/quoted/internal/Type.scala
+++ b/library/src/scala/quoted/internal/Type.scala
@@ -1,4 +1,0 @@
-package scala.quoted.internal
-
-/** Implementation of scala.quoted.Type that sould only be extended by the implementation of `QuoteContext` */
-abstract class Type[T <: AnyKind] extends scala.quoted.Type[T]

--- a/scala3doc/src/dotty/dokka/tasty/TastyParser.scala
+++ b/scala3doc/src/dotty/dokka/tasty/TastyParser.scala
@@ -41,7 +41,7 @@ case class SbtDokkaTastyInspector(
   import dotty.tools.dotc.core.Mode
   import dotty.tools.dotc.core.Phases.Phase
   import dotty.tools.dotc.fromtasty._
-  import dotty.tools.dotc.quoted.QuoteContextImpl
+  import scala.quoted.internal.impl.QuoteContextImpl
 
 
   val parser: Parser = null

--- a/staging/src/scala/quoted/staging/QuoteCompiler.scala
+++ b/staging/src/scala/quoted/staging/QuoteCompiler.scala
@@ -21,6 +21,8 @@ import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.io.{Path, VirtualFile}
 
+import scala.quoted.internal.impl.QuoteContextImpl
+
 import scala.annotation.tailrec
 import scala.concurrent.Promise
 import scala.quoted.{Expr, QuoteContext, Type}
@@ -68,7 +70,7 @@ private class QuoteCompiler extends Compiler:
 
           val quoted =
             given Context = unitCtx.withOwner(meth)
-            val qctx = dotty.tools.dotc.quoted.QuoteContextImpl()
+            val qctx = QuoteContextImpl()
             val quoted = PickledQuotes.quotedExprToTree(exprUnit.exprBuilder.apply(qctx))
             checkEscapedVariables(quoted, meth)
           end quoted

--- a/staging/src/scala/quoted/staging/Toolbox.scala
+++ b/staging/src/scala/quoted/staging/Toolbox.scala
@@ -3,7 +3,7 @@ package staging
 
 import scala.annotation.implicitNotFound
 
-import dotty.tools.dotc.quoted.ScopeException
+import scala.quoted.internal.impl.ScopeException
 
 @implicitNotFound("Could not find implicit scala.quoted.staging.Toolbox.\n\nDefault toolbox can be instantiated with:\n  `given scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)`\n\n")
 trait Toolbox:

--- a/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
+++ b/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
@@ -1,6 +1,7 @@
 package scala.tasty.inspector
 
 import scala.quoted._
+import scala.quoted.internal.impl.QuoteContextImpl
 
 import dotty.tools.dotc.Compiler
 import dotty.tools.dotc.Driver
@@ -9,7 +10,6 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Mode
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.fromtasty._
-import dotty.tools.dotc.quoted.QuoteContextImpl
 import dotty.tools.dotc.util.ClasspathFromClassloader
 
 import java.io.File.pathSeparator

--- a/tests/run-staging/i4730.scala
+++ b/tests/run-staging/i4730.scala
@@ -5,7 +5,7 @@ object Test {
   given Toolbox = Toolbox.make(getClass.getClassLoader)
   def ret(using QuoteContext): Expr[Int => Int] = '{ (x: Int) =>
     ${
-      val z = run('{x + 1}) // throws dotty.tools.dotc.quoted.ScopeException =>
+      val z = run('{x + 1}) // throws scala.quoted.internal.impl.ScopeException =>
       Expr(z)
     }
   }
@@ -21,7 +21,7 @@ package scala {
         run(Test.ret).apply(10)
         throw new Exception
       } catch {
-        case ex: Exception if ex.getClass.getName == "dotty.tools.dotc.quoted.ScopeException" =>
+        case ex: Exception if ex.getClass.getName == "scala.quoted.internal.impl.ScopeException" =>
           // ok
       }
     }

--- a/tests/run-staging/i6754.scala
+++ b/tests/run-staging/i6754.scala
@@ -22,7 +22,7 @@ package scala {
         throw new Exception
       } catch {
         case ex: java.lang.reflect.InvocationTargetException =>
-          assert(ex.getTargetException.getClass.getName == "dotty.tools.dotc.quoted.ScopeException")
+          assert(ex.getTargetException.getClass.getName == "scala.quoted.internal.impl.ScopeException")
       }
     }
   }

--- a/tests/run-staging/i6992/Macro_1.scala
+++ b/tests/run-staging/i6992/Macro_1.scala
@@ -25,7 +25,7 @@ package scala {
           case '{$x: Foo} => Expr(run(x).x)
         }
       } catch {
-        case ex: Exception if ex.getClass.getName == "dotty.tools.dotc.quoted.ScopeException" =>
+        case ex: Exception if ex.getClass.getName == "scala.quoted.internal.impl.ScopeException" =>
           '{"OK"}
       }
     }


### PR DESCRIPTION
* `scala.quoted.internal.impl` is defined in the compiler
* Remove `scala.quoted.internal.{Expr,Type}`
* Move all classes related to the implemetation of the QuoteContext into `impl`