### PR TITLE
Drop DottyPredef.assertFail.

### DIFF
--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -54,7 +54,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
     val sources = List(
       mkSource("assert(true)", "()"),
       mkSource("assert(true, ???)", "()"),
-      mkSource("assert(false)", "assertFail()")
+      mkSource("assert(false)", "{ throw new java.lang.AssertionError(\"assertion failed\") }")
     )
     for (source <- sources)
       checkBCode(source) { dir =>

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -54,7 +54,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
     val sources = List(
       mkSource("assert(true)", "()"),
       mkSource("assert(true, ???)", "()"),
-      mkSource("assert(false)", "{ throw new java.lang.AssertionError(\"assertion failed\") }")
+      mkSource("assert(false)", "scala.runtime.Scala3RunTime.assertFailed()")
     )
     for (source <- sources)
       checkBCode(source) { dir =>

--- a/docs/docs/internals/debug-macros.md
+++ b/docs/docs/internals/debug-macros.md
@@ -37,7 +37,6 @@ Here is the usually stacktrace for unresolved symbols in pickling:
 
 ```
 [error] java.lang.AssertionError: assertion failed: unresolved symbols: value pos (line 5565) when pickling scalatest/scalatest-test.dotty/target/scala-0.17/src_managed/test/org/scalatest/AssertionsSpec.scala
-[error] 	at dotty.DottyPredef$.assertFail(DottyPredef.scala:16)
 [error] 	at dotty.tools.dotc.core.tasty.TreePickler.pickle(TreePickler.scala:699)
 [error] 	at dotty.tools.dotc.transform.Pickler.run$$anonfun$10$$anonfun$8(Pickler.scala:60)
 [error] 	at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)

--- a/library/src/dotty/DottyPredef.scala
+++ b/library/src/dotty/DottyPredef.scala
@@ -5,12 +5,12 @@ object DottyPredef {
 
   inline final def assert(inline assertion: Boolean, inline message: => Any): Unit = {
     if (!assertion)
-      throw new java.lang.AssertionError("assertion failed: " + message)
+      scala.runtime.Scala3RunTime.assertFailed(message)
   }
 
   transparent inline final def assert(inline assertion: Boolean): Unit = {
     if (!assertion)
-      throw new java.lang.AssertionError("assertion failed")
+      scala.runtime.Scala3RunTime.assertFailed()
   }
 
   inline final def implicitly[T](implicit ev: T): T = ev

--- a/library/src/dotty/DottyPredef.scala
+++ b/library/src/dotty/DottyPredef.scala
@@ -5,16 +5,13 @@ object DottyPredef {
 
   inline final def assert(inline assertion: Boolean, inline message: => Any): Unit = {
     if (!assertion)
-      assertFail(message)
+      throw new java.lang.AssertionError("assertion failed: " + message)
   }
 
   transparent inline final def assert(inline assertion: Boolean): Unit = {
     if (!assertion)
-      assertFail()
+      throw new java.lang.AssertionError("assertion failed")
   }
-
-  def assertFail(): Nothing = throw new java.lang.AssertionError("assertion failed")
-  def assertFail(message: => Any): Nothing = throw new java.lang.AssertionError("assertion failed: " + message)
 
   inline final def implicitly[T](implicit ev: T): T = ev
 

--- a/library/src/scala/runtime/Scala3RunTime.scala
+++ b/library/src/scala/runtime/Scala3RunTime.scala
@@ -1,0 +1,13 @@
+package scala.runtime
+
+object Scala3RunTime:
+
+  // Called by inline def assert's. Extracted to minimize the bytecode size at call site.
+
+  def assertFailed(message: Any): Nothing =
+    throw new java.lang.AssertionError("assertion failed: " + message)
+
+  def assertFailed(): Nothing =
+    throw new java.lang.AssertionError("assertion failed")
+
+end Scala3RunTime

--- a/scala3doc/resources/dotty_res/scripts/hljs-scala3.js
+++ b/scala3doc/resources/dotty_res/scripts/hljs-scala3.js
@@ -25,7 +25,7 @@ function highlightDotty(hljs) {
       'if implicit import lazy match new object package private protected override return '+
       'sealed then throw trait true try type val var while with yield =>> => ?=> <: >: _ ? <-',
     literal: 'true false null this super',
-    built_in: '??? asInstanceOf isInstanceOf assert assertFail implicitly locally summon .nn'
+    built_in: '??? asInstanceOf isInstanceOf assert implicitly locally summon .nn'
   }
   const modifiers = 'abstract|final|implicit|override|private|protected|sealed'
 

--- a/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
+++ b/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
@@ -146,7 +146,6 @@ object BootstrappedStdLibTASYyTest:
   def compileBlacklist = List[String](
     // See #10048
     // failed: java.lang.AssertionError: assertion failed: class Boolean
-    //   at dotty.DottyPredef$.assertFail(DottyPredef.scala:17)
     //   at dotty.tools.backend.jvm.BCodeHelpers$BCInnerClassGen.assertClassNotArrayNotPrimitive(BCodeHelpers.scala:247)
     //   at dotty.tools.backend.jvm.BCodeHelpers$BCInnerClassGen.getClassBTypeAndRegisterInnerClass(BCodeHelpers.scala:265)
     //   at dotty.tools.backend.jvm.BCodeHelpers$BCInnerClassGen.getClassBTypeAndRegisterInnerClass$(BCodeHelpers.scala:210)

--- a/tests/pos/main-method-scheme-class-based.scala
+++ b/tests/pos/main-method-scheme-class-based.scala
@@ -62,7 +62,7 @@ class main extends MainAnnotation:
     /** Issue an error, and return an uncallable getter */
     private def error(msg: String): () => Nothing =
       errors += msg
-      () => assertFail("trying to get invalid argument")
+      () => throw new AssertionError("trying to get invalid argument")
 
     /** The next argument index */
     private var argIdx: Int = 0

--- a/tests/pos/matches.scala
+++ b/tests/pos/matches.scala
@@ -5,7 +5,7 @@ object Test:
     case 3 => "?"
   match
     case "OK" =>
-    case "?" => assertFail()
+    case "?" => throw new AssertionError()
 
   val x = 4
   if 2 < 3

--- a/tests/run/Signals.scala
+++ b/tests/run/Signals.scala
@@ -53,7 +53,7 @@ class BankAccount:
       val b = myBalance()
       myBalance() = b - amount
       myBalance()
-    else assertFail("insufficient funds")
+    else throw new AssertionError("insufficient funds")
 end BankAccount
 
 @main def Test() =

--- a/tests/run/Signals1.scala
+++ b/tests/run/Signals1.scala
@@ -66,7 +66,7 @@ class BankAccount:
       val b = myBalance()
       myBalance() = b - amount
       myBalance()
-    else assertFail("insufficient funds")
+    else throw new AssertionError("insufficient funds")
 end BankAccount
 
 @main def Test() =

--- a/tests/run/decorators/main.scala
+++ b/tests/run/decorators/main.scala
@@ -32,7 +32,7 @@ class main extends EntryPoint.Annotation:
       /** Issue an error, and return an uncallable getter */
       private def error(msg: String): () => Nothing =
         errors += msg
-        () => assertFail("trying to get invalid argument")
+        () => throw new AssertionError("trying to get invalid argument")
 
       /** The next argument index */
       private var argIdx: Int = 0

--- a/tests/run/enum-values.scala
+++ b/tests/run/enum-values.scala
@@ -55,7 +55,7 @@ enum ClassOnly: // this should still generate the `ordinal` and `fromOrdinal` co
   def cantFind[T](companion: FromOrdinal[T], ordinal: Int): Unit =
     try
       companion.fromOrdinal(ordinal)
-      assertFail(s"$companion.fromOrdinal(${ordinal}) did not fail")
+      throw new AssertionError(s"$companion.fromOrdinal(${ordinal}) did not fail")
     catch
       case e: java.lang.reflect.InvocationTargetException => // TODO: maybe reflect.Selectable should catch this?
         assert(e.getCause.isInstanceOf[java.util.NoSuchElementException]

--- a/tests/semanticdb/expect/inlinedefs.expect.scala
+++ b/tests/semanticdb/expect/inlinedefs.expect.scala
@@ -2,8 +2,6 @@ package inlinedefs
 
 object FakePredef/*<-inlinedefs::FakePredef.*/:
 
-  def assertFail/*<-inlinedefs::FakePredef.assertFail().*/(): Nothing/*->scala::Nothing#*/ = throw new java.lang.AssertionError/*->java::lang::AssertionError#*//*->java::lang::AssertionError#`<init>`(+2).*/("assertion failed")
-
   /** Super long padded documentation
    *  Lorem ipsum dolor sit amet, consectetur adipiscing elit,
    *  sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -15,5 +13,5 @@ object FakePredef/*<-inlinedefs::FakePredef.*/:
    */
   transparent inline final def assert/*<-inlinedefs::FakePredef.assert().*/(inline assertion/*<-inlinedefs::FakePredef.assert().(assertion)*/: Boolean/*->scala::Boolean#*/): Unit/*->scala::Unit#*/ = {
     if (!assertion/*->inlinedefs::FakePredef.assert().(assertion)*//*->scala::Boolean#`unary_!`().*/)
-      assertFail/*->inlinedefs::FakePredef.assertFail().*/()
+      throw new java.lang.AssertionError/*->java::lang::AssertionError#*//*->java::lang::AssertionError#`<init>`(+2).*/("assertion failed")
   }

--- a/tests/semanticdb/expect/inlinedefs.scala
+++ b/tests/semanticdb/expect/inlinedefs.scala
@@ -2,8 +2,6 @@ package inlinedefs
 
 object FakePredef:
 
-  def assertFail(): Nothing = throw new java.lang.AssertionError("assertion failed")
-
   /** Super long padded documentation
    *  Lorem ipsum dolor sit amet, consectetur adipiscing elit,
    *  sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -15,5 +13,5 @@ object FakePredef:
    */
   transparent inline final def assert(inline assertion: Boolean): Unit = {
     if (!assertion)
-      assertFail()
+      throw new java.lang.AssertionError("assertion failed")
   }

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3111,31 +3111,27 @@ Schema => SemanticDB v4
 Uri => inlinedefs.scala
 Text => empty
 Language => Scala
-Symbols => 4 entries
-Occurrences => 15 entries
+Symbols => 3 entries
+Occurrences => 12 entries
 
 Symbols:
 inlinedefs/FakePredef. => final object FakePredef
 inlinedefs/FakePredef.assert(). => final macro assert
 inlinedefs/FakePredef.assert().(assertion) => param assertion
-inlinedefs/FakePredef.assertFail(). => method assertFail
 
 Occurrences:
 [0:8..0:18): inlinedefs <- inlinedefs/
 [2:7..2:17): FakePredef <- inlinedefs/FakePredef.
-[4:6..4:16): assertFail <- inlinedefs/FakePredef.assertFail().
-[4:20..4:27): Nothing -> scala/Nothing#
-[4:40..4:44): java -> java/
-[4:45..4:49): lang -> java/lang/
-[4:50..4:64): AssertionError -> java/lang/AssertionError#
-[4:64..4:64): -> java/lang/AssertionError#`<init>`(+2).
-[15:31..15:37): assert <- inlinedefs/FakePredef.assert().
-[15:45..15:54): assertion <- inlinedefs/FakePredef.assert().(assertion)
-[15:56..15:63): Boolean -> scala/Boolean#
-[15:66..15:70): Unit -> scala/Unit#
-[16:9..16:18): assertion -> inlinedefs/FakePredef.assert().(assertion)
-[16:18..16:18): -> scala/Boolean#`unary_!`().
-[17:6..17:16): assertFail -> inlinedefs/FakePredef.assertFail().
+[13:31..13:37): assert <- inlinedefs/FakePredef.assert().
+[13:45..13:54): assertion <- inlinedefs/FakePredef.assert().(assertion)
+[13:56..13:63): Boolean -> scala/Boolean#
+[13:66..13:70): Unit -> scala/Unit#
+[14:9..14:18): assertion -> inlinedefs/FakePredef.assert().(assertion)
+[14:18..14:18): -> scala/Boolean#`unary_!`().
+[15:16..15:20): java -> java/
+[15:21..15:25): lang -> java/lang/
+[15:26..15:40): AssertionError -> java/lang/AssertionError#
+[15:40..15:40): -> java/lang/AssertionError#`<init>`(+2).
 
 expect/local-file.scala
 -----------------------


### PR DESCRIPTION
Although it is a useful thing to have, there is nothing specific to Scala 3 about it. Therefore, it does not carry its weight in `DottyPredef`.