### PR TITLE
Add a "terminal" callback to TastyInspector

### DIFF
--- a/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
+++ b/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
@@ -20,6 +20,9 @@ trait TastyInspector:
   /** Process a TASTy file using TASTy reflect */
   protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit
 
+  /** Called after all compilation units are processed */
+  protected def finishProcessingCompilationUnits(using QuoteContext): Unit = ()
+
   /** Load and process TASTy files using TASTy reflect
    *
    *  @param tastyFiles List of paths of `.tasty` files
@@ -70,7 +73,8 @@ trait TastyInspector:
       override protected def transformPhases: List[List[Phase]] = Nil
 
       override protected def backendPhases: List[List[Phase]] =
-        List(new TastyInspectorPhase) ::  // Print all loaded classes
+        List(new TastyInspectorPhase) ::  // Perform a callback for each compilation unit
+        List(new TastyInspectorFinishPhase) :: // Perform a final callback
         Nil
 
       override def newRun(implicit ctx: Context): Run =
@@ -88,6 +92,19 @@ trait TastyInspector:
         self.processCompilationUnit(using qctx)(ctx.compilationUnit.tpdTree.asInstanceOf[qctx.reflect.Tree])
 
     end TastyInspectorPhase
+
+    class TastyInspectorFinishPhase extends Phase:
+
+      override def phaseName: String = "tastyInspectorFinish"
+
+      override def run(implicit ctx: Context): Unit =
+        if !alreadyRan then
+          val qctx = QuoteContextImpl()
+          self.finishProcessingCompilationUnits(using qctx)
+          alreadyRan = true
+
+      var alreadyRan = false
+    end TastyInspectorFinishPhase
 
     val currentClasspath = ClasspathFromClassloader(getClass.getClassLoader)
     val fullClasspath = (classpath :+ currentClasspath).mkString(pathSeparator)

--- a/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
+++ b/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
@@ -99,9 +99,11 @@ trait TastyInspector:
 
       override def run(implicit ctx: Context): Unit =
         if !alreadyRan then
-          val qctx = QuoteContextImpl()
-          self.finishProcessingCompilationUnits(using qctx)
-          alreadyRan = true
+          try
+            val qctx = QuoteContextImpl()
+            self.finishProcessingCompilationUnits(using qctx)
+          finally
+            alreadyRan = true
 
       var alreadyRan = false
     end TastyInspectorFinishPhase

--- a/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
+++ b/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
@@ -11,6 +11,8 @@ import dotty.tools.dotc.core.Mode
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.fromtasty._
 import dotty.tools.dotc.util.ClasspathFromClassloader
+import dotty.tools.dotc.CompilationUnit
+import dotty.tools.unsupported
 
 import java.io.File.pathSeparator
 
@@ -21,7 +23,7 @@ trait TastyInspector:
   protected def processCompilationUnit(using QuoteContext)(root: qctx.reflect.Tree): Unit
 
   /** Called after all compilation units are processed */
-  protected def finishProcessingCompilationUnits(using QuoteContext): Unit = ()
+  protected def postProcess(using QuoteContext): Unit = ()
 
   /** Load and process TASTy files using TASTy reflect
    *
@@ -97,15 +99,13 @@ trait TastyInspector:
 
       override def phaseName: String = "tastyInspectorFinish"
 
-      override def run(implicit ctx: Context): Unit =
-        if !alreadyRan then
-          try
-            val qctx = QuoteContextImpl()
-            self.finishProcessingCompilationUnits(using qctx)
-          finally
-            alreadyRan = true
+      override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
+        val qctx = QuoteContextImpl()
+        self.postProcess(using qctx)
+        units
 
-      var alreadyRan = false
+      override def run(implicit ctx: Context): Unit = unsupported("run")
+
     end TastyInspectorFinishPhase
 
     val currentClasspath = ClasspathFromClassloader(getClass.getClassLoader)


### PR DESCRIPTION
@nicolasstucki I think we should allow defining a "final" callback in TastyInspector that runs after all compilation units are processed. The reason is very simple - this way, users can encode arbitrary operations on the full list of compilation units.

I've found a bunch of uses for that in the doctool and I suspect that external users will quickly need this as well.