### PR TITLE
Fix #10253: Fix result type of outer accessors

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -96,7 +96,6 @@ class ExplicitOuter extends MiniPhase with InfoTransformer { thisPhase =>
           val parentTp = cls.denot.thisType.baseType(parentTrait)
           val outerAccImpl = newOuterAccessor(cls, parentTrait).enteredAfter(thisPhase)
           newDefs += DefDef(outerAccImpl, singleton(fixThis(outerPrefix(parentTp))))
-            .showing(i"outAcc $result, ${outerPrefix(parentTp)}")
         }
 
       val parents1 =

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -171,12 +171,14 @@ object ExplicitOuter {
     val outerCls = outerClass(cls)
     val prefix = owner.thisType.baseType(cls).normalizedPrefix
     val target =
-      if (owner == cls)
-        outerCls.appliedRef
-      else
-        outerThis.baseType(outerCls)
-          .orElse(prefix.widen)
-          .orElse(outerCls.typeRef.appliedTo(outerCls.typeParams.map(_ => TypeBounds.empty)))
+      if owner == cls then outerCls.appliedRef
+      else outerThis.baseType(outerCls).orElse(prefix.widen)
+    /*println(i"""new outer $name in $owner, $cls,
+               |prefix = $prefix,
+               |outerThis = $outerThis,
+               |outCls = $outerCls,
+               |baseType = ${outerThis.baseType(outerCls)}
+               |target = $target""")*/
     val info = if (flags.is(Method)) ExprType(target) else target
     atPhaseNoEarlier(explicitOuterPhase.next) { // outer accessors are entered at explicitOuter + 1, should not be defined before.
       newSymbol(owner, name, Synthetic | flags, info, coord = cls.coord)

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -169,12 +169,14 @@ object ExplicitOuter {
   private def newOuterSym(owner: ClassSymbol, cls: ClassSymbol, name: TermName, flags: FlagSet)(using Context) = {
     val outerThis = owner.owner.enclosingClass.thisType
     val outerCls = outerClass(cls)
+    val prefix = owner.thisType.baseType(cls).normalizedPrefix
     val target =
       if (owner == cls)
         outerCls.appliedRef
       else
-        outerThis.baseType(outerCls).orElse(
-  		    outerCls.typeRef.appliedTo(outerCls.typeParams.map(_ => TypeBounds.empty)))
+        outerThis.baseType(outerCls)
+          .orElse(prefix.widen)
+          .orElse(outerCls.typeRef.appliedTo(outerCls.typeParams.map(_ => TypeBounds.empty)))
     val info = if (flags.is(Method)) ExprType(target) else target
     atPhaseNoEarlier(explicitOuterPhase.next) { // outer accessors are entered at explicitOuter + 1, should not be defined before.
       newSymbol(owner, name, Synthetic | flags, info, coord = cls.coord)

--- a/tests/pos/i10253.scala
+++ b/tests/pos/i10253.scala
@@ -1,0 +1,9 @@
+object test:
+  def foo(qc: QC): Unit =
+    object treeMap extends qc.reflect.TreeMap
+
+trait QC:
+  val reflect: Reflection
+  trait Reflection:
+    trait TreeMap:
+      def transformTree: Unit = ???


### PR DESCRIPTION
Use the actual prefix of the base type rather than an applied ThisType