### PR TITLE
Fix #10016: Bypass normalize for context function closure arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -677,7 +677,9 @@ trait Applications extends Compatibility {
    */
   class ApplicableToTrees(methRef: TermRef, args: List[Tree], resultType: Type)(using Context)
   extends TestApplication(methRef, methRef.widen, args, resultType) {
-    def argType(arg: Tree, formal: Type): Type = normalize(arg.tpe, formal)
+    def argType(arg: Tree, formal: Type): Type =
+      if untpd.isContextualClosure(arg) && defn.isContextFunctionType(formal) then arg.tpe
+      else normalize(arg.tpe, formal)
     def treeToArg(arg: Tree): Tree = arg
     def isVarArg(arg: Tree): Boolean = tpd.isWildcardStarArg(arg)
     def typeOfArg(arg: Tree): Type = arg.tpe

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -630,7 +630,8 @@ object ProtoTypes {
         normalize(et.resultType, pt)
       case wtp =>
         val iftp = defn.asContextFunctionType(wtp)
-        if (iftp.exists) normalize(iftp.dropDependentRefinement.argInfos.last, pt) else tp
+        if iftp.exists then normalize(iftp.dropDependentRefinement.argInfos.last, pt)
+        else tp
     }
   }
 

--- a/tests/run/i10016.scala
+++ b/tests/run/i10016.scala
@@ -1,0 +1,5 @@
+def f(init: Int ?=> Int) : Int = 1
+def f(s: String)(init: Int ?=> Int) : Int = 2
+
+@main def Test() =
+  assert(f((using x:Int) => x) == 1)


### PR DESCRIPTION
Do not widen to their result type if expected type is again a context function