### PR TITLE
Fix #9200: Add regression test

### DIFF
--- a/sbt-dotty/sbt-test/java-compat/i9200/build.sbt
+++ b/sbt-dotty/sbt-test/java-compat/i9200/build.sbt
@@ -1,0 +1,2 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+compileOrder := CompileOrder.ScalaThenJava

--- a/sbt-dotty/sbt-test/java-compat/i9200/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/java-compat/i9200/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))

--- a/sbt-dotty/sbt-test/java-compat/i9200/src/main/java/J.java
+++ b/sbt-dotty/sbt-test/java-compat/i9200/src/main/java/J.java
@@ -1,0 +1,1 @@
+class J { T.O$ o; }

--- a/sbt-dotty/sbt-test/java-compat/i9200/src/main/scala/T.scala
+++ b/sbt-dotty/sbt-test/java-compat/i9200/src/main/scala/T.scala
@@ -1,0 +1,1 @@
+trait T { object O }

--- a/sbt-dotty/sbt-test/java-compat/i9200/test
+++ b/sbt-dotty/sbt-test/java-compat/i9200/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
Fixed by #8652.  Closes #9200.

**Note:** CI as currently configured will not catch a regression here. The issue occurs on JDK 11, but not JDK 8 or JDK 14 (the two JDK versions used in CI).