### PR TITLE
Fix #9886: Disallow by-name trait parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -428,6 +428,11 @@ object desugar {
       }
       else originalTparams
 
+    if mods.is(Trait) then
+      for vparams <- originalVparamss; vparam <- vparams do
+        if vparam.tpt.isInstanceOf[ByNameTypeTree] then
+          report.error(em"implementation restriction: traits cannot have by name parameters", vparam.srcPos)
+
     // Annotations on class _type_ parameters are set on the derived parameters
     // but not on the constructor parameters. The reverse is true for
     // annotations on class _value_ parameters.

--- a/tests/neg/i9886.scala
+++ b/tests/neg/i9886.scala
@@ -1,0 +1,2 @@
+trait D(l: => Any):  // error
+  def f = l


### PR DESCRIPTION
This is at best a partial fix. We disallow by-name trait parameters as an implementation restriction. It's better than crashing. 

I tried for two days to make it work but gave up in the end. By-name parameters and traits are both very challenging to implement and their feature interaction in the various transformation stages is substantial. I will probably not go back to try to fix it again. If somebody wants to have a go, I can push the branch of my work so far. 


