### PR TITLE
Fix #9992: Reset toplevel indent region width on left indent

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -472,7 +472,6 @@ object Scanners {
            || nextWidth == lastWidth && (indentPrefix == MATCH || indentPrefix == CATCH) && token != CASE then
           if currentRegion.isOutermost then
             if nextWidth < lastWidth then currentRegion = topLevelRegion(nextWidth)
-//              report.error("Line is indented too far to the left", sourcePos())
           else if !isLeadingInfixOperator() && !statCtdTokens.contains(lastToken) then
             currentRegion match
               case r: Indented =>

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -470,16 +470,16 @@ object Scanners {
       else if indentIsSignificant then
         if nextWidth < lastWidth
            || nextWidth == lastWidth && (indentPrefix == MATCH || indentPrefix == CATCH) && token != CASE then
-          if !currentRegion.isOutermost &&
-             !isLeadingInfixOperator() &&
-             !statCtdTokens.contains(lastToken) then
+          if currentRegion.isOutermost then
+            if nextWidth < lastWidth then currentRegion = topLevelRegion(nextWidth)
+//              report.error("Line is indented too far to the left", sourcePos())
+          else if !isLeadingInfixOperator() && !statCtdTokens.contains(lastToken) then
             currentRegion match
               case r: Indented =>
                 currentRegion = r.enclosing
                 insert(OUTDENT, offset)
               case r: InBraces if !closingRegionTokens.contains(token) =>
-                report.warning("Line is indented too far to the left, or a `}` is missing",
-                  source.atSpan(Span(offset)))
+                report.warning("Line is indented too far to the left, or a `}` is missing", sourcePos())
               case _ =>
 
         else if lastWidth < nextWidth
@@ -1316,7 +1316,7 @@ object Scanners {
    /* Initialization: read first char, then first token */
     nextChar()
     nextToken()
-    currentRegion = Indented(indentWidth(offset), Set(), EMPTY, null)
+    currentRegion = topLevelRegion(indentWidth(offset))
   }
   // end Scanner
 
@@ -1356,6 +1356,8 @@ object Scanners {
    */
   case class Indented(width: IndentWidth, others: Set[IndentWidth], prefix: Token, outer: Region | Null) extends Region:
     knownWidth = width
+
+  def topLevelRegion(width: IndentWidth) = Indented(width, Set(), EMPTY, null)
 
   enum IndentWidth {
     case Run(ch: Char, n: Int)

--- a/tests/pos/i9992.scala
+++ b/tests/pos/i9992.scala
@@ -1,0 +1,5 @@
+  import scala.concurrent._
+
+@main def test(): Unit =
+  def test = ()
+  test

--- a/tests/pos/opaques-queue.scala
+++ b/tests/pos/opaques-queue.scala
@@ -1,0 +1,25 @@
+class Elem
+trait QueueSignature:
+  type Queue
+  def empty: Queue
+  def append(q: Queue, e: Elem): Queue
+  def pop(q: Queue): Option[(Elem, Queue)]
+val QueueModule: QueueSignature =
+  object QueueImpl extends QueueSignature:
+    type Queue = (List[Elem], List[Elem])
+    def empty = (Nil, Nil)
+    def append(q: Queue, e: Elem): Queue = (q._1, e :: q._2)
+    def pop(q: Queue): Option[(Elem, Queue)] = q match
+      case (Nil, Nil) => None
+      case (x :: xs, ys) => Some((x, (xs, ys)))
+      case (Nil, ys) => pop((ys.reverse, Nil))
+  QueueImpl
+
+object queues:
+  opaque type Queue = (List[Elem], List[Elem])
+  def empty = (Nil, Nil)
+  def append(q: Queue, e: Elem): Queue = (q._1, e :: q._2)
+  def pop(q: Queue): Option[(Elem, Queue)] = q match
+    case (Nil, Nil) => None
+    case (x :: xs, ys) => Some((x, (xs, ys)))
+    case (Nil, ys) => pop((ys.reverse, Nil))


### PR DESCRIPTION
If we start with a toplevel region with greater than 0 indent, and we
find a following line with less indentation, reset the current indentation
width to that smaller number.