### PR TITLE
Fix #9515: Fix handling of selftype for indentation

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3766,7 +3766,7 @@ object Parsers {
               if (name != nme.ERROR)
                 self = makeSelfDef(name, tpt).withSpan(first.span)
           }
-          in.token = EMPTY // hack to suppress INDENT insertion after `=>`
+          in.token = SELFARROW // suppresses INDENT insertion after `=>`
           in.nextToken()
         }
         else {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -487,6 +487,8 @@ object Scanners {
           if canStartIndentTokens.contains(lastToken) then
             currentRegion = Indented(nextWidth, Set(), lastToken, currentRegion)
             insert(INDENT, offset)
+          else if lastToken == SELFARROW then
+            currentRegion.knownWidth = nextWidth
         else if (lastWidth != nextWidth)
           errorButContinue(spaceTabMismatchMsg(lastWidth, nextWidth))
       currentRegion match {

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -204,6 +204,7 @@ object Tokens extends TokensCommon {
   final val QUOTE = 87;            enter(QUOTE, "'")
 
   final val COLONEOL = 88;         enter(COLONEOL, ":", ": at eol")
+  final val SELFARROW = 89;        enter(SELFARROW, "=>") // reclassified ARROW following self-type
 
   /** XML mode */
   final val XMLSTART = 98;         enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate

--- a/tests/pos/i9515.scala
+++ b/tests/pos/i9515.scala
@@ -1,0 +1,7 @@
+trait C {
+self =>
+
+  class D
+
+  class E
+}


### PR DESCRIPTION
The indentation of the self type does not matter anymore; it's the next token after
the `=>` that determines the indentation width.