### PR TITLE
Fix #9790: Update indentation spec to match observed behavior

### DIFF
--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -74,6 +74,11 @@ There are two rules:
 
     - the first token on the next line has an indentation width strictly less
         than the current indentation width, and
+    - the last token on the previous line is not one of the following tokens
+      which indicate that the previous statement continues:
+      ```
+      then  else  do  catch  finally  yield  match
+      ```
     - the first token on the next line is not a
         [leading infix operator](../changed-features/operators.html).
 

--- a/tests/neg/i9790.scala
+++ b/tests/neg/i9790.scala
@@ -1,0 +1,7 @@
+object A:
+   def fn: Unit =
+    if true then
+  println(1)
+  println(2) // error: start of line does not match previous indentation widths
+    else
+  println(2)


### PR DESCRIPTION
I added the clause

 2. An `<outdent>` is inserted at a line break, if

    - ...
    - the last token on the previous line is not one of the following tokens
      which indicate that the previous statement continues:
      ```
      then  else  do  catch  finally  yield  match
      ```

I tried to do without the added clause but lots of tests break. To verify, set
Tokens.statCtdTokens to BitSet() and observe the breakage.