### PR TITLE
Add `Tree.of` and `Term.of` to transform `Expr` into `Tree`

### DIFF
--- a/docs/docs/reference/metaprogramming/tasty-reflect.md
+++ b/docs/docs/reference/metaprogramming/tasty-reflect.md
@@ -42,7 +42,7 @@ trees. For example the `Literal(_)` extractor used below.
 ```scala
 def natConstImpl(x: Expr[Int])(using qctx: QuoteContext): Expr[Int] = {
   import qctx.reflect._
-  val xTree: Term = x.unseal
+  val xTree: Term = Term.of(x)
   xTree match {
     case Inlined(_, _, Literal(Constant(n: Int))) =>
       if (n <= 0) {

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -14,7 +14,8 @@ object Expr {
    *   Some bindings may be elided as an early optimization.
    */
   def betaReduce[T](expr: Expr[T])(using qctx: QuoteContext): Expr[T] =
-    qctx.reflect.Term.betaReduce(expr.unseal) match
+    import qctx.reflect._
+    Term.betaReduce(Term.of(expr)) match
       case Some(expr1) => expr1.asExpr.asInstanceOf[Expr[T]]
       case _ => expr
 
@@ -24,7 +25,7 @@ object Expr {
    */
   def block[T](statements: List[Expr[Any]], expr: Expr[T])(using qctx: QuoteContext): Expr[T] = {
     import qctx.reflect._
-    Block(statements.map(_.unseal), expr.unseal).asExpr.asInstanceOf[Expr[T]]
+    Block(statements.map(Term.of), Term.of(expr)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Lift a value into an expression containing the construction of that value */

--- a/library/src-bootstrapped/scala/quoted/ExprMap.scala
+++ b/library/src-bootstrapped/scala/quoted/ExprMap.scala
@@ -104,7 +104,8 @@ trait ExprMap:
             type X
             val expr = tree.asExpr.asInstanceOf[Expr[X]]
             val t = tpe.asType.asInstanceOf[Type[X]]
-            transform(expr)(using qctx, t).unseal
+            val transformedExpr = transform(expr)(using qctx, t)
+            Term.of(transformedExpr)
           case _ =>
             transformTermChildren(tree, tpe)
 
@@ -144,7 +145,7 @@ trait ExprMap:
         trees mapConserve (transformTypeCaseDef(_))
 
     }
-    new MapChildren().transformTermChildren(e.unseal, TypeRepr.of[T]).asExprOf[T]
+    new MapChildren().transformTermChildren(Term.of(e), TypeRepr.of[T]).asExprOf[T]
   }
 
 end ExprMap

--- a/library/src/scala/quoted/Const.scala
+++ b/library/src/scala/quoted/Const.scala
@@ -23,7 +23,7 @@ object Const {
       case Inlined(_, Nil, e) => rec(e)
       case _  => None
     }
-    rec(expr.unseal)
+    rec(Term.of(expr))
   }
 
 }

--- a/library/src/scala/quoted/QuoteContext.scala
+++ b/library/src/scala/quoted/QuoteContext.scala
@@ -48,10 +48,13 @@ trait QuoteContext { self: internal.QuoteUnpickler & internal.QuoteMatching =>
       unlift.fromExpr(self)(using QuoteContext.this).getOrElse(reportError)
 
     /** View this expression `quoted.Expr[T]` as a `Term` */
+    @deprecated("Use reflect.Term.of", "")
     def unseal: reflect.Term = self.asReflectTree // TODO remove
 
     /** View this expression `quoted.Expr[T]` as a `Term` */
-    def asReflectTree: reflect.Term
+    @deprecated("Use reflect.Term.of", "")
+    def asReflectTree: reflect.Term = // TODO remove
+      reflect.Term.of(self)
   end extension
 
   // Extension methods for `Expr[Any]` that take another explicit type parameter

--- a/library/src/scala/quoted/Reflection.scala
+++ b/library/src/scala/quoted/Reflection.scala
@@ -129,7 +129,10 @@ trait Reflection { reflection =>
 
   val Tree: TreeModule
 
-  trait TreeModule { this: Tree.type => }
+  trait TreeModule { this: Tree.type =>
+    /** Returns the Term representation this expression */
+    def of(expr: Expr[Any]): Tree
+  }
 
   given TreeMethods as TreeMethods = TreeMethodsImpl
   protected val TreeMethodsImpl: TreeMethods
@@ -371,6 +374,9 @@ trait Reflection { reflection =>
   val Term: TermModule
 
   trait TermModule { this: Term.type =>
+
+    /** Returns the Term representation this expression */
+    def of(expr: Expr[Any]): Term
 
     /** Returns a term that is functionally equivalent to `t`,
      *  however if `t` is of the form `((y1, ..., yn) => e2)(e1, ..., en)`

--- a/library/src/scala/quoted/Varargs.scala
+++ b/library/src/scala/quoted/Varargs.scala
@@ -17,7 +17,7 @@ object Varargs {
    */
   def apply[T](xs: Seq[Expr[T]])(using tp: Type[T], qctx: QuoteContext): Expr[Seq[T]] = {
     import qctx.reflect._
-    Repeated(xs.map[Term](_.unseal).toList, TypeTree.of[T]).asExpr.asInstanceOf[Expr[Seq[T]]]
+    Repeated(xs.map(Term.of).toList, TypeTree.of[T]).asExpr.asInstanceOf[Expr[Seq[T]]]
   }
 
   /** Matches a literal sequence of expressions and return a sequence of expressions.
@@ -40,7 +40,7 @@ object Varargs {
       case Inlined(_, Nil, e) => rec(e)
       case _  => None
     }
-    rec(expr.unseal)
+    rec(Term.of(expr))
   }
 
 }

--- a/library/src/scala/quoted/report.scala
+++ b/library/src/scala/quoted/report.scala
@@ -4,11 +4,13 @@ object report:
 
   /** Report an error at the position of the macro expansion */
   def error(msg: => String)(using qctx: QuoteContext): Unit =
-    qctx.reflect.Reporting.error(msg, qctx.reflect.Position.ofMacroExpansion)
+    import qctx.reflect._
+    Reporting.error(msg, Position.ofMacroExpansion)
 
   /** Report an error at the on the position of `expr` */
   def error(msg: => String, expr: Expr[Any])(using qctx: QuoteContext): Unit =
-    qctx.reflect.Reporting.error(msg, expr.unseal.pos)
+    import qctx.reflect._
+    Reporting.error(msg, Term.of(expr).pos)
 
   /** Report an error at the position of the macro expansion and throws a StopQuotedContext */
   def throwError(msg: => String)(using qctx: QuoteContext): Nothing = {
@@ -23,11 +25,13 @@ object report:
 
   /** Report a warning */
   def warning(msg: => String)(using qctx: QuoteContext): Unit =
-    qctx.reflect.Reporting.warning(msg, qctx.reflect.Position.ofMacroExpansion)
+    import qctx.reflect._
+    Reporting.warning(msg, Position.ofMacroExpansion)
 
   /** Report a warning at the on the position of `expr` */
-  def warning(msg: => String, expr: Expr[_])(using qctx: QuoteContext): Unit =
-    qctx.reflect.Reporting.warning(msg, expr.unseal.pos)
+  def warning(msg: => String, expr: Expr[Any])(using qctx: QuoteContext): Unit =
+    import qctx.reflect._
+    Reporting.warning(msg, Term.of(expr).pos)
 
   /** Throwable used to stop the expansion of a macro after an error was reported */
   class StopQuotedContext extends Throwable

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)
-          Reporting.error(s, part.unseal.pos)
+          Reporting.error(s, Term.of(part).pos)
     }
     '{}
   }

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)
-          Reporting.error(s, part.unseal.pos)
+          Reporting.error(s, Term.of(part).pos)
     }
     '{}
   }

--- a/tests/neg-macros/i6976/Macro_1.scala
+++ b/tests/neg-macros/i6976/Macro_1.scala
@@ -7,6 +7,6 @@ object macros {
 
   def mcrImpl(body: Expr[Any])(using ctx: QuoteContext) : Expr[Any] = {
     import ctx.reflect._
-    body.unseal match { case Block(_, _) => '{2} }
+    Term.of(body) match { case Block(_, _) => '{2} }
   }
 }

--- a/tests/neg-macros/i7698.scala
+++ b/tests/neg-macros/i7698.scala
@@ -5,7 +5,8 @@ trait Show[T] {
 }
 
 def showInterpolatorImpl(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext): Expr[String] =
-  argsExpr.unseal match
+  import qctx.reflect._
+  Term.of(argsExpr) match
     case '{ $arg: $t } => // error
     case '[ Int ] => // error
   ???

--- a/tests/neg-macros/i9801/Macro_1.scala
+++ b/tests/neg-macros/i9801/Macro_1.scala
@@ -11,10 +11,11 @@ def triggerStackOverflow(n: Int): Expr[Double] = {
 inline def loop(inline prog: Double): Double = ${impl('prog)}
 
 def impl(prog: Expr[Double])(using QuoteContext) : Expr[Double] =
+  import qctx.reflect._
   try {
     triggerStackOverflow(0)
   } catch {
     case e =>
-      qctx.reflect.Reporting.error(e.getMessage, prog.unseal.pos)
+      qctx.reflect.Reporting.error(e.getMessage, Term.of(prog).pos)
       '{ 42.0 }
   }

--- a/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val tree = cond.unseal
+    val tree = Term.of(cond)
 
     def isOps(tpe: TypeRepr): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts

--- a/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val tree = cond.unseal
+    val tree = Term.of(cond)
 
     def isOps(tpe: TypeRepr): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts

--- a/tests/neg-macros/tasty-macro-error/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-error/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
-    Reporting.error("here is the the argument is " + x.unseal.underlyingArgument.show, x.unseal.underlyingArgument.pos)
+    Reporting.error("here is the the argument is " + Term.of(x).underlyingArgument.show, Term.of(x).underlyingArgument.pos)
     '{}
   }
 

--- a/tests/neg-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-positions/quoted_1.scala
@@ -6,9 +6,9 @@ object Macros {
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
-    val pos = x.unseal.underlyingArgument.pos
-    Reporting.error("here is the the argument is " + x.unseal.underlyingArgument.show, pos)
-    Reporting.error("here (+5) is the the argument is " + x.unseal.underlyingArgument.show, pos.sourceFile, pos.start + 5, pos.end + 5)
+    val pos = Term.of(x).underlyingArgument.pos
+    Reporting.error("here is the the argument is " + Term.of(x).underlyingArgument.show, pos)
+    Reporting.error("here (+5) is the the argument is " + Term.of(x).underlyingArgument.show, pos.sourceFile, pos.start + 5, pos.end + 5)
     '{}
   }
 

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -11,7 +11,7 @@ object FIntepolator {
 
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.reflect._
-    Reporting.error("there are no parts", strCtxExpr.unseal.underlyingArgument.pos)
+    Reporting.error("there are no parts", Term.of(strCtxExpr).underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }
 

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
 object FIntepolator {
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.reflect._
-    Reporting.error("there are no args", argsExpr.unseal.underlyingArgument.pos)
+    Reporting.error("there are no args", Term.of(argsExpr).underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }
 

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -17,10 +17,10 @@ object Lens {
     import util._
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =
-      Select.overloaded(obj.unseal, "copy", Nil, NamedArg(field, value.unseal) :: Nil, TypeBounds.empty).asExprOf[S]
+      Select.overloaded(Term.of(obj), "copy", Nil, NamedArg(field, Term.of(value)) :: Nil, TypeBounds.empty).asExprOf[S]
 
-    // exception: getter.unseal.underlyingArgument
-    getter.unseal match {
+    // exception: Term.of(getter).underlyingArgument
+    Term.of(getter) match {
       case Inlined(
         None, Nil,
         Block(

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -9,7 +9,7 @@ object Macros {
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val tree = x.unseal
+    val tree = Term.of(x)
     tree.symbol.comment.map(_.raw) match {
       case Some(str) => '{ println(${str}) }
       case None => '{ println() }

--- a/tests/pos-macros/i6171/Macro_1.scala
+++ b/tests/pos-macros/i6171/Macro_1.scala
@@ -6,7 +6,7 @@ object scalatest {
 
   def assertImpl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
-    x.unseal.underlyingArgument
+    Term.of(x).underlyingArgument
     '{ () }
   }
 }

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -9,7 +9,7 @@ object scalatest {
     import util._
     import ValDef.let
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         let(lhs) { left =>
           let(rhs) { right =>
@@ -19,7 +19,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]

--- a/tests/pos-macros/i7011/Macros_1.scala
+++ b/tests/pos-macros/i7011/Macros_1.scala
@@ -5,7 +5,7 @@ inline def mcr(body: => Any): Unit = ${mcrImpl('body)}
 def mcrImpl[T](body: Expr[Any])(using QuoteContext) : Expr[Any] = {
   import qctx.reflect._
 
-  val bTree = body.unseal
+  val bTree = Term.of(body)
   val under = bTree.underlyingArgument
 
   val res = '{Box(${under.asInstanceOf[Term].asExpr})}

--- a/tests/pos-macros/i7030/Macros_1.scala
+++ b/tests/pos-macros/i7030/Macros_1.scala
@@ -7,5 +7,5 @@ def innerImpl(exprs: Expr[Any])(using QuoteContext): Expr[Any] =
 inline def outer(expr: => Any): Any = ${outerImpl('expr)}
 def outerImpl(body: Expr[Any])(using QuoteContext): Expr[Any] = {
   import qctx.reflect._
-  body.unseal.underlyingArgument.asExpr
+  Term.of(body).underlyingArgument.asExpr
 }

--- a/tests/pos-macros/i8325/Macro_1.scala
+++ b/tests/pos-macros/i8325/Macro_1.scala
@@ -13,7 +13,7 @@ object A:
 
   def transformImplExpr[A:Type](using qctx: QuoteContext)(expr: Expr[A]): Expr[A] = {
      import qctx.reflect._
-     expr.unseal match {
+     Term.of(expr) match {
          case Inlined(x,y,z) => transformImplExpr(z.asExpr.asInstanceOf[Expr[A]])
          case Apply(fun,args) =>  '{  A.pure(${Apply(fun,args).asExpr.asInstanceOf[Expr[A]]}) }
          case other => expr

--- a/tests/pos-macros/i8325b/Macro_1.scala
+++ b/tests/pos-macros/i8325b/Macro_1.scala
@@ -13,7 +13,7 @@ object A:
 
   def transformImplExpr[A:Type](using qctx: QuoteContext)(expr: Expr[A]): Expr[A] = {
      import qctx.reflect._
-     expr.unseal match {
+     Term.of(expr) match {
          case Inlined(x,y,z) => transformImplExpr(z.asExpr.asInstanceOf[Expr[A]])
          case r@Apply(fun,args) =>  '{
               A.pure(${r.asExpr.asInstanceOf[Expr[A]]}) }

--- a/tests/pos-macros/i8866/Macro_1.scala
+++ b/tests/pos-macros/i8866/Macro_1.scala
@@ -16,7 +16,7 @@ object Macro {
 
     ValDef.let(
       Select.unique(
-        '{ OtherMacro }.unseal,
+        Term.of('{ OtherMacro }),
         "apply"
       )
     )(identity).asExprOf[Int]

--- a/tests/pos-macros/i8866b/Macro_1.scala
+++ b/tests/pos-macros/i8866b/Macro_1.scala
@@ -11,7 +11,7 @@ object Macro {
 
     ValDef.let(
       Select.unique(
-        '{ Other }.unseal,
+        Term.of('{ Other }),
         "apply"
       )
     )(identity).asExprOf[Int]

--- a/tests/pos-macros/i9251/Macro_1.scala
+++ b/tests/pos-macros/i9251/Macro_1.scala
@@ -21,7 +21,7 @@ object Async {
   def checkPrintTypeImpl[F[_]:Type,T:Type](f: Expr[T])(using qctx: QuoteContext): Expr[Unit] =
     import qctx.reflect._
 
-    val fu = f.unseal
+    val fu = Term.of(f)
     fu match
       case Inlined(_,_,Block(_,Apply(TypeApply(Select(q,n),tparams),List(param)))) =>
         param.tpe match

--- a/tests/pos-macros/i9518/Macro_1.scala
+++ b/tests/pos-macros/i9518/Macro_1.scala
@@ -7,7 +7,7 @@ inline def shift : Unit = ${ shiftTerm }
 
 def shiftTerm(using QuoteContext): Expr[Unit] = {
   import qctx.reflect._
-  val nTree = '{ ??? : CB[Int] }.unseal
+  val nTree = Term.of('{ ??? : CB[Int] })
   val tp1 = TypeRepr.of[CB[Int]]
   val tp2 = TypeRepr.of[([X] =>> CB[X])[Int]]
   val ta = Type.of[[X] =>> CB[X]]

--- a/tests/pos-macros/i9687/Macro_1.scala
+++ b/tests/pos-macros/i9687/Macro_1.scala
@@ -24,8 +24,8 @@ object X {
 
  def transformImpl[A:Type](x:Expr[A])(using qctx: QuoteContext):Expr[A] = {
     import qctx.reflect._
-    val slowPath = '{ SlowPath }.unseal
-    val fastPath = '{ FastPath }.unseal
+    val slowPath = Term.of('{ SlowPath })
+    val fastPath = Term.of('{ FastPath })
     val transformer = new TreeMap() {
       override def transformTerm(term:Term)(using ctx:Context):Term = {
         term match
@@ -37,7 +37,7 @@ object X {
           case _ => super.transformTerm(term)
       }
     }
-    val r = transformer.transformTerm(x.unseal).asExprOf[A]
+    val r = transformer.transformTerm(Term.of(x)).asExprOf[A]
     s"result: ${r.show}"
     r
  }

--- a/tests/pos-macros/i9894/Macro_1.scala
+++ b/tests/pos-macros/i9894/Macro_1.scala
@@ -36,7 +36,7 @@ object X:
         case Block(stats, last) => Block(stats, transform(last))
         case Inlined(x,List(),body) => transform(body)
         case l@Literal(x) =>
-             '{ CBM.pure(${term.asExpr}) }.unseal
+          Term.of('{ CBM.pure(${term.asExpr}) })
         case other =>
              throw RuntimeException(s"Not supported $other")
 
@@ -64,4 +64,4 @@ object X:
          }
          changes.transformTerm(body)
 
-   transform(f.unseal).asExprOf[CB[T]]
+   transform(Term.of(f)).asExprOf[CB[T]]

--- a/tests/pos-macros/treemap-unapply/Macro.scala
+++ b/tests/pos-macros/treemap-unapply/Macro.scala
@@ -3,6 +3,6 @@ import scala.quoted._
 inline def mcr(x: => Unit): Unit = ${mcrImpl('x)}
 def mcrImpl(x: Expr[Unit])(using QuoteContext) : Expr[Unit] =
   import qctx.reflect._
-  val tr: Term = x.unseal
+  val tr: Term = Term.of(x)
   object m extends TreeMap
   m.transformTerm(tr).asExprOf[Unit]

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -7,7 +7,7 @@ object Foo {
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.reflect._
-    x.unseal match {
+    Term.of(x) match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -7,7 +7,7 @@ object Foo {
 
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.reflect._
-    x.unseal match {
+    Term.of(x) match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -12,7 +12,7 @@ object Macros {
 
     val output = myTraverser(buff)
 
-    val tree = x.unseal
+    val tree = Term.of(x)
     output.traverseTree(tree)
     '{print(${Expr(buff.result())})}
   }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -13,7 +13,7 @@ object Foo {
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)
       else '{"NO DEFINTION"}
 
-    x.unseal match {
+    Term.of(x) match {
       case Inlined(None, Nil, arg) => definitionString(arg.symbol)
       case arg => definitionString(arg.symbol) // TODO should all by name parameters be in an inline node
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -12,7 +12,7 @@ object Foo {
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)
       else '{"NO DEFINTION"}
 
-    x.unseal match {
+    Term.of(x) match {
       case Inlined(None, Nil, arg) => definitionString(arg.symbol)
       case arg => definitionString(arg.symbol) // TODO should all by name parameters be in an inline node
     }

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -31,7 +31,7 @@ object FQuote {
       tree.symbol.fullName == "scala.StringContext$.apply"
 
     // FQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts = receiver.unseal.underlyingArgument match {
+    val parts = Term.of(receiver).underlyingArgument match {
       case Apply(conv, List(Apply(fun, List(Typed(Repeated(values, _), _)))))
           if isSCOpsConversion(conv) &&
              isStringContextApply(fun) &&
@@ -43,7 +43,7 @@ object FQuote {
     }
 
     // [a0, ...]: Any*
-    val Typed(Repeated(allArgs, _), _) = args.unseal.underlyingArgument
+    val Typed(Repeated(allArgs, _), _) = Term.of(args).underlyingArgument
 
     for ((arg, part) <- allArgs.zip(parts.tail)) {
       if (part.startsWith("%d") && !(arg.tpe <:< TypeRepr.of[Int])) {

--- a/tests/run-macros/i10011/Macro_1.scala
+++ b/tests/run-macros/i10011/Macro_1.scala
@@ -4,5 +4,6 @@ inline def printPos[T](inline expr: T): (Int, Int) =
   ${ printPos('expr) }
 
 private def printPos[T](expr: Expr[T])(using QuoteContext): Expr[(Int, Int)] =
-  val pos = expr.unseal.pos
+  import qctx.reflect._
+  val pos = Term.of(expr).pos
   Expr((pos.start, pos.end))

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -7,6 +7,6 @@ object Macro {
   implicit inline def XmlQuote(inline sc: StringContext): StringContextOps = new StringContextOps(sc)
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.reflect._
-    Expr(sc.unseal.underlyingArgument.showExtractors + "\n" + args.unseal.underlyingArgument.showExtractors)
+    Expr(Term.of(sc).underlyingArgument.showExtractors + "\n" + Term.of(args).underlyingArgument.showExtractors)
   }
 }

--- a/tests/run-macros/i5119b/Macro_1.scala
+++ b/tests/run-macros/i5119b/Macro_1.scala
@@ -6,6 +6,7 @@ object Macro {
   inline def ff(arg1: Any,  arg2: Any): String = ${ Macro.impl('{arg1}, '{arg2}) }
 
   def impl(arg1: Expr[Any], arg2: Expr[Any])(using qctx: QuoteContext) : Expr[String] =
-    Expr(arg1.unseal.underlyingArgument.showExtractors + "\n" + arg2.unseal.underlyingArgument.showExtractors)
+    import qctx.reflect._
+    Expr(Term.of(arg1).underlyingArgument.showExtractors + "\n" + Term.of(arg2).underlyingArgument.showExtractors)
 
 }

--- a/tests/run-macros/i5533/Macro_1.scala
+++ b/tests/run-macros/i5533/Macro_1.scala
@@ -10,7 +10,7 @@ object scalatest {
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val tree = condition.unseal
+    val tree = Term.of(condition)
 
     val expr = tree.asExprOf[Boolean]
 

--- a/tests/run-macros/i5533b/Macro_1.scala
+++ b/tests/run-macros/i5533b/Macro_1.scala
@@ -8,7 +8,7 @@ object scalatest {
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
-    val tree = condition.unseal
+    val tree = Term.of(condition)
     def exprStr: String = condition.show
 
     tree.underlyingArgument match {

--- a/tests/run-macros/i5536/Macro_1.scala
+++ b/tests/run-macros/i5536/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
 
   def assertImpl(condition: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
-    val tree = condition.unseal
+    val tree = Term.of(condition)
     def exprStr: String = condition.show
 
     tree.underlyingArgument match {

--- a/tests/run-macros/i5629/Macro_1.scala
+++ b/tests/run-macros/i5629/Macro_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
-    val b = cond.unseal.underlyingArgument.asExprOf[Boolean]
+    val b = Term.of(cond).underlyingArgument.asExprOf[Boolean]
     '{ scala.Predef.assert($b) }
   }
 

--- a/tests/run-macros/i5715/Macro_1.scala
+++ b/tests/run-macros/i5715/Macro_1.scala
@@ -7,7 +7,7 @@ object scalatest {
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case app @ Apply(select @ Select(lhs, op), rhs :: Nil) =>
         val cond = Apply(Select.copy(select)(lhs, "exists"), rhs :: Nil).asExprOf[Boolean]
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -45,11 +45,11 @@ object Lens {
       }
     }
 
-    // exception: getter.unseal.underlyingArgument
-    getter.unseal match {
+    // exception: Term.of(getter).underlyingArgument
+    Term.of(getter) match {
       case Function(param :: Nil, Path(o, parts)) if o.symbol == param.symbol =>
         '{
-          val setter = (t: T) => (s: S) => ${ setterBody(('s).unseal, ('t).unseal, parts).asExprOf[S] }
+          val setter = (t: T) => (s: S) => ${ setterBody(Term.of('s), Term.of('t), parts).asExprOf[S] }
           apply($getter)(setter)
         }
       case _ =>
@@ -116,9 +116,9 @@ object Iso {
       '{???}
     } else '{
       // (p: S) => p._1
-      val to = (p: S) =>  ${ Select.unique(('p).unseal, "_1").asExprOf[A] }
+      val to = (p: S) =>  ${ Select.unique(Term.of('p), "_1").asExprOf[A] }
       // (p: A) => S(p)
-      val from = (p: A) =>  ${ Select.overloaded(Ident(companion), "apply", Nil, ('p).unseal :: Nil).asExprOf[S] }
+      val from = (p: A) =>  ${ Select.overloaded(Ident(companion), "apply", Nil, Term.of('p) :: Nil).asExprOf[S] }
       apply(from)(to)
     }
   }

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         ValDef.let(lhs) { left =>
           ValDef.let(rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/i6679/Macro_1.scala
+++ b/tests/run-macros/i6679/Macro_1.scala
@@ -4,7 +4,7 @@ def makeMatch[A: Type](head : Expr[A])(using qctx : QuoteContext) : Expr[Unit] =
   import qctx.reflect._
 
   val sacrifice = '{ $head match { case _ => ??? } }
-  sacrifice.unseal
+  Term.of(sacrifice)
 
   '{ println("Ok") }
 }

--- a/tests/run-macros/i7887/Macro_1.scala
+++ b/tests/run-macros/i7887/Macro_1.scala
@@ -1,10 +1,10 @@
 def myMacroImpl(a: quoted.Expr[_])(using qctx: quoted.QuoteContext) = {
   import qctx.reflect._
   def typed[A] = {
-    implicit val t: quoted.Type[A] = a.unseal.tpe.widen.asType.asInstanceOf[quoted.Type[A]]
+    implicit val t: quoted.Type[A] = Term.of(a).tpe.widen.asType.asInstanceOf[quoted.Type[A]]
     '{
       type T = A
-      ${a.unseal.asExprOf[T]}
+      ${Term.of(a).asExprOf[T]}
     }
   }
 

--- a/tests/run-macros/i7898/Macro_1.scala
+++ b/tests/run-macros/i7898/Macro_1.scala
@@ -4,7 +4,7 @@ object Main {
 
   def myMacroImpl(body: Expr[_])(using qctx: QuoteContext) : Expr[_] = {
     import qctx.reflect._
-    val bodyTerm = underlyingArgument(body).unseal
+    val bodyTerm = Term.of(underlyingArgument(body))
     val showed = bodyTerm.show
     '{
       println(${Expr(showed)})
@@ -17,5 +17,6 @@ object Main {
   }
 
   def underlyingArgument[T](expr: Expr[T])(using qctx: QuoteContext): Expr[T] =
-    expr.unseal.underlyingArgument.asExpr.asInstanceOf[Expr[T]]
+    import qctx.reflect._
+    Term.of(expr).underlyingArgument.asExpr.asInstanceOf[Expr[T]]
 }

--- a/tests/run-macros/i8007/Macro_2.scala
+++ b/tests/run-macros/i8007/Macro_2.scala
@@ -30,7 +30,7 @@ object Macro2 {
 
       val body: Expr[T] => Expr[String] = elem =>
         fields.reverse.foldLeft(Expr("")){ (acc, field) =>
-          val res = Select.unique(elem.unseal, field).asExpr
+          val res = Select.unique(Term.of(elem), field).asExpr
           '{ $res.toString + " " + $acc }
         }
 

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -5,7 +5,7 @@ object Macros {
   def impl[T](expr: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val tree = expr.unseal
+    val tree = Term.of(expr)
 
     val methods =
       tree.tpe.classSymbol.get.classMethods.map { m =>

--- a/tests/run-macros/paramSymss/Macro_1.scala
+++ b/tests/run-macros/paramSymss/Macro_1.scala
@@ -4,8 +4,9 @@ inline def showParamSyms(inline x: Any): String =
   ${ showParamSymsExpr('x) }
 
 def showParamSymsExpr(using QuoteContext)(x: Expr[Any]): Expr[String] =
+  import qctx.reflect._
   val '{ $y: Any } = x // Drop Inlined not to access the symbol
-  val sym = y.unseal.symbol
+  val sym = Term.of(y).symbol
   Expr(
     s"""sym: ${sym.show}
        |paramSymss: ${sym.paramSymss.map(_.map(_.show))}

--- a/tests/run-macros/quote-matcher-runtime/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-runtime/quoted_1.scala
@@ -17,8 +17,8 @@ object Macros {
     }
 
     '{
-      println("Scrutinee: " + ${Expr(a.unseal.show)})
-      println("Pattern: " + ${Expr(b.unseal.show)})
+      println("Scrutinee: " + ${Expr(Term.of(a).show)})
+      println("Pattern: " + ${Expr(Term.of(b).show)})
       println("Result: " + ${Expr(res.toString)})
       println()
     }

--- a/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
@@ -21,7 +21,7 @@ object Macros {
 
       case _ =>
         import qctx.reflect._
-        Reporting.error("Expected explicit DSL", e.unseal.pos)
+        Reporting.error("Expected explicit DSL", Term.of(e).pos)
         '{ ??? }
 
     }

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -39,7 +39,7 @@ object Macros {
 
       case _ =>
         import qctx.reflect._
-        Reporting.error("Expected explicit DSL " + e.show, e.unseal.pos)
+        Reporting.error("Expected explicit DSL " + e.show, Term.of(e).pos)
         ???
     }
 
@@ -53,7 +53,7 @@ object Macros {
         )
       case _ =>
         import qctx.reflect._
-        Reporting.error("Expected explicit DSL => DSL "  + e.show, e.unseal.pos)
+        Reporting.error("Expected explicit DSL => DSL "  + e.show, Term.of(e).pos)
         ???
     }
 
@@ -64,12 +64,13 @@ object Macros {
 
 object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using qctx: QuoteContext): X = {
+    import qctx.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.unseal, params, List(v.unseal)).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.unseal.etaExpand
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
@@ -76,12 +76,13 @@ object Macros {
 
 object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using qctx: QuoteContext): X = {
+    import qctx.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.unseal, params, List(v.unseal)).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.unseal.etaExpand
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matching-open/Macro_1.scala
+++ b/tests/run-macros/quote-matching-open/Macro_1.scala
@@ -17,21 +17,24 @@ object Macro {
 
 object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using qctx: QuoteContext): X = {
+    import qctx.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.unseal, params, List(v.unseal)).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
   }
   def open[T1, T2, R, X](f: Expr[(T1, T2) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2]) => Expr[t]) => X)(using qctx: QuoteContext)(using DummyImplicit): X = {
+    import qctx.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2]) => bodyFn[t](e.unseal, params, List(v1.unseal, v2.unseal)).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2]) => bodyFn[t](Term.of(e), params, List(Term.of(v1), Term.of(v2))).asExpr.asInstanceOf[Expr[t]])
   }
 
   def open[T1, T2, T3, R, X](f: Expr[(T1, T2, T3) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2], Expr[T3]) => Expr[t]) => X)(using qctx: QuoteContext)(using DummyImplicit, DummyImplicit): X = {
+    import qctx.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](e.unseal, params, List(v1.unseal, v2.unseal, v3.unseal)).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](Term.of(e), params, List(Term.of(v1), Term.of(v2), Term.of(v3))).asExpr.asInstanceOf[Expr[t]])
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.unseal.etaExpand
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quoted-matching-docs/Macro_1.scala
+++ b/tests/run-macros/quoted-matching-docs/Macro_1.scala
@@ -8,7 +8,6 @@ private def sumExprShow(argsExpr: Expr[Seq[Int]]) (using QuoteContext): Expr[Str
   Expr(sumExpr(argsExpr).show)
 
 private def sumExpr(argsExpr: Expr[Seq[Int]])(using qctx: QuoteContext) : Expr[Int] = {
-  import qctx.reflect._
   UnsafeExpr.underlyingArgument(argsExpr) match {
     case Varargs(Consts(args)) => // args is of type Seq[Int]
       Expr(args.sum) // precompute result of sum
@@ -29,5 +28,6 @@ private def sumExpr(argsExpr: Expr[Seq[Int]])(using qctx: QuoteContext) : Expr[I
 
 object UnsafeExpr {
   def underlyingArgument[T](expr: Expr[T])(using qctx: QuoteContext): Expr[T] =
-    expr.unseal.underlyingArgument.asExpr.asInstanceOf[Expr[T]]
+    import qctx.reflect._
+    Term.of(expr).underlyingArgument.asExpr.asInstanceOf[Expr[T]]
 }

--- a/tests/run-macros/refined-selectable-macro/Macro_1.scala
+++ b/tests/run-macros/refined-selectable-macro/Macro_1.scala
@@ -17,7 +17,7 @@ object Macro {
   private def toTupleImpl(s: Expr[Selectable])(using qctx:QuoteContext) : Expr[Tuple] = {
     import qctx.reflect._
 
-    val repr = s.unseal.tpe.widenTermRefExpr.dealias
+    val repr = Term.of(s).tpe.widenTermRefExpr.dealias
 
     def rec(tpe: TypeRepr): List[(String, TypeRepr)] = {
       tpe match {
@@ -51,7 +51,7 @@ object Macro {
   private def fromTupleImpl[T: Type](s: Expr[Tuple], newRecord: Expr[Array[(String, Any)] => T])(using qctx:QuoteContext) : Expr[Any] = {
     import qctx.reflect._
 
-    val repr = s.unseal.tpe.widenTermRefExpr.dealias
+    val repr = Term.of(s).tpe.widenTermRefExpr.dealias
 
     def isTupleCons(sym: Symbol): Boolean = sym.owner == defn.ScalaPackageClass && sym.name == "*:"
 

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         ValDef.let(lhs) { left =>
           ValDef.let(rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-lambda/assert_1.scala
+++ b/tests/run-macros/reflect-lambda/assert_1.scala
@@ -8,7 +8,7 @@ object lib {
     import qctx.reflect._
     import util._
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), Lambda(param :: Nil, Apply(Select(a, "=="), b :: Nil)) :: Nil)
       if a.symbol == param.symbol || b.symbol == param.symbol =>
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -8,13 +8,13 @@ object scalatest {
     import qctx.reflect._
     import util._
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case t @ Apply(TypeApply(Select(lhs, op), targs), rhs) =>
         ValDef.let(lhs) { left =>
           ValDef.let(rhs) { rs =>
             val app = Select.overloaded(left, op, targs.map(_.tpe), rs)
             val b = app.asExprOf[Boolean]
-            '{ scala.Predef.assert($b) }.unseal
+            Term.of('{ scala.Predef.assert($b) })
           }
         }.asExprOf[Unit]
     }

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         ValDef.let(lhs) { left =>
           ValDef.let(rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-select-copy-2/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy-2/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         ValDef.let(lhs) { left =>
           ValDef.let(rhs) { right =>
@@ -21,7 +21,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert(${b}) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]
@@ -34,7 +34,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert(${b}) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/assert_1.scala
@@ -7,7 +7,7 @@ object scalatest {
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case Apply(select @ Select(lhs, op), rhs :: Nil) =>
         val cond = Apply(Select.copy(select)(lhs, ">"), rhs :: Nil).asExprOf[Boolean]
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         ValDef.let(lhs) { left =>
           ValDef.let(rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    cond.unseal.underlyingArgument match {
+    Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         ValDef.let(lhs) { left =>
           ValDef.let(rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              code.unseal
+              Term.of(code)
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-sourceCode/Macro_1.scala
+++ b/tests/run-macros/reflect-sourceCode/Macro_1.scala
@@ -6,6 +6,6 @@ object api {
 
   private def reflImpl[T](x: Expr[T])(implicit qctx: QuoteContext): Expr[String] = {
     import qctx.reflect._
-    Expr(x.unseal.pos.sourceCode)
+    Expr(Term.of(x).pos.sourceCode)
   }
 }

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
-    val tree = x.unseal
+    val tree = Term.of(x)
     '{
       println()
       println("tree: " + ${Expr(tree.showExtractors)})

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -27,7 +27,7 @@ object Macros {
         "T",
         TypeBounds(TypeRepr.of[Int], TypeRepr.of[Int]))
     val x6T = TypeRepr.of[List].appliedTo(List(TypeRepr.of[Int]))
-    val x7T = AnnotatedType(ConstantType(Constant.Int(7)), '{ new TestAnnotation }.unseal)
+    val x7T = AnnotatedType(ConstantType(Constant.Int(7)), Term.of('{ new TestAnnotation }))
     val x8T =
       MatchType(
         TypeRepr.of[Int],

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -20,10 +20,10 @@ object Macros {
       DefDef(sym1, {
         case List() => {
           case List(List(a, b)) =>
-            Some('{ ${ a.asExpr.asInstanceOf[Expr[Int]] } - ${ b.asExpr.asInstanceOf[Expr[Int]] } }.unseal)
+            Some(Term.of('{ ${ a.asExpr.asInstanceOf[Expr[Int]] } - ${ b.asExpr.asInstanceOf[Expr[Int]] } }))
         }
       }),
-      '{ assert(${ Apply(Ref(sym1), List(Literal(Constant.Int(2)), Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == -1) }.unseal)
+      Term.of('{ assert(${ Apply(Ref(sym1), List(Literal(Constant.Int(2)), Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == -1) }))
 
     // test for no argument list (no Apply node)
     val sym2 : Symbol = Symbol.newMethod(
@@ -39,7 +39,7 @@ object Macros {
             Some(Literal(Constant.Int(2)))
         }
       }),
-      '{ assert(${ Ref(sym2).asExpr.asInstanceOf[Expr[Int]] } == 2) }.unseal)
+      Term.of('{ assert(${ Ref(sym2).asExpr.asInstanceOf[Expr[Int]] } == 2) }))
 
    // test for multiple argument lists
    val sym3 : Symbol = Symbol.newMethod(
@@ -59,7 +59,7 @@ object Macros {
             Some(a)
         }
       }),
-      '{ assert(${ Apply(Apply(Ref(sym3), List(Literal(Constant.Int(3)))), List(Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == 3) }.unseal)
+      Term.of('{ assert(${ Apply(Apply(Ref(sym3), List(Literal(Constant.Int(3)))), List(Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == 3) }))
 
     // test for recursive references
     val sym4 : Symbol = Symbol.newMethod(
@@ -74,14 +74,14 @@ object Macros {
       DefDef(sym4, {
         case List() => {
           case List(List(x)) =>
-            Some('{
+            Some(Term.of('{
               if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
               then 0
-              else ${ Apply(Ref(sym4), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.unseal)).asExpr.asInstanceOf[Expr[Int]] }
-            }.unseal)
+              else ${ Apply(Ref(sym4), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
+            }))
         }
       }),
-      '{ assert(${ Apply(Ref(sym4), List(Literal(Constant.Int(4)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }.unseal)
+      Term.of('{ assert(${ Apply(Ref(sym4), List(Literal(Constant.Int(4)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }))
 
     // test for nested functions (one symbol is the other's parent, and we use a Closure)
     val sym5 : Symbol = Symbol.newMethod(
@@ -108,14 +108,14 @@ object Macros {
                   DefDef(sym51, {
                     case List() => {
                       case List(List(xx)) =>
-                        Some('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - ${ xx.asExpr.asInstanceOf[Expr[Int]] } }.unseal)
+                        Some(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - ${ xx.asExpr.asInstanceOf[Expr[Int]] } }))
                     }
                   })),
                 Closure(Ref(sym51), None))
             }
         }
       }),
-      '{ assert(${ Apply(Ref(sym5), List(Literal(Constant.Int(5)))).asExpr.asInstanceOf[Expr[Int=>Int]] }(4) == 1) }.unseal)
+      Term.of('{ assert(${ Apply(Ref(sym5), List(Literal(Constant.Int(5)))).asExpr.asInstanceOf[Expr[Int=>Int]] }(4) == 1) }))
 
     // test mutually recursive definitions
     val sym6_1 : Symbol = Symbol.newMethod(
@@ -139,12 +139,12 @@ object Macros {
         case List() => {
           case List(List(x)) =>
             Some {
-              '{
+              Term.of('{
                 println(s"sym6_1: ${ ${ x.asExpr.asInstanceOf[Expr[Int]] } }")
                 if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
                 then 0
-                else ${ Apply(Ref(sym6_2), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.unseal)).asExpr.asInstanceOf[Expr[Int]] }
-              }.unseal
+                else ${ Apply(Ref(sym6_2), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
+              })
             }
         }
       }),
@@ -152,17 +152,17 @@ object Macros {
         case List() => {
           case List(List(x)) =>
             Some {
-              '{
+              Term.of('{
                 println(s"sym6_2: ${ ${ x.asExpr.asInstanceOf[Expr[Int]] } }")
                 if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
                 then 0
-                else ${ Apply(Ref(sym6_1), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.unseal)).asExpr.asInstanceOf[Expr[Int]] }
-              }.unseal
+                else ${ Apply(Ref(sym6_1), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
+              })
             }
         }
 
       }),
-      '{ assert(${ Apply(Ref(sym6_2), List(Literal(Constant.Int(6)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }.unseal)
+      Term.of('{ assert(${ Apply(Ref(sym6_2), List(Literal(Constant.Int(6)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }))
 
     // test polymorphic methods by synthesizing an identity method
     val sym7 : Symbol = Symbol.newMethod(
@@ -182,7 +182,7 @@ object Macros {
             Some(Typed(x, Inferred(t)))
         }
       }),
-      '{ assert(${ Apply(TypeApply(Ref(sym7), List(Inferred(TypeRepr.of[Int]))), List(Literal(Constant.Int(7)))).asExpr.asInstanceOf[Expr[Int]] } == 7) }.unseal)
+      Term.of('{ assert(${ Apply(TypeApply(Ref(sym7), List(Inferred(TypeRepr.of[Int]))), List(Literal(Constant.Int(7)))).asExpr.asInstanceOf[Expr[Int]] } == 7) }))
 
     Block(
       sym1Statements ++
@@ -192,7 +192,7 @@ object Macros {
       sym5Statements ++
       sym6Statements ++
       sym7Statements ++
-      List('{ println("Ok") }.unseal),
+      List(Term.of('{ println("Ok") })),
       Literal(Constant.Unit())).asExpr.asInstanceOf[Expr[Unit]]
   }
 }

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -19,7 +19,7 @@ object Macros {
     override def value(e: Expr[Int])(using qctx: QuoteContext) : Option[Int] = {
       import qctx.reflect._
 
-      e.unseal.tpe match {
+      Term.of(e).tpe match {
         case pre: TermRef if pre.termSymbol.isValDef =>
           pre.termSymbol.tree match
             case t: ValDef =>

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val tree = x.unseal
+    val tree = Term.of(x)
     val treeStr = Expr(tree.showExtractors)
     val treeTpeStr = Expr(tree.tpe.showExtractors)
 

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
   def impl[T](x: Expr[T])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val tree = x.unseal
+    val tree = Term.of(x)
 
     val treeStr = Expr(tree.showExtractors)
     val treeTpeStr = Expr(tree.tpe.showExtractors)

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -25,7 +25,7 @@ object Macros {
       }
     }
 
-    val tree = x.unseal
+    val tree = Term.of(x)
     traverser.traverseTree(tree)
     '{print(${Expr(buff.result())})}
   }

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -56,7 +56,7 @@ abstract class MacroStringInterpolator[T] {
 
   protected def getStaticStringContext(strCtxExpr: Expr[StringContext])(using qctx: QuoteContext) : StringContext = {
     import qctx.reflect._
-    strCtxExpr.unseal.underlyingArgument match {
+    Term.of(strCtxExpr).underlyingArgument match {
       case Select(Typed(Apply(_, List(Apply(_, List(Typed(Repeated(strCtxArgTrees, _), Inferred()))))), _), _) =>
         val strCtxArgs = strCtxArgTrees.map {
           case Literal(Constant.String(str)) => str
@@ -70,7 +70,7 @@ abstract class MacroStringInterpolator[T] {
 
   protected def getArgsList(argsExpr: Expr[Seq[Any]])(using qctx: QuoteContext) : List[Expr[Any]] = {
     import qctx.reflect._
-    argsExpr.unseal.underlyingArgument match {
+    Term.of(argsExpr).underlyingArgument match {
       case Typed(Repeated(args, _), _) => args.map(_.asExpr)
       case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.asExpr)
     }

--- a/tests/run-macros/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-assert/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val tree = cond.unseal
+    val tree = Term.of(cond)
 
     def isOps(tpe: TypeRepr): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def natConstImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
     import qctx.reflect._
-    val xTree: Term = x.unseal
+    val xTree: Term = Term.of(x)
     xTree match {
       case Inlined(_, _, Literal(Constant.Int(n))) =>
         if (n <= 0) {

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -10,8 +10,8 @@ object Macros {
 
   def impl(x: Expr[Any])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
-    val pos = x.unseal.underlyingArgument.pos
-    val code = x.unseal.underlyingArgument.show
+    val pos = Term.of(x).underlyingArgument.pos
+    val code = Term.of(x).underlyingArgument.show
     '{
       println(${posStr(qctx)(pos)})
       println(${Expr(code)})

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   private def impl(arg: Expr[Any])(using qctx: QuoteContext) : Expr[(String, Any)] = {
     import qctx.reflect._
-    val source = Expr(arg.unseal.underlyingArgument.pos.sourceCode.toString)
+    val source = Expr(Term.of(arg).underlyingArgument.pos.sourceCode.toString)
     '{Tuple2($source, $arg)}
   }
 

--- a/tests/run-macros/tasty-overload-secondargs/Macro_1.scala
+++ b/tests/run-macros/tasty-overload-secondargs/Macro_1.scala
@@ -23,12 +23,12 @@ object Macro:
 
     def mThenImpl[A:Type, B:Type, S<:(A=>B) :Type, R:Type](x:Expr[S])(using qctx: QuoteContext):Expr[R]=
        import qctx.reflect._
-       val fun = '{X}.unseal
+       val fun = Term.of('{X})
        val returnType = TypeRepr.of[(S) => ?]
        val firstPart = Select.overloaded(fun,"andThen",
                                  List(TypeIdent(defn.IntClass).tpe, TypeIdent(defn.IntClass).tpe),
                                  List(Literal(Constant.Int(1))),
                                  TypeRepr.of[(S) => R]
                        )
-       val r = Apply(firstPart,List(x.unseal))
+       val r = Apply(firstPart,List(Term.of(x)))
        r.asExprOf[R]

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -9,7 +9,7 @@ object Asserts {
   def zeroLastArgsImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[Int] = {
     import qctx.reflect._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
-    x.unseal.underlyingArgument match {
+    Term.of(x).underlyingArgument match {
       case Apply(fn, args) =>
         fn.tpe.widen match {
           case _: MethodType =>
@@ -35,15 +35,15 @@ object Asserts {
       case Apply(fn, args) =>
         val pre = rec(fn)
         args.size match {
-          case 0 => Expr.betaReduce('{ ${pre.etaExpand.asExprOf[() => Any]}() }).unseal
-          case 1 => Expr.betaReduce('{ ${pre.etaExpand.asExprOf[Int => Any]}(0) }).unseal
-          case 2 => Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int) => Any]}(0, 0) }).unseal
-          case 3 => Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }).unseal
+          case 0 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[() => Any]}() }))
+          case 1 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[Int => Any]}(0) }))
+          case 2 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int) => Any]}(0, 0) }))
+          case 3 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }))
         }
       case _ => term
     }
 
-    rec(x.unseal.underlyingArgument).asExprOf[Int]
+    rec(Term.of(x).underlyingArgument).asExprOf[Int]
   }
 
 }

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -24,7 +24,7 @@ object Macro {
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
             import qctx.reflect._
-            Reporting.error(msg, parts(partIdx).unseal.pos)
+            Reporting.error(msg, Term.of(parts(partIdx)).pos)
           }
         }
         fooCore(parts, args, reporter)
@@ -38,7 +38,7 @@ object Macro {
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
             import qctx.reflect._
-            val pos = parts(partIdx).unseal.pos
+            val pos = Term.of(parts(partIdx)).pos
             errors += '{ Tuple4(${Expr(partIdx)}, ${Expr(pos.start)}, ${Expr(pos.end)}, ${Expr(msg)}) }
           }
         }

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -7,6 +7,6 @@ object MacrosImpl:
   def impl[T: Type](x: Expr[T])(using qctx: QuoteContext) : Expr[T] = {
     import qctx.reflect._
     val identityMap = new TreeMap { }
-    val transformed = identityMap.transformTerm(x.unseal).asExprOf[T]
+    val transformed = identityMap.transformTerm(Term.of(x)).asExprOf[T]
     transformed
   }

--- a/tests/run-macros/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-macros/tasty-unsafe-let/quoted_1.scala
@@ -8,11 +8,11 @@ object Macros {
   private def impl[T: Type](rhs: Expr[T], body: Expr[T => Unit])(using qctx: QuoteContext) : Expr[Unit] = {
     import qctx.reflect._
 
-    val rhsTerm = rhs.unseal
+    val rhsTerm = Term.of(rhs)
 
     import qctx.reflect._
     ValDef.let(rhsTerm) { rhsId =>
-      Expr.betaReduce('{$body(${rhsId.asExpr.asInstanceOf[Expr[T]]})}).unseal // Dangerous uncheked cast!
+      Term.of(Expr.betaReduce('{$body(${rhsId.asExpr.asInstanceOf[Expr[T]]})})) // Dangerous uncheked cast!
     }.asExprOf[Unit]
   }
 

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -41,7 +41,7 @@ object XmlQuote {
       tree.symbol.fullName == "scala.StringContext$.apply"
 
     // XmlQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts = receiver.unseal.underlyingArgument match {
+    val parts = Term.of(receiver).underlyingArgument match {
       case Apply(conv, List(Apply(fun, List(Typed(Repeated(values, _), _)))))
           if isSCOpsConversion(conv) &&
              isStringContextApply(fun) &&
@@ -53,7 +53,7 @@ object XmlQuote {
     }
 
     // [a0, ...]: Any*
-    val Typed(Repeated(args0, _), _) = args.unseal.underlyingArgument
+    val Typed(Repeated(args0, _), _) = Term.of(args).underlyingArgument
 
     val string = parts.mkString("??")
     '{new Xml(${Expr(string)}, ${liftListOfAny(args0)})}

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -36,7 +36,7 @@ object XmlQuote {
     }
 
     // XmlQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts: List[String] = stripTyped(receiver.unseal.underlying) match {
+    val parts: List[String] = stripTyped(Term.of(receiver).underlying) match {
       case Apply(conv, List(ctx1)) if isSCOpsConversion(conv) =>
         ctx1 match {
           case Apply(fun, List(Typed(Repeated(values, _), _))) if isStringContextApply(fun) =>
@@ -56,7 +56,7 @@ object XmlQuote {
     }
 
     // [a0, ...]: Any*
-    val args2: Expr[List[Any]] = args.unseal.underlyingArgument match {
+    val args2: Expr[List[Any]] = Term.of(args).underlyingArgument match {
       case Typed(Repeated(args0, _), _) => // statically known args, make list directly
         Expr.ofList(args0.map(_.asExpr))
       case _ =>


### PR DESCRIPTION
This is replacement for `Expr.asReflectTree` (which replaced `unseal`). This version of the API aligns with `Type.of`, `TypeRepr.of` and `TypeTree.of`. By requiring the `Tree` or `Term` modules to do the transformation we can ensure that all uses of the reflection API have the `qctx.reflect` import or explicit path. This delimits in a clearer way where the reflect API is used.

__Migration__

```diff
val expr: Expr[Any] = ...
- val term: Term = expr.unseal
- val term: Term = expr.asReflectTree
+ val term: Term = Term.of(expr)

- val tree: Tree = expr.unseal
- val tree: Tree = expr.asReflectTree
+ val tree: Tree = Tree.of(expr)

val exprList: List[Expr[Any]] = ...
- exprList.map(_.unseal)
- exprList.map(_.asReflectTree)
+ exprList.map(Term.of)
```