### PR TITLE
Fix #9632: Don't use inDefScopeBraces for staged blocks

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1566,7 +1566,10 @@ object Parsers {
       else t
 
     /** The block in a quote or splice */
-    def stagedBlock() = inDefScopeBraces(block(simplify = true))
+    def stagedBlock() =
+      val saved = lastStatOffset
+      try inBraces(block(simplify = true))
+      finally lastStatOffset = saved
 
     /** SimpleEpxr  ::=  spliceId | ‘$’ ‘{’ Block ‘}’)
      *  SimpleType  ::=  spliceId | ‘$’ ‘{’ Block ‘}’)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1534,7 +1534,9 @@ object Parsers {
     def refinedTypeRest(t: Tree): Tree = {
       argumentStart()
       if (in.isNestedStart)
-        refinedTypeRest(atSpan(startOffset(t)) { RefinedTypeTree(rejectWildcardType(t), refinement()) })
+        refinedTypeRest(atSpan(startOffset(t)) {
+          RefinedTypeTree(rejectWildcardType(t), refinement(indentOK = true))
+        })
       else t
     }
 
@@ -1631,7 +1633,7 @@ object Parsers {
           makeTupleOrParens(inParens(argTypes(namedOK = false, wildOK = true)))
         }
       else if in.token == LBRACE then
-        atSpan(in.offset) { RefinedTypeTree(EmptyTree, refinement()) }
+        atSpan(in.offset) { RefinedTypeTree(EmptyTree, refinement(indentOK = false)) }
       else if (isSplice)
         splice(isType = true)
       else
@@ -1775,8 +1777,11 @@ object Parsers {
 
     /** Refinement ::= `{' RefineStatSeq `}'
      */
-    def refinement(): List[Tree] =
-      inBracesOrIndented(refineStatSeq(), rewriteWithColon = true)
+    def refinement(indentOK: Boolean): List[Tree] =
+      if indentOK then
+        inBracesOrIndented(refineStatSeq(), rewriteWithColon = true)
+      else
+        inBraces(refineStatSeq())
 
     /** TypeBounds ::= [`>:' Type] [`<:' Type]
      */

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -66,7 +66,8 @@ class CompilationTests {
 
     aggregateTests(
       compileFile("tests/rewrites/rewrites.scala", scala2CompatMode.and("-rewrite", "-indent")),
-      compileFile("tests/rewrites/i8982.scala", defaultOptions.and("-indent", "-rewrite"))
+      compileFile("tests/rewrites/i8982.scala", defaultOptions.and("-indent", "-rewrite")),
+      compileFile("tests/rewrites/i9632.scala", defaultOptions.and("-indent", "-rewrite"))
     ).checkRewrites()
   }
 

--- a/tests/rewrites/i9632.scala
+++ b/tests/rewrites/i9632.scala
@@ -5,3 +5,17 @@ def f(using scala.quoted.QuoteContext) =
         }
         x
      }
+
+type HasPath = {
+  def getPath: String
+}
+type HashPath2 = Any {
+  def getPath: String
+}
+val x = new {
+  val y = 1
+}
+val y = new AnyRef {
+  val y = 1
+}
+

--- a/tests/rewrites/i9632.scala
+++ b/tests/rewrites/i9632.scala
@@ -1,0 +1,7 @@
+def f(using scala.quoted.QuoteContext) =
+    '{
+        val x = ${
+          ???
+        }
+        x
+     }


### PR DESCRIPTION
inDefScopeBraces blocks can be rewritten, but that would give illegal code for staged blocks.