### PR TITLE
Add tests for DRIs in scala3doc

### DIFF
--- a/scala3doc-testcases/src/tests/extensionDRIs.scala
+++ b/scala3doc-testcases/src/tests/extensionDRIs.scala
@@ -1,0 +1,9 @@
+package tests.extensionDRIs
+
+class A
+
+class B
+
+extension (a: A) def fun = 8
+extension (b: B) def fun = 9
+extension (as: Seq[A]) def fun = 10

--- a/scala3doc-testcases/src/tests/functionDRI.scala
+++ b/scala3doc-testcases/src/tests/functionDRI.scala
@@ -1,0 +1,33 @@
+package tests.functionDRI
+
+import scala.annotation.targetName
+
+
+class A
+class B
+
+def a(as: Seq[A]) = 1
+def a(a: A) = 2
+def b(b: B) = 3
+
+// scala3doc right now is ignroing @targetName
+// def b(a: A, b: B) = 4
+// @targetName("b2") def b(a: A)(b: B) = 5
+
+// @targetName("c_a") def c(p: Seq[A]) = 6
+// @targetName("c_b") def c(p: Seq[B]) = 7
+
+// scala3 doc right now is not differentiating between fields and nested classlikes
+// class C(val b: Int):
+//   trait b
+
+class D:
+  trait b:
+    def b = 8
+  def b = 9
+
+class E:
+  class F:
+    def b = 10
+  object F:
+    def b = 11

--- a/scala3doc-testcases/src/tests/genericDRI.scala
+++ b/scala3doc-testcases/src/tests/genericDRI.scala
@@ -1,0 +1,9 @@
+package tests.genericDRI
+
+class A
+class B
+
+def a[T <: A](t: T) = 1
+def a[T <: B](t: T) = 2
+
+def a[T >: A](t: T) = 3

--- a/scala3doc-testcases/src/tests/givenDRI.scala
+++ b/scala3doc-testcases/src/tests/givenDRI.scala
@@ -1,0 +1,34 @@
+package tests.givenDRI
+
+trait A[T]
+trait B[T]
+trait C
+
+given A[Int]
+
+given A[String]
+
+given A[Seq[String]]
+
+given [T: A] as A[Option[T]]
+
+given [T: B] as A[T]
+
+given [C] as A[C]
+
+given A[C]
+
+given [S <: C] as A[S]
+
+class R:
+  def a = 1
+
+given R as A[Int]:
+  def a = 2
+
+class S:
+  class R:
+    def a = 3
+
+  given R as A[Int]:
+    def a = 5

--- a/scala3doc-testcases/src/tests/shadowingDRI.scala
+++ b/scala3doc-testcases/src/tests/shadowingDRI.scala
@@ -1,0 +1,10 @@
+package tests.shadowingDRI
+
+trait A[T]
+class B
+
+class S:
+  class R:
+    def findThisDeclaration = 1
+
+  given R as A[B]

--- a/scala3doc/test/dotty/dokka/linking/DriTest.scala
+++ b/scala3doc/test/dotty/dokka/linking/DriTest.scala
@@ -1,0 +1,32 @@
+package dotty.dokka.linking
+
+import scala.jdk.CollectionConverters._
+import scala.Function.const
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.DModule
+import dotty.dokka.model.api._
+import dotty.dokka.{ScaladocTest, Assertion}
+
+abstract class DriTest(testName: String) extends ScaladocTest(testName):
+  // override for additional assertions
+  def assertOnDRIs(dris: Seq[DRI]): Unit = ()
+
+  override def assertions = Assertion.AfterDocumentablesTransformation { root =>
+    val dris = root.collectMembers.map(_.dri)
+
+    val grouping = dris.groupMapReduce(identity)(const(1))(_+_)
+    val duplicates = grouping.filter { (_, v )=> v > 1 }
+
+    if duplicates.nonEmpty then
+      val duplicatesMessage = duplicates.map { (k, v) => s"$k - $v times" }.mkString("\n")
+      val otherMessage = grouping.flatMap { (k, v) => Option.when(v == 1)(k) }.mkString("\n")
+      val message = s"\nThere were some repeating DRIs:\n$duplicatesMessage\n\nOther DRIs:\n$otherMessage\n\n"
+      reportError(message)
+
+    assertOnDRIs(dris)
+  } :: Nil
+
+extension (m: DModule) private def collectMembers = m.getPackages.asScala.toList.flatMap(collectFrom)
+
+private def collectFrom(m: Member): Seq[Member] =
+  m +: m.allMembers.filter(_.origin == Origin.DefinedWithin).flatMap(collectFrom)

--- a/scala3doc/test/dotty/dokka/linking/DriTestCases.scala
+++ b/scala3doc/test/dotty/dokka/linking/DriTestCases.scala
@@ -1,0 +1,17 @@
+package dotty.dokka.linking
+
+import org.jetbrains.dokka.links.DRI
+import org.junit.Ignore
+
+class ExtensionTest extends DriTest("extensionDRIs")
+
+class GivenTest extends DriTest("givenDRI")
+
+class GenericTest extends DriTest("genericDRI")
+
+class FunctionTest extends DriTest("functionDRI")
+
+@Ignore class ShadowingTest extends DriTest("shadowingDRI"):
+  override def assertOnDRIs(dris: Seq[DRI]) =
+    if (!dris.flatMap(d => Option(d.getExtra)).exists(_.contains("findThisDeclaration"))) then
+      reportError("\n\nSymbol with name `findThisDeclaration` was expected but not found\n\n")


### PR DESCRIPTION
This PR adds tests for DRIs generated by doctool. Unique DRIs are crucial for linking inside the documentation to work properly. Fortunately, scala has rather strict rules for avoiding double definitions what makes declaring unique DRIs easy. Nevertheless, those tests have found at least 3 different problems with DRI generation. The cases verifying them are ignored or commented out.

Reported issues:
- #10338 
- #10339 
- #10341 