### PR TITLE
Improve owner handling in Reflection

### DIFF
--- a/compiler/src/scala/quoted/internal/impl/Matcher.scala
+++ b/compiler/src/scala/quoted/internal/impl/Matcher.scala
@@ -211,7 +211,7 @@ object Matcher {
             }
             val argTypes = args.map(x => x.tpe.widenTermRefExpr)
             val resType = pattern.tpe
-            val res = Lambda(MethodType(names)(_ => argTypes, _ => resType), bodyFn)
+            val res = Lambda(Symbol.currentOwner, MethodType(names)(_ => argTypes, _ => resType), (meth, x) => bodyFn(x).changeOwner(meth))
             matched(res.asExpr)
 
           //

--- a/tests/pos-macros/i10151/Test_2.scala
+++ b/tests/pos-macros/i10151/Test_2.scala
@@ -1,0 +1,14 @@
+package x
+
+object Main {
+
+ def main(args:Array[String]):Unit =
+   val arr = new MyArr[Int,Int]()
+   val r = X.process{
+       arr.map1( (x,y) =>
+         ( 1, await(CBM.pure(x)) )
+       )
+   }
+   println("r")
+
+}

--- a/tests/pos-macros/i10211/Macro_1.scala
+++ b/tests/pos-macros/i10211/Macro_1.scala
@@ -1,0 +1,102 @@
+package x
+
+import scala.quoted._
+
+trait CB[T]:
+ def map[S](f: T=>S): CB[S] = ???
+
+
+class MyArr[A]:
+ def map[B](f: A=>B):MyArr[B] = ???
+ def mapOut[B](f: A=> CB[B]): CB[MyArr[B]] = ???
+ def flatMap[B](f: A=>MyArr[B]):MyArr[B] = ???
+ def flatMapOut[B](f: A=>CB[MyArr[B]]):MyArr[B] = ???
+ def withFilter(p: A=>Boolean): MyArr[A] = ???
+ def withFilterOut(p: A=>CB[Boolean]): DelayedWithFilter[A] = ???
+ def map2[B](f: A=>B):MyArr[B] = ???
+
+class DelayedWithFilter[A]:
+ def map[B](f: A=>B):MyArr[B] = ???
+ def mapOut[B](f: A=> CB[B]): CB[MyArr[B]] = ???
+ def flatMap[B](f: A=>MyArr[B]):MyArr[B] = ???
+ def flatMapOut[B](f: A=>CB[MyArr[B]]): CB[MyArr[B]] = ???
+ def map2[B](f: A=>B):CB[MyArr[B]] = ???
+
+
+def await[T](x:CB[T]):T = ???
+
+object CBM:
+  def pure[T](t:T):CB[T] = ???
+  def map[T,S](a:CB[T])(f:T=>S):CB[S] = ???
+
+object X:
+
+ inline def process[T](inline f:T) = ${
+   processImpl[T]('f)
+ }
+
+ def processImpl[T:Type](f:Expr[T])(using qctx: QuoteContext):Expr[CB[T]] =
+   import qctx.reflect._
+
+   def transform(term:Term):Term =
+     term match
+        case ap@Apply(TypeApply(Select(obj,name),targs),args)
+               if (name=="map"||name=="flatMap") =>
+                  obj match
+                    case Apply(Select(obj1,"withFilter"),args1) =>
+                      val nObj = transform(obj)
+                      transform(Apply(TypeApply(Select.unique(nObj,name),targs),args))
+                    case _ =>
+                      val nArgs = args.map(x => shiftLambda(x))
+                      val nSelect = Select.unique(obj, name+"Out")
+                      Apply(TypeApply(nSelect,targs),nArgs)
+        case ap@Apply(Select(obj,"withFilter"),args) =>
+             val nArgs = args.map(x => shiftLambda(x))
+             val nSelect = Select.unique(obj, "withFilterOut")
+             Apply(nSelect,nArgs)
+        case ap@Apply(TypeApply(Select(obj,"map2"),targs),args) =>
+              val nObj = transform(obj)
+              Apply(TypeApply(
+                     Select.unique(nObj,"map2"),
+                     List(TypeTree.of[Int])
+                   ),
+                   args
+              )
+        case Apply(TypeApply(Ident("await"),targs),args) => args.head
+        case Apply(Select(obj,"=="),List(b)) =>
+             val tb = transform(b).asExprOf[CB[Int]]
+             val mt = MethodType(List("p"))(_ => List(b.tpe.widen), _ => TypeRepr.of[Boolean])
+             val mapLambda = Lambda(Symbol.currentOwner, mt, (_, x) => Select.overloaded(obj,"==",List(),List(x.head.asInstanceOf[Term]))).asExprOf[Int=>Boolean]
+             Term.of('{ CBM.map($tb)($mapLambda) })
+        case Block(stats, last) => Block(stats, transform(last))
+        case Inlined(x,List(),body) => transform(body)
+        case l@Literal(x) =>
+             Term.of('{ CBM.pure(${term.asExpr}) })
+        case other =>
+             throw RuntimeException(s"Not supported $other")
+
+   def shiftLambda(term:Term): Term =
+        term match
+          case lt@Lambda(params, body) =>
+            val paramTypes = params.map(_.tpt.tpe)
+            val paramNames = params.map(_.name)
+            val mt = MethodType(paramNames)(_ => paramTypes, _ => TypeRepr.of[CB].appliedTo(body.tpe.widen) )
+            val r = Lambda(Symbol.currentOwner, mt, (meth, args) => changeArgs(params,args,transform(body)).changeOwner(meth) )
+            r
+          case _ =>
+            throw RuntimeException("lambda expected")
+
+   def changeArgs(oldArgs:List[Tree], newArgs:List[Tree], body:Term):Term =
+         val association: Map[Symbol, Term] = (oldArgs zip newArgs).foldLeft(Map.empty){
+             case (m, (oldParam, newParam: Term)) => m.updated(oldParam.symbol, newParam)
+             case (m, (oldParam, newParam: Tree)) => throw RuntimeException("Term expected")
+         }
+         val changes = new TreeMap() {
+             override def transformTerm(tree:Term)(using Context): Term =
+               tree match
+                 case ident@Ident(name) => association.getOrElse(ident.symbol, super.transformTerm(tree))
+                 case _ => super.transformTerm(tree)
+         }
+         changes.transformTerm(body)
+
+   transform(Term.of(f)).asExprOf[CB[T]]

--- a/tests/pos-macros/i10211/Test_2.scala
+++ b/tests/pos-macros/i10211/Test_2.scala
@@ -1,0 +1,18 @@
+package x
+
+
+object Main {
+
+ def main(args:Array[String]):Unit =
+   val arr1 = new MyArr[Int]()
+   val arr2 = new MyArr[Int]()
+   val r = X.process{
+       arr1.withFilter(x => x == await(CBM.pure(1)))
+           .flatMap(x =>
+              arr2.withFilter( y => y == await(CBM.pure(2)) ).
+                map2( y => x + y )
+           )
+   }
+   println(r)
+
+}

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -70,7 +70,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
@@ -82,7 +82,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matching-open/Macro_1.scala
+++ b/tests/run-macros/quote-matching-open/Macro_1.scala
@@ -34,7 +34,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -14,10 +14,10 @@ object Asserts {
         fn.tpe.widen match {
           case _: MethodType =>
             args.size match {
-              case 0 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[() => Int]}() })
-              case 1 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[Int => Int]}(0) })
-              case 2 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[(Int, Int) => Int]}(0, 0) })
-              case 3 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[(Int, Int, Int) => Int]}(0, 0, 0) })
+              case 0 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[() => Int]}() })
+              case 1 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[Int => Int]}(0) })
+              case 2 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int) => Int]}(0, 0) })
+              case 3 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int, Int) => Int]}(0, 0, 0) })
             }
         }
       case _ => x
@@ -35,10 +35,10 @@ object Asserts {
       case Apply(fn, args) =>
         val pre = rec(fn)
         args.size match {
-          case 0 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[() => Any]}() }))
-          case 1 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[Int => Any]}(0) }))
-          case 2 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int) => Any]}(0, 0) }))
-          case 3 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }))
+          case 0 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[() => Any]}() }))
+          case 1 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[Int => Any]}(0) }))
+          case 2 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int) => Any]}(0, 0) }))
+          case 3 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }))
         }
       case _ => term
     }


### PR DESCRIPTION
* Add `changeOwner`
* Add owner and symbol to `Lambda.apply`
* Add owner to etaExpand for the creation of the closure
* Ycheck the owners during macro expansion
* Fix #10151
* Fix #10211