### PR TITLE
Fix #10357: Add MATCHCASEtype tag to Tasty

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -185,8 +185,12 @@ class TreePickler(pickler: TastyPickler) {
 
   private def pickleNewType(tpe: Type, richTypes: Boolean)(using Context): Unit = tpe match {
     case AppliedType(tycon, args) =>
-      writeByte(APPLIEDtype)
-      withLength { pickleType(tycon); args.foreach(pickleType(_)) }
+      if tycon.typeSymbol == defn.MatchCaseClass then
+        writeByte(MATCHCASEtype)
+        withLength { args.foreach(pickleType(_)) }
+      else
+        writeByte(APPLIEDtype)
+        withLength { pickleType(tycon); args.foreach(pickleType(_)) }
     case ConstantType(value) =>
       pickleConstant(value)
     case tpe: NamedType =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -373,6 +373,8 @@ class TreeUnpickler(reader: TastyReader,
               SuperType(readType(), readType())
             case MATCHtype =>
               MatchType(readType(), readType(), until(end)(readType()))
+            case MATCHCASEtype =>
+              defn.MatchCaseClass.typeRef.appliedTo(readType(), readType())
             case POLYtype =>
               readMethodic(_ => PolyType, _.toTypeName)
             case METHODtype =>

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -158,6 +158,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   ANDtype        Length left_Type right_Type                       -- left & right
                   ORtype         Length left_Type right_Type                       -- lefgt | right
                   MATCHtype      Length bound_Type sel_Type case_Type*             -- sel match {cases} with optional upper `bound`
+                  MATCHCASEtype  Length pat_type rhs_Type                          -- match cases are MATCHCASEtypes or TYPELAMBDAtypes over MATCHCASEtypes
                   BIND           Length boundName_NameRef bounds_Type              -- boundName @ bounds,  for type-variables defined in a type pattern
                   BYNAMEtype            underlying_Type                            -- => underlying
                   PARAMtype      Length binder_ASTRef paramNum_Nat                 -- A reference to parameter # paramNum in lambda type `binder`
@@ -253,8 +254,8 @@ Standard Section: "Comments" Comment*
 object TastyFormat {
 
   final val header: Array[Int] = Array(0x5C, 0xA1, 0xAB, 0x1F)
-  val MajorVersion: Int = 24
-  val MinorVersion: Int = 1
+  val MajorVersion: Int = 25
+  val MinorVersion: Int = 0
 
   /** Tags used to serialize names, should update [[nameTagToString]] if a new constant is added */
   class NameTags {
@@ -469,6 +470,7 @@ object TastyFormat {
 
   final val MATCHtype = 190
   final val MATCHtpt = 191
+  final val MATCHCASEtype = 192
 
   final val HOLE = 255
 
@@ -676,6 +678,7 @@ object TastyFormat {
     case TYPELAMBDAtype => "TYPELAMBDAtype"
     case LAMBDAtpt => "LAMBDAtpt"
     case MATCHtype => "MATCHtype"
+    case MATCHCASEtype => "MATCHCASEtype"
     case MATCHtpt => "MATCHtpt"
     case PARAMtype => "PARAMtype"
     case ANNOTATION => "ANNOTATION"


### PR DESCRIPTION
We thus avoid references to a "magic" scala.internal.MatchCase class.