### PR TITLE
Use bootstrapped projects to generate documentation for Scala 3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1497,8 +1497,8 @@ object Build {
           generateScala3Documentation := Def.taskDyn {
             val dottyJars: Seq[java.io.File] = Seq(
               (`scala3-interfaces`/Compile/products).value,
-              (`tasty-core`/Compile/products).value,
-              (`scala3-library`/Compile/products).value,
+              (`tasty-core-bootstrapped`/Compile/products).value,
+              (`scala3-library-bootstrapped`/Compile/products).value,
               // TODO we can't load stdlib from Tasty
               // (`stdlib-bootstrapped`/Compile/products).value,
             ).flatten


### PR DESCRIPTION
This should fixed problem in #10362