### PR TITLE
Fix #8623: Treat parameterless givens as stable

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -166,6 +166,7 @@ object desugar {
     val mods = vdef.mods
 
     val valName = normalizeName(vdef, tpt).asTermName
+    val vdef1 = cpy.ValDef(vdef)(name = valName)
 
     if (isSetterNeeded(vdef)) {
       // TODO: copy of vdef as getter needed?
@@ -182,9 +183,9 @@ object desugar {
         tpt      = TypeTree(defn.UnitType),
         rhs      = setterRhs
       ).withMods((mods | Accessor) &~ (CaseAccessor | GivenOrImplicit | Lazy))
-      Thicket(vdef, setter)
+      Thicket(vdef1, setter)
     }
-    else vdef
+    else vdef1
   }
 
   def makeImplicitParameters(tpts: List[Tree], implicitFlag: FlagSet, forPrimaryConstructor: Boolean = false)(using Context): List[ValDef] =

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3536,13 +3536,18 @@ object Parsers {
           then paramClauses(givenOnly = true)
           else Nil
         newLinesOpt()
-        if !name.isEmpty || !tparams.isEmpty || !vparamss.isEmpty then
+        val noParams = tparams.isEmpty && vparamss.isEmpty
+        if !(name.isEmpty && noParams) then
           accept(nme.as)
         val parents = constrApps(commaOK = true, templateCanFollow = true)
         if in.token == EQUALS && parents.length == 1 && parents.head.isType then
           accept(EQUALS)
           mods1 |= Final
-          DefDef(name, tparams, vparamss, parents.head, subExpr())
+          if noParams && !mods.is(Inline) then
+            mods1 |= Lazy
+            ValDef(name, parents.head, subExpr())
+          else
+            DefDef(name, tparams, vparamss, parents.head, subExpr())
         else
           possibleTemplateStart()
           val tparams1 = tparams.map(tparam => tparam.withMods(tparam.mods | PrivateLocal))

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -150,7 +150,7 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     UnknownNamedEnclosingClassOrObjectID,
     IllegalCyclicTypeReferenceID,
     MissingTypeParameterInTypeAppID,
-    UNUSED_ImplicitTypesCanOnlyBeFunctionTypesID,
+    SkolemInInferredID,
     ErasedTypesCanOnlyBeFunctionTypesID,
     CaseClassMissingNonImplicitParamListID,
     EnumerationsShouldNotBeEmptyID,

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1244,6 +1244,24 @@ import transform.SymUtils._
            |""".stripMargin
   }
 
+  class SkolemInInferred(tree: tpd.Tree, pt: Type, argument: tpd.Tree)(using Context)
+  extends TypeMsg(SkolemInInferredID):
+    private def argStr =
+      if argument.isEmpty then ""
+      else i" from argument of type ${argument.tpe.widen}"
+    def msg =
+      em"""Failure to generate given instance for type $pt$argStr)
+          |
+          |I found: $tree
+          |But the part corresponding to `<skolem>` is not a reference that can be generated.
+          |This might be because resolution yielded as given instance a function that is not known to be pure."""
+    def explain =
+      em"""The part of given resolution that corresponds to `<skolem>` produced a term that
+          |is not a stable reference. Therefore a given instance could not be generated.
+          |
+          |To trouble-shoot the problem, try to supply an explicit expression instead of
+          |relying on implicit search at this point."""
+
   class SuperQualMustBeParent(qual: untpd.Ident, cls: ClassSymbol)(using Context)
   extends ReferenceMsg(SuperQualMustBeParentID) {
     def msg = em"""|$qual does not name a parent of $cls"""

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1254,7 +1254,8 @@ import transform.SymUtils._
           |
           |I found: $tree
           |But the part corresponding to `<skolem>` is not a reference that can be generated.
-          |This might be because resolution yielded as given instance a function that is not known to be pure."""
+          |This might be because resolution yielded as given instance a function that is not
+          |known to be total and side-effect free."""
     def explain =
       em"""The part of given resolution that corresponds to `<skolem>` produced a term that
           |is not a stable reference. Therefore a given instance could not be generated.

--- a/compiler/src/dotty/tools/dotc/transform/CacheAliasImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CacheAliasImplicits.scala
@@ -18,28 +18,20 @@ object CacheAliasImplicits {
 
   /** Flags that disable caching */
   val NoCacheFlags =
-    StableRealizable |  // It's a simple forwarder, leave it as one
-    Exported            // Export forwarders are never cached
+    StableRealizable  // It's a simple forwarder, leave it as one
+    | Exported        // Export forwarders are never cached
 }
 
 /** This phase ensures that the right hand side of parameterless alias implicits
- *  is cached. It applies to all alias implicits that have neither type parameters
- *  nor a given clause. Example: The alias
+ *  is cached if necessary. Dually, it optimizes lazy vak alias implicit to be uncached
+ *  if that does not change runtime behavior.
  *
- *      TC = rhs
+ *  A definition does not need to be cached if its right hand side has a stable type
+ *  and is of one of them forms
  *
- *  is expanded before this phase to:
- *
- *      implicit def a: TC = rhs
- *
- *  It is then expanded further as follows:
- *
- *  1. If `rhs` is a simple name `x` (possibly with a `this.` prefix) that
- *     refers to a value, leave it as is.
- *
- *  2. Otherwise, replace the definition with
- *
- *      lazy implicit val a: TC = rhs
+ *    this
+ *    this.y
+ *    y
  */
 class CacheAliasImplicits extends MiniPhase with IdentityDenotTransformer { thisPhase =>
   import tpd._

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -353,7 +353,7 @@ object ExplicitOuter {
    */
   class OuterOps(val ictx: Context) extends AnyVal {
     /** The context of all operations of this class */
-    given Context = ictx
+    given [Dummy] as Context = ictx
 
     /** If `cls` has an outer parameter add one to the method type `tp`. */
     def addParam(cls: ClassSymbol, tp: Type): Type =

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -737,7 +737,7 @@ trait Checking {
         defn.ObjectType
     }
 
-  /** If `sym` is an implicit conversion, check that implicit conversions are enabled.
+  /** If `sym` is an old-style implicit conversion, check that implicit conversions are enabled.
    *  @pre  sym.is(GivenOrImplicit)
    */
   def checkImplicitConversionDefOK(sym: Symbol)(using Context): Unit = {
@@ -750,10 +750,7 @@ trait Checking {
 
     sym.info.stripPoly match {
       case mt @ MethodType(_ :: Nil)
-      if !mt.isImplicitMethod && !sym.is(Synthetic) => // it's a conversion
-        check()
-      case AppliedType(tycon, _)
-      if tycon.derivesFrom(defn.ConversionClass) && !sym.is(Synthetic) =>
+      if !mt.isImplicitMethod && !sym.is(Synthetic) => // it's an old-styleconversion
         check()
       case _ =>
     }

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -155,7 +155,7 @@ class ReplCompilerTests extends ReplTest {
     fromInitialState { implicit state => run("given Int = 10") }
     .andThen         { implicit state =>
       assertEquals(
-        "def given_Int: Int",
+        "lazy val given_Int: Int",
         storedOutput().trim
       )
       run("implicitly[Int]")

--- a/tests/neg-macros/i7048e.scala
+++ b/tests/neg-macros/i7048e.scala
@@ -9,31 +9,31 @@ abstract class Test {
 
   def foo(using QuoteContext): Expr[Any] = {
 
-    val r = '{Option.empty[T]} // error: is not stable
+    val r = '{Option.empty[T]} // works
 
     {
       val t: Test = this
       import t.given
       println(Type.show[t.T])
-      // val r = '{Option.empty[t.T]} // access to value t from wrong staging level
+      val r = '{Option.empty[t.T]} // works
       val r2 = '{Option.empty[t.T.Underlying]} // works
     }
 
     {
       val r1 = '{Option.empty[T.Underlying]} // works
       val r2 = '{Option.empty[List[T.Underlying]]} // works
-      val r3 = '{summon[Type[T.Underlying]]} // error: is not stable
-      val r4 = '{summon[T.Underlying <:< Any]} // error: is not stable
+      val r3 = '{summon[Type[T.Underlying]]} // error: access to value t from wrong staging level
+      val r4 = '{summon[T.Underlying <:< Any]} // works
     }
 
     {
       val s = '{Option.empty[T.Underlying]} // works
       val r = '{identity($s)} // works
-      val r2 = '{identity(${s: Expr[Option[T]]})} // error // error : is not stable
+      val r2 = '{identity(${s: Expr[Option[T]]})} //works
     }
 
     r
   }
 }
 
-@main def main = ()
+@main def tester = ()

--- a/tests/neg/i8623.check
+++ b/tests/neg/i8623.check
@@ -5,6 +5,7 @@
    |
    |  I found: <skolem>.tasty.pos(unseal(given_QC[Any]))
    |  But the part corresponding to `<skolem>` is not a reference that can be generated.
-   |  This might be because resolution yielded as given instance a function that is not known to be pure.
+   |  This might be because resolution yielded as given instance a function that is not
+   |  known to be total and side-effect free.
 
 longer explanation available when compiling with `-explain`

--- a/tests/neg/i8623.check
+++ b/tests/neg/i8623.check
@@ -1,0 +1,10 @@
+-- [E142] Type Error: tests/neg/i8623.scala:11:2 -----------------------------------------------------------------------
+11 |  unseal.pos  // error
+   |  ^^^^^^
+   |  Failure to generate given instance for type ?{ pos: ? } from argument of type ?1.tasty.Tree)
+   |
+   |  I found: <skolem>.tasty.pos(unseal(given_QC[Any]))
+   |  But the part corresponding to `<skolem>` is not a reference that can be generated.
+   |  This might be because resolution yielded as given instance a function that is not known to be pure.
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i8623.scala
+++ b/tests/neg/i8623.scala
@@ -1,0 +1,12 @@
+
+trait QC:
+  object tasty:
+    type Tree
+    extension (tree: Tree)
+      def pos: Tree = ???
+
+def test =
+  given [T] as QC = ???
+  def unseal(using qctx: QC): qctx.tasty.Tree = ???
+  unseal.pos  // error
+

--- a/tests/neg/i8623a.scala
+++ b/tests/neg/i8623a.scala
@@ -1,0 +1,19 @@
+object Test {
+  trait A {
+    type X = String
+  }
+  trait B {
+    type X = Int
+  }
+
+  def foo: A & B = o
+  given o as (A & B) = foo
+
+  def xToString(x: o.X): String = x  // error
+
+  def intToString(i: Int): String = xToString(i)
+
+  def main(args: Array[String]): Unit = {
+    val z: String = intToString(1)
+  }
+}

--- a/tests/pos/i8623.scala
+++ b/tests/pos/i8623.scala
@@ -1,0 +1,17 @@
+
+trait QC:
+  object tasty:
+    type Tree
+    extension (tree: Tree)
+      def pos: Tree = ???
+
+def test1 =
+  given QC = ???
+  def unseal(using qctx: QC): qctx.tasty.Tree = ???
+  unseal.pos
+
+def test2 =
+  given QC
+  def unseal(using qctx: QC): qctx.tasty.Tree = ???
+  unseal.pos
+

--- a/tests/pos/i9103.scala
+++ b/tests/pos/i9103.scala
@@ -1,5 +1,5 @@
 object a:
-  type Foo[T]
+  trait Foo[T]
   given Foo[Unit] = ???
 
 val b = a


### PR DESCRIPTION
Parameterless givens can be evaluated lazily, but should not have side
effects. Therefore, we should treat them as stable. This avoids
generation of skolem types when computing the result type of a dependent
method that takes another given as argument and whose result type
depends on that argument. Skolem types cannot be used for term inference
since they cannot be materialized as legal trees.