### PR TITLE
Use scala3 doc to generate dotty website

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1173,7 +1173,7 @@ object Build {
   val testcasesSourceRoot = taskKey[String]("Root directory where tests sources are generated")
   val generateSelfDocumentation = taskKey[Unit]("Generate example documentation")
   // Note: the two tasks below should be one, but a bug in Tasty prevents that
-  val generateScala3Documentation = taskKey[Unit]("Generate documentation for dotty lib")
+  val generateScala3Documentation = inputKey[Unit]("Generate documentation for dotty lib")
   val generateScala3StdlibDocumentation = taskKey[Unit]("Generate documentation for Scala3 standard library")
   val generateTestcasesDocumentation  = taskKey[Unit]("Generate documentation for testcases, usefull for debugging tests")
   lazy val `scala3doc` = project.in(file("scala3doc")).asScala3doc
@@ -1468,12 +1468,11 @@ object Build {
       enablePlugins(JmhPlugin)
 
     def asScala3doc: Project = {
-      def generateDocumentation(targets: String, name: String, outDir: String, params: String = "") = Def.taskDyn {
+      def generateDocumentation(targets: String, name: String, outDir: String, ref: String, params: String = "") = Def.taskDyn {
           val projectVersion = version.value
-          val sourcesAndRevision = s"-s github://lampepfl/dotty --projectVersion $projectVersion"
-          run.in(Compile).toTask(
-            s""" -d scala3doc/output/$outDir -t $targets -n "$name" $sourcesAndRevision $params"""
-          )
+          val sourcesAndRevision = s"-s github://lampepfl/dotty  --revision $ref --projectVersion $projectVersion"
+          val cmd = s""" -d $outDir -t $targets -n "$name" $sourcesAndRevision $params"""
+          run.in(Compile).toTask(cmd)
       }
 
       def joinProducts(products: Seq[java.io.File]): String =
@@ -1508,14 +1507,17 @@ object Build {
           fork.in(test) := true,
           baseDirectory.in(run) := baseDirectory.in(ThisBuild).value,
           generateSelfDocumentation := Def.taskDyn {
-            val revision = VersionUtil.gitHash
             generateDocumentation(
               classDirectory.in(Compile).value.getAbsolutePath,
-              "scala3doc", "self",
-              s"-p scala3doc/documentation --projectLogo scala3doc/documentation/logo.svg  --revision $revision",
-            )
+              "scala3doc", "scala3doc/output/self", VersionUtil.gitHash,
+              "-p scala3doc/documentation --projectLogo scala3doc/documentation/logo.svg")
           }.value,
-          generateScala3Documentation := Def.taskDyn {
+
+          generateScala3Documentation := Def.inputTaskDyn {
+            val dottydocExtraArgs = spaceDelimited("[output]").parsed
+            val dest = file(dottydocExtraArgs.headOption.getOrElse("scala3doc/output/scala3")).getAbsoluteFile
+            val majorVersion = (scalaBinaryVersion in LocalProject("scala3-library-bootstrapped")).value
+
             val dottyJars: Seq[java.io.File] = Seq(
               (`scala3-interfaces`/Compile/products).value,
               (`tasty-core-bootstrapped`/Compile/products).value,
@@ -1525,8 +1527,16 @@ object Build {
             val roots = joinProducts(dottyJars)
 
             if (dottyJars.isEmpty) Def.task { streams.value.log.error("Dotty lib wasn't found") }
-            else generateDocumentation(roots, "Scala 3", "scala3", "-p scala3doc/scala3-docs --projectLogo scala3doc/scala3-docs/logo.svg  --revision master")
-          }.value,
+            else Def.task{
+              IO.write(dest / "versions" / "latest-nightly-base", majorVersion)
+
+              // This file is used by GitHub Pages when the page is available in a custom domain
+              IO.write(dest / "CNAME", "dotty.epfl.ch")
+            }.dependsOn(generateDocumentation(
+              roots, "Scala 3", dest.getAbsolutePath, "master",
+              "-p scala3doc/scala3-docs --projectLogo scala3doc/scala3-docs/logo.svg"))
+          }.evaluated,
+
 
           generateScala3StdlibDocumentation:= Def.taskDyn {
             val dottyJars: Seq[java.io.File] = Seq(
@@ -1536,11 +1546,16 @@ object Build {
             val roots = joinProducts(dottyJars)
 
             if (dottyJars.isEmpty) Def.task { streams.value.log.error("Dotty lib wasn't found") }
-            else generateDocumentation(roots, "Scala 3", "scala3-stdlib", "-p scala3doc/scala3-docs --syntax wiki --projectLogo scala3doc/scala3-docs/logo.svg  --revision master")
+            else generateDocumentation(
+              roots, "Scala 3", "scala3doc/output/scala3-stdlib", "maser",
+              "-p scala3doc/scala3-docs --syntax wiki --projectLogo scala3doc/scala3-docs/logo.svg "
+            )
           }.value,
+
           generateTestcasesDocumentation := Def.taskDyn {
-            generateDocumentation(Build.testcasesOutputDir.in(Test).value, "Scala3doc testcases", "testcases", "--revision master")
+            generateDocumentation(Build.testcasesOutputDir.in(Test).value, "Scala3doc testcases", "scala3doc/output/testcases", "master")
           }.value,
+
           buildInfoKeys in Test := Seq[BuildInfoKey](
             Build.testcasesOutputDir.in(Test),
             Build.testcasesSourceRoot.in(Test),

--- a/project/scripts/genDocs
+++ b/project/scripts/genDocs
@@ -25,7 +25,7 @@ git checkout "$GIT_HEAD"
 ### Generate the current snapshot of the website ###
 # this command will generate docs in $PWD/docs/_site
 SBT="$SCRIPT_DIR/sbt"
-"$SBT" "scala3-bootstrapped/genDocs $GENDOC_EXTRA_ARGS"
+"$SBT" "scala3doc/generateScala3Documentation docs/_site"
 
 # make sure that the previous command actually succeeded
 if [ ! -d "$SITE_OUT_DIR" ]; then


### PR DESCRIPTION
This needs to wait for #10320 to be merged.

I've deployed website generated by scala3do to [gh-page of my fork](https://romanowski.github.io/dotty-website/) using slightly modified [GH action](https://github.com/romanowski/dotty/commit/fce95265166ed8b2b45669b06569c44810b09cae) (build is [here](https://github.com/romanowski/dotty/runs/1417926633))