### PR TITLE
Use jl.Class'es instead of ClassTag's in structural calls.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -231,13 +231,8 @@ object JSEncoding {
   }
 
   /** Computes the type ref for a type, to be used in a method signature. */
-  private def paramOrResultTypeRef(tpe: Type)(using Context): jstpe.TypeRef = {
-    toTypeRef(tpe) match {
-      case jstpe.ClassRef(ScalaRuntimeNullClassName)    => jstpe.NullRef
-      case jstpe.ClassRef(ScalaRuntimeNothingClassName) => jstpe.NothingRef
-      case otherTypeRef                                 => otherTypeRef
-    }
-  }
+  private def paramOrResultTypeRef(tpe: Type)(using Context): jstpe.TypeRef =
+    toParamOrResultTypeRef(toTypeRef(tpe))
 
   def encodeLocalSym(sym: Symbol)(
       implicit ctx: Context, pos: ir.Position, localNames: LocalNameGenerator): js.LocalIdent = {
@@ -282,6 +277,15 @@ object JSEncoding {
       ScalaRuntimeNullClassName
     else
       ClassName(sym1.javaClassName)
+  }
+
+  /** Converts a general TypeRef to a TypeRef to be used in a method signature. */
+  def toParamOrResultTypeRef(typeRef: jstpe.TypeRef): jstpe.TypeRef = {
+    typeRef match {
+      case jstpe.ClassRef(ScalaRuntimeNullClassName)    => jstpe.NullRef
+      case jstpe.ClassRef(ScalaRuntimeNothingClassName) => jstpe.NothingRef
+      case _                                            => typeRef
+    }
   }
 
   def toIRTypeAndTypeRef(tp: Type)(using Context): (jstpe.Type, jstpe.TypeRef) = {

--- a/docs/docs/reference/changed-features/structural-types-spec.md
+++ b/docs/docs/reference/changed-features/structural-types-spec.md
@@ -35,13 +35,17 @@ def selectDynamic(name: String): T
 ```
 Often, the return type `T` is `Any`.
 
-The `applyDynamic` method is used for selections that are applied to arguments. It takes a method name and possibly `ClassTag`s representing its parameters types as well as the arguments to pass to the function.
+Unlike `scala.Dynamic`, there is no special meaning for an `updateDynamic` method.
+However, we reserve the right to give it meaning in the future.
+Consequently, it is recommended not to define any member called `updateDynamic` in `Selectable`s.
+
+The `applyDynamic` method is used for selections that are applied to arguments. It takes a method name and possibly `Class`es representing its parameters types as well as the arguments to pass to the function.
 Its signature should be of one of the two following forms:
 ```scala
 def applyDynamic(name: String)(args: Any*): T
-def applyDynamic(name: String, ctags: ClassTag[?]*)(args: Any*): T
+def applyDynamic(name: String, ctags: Class[?]*)(args: Any*): T
 ```
-Both versions are passed the actual arguments in the `args` parameter. The second version takes in addition a vararg argument of class tags that identify the method's parameter classes. Such an argument is needed
+Both versions are passed the actual arguments in the `args` parameter. The second version takes in addition a vararg argument of `java.lang.Class`es that identify the method's parameter classes. Such an argument is needed
 if `applyDynamic` is implemented using Java reflection, but it could be
 useful in other cases as well. `selectDynamic` and `applyDynamic` can also take additional context parameters in using clauses. These are resolved in the normal way at the callsite.
 
@@ -58,13 +62,13 @@ and `Rs` are structural refinement declarations, and given `v.a` of type `U`, we
   v.applyDynamic("a")(a11, ..., a1n, ..., aN1, ..., aNn)
     .asInstanceOf[R]
   ```
-  If this call resolves to an `applyDynamic` method of the second form that takes a `ClassTag[?]*` argument, we further rewrite this call to
+  If this call resolves to an `applyDynamic` method of the second form that takes a `Class[?]*` argument, we further rewrite this call to
   ```scala
-  v.applyDynamic("a", CT11, ..., CT1n, ..., CTN1, ... CTNn)(
+  v.applyDynamic("a", c11, ..., c1n, ..., cN1, ... cNn)(
     a11, ..., a1n, ..., aN1, ..., aNn)
     .asInstanceOf[R]
   ```
-   where each `CT_ij` is the class tag of the type of the formal parameter `Tij`
+   where each `c_ij` is the literal `java.lang.Class[?]` of the type of the formal parameter `Tij`, i.e., `classOf[Tij]`.
 
 - If `U` is neither a value nor a method type, or a dependent method
   type, an error is emitted.

--- a/docs/docs/reference/changed-features/structural-types.md
+++ b/docs/docs/reference/changed-features/structural-types.md
@@ -175,8 +175,8 @@ differences.
   `Selectable` is a trait which declares the access operations.
 
 - Two access operations, `selectDynamic` and `applyDynamic` are shared
-  between both approaches. In `Selectable`, `applyDynamic` also takes
-  `ClassTag` indicating the method's formal parameter types. `Dynamic`
-  comes with `updateDynamic`.
+  between both approaches. In `Selectable`, `applyDynamic` also may also take
+  `java.lang.Class` arguments indicating the method's formal parameter types.
+  `Dynamic` comes with `updateDynamic`.
 
 [More details](structural-types-spec.md)

--- a/library/src/scala/Selectable.scala
+++ b/library/src/scala/Selectable.scala
@@ -13,12 +13,13 @@ package scala
  *  `applyDynamic` is invoked for selections with arguments `v.m(...)`.
  *  If there's only one kind of selection, the method supporting the
  *  other may be omitted. The `applyDynamic` can also have a second parameter
- *  list of class tag arguments, i.e. it may alternatively have the signature
+ *  list of `java.lang.Class` arguments, i.e. it may alternatively have the
+ *  signature
  *
- *    def applyDynamic(name: String, paramClasses: ClassTag[_]*)(args: Any*): Any
+ *    def applyDynamic(name: String, paramClasses: Class[_]*)(args: Any*): Any
  *
- *  In this case the call will synthesize `ClassTag` arguments for all formal parameter
- *  types of the method in the structural type.
+ *  In this case the call will synthesize `Class` arguments for the erasure of
+ *  all formal parameter types of the method in the structural type.
  */
 trait Selectable extends Any
 

--- a/library/src/scala/reflect/Selectable.scala
+++ b/library/src/scala/reflect/Selectable.scala
@@ -27,10 +27,9 @@ trait Selectable extends scala.Selectable:
    *  @param paramTypes The class tags of the selected method's formal parameter types
    *  @param args       The arguments to pass to the selected method
    */
-  def applyDynamic(name: String, paramTypes: ClassTag[_]*)(args: Any*): Any =
+  def applyDynamic(name: String, paramTypes: Class[_]*)(args: Any*): Any =
     val rcls = selectedValue.getClass
-    val paramClasses = paramTypes.map(_.runtimeClass)
-    val mth = rcls.getMethod(name, paramClasses: _*)
+    val mth = rcls.getMethod(name, paramTypes: _*)
     ensureAccessible(mth)
     mth.invoke(selectedValue, args.asInstanceOf[Seq[AnyRef]]: _*)
 

--- a/tests/neg-scalajs/reflective-calls.scala
+++ b/tests/neg-scalajs/reflective-calls.scala
@@ -9,7 +9,7 @@ object Test {
     val receiver: Any = ???
     reflectiveSelectable(receiver).selectDynamic("foo") // OK
     reflectiveSelectable(receiver).applyDynamic("foo")() // OK
-    reflectiveSelectable(receiver).applyDynamic("foo", ClassTag(classOf[String]), ClassTag(classOf[List[_]]))("bar", Nil) // OK
+    reflectiveSelectable(receiver).applyDynamic("foo", classOf[String], classOf[List[_]])("bar", Nil) // OK
   }
 
   def badReceider(): Unit = {
@@ -25,21 +25,21 @@ object Test {
     reflectiveSelectable(receiver).applyDynamic(methodName)() // error
   }
 
-  def nonLiteralClassTag(): Unit = {
+  def nonLiteralClassOf(): Unit = {
     val receiver: Any = ???
-    val myClassTag: ClassTag[String] = ClassTag(classOf[String])
-    reflectiveSelectable(receiver).applyDynamic("foo", myClassTag, ClassTag(classOf[List[_]]))("bar", Nil) // error
+    val myClassOf: Class[String] = classOf[String]
+    reflectiveSelectable(receiver).applyDynamic("foo", myClassOf, classOf[List[_]])("bar", Nil) // error
   }
 
-  def classTagVarArgs(): Unit = {
+  def classOfVarArgs(): Unit = {
     val receiver: Any = ???
-    val classTags: List[ClassTag[_]] = List(ClassTag(classOf[String]), ClassTag(classOf[List[_]]))
-    reflectiveSelectable(receiver).applyDynamic("foo", classTags: _*)("bar", Nil) // error
+    val classOfs: List[Class[_]] = List(classOf[String], classOf[List[_]])
+    reflectiveSelectable(receiver).applyDynamic("foo", classOfs: _*)("bar", Nil) // error
   }
 
   def argsVarArgs(): Unit = {
     val receiver: Any = ???
     val args: List[Any] = List("bar", Nil)
-    reflectiveSelectable(receiver).applyDynamic("foo", ClassTag(classOf[String]), ClassTag(classOf[List[_]]))(args: _*) // error
+    reflectiveSelectable(receiver).applyDynamic("foo", classOf[String], classOf[List[_]])(args: _*) // error
   }
 }

--- a/tests/neg/structural.scala
+++ b/tests/neg/structural.scala
@@ -1,6 +1,6 @@
 object Test3 {
   import scala.reflect.Selectable.reflectiveSelectable
-  def g(x: { type T ; def t: T ; def f(a: T): Boolean }) = x.f(x.t) // error: no ClassTag for x.T
+  def g(x: { type T ; def t: T ; def f(a: T): Boolean }) = x.f(x.t) // error: it has a parameter type with an unstable erasure
   g(new { type T = Int; def t = 4; def f(a:T) = true })
   g(new { type T = Any; def t = 4; def f(a:T) = true })
   val y: { type T = Int; def t = 4; def f(a:T) = true }  // error: illegal refinement // error: illegal refinement

--- a/tests/semanticdb/expect/Advanced.expect.scala
+++ b/tests/semanticdb/expect/Advanced.expect.scala
@@ -26,7 +26,7 @@ object Test/*<-advanced::Test.*/ {
   val s2/*<-advanced::Test.s2.*/ = s/*->advanced::Test.s.*/.s2/*->advanced::Structural#s2().*/
   val s2x/*<-advanced::Test.s2x.*/ = /*->scala::reflect::Selectable.reflectiveSelectable().*/s/*->advanced::Test.s.*/.s2/*->advanced::Structural#s2().*//*->scala::reflect::Selectable#selectDynamic().*/.x
   val s3/*<-advanced::Test.s3.*/ = s/*->advanced::Test.s.*/.s3/*->advanced::Structural#s3().*/
-  val s3x/*<-advanced::Test.s3x.*/ = /*->scala::reflect::Selectable.reflectiveSelectable().*/s/*->advanced::Test.s.*/.s3/*->advanced::Structural#s3().*//*->scala::reflect::Selectable#applyDynamic().*/.m/*->scala::reflect::ClassTag.apply().*/(???/*->scala::Predef.`???`().*/)
+  val s3x/*<-advanced::Test.s3x.*/ = /*->scala::reflect::Selectable.reflectiveSelectable().*/s/*->advanced::Test.s.*/.s3/*->advanced::Structural#s3().*//*->scala::reflect::Selectable#applyDynamic().*/.m(???/*->scala::Predef.`???`().*/)
 
   val e/*<-advanced::Test.e.*/ = new Wildcards/*->advanced::Wildcards#*/
   val e1/*<-advanced::Test.e1.*/ = e/*->advanced::Test.e.*/.e1/*->advanced::Wildcards#e1().*/

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -50,7 +50,7 @@ Uri => Advanced.scala
 Text => empty
 Language => Scala
 Symbols => 34 entries
-Occurrences => 91 entries
+Occurrences => 90 entries
 
 Symbols:
 advanced/C# => class C
@@ -161,7 +161,6 @@ Occurrences:
 [28:12..28:13): s -> advanced/Test.s.
 [28:14..28:16): s3 -> advanced/Structural#s3().
 [28:16..28:16): -> scala/reflect/Selectable#applyDynamic().
-[28:18..28:18): -> scala/reflect/ClassTag.apply().
 [28:19..28:22): ??? -> scala/Predef.`???`().
 [30:6..30:7): e <- advanced/Test.e.
 [30:14..30:23): Wildcards -> advanced/Wildcards#

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/ReflectiveCallTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/ReflectiveCallTestScala3.scala
@@ -163,13 +163,11 @@ class ReflectiveCallTestScala3 {
     assertEquals("undefined any-string 5 Some(5) None",
         foo.foo((), "any-string", 5, Some[Int](5), None))
 
-    // The following calls do not compile in Dotty because
-    //   No ClassTag available for Null/Nothing
+    assertEquals("null", foo.nullMeth(null))
 
-    //assertEquals("null", foo.nullMeth(null))
-    //// Make sure that a call to nothingMeth can link
-    //if (Math.random() > 2) // always false
-    //  foo.nothingMeth(???)
+    // Make sure that a call to nothingMeth can link
+    if (Math.random() > 2) // always false
+      foo.nothingMeth(???)
   }
 
 }


### PR DESCRIPTION
This simplifies the life of everyone: the expansion of structural calls, the implementation of `scala.reflect.Selectable`, and the reverse engineering performed by the Scala.js back-end.

As a side benefit, the new transformation supports bottom types in the arguments. It was previously limited because we do not allow the generation of `ClassTag`s for `Null` and `Nothing`: they are unsound in arrays, which is what `ClassTag`s are designed for, but on their own they have perfectly valid `Class`'es.