### PR TITLE
Enable some recursive gadt to work with inline match

### DIFF
--- a/tests/run/enum-nat.scala
+++ b/tests/run/enum-nat.scala
@@ -1,0 +1,37 @@
+import Nat._
+import compiletime._
+
+enum Nat:
+  case Zero
+  case Succ[N <: Nat.Refract](n: N)
+
+object Nat:
+  type Refract = Zero.type | Succ[_]
+
+inline def toIntTypeLevel[N <: Nat]: Int = inline erasedValue[N] match
+  case _: Zero.type => 0
+  case _: Succ[n]   => toIntTypeLevel[n] + 1
+
+inline def toInt[N <: Nat.Refract](inline nat: N): Int = inline nat match
+  case nat: Zero.type => 0
+  case nat: Succ[n]   => toInt(nat.n) + 1
+
+inline def toIntUnapply[N <: Nat.Refract](inline nat: N): Int = inline nat match
+  case Zero    => 0
+  case Succ(n) => toIntUnapply(n) + 1
+
+inline def toIntTypeTailRec[N <: Nat, Acc <: Int]: Int = inline erasedValue[N] match
+  case _: Zero.type => constValue[Acc]
+  case _: Succ[n]   => toIntTypeTailRec[n, S[Acc]]
+
+inline def toIntErased[N <: Nat.Refract](inline nat: N): Int = toIntTypeTailRec[N, 0]
+
+@main def Test: Unit =
+  println("erased value:")
+  assert(toIntTypeLevel[Succ[Succ[Succ[Zero.type]]]] == 3)
+  println("type test:")
+  assert(toInt(Succ(Succ(Succ(Zero)))) == 3)
+  println("unapply:")
+  assert(toIntUnapply(Succ(Succ(Succ(Zero)))) == 3)
+  println("infer erased:")
+  assert(toIntErased(Succ(Succ(Succ(Zero)))) == 3)


### PR DESCRIPTION
Enable one encoding of recursive gadts to work with inline match, e.g:

```scala
enum Nat:
  case Zero
  case Succ[N <: Nat.Refract](pred: N)

object Nat:
  type Refract = Zero.type | Succ[_]
```

If the recursive part is fixed to a subtype of the union of the
cases of the enum, enable inline match to reduce cases.

Notes: this encoding could be supported by a
`compiletime.Refract[S]` type to split cases of a sum type.

This does not help #6781 due to requiring a precise bound to narrow the predecessor of `Succ`, it would be good to invest some time in inline match to make it work for the case where `Succ` has a weaker upper bound