### PR TITLE
Contextualize owners in reflection API

### DIFF
--- a/compiler/src/scala/quoted/internal/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/internal/impl/printers/SourceCode.scala
@@ -1409,7 +1409,7 @@ object SourceCode {
     private[this] val namesIndex = collection.mutable.Map.empty[String, Int]
 
     private def splicedName(sym: Symbol): Option[String] = {
-      if sym.owner.isClassDef then None
+      if sym.maybeOwner.isClassDef then None
       else names.get(sym).orElse {
         val name0 = sym.name
         val index = namesIndex.getOrElse(name0, 1)

--- a/scala3doc/src/dotty/dokka/tasty/TastyParser.scala
+++ b/scala3doc/src/dotty/dokka/tasty/TastyParser.scala
@@ -188,7 +188,7 @@ case class TastyParser(qctx: QuoteContext, inspector: DokkaBaseTastyInspector, c
     object Traverser extends TreeTraverser:
       var seen: List[Tree] = Nil
 
-      override def traverseTree(tree: Tree)(using ctx: Context): Unit =
+      override def traverseTree(tree: Tree)(using Owner): Unit =
         seen = tree :: seen
         tree match {
           case pck: PackageClause =>
@@ -202,7 +202,7 @@ case class TastyParser(qctx: QuoteContext, inspector: DokkaBaseTastyInspector, c
         }
         seen = seen.tail
 
-    try Traverser.traverseTree(root)(using qctx.reflect.rootContext)
+    try Traverser.traverseTree(root)
     catch case e: Throwable =>
       println(s"Problem parsing ${root.pos}, documentation may not be generated.")
       e.printStackTrace()

--- a/tests/pos-macros/i10151/Macro_1.scala
+++ b/tests/pos-macros/i10151/Macro_1.scala
@@ -39,19 +39,19 @@ object X:
                              List(Inferred(a.tpe.widen))
                             ),
                    List(
-                     Lambda(Symbol.currentOwner, mty, (meth, yArgs) =>
+                     Lambda(mty, yArgs =>
                        Apply(
                           TypeApply(Select.unique(transform(z),"map"),
                              List(Inferred(a.tpe.widen))
                           ),
                           List(
-                            Lambda(Symbol.currentOwner, mtz, (_, zArgs) => {
+                            Lambda(mtz, zArgs => {
                               val termYArgs = yArgs.asInstanceOf[List[Term]]
                               val termZArgs = zArgs.asInstanceOf[List[Term]]
                               Apply(x,List(termYArgs.head,termZArgs.head))
                             })
                           )
-                       ).changeOwner(meth)
+                       ).adaptOwner
                      )
                    )
                  )
@@ -70,7 +70,7 @@ object X:
             val paramTypes = params.map(_.tpt.tpe)
             val paramNames = params.map(_.name)
             val mt = MethodType(paramNames)(_ => paramTypes, _ => TypeRepr.of[CB].appliedTo(body.tpe.widen) )
-            Lambda(Symbol.currentOwner, mt, (meth, args) => changeArgs(params,args,transform(body)).changeOwner(meth) )
+            Lambda(mt, args => changeArgs(params,args,transform(body)).adaptOwner )
           case Block(stats, last) =>
             Block(stats, shiftLambda(last))
           case _ =>
@@ -82,7 +82,7 @@ object X:
              case (m, (oldParam, newParam: Tree)) => throw RuntimeException("Term expected")
          }
          val changes = new TreeMap() {
-             override def transformTerm(tree:Term)(using Context): Term =
+             override def transformTerm(tree:Term)(using Owner): Term =
                tree match
                  case ident@Ident(name) => association.getOrElse(ident.symbol, super.transformTerm(tree))
                  case _ => super.transformTerm(tree)

--- a/tests/pos-macros/i10211/Macro_1.scala
+++ b/tests/pos-macros/i10211/Macro_1.scala
@@ -66,7 +66,7 @@ object X:
         case Apply(Select(obj,"=="),List(b)) =>
              val tb = transform(b).asExprOf[CB[Int]]
              val mt = MethodType(List("p"))(_ => List(b.tpe.widen), _ => TypeRepr.of[Boolean])
-             val mapLambda = Lambda(Symbol.currentOwner, mt, (_, x) => Select.overloaded(obj,"==",List(),List(x.head.asInstanceOf[Term]))).asExprOf[Int=>Boolean]
+             val mapLambda = Lambda(mt, x => Select.overloaded(obj,"==",List(),List(x.head.asInstanceOf[Term]))).asExprOf[Int=>Boolean]
              Term.of('{ CBM.map($tb)($mapLambda) })
         case Block(stats, last) => Block(stats, transform(last))
         case Inlined(x,List(),body) => transform(body)
@@ -81,7 +81,7 @@ object X:
             val paramTypes = params.map(_.tpt.tpe)
             val paramNames = params.map(_.name)
             val mt = MethodType(paramNames)(_ => paramTypes, _ => TypeRepr.of[CB].appliedTo(body.tpe.widen) )
-            val r = Lambda(Symbol.currentOwner, mt, (meth, args) => changeArgs(params,args,transform(body)).changeOwner(meth) )
+            val r = Lambda(mt, args => changeArgs(params,args,transform(body)).adaptOwner )
             r
           case _ =>
             throw RuntimeException("lambda expected")
@@ -92,7 +92,7 @@ object X:
              case (m, (oldParam, newParam: Tree)) => throw RuntimeException("Term expected")
          }
          val changes = new TreeMap() {
-             override def transformTerm(tree:Term)(using Context): Term =
+             override def transformTerm(tree:Term)(using Owner): Term =
                tree match
                  case ident@Ident(name) => association.getOrElse(ident.symbol, super.transformTerm(tree))
                  case _ => super.transformTerm(tree)

--- a/tests/pos-macros/i9687/Macro_1.scala
+++ b/tests/pos-macros/i9687/Macro_1.scala
@@ -27,7 +27,7 @@ object X {
     val slowPath = Term.of('{ SlowPath })
     val fastPath = Term.of('{ FastPath })
     val transformer = new TreeMap() {
-      override def transformTerm(term:Term)(using ctx:Context):Term = {
+      override def transformTerm(term:Term)(using Owner):Term = {
         term match
           case Apply(sel@Select(o,m),args) =>
                 if ( o.tpe =:= slowPath.tpe && m=="sum" )

--- a/tests/pos-macros/i9894/Macro_1.scala
+++ b/tests/pos-macros/i9894/Macro_1.scala
@@ -46,7 +46,7 @@ object X:
             val paramTypes = params.map(_.tpt.tpe)
             val paramNames = params.map(_.name)
             val mt = MethodType(paramNames)(_ => paramTypes, _ => TypeRepr.of[CB].appliedTo(body.tpe.widen) )
-            val r = Lambda(Symbol.currentOwner, mt, (newMeth, args) => changeArgs(params,args,transform(body).changeOwner(newMeth)) )
+            val r = Lambda(mt, args => changeArgs(params,args,transform(body).adaptOwner))
             r
           case _ =>
             throw RuntimeException("lambda expected")
@@ -57,7 +57,7 @@ object X:
              case (m, (oldParam, newParam: Tree)) => throw RuntimeException("Term expected")
          }
          val changes = new TreeMap() {
-             override def transformTerm(tree:Term)(using Context): Term =
+             override def transformTerm(tree:Term)(using Owner): Term =
                tree match
                  case ident@Ident(name) => association.getOrElse(ident.symbol, super.transformTerm(tree))
                  case _ => super.transformTerm(tree)

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -20,7 +20,7 @@ object Macros {
 
   def myTraverser(using qctx: QuoteContext)(buff: StringBuilder): qctx.reflect.TreeTraverser = new {
     import qctx.reflect._
-    override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = {
+    override def traverseTree(tree: Tree)(using Owner): Unit = {
       tree match {
         case tree @ DefDef(name, _, _, _, _) =>
           buff.append(name)

--- a/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
@@ -19,7 +19,7 @@ class DocumentationInspector extends TastyInspector {
     import qctx.reflect._
     object Traverser extends TreeTraverser {
 
-      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      override def traverseTree(tree: Tree)(using Owner): Unit = tree match {
         case tree: Definition =>
           tree.symbol.documentation match {
             case Some(doc) => println(doc.raw)

--- a/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
@@ -19,7 +19,7 @@ class DBInspector extends TastyInspector {
     import qctx.reflect._
     object Traverser extends TreeTraverser {
 
-      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      override def traverseTree(tree: Tree)(using Owner): Unit = tree match {
         case tree: Definition =>
           println(tree.showExtractors)
           super.traverseTree(tree)

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
@@ -9,7 +9,7 @@ class TastyInterpreter extends TastyInspector {
     import qctx.reflect._
     object Traverser extends TreeTraverser {
 
-      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      override def traverseTree(tree: Tree)(using Owner): Unit = tree match {
         // TODO: check the correct sig and object enclosement for main
         case DefDef("main", _, _, _, Some(rhs)) =>
           val interpreter = new jvm.Interpreter

--- a/tests/run-macros/i6988/FirstArg_1.scala
+++ b/tests/run-macros/i6988/FirstArg_1.scala
@@ -11,7 +11,7 @@ object Macros {
   def argsImpl(using qctx: QuoteContext) : Expr[FirstArg] = {
     import qctx.reflect._
 
-    def enclosingClass(cur: Symbol = Symbol.currentOwner): Symbol =
+    def enclosingClass(cur: Symbol = Owner.current.symbol): Symbol =
       if (cur.isClassDef) cur
       else enclosingClass(cur.owner)
 
@@ -24,7 +24,7 @@ object Macros {
 
     def literal(value: String): Expr[String] =
       Literal(Constant.String(value)).asExpr.asInstanceOf[Expr[String]]
-    val paramss = enclosingParamList(Symbol.currentOwner)
+    val paramss = enclosingParamList(Owner.current.symbol)
     val firstArg = paramss.flatten.head
     val ref = Select.unique(This(enclosingClass()), firstArg.name)
     '{ FirstArg(${ref.asExpr}, ${Expr(firstArg.name)}) }

--- a/tests/run-macros/i7025/Macros_1.scala
+++ b/tests/run-macros/i7025/Macros_1.scala
@@ -10,7 +10,7 @@ object Macros {
       if owner.isClassDef then owner
       else nearestEnclosingDef(owner.owner)
 
-    val x = nearestEnclosingDef(Symbol.currentOwner)
+    val x = nearestEnclosingDef(Owner.current.symbol)
     if x.isDefDef then
       val code = x.signature.toString
       '{ println(${Expr(code)}) }

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -70,7 +70,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
@@ -78,7 +78,7 @@ object UnsafeExpr {
     import qctx.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
-      override def transformTerm(tree: Term)(using ctx: Context): Term =
+      override def transformTerm(tree: Term)(using Owner): Term =
         super.transformTerm(tree) match
           case tree: Ident => map.getOrElse(tree.symbol, tree)
           case tree => tree

--- a/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
@@ -82,7 +82,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
@@ -90,7 +90,7 @@ object UnsafeExpr {
     import qctx.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
-      override def transformTerm(tree: Term)(using ctx: Context): Term =
+      override def transformTerm(tree: Term)(using Owner): Term =
         super.transformTerm(tree) match
           case tree: Ident => map.getOrElse(tree.symbol, tree)
           case tree => tree

--- a/tests/run-macros/quote-matching-open/Macro_1.scala
+++ b/tests/run-macros/quote-matching-open/Macro_1.scala
@@ -34,7 +34,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
@@ -42,7 +42,7 @@ object UnsafeExpr {
     import qctx.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
-      override def transformTerm(tree: Term)(using ctx: Context): Term =
+      override def transformTerm(tree: Term)(using Owner): Term =
         super.transformTerm(tree) match
           case tree: Ident => map.getOrElse(tree.symbol, tree)
           case tree => tree

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -9,7 +9,6 @@ object Macros {
 
     // simple smoke test
     val sym1 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
       "sym1",
       MethodType(List("a","b"))(
         _ => List(TypeRepr.of[Int], TypeRepr.of[Int]),
@@ -27,7 +26,6 @@ object Macros {
 
     // test for no argument list (no Apply node)
     val sym2 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
       "sym2",
       ByNameType(TypeRepr.of[Int]))
     assert(sym2.isDefDef)
@@ -43,7 +41,6 @@ object Macros {
 
    // test for multiple argument lists
    val sym3 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
       "sym3",
       MethodType(List("a"))(
         _ => List(TypeRepr.of[Int]),
@@ -63,7 +60,6 @@ object Macros {
 
     // test for recursive references
     val sym4 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
       "sym4",
       MethodType(List("x"))(
         _ => List(TypeRepr.of[Int]),
@@ -85,7 +81,6 @@ object Macros {
 
     // test for nested functions (one symbol is the other's parent, and we use a Closure)
     val sym5 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
       "sym5",
       MethodType(List("x"))(
         _ => List(TypeRepr.of[Int]),
@@ -98,11 +93,10 @@ object Macros {
           case List(List(x)) =>
             Some {
               val sym51 : Symbol = Symbol.newMethod(
-                sym5,
                 "sym51",
                 MethodType(List("x"))(
                   _ => List(TypeRepr.of[Int]),
-                  _ => TypeRepr.of[Int]))
+                  _ => TypeRepr.of[Int]))(using Owner(sym5))
               Block(
                 List(
                   DefDef(sym51, {
@@ -119,13 +113,11 @@ object Macros {
 
     // test mutually recursive definitions
     val sym6_1 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
       "sym6_1",
       MethodType(List("x"))(
         _ => List(TypeRepr.of[Int]),
         _ => TypeRepr.of[Int]))
     val sym6_2 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
       "sym6_2",
       MethodType(List("x"))(
         _ => List(TypeRepr.of[Int]),
@@ -166,7 +158,6 @@ object Macros {
 
     // test polymorphic methods by synthesizing an identity method
     val sym7 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
       "sym7",
       PolyType(List("T"))(
         tp => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -11,7 +11,7 @@ object Macros {
 
     val buff = new StringBuilder
     val traverser = new TreeTraverser {
-      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      override def traverseTree(tree: Tree)(using Owner): Unit = tree match {
         case tree: TypeBoundsTree =>
           buff.append(tree.tpe.showExtractors)
           buff.append("\n\n")

--- a/tests/run-macros/tasty-location/quoted_1.scala
+++ b/tests/run-macros/tasty-location/quoted_1.scala
@@ -13,7 +13,7 @@ object Location {
       if (sym == defn.RootClass || sym == defn.EmptyPackageClass) acc
       else listOwnerNames(sym.owner, sym.name :: acc)
 
-    val list = listOwnerNames(Symbol.currentOwner, Nil)
+    val list = listOwnerNames(Owner.current.symbol, Nil)
     '{new Location(${Expr(list)})}
   }
 

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -14,10 +14,10 @@ object Asserts {
         fn.tpe.widen match {
           case _: MethodType =>
             args.size match {
-              case 0 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[() => Int]}() })
-              case 1 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[Int => Int]}(0) })
-              case 2 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int) => Int]}(0, 0) })
-              case 3 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int, Int) => Int]}(0, 0, 0) })
+              case 0 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[() => Int]}() })
+              case 1 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[Int => Int]}(0) })
+              case 2 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[(Int, Int) => Int]}(0, 0) })
+              case 3 => Expr.betaReduce('{ ${fn.etaExpand.asExprOf[(Int, Int, Int) => Int]}(0, 0, 0) })
             }
         }
       case _ => x
@@ -35,10 +35,10 @@ object Asserts {
       case Apply(fn, args) =>
         val pre = rec(fn)
         args.size match {
-          case 0 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[() => Any]}() }))
-          case 1 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[Int => Any]}(0) }))
-          case 2 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int) => Any]}(0, 0) }))
-          case 3 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }))
+          case 0 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[() => Any]}() }))
+          case 1 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[Int => Any]}(0) }))
+          case 2 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int) => Any]}(0, 0) }))
+          case 3 => Term.of(Expr.betaReduce('{ ${pre.etaExpand.asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }))
         }
       case _ => term
     }


### PR DESCRIPTION
* Introduce an `Owner` abstraction
* Replace `Tree.changeOwner` with contextualized `Tree.adaptOwner`
* Contextualize owner in `Lambda.apply`
* Contextualize owner in `Term.etaExpand`
* Contextualize owner in `Symbol.{newVal, newMethod, newBind}`
* Recontextualize `TreeMap`, `TreeAccumulator`, `TreeTaverser`
* Fix owner in `ValDef.let`