### PR TITLE
Make the extension method `nn` inline.

### DIFF
--- a/library/src/dotty/DottyPredef.scala
+++ b/library/src/dotty/DottyPredef.scala
@@ -79,7 +79,6 @@ object DottyPredef {
    *
    *  Note that `.nn` performs a checked cast, so if invoked on a null value it'll throw an NPE.
    */
-  extension [T](x: T | Null) def nn: x.type & T =
-    if (x == null) throw new NullPointerException("tried to cast away nullability, but value is null")
-    else x.asInstanceOf[x.type & T]
+  extension [T](x: T | Null) inline def nn: x.type & T =
+    scala.runtime.Scala3RunTime.nn(x)
 }

--- a/library/src/scala/runtime/Scala3RunTime.scala
+++ b/library/src/scala/runtime/Scala3RunTime.scala
@@ -10,4 +10,12 @@ object Scala3RunTime:
   def assertFailed(): Nothing =
     throw new java.lang.AssertionError("assertion failed")
 
+  /** Called by the inline extension def `nn`.
+   *
+   *  Extracted to minimize the bytecode size at call site.
+   */
+  def nn[T](x: T | Null): x.type & T =
+    if (x == null) throw new NullPointerException("tried to cast away nullability, but value is null")
+    else x.asInstanceOf[x.type & T]
+
 end Scala3RunTime


### PR DESCRIPTION
And delegate its body to a runtime method in Scala3RunTime.

With this change, all the methods of DottyPredef are inline methods. We will therefore be able to patch them on Predef in the future, rather than having DottyPredef.