### PR TITLE
Update Getting Started page: publishLocal option

### DIFF
--- a/docs/docs/contributing/getting-started.md
+++ b/docs/docs/contributing/getting-started.md
@@ -65,6 +65,19 @@ or via bash:
 $ scala
 ```
 
+Publish to local repository
+---------------------------------
+To test our cloned compiler on local projects:
+
+```bash
+$ sbt publishLocal
+```
+Then in the `build.sbt` file of a test project:
+
+```bash
+ThisBuild / scalaVersion := "<dotty-version>-bin-SNAPSHOT"
+```
+where `dotty-version` can be found in the file `project/Build.scala`, like `3.0.0-M2`
 
 Generating Documentation
 -------------------------


### PR DESCRIPTION
Add info on how to publish locally the dotty compiler and use it on sbt projects.