### PR TITLE
Add missing owner for `ValDef.let`

### DIFF
--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -11,10 +11,10 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
-        let(lhs) { left =>
-          let(rhs) { right =>
+        let(Symbol.currentOwner, lhs) { left =>
+          let(Symbol.currentOwner, rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
-            let(app) { result =>
+            let(Symbol.currentOwner, app) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]

--- a/tests/pos-macros/i8866/Macro_1.scala
+++ b/tests/pos-macros/i8866/Macro_1.scala
@@ -15,6 +15,7 @@ object Macro {
     import qctx.reflect._
 
     ValDef.let(
+      Symbol.currentOwner,
       Select.unique(
         Term.of('{ OtherMacro }),
         "apply"

--- a/tests/pos-macros/i8866b/Macro_1.scala
+++ b/tests/pos-macros/i8866b/Macro_1.scala
@@ -10,6 +10,7 @@ object Macro {
     import qctx.reflect._
 
     ValDef.let(
+      Symbol.spliceOwner,
       Select.unique(
         Term.of('{ Other }),
         "apply"

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
-            ValDef.let(app) { result =>
+            ValDef.let(Symbol.spliceOwner, app) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.asExprOf[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
         if isImplicitMethodType(f.tpe) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
-            ValDef.let(Apply(app, implicits)) { result =>
+            ValDef.let(Symbol.spliceOwner, Apply(app, implicits)) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = left.select(sel.symbol).appliedTo(right)
-            ValDef.let(app) { result =>
+            ValDef.let(Symbol.spliceOwner, app) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.asExprOf[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = qual.appliedTo(left).select(sel.symbol).appliedTo(right)
-            ValDef.let(Apply(app, implicits)) { result =>
+            ValDef.let(Symbol.spliceOwner, Apply(app, implicits)) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -10,8 +10,8 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case t @ Apply(TypeApply(Select(lhs, op), targs), rhs) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { rs =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { rs =>
             val app = Select.overloaded(left, op, targs.map(_.tpe), rs)
             val b = app.asExprOf[Boolean]
             Term.of('{ scala.Predef.assert($b) })

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
-            ValDef.let(app) { result =>
+            ValDef.let(Symbol.spliceOwner, app) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.asExprOf[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
-            ValDef.let(Apply(app, implicits)) { result =>
+            ValDef.let(Symbol.spliceOwner, Apply(app, implicits)) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]

--- a/tests/run-macros/reflect-select-copy-2/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy-2/assert_1.scala
@@ -14,9 +14,9 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case Apply(sel @ Select(lhs, op), rhs :: Nil) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
-            ValDef.let(Apply(Select.copy(sel)(left, op), right :: Nil)) { result =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
+            ValDef.let(Symbol.spliceOwner, Apply(Select.copy(sel)(left, op), right :: Nil)) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
@@ -27,9 +27,9 @@ object scalatest {
         }.asExprOf[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
-            ValDef.let(Apply(Apply(Select.copy(sel)(Apply(qual, left :: Nil), op), right :: Nil), implicits)) { result =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
+            ValDef.let(Symbol.spliceOwner, Apply(Apply(Select.copy(sel)(Apply(qual, left :: Nil), op), right :: Nil), implicits)) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = Apply(Select(left, sel.symbol), right :: Nil)
-            ValDef.let(app) { result =>
+            ValDef.let(Symbol.spliceOwner, app) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.asExprOf[Unit]
       case Apply(f @ Apply(sel @ Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = Apply(Select(Apply(qual, left :: Nil), sel.symbol), right :: Nil)
-            ValDef.let(Apply(app, implicits)) { result =>
+            ValDef.let(Symbol.spliceOwner, Apply(app, implicits)) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -14,10 +14,10 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
-            ValDef.let(app) { result =>
+            ValDef.let(Symbol.spliceOwner, app) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
@@ -28,10 +28,10 @@ object scalatest {
         }.asExprOf[Unit]
       case Apply(f @ Apply(Select(Apply(qual, lhs :: Nil), op), rhs :: Nil), implicits)
       if isImplicitMethodType(f.tpe) =>
-        ValDef.let(lhs) { left =>
-          ValDef.let(rhs) { right =>
+        ValDef.let(Symbol.spliceOwner, lhs) { left =>
+          ValDef.let(Symbol.spliceOwner, rhs) { right =>
             val app = Select.overloaded(Apply(qual, left :: Nil), op, Nil, right :: Nil)
-            ValDef.let(Apply(app, implicits)) { result =>
+            ValDef.let(Symbol.spliceOwner, Apply(app, implicits)) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]

--- a/tests/run-macros/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-macros/tasty-unsafe-let/quoted_1.scala
@@ -11,7 +11,7 @@ object Macros {
     val rhsTerm = Term.of(rhs)
 
     import qctx.reflect._
-    ValDef.let(rhsTerm) { rhsId =>
+    ValDef.let(Symbol.spliceOwner, rhsTerm) { rhsId =>
       Term.of(Expr.betaReduce('{$body(${rhsId.asExpr.asInstanceOf[Expr[T]]})})) // Dangerous uncheked cast!
     }.asExprOf[Unit]
   }


### PR DESCRIPTION
Alternative fix of the missing owner of `ValDef.let` with explicit owners. Alternative with contextual owners in #10394.