### PR TITLE
Make owners explicit in reflection API 

### DIFF
--- a/compiler/src/scala/quoted/internal/impl/QuoteContextImpl.scala
+++ b/compiler/src/scala/quoted/internal/impl/QuoteContextImpl.scala
@@ -2205,7 +2205,6 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext, QuoteUnpickl
 
     object Symbol extends SymbolModule:
       def spliceOwner: Symbol = ctx.owner
-      def currentOwner(using ctx: Context): Symbol = ctx.owner
       def requiredPackage(path: String): Symbol = dotc.core.Symbols.requiredPackage(path)
       def requiredClass(path: String): Symbol = dotc.core.Symbols.requiredClass(path)
       def requiredModule(path: String): Symbol = dotc.core.Symbols.requiredModule(path)
@@ -2244,8 +2243,6 @@ class QuoteContextImpl private (ctx: Context) extends QuoteContext, QuoteUnpickl
         def fullName: String = self.denot.fullName.toString
         def pos: Position = self.sourcePos
 
-        def localContext: Context =
-          if self.exists then ctx.withOwner(self) else ctx
         def documentation: Option[Documentation] =
           import dotc.core.Comments.CommentsContext
           val docCtx = ctx.docCtx.getOrElse {

--- a/library/src-bootstrapped/scala/quoted/ExprMap.scala
+++ b/library/src-bootstrapped/scala/quoted/ExprMap.scala
@@ -10,96 +10,94 @@ trait ExprMap:
     import qctx.reflect._
     final class MapChildren() {
 
-      def transformStatement(tree: Statement)(using ctx: Context): Statement = {
-        def localCtx(definition: Definition): Context = definition.symbol.localContext
+      def transformStatement(tree: Statement)(owner: Symbol): Statement = {
         tree match {
           case tree: Term =>
-            transformTerm(tree, TypeRepr.of[Any])
+            transformTerm(tree, TypeRepr.of[Any])(owner)
           case tree: Definition =>
-            transformDefinition(tree)
+            transformDefinition(tree)(owner)
           case tree: Import =>
             tree
         }
       }
 
-      def transformDefinition(tree: Definition)(using ctx: Context): Definition = {
-        def localCtx(definition: Definition): Context = definition.symbol.localContext
+      def transformDefinition(tree: Definition)(owner: Symbol): Definition = {
         tree match {
           case tree: ValDef =>
-            given Context = localCtx(tree)
-            val rhs1 = tree.rhs.map(x => transformTerm(x, tree.tpt.tpe))
+            val owner = tree.symbol
+            val rhs1 = tree.rhs.map(x => transformTerm(x, tree.tpt.tpe)(owner))
             ValDef.copy(tree)(tree.name, tree.tpt, rhs1)
           case tree: DefDef =>
-            given Context = localCtx(tree)
-            DefDef.copy(tree)(tree.name, tree.typeParams, tree.paramss, tree.returnTpt, tree.rhs.map(x => transformTerm(x, tree.returnTpt.tpe)))
+            val owner = tree.symbol
+            DefDef.copy(tree)(tree.name, tree.typeParams, tree.paramss, tree.returnTpt, tree.rhs.map(x => transformTerm(x, tree.returnTpt.tpe)(owner)))
           case tree: TypeDef =>
             tree
           case tree: ClassDef =>
-            val newBody = transformStats(tree.body)
+            val newBody = transformStats(tree.body)(owner)
             ClassDef.copy(tree)(tree.name, tree.constructor, tree.parents, tree.derived, tree.self, newBody)
         }
       }
 
-      def transformTermChildren(tree: Term, tpe: TypeRepr)(using ctx: Context): Term = tree match {
+      def transformTermChildren(tree: Term, tpe: TypeRepr)(owner: Symbol): Term = tree match {
         case Ident(name) =>
           tree
         case Select(qualifier, name) =>
-          Select.copy(tree)(transformTerm(qualifier, qualifier.tpe), name)
+          Select.copy(tree)(transformTerm(qualifier, qualifier.tpe)(owner), name)
         case This(qual) =>
           tree
         case Super(qual, mix) =>
           tree
         case tree as Apply(fun, args) =>
           val MethodType(_, tpes, _) = fun.tpe.widen
-          Apply.copy(tree)(transformTerm(fun, TypeRepr.of[Any]), transformTerms(args, tpes))
+          Apply.copy(tree)(transformTerm(fun, TypeRepr.of[Any])(owner), transformTerms(args, tpes)(owner))
         case TypeApply(fun, args) =>
-          TypeApply.copy(tree)(transformTerm(fun, TypeRepr.of[Any]), args)
+          TypeApply.copy(tree)(transformTerm(fun, TypeRepr.of[Any])(owner), args)
         case _: Literal =>
           tree
         case New(tpt) =>
-          New.copy(tree)(transformTypeTree(tpt))
+          New.copy(tree)(transformTypeTree(tpt)(owner))
         case Typed(expr, tpt) =>
           val tp = tpt.tpe match
             case AppliedType(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "<repeated>"), List(tp0: TypeRepr)) =>
               TypeRepr.of[Seq].appliedTo(tp0)
             case tp => tp
-          Typed.copy(tree)(transformTerm(expr, tp), transformTypeTree(tpt))
+          Typed.copy(tree)(transformTerm(expr, tp)(owner), transformTypeTree(tpt)(owner))
         case tree: NamedArg =>
-          NamedArg.copy(tree)(tree.name, transformTerm(tree.value, tpe))
+          NamedArg.copy(tree)(tree.name, transformTerm(tree.value, tpe)(owner))
         case Assign(lhs, rhs) =>
-          Assign.copy(tree)(lhs, transformTerm(rhs, lhs.tpe.widen))
+          Assign.copy(tree)(lhs, transformTerm(rhs, lhs.tpe.widen)(owner))
         case Block(stats, expr) =>
-          Block.copy(tree)(transformStats(stats), transformTerm(expr, tpe))
+          Block.copy(tree)(transformStats(stats)(owner), transformTerm(expr, tpe)(owner))
         case If(cond, thenp, elsep) =>
           If.copy(tree)(
-            transformTerm(cond, TypeRepr.of[Boolean]),
-            transformTerm(thenp, tpe),
-            transformTerm(elsep, tpe))
+            transformTerm(cond, TypeRepr.of[Boolean])(owner),
+            transformTerm(thenp, tpe)(owner),
+            transformTerm(elsep, tpe)(owner))
         case _: Closure =>
           tree
         case Match(selector, cases) =>
-          Match.copy(tree)(transformTerm(selector, selector.tpe), transformCaseDefs(cases, tpe))
+          Match.copy(tree)(transformTerm(selector, selector.tpe)(owner), transformCaseDefs(cases, tpe)(owner))
         case Return(expr) =>
           // FIXME
           // ctx.owner seems to be set to the wrong symbol
           // Return.copy(tree)(transformTerm(expr, expr.tpe))
           tree
         case While(cond, body) =>
-          While.copy(tree)(transformTerm(cond, TypeRepr.of[Boolean]), transformTerm(body, TypeRepr.of[Any]))
+          While.copy(tree)(transformTerm(cond, TypeRepr.of[Boolean])(owner), transformTerm(body, TypeRepr.of[Any])(owner))
         case Try(block, cases, finalizer) =>
-          Try.copy(tree)(transformTerm(block, tpe), transformCaseDefs(cases, TypeRepr.of[Any]), finalizer.map(x => transformTerm(x, TypeRepr.of[Any])))
+          Try.copy(tree)(transformTerm(block, tpe)(owner), transformCaseDefs(cases, TypeRepr.of[Any])(owner), finalizer.map(x => transformTerm(x, TypeRepr.of[Any])(owner)))
         case Repeated(elems, elemtpt) =>
-          Repeated.copy(tree)(transformTerms(elems, elemtpt.tpe), elemtpt)
+          Repeated.copy(tree)(transformTerms(elems, elemtpt.tpe)(owner), elemtpt)
         case Inlined(call, bindings, expansion) =>
-          Inlined.copy(tree)(call, transformDefinitions(bindings), transformTerm(expansion, tpe)/*()call.symbol.localContext)*/)
+          Inlined.copy(tree)(call, transformDefinitions(bindings)(owner), transformTerm(expansion, tpe)(owner))
       }
 
-      def transformTerm(tree: Term, tpe: TypeRepr)(using ctx: Context): Term =
+      def transformTerm(tree: Term, tpe: TypeRepr)(owner: Symbol): Term =
         tree match
           case _: Closure =>
             tree
           case _: Inlined =>
-            transformTermChildren(tree, tpe)
+            transformTermChildren(tree, tpe)(owner)
           case _ if tree.isExpr =>
             type X
             val expr = tree.asExpr.asInstanceOf[Expr[X]]
@@ -107,45 +105,44 @@ trait ExprMap:
             val transformedExpr = transform(expr)(using qctx, t)
             Term.of(transformedExpr)
           case _ =>
-            transformTermChildren(tree, tpe)
+            transformTermChildren(tree, tpe)(owner)
 
-      def transformTypeTree(tree: TypeTree)(using ctx: Context): TypeTree = tree
+      def transformTypeTree(tree: TypeTree)(owner: Symbol): TypeTree = tree
 
-      def transformCaseDef(tree: CaseDef, tpe: TypeRepr)(using ctx: Context): CaseDef =
-        CaseDef.copy(tree)(tree.pattern, tree.guard.map(x => transformTerm(x, TypeRepr.of[Boolean])), transformTerm(tree.rhs, tpe))
+      def transformCaseDef(tree: CaseDef, tpe: TypeRepr)(owner: Symbol): CaseDef =
+        CaseDef.copy(tree)(tree.pattern, tree.guard.map(x => transformTerm(x, TypeRepr.of[Boolean])(owner)), transformTerm(tree.rhs, tpe)(owner))
 
-      def transformTypeCaseDef(tree: TypeCaseDef)(using ctx: Context): TypeCaseDef = {
-        TypeCaseDef.copy(tree)(transformTypeTree(tree.pattern), transformTypeTree(tree.rhs))
-      }
+      def transformTypeCaseDef(tree: TypeCaseDef)(owner: Symbol): TypeCaseDef =
+        TypeCaseDef.copy(tree)(transformTypeTree(tree.pattern)(owner), transformTypeTree(tree.rhs)(owner))
 
-      def transformStats(trees: List[Statement])(using ctx: Context): List[Statement] =
-        trees mapConserve (transformStatement(_))
+      def transformStats(trees: List[Statement])(owner: Symbol): List[Statement] =
+        trees.mapConserve(x => transformStatement(x)(owner))
 
-      def transformDefinitions(trees: List[Definition])(using ctx: Context): List[Definition] =
-        trees mapConserve (transformDefinition(_))
+      def transformDefinitions(trees: List[Definition])(owner: Symbol): List[Definition] =
+        trees.mapConserve(x => transformDefinition(x)(owner))
 
-      def transformTerms(trees: List[Term], tpes: List[TypeRepr])(using ctx: Context): List[Term] =
+      def transformTerms(trees: List[Term], tpes: List[TypeRepr])(owner: Symbol): List[Term] =
         var tpes2 = tpes // TODO use proper zipConserve
-        trees mapConserve { x =>
+        trees.mapConserve{ x =>
           val tpe :: tail = tpes2
           tpes2 = tail
-          transformTerm(x, tpe)
+          transformTerm(x, tpe)(owner)
         }
 
-      def transformTerms(trees: List[Term], tpe: TypeRepr)(using ctx: Context): List[Term] =
-        trees.mapConserve(x => transformTerm(x, tpe))
+      def transformTerms(trees: List[Term], tpe: TypeRepr)(owner: Symbol): List[Term] =
+        trees.mapConserve(x => transformTerm(x, tpe)(owner))
 
-      def transformTypeTrees(trees: List[TypeTree])(using ctx: Context): List[TypeTree] =
-        trees mapConserve (transformTypeTree(_))
+      def transformTypeTrees(trees: List[TypeTree])(owner: Symbol): List[TypeTree] =
+        trees.mapConserve(x => transformTypeTree(x)(owner))
 
-      def transformCaseDefs(trees: List[CaseDef], tpe: TypeRepr)(using ctx: Context): List[CaseDef] =
-        trees mapConserve (x => transformCaseDef(x, tpe))
+      def transformCaseDefs(trees: List[CaseDef], tpe: TypeRepr)(owner: Symbol): List[CaseDef] =
+        trees.mapConserve(x => transformCaseDef(x, tpe)(owner))
 
-      def transformTypeCaseDefs(trees: List[TypeCaseDef])(using ctx: Context): List[TypeCaseDef] =
-        trees mapConserve (transformTypeCaseDef(_))
+      def transformTypeCaseDefs(trees: List[TypeCaseDef])(owner: Symbol): List[TypeCaseDef] =
+        trees.mapConserve(x => transformTypeCaseDef(x)(owner))
 
     }
-    new MapChildren().transformTermChildren(Term.of(e), TypeRepr.of[T]).asExprOf[T]
+    new MapChildren().transformTermChildren(Term.of(e), TypeRepr.of[T])(Symbol.spliceOwner).asExprOf[T]
   }
 
 end ExprMap

--- a/scala3doc/src/dotty/dokka/tasty/TastyParser.scala
+++ b/scala3doc/src/dotty/dokka/tasty/TastyParser.scala
@@ -188,12 +188,12 @@ case class TastyParser(qctx: QuoteContext, inspector: DokkaBaseTastyInspector, c
     object Traverser extends TreeTraverser:
       var seen: List[Tree] = Nil
 
-      override def traverseTree(tree: Tree)(using ctx: Context): Unit =
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit =
         seen = tree :: seen
         tree match {
           case pck: PackageClause =>
             docs += parsePackage(pck)
-            super.traverseTree(tree)
+            super.traverseTree(tree)(owner)
           case packageObject: ClassDef if(packageObject.symbol.name.contains("package$")) =>
             docs += parsePackageObject(packageObject)
           case clazz: ClassDef if clazz.symbol.shouldDocumentClasslike =>
@@ -202,7 +202,7 @@ case class TastyParser(qctx: QuoteContext, inspector: DokkaBaseTastyInspector, c
         }
         seen = seen.tail
 
-    try Traverser.traverseTree(root)(using qctx.reflect.rootContext)
+    try Traverser.traverseTree(root)(Symbol.spliceOwner)
     catch case e: Throwable =>
       println(s"Problem parsing ${root.pos}, documentation may not be generated.")
       e.printStackTrace()

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -11,10 +11,10 @@ object scalatest {
 
     Term.of(cond).underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
-        let(Symbol.currentOwner, lhs) { left =>
-          let(Symbol.currentOwner, rhs) { right =>
+        let(Symbol.spliceOwner, lhs) { left =>
+          let(Symbol.spliceOwner, rhs) { right =>
             val app = Select.overloaded(left, op, Nil, right :: Nil)
-            let(Symbol.currentOwner, app) { result =>
+            let(Symbol.spliceOwner, app) { result =>
               val l = left.asExpr
               val r = right.asExpr
               val b = result.asExprOf[Boolean]

--- a/tests/pos-macros/i8866/Macro_1.scala
+++ b/tests/pos-macros/i8866/Macro_1.scala
@@ -15,7 +15,7 @@ object Macro {
     import qctx.reflect._
 
     ValDef.let(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       Select.unique(
         Term.of('{ OtherMacro }),
         "apply"

--- a/tests/pos-macros/i9687/Macro_1.scala
+++ b/tests/pos-macros/i9687/Macro_1.scala
@@ -27,17 +27,17 @@ object X {
     val slowPath = Term.of('{ SlowPath })
     val fastPath = Term.of('{ FastPath })
     val transformer = new TreeMap() {
-      override def transformTerm(term:Term)(using ctx:Context):Term = {
+      override def transformTerm(term:Term)(owner: Symbol):Term = {
         term match
           case Apply(sel@Select(o,m),args) =>
                 if ( o.tpe =:= slowPath.tpe && m=="sum" )
                    Apply(Select.unique(fastPath,"sum"), args)
                 else
-                   super.transformTerm(term)
-          case _ => super.transformTerm(term)
+                   super.transformTerm(term)(owner)
+          case _ => super.transformTerm(term)(owner)
       }
     }
-    val r = transformer.transformTerm(Term.of(x)).asExprOf[A]
+    val r = transformer.transformTerm(Term.of(x))(Symbol.spliceOwner).asExprOf[A]
     s"result: ${r.show}"
     r
  }

--- a/tests/pos-macros/i9894/Macro_1.scala
+++ b/tests/pos-macros/i9894/Macro_1.scala
@@ -46,7 +46,7 @@ object X:
             val paramTypes = params.map(_.tpt.tpe)
             val paramNames = params.map(_.name)
             val mt = MethodType(paramNames)(_ => paramTypes, _ => TypeRepr.of[CB].appliedTo(body.tpe.widen) )
-            val r = Lambda(Symbol.currentOwner, mt, (newMeth, args) => changeArgs(params,args,transform(body).changeOwner(newMeth)) )
+            val r = Lambda(Symbol.spliceOwner, mt, (newMeth, args) => changeArgs(params,args,transform(body).changeOwner(newMeth)) )
             r
           case _ =>
             throw RuntimeException("lambda expected")
@@ -57,11 +57,11 @@ object X:
              case (m, (oldParam, newParam: Tree)) => throw RuntimeException("Term expected")
          }
          val changes = new TreeMap() {
-             override def transformTerm(tree:Term)(using Context): Term =
+             override def transformTerm(tree:Term)(owner: Symbol): Term =
                tree match
-                 case ident@Ident(name) => association.getOrElse(ident.symbol, super.transformTerm(tree))
-                 case _ => super.transformTerm(tree)
+                 case ident@Ident(name) => association.getOrElse(ident.symbol, super.transformTerm(tree)(owner))
+                 case _ => super.transformTerm(tree)(owner)
          }
-         changes.transformTerm(body)
+         changes.transformTerm(body)(Symbol.spliceOwner)
 
    transform(Term.of(f)).asExprOf[CB[T]]

--- a/tests/pos-macros/treemap-unapply/Macro.scala
+++ b/tests/pos-macros/treemap-unapply/Macro.scala
@@ -5,4 +5,4 @@ def mcrImpl(x: Expr[Unit])(using QuoteContext) : Expr[Unit] =
   import qctx.reflect._
   val tr: Term = Term.of(x)
   object m extends TreeMap
-  m.transformTerm(tr).asExprOf[Unit]
+  m.transformTerm(tr)(Symbol.spliceOwner).asExprOf[Unit]

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -13,14 +13,14 @@ object Macros {
     val output = myTraverser(buff)
 
     val tree = Term.of(x)
-    output.traverseTree(tree)
+    output.traverseTree(tree)(Symbol.spliceOwner)
     '{print(${Expr(buff.result())})}
   }
 
 
   def myTraverser(using qctx: QuoteContext)(buff: StringBuilder): qctx.reflect.TreeTraverser = new {
     import qctx.reflect._
-    override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = {
+    override def traverseTree(tree: Tree)(owner: Symbol): Unit = {
       tree match {
         case tree @ DefDef(name, _, _, _, _) =>
           buff.append(name)
@@ -34,7 +34,7 @@ object Macros {
           buff.append("\n\n")
         case _ =>
       }
-      traverseTreeChildren(tree)
+      traverseTreeChildren(tree)(owner)
     }
   }
 

--- a/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
@@ -19,15 +19,15 @@ class DocumentationInspector extends TastyInspector {
     import qctx.reflect._
     object Traverser extends TreeTraverser {
 
-      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {
         case tree: Definition =>
           tree.symbol.documentation match {
             case Some(doc) => println(doc.raw)
             case None => println()
           }
-          super.traverseTree(tree)
+          super.traverseTree(tree)(owner)
         case tree =>
-          super.traverseTree(tree)
+          super.traverseTree(tree)(owner)
       }
 
     }

--- a/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
@@ -19,12 +19,12 @@ class DBInspector extends TastyInspector {
     import qctx.reflect._
     object Traverser extends TreeTraverser {
 
-      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {
         case tree: Definition =>
           println(tree.showExtractors)
-          super.traverseTree(tree)
+          super.traverseTree(tree)(owner)
         case tree =>
-          super.traverseTree(tree)
+          super.traverseTree(tree)(owner)
       }
 
     }

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
@@ -9,7 +9,7 @@ class TastyInterpreter extends TastyInspector {
     import qctx.reflect._
     object Traverser extends TreeTraverser {
 
-      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {
         // TODO: check the correct sig and object enclosement for main
         case DefDef("main", _, _, _, Some(rhs)) =>
           val interpreter = new jvm.Interpreter
@@ -17,9 +17,9 @@ class TastyInterpreter extends TastyInspector {
           interpreter.eval(rhs)(using Map.empty)
         // TODO: recurse only for PackageDef, ClassDef
         case tree =>
-          super.traverseTree(tree)
+          super.traverseTree(tree)(owner)
       }
     }
-    Traverser.traverseTree(root)
+    Traverser.traverseTree(root)(Symbol.spliceOwner)
   }
 }

--- a/tests/run-macros/i6988/FirstArg_1.scala
+++ b/tests/run-macros/i6988/FirstArg_1.scala
@@ -11,7 +11,7 @@ object Macros {
   def argsImpl(using qctx: QuoteContext) : Expr[FirstArg] = {
     import qctx.reflect._
 
-    def enclosingClass(cur: Symbol = Symbol.currentOwner): Symbol =
+    def enclosingClass(cur: Symbol = Symbol.spliceOwner): Symbol =
       if (cur.isClassDef) cur
       else enclosingClass(cur.owner)
 
@@ -24,7 +24,7 @@ object Macros {
 
     def literal(value: String): Expr[String] =
       Literal(Constant.String(value)).asExpr.asInstanceOf[Expr[String]]
-    val paramss = enclosingParamList(Symbol.currentOwner)
+    val paramss = enclosingParamList(Symbol.spliceOwner)
     val firstArg = paramss.flatten.head
     val ref = Select.unique(This(enclosingClass()), firstArg.name)
     '{ FirstArg(${ref.asExpr}, ${Expr(firstArg.name)}) }

--- a/tests/run-macros/i7025/Macros_1.scala
+++ b/tests/run-macros/i7025/Macros_1.scala
@@ -10,7 +10,7 @@ object Macros {
       if owner.isClassDef then owner
       else nearestEnclosingDef(owner.owner)
 
-    val x = nearestEnclosingDef(Symbol.currentOwner)
+    val x = nearestEnclosingDef(Symbol.spliceOwner)
     if x.isDefDef then
       val code = x.signature.toString
       '{ println(${Expr(code)}) }

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -70,7 +70,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
@@ -78,11 +78,11 @@ object UnsafeExpr {
     import qctx.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
-      override def transformTerm(tree: Term)(using ctx: Context): Term =
-        super.transformTerm(tree) match
+      override def transformTerm(tree: Term)(owner: Symbol): Term =
+        super.transformTerm(tree)(owner) match
           case tree: Ident => map.getOrElse(tree.symbol, tree)
           case tree => tree
-    }.transformTerm(e)
+    }.transformTerm(e)(Symbol.spliceOwner)
   }
 }
 

--- a/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
@@ -82,7 +82,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
@@ -90,11 +90,11 @@ object UnsafeExpr {
     import qctx.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
-      override def transformTerm(tree: Term)(using ctx: Context): Term =
-        super.transformTerm(tree) match
+      override def transformTerm(tree: Term)(owner: Symbol): Term =
+        super.transformTerm(tree)(owner) match
           case tree: Ident => map.getOrElse(tree.symbol, tree)
           case tree => tree
-    }.transformTerm(e)
+    }.transformTerm(e)(Symbol.spliceOwner)
   }
 }
 

--- a/tests/run-macros/quote-matching-open/Macro_1.scala
+++ b/tests/run-macros/quote-matching-open/Macro_1.scala
@@ -34,7 +34,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.currentOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
@@ -42,10 +42,10 @@ object UnsafeExpr {
     import qctx.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
-      override def transformTerm(tree: Term)(using ctx: Context): Term =
-        super.transformTerm(tree) match
+      override def transformTerm(tree: Term)(owner: Symbol): Term =
+        super.transformTerm(tree)(owner) match
           case tree: Ident => map.getOrElse(tree.symbol, tree)
           case tree => tree
-    }.transformTerm(e)
+    }.transformTerm(e)(Symbol.spliceOwner)
   }
 }

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -9,7 +9,7 @@ object Macros {
 
     // simple smoke test
     val sym1 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       "sym1",
       MethodType(List("a","b"))(
         _ => List(TypeRepr.of[Int], TypeRepr.of[Int]),
@@ -27,7 +27,7 @@ object Macros {
 
     // test for no argument list (no Apply node)
     val sym2 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       "sym2",
       ByNameType(TypeRepr.of[Int]))
     assert(sym2.isDefDef)
@@ -43,7 +43,7 @@ object Macros {
 
    // test for multiple argument lists
    val sym3 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       "sym3",
       MethodType(List("a"))(
         _ => List(TypeRepr.of[Int]),
@@ -63,7 +63,7 @@ object Macros {
 
     // test for recursive references
     val sym4 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       "sym4",
       MethodType(List("x"))(
         _ => List(TypeRepr.of[Int]),
@@ -85,7 +85,7 @@ object Macros {
 
     // test for nested functions (one symbol is the other's parent, and we use a Closure)
     val sym5 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       "sym5",
       MethodType(List("x"))(
         _ => List(TypeRepr.of[Int]),
@@ -119,13 +119,13 @@ object Macros {
 
     // test mutually recursive definitions
     val sym6_1 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       "sym6_1",
       MethodType(List("x"))(
         _ => List(TypeRepr.of[Int]),
         _ => TypeRepr.of[Int]))
     val sym6_2 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       "sym6_2",
       MethodType(List("x"))(
         _ => List(TypeRepr.of[Int]),
@@ -166,7 +166,7 @@ object Macros {
 
     // test polymorphic methods by synthesizing an identity method
     val sym7 : Symbol = Symbol.newMethod(
-      Symbol.currentOwner,
+      Symbol.spliceOwner,
       "sym7",
       PolyType(List("T"))(
         tp => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -11,22 +11,22 @@ object Macros {
 
     val buff = new StringBuilder
     val traverser = new TreeTraverser {
-      override def traverseTree(tree: Tree)(implicit ctx: Context): Unit = tree match {
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {
         case tree: TypeBoundsTree =>
           buff.append(tree.tpe.showExtractors)
           buff.append("\n\n")
-          traverseTreeChildren(tree)
+          traverseTreeChildren(tree)(owner)
         case tree: TypeTree =>
           buff.append(tree.tpe.showExtractors)
           buff.append("\n\n")
-          traverseTreeChildren(tree)
+          traverseTreeChildren(tree)(owner)
         case _ =>
-          super.traverseTree(tree)
+          super.traverseTree(tree)(owner)
       }
     }
 
     val tree = Term.of(x)
-    traverser.traverseTree(tree)
+    traverser.traverseTree(tree)(Symbol.spliceOwner)
     '{print(${Expr(buff.result())})}
   }
 }

--- a/tests/run-macros/tasty-location/quoted_1.scala
+++ b/tests/run-macros/tasty-location/quoted_1.scala
@@ -13,7 +13,7 @@ object Location {
       if (sym == defn.RootClass || sym == defn.EmptyPackageClass) acc
       else listOwnerNames(sym.owner, sym.name :: acc)
 
-    val list = listOwnerNames(Symbol.currentOwner, Nil)
+    val list = listOwnerNames(Symbol.spliceOwner, Nil)
     '{new Location(${Expr(list)})}
   }
 

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -14,10 +14,10 @@ object Asserts {
         fn.tpe.widen match {
           case _: MethodType =>
             args.size match {
-              case 0 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[() => Int]}() })
-              case 1 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[Int => Int]}(0) })
-              case 2 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int) => Int]}(0, 0) })
-              case 3 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int, Int) => Int]}(0, 0, 0) })
+              case 0 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.spliceOwner).asExprOf[() => Int]}() })
+              case 1 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.spliceOwner).asExprOf[Int => Int]}(0) })
+              case 2 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.spliceOwner).asExprOf[(Int, Int) => Int]}(0, 0) })
+              case 3 => Expr.betaReduce('{ ${fn.etaExpand(Symbol.spliceOwner).asExprOf[(Int, Int, Int) => Int]}(0, 0, 0) })
             }
         }
       case _ => x
@@ -35,10 +35,10 @@ object Asserts {
       case Apply(fn, args) =>
         val pre = rec(fn)
         args.size match {
-          case 0 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[() => Any]}() }))
-          case 1 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[Int => Any]}(0) }))
-          case 2 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int) => Any]}(0, 0) }))
-          case 3 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.currentOwner).asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }))
+          case 0 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[() => Any]}() }))
+          case 1 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[Int => Any]}(0) }))
+          case 2 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[(Int, Int) => Any]}(0, 0) }))
+          case 3 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }))
         }
       case _ => term
     }

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -7,6 +7,6 @@ object MacrosImpl:
   def impl[T: Type](x: Expr[T])(using qctx: QuoteContext) : Expr[T] = {
     import qctx.reflect._
     val identityMap = new TreeMap { }
-    val transformed = identityMap.transformTerm(Term.of(x)).asExprOf[T]
+    val transformed = identityMap.transformTerm(Term.of(x))(Symbol.spliceOwner).asExprOf[T]
     transformed
   }


### PR DESCRIPTION
* Make owners explicit in `TreeMap`, `TreeTraverser` and `TreeAccumulator`
    
This aligns the API design with `Symbol.newXYZ`, `ValDef.let` and `Lambda.apply`.