### PR TITLE
Remove the `Eql` instance for `Proxy`.

### DIFF
--- a/library/src/scala/Eql.scala
+++ b/library/src/scala/Eql.scala
@@ -1,7 +1,7 @@
 package scala
 
 import annotation.implicitNotFound
-import scala.collection.{GenSeq, Set}
+import scala.collection.{Seq, Set}
 
 /** A marker trait indicating that values of type `L` can be compared to values of type `R`. */
 @implicitNotFound("Values of types ${L} and ${R} cannot be compared with == or !=")
@@ -29,7 +29,7 @@ object Eql {
   // The next three definitions can go into the companion objects of classes
   // Seq, Set, and Proxy. For now they are here in order not to have to touch the
   // source code of these classes
-  given eqlSeq[T, U](using eq: Eql[T, U]) as Eql[GenSeq[T], GenSeq[U]] = derived
+  given eqlSeq[T, U](using eq: Eql[T, U]) as Eql[Seq[T], Seq[U]] = derived
   given eqlSet[T, U](using eq: Eql[T, U]) as Eql[Set[T], Set[U]] = derived
 
   // true asymmetry, modeling the (somewhat problematic) nature of equals on Proxies

--- a/library/src/scala/Eql.scala
+++ b/library/src/scala/Eql.scala
@@ -27,11 +27,8 @@ object Eql {
   given eqlString as Eql[String, String] = derived
 
   // The next three definitions can go into the companion objects of classes
-  // Seq, Set, and Proxy. For now they are here in order not to have to touch the
+  // Seq and Set. For now they are here in order not to have to touch the
   // source code of these classes
   given eqlSeq[T, U](using eq: Eql[T, U]) as Eql[Seq[T], Seq[U]] = derived
   given eqlSet[T, U](using eq: Eql[T, U]) as Eql[Set[T], Set[U]] = derived
-
-  // true asymmetry, modeling the (somewhat problematic) nature of equals on Proxies
-  given eqlProxy as Eql[Proxy, AnyRef]  = derived
 }

--- a/tests/neg/equality.scala
+++ b/tests/neg/equality.scala
@@ -14,10 +14,6 @@ object equality {
   implicit def eqNum: Eql[Num, Num] = Eql.derived
   implicit def eqOption[T, U](implicit e: Eql[T, U]): Eql[Option[T], Option[U]] = Eql.derived
 
-  case class PString(a: String) extends Proxy {
-    def self = a
-  }
-
 /*
   implicit def eqString: Eql[String, String] = Eql.derived
   implicit def eqInt: Eql[Int, Int] = Eql.derived
@@ -84,9 +80,6 @@ object equality {
     i == bi
     bi == i
 
-    val ps = PString("hello")
-    ps == "world"
-
     n match {
       case None =>   // error
     }
@@ -110,7 +103,6 @@ object equality {
     1 == "abc" // error
     "abc" == bi // error
     bi == "abc" // error
-    "world" == ps // error
 
     val s1 = Set(1, 2, 3)
     val s2 = Set()

--- a/tests/run/proxy.scala
+++ b/tests/run/proxy.scala
@@ -13,5 +13,5 @@ object Test extends App {
 
   val label = Bippy("bippy!")
   println(label == label)
-  println(label == "bippy!")
+  println((label: Any) == ("bippy!": Any))
 }


### PR DESCRIPTION
`Proxy` is deprecated in Scala 2.13. We should not burden the newly
introduced `Eql` with an instance for it.