### PR TITLE
Move Tuple.Widen to compiletime package

### DIFF
--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -142,18 +142,6 @@ object Tuple {
     }
   }
 
-  /**
-   * Use this type to widen a self-type to a tuple. E.g.
-   * ```
-   * val x: (1, 3) = (1, 3)
-   * val y: Widen[x.type] = x
-   * ```
-   */
-  type Widen[Tup <: Tuple] <: Tuple = Tup match {
-    case EmptyTuple => EmptyTuple
-    case h *: t => h *: t
-  }
-
   /** Given two tuples, `A1 *: ... *: An * At` and `B1 *: ... *: Bn *: Bt`
    *  where at least one of `At` or `Bt` is `EmptyTuple` or `Tuple`,
    *  returns the tuple type `(A1, B1) *: ... *: (An, Bn) *: Ct`

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -85,16 +85,28 @@ package object compiletime {
     // implemented in dotty.tools.dotc.typer.Inliner
     error("Compiler bug: `constValue` was not evaluated by the compiler")
 
+  /**
+   * Use this type to widen a self-type to a tuple. E.g.
+   * ```
+   * val x: (1, 3) = (1, 3)
+   * val y: Widen[x.type] = x
+   * ```
+   */
+  type Widen[Tup <: Tuple] <: Tuple = Tup match {
+    case EmptyTuple => EmptyTuple
+    case h *: t => h *: t
+  }
+
   /** Given a tuple type `(X1, ..., Xn)`, returns a tuple value
    *  `(constValue[X1], ..., constValue[Xn])`.
    */
-  inline def constValueTuple[T <: Tuple]: Tuple.Widen[T]=
+  inline def constValueTuple[T <: Tuple]: Widen[T]=
     val res =
       inline erasedValue[T] match
         case _: EmptyTuple => EmptyTuple
         case _: (t *: ts) => constValue[t] *: constValueTuple[ts]
       end match
-    res.asInstanceOf[Tuple.Widen[T]]
+    res.asInstanceOf[Widen[T]]
   end constValueTuple
 
   /** Summons first given matching one of the listed cases. E.g. in
@@ -129,13 +141,13 @@ package object compiletime {
    *  @tparam T the tuple containing the types of the values to be summoned
    *  @return the given values typed as elements of the tuple
    */
-  inline def summonAll[T <: Tuple]: Tuple.Widen[T] =
+  inline def summonAll[T <: Tuple]: Widen[T] =
     val res =
       inline erasedValue[T] match
         case _: EmptyTuple => EmptyTuple
         case _: (t *: ts) => summonInline[t] *: summonAll[ts]
       end match
-    res.asInstanceOf[Tuple.Widen[T]]
+    res.asInstanceOf[Widen[T]]
   end summonAll
 
   /** Succesor of a natural number where zero is the type 0 and successors are reduced as if the definition was

--- a/library/src/scala/util/FromDigits.scala
+++ b/library/src/scala/util/FromDigits.scala
@@ -156,11 +156,11 @@ object FromDigits {
     x
   }
 
-  given BigIntFromDigits as FromDigits.WithRadix[BigInt] {
+  given BigIntFromDigits as WithRadix[BigInt] {
     def fromDigits(digits: String, radix: Int): BigInt = BigInt(digits, radix)
   }
 
-  given BigDecimalFromDigits as FromDigits.Floating[BigDecimal] {
+  given BigDecimalFromDigits as Floating[BigDecimal] {
     def fromDigits(digits: String): BigDecimal = BigDecimal(digits)
   }
 }


### PR DESCRIPTION
Move Tuple.Widen to compiletime package

Meeting notes:

- Private doesn't matter for `scala.runtime`
- Move `Widen` to `compiletime`