### PR TITLE
remove annotation.internal.WithBounds annotation

### DIFF
--- a/library/src/scala/annotation/internal/WithBounds.scala
+++ b/library/src/scala/annotation/internal/WithBounds.scala
@@ -1,8 +1,0 @@
-package scala.annotation.internal
-
-import scala.annotation.Annotation
-
-/** An annotation to indicate a pair of type bounds that comes with a type.
- *  Used to indicate optional bounds of an opaque type
- */
-class WithBounds[Lo <: AnyKind, Hi <: AnyKind] extends Annotation


### PR DESCRIPTION
this was only required when `TypeBoundsTree' had no alias parameter