### PR TITLE
Deprecate the helpers in scala.deriving.

### DIFF
--- a/library/src/scala/deriving/Helpers.scala
+++ b/library/src/scala/deriving/Helpers.scala
@@ -1,6 +1,7 @@
 package scala.deriving
 
 /** Helper class to turn arrays into products */
+@deprecated("explicitly create a `new Product {...}` wrapper for the array or use `Tuple.fromArray`", "3.0.0-M2")
 class ArrayProduct(val elems: Array[AnyRef]) extends Product {
   def this(size: Int) = this(new Array[AnyRef](size))
   def canEqual(that: Any): Boolean = true
@@ -11,8 +12,10 @@ class ArrayProduct(val elems: Array[AnyRef]) extends Product {
 }
 
 /** The empty product */
+@deprecated("use EmptyTuple instead", "3.0.0-M2")
 object EmptyProduct extends ArrayProduct(Array.emptyObjectArray)
 
 /** Helper method to select a product element */
+@deprecated("use x.asInstanceOf[Product].productElement(idx).asInstanceOf[T] instead", "3.0.0-M2")
 def productElement[T](x: Any, idx: Int): T =
   x.asInstanceOf[Product].productElement(idx).asInstanceOf[T]

--- a/tests/run/deriving.scala
+++ b/tests/run/deriving.scala
@@ -8,7 +8,7 @@ sealed trait U
 case class C() extends U
 
 object Test extends App {
-  import deriving.{Mirror, EmptyProduct}
+  import deriving._
 
   case class AA[X >: Null <: AnyRef](x: X, y: X, z: String)
 
@@ -21,7 +21,7 @@ object Test extends App {
   }
   summon[Mirror.Of[B.type]] match {
     case m: Mirror.Product =>
-      println(m.fromProduct(EmptyProduct))
+      println(m.fromProduct(EmptyTuple))
   }
   summon[Mirror.Of[T]] match {
     case m: Mirror.SumOf[T] =>


### PR DESCRIPTION
* `ArrayProduct`
* `EmptyProduct`
* `productElement`

These helpers are not mandated by the spec, nor used by the
compiler. They were used in a few tests for typeclass derivation,
but it does not seem that they are fundamental. We now use
replacements in the relevant tests.

`EmptyProduct` can be replaced by `EmptyTuple`.

`ArrayProduct` seems to be used by "unpickling" kinds of
derivations (an impression confirmed by the community build). This
is too specific a use case to be defined generally in
`scala.deriving`. Moreover, it is not clear why Arrays receive
special treatment, but not other kinds of sequences or even
immutable arrays. `ArrayProduct` can be replaced by a custom
`new Product {...}` wrapper, which in the case of our tests ends up
being simpler than the "feature-rich" `ArrayProduct`.

`productElement` seems to be more generally useful, but at the same
time is very unsafe, and is not hard to re-implement. Removing it
forces the call sites to perform the `asInstanceOf`s themselves,
which is not a bad thing as it allows to better reason about the
code. In particular, our tests benefitted from pushing the cast to
`Product` ahead in the call chain, at a place where it is
relatively easier to convince oneself that the value is indeed a
`Product`.

---

Since it looks like we're going to release an M2, it makes sense to deprecate in M2, and later remove in RC1. Compared to #10405, I have done deeper changes in the tests, that illustrate that the replacements are actually better, IMO, than using the helpers anyway. Especially, the decoupling of the places where the two casts of the former `productElement` seems really easier to reason about, IMO.