### PR TITLE
Add summonInlineOpt

### DIFF
--- a/community-build/sbt-scalajs-sbt
+++ b/community-build/sbt-scalajs-sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -123,6 +123,18 @@ package object compiletime {
     case t: T => t
   }
 
+  /** Summon a given value of type `T` in a `Some`, otherwise returns `None`.
+   *  The summoning is delayed until the call has been fully inlined.
+   *  The resulting option can be passed to an `inline summonInlineOpt[T] match`.
+   *
+   *  @tparam T the type of the value to be summoned
+   *  @return the given value typed as the provided type parameter
+   */
+   transparent inline def summonInlineOpt[T]: Option[T] = summonFrom {
+    case t: T => Some(t)
+    case _ => None
+  }
+
   /** Given a tuple T, summons each of its member types and returns them in
    *  a Tuple.
    *

--- a/tests/neg/machine-state-encoding-with-implicit-match.scala
+++ b/tests/neg/machine-state-encoding-with-implicit-match.scala
@@ -1,5 +1,5 @@
 import scala.annotation.implicitNotFound
-import scala.compiletime.summonFrom
+import scala.compiletime.summonInline
 
 sealed trait State
 final class On extends State
@@ -18,11 +18,13 @@ object IsOn {
 }
 
 class Machine[S <: State] {
-  transparent inline def turnOn()(using s: IsOff[S]): Machine[On] = summonFrom {
-    case _: IsOff[Off]  => new Machine[On]
+  transparent inline def turnOn()(using s: IsOff[S]): Machine[On] = {
+    summonInline[IsOff[Off]]
+    new Machine[On]
   }
-  transparent inline def turnOff()(using s: IsOn[S]): Machine[Off] = summonFrom {
-    case _: IsOn[On]    => new Machine[Off]
+  transparent inline def turnOff()(using s: IsOn[S]): Machine[Off] = {
+    summonInline[IsOn[On]]
+    new Machine[Off]
   }
 }
 

--- a/tests/pos-custom-args/i5938.scala
+++ b/tests/pos-custom-args/i5938.scala
@@ -1,13 +1,10 @@
-import compiletime.summonFrom
+import compiletime._
 
 trait Link[T, A]
 
 inline def link[T] =
-  summonFrom {
-    case _: Link[T, s] =>
-      summonFrom {
-        case stuff: s => stuff
-      }
+  inline summonInline[Link[T, _]] match {
+    case Some(_: Link[T, s]) => summonInline[s]
   }
 
 class Foo

--- a/tests/pos-macros/i7358.scala
+++ b/tests/pos-macros/i7358.scala
@@ -7,8 +7,8 @@ transparent inline def summonT[Tp <: Tuple](using QuoteContext): Tuple = inline 
   case _ : EmptyTuple => Tuple()
   case _ : (hd *: tl) => {
     type H = hd
-    summonFrom {
-      case given Type[H] => summon[Type[H]] *: summonT[tl]
+    inline summonInlineOpt[Type[H]] match {
+      case Some(given Type[H]) => summon[Type[H]] *: summonT[tl]
     }
   }
 }

--- a/tests/pos/i6014-gadt.scala
+++ b/tests/pos/i6014-gadt.scala
@@ -10,14 +10,11 @@ object Test1 {
 }
 
 object Test2 {
-  inline def summon[T] = summonFrom {
-    case t: T => t
-  }
 
   class Foo[F[_]]
 
   inline def bar[T] = inline erasedValue[T] match {
-    case _: Foo[f] => summon[f[Int]]
+    case _: Foo[f] => summonInline[f[Int]]
   }
 
   implicit val li: List[Int] = List(1, 2, 3)
@@ -25,16 +22,13 @@ object Test2 {
 }
 
 object Test3 {
-  inline def summon[T] = summonFrom {
-    case t: T => t
-  }
 
   type K1Top = [t] =>> Any
 
   class Foo[F[X] <: K1Top[X]]
 
   inline def bar[T] = inline erasedValue[T] match {
-    case _: Foo[f] => summon[f[Int]]
+    case _: Foo[f] => summonInline[f[Int]]
   }
 
   implicit val li: List[Int] = List(1, 2, 3)
@@ -42,14 +36,11 @@ object Test3 {
 }
 
 object Test4 {
-  inline def summon[T] = summonFrom {
-    case t: T => t
-  }
 
   class Foo[F[t] >: List[t]]
 
   inline def bar[T] = inline erasedValue[T] match {
-    case _: Foo[f] => summon[f[Int]]
+    case _: Foo[f] => summonInline[f[Int]]
   }
 
   implicit val li: List[Int] = List(1, 2, 3)

--- a/tests/pos/implicit-match-and-inline-match.scala
+++ b/tests/pos/implicit-match-and-inline-match.scala
@@ -5,8 +5,8 @@ object `implicit-match-and-inline-match` {
   implicit val ibox: Box[Int] = Box(0)
 
   object a {
-    inline def isTheBoxInScopeAnInt = summonFrom {
-      case _: Box[t] => inline erasedValue[t] match {
+    inline def isTheBoxInScopeAnInt = inline summonInlineOpt[Box[_]] match {
+      case Some(_: Box[t]) => inline erasedValue[t] match {
         case _: Int => true
       }
     }
@@ -14,8 +14,8 @@ object `implicit-match-and-inline-match` {
   }
 
   object b {
-    inline def isTheBoxInScopeAnInt = summonFrom {
-      case _: Box[t] => inline 0 match {
+    inline def isTheBoxInScopeAnInt = inline summonInlineOpt[Box[_]] match {
+      case Some(_: Box[t]) => inline 0 match {
         case _: t => true
       }
     }

--- a/tests/pos/implicit-match-nested.scala
+++ b/tests/pos/implicit-match-nested.scala
@@ -1,5 +1,5 @@
 object `implicit-match-nested` {
-  import compiletime.summonFrom
+  import compiletime._
 
   case class A[T]()
   case class B[T]()
@@ -9,11 +9,8 @@ object `implicit-match-nested` {
   implicit val b2: B[String] = B[String]()
 
   transparent inline def locateB: B[_] =
-    summonFrom {
-      case _: A[t] =>
-        summonFrom {
-          case b: B[`t`] => b
-        }
+    inline summonInlineOpt[A[_]] match {
+      case Some(_: A[t]) => summonInline[B[t]]
     }
 
   locateB

--- a/tests/pos/inline-separate/A_1.scala
+++ b/tests/pos/inline-separate/A_1.scala
@@ -1,5 +1,3 @@
 object A {
-  inline def summon[T] = compiletime.summonFrom {
-    case t: T => t
-  }
+  inline def summon[T] = compiletime.summonInline[T]
 }

--- a/tests/pos/scala-days-2019-slides/metaprogramming-1-forset.scala
+++ b/tests/pos/scala-days-2019-slides/metaprogramming-1-forset.scala
@@ -1,12 +1,12 @@
 object ForSetExample {
 
   import scala.collection.immutable._
-  import scala.compiletime.summonFrom
+  import scala.compiletime.summonInlineOpt
 
   inline def setFor[T]: Set[T] =
-    summonFrom {
-      case ord: Ordering[T] => new TreeSet[T]
-      case _                => new HashSet[T]
+    inline summonInlineOpt[Ordering[T]] match {
+      case Some(given _) => new TreeSet[T]
+      case _             => new HashSet[T]
     }
 
   setFor[String] // new TreeSet(scala.math.Ordering.String)

--- a/tests/run-custom-args/companion-loading.scala
+++ b/tests/run-custom-args/companion-loading.scala
@@ -19,14 +19,11 @@ implicit object FooAssoc extends Assoc[Foo] {
   def foo(t: Foo): Int = t.i
 }
 
-import compiletime.summonFrom
+import compiletime.{summonInline, summonInlineOpt}
 
 transparent inline def link[T]: Any =
-  summonFrom {
-    case _: Link[T, s] =>
-      summonFrom {
-        case stuff: s => stuff
-      }
+  inline summonInlineOpt[Link[T, _]] match {
+    case Some(_: Link[T, s]) => summonInline[s]
   }
 
 object Test {

--- a/tests/run-custom-args/typeclass-derivation2.scala
+++ b/tests/run-custom-args/typeclass-derivation2.scala
@@ -224,7 +224,7 @@ trait Eq[T] {
 }
 
 object Eq {
-  import scala.compiletime.{erasedValue, error, summonFrom}
+  import scala.compiletime.{erasedValue, error}
   import TypeLevel._
 
   inline def tryEql[T](x: T, y: T) = summonInline[Eq[T]].eql(x, y)
@@ -373,7 +373,7 @@ trait Show[T] {
   def show(x: T): String
 }
 object Show {
-  import scala.compiletime.{erasedValue, error, summonFrom}
+  import scala.compiletime.{erasedValue, error}
   import TypeLevel._
 
   inline def tryShow[T](x: T): String = summonInline[Show[T]].show(x)

--- a/tests/run/implicitMatch.scala
+++ b/tests/run/implicitMatch.scala
@@ -1,15 +1,15 @@
 object Test extends App {
   import collection.immutable.TreeSet
   import collection.immutable.HashSet
-  import compiletime.summonFrom
+  import compiletime.summonInlineOpt
 
-  inline def f1[T]() = summonFrom {
-    case ord: Ordering[T] => new TreeSet[T]
+  inline def f1[T]() = inline summonInlineOpt[Ordering[T]] match {
+    case Some(ord as given Ordering[T]) => new TreeSet[T]
     case _ => new HashSet[T]
   }
 
-  inline def f2[T]() = summonFrom {
-    case _: Ordering[T] => new TreeSet[T]
+  inline def f2[T]() = inline summonInlineOpt[Ordering[T]] match {
+    case Some(given Ordering[T]) => new TreeSet[T]
     case _ => new HashSet[T]
   }
 
@@ -17,9 +17,12 @@ object Test extends App {
   class B
   implicit val b: B = new B
 
-  inline def g = summonFrom {
-    case _: A => println("A")
-    case _: B => println("B")
+  inline def g = inline summonInlineOpt[A] match {
+    case _: Some[A] => println("A")
+    case _ =>
+      inline summonInlineOpt[B] match {
+        case _: Some[B] => println("B")
+      }
   }
 
   implicitly[Ordering[String]]

--- a/tests/run/typeclass-derivation2d.scala
+++ b/tests/run/typeclass-derivation2d.scala
@@ -342,7 +342,7 @@ trait Show[T] {
   def show(x: T): String
 }
 object Show {
-  import scala.compiletime.{erasedValue, constValue, summonFrom, summonInline}
+  import scala.compiletime.{erasedValue, constValue, summonInline}
 
   inline def tryShow[T](x: T): String = summonInline[Show[T]].show(x)
 
@@ -370,11 +370,7 @@ object Show {
   inline def showCases[Alts <: Tuple](n: Int)(x: Any, ord: Int): String =
     inline erasedValue[Alts] match {
       case _: (alt *: alts1) =>
-        if (ord == n)
-          summonFrom {
-            case m: Mirror.ProductOf[`alt`] =>
-              showCase(x, m)
-          }
+        if (ord == n) showCase(x, summonInline[Mirror.ProductOf[`alt`]])
         else showCases[alts1](n + 1)(x, ord)
       case _: EmptyTuple =>
         throw new MatchError(x)

--- a/tests/run/typeclass-derivation3.scala
+++ b/tests/run/typeclass-derivation3.scala
@@ -31,13 +31,12 @@ object typeclasses {
   }
 
   object Eq {
-    import scala.compiletime.{erasedValue, summonFrom}
+    import scala.compiletime.{erasedValue, summonInline, summonFrom}
     import compiletime._
     import scala.deriving._
 
-    inline def tryEql[TT](x: TT, y: TT): Boolean = summonFrom {
-      case eq: Eq[TT] => eq.eql(x, y)
-    }
+    inline def tryEql[TT](x: TT, y: TT): Boolean =
+      summonInline[Eq[TT]].eql(x, y)
 
     inline def eqlElems[Elems <: Tuple](n: Int)(x: Any, y: Any): Boolean =
       inline erasedValue[Elems] match {
@@ -86,15 +85,14 @@ object typeclasses {
   }
 
   object Pickler {
-    import scala.compiletime.{erasedValue, constValue, summonFrom}
+    import scala.compiletime.{erasedValue, constValue, summonInline, summonFrom}
     import compiletime._
     import deriving._
 
     def nextInt(buf: mutable.ListBuffer[Int]): Int = try buf.head finally buf.trimStart(1)
 
-    inline def tryPickle[T](buf: mutable.ListBuffer[Int], x: T): Unit = summonFrom {
-      case pkl: Pickler[T] => pkl.pickle(buf, x)
-    }
+    inline def tryPickle[T](buf: mutable.ListBuffer[Int], x: T): Unit =
+      summonInline[Pickler[T]].pickle(buf, x)
 
     inline def pickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], x: Any): Unit =
       inline erasedValue[Elems] match {
@@ -115,9 +113,8 @@ object typeclasses {
         case _: EmptyTuple =>
       }
 
-    inline def tryUnpickle[T](buf: mutable.ListBuffer[Int]): T = summonFrom {
-      case pkl: Pickler[T] => pkl.unpickle(buf)
-    }
+    inline def tryUnpickle[T](buf: mutable.ListBuffer[Int]): T =
+      summonInline[Pickler[T]].unpickle(buf)
 
     inline def unpickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], elems: ArrayProduct): Unit =
       inline erasedValue[Elems] match {


### PR DESCRIPTION
The combination of `sumonInlineOpt`, `inline match` and `given` patterns can encode most cases of `summonFrom`.  This alternative provides a better separation of concerns between summoning, match reduction and given patterns.

There are a few cases `typeclass-derivation3.scala` (and in `scodec`) involving type selection that do not work. These seem to be a limitation of inline match that should be fixed.