### PR TITLE
Fix #9783: Scala.js: Implement the `-scalajs-mapSourceURI` option.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
@@ -1,7 +1,11 @@
 package dotty.tools.backend.sjs
 
+import java.net.{URI, URISyntaxException}
+
 import dotty.tools.dotc.core._
 import Contexts._
+
+import dotty.tools.dotc.report
 
 import dotty.tools.dotc.util.{SourceFile, SourcePosition}
 import dotty.tools.dotc.util.Spans.Span
@@ -10,6 +14,27 @@ import org.scalajs.ir
 
 /** Conversion utilities from dotty Positions to IR Positions. */
 class JSPositions()(using Context) {
+  import JSPositions._
+
+  private val sourceURIMaps: List[URIMap] = {
+    ctx.settings.scalajsMapSourceURI.value.flatMap { option =>
+      val uris = option.split("->")
+      if (uris.length != 1 && uris.length != 2) {
+        report.error("-scalajs-mapSourceURI needs one or two URIs as argument (separated by '->').")
+        Nil
+      } else {
+        try {
+          val from = new URI(uris.head)
+          val to = uris.lift(1).map(str => new URI(str))
+          URIMap(from, to) :: Nil
+        } catch {
+          case e: URISyntaxException =>
+            report.error(s"${e.getInput} is not a valid URI")
+            Nil
+        }
+      }
+    }
+  }
 
   private def sourceAndSpan2irPos(source: SourceFile, span: Span): ir.Position = {
     if (!span.exists) ir.Position.NoPosition
@@ -59,16 +84,16 @@ class JSPositions()(using Context) {
           )
         case file =>
           val srcURI = file.toURI
-          def matches(pat: java.net.URI) = pat.relativize(srcURI) != srcURI
-
-          // TODO
-          /*scalaJSOpts.sourceURIMaps.collectFirst {
-            case ScalaJSOptions.URIMap(from, to) if matches(from) =>
+          sourceURIMaps.collectFirst {
+            case URIMap(from, to) if from.relativize(srcURI) != srcURI =>
               val relURI = from.relativize(srcURI)
               to.fold(relURI)(_.resolve(relURI))
-          } getOrElse*/
-          srcURI
+          }.getOrElse(srcURI)
       }
     }
   }
+}
+
+object JSPositions {
+  final case class URIMap(from: URI, to: Option[URI])
 }

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -67,6 +67,7 @@ class ScalaSettings extends Settings.SettingGroup {
 
   /** Scala.js-related settings */
   val scalajsGenStaticForwardersForNonTopLevelObjects: Setting[Boolean] = BooleanSetting("-scalajs-genStaticForwardersForNonTopLevelObjects", "Generate static forwarders even for non-top-level objects (Scala.js only)")
+  val scalajsMapSourceURI: Setting[List[String]] = MultiStringSetting("-scalajs-mapSourceURI", "uri1[->uri2]", "rebases source URIs from uri1 to uri2 (or to a relative URI) for source maps (Scala.js only)")
 
   /** -X "Advanced" settings
    */

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -78,6 +78,7 @@ object Build {
 
   val dottyOrganization = "org.scala-lang"
   val dottyGithubUrl = "https://github.com/lampepfl/dotty"
+  val dottyGithubRawUserContentUrl = "https://raw.githubusercontent.com/lampepfl/dotty"
 
 
   val isRelease = sys.env.get("RELEASEBUILD") == Some("yes")
@@ -772,6 +773,17 @@ object Build {
         ("org.scala-js" %% "scalajs-library" % scalaJSVersion).withDottyCompat(scalaVersion.value),
       unmanagedSourceDirectories in Compile :=
         (unmanagedSourceDirectories in (`scala3-library-bootstrapped`, Compile)).value,
+
+      // Configure the source maps to point to GitHub for releases
+      scalacOptions ++= {
+        if (isRelease) {
+          val baseURI = (baseDirectory in LocalRootProject).value.toURI
+          val dottyVersion = version.value
+          Seq(s"-scalajs-mapSourceURI:$baseURI->$dottyGithubRawUserContentUrl/v$dottyVersion/")
+        } else {
+          Nil
+        }
+      },
 
       // Make sure `scala3-bootstrapped/test` doesn't fail on this project for no reason
       test in Test := {},


### PR DESCRIPTION
We apply it to the scala3-library-bootstrappedJS project, so that source maps can correctly work for the Scala 3 library.

Additionally, it serves as a smoke test.