### PR TITLE
Rename `qctx` to `quotes`

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/TypeImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/TypeImpl.scala
@@ -13,10 +13,10 @@ final class TypeImpl(val typeTree: tpd.Tree, val scopeId: Int) extends Type[?] {
     case _ => false
   }
 
-  /** View this expression `quoted.Type[T]` as a `TypeTree` */
-  def unseal(using Quotes): qctx.reflect.TypeTree =
-    checkScopeId(qctx.hashCode)
-    typeTree.asInstanceOf[qctx.reflect.TypeTree]
+  /** View this expression `q.Type[T]` as a `TypeTree` */
+  def unseal(using q: Quotes): q.reflect.TypeTree =
+    checkScopeId(q.hashCode)
+    typeTree.asInstanceOf[q.reflect.TypeTree]
 
   def checkScopeId(expectedScopeId: Int): Unit =
     if expectedScopeId != scopeId then

--- a/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
@@ -5,20 +5,20 @@ import scala.quoted._
 
 object Extractors {
 
-  def showTree(using Quotes)(tree: qctx.reflect.Tree): String =
-    new ExtractorsPrinter[qctx.type]().visitTree(tree).result()
+  def showTree(using Quotes)(tree: quotes.reflect.Tree): String =
+    new ExtractorsPrinter[quotes.type]().visitTree(tree).result()
 
-  def showType(using Quotes)(tpe: qctx.reflect.TypeRepr): String =
-    new ExtractorsPrinter[qctx.type]().visitType(tpe).result()
+  def showType(using Quotes)(tpe: quotes.reflect.TypeRepr): String =
+    new ExtractorsPrinter[quotes.type]().visitType(tpe).result()
 
-  def showConstant(using Quotes)(const: qctx.reflect.Constant): String =
-    new ExtractorsPrinter[qctx.type]().visitConstant(const).result()
+  def showConstant(using Quotes)(const: quotes.reflect.Constant): String =
+    new ExtractorsPrinter[quotes.type]().visitConstant(const).result()
 
-  def showSymbol(using Quotes)(symbol: qctx.reflect.Symbol): String =
-    new ExtractorsPrinter[qctx.type]().visitSymbol(symbol).result()
+  def showSymbol(using Quotes)(symbol: quotes.reflect.Symbol): String =
+    new ExtractorsPrinter[quotes.type]().visitSymbol(symbol).result()
 
-  def showFlags(using Quotes)(flags: qctx.reflect.Flags): String = {
-    import qctx.reflect._
+  def showFlags(using Quotes)(flags: quotes.reflect.Flags): String = {
+    import quotes.reflect._
     val flagList = List.newBuilder[String]
     if (flags.is(Flags.Abstract)) flagList += "Flags.Abstract"
     if (flags.is(Flags.Artifact)) flagList += "Flags.Artifact"
@@ -57,8 +57,8 @@ object Extractors {
     flagList.result().mkString(" | ")
   }
 
-  private class ExtractorsPrinter[QCtx <: Quotes & Singleton](using val qctx: QCtx) { self =>
-    import qctx.reflect._
+  private class ExtractorsPrinter[Q <: Quotes & Singleton](using val quotes: Q) { self =>
+    import quotes.reflect._
 
     private val sb: StringBuilder = new StringBuilder
 

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -6,20 +6,20 @@ import scala.annotation.switch
 /** Printer for fully elaborated representation of the source code */
 object SourceCode {
 
-  def showTree(using Quotes)(tree: qctx.reflect.Tree)(syntaxHighlight: SyntaxHighlight): String =
-    new SourceCodePrinter[qctx.type](syntaxHighlight).printTree(tree).result()
+  def showTree(using Quotes)(tree: quotes.reflect.Tree)(syntaxHighlight: SyntaxHighlight): String =
+    new SourceCodePrinter[quotes.type](syntaxHighlight).printTree(tree).result()
 
-  def showType(using Quotes)(tpe: qctx.reflect.TypeRepr)(syntaxHighlight: SyntaxHighlight): String =
-    new SourceCodePrinter[qctx.type](syntaxHighlight).printType(tpe)(using None).result()
+  def showType(using Quotes)(tpe: quotes.reflect.TypeRepr)(syntaxHighlight: SyntaxHighlight): String =
+    new SourceCodePrinter[quotes.type](syntaxHighlight).printType(tpe)(using None).result()
 
-  def showConstant(using Quotes)(const: qctx.reflect.Constant)(syntaxHighlight: SyntaxHighlight): String =
-    new SourceCodePrinter[qctx.type](syntaxHighlight).printConstant(const).result()
+  def showConstant(using Quotes)(const: quotes.reflect.Constant)(syntaxHighlight: SyntaxHighlight): String =
+    new SourceCodePrinter[quotes.type](syntaxHighlight).printConstant(const).result()
 
-  def showSymbol(using Quotes)(symbol: qctx.reflect.Symbol)(syntaxHighlight: SyntaxHighlight): String =
+  def showSymbol(using Quotes)(symbol: quotes.reflect.Symbol)(syntaxHighlight: SyntaxHighlight): String =
     symbol.fullName
 
-  def showFlags(using Quotes)(flags: qctx.reflect.Flags)(syntaxHighlight: SyntaxHighlight): String = {
-    import qctx.reflect._
+  def showFlags(using Quotes)(flags: quotes.reflect.Flags)(syntaxHighlight: SyntaxHighlight): String = {
+    import quotes.reflect._
     val flagList = List.newBuilder[String]
     if (flags.is(Flags.Abstract)) flagList += "abstract"
     if (flags.is(Flags.Artifact)) flagList += "artifact"
@@ -58,9 +58,9 @@ object SourceCode {
     flagList.result().mkString("/*", " ", "*/")
   }
 
-  private class SourceCodePrinter[QCtx <: Quotes & Singleton](syntaxHighlight: SyntaxHighlight)(using val qctx: QCtx) {
+  private class SourceCodePrinter[Q <: Quotes & Singleton](syntaxHighlight: SyntaxHighlight)(using val quotes: Q) {
     import syntaxHighlight._
-    import qctx.reflect._
+    import quotes.reflect._
 
     private[this] val sb: StringBuilder = new StringBuilder
 

--- a/docs/docs/reference/contextual/derivation-macro.md
+++ b/docs/docs/reference/contextual/derivation-macro.md
@@ -42,7 +42,7 @@ from the signature. The body of the `derived` method is shown below:
 
 ```scala
 given derived[T: Type](using Quotes) as Expr[Eq[T]] = {
-  import qctx.reflect._
+  import quotes.reflect._
 
   val ev: Expr[Mirror.Of[T]] = Expr.summon[Mirror.Of[T]].get
 
@@ -177,7 +177,7 @@ object Eq {
   }
 
   given derived[T: Type](using q: Quotes) as Expr[Eq[T]] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val ev: Expr[Mirror.Of[T]] = Expr.summon[Mirror.Of[T]].get
 

--- a/docs/docs/reference/metaprogramming/tasty-reflect.md
+++ b/docs/docs/reference/metaprogramming/tasty-reflect.md
@@ -20,7 +20,7 @@ guarantees and may fail at macro expansion time, hence additional explicit
 checks must be done.
 
 To provide reflection capabilities in macros we need to add an implicit
-parameter of type `scala.quoted.Quotes` and import `qctx.reflect._` from it in
+parameter of type `scala.quoted.Quotes` and import `quotes.reflect._` from it in
 the scope where it is used.
 
 ```scala
@@ -29,19 +29,19 @@ import scala.quoted._
 inline def natConst(inline x: Int): Int = ${natConstImpl('{x})}
 
 def natConstImpl(x: Expr[Int])(using Quotes): Expr[Int] = {
-  import qctx.reflect._
+  import quotes.reflect._
   ...
 }
 ```
 
 ### Extractors
 
-`import qctx.reflect._` will provide all extractors and methods on TASTy Reflect
+`import quotes.reflect._` will provide all extractors and methods on TASTy Reflect
 trees. For example the `Literal(_)` extractor used below.
 
 ```scala
 def natConstImpl(x: Expr[Int])(using Quotes): Expr[Int] = {
-  import qctx.reflect._
+  import quotes.reflect._
   val xTree: Term = Term.of(x)
   xTree match {
     case Inlined(_, _, Literal(Constant(n: Int))) =>
@@ -59,9 +59,9 @@ def natConstImpl(x: Expr[Int])(using Quotes): Expr[Int] = {
 ```
 
 To easily know which extractors are needed, the `showExtractors` method on a
-`qctx.reflect.Term` returns the string representation of the extractors.
+`quotes.reflect.Term` returns the string representation of the extractors.
 
-The methods `qctx.reflect.Term.{asExpr, asExprOf}` provide a way to go back to a `quoted.Expr`.
+The methods `quotes.reflect.Term.{asExpr, asExprOf}` provide a way to go back to a `quoted.Expr`.
 Note that `asExpr` returns a `Expr[Any]`.
 On the other hand `asExprOf[T]` returns a `Expr[T]`, if the type does not conform to it an exception will be thrown at runtime.
 
@@ -75,8 +75,8 @@ such as the start line, the end line or even the source code at the expansion
 point.
 
 ```scala
-def macroImpl()(qctx: Quotes): Expr[Unit] = {
-  import qctx.reflect._
+def macroImpl()(quotes: Quotes): Expr[Unit] = {
+  import quotes.reflect._
   val pos = rootPosition
 
   val path = pos.sourceFile.jpath.toString

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -14,7 +14,7 @@ object Expr {
    *   Some bindings may be elided as an early optimization.
    */
   def betaReduce[T](expr: Expr[T])(using Quotes): Expr[T] =
-    import qctx.reflect._
+    import quotes.reflect._
     Term.betaReduce(Term.of(expr)) match
       case Some(expr1) => expr1.asExpr.asInstanceOf[Expr[T]]
       case _ => expr
@@ -24,7 +24,7 @@ object Expr {
    *  will be equivalent to `'{ $s1; $s2; ...; $e }`.
    */
   def block[T](statements: List[Expr[Any]], expr: Expr[T])(using Quotes): Expr[T] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Block(statements.map(Term.of), Term.of(expr)).asExpr.asInstanceOf[Expr[T]]
   }
 
@@ -40,7 +40,7 @@ object Expr {
    *    `'{ Seq($e1, $e2, ...) }` typed as an `Expr[Seq[T]]`
    *  ```
    */
-  def ofSeq[T](xs: Seq[Expr[T]])(using tp: Type[T], qctx: Quotes): Expr[Seq[T]] =
+  def ofSeq[T](xs: Seq[Expr[T]])(using Type[T])(using Quotes): Expr[Seq[T]] =
     Varargs(xs)
 
   /** Lifts this list of expressions into an expression of a list
@@ -208,11 +208,9 @@ object Expr {
    * `None` if implicit resolution failed.
    *
    *  @tparam T type of the implicit parameter
-   *  @param tpe quoted type of the implicit parameter
-   *  @param qctx current context
    */
   def summon[T](using Type[T])(using Quotes): Option[Expr[T]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Implicits.search(TypeRepr.of[T]) match {
       case iss: ImplicitSearchSuccess => Some(iss.tree.asExpr.asInstanceOf[Expr[T]])
       case isf: ImplicitSearchFailure => None

--- a/library/src-bootstrapped/scala/quoted/ExprMap.scala
+++ b/library/src-bootstrapped/scala/quoted/ExprMap.scala
@@ -7,7 +7,7 @@ trait ExprMap:
 
   /** Map subexpressions an expression `e` with a type `T` */
   def transformChildren[T](e: Expr[T])(using Quotes, Type[T]): Expr[T] = {
-    import qctx.reflect._
+    import quotes.reflect._
     final class MapChildren() {
 
       def transformStatement(tree: Statement)(owner: Symbol): Statement = {
@@ -102,7 +102,7 @@ trait ExprMap:
             type X
             val expr = tree.asExpr.asInstanceOf[Expr[X]]
             val t = tpe.asType.asInstanceOf[Type[X]]
-            val transformedExpr = transform(expr)(using qctx, t)
+            val transformedExpr = transform(expr)(using quotes, t)
             Term.of(transformedExpr)
           case _ =>
             transformTermChildren(tree, tpe)(owner)

--- a/library/src-bootstrapped/scala/quoted/Liftable.scala
+++ b/library/src-bootstrapped/scala/quoted/Liftable.scala
@@ -24,70 +24,70 @@ object Liftable {
   /** Default liftable for Boolean */
   given BooleanLiftable[T <: Boolean] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.Boolean(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Byte */
   given ByteLiftable[T <: Byte] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.Byte(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Short */
   given ShortLiftable[T <: Short] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.Short(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Int */
   given IntLiftable[T <: Int] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.Int(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Long */
   given LongLiftable[T <: Long] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.Long(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Float */
   given FloatLiftable[T <: Float] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.Float(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Double */
   given DoubleLiftable[T <: Double] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.Double(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Char */
   given CharLiftable[T <: Char] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.Char(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for String */
   given StringLiftable[T <: String] as Liftable[T] {
     def toExpr(x: T) =
-      import qctx.reflect._
+      import quotes.reflect._
       Literal(Constant.String(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Default liftable for Class[T] */
   given ClassLiftable[T] as Liftable[Class[T]] = new Liftable[Class[T]] {
     def toExpr(x: Class[T]) = {
-      import qctx.reflect._
+      import quotes.reflect._
       Ref(defn.Predef_classOf).appliedToType(TypeRepr.typeConstructorOf(x)).asExpr.asInstanceOf[Expr[Class[T]]]
     }
   }

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -13,11 +13,11 @@ object Type:
 
   /** Show a source code like representation of this type without syntax highlight */
   def show[T](using Type[T])(using Quotes): String =
-    qctx.reflect.TypeTree.of[T].show
+    quotes.reflect.TypeTree.of[T].show
 
   /** Shows the tree as fully typed source code colored with ANSI */
   def showAnsiColored[T](using Type[T])(using Quotes): String =
-    qctx.reflect.TypeTree.of[T].showAnsiColored
+    quotes.reflect.TypeTree.of[T].showAnsiColored
 
   /** Return a quoted.Type with the given type */
   @compileTimeOnly("Reference to `scala.quoted.Type.of` was not handled by PickleQuotes")

--- a/library/src/scala/quoted/Const.scala
+++ b/library/src/scala/quoted/Const.scala
@@ -15,7 +15,7 @@ object Const {
    *  ```
    */
   def unapply[T](expr: Expr[T])(using Quotes): Option[T] = {
-    import qctx.reflect._
+    import quotes.reflect._
     def rec(tree: Term): Option[T] = tree match {
       case Literal(c) => Some(c.value.asInstanceOf[T])
       case Block(Nil, e) => rec(e)

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -2,13 +2,16 @@ package scala.quoted
 
 import scala.reflect.TypeTest
 
+/** Current Quotes in scope */
+inline def quotes(using q: Quotes): q.type = q
+
 /** Quotation context provided by a macro expansion or in the scope of `scala.quoted.run`.
  *  Used to perform all operations on quoted `Expr` or `Type`.
  *
  *  It contains the low-level Typed AST API metaprogramming API.
  *  This API does not have the static type guarantiees that `Expr` and `Type` provide.
  *
- *  @param tasty Typed AST API. Usage: `def f(qctx: Quotes) = { import qctx.reflect._; ... }`.
+ *  @param tasty Typed AST API. Usage: `def f(qctx: Quotes) = { import quotes.reflect._; ... }`.
  */
 trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
@@ -3534,7 +3537,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     *
     *  Usage:
     *  ```
-    *  import qctx.reflect._
+    *  import quotes.reflect._
     *  class MyTreeMap extends TreeMap {
     *    override def transformTree(tree: Tree)(owner: Symbol): Tree = ...
     *  }

--- a/library/src/scala/quoted/Varargs.scala
+++ b/library/src/scala/quoted/Varargs.scala
@@ -16,7 +16,7 @@ object Varargs {
    *  ```
    */
   def apply[T](xs: Seq[Expr[T]])(using Type[T])(using Quotes): Expr[Seq[T]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Repeated(xs.map(Term.of).toList, TypeTree.of[T]).asExpr.asInstanceOf[Expr[Seq[T]]]
   }
 
@@ -33,7 +33,7 @@ object Varargs {
    *  ```
    */
   def unapply[T](expr: Expr[Seq[T]])(using Quotes): Option[Seq[Expr[T]]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     def rec(tree: Term): Option[Seq[Expr[T]]] = tree match {
       case Typed(Repeated(elems, _), _) => Some(elems.map(x => x.asExpr.asInstanceOf[Expr[T]]))
       case Block(Nil, e) => rec(e)

--- a/library/src/scala/quoted/qctx.scala
+++ b/library/src/scala/quoted/qctx.scala
@@ -1,4 +1,0 @@
-package scala.quoted
-
-/** Current Quotes in scope */
-def qctx(using q: Quotes): q.type = q

--- a/library/src/scala/quoted/report.scala
+++ b/library/src/scala/quoted/report.scala
@@ -4,12 +4,12 @@ object report:
 
   /** Report an error at the position of the macro expansion */
   def error(msg: => String)(using Quotes): Unit =
-    import qctx.reflect._
+    import quotes.reflect._
     Reporting.error(msg, Position.ofMacroExpansion)
 
   /** Report an error at the on the position of `expr` */
   def error(msg: => String, expr: Expr[Any])(using Quotes): Unit =
-    import qctx.reflect._
+    import quotes.reflect._
     Reporting.error(msg, Term.of(expr).pos)
 
   /** Report an error at the position of the macro expansion and throws a StopMacroExpansion */
@@ -25,12 +25,12 @@ object report:
 
   /** Report a warning */
   def warning(msg: => String)(using Quotes): Unit =
-    import qctx.reflect._
+    import quotes.reflect._
     Reporting.warning(msg, Position.ofMacroExpansion)
 
   /** Report a warning at the on the position of `expr` */
   def warning(msg: => String, expr: Expr[Any])(using Quotes): Unit =
-    import qctx.reflect._
+    import quotes.reflect._
     Reporting.warning(msg, Term.of(expr).pos)
 
 end report

--- a/scala3doc/src/dotty/dokka/tasty/comments/MemberLookup.scala
+++ b/scala3doc/src/dotty/dokka/tasty/comments/MemberLookup.scala
@@ -6,15 +6,15 @@ trait MemberLookup {
 
   def lookup(using Quotes)(
     query: Query,
-    owner: qctx.reflect.Symbol,
-  ): Option[(qctx.reflect.Symbol, String)] = lookupOpt(query, Some(owner))
+    owner: quotes.reflect.Symbol,
+  ): Option[(quotes.reflect.Symbol, String)] = lookupOpt(query, Some(owner))
 
   def lookupOpt(using Quotes)(
     query: Query,
-    ownerOpt: Option[qctx.reflect.Symbol],
-  ): Option[(qctx.reflect.Symbol, String)] =
+    ownerOpt: Option[quotes.reflect.Symbol],
+  ): Option[(quotes.reflect.Symbol, String)] =
     try
-      import qctx.reflect._
+      import quotes.reflect._
 
       def nearestClass(sym: Symbol): Symbol =
         if sym.isClassDef then sym else nearestClass(sym.owner)
@@ -59,25 +59,25 @@ trait MemberLookup {
         println(s"[WARN] Unable to find a link for ${query} ${ownerOpt.fold("")(o => "in " + o.name)}")
         None
 
-  private def hackMembersOf(using Quotes)(rsym: qctx.reflect.Symbol) = {
-    import qctx.reflect._
+  private def hackMembersOf(using Quotes)(rsym: quotes.reflect.Symbol) = {
+    import quotes.reflect._
     import dotty.tools.dotc
-    given dotc.core.Contexts.Context = qctx.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+    given dotc.core.Contexts.Context = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
     val sym = rsym.asInstanceOf[dotc.core.Symbols.Symbol]
     val members = sym.info.decls.iterator.filter(_.isCompleted)
     // println(s"members of ${sym.show} : ${members.map(_.show).mkString(", ")}")
     members.asInstanceOf[Iterator[Symbol]]
   }
 
-  private def hackIsNotAbsent(using Quotes)(rsym: qctx.reflect.Symbol) = {
+  private def hackIsNotAbsent(using Quotes)(rsym: quotes.reflect.Symbol) = {
     import dotty.tools.dotc
-    given dotc.core.Contexts.Context = qctx.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+    given dotc.core.Contexts.Context = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
     val sym = rsym.asInstanceOf[dotc.core.Symbols.Symbol]
     sym.isCompleted
   }
 
-  private def localLookup(using Quotes)(query: String, owner: qctx.reflect.Symbol): Option[qctx.reflect.Symbol] = {
-    import qctx.reflect._
+  private def localLookup(using Quotes)(query: String, owner: quotes.reflect.Symbol): Option[quotes.reflect.Symbol] = {
+    import quotes.reflect._
 
     inline def whenExists(s: Symbol)(otherwise: => Option[Symbol]): Option[Symbol] =
       if s.exists then Some(s) else otherwise
@@ -129,7 +129,7 @@ trait MemberLookup {
       }
   }
 
-  private def downwardLookup(using Quotes)(query: List[String], owner: qctx.reflect.Symbol): Option[qctx.reflect.Symbol] =
+  private def downwardLookup(using Quotes)(query: List[String], owner: quotes.reflect.Symbol): Option[quotes.reflect.Symbol] =
     query match {
       case Nil => None
       case q :: Nil => localLookup(q, owner)

--- a/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
+++ b/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
@@ -102,7 +102,7 @@ object BootstrappedStdLibTASYyTest:
 
   def loadWithTastyInspector(blacklisted: Set[String]): Unit =
     val inspector = new scala.tasty.inspector.TastyInspector {
-      def processCompilationUnit(using Quotes)(root: qctx.reflect.Tree): Unit =
+      def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit =
         root.showExtractors // Check that we can traverse the full tree
         ()
     }

--- a/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
+++ b/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
@@ -20,7 +20,7 @@ trait TastyInspector:
   self =>
 
   /** Process a TASTy file using TASTy reflect */
-  protected def processCompilationUnit(using Quotes)(root: qctx.reflect.Tree): Unit
+  protected def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit
 
   /** Called after all compilation units are processed */
   protected def postProcess(using Quotes): Unit = ()

--- a/tests/disabled/pos-macros/i7853/SummonJsonEncoderTest_2.scala
+++ b/tests/disabled/pos-macros/i7853/SummonJsonEncoderTest_2.scala
@@ -7,7 +7,7 @@ object SummonJsonEncoderTest {
   inline def encodeAndMessAroundType[T](value: =>T): String = ${ encodeAndMessAroundTypeImpl('value) }
 
   def encodeAndMessAroundTypeImpl[T: Type](value: Expr[T])(using Quotes): Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val mirrorExpr = Expr.summon[Mirror.Of[T]] match {
       case Some(mirror) => mirror

--- a/tests/neg-macros/delegate-match-1/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-1/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def f: Any = ${ fImpl }
 
 private def fImpl(using Quotes): Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
   Implicits.search(TypeRepr.of[A]) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/delegate-match-2/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-2/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def f: Any = ${ fImpl }
 
 private def fImpl (using Quotes) : Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
   Implicits.search(TypeRepr.of[A]) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/delegate-match-3/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-3/Macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def f: Any = ${ fImpl }
 
 private def fImpl(using Quotes) : Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
   Implicits.search(TypeRepr.of[A]) match {
     case x: ImplicitSearchSuccess =>
       '{}

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
   extension (inline sc: StringContext) inline def foo(args: String*): Unit = ${ impl('sc) }
 
   def impl(sc: Expr[StringContext])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
   extension (inline sc: StringContext) inline def foo(args: String*): Unit = ${ impl('sc) }
 
   def impl(sc: Expr[StringContext])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)

--- a/tests/neg-macros/i7698.scala
+++ b/tests/neg-macros/i7698.scala
@@ -5,7 +5,7 @@ trait Show[T] {
 }
 
 def showInterpolatorImpl(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes): Expr[String] =
-  import qctx.reflect._
+  import quotes.reflect._
   Term.of(argsExpr) match
     case '{ $arg: $t } => // error
     case '[ Int ] => // error

--- a/tests/neg-macros/i7919.scala
+++ b/tests/neg-macros/i7919.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Test {
   def staged[T](using Quotes) = {
-    import qctx.reflect._
+    import quotes.reflect._
     given typeT as Type[T] // error
     val tt = TypeRepr.of[T]
     '{ "in staged" }

--- a/tests/neg-macros/i8871.scala
+++ b/tests/neg-macros/i8871.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Macro {
   def impl[A : Type](using Quotes): Unit = {
-    import qctx.reflect._
+    import quotes.reflect._
     val tpe = TypeRepr.of[A].asType.asInstanceOf[Type[_ <: AnyRef]]
     '{ (a: ${tpe}) => ???} // error
   }

--- a/tests/neg-macros/i8871b.scala
+++ b/tests/neg-macros/i8871b.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Macro {
   def impl[A : Type](using Quotes) = {
-    import qctx.reflect._
+    import quotes.reflect._
     val tpe/*: Type[? <: AnyKind]*/ = TypeRepr.of[A].asType
     '{ f[$tpe] } // error
   }

--- a/tests/neg-macros/i9801/Macro_1.scala
+++ b/tests/neg-macros/i9801/Macro_1.scala
@@ -11,11 +11,11 @@ def triggerStackOverflow(n: Int): Expr[Double] = {
 inline def loop(inline prog: Double): Double = ${impl('prog)}
 
 def impl(prog: Expr[Double])(using Quotes) : Expr[Double] =
-  import qctx.reflect._
+  import quotes.reflect._
   try {
     triggerStackOverflow(0)
   } catch {
     case e =>
-      qctx.reflect.Reporting.error(e.getMessage, Term.of(prog).pos)
+      quotes.reflect.Reporting.error(e.getMessage, Term.of(prog).pos)
       '{ 42.0 }
   }

--- a/tests/neg-macros/macros-in-same-project-6/Foo.scala
+++ b/tests/neg-macros/macros-in-same-project-6/Foo.scala
@@ -5,7 +5,7 @@ object Foo {
   inline def myMacro(): Unit = ${ aMacroImplementation }
 
   def aMacroImplementation(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Reporting.error("some error", Position.ofMacroExpansion)
     throw new NoClassDefFoundError("Bar$")
   }

--- a/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${impl('cond)}
 
   def impl(cond: Expr[Boolean])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val tree = Term.of(cond)
 

--- a/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${ impl('cond) }
 
   def impl(cond: Expr[Boolean])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val tree = Term.of(cond)
 

--- a/tests/neg-macros/tasty-macro-error/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-error/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def fun(x: Any): Unit = ${ impl('x) }
 
   def impl(x: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Reporting.error("here is the the argument is " + Term.of(x).underlyingArgument.show, Term.of(x).underlyingArgument.pos)
     '{}
   }

--- a/tests/neg-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-positions/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def fun(x: Any): Unit = ${ impl('x) }
 
   def impl(x: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val pos = Term.of(x).underlyingArgument.pos
     Reporting.error("here is the the argument is " + Term.of(x).underlyingArgument.show, pos)
     Reporting.error("here (+5) is the the argument is " + Term.of(x).underlyingArgument.show, pos.sourceFile, pos.start + 5, pos.end + 5)

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
 object FIntepolator {
 
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Reporting.error("there are no parts", Term.of(strCtxExpr).underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -9,7 +9,7 @@ object Macro {
 
 object FIntepolator {
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Reporting.error("there are no args", Term.of(argsExpr).underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -13,7 +13,7 @@ object Lens {
 
   def impl[S: Type, T: Type](getter: Expr[S => T])(using Quotes): Expr[Lens[S, T]] = {
     implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(this.getClass.getClassLoader)
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =

--- a/tests/pending/pos/cps-async-failure.scala
+++ b/tests/pending/pos/cps-async-failure.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 trait App[F[_],CT]:
   this: Base[F,CT] =>
 
-  import qctx.reflect._
+  import quotes.reflect._
 
   trait AA
 

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
     ${ impl('t) }
 
   def impl[T](x: Expr[T])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val tree = Term.of(x)
     tree.symbol.comment.map(_.raw) match {

--- a/tests/pos-macros/i10151/Macro_1.scala
+++ b/tests/pos-macros/i10151/Macro_1.scala
@@ -22,7 +22,7 @@ object X:
  }
 
  def processImpl[T:Type](f:Expr[T])(using Quotes):Expr[CB[T]] =
-   import qctx.reflect._
+   import quotes.reflect._
 
    def transform(term:Term):Term =
      term match

--- a/tests/pos-macros/i10211/Macro_1.scala
+++ b/tests/pos-macros/i10211/Macro_1.scala
@@ -36,7 +36,7 @@ object X:
  }
 
  def processImpl[T:Type](f:Expr[T])(using Quotes):Expr[CB[T]] =
-   import qctx.reflect._
+   import quotes.reflect._
 
    def transform(term:Term):Term =
      term match

--- a/tests/pos-macros/i6171/Macro_1.scala
+++ b/tests/pos-macros/i6171/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(x: => Any): Unit = ${ assertImpl('x) }
 
   def assertImpl(x: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Term.of(x).underlyingArgument
     '{ () }
   }

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition) }
 
   def assertImpl(cond: Expr[Boolean])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
     import ValDef.let
 

--- a/tests/pos-macros/i6803b/Macro_1.scala
+++ b/tests/pos-macros/i6803b/Macro_1.scala
@@ -9,7 +9,7 @@ object AsObject {
     def unsafe(i: Int): LineNo = new LineNo(i)
     inline given x as LineNo = ${impl}
     private def impl(using Quotes) : Expr[LineNo] = {
-      import qctx.reflect._
+      import quotes.reflect._
       '{unsafe(${Expr(Position.ofMacroExpansion.startLine)})}
     }
   }

--- a/tests/pos-macros/i7011/Macros_1.scala
+++ b/tests/pos-macros/i7011/Macros_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 inline def mcr(body: => Any): Unit = ${mcrImpl('body)}
 
 def mcrImpl[T](body: Expr[Any])(using Quotes) : Expr[Any] = {
-  import qctx.reflect._
+  import quotes.reflect._
 
   val bTree = Term.of(body)
   val under = bTree.underlyingArgument

--- a/tests/pos-macros/i7030/Macros_1.scala
+++ b/tests/pos-macros/i7030/Macros_1.scala
@@ -6,6 +6,6 @@ def innerImpl(exprs: Expr[Any])(using Quotes): Expr[Any] =
 
 inline def outer(expr: => Any): Any = ${outerImpl('expr)}
 def outerImpl(body: Expr[Any])(using Quotes): Expr[Any] = {
-  import qctx.reflect._
+  import quotes.reflect._
   Term.of(body).underlyingArgument.asExpr
 }

--- a/tests/pos-macros/i7204.scala
+++ b/tests/pos-macros/i7204.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Foo {
   def impl(using Quotes) : Unit = {
-    import qctx.reflect._
+    import quotes.reflect._
     val Select(_, _) = (??? : Term)
   }
 }

--- a/tests/pos-macros/i7887.scala
+++ b/tests/pos-macros/i7887.scala
@@ -1,5 +1,5 @@
-def typed[A](using t: quoted.Type[A], qctx: quoted.Quotes): Unit = {
-  import qctx.reflect._
+def typed[A](using t: quoted.Type[A], q: quoted.Quotes): Unit = {
+  import q.reflect._
   '{
     type T = A
     ${'{???}.asExprOf[T]}

--- a/tests/pos-macros/i8045.scala
+++ b/tests/pos-macros/i8045.scala
@@ -1,5 +1,5 @@
 import scala.quoted._
 object Test
-  def run(using Quotes)(tree: qctx.reflect.Tree): Unit =
+  def run(using Quotes)(tree: quotes.reflect.Tree): Unit =
     '{  ${ makeExpr(tree) } + 1  }
-  def makeExpr(using Quotes)(tree: qctx.reflect.Tree): Expr[Int] = ???
+  def makeExpr(using Quotes)(tree: quotes.reflect.Tree): Expr[Int] = ???

--- a/tests/pos-macros/i8325/Macro_1.scala
+++ b/tests/pos-macros/i8325/Macro_1.scala
@@ -12,7 +12,7 @@ object A:
   def pure[A](a:A):A = ???
 
   def transformImplExpr[A:Type](using Quotes)(expr: Expr[A]): Expr[A] = {
-     import qctx.reflect._
+     import quotes.reflect._
      Term.of(expr) match {
          case Inlined(x,y,z) => transformImplExpr(z.asExpr.asInstanceOf[Expr[A]])
          case Apply(fun,args) =>  '{  A.pure(${Apply(fun,args).asExpr.asInstanceOf[Expr[A]]}) }

--- a/tests/pos-macros/i8325b/Macro_1.scala
+++ b/tests/pos-macros/i8325b/Macro_1.scala
@@ -12,7 +12,7 @@ object A:
   def pure[A](a:A):A = ???
 
   def transformImplExpr[A:Type](using Quotes)(expr: Expr[A]): Expr[A] = {
-     import qctx.reflect._
+     import quotes.reflect._
      Term.of(expr) match {
          case Inlined(x,y,z) => transformImplExpr(z.asExpr.asInstanceOf[Expr[A]])
          case r@Apply(fun,args) =>  '{

--- a/tests/pos-macros/i8521/Macro_1.scala
+++ b/tests/pos-macros/i8521/Macro_1.scala
@@ -4,7 +4,7 @@ object Foo {
   inline def foo[T <: AnyKind]: String = ${ bar[T] }
 
   def bar[T <: AnyKind : Type](using Quotes): Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def packageToName(sym: Symbol): Unit = {
       if sym.isPackageDef then

--- a/tests/pos-macros/i8651b.scala
+++ b/tests/pos-macros/i8651b.scala
@@ -9,7 +9,7 @@ object Macros {
  inline def coroutine[T](inline body: Any): Coroutine[T] = ${ coroutineImpl('{body}) }
 
  def coroutineImpl[T: Type](expr: Expr[_ <: Any])(using Quotes): Expr[Coroutine[T]] = {
-   import qctx.reflect._
+   import quotes.reflect._
 
    '{
      new Coroutine[T] {

--- a/tests/pos-macros/i8866/Macro_1.scala
+++ b/tests/pos-macros/i8866/Macro_1.scala
@@ -12,7 +12,7 @@ object OtherMacro {
 object Macro {
 
   def impl(using Quotes): Expr[Int] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     ValDef.let(
       Symbol.spliceOwner,

--- a/tests/pos-macros/i8866b/Macro_1.scala
+++ b/tests/pos-macros/i8866b/Macro_1.scala
@@ -7,7 +7,7 @@ object Other {
 object Macro {
 
   def impl(using Quotes): Expr[Int] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     ValDef.let(
       Symbol.spliceOwner,

--- a/tests/pos-macros/i8879/Macro_1.scala
+++ b/tests/pos-macros/i8879/Macro_1.scala
@@ -6,7 +6,7 @@ object Test {
 
   def impl[T](t: T)(using Quotes, Type[T]): Expr[Any] = {
 
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     val foo = TypeRepr.of[Foo[String]]

--- a/tests/pos-macros/i9240/Macro_1.scala
+++ b/tests/pos-macros/i9240/Macro_1.scala
@@ -3,11 +3,11 @@ import scala.quoted._
 inline def diveInto[T]: String = ${ diveIntoImpl[T]() }
 
 def diveIntoImpl[T]()(implicit qctx: Quotes, ttype: Type[T]): Expr[String] =
-  import qctx.reflect._
+  import quotes.reflect._
   Expr( unwindType(TypeRepr.of[T]) )
 
-def unwindType(using Quotes)(aType: qctx.reflect.TypeRepr): String =
-  import qctx.reflect._
+def unwindType(using Quotes)(aType: quotes.reflect.TypeRepr): String =
+  import quotes.reflect._
 
   aType match {
     case AppliedType(t,tob) =>

--- a/tests/pos-macros/i9251/Macro_1.scala
+++ b/tests/pos-macros/i9251/Macro_1.scala
@@ -19,7 +19,7 @@ object Async {
 
 
   def checkPrintTypeImpl[F[_]:Type,T:Type](f: Expr[T])(using Quotes): Expr[Unit] =
-    import qctx.reflect._
+    import quotes.reflect._
 
     val fu = Term.of(f)
     fu match

--- a/tests/pos-macros/i9518/Macro_1.scala
+++ b/tests/pos-macros/i9518/Macro_1.scala
@@ -6,7 +6,7 @@ trait CB[T]
 inline def shift : Unit = ${ shiftTerm }
 
 def shiftTerm(using Quotes): Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
   val nTree = Term.of('{ ??? : CB[Int] })
   val tp1 = TypeRepr.of[CB[Int]]
   val tp2 = TypeRepr.of[([X] =>> CB[X])[Int]]

--- a/tests/pos-macros/i9570.scala
+++ b/tests/pos-macros/i9570.scala
@@ -8,7 +8,7 @@ object Macros {
     case object HNil extends HList
 
     private def sizeImpl(e: Expr[HList], n:Int)(using qctx:Quotes): Expr[Int] = {
-      import qctx.reflect._
+      import quotes.reflect._
       e match {
         case '{HCons(_,$t)} => // error if run with fatal warinings in BootstrappedOnlyCompilationTests
           sizeImpl(t,n+1)

--- a/tests/pos-macros/i9687/Macro_1.scala
+++ b/tests/pos-macros/i9687/Macro_1.scala
@@ -23,7 +23,7 @@ object X {
  }
 
  def transformImpl[A:Type](x:Expr[A])(using Quotes):Expr[A] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val slowPath = Term.of('{ SlowPath })
     val fastPath = Term.of('{ FastPath })
     val transformer = new TreeMap() {

--- a/tests/pos-macros/i9894/Macro_1.scala
+++ b/tests/pos-macros/i9894/Macro_1.scala
@@ -21,7 +21,7 @@ object X:
  }
 
  def processImpl[T:Type](f:Expr[T])(using Quotes):Expr[CB[T]] =
-   import qctx.reflect._
+   import quotes.reflect._
 
    def transform(term:Term):Term =
      term match

--- a/tests/pos-macros/quote-aliases.scala
+++ b/tests/pos-macros/quote-aliases.scala
@@ -1,0 +1,11 @@
+import scala.quoted._
+
+object Test:
+
+  def f1(using Quotes)(t: quotes.reflect.Tree): Unit = ()
+
+  inline def q(using q: Quotes): q.type = q
+  def f2(using Quotes)(t: q.reflect.Tree): Unit = ()
+
+  inline def r(using q: Quotes): q.reflect.type = q.reflect
+  def f3(using Quotes)(t: r.Tree): Unit = ()

--- a/tests/pos-macros/quotedPatterns-4.scala
+++ b/tests/pos-macros/quotedPatterns-4.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 object Test {
   def impl(receiver: Expr[StringContext])(using qctx: scala.quoted.Quotes) = {
-    import qctx.reflect.Repeated
+    import quotes.reflect.Repeated
     receiver match {
       case '{ StringContext(${Repeated(parts)}: _*) } => // now OK
     }

--- a/tests/pos-macros/scala2-macro-compat-1.scala
+++ b/tests/pos-macros/scala2-macro-compat-1.scala
@@ -20,7 +20,7 @@ object LineNumberMacro2 {
 object LineNumberMacro3 {
   import scala.quoted._
   def thisLineNumberExpr(using Quotes): Expr[Int] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(Position.ofMacroExpansion.startLine + 1)
   }
 }

--- a/tests/pos-macros/tasty-constant-type/Macro_1.scala
+++ b/tests/pos-macros/tasty-constant-type/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
   transparent inline def ff[A <: Int, B <: Int](): AddInt[A, B] = ${ impl[A, B] }
 
   def impl[A <: Int : Type, B <: Int : Type](using Quotes) : Expr[AddInt[A, B]] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val ConstantType(Constant.Int(v1)) = TypeRepr.of[A]
     val ConstantType(Constant.Int(v2)) = TypeRepr.of[B]

--- a/tests/pos-macros/treemap-unapply/Macro.scala
+++ b/tests/pos-macros/treemap-unapply/Macro.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 inline def mcr(x: => Unit): Unit = ${mcrImpl('x)}
 def mcrImpl(x: Expr[Unit])(using Quotes) : Expr[Unit] =
-  import qctx.reflect._
+  import quotes.reflect._
   val tr: Term = Term.of(x)
   object m extends TreeMap
   m.transformTerm(tr)(Symbol.spliceOwner).asExprOf[Unit]

--- a/tests/pos-special/fatal-warnings/tasty-parent-unapply.scala
+++ b/tests/pos-special/fatal-warnings/tasty-parent-unapply.scala
@@ -4,7 +4,7 @@ object Macros {
 
 
   def impl(using Quotes): Unit = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def foo(tree: Tree, term: Term, typeTree: TypeTree, parent: Tree) = {
 

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -6,7 +6,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Term.of(x) match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -6,7 +6,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Term.of(x) match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val buff = new StringBuilder
 
@@ -18,8 +18,8 @@ object Macros {
   }
 
 
-  def myTraverser(using Quotes)(buff: StringBuilder): qctx.reflect.TreeTraverser = new {
-    import qctx.reflect._
+  def myTraverser(using Quotes)(buff: StringBuilder): quotes.reflect.TreeTraverser = new {
+    import quotes.reflect._
     override def traverseTree(tree: Tree)(owner: Symbol): Unit = {
       tree match {
         case tree @ DefDef(name, _, _, _, _) =>

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -7,7 +7,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def definitionString(sym: Symbol): Expr[String] =
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -6,7 +6,7 @@ object Foo {
     ${ inspectBodyImpl('i) }
 
   def inspectBodyImpl(x: Expr[Int])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def definitionString(sym: Symbol): Expr[String] =
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.showExtractors)

--- a/tests/run-custom-args/run-macros-erased/reflect-isFunctionType/macro_1.scala
+++ b/tests/run-custom-args/run-macros-erased/reflect-isFunctionType/macro_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 inline def isFunctionType[T]: Boolean = ${ isFunctionTypeImpl[T] }
 
 def isFunctionTypeImpl[T: Type](using Quotes) : Expr[Boolean] = {
-  import qctx.reflect._
+  import quotes.reflect._
   Expr(TypeRepr.of[T].isFunctionType)
 }
 
@@ -12,7 +12,7 @@ def isFunctionTypeImpl[T: Type](using Quotes) : Expr[Boolean] = {
 inline def isContextFunctionType[T]: Boolean = ${ isContextFunctionTypeImpl[T] }
 
 def isContextFunctionTypeImpl[T: Type](using Quotes) : Expr[Boolean] = {
-  import qctx.reflect._
+  import quotes.reflect._
   Expr(TypeRepr.of[T].isContextFunctionType)
 }
 
@@ -20,14 +20,14 @@ def isContextFunctionTypeImpl[T: Type](using Quotes) : Expr[Boolean] = {
 inline def isErasedFunctionType[T]: Boolean = ${ isErasedFunctionTypeImpl[T] }
 
 def isErasedFunctionTypeImpl[T: Type](using Quotes) : Expr[Boolean] = {
-  import qctx.reflect._
+  import quotes.reflect._
   Expr(TypeRepr.of[T].isErasedFunctionType)
 }
 
 inline def isDependentFunctionType[T]: Boolean = ${ isDependentFunctionTypeImpl[T] }
 
 def isDependentFunctionTypeImpl[T: Type](using Quotes) : Expr[Boolean] = {
-  import qctx.reflect._
+  import quotes.reflect._
   Expr(TypeRepr.of[T].isDependentFunctionType)
 }
 

--- a/tests/run-custom-args/tasty-inspector/i8163.scala
+++ b/tests/run-custom-args/tasty-inspector/i8163.scala
@@ -22,11 +22,11 @@ object Test {
 
 class TestInspector() extends TastyInspector:
 
-  protected def processCompilationUnit(using Quotes)(root: qctx.reflect.Tree): Unit =
+  protected def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit =
     inspectClass(root)
 
-  private def inspectClass(using Quotes)(tree: qctx.reflect.Tree): Unit =
-    import qctx.reflect._
+  private def inspectClass(using Quotes)(tree: quotes.reflect.Tree): Unit =
+    import quotes.reflect._
     tree match {
       case t: PackageClause =>
         t.stats.map( m => inspectClass(m) )

--- a/tests/run-custom-args/tasty-inspector/i8364.scala
+++ b/tests/run-custom-args/tasty-inspector/i8364.scala
@@ -3,7 +3,7 @@ import scala.tasty.inspector._
 
 @main def Test = {
   val inspector = new TastyInspector {
-    protected def processCompilationUnit(using Quotes)(tree: qctx.reflect.Tree): Unit = {
+    protected def processCompilationUnit(using Quotes)(tree: quotes.reflect.Tree): Unit = {
       tree.showExtractors // Make sure that tree is loaded and can be traveresed
     }
   }

--- a/tests/run-custom-args/tasty-inspector/i8389.scala
+++ b/tests/run-custom-args/tasty-inspector/i8389.scala
@@ -10,7 +10,7 @@ import scala.tasty.inspector._
 
   // in dotty-example-project
   val inspector = new TastyInspector {
-    protected def processCompilationUnit(using Quotes)(tree: qctx.reflect.Tree): Unit = {
+    protected def processCompilationUnit(using Quotes)(tree: quotes.reflect.Tree): Unit = {
       println(tree.show)
     }
   }

--- a/tests/run-custom-args/tasty-inspector/i8460.scala
+++ b/tests/run-custom-args/tasty-inspector/i8460.scala
@@ -37,12 +37,12 @@ class TestInspector_Children() extends TastyInspector:
 
   var kids: List[String] = Nil
 
-  protected def processCompilationUnit(using Quotes)(root: qctx.reflect.Tree): Unit =
-    import qctx.reflect._
+  protected def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit =
+    import quotes.reflect._
     inspectClass(root)
 
-  private def inspectClass(using Quotes)(tree: qctx.reflect.Tree): Unit =
-    import qctx.reflect._
+  private def inspectClass(using Quotes)(tree: quotes.reflect.Tree): Unit =
+    import quotes.reflect._
     tree match {
       case t: PackageClause =>
         t.stats.map( m => inspectClass(m) )

--- a/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
@@ -15,8 +15,8 @@ object Test {
 
 class DocumentationInspector extends TastyInspector {
 
-  protected def processCompilationUnit(using Quotes)(root: qctx.reflect.Tree): Unit = {
-    import qctx.reflect._
+  protected def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit = {
+    import quotes.reflect._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {

--- a/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-inspector/Test.scala
@@ -15,8 +15,8 @@ object Test {
 
 class DBInspector extends TastyInspector {
 
-  protected def processCompilationUnit(using Quotes)(root: qctx.reflect.Tree): Unit = {
-    import qctx.reflect._
+  protected def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit = {
+    import quotes.reflect._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
@@ -5,8 +5,8 @@ import scala.tasty.inspector.TastyInspector
 
 class TastyInterpreter extends TastyInspector {
 
-  protected def processCompilationUnit(using Quotes)(root: qctx.reflect.Tree): Unit = {
-    import qctx.reflect._
+  protected def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit = {
+    import quotes.reflect._
     object Traverser extends TreeTraverser {
 
       override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
@@ -3,8 +3,8 @@ package scala.tasty.interpreter
 import scala.quoted._
 import scala.tasty.interpreter.jvm.JVMReflection
 
-abstract class TreeInterpreter[QCtx <: Quotes & Singleton](using val qctx: QCtx) {
-  import qctx.reflect._
+abstract class TreeInterpreter[Q <: Quotes & Singleton](using val q: Q) {
+  import quotes.reflect._
 
   final val LOG = false
 

--- a/tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
@@ -4,13 +4,13 @@ package jvm
 import scala.quoted._
 import scala.tasty.interpreter.jvm.JVMReflection
 
-class Interpreter[QCtx <: Quotes & Singleton](using qctx0: QCtx) extends TreeInterpreter[QCtx] {
-  import qctx.reflect._
+class Interpreter[Q <: Quotes & Singleton](using q0: Q) extends TreeInterpreter[Q] {
+  import q.reflect._
 
   // All references are represented by themselves and values are boxed
   type AbstractAny = Any
 
-  val jvmReflection = new JVMReflection(using qctx)
+  val jvmReflection = new JVMReflection(using q)
 
   def interpretNew(fn: Tree, argss: List[List[Term]]): Result = {
     if (fn.symbol.isDefinedInCurrentRun) {

--- a/tests/run-custom-args/tasty-interpreter/interpreter/jvm/JVMReflection.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/jvm/JVMReflection.scala
@@ -2,8 +2,8 @@ package scala.tasty.interpreter.jvm
 
 import scala.quoted._
 
-class JVMReflection[QCtx <: Quotes & Singleton](using val tasty: QCtx) {
-  import qctx.reflect._
+class JVMReflection[Q <: Quotes & Singleton](using val q: Q) {
+  import q.reflect._
 
   import java.lang.reflect.{InvocationTargetException, Method}
   private val classLoader: ClassLoader = getClass.getClassLoader

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -9,7 +9,7 @@ object FQuote {
   }
 
   /*private*/ def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def liftListOfAny(lst: List[Term]): Expr[List[Any]] = lst match {
       case x :: xs  =>

--- a/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -7,28 +7,28 @@ object TypeToolbox {
   /** are the two types equal? */
   inline def =:=[A, B]: Boolean = ${tpEqImpl[A, B]}
   private def tpEqImpl[A: Type, B: Type](using Quotes) : Expr[Boolean] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(TypeRepr.of[A] =:= TypeRepr.of[B])
   }
 
   /** is `tp1` a subtype of `tp2` */
   inline def <:<[A, B]: Boolean = ${tpLEqImpl[A, B]}
   private def tpLEqImpl[A: Type, B: Type](using Quotes) : Expr[Boolean] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(TypeRepr.of[A] <:< TypeRepr.of[B])
   }
 
   /** type associated with the tree */
   inline def typeOf[T, Expected](a: T): Boolean = ${typeOfImpl[T, Expected]('a)}
   private def typeOfImpl[A: Type, E: Type](a: Expr[A])(using Quotes) : Expr[Boolean] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(TypeRepr.of[A] =:= TypeRepr.of[E])
   }
 
   /** does the type refer to a case class? */
   inline def isCaseClass[A]: Boolean = ${isCaseClassImpl[A]}
   private def isCaseClassImpl[T: Type](using Quotes) : Expr[Boolean] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val sym = TypeTree.of[T].symbol
     Expr(sym.isClassDef && sym.flags.is(Flags.Case))
   }
@@ -36,66 +36,66 @@ object TypeToolbox {
   /** val fields of a case class Type -- only the ones declared in primary constructor */
   inline def caseFields[T]: List[String] = ${caseFieldsImpl[T]}
   private def caseFieldsImpl[T: Type](using Quotes) : Expr[List[String]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val fields = TypeTree.of[T].symbol.caseFields.map(_.name)
     Expr(fields)
   }
 
   inline def fieldIn[T](inline mem: String): String = ${fieldInImpl[T]('mem)}
   private def fieldInImpl[T: Type](mem: Expr[String])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val field = TypeTree.of[T].symbol.field(mem.unliftOrError)
     Expr(if field.isNoSymbol then "" else field.name)
   }
 
   inline def fieldsIn[T]: Seq[String] = ${fieldsInImpl[T]}
   private def fieldsInImpl[T: Type](using Quotes) : Expr[Seq[String]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val fields = TypeTree.of[T].symbol.fields
     Expr(fields.map(_.name).toList)
   }
 
   inline def methodIn[T](inline mem: String): Seq[String] = ${methodInImpl[T]('mem)}
   private def methodInImpl[T: Type](mem: Expr[String])(using Quotes) : Expr[Seq[String]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(TypeTree.of[T].symbol.classMethod(mem.unliftOrError).map(_.name))
   }
 
   inline def methodsIn[T]: Seq[String] = ${methodsInImpl[T]}
   private def methodsInImpl[T: Type](using Quotes) : Expr[Seq[String]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(TypeTree.of[T].symbol.classMethods.map(_.name))
   }
 
   inline def method[T](inline mem: String): Seq[String] = ${methodImpl[T]('mem)}
   private def methodImpl[T: Type](mem: Expr[String])(using Quotes) : Expr[Seq[String]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(TypeTree.of[T].symbol.method(mem.unliftOrError).map(_.name))
   }
 
   inline def methods[T]: Seq[String] = ${methodsImpl[T]}
   private def methodsImpl[T: Type](using Quotes) : Expr[Seq[String]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(TypeTree.of[T].symbol.methods.map(_.name))
   }
 
   inline def typeTag[T](x: T): String = ${typeTagImpl[T]}
   private def typeTagImpl[T: Type](using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val res = TypeRepr.of[T].show
     Expr(res)
   }
 
   inline def companion[T1, T2]: Boolean = ${companionImpl[T1, T2]}
   private def companionImpl[T1: Type, T2: Type](using Quotes) : Expr[Boolean] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val res = TypeTree.of[T1].symbol.companionModule == TypeTree.of[T2].symbol
     Expr(res)
   }
 
   inline def companionName[T1]: String = ${companionNameImpl[T1]}
   private def companionNameImpl[T: Type](using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val sym = TypeTree.of[T].symbol
     val companionClass =
       if sym.isClassDef then sym.companionModule.companionClass

--- a/tests/run-macros/i10011/Macro_1.scala
+++ b/tests/run-macros/i10011/Macro_1.scala
@@ -4,6 +4,6 @@ inline def printPos[T](inline expr: T): (Int, Int) =
   ${ printPos('expr) }
 
 private def printPos[T](expr: Expr[T])(using Quotes): Expr[(Int, Int)] =
-  import qctx.reflect._
+  import quotes.reflect._
   val pos = Term.of(expr).pos
   Expr((pos.start, pos.end))

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
   }
   implicit inline def XmlQuote(inline sc: StringContext): StringContextOps = new StringContextOps(sc)
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(Term.of(sc).underlyingArgument.showExtractors + "\n" + Term.of(args).underlyingArgument.showExtractors)
   }
 }

--- a/tests/run-macros/i5119b/Macro_1.scala
+++ b/tests/run-macros/i5119b/Macro_1.scala
@@ -6,7 +6,7 @@ object Macro {
   inline def ff(arg1: Any,  arg2: Any): String = ${ Macro.impl('{arg1}, '{arg2}) }
 
   def impl(arg1: Expr[Any], arg2: Expr[Any])(using Quotes) : Expr[String] =
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(Term.of(arg1).underlyingArgument.showExtractors + "\n" + Term.of(arg2).underlyingArgument.showExtractors)
 
 }

--- a/tests/run-macros/i5533/Macro_1.scala
+++ b/tests/run-macros/i5533/Macro_1.scala
@@ -8,7 +8,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val tree = Term.of(condition)
 

--- a/tests/run-macros/i5533b/Macro_1.scala
+++ b/tests/run-macros/i5533b/Macro_1.scala
@@ -7,7 +7,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val tree = Term.of(condition)
     def exprStr: String = condition.show
 

--- a/tests/run-macros/i5536/Macro_1.scala
+++ b/tests/run-macros/i5536/Macro_1.scala
@@ -4,7 +4,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${assertImpl('condition)}
 
   def assertImpl(condition: Expr[Boolean])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val tree = Term.of(condition)
     def exprStr: String = condition.show
 

--- a/tests/run-macros/i5629/Macro_1.scala
+++ b/tests/run-macros/i5629/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('{condition}, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val b = Term.of(cond).underlyingArgument.asExprOf[Boolean]
     '{ scala.Predef.assert($b) }
   }
@@ -13,7 +13,7 @@ object Macros {
   inline def thisLineNumber = ${ thisLineNumberImpl }
 
   def thisLineNumberImpl(using Quotes) : Expr[Int] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(Position.ofMacroExpansion.startLine)
   }
 }

--- a/tests/run-macros/i5715/Macro_1.scala
+++ b/tests/run-macros/i5715/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     Term.of(cond).underlyingArgument match {
       case app @ Apply(select @ Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -12,7 +12,7 @@ object Lens {
   }
 
   def impl[S: Type, T: Type](getter: Expr[S => T])(using Quotes) : Expr[Lens[S, T]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     // obj.copy(a = obj.a.copy(b = a.b.copy(c = v)))
@@ -85,7 +85,7 @@ object Iso {
   }
 
   def impl[S: Type, A: Type](using Quotes) : Expr[Iso[S, A]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     val tpS = TypeRepr.of[S]
@@ -124,7 +124,7 @@ object Iso {
   }
 
   def implUnit[S: Type](using Quotes) : Expr[Iso[S, 1]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     val tpS = TypeRepr.of[S]
@@ -196,7 +196,7 @@ object Prism {
   }
 
   def impl[S: Type, A <: S : Type](using Quotes) : Expr[Prism[S, A]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     '{

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     def isImplicitMethodType(tp: TypeRepr): Boolean = tp match

--- a/tests/run-macros/i6270/Macro_1.scala
+++ b/tests/run-macros/i6270/Macro_1.scala
@@ -5,7 +5,7 @@ object api {
     ${ reflImpl('x) }
 
   private def reflImpl(x: Expr[String])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(x.show)
   }
 
@@ -13,7 +13,7 @@ object api {
     ${ reflImplColor('x) }
 
   private def reflImplColor(x: Expr[String])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(x.showAnsiColored)
   }
 }

--- a/tests/run-macros/i6518/Macro_1.scala
+++ b/tests/run-macros/i6518/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def test(): String = ${ testImpl }
 
   private def testImpl(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val classSym = TypeRepr.of[Function1].classSymbol.get
     classSym.classMethod("apply")
     classSym.classMethods

--- a/tests/run-macros/i6679/Macro_1.scala
+++ b/tests/run-macros/i6679/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 
 def makeMatch[A: Type](head : Expr[A])(using qctx : Quotes) : Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
 
   val sacrifice = '{ $head match { case _ => ??? } }
   Term.of(sacrifice)

--- a/tests/run-macros/i6765/Macro_1.scala
+++ b/tests/run-macros/i6765/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 inline def foo = ${fooImpl}
 
 def fooImpl(using Quotes) = {
-  import qctx.reflect._
+  import quotes.reflect._
   val res = Expr.ofList(List('{"One"}))
   Expr(res.show)
 }

--- a/tests/run-macros/i6803/Macro_1.scala
+++ b/tests/run-macros/i6803/Macro_1.scala
@@ -9,7 +9,7 @@ object AsObject {
     def unsafe(i: Int): LineNo = new LineNo(i)
     inline given LineNo = ${impl}
     private def impl(using Quotes): Expr[LineNo] = {
-      import qctx.reflect._
+      import quotes.reflect._
       '{unsafe(${Expr(Position.ofMacroExpansion.startLine)})}
     }
   }
@@ -21,7 +21,7 @@ package AsPackage {
     def unsafe(i: Int): LineNo = new LineNo(i)
     inline given LineNo = ${impl}
     private def impl(using Quotes): Expr[LineNo] = {
-      import qctx.reflect._
+      import quotes.reflect._
       '{unsafe(${Expr(Position.ofMacroExpansion.startLine)})}
     }
   }

--- a/tests/run-macros/i6988/FirstArg_1.scala
+++ b/tests/run-macros/i6988/FirstArg_1.scala
@@ -9,7 +9,7 @@ object Macros {
   import scala.quoted._
 
   def argsImpl(using Quotes) : Expr[FirstArg] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def enclosingClass(cur: Symbol = Symbol.spliceOwner): Symbol =
       if (cur.isClassDef) cur

--- a/tests/run-macros/i7008/macro_1.scala
+++ b/tests/run-macros/i7008/macro_1.scala
@@ -11,7 +11,7 @@ def mcrProxy(expr: Expr[Boolean])(using Quotes): Expr[Unit] = {
 }
 
 def mcrImpl[T](func: Expr[Seq[Box[T]] => Unit], expr: Expr[T])(using Quotes, Type[T]): Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
   val arg = Varargs(Seq('{(Box($expr))}))
   Expr.betaReduce('{$func($arg)})
 }

--- a/tests/run-macros/i7025/Macros_1.scala
+++ b/tests/run-macros/i7025/Macros_1.scala
@@ -4,7 +4,7 @@ object Macros {
   inline def debug: Unit = ${Macros.debugImpl}
 
   def debugImpl(using Quotes): Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def nearestEnclosingDef(owner: Symbol): Symbol =
       if owner.isClassDef then owner

--- a/tests/run-macros/i7887/Macro_1.scala
+++ b/tests/run-macros/i7887/Macro_1.scala
@@ -1,5 +1,5 @@
 def myMacroImpl(a: quoted.Expr[_])(using qctx: quoted.Quotes) = {
-  import qctx.reflect._
+  import scala.quoted.quotes.reflect._
   def typed[A] = {
     implicit val t: quoted.Type[A] = Term.of(a).tpe.widen.asType.asInstanceOf[quoted.Type[A]]
     '{

--- a/tests/run-macros/i7898/Macro_1.scala
+++ b/tests/run-macros/i7898/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 object Main {
 
   def myMacroImpl(body: Expr[_])(using Quotes) : Expr[_] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val bodyTerm = Term.of(underlyingArgument(body))
     val showed = bodyTerm.show
     '{
@@ -17,6 +17,6 @@ object Main {
   }
 
   def underlyingArgument[T](expr: Expr[T])(using Quotes): Expr[T] =
-    import qctx.reflect._
+    import quotes.reflect._
     Term.of(expr).underlyingArgument.asExpr.asInstanceOf[Expr[T]]
 }

--- a/tests/run-macros/i8007/Macro_1.scala
+++ b/tests/run-macros/i8007/Macro_1.scala
@@ -17,7 +17,7 @@ object Macro1 {
     ${ test1Impl('value) }
 
   def test1Impl[T: Type](value: Expr[T])(using Quotes): Expr[List[String]] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val mirrorTpe = Type.of[Mirror.Of[T]]
 

--- a/tests/run-macros/i8007/Macro_2.scala
+++ b/tests/run-macros/i8007/Macro_2.scala
@@ -21,7 +21,7 @@ object Macro2 {
         }
 
     def derived[T: Type](ev: Expr[Mirror.Of[T]])(using Quotes): Expr[JsonEncoder[T]] = {
-      import qctx.reflect._
+      import quotes.reflect._
 
       val fields = ev match {
         case '{ $m: Mirror.ProductOf[T] { type MirroredElemLabels = labels } } =>
@@ -43,7 +43,7 @@ object Macro2 {
   inline def test2[T](value: =>T): Unit = ${ test2Impl('value) }
 
   def test2Impl[T: Type](value: Expr[T])(using Quotes): Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val mirrorTpe = Type.of[Mirror.Of[T]]
     val mirrorExpr = Expr.summon(using mirrorTpe).get

--- a/tests/run-macros/i8007/Macro_3.scala
+++ b/tests/run-macros/i8007/Macro_3.scala
@@ -33,7 +33,7 @@ object Eq {
   }
 
   given derived[T: Type](using q: Quotes) as Expr[Eq[T]] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val ev: Expr[Mirror.Of[T]] = Expr.summon(using Type.of[Mirror.Of[T]]).get
 

--- a/tests/run-macros/i8514/Macro_1.scala
+++ b/tests/run-macros/i8514/Macro_1.scala
@@ -7,7 +7,7 @@ class C extends B
 inline def test(): Unit = ${ testExpr }
 
 def testExpr(using Quotes): Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
 
   '{
     println(${Expr(TypeRepr.of[Object].baseClasses.toString)})

--- a/tests/run-macros/i8514b/Macro_1.scala
+++ b/tests/run-macros/i8514b/Macro_1.scala
@@ -7,7 +7,7 @@ class B extends A[P, String]
 inline def test(): Unit = ${ testExpr }
 
 def testExpr(using Quotes): Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
 
   val t = TypeRepr.of[B]
   val baseTypes = t.baseClasses.map(b => t.baseType(b))

--- a/tests/run-macros/i8520/Macro_1.scala
+++ b/tests/run-macros/i8520/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 inline def test[T[_]]: Unit = ${ testExpr[T] }
 
 def testExpr[T[_]: Type](using Quotes): Expr[Unit] = {
-  import qctx.reflect._
+  import quotes.reflect._
   def variance(f: Flags) =
      if f.is(Flags.Covariant) then "+"
      else if f.is(Flags.Contravariant) then "-"

--- a/tests/run-macros/i9206/Macros_1.scala
+++ b/tests/run-macros/i9206/Macros_1.scala
@@ -5,7 +5,7 @@ object Inspect {
   inline def inspect[T <: AnyKind]: String = ${ inspectTpe[T] }
 
   def inspectTpe[T <: AnyKind: Type](using Quotes): Expr[String] = {
-    import qctx.reflect.TypeRepr
+    import quotes.reflect.TypeRepr
     val tree = TypeRepr.of[T].typeSymbol.tree
     Expr(tree.show)
   }

--- a/tests/run-macros/i9570/Macro_1.scala
+++ b/tests/run-macros/i9570/Macro_1.scala
@@ -8,7 +8,7 @@ object Macros {
     case object HNil extends HList
 
     private def sizeImpl(e: Expr[HList], n:Int)(using qctx:Quotes): Expr[Int] = {
-      import qctx.reflect._
+      import quotes.reflect._
       e match {
         case '{HCons($_,$t)} =>
         //case '{HCons($a,$t)} =>

--- a/tests/run-macros/i9812b/Macro_1.scala
+++ b/tests/run-macros/i9812b/Macro_1.scala
@@ -28,7 +28,7 @@ case object NIL extends Lst[Nothing]
 
 given IntLiftable[T <: Int] as Liftable[T]:
   def toExpr(x: T): Quotes ?=> Expr[T] = (using qctx) => {
-    import qctx.reflect._
+    import quotes.reflect._
     Literal(Constant.Int(x)).asExpr.asInstanceOf[Expr[T]]
   }
 

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -3,7 +3,7 @@ object Macros {
 
   inline def go[T](inline t: T) = ${ impl('t) }
   def impl[T](expr: Expr[T])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val tree = Term.of(expr)
 

--- a/tests/run-macros/no-symbol/1.scala
+++ b/tests/run-macros/no-symbol/1.scala
@@ -9,7 +9,7 @@ object Macro {
     ${ fooImpl[T] }
 
   def fooImpl[T](implicit t: Type[T], qctx: Quotes): Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val sym = TypeTree.of[T].symbol
     if sym.isClassDef then '{ "symbol" }
     else if sym.isNoSymbol then '{ "no symbol" }

--- a/tests/run-macros/paramSymss/Macro_1.scala
+++ b/tests/run-macros/paramSymss/Macro_1.scala
@@ -4,7 +4,7 @@ inline def showParamSyms(inline x: Any): String =
   ${ showParamSymsExpr('x) }
 
 def showParamSymsExpr(using Quotes)(x: Expr[Any]): Expr[String] =
-  import qctx.reflect._
+  import quotes.reflect._
   val '{ $y: Any } = x // Drop Inlined not to access the symbol
   val sym = Term.of(y).symbol
   Expr(

--- a/tests/run-macros/quote-inline-function/quoted_1.scala
+++ b/tests/run-macros/quote-inline-function/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
   inline def foreach3(start: Int, end: Int, inline f: Int => Unit): String = ${impl('start, 'end, 'f)}
 
   def impl(start: Expr[Int], end: Expr[Int], f: Expr[Int => Unit])(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val res = '{
       var i = $start
       val j = $end

--- a/tests/run-macros/quote-matcher-runtime/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-runtime/quoted_1.scala
@@ -5,9 +5,9 @@ object Macros {
   inline def matches[A, B](inline a: A, inline b: B): Unit = ${impl('a, 'b)}
 
   private def impl[A, B](a: Expr[A], b: Expr[B])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
-    val res = qctx.asInstanceOf[scala.quoted.runtime.QuoteMatching].ExprMatch.unapply[Tuple, Tuple](a)(using b).map { tup =>
+    val res = quotes.asInstanceOf[scala.quoted.runtime.QuoteMatching].ExprMatch.unapply[Tuple, Tuple](a)(using b).map { tup =>
       tup.toArray.toList.map {
         case r: Expr[_] =>
           s"Expr(${r.show})"

--- a/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
@@ -20,7 +20,7 @@ object Macros {
         '{ $sym.times(${lift(x)}, ${lift(y)}) }
 
       case _ =>
-        import qctx.reflect._
+        import quotes.reflect._
         Reporting.error("Expected explicit DSL", Term.of(e).pos)
         '{ ??? }
 

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -38,7 +38,7 @@ object Macros {
       case '{ envVar(${Const(i)}) } => env(i)
 
       case _ =>
-        import qctx.reflect._
+        import quotes.reflect._
         Reporting.error("Expected explicit DSL " + e.show, Term.of(e).pos)
         ???
     }
@@ -52,7 +52,7 @@ object Macros {
           }
         )
       case _ =>
-        import qctx.reflect._
+        import quotes.reflect._
         Reporting.error("Expected explicit DSL => DSL "  + e.show, Term.of(e).pos)
         ???
     }
@@ -64,18 +64,18 @@ object Macros {
 
 object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using Quotes): X = {
-    import qctx.reflect._
+    import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
     content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
   }
-  private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
-    import qctx.reflect._
+  private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
+    import quotes.reflect._
     val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
-  private def bodyFn[t](using Quotes)(e: qctx.reflect.Term, params: List[qctx.reflect.ValDef], args: List[qctx.reflect.Term]): qctx.reflect.Term = {
-    import qctx.reflect._
+  private def bodyFn[t](using Quotes)(e: quotes.reflect.Term, params: List[quotes.reflect.ValDef], args: List[quotes.reflect.Term]): quotes.reflect.Term = {
+    import quotes.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
       override def transformTerm(tree: Term)(owner: Symbol): Term =

--- a/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
@@ -76,18 +76,18 @@ object Macros {
 
 object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using Quotes): X = {
-    import qctx.reflect._
+    import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
     content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
   }
-  private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
-    import qctx.reflect._
+  private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
+    import quotes.reflect._
     val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
-  private def bodyFn[t](using Quotes)(e: qctx.reflect.Term, params: List[qctx.reflect.ValDef], args: List[qctx.reflect.Term]): qctx.reflect.Term = {
-    import qctx.reflect._
+  private def bodyFn[t](using Quotes)(e: quotes.reflect.Term, params: List[quotes.reflect.ValDef], args: List[quotes.reflect.Term]): quotes.reflect.Term = {
+    import quotes.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
       override def transformTerm(tree: Term)(owner: Symbol): Term =

--- a/tests/run-macros/quote-matching-open/Macro_1.scala
+++ b/tests/run-macros/quote-matching-open/Macro_1.scala
@@ -17,29 +17,29 @@ object Macro {
 
 object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using Quotes): X = {
-    import qctx.reflect._
+    import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
     content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
   }
   def open[T1, T2, R, X](f: Expr[(T1, T2) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2]) => Expr[t]) => X)(using Quotes)(using DummyImplicit): X = {
-    import qctx.reflect._
+    import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
     content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2]) => bodyFn[t](Term.of(e), params, List(Term.of(v1), Term.of(v2))).asExpr.asInstanceOf[Expr[t]])
   }
 
   def open[T1, T2, T3, R, X](f: Expr[(T1, T2, T3) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2], Expr[T3]) => Expr[t]) => X)(using Quotes)(using DummyImplicit, DummyImplicit): X = {
-    import qctx.reflect._
+    import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
     content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](Term.of(e), params, List(Term.of(v1), Term.of(v2), Term.of(v3))).asExpr.asInstanceOf[Expr[t]])
   }
-  private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
-    import qctx.reflect._
+  private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
+    import quotes.reflect._
     val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 
-  private def bodyFn[t](using Quotes)(e: qctx.reflect.Term, params: List[qctx.reflect.ValDef], args: List[qctx.reflect.Term]): qctx.reflect.Term = {
-    import qctx.reflect._
+  private def bodyFn[t](using Quotes)(e: quotes.reflect.Term, params: List[quotes.reflect.ValDef], args: List[quotes.reflect.Term]): quotes.reflect.Term = {
+    import quotes.reflect._
     val map = params.map(_.symbol).zip(args).toMap
     new TreeMap {
       override def transformTerm(tree: Term)(owner: Symbol): Term =

--- a/tests/run-macros/quote-toExprOfTuple/Macro_1.scala
+++ b/tests/run-macros/quote-toExprOfTuple/Macro_1.scala
@@ -4,7 +4,7 @@ object Macro {
   inline def t2[T0, T1](t0: T0, t1: T1): (T0, T1) = ${ impl2('{t0}, '{t1}) }
 
   def impl2[T0: Type, T1: Type](t0: Expr[T0], t1: Expr[T1])(using Quotes) : Expr[(T0, T1)] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     val seq = List(t0, t1)

--- a/tests/run-macros/quote-type-matcher/quoted_1.scala
+++ b/tests/run-macros/quote-type-matcher/quoted_1.scala
@@ -5,9 +5,9 @@ object Macros {
   inline def matches[A, B]: Unit = ${ matchesExpr[A, B] }
 
   private def matchesExpr[A, B](using a: Type[A], b: Type[B])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
-    val res = qctx.asInstanceOf[scala.quoted.runtime.QuoteMatching].TypeMatch.unapply[Tuple, Tuple](a)(using b).map { tup =>
+    val res = quotes.asInstanceOf[scala.quoted.runtime.QuoteMatching].TypeMatch.unapply[Tuple, Tuple](a)(using b).map { tup =>
       tup.toArray.toList.map {
         case r: Type[_] =>
           s"Type(${TypeTree.of(using r).show})"

--- a/tests/run-macros/quoted-matching-docs/Macro_1.scala
+++ b/tests/run-macros/quoted-matching-docs/Macro_1.scala
@@ -28,6 +28,6 @@ private def sumExpr(argsExpr: Expr[Seq[Int]])(using Quotes) : Expr[Int] = {
 
 object UnsafeExpr {
   def underlyingArgument[T](expr: Expr[T])(using Quotes): Expr[T] =
-    import qctx.reflect._
+    import quotes.reflect._
     Term.of(expr).underlyingArgument.asExpr.asInstanceOf[Expr[T]]
 }

--- a/tests/run-macros/refined-selectable-macro/Macro_1.scala
+++ b/tests/run-macros/refined-selectable-macro/Macro_1.scala
@@ -15,7 +15,7 @@ object Macro {
   }
 
   private def toTupleImpl(s: Expr[Selectable])(using qctx:Quotes) : Expr[Tuple] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val repr = Term.of(s).tpe.widenTermRefExpr.dealias
 
@@ -49,7 +49,7 @@ object Macro {
   }
 
   private def fromTupleImpl[T: Type](s: Expr[Tuple], newRecord: Expr[Array[(String, Any)] => T])(using qctx:Quotes) : Expr[Any] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val repr = Term.of(s).tpe.widenTermRefExpr.dealias
 

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes): Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     def isImplicitMethodType(tp: TypeRepr): Boolean = tp match

--- a/tests/run-macros/reflect-lambda/assert_1.scala
+++ b/tests/run-macros/reflect-lambda/assert_1.scala
@@ -5,7 +5,7 @@ object lib {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     Term.of(cond).underlyingArgument match {

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition) }
 
   def assertImpl(cond: Expr[Boolean])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     Term.of(cond).underlyingArgument match {

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     def isImplicitMethodType(tp: TypeRepr): Boolean = tp match

--- a/tests/run-macros/reflect-select-copy-2/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy-2/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     def isImplicitMethodType(tp: TypeRepr): Boolean = tp match

--- a/tests/run-macros/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     Term.of(cond).underlyingArgument match {
       case Apply(select @ Select(lhs, op), rhs :: Nil) =>

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     def isImplicitMethodType(tp: TypeRepr): Boolean = tp match

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -5,7 +5,7 @@ object scalatest {
   inline def assert(condition: => Boolean): Unit = ${ assertImpl('condition, '{""}) }
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     import util._
 
     def isImplicitMethodType(tp: TypeRepr): Boolean = tp match

--- a/tests/run-macros/reflect-sourceCode/Macro_1.scala
+++ b/tests/run-macros/reflect-sourceCode/Macro_1.scala
@@ -5,7 +5,7 @@ object api {
     ${ reflImpl('x) }
 
   private def reflImpl[T](x: Expr[T])(implicit qctx: Quotes): Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(Term.of(x).pos.sourceCode)
   }
 }

--- a/tests/run-macros/requiredSymbols/Macro_1.scala
+++ b/tests/run-macros/requiredSymbols/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 object Macro {
   inline def foo: String = ${ fooImpl }
   def fooImpl(using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val list = List(
       Symbol.requiredPackage("java"),
       Symbol.requiredPackage("java.lang"),

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def inspect[T](x: T): Unit = ${ impl('x) }
 
   def impl[T](x: Expr[T])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val tree = Term.of(x)
     '{
       println()

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -11,7 +11,7 @@ object Macros {
   class TestAnnotation extends scala.annotation.Annotation
 
   def theTestBlockImpl(using qctx : Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val x1T = ConstantType(Constant.Int(1))
     val x2T = OrType(ConstantType(Constant.Int(1)), ConstantType(Constant.Int(2)))

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def theTestBlock : Unit = ${ theTestBlockImpl }
 
   def theTestBlockImpl(using q: Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     // simple smoke test
     val sym1 : Symbol = Symbol.newMethod(

--- a/tests/run-macros/tasty-dealias/quoted_1.scala
+++ b/tests/run-macros/tasty-dealias/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def dealias[T]: String = ${ impl[T] }
 
   def impl[T: Type](using Quotes) : Expr[String] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Expr(TypeRepr.of[T].dealias.show)
   }
 }

--- a/tests/run-macros/tasty-definitions-1/quoted_1.scala
+++ b/tests/run-macros/tasty-definitions-1/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def testDefinitions(): Unit = ${testDefinitionsImpl}
 
   def testDefinitionsImpl(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val buff = List.newBuilder[String]
     def printout(x: => String): Unit = {

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -17,7 +17,7 @@ object Macros {
 
   implicit def intIsEvalable: Valuable[Int] = new Valuable[Int] {
     override def value(e: Expr[Int])(using Quotes) : Option[Int] = {
-      import qctx.reflect._
+      import quotes.reflect._
 
       Term.of(e).tpe match {
         case pre: TermRef if pre.termSymbol.isValDef =>

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val tree = Term.of(x)
     val treeStr = Expr(tree.showExtractors)

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
     ${ impl('x) }
 
   def impl[T](x: Expr[T])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val tree = Term.of(x)
 

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -7,7 +7,7 @@ object Macros {
     ${impl('x)}
 
   def impl[T](x: Expr[T])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val buff = new StringBuilder
     val traverser = new TreeTraverser {

--- a/tests/run-macros/tasty-extractors-types/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-types/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   implicit inline def printType[T]: Unit = ${ impl[T] }
 
   def impl[T: Type](using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     '{
       println(${Expr(TypeTree.of[T].showExtractors)})
       println(${Expr(TypeRepr.of[T].showExtractors)})

--- a/tests/run-macros/tasty-getfile-implicit-by-name-fun-context/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile-implicit-by-name-fun-context/Macro_1.scala
@@ -8,6 +8,6 @@ object SourceFiles {
     ${getThisFileImpl}
 
   def getThisFileImpl: Macro[String] =
-    Expr(qctx.reflect.Source.path.getFileName.toString)
+    Expr(quotes.reflect.Source.path.getFileName.toString)
 
 }

--- a/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile-implicit-fun-context/Macro_1.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 object SourceFiles {
 
   type Macro[X] = Quotes ?=> Expr[X]
-  def tastyContext(using Quotes): Quotes = qctx
+  def tastyContext(using q: Quotes): Quotes = q
 
   implicit inline def getThisFile: String =
     ${getThisFileImpl}

--- a/tests/run-macros/tasty-getfile/Macro_1.scala
+++ b/tests/run-macros/tasty-getfile/Macro_1.scala
@@ -7,6 +7,6 @@ object SourceFiles {
     ${getThisFileImpl}
 
   private def getThisFileImpl(using Quotes) : Expr[String] =
-    Expr(qctx.reflect.Source.path.getFileName.toString)
+    Expr(quotes.reflect.Source.path.getFileName.toString)
 
 }

--- a/tests/run-macros/tasty-indexed-map/quoted_1.scala
+++ b/tests/run-macros/tasty-indexed-map/quoted_1.scala
@@ -25,7 +25,7 @@ object Index {
   implicit inline def succ[K, H, T](implicit prev: => Index[K, T]): Index[K, (H, T)] = ${succImpl[K, H, T]}
 
   def succImpl[K, H, T](implicit qctx: Quotes, k: Type[K], h: Type[H], t: Type[T]): Expr[Index[K, (H, T)]] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def name(tp: TypeRepr): String = tp match {
       case ConstantType(Constant.String(str)) => str

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -55,7 +55,7 @@ abstract class MacroStringInterpolator[T] {
   protected def interpolate(strCtx: StringContext, argExprs: List[Expr[Any]]) (using Quotes): Expr[T]
 
   protected def getStaticStringContext(strCtxExpr: Expr[StringContext])(using Quotes) : StringContext = {
-    import qctx.reflect._
+    import quotes.reflect._
     Term.of(strCtxExpr).underlyingArgument match {
       case Select(Typed(Apply(_, List(Apply(_, List(Typed(Repeated(strCtxArgTrees, _), Inferred()))))), _), _) =>
         val strCtxArgs = strCtxArgTrees.map {
@@ -69,7 +69,7 @@ abstract class MacroStringInterpolator[T] {
   }
 
   protected def getArgsList(argsExpr: Expr[Seq[Any]])(using Quotes) : List[Expr[Any]] = {
-    import qctx.reflect._
+    import quotes.reflect._
     Term.of(argsExpr).underlyingArgument match {
       case Typed(Repeated(args, _), _) => args.map(_.asExpr)
       case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.asExpr)

--- a/tests/run-macros/tasty-linenumber-2/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber-2/quoted_1.scala
@@ -9,7 +9,7 @@ object LineNumber {
   implicit inline def line: LineNumber = ${lineImpl}
 
   def lineImpl(using Quotes) : Expr[LineNumber] = {
-    import qctx.reflect._
+    import quotes.reflect._
     '{new LineNumber(${Expr(Position.ofMacroExpansion.startLine)})}
   }
 

--- a/tests/run-macros/tasty-linenumber/quoted_1.scala
+++ b/tests/run-macros/tasty-linenumber/quoted_1.scala
@@ -10,7 +10,7 @@ object LineNumber {
     ${lineImpl(Type.of[T])}
 
   def lineImpl(x: Type[Unit])(using Quotes) : Expr[LineNumber] = {
-    import qctx.reflect._
+    import quotes.reflect._
     '{new LineNumber(${Expr(Position.ofMacroExpansion.startLine)})}
   }
 

--- a/tests/run-macros/tasty-location/quoted_1.scala
+++ b/tests/run-macros/tasty-location/quoted_1.scala
@@ -7,7 +7,7 @@ object Location {
   implicit inline def location: Location = ${impl}
 
   def impl(using Quotes) : Expr[Location] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def listOwnerNames(sym: Symbol, acc: List[String]): List[String] =
       if (sym == defn.RootClass || sym == defn.EmptyPackageClass) acc

--- a/tests/run-macros/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-assert/quoted_1.scala
@@ -13,7 +13,7 @@ object Asserts {
     ${impl('cond)}
 
   def impl(cond: Expr[Boolean])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val tree = Term.of(cond)
 

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def natConst(x: Int): Int = ${ natConstImpl('x) }
 
   def natConstImpl(x: Expr[Int])(using Quotes) : Expr[Int] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val xTree: Term = Term.of(x)
     xTree match {
       case Inlined(_, _, Literal(Constant.Int(n))) =>

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -9,28 +9,27 @@ object Macros {
   inline def fun3[T]: Unit = ${ impl2(using Type.of[T]) }
 
   def impl(x: Expr[Any])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val pos = Term.of(x).underlyingArgument.pos
     val code = Term.of(x).underlyingArgument.show
     '{
-      println(${posStr(qctx)(pos)})
+      println(${posStr(pos)})
       println(${Expr(code)})
     }
   }
 
   def impl2[T](using x: Type[T])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val pos = TypeTree.of[T].pos
     val code = TypeTree.of[T].show
     '{
-      println(${posStr(qctx)(pos)})
+      println(${posStr(pos)})
       println(${Expr(code)})
     }
   }
 
-  def posStr(qctx: Quotes)(pos: qctx.reflect.Position): Expr[String] = {
-    given Quotes = qctx
-    import qctx.reflect._
+  def posStr(using Quotes)(pos: quotes.reflect.Position): Expr[String] = {
+    import quotes.reflect._
     Expr(s"${pos.sourceFile.jpath.getFileName.toString}:[${pos.start}..${pos.end}]")
   }
 }

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -5,7 +5,7 @@ object Macros {
   implicit inline def withSource(arg: Any): (String, Any) = ${ impl('arg) }
 
   private def impl(arg: Expr[Any])(using Quotes) : Expr[(String, Any)] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val source = Expr(Term.of(arg).underlyingArgument.pos.sourceCode.toString)
     '{Tuple2($source, $arg)}
   }

--- a/tests/run-macros/tasty-overload-secondargs/Macro_1.scala
+++ b/tests/run-macros/tasty-overload-secondargs/Macro_1.scala
@@ -22,7 +22,7 @@ object Macro:
     }
 
     def mThenImpl[A:Type, B:Type, S<:(A=>B) :Type, R:Type](x:Expr[S])(using Quotes):Expr[R]=
-       import qctx.reflect._
+       import quotes.reflect._
        val fun = Term.of('{X})
        val returnType = TypeRepr.of[(S) => ?]
        val firstPart = Select.overloaded(fun,"andThen",

--- a/tests/run-macros/tasty-positioned/quoted_1.scala
+++ b/tests/run-macros/tasty-positioned/quoted_1.scala
@@ -10,7 +10,7 @@ object Positioned {
   implicit inline def apply[T](x: => T): Positioned[T] = ${impl('x)}
 
   def impl[T](x: Expr[T])(implicit ev: Type[T], qctx: Quotes): Expr[Positioned[T]] = {
-    import qctx.reflect.{Position => Pos, _}
+    import quotes.reflect.{Position => Pos, _}
     val pos = Pos.ofMacroExpansion
 
     val path = Expr(pos.sourceFile.jpath.toString)

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -7,7 +7,7 @@ object Asserts {
 
   /** Replaces last argument list by 0s */
   def zeroLastArgsImpl(x: Expr[Int])(using Quotes) : Expr[Int] = {
-    import qctx.reflect._
+    import quotes.reflect._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
     Term.of(x).underlyingArgument match {
       case Apply(fn, args) =>
@@ -29,7 +29,7 @@ object Asserts {
 
   /** Replaces all argument list by 0s */
   def zeroAllArgsImpl(x: Expr[Int])(using Quotes) : Expr[Int] = {
-    import qctx.reflect._
+    import quotes.reflect._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
     def rec(term: Term): Term = term match {
       case Apply(fn, args) =>

--- a/tests/run-macros/tasty-simplified/quoted_1.scala
+++ b/tests/run-macros/tasty-simplified/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def simplified[T <: Tuple]: Seq[String] = ${ impl[T] }
 
   def impl[T: Type](using Quotes) : Expr[Seq[String]] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     def unpackTuple(tp: TypeRepr): List[TypeRepr] = {
       @tailrec

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -23,7 +23,7 @@ object Macro {
       case ('{ StringContext(${Varargs(parts)}: _*) }, Varargs(args)) =>
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
-            import qctx.reflect._
+            import quotes.reflect._
             Reporting.error(msg, Term.of(parts(partIdx)).pos)
           }
         }
@@ -37,7 +37,7 @@ object Macro {
         val errors = List.newBuilder[Expr[(Int, Int, Int, String)]]
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
-            import qctx.reflect._
+            import quotes.reflect._
             val pos = Term.of(parts(partIdx)).pos
             errors += '{ Tuple4(${Expr(partIdx)}, ${Expr(pos.start)}, ${Expr(pos.end)}, ${Expr(msg)}) }
           }

--- a/tests/run-macros/tasty-subtyping/quoted_1.scala
+++ b/tests/run-macros/tasty-subtyping/quoted_1.scala
@@ -9,13 +9,13 @@ object Macros {
     ${isSubTypeOfImpl[T, U]}
 
   def isTypeEqualImpl[T: Type, U: Type](using Quotes) : Expr[Boolean] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val isTypeEqual = TypeRepr.of[T] =:= TypeRepr.of[U]
     Expr(isTypeEqual)
   }
 
   def isSubTypeOfImpl[T: Type, U: Type](using Quotes) : Expr[Boolean] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val isTypeEqual = TypeRepr.of[T] <:< TypeRepr.of[U]
     Expr(isTypeEqual)
   }

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -5,7 +5,7 @@ object Macros:
 
 object MacrosImpl:
   def impl[T: Type](x: Expr[T])(using Quotes) : Expr[T] = {
-    import qctx.reflect._
+    import quotes.reflect._
     val identityMap = new TreeMap { }
     val transformed = identityMap.transformTerm(Term.of(x))(Symbol.spliceOwner).asExprOf[T]
     transformed

--- a/tests/run-macros/tasty-typeof/Macro_1.scala
+++ b/tests/run-macros/tasty-typeof/Macro_1.scala
@@ -5,7 +5,7 @@ object Macros {
   inline def testTypeOf(): Unit = ${ testTypeOfImpl }
 
   private def testTypeOfImpl(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
     '{
       assert(${Expr(TypeRepr.of[Unit] =:= TypeRepr.of[Unit])}, "Unit")
       assert(${Expr(TypeRepr.of[Byte] =:= TypeRepr.of[Byte])}, "Byte")

--- a/tests/run-macros/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-macros/tasty-unsafe-let/quoted_1.scala
@@ -6,11 +6,11 @@ object Macros {
     ${ impl('rhs, 'body) }
 
   private def impl[T: Type](rhs: Expr[T], body: Expr[T => Unit])(using Quotes) : Expr[Unit] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     val rhsTerm = Term.of(rhs)
 
-    import qctx.reflect._
+    import quotes.reflect._
     ValDef.let(Symbol.spliceOwner, rhsTerm) { rhsId =>
       Term.of(Expr.betaReduce('{$body(${rhsId.asExpr.asInstanceOf[Expr[T]]})})) // Dangerous uncheked cast!
     }.asExprOf[Unit]

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -13,7 +13,7 @@ object XmlQuote {
 
   def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])
           (using Quotes) : Expr[Xml] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     // for debugging purpose
     def pp(tree: Tree): Unit = {

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -14,7 +14,7 @@ object XmlQuote {
   implicit inline def SCOps(ctx: => StringContext): SCOps = new SCOps(ctx)
 
   def impl(receiver: Expr[SCOps], args: Expr[Seq[Any]])(using Quotes) : Expr[Xml] = {
-    import qctx.reflect._
+    import quotes.reflect._
 
     // for debugging purpose
     def pp(tree: Tree): Unit = {


### PR DESCRIPTION
Based on #10432

We add the definition of `quotes` that replaces the previous `qctx` definition. This name is more meaningful.
```scala
inline def quotes(using q: Quotes): q.type = q

def f(using Quotes)(t: quotes.reflect.Tree): Unit = 
  import quotes.refelct._
  ...
```

If users want shorter names they can define it themselfs

```scala
inline def q(using q: Quotes): q.type = q

def f(using Quotes)(t: q.reflect.Tree): Unit = 
  import q.refelct._
  ...
```
or
```scala
inline def r(using q: Quotes): q.reflect.type = q.reflect

def f(using Quotes)(t: r.Tree): Unit =
  import r._
  ...
```