### PR TITLE
Add EmptyTree to reflection API

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
@@ -106,9 +106,7 @@ object Extractors {
       case Repeated(elems, elemtpt) =>
         this += "Repeated(" ++= elems += ", " += elemtpt += ")"
       case Inlined(call, bindings, expansion) =>
-        this += "Inlined("
-        visitOption(call, visitTree)
-        this += ", " ++= bindings += ", " += expansion += ")"
+        this += "Inlined(" += call += ", " ++= bindings += ", " += expansion += ")"
       case ValDef(name, tpt, rhs) =>
         this += "ValDef(\"" += name += "\", " += tpt += ", " += rhs += ")"
       case DefDef(name, typeParams, paramss, returnTpt, rhs) =>
@@ -165,6 +163,8 @@ object Extractors {
         this += "Unapply(" += fun += ", " ++= implicits += ", " ++= patterns += ")"
       case Alternatives(patterns) =>
         this += "Alternative(" ++= patterns += ")"
+      case EmptyTree() =>
+        this += "EmptyTree()"
     }
 
     def visitConstant(x: Constant): this.type = x match {

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2.check
@@ -1,3 +1,3 @@
-DefDef("foo", Nil, Nil, TypeIdent("Int"), Some(Apply(Select(Literal(Constant.Int(1)), "+"), List(Literal(Constant.Int(2))))))
-ValDef("bar", TypeIdent("Int"), Some(Apply(Select(Literal(Constant.Int(2)), "+"), List(Literal(Constant.Int(3))))))
+DefDef("foo", Nil, Nil, TypeIdent("Int"), Apply(Select(Literal(Constant.Int(1)), "+"), List(Literal(Constant.Int(2)))))
+ValDef("bar", TypeIdent("Int"), Apply(Select(Literal(Constant.Int(2)), "+"), List(Literal(Constant.Int(3)))))
 Bind("x", Ident("_"))

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -8,7 +8,7 @@ object Foo {
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.reflect._
     Term.of(x) match {
-      case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
+      case Inlined(EmptyTree(), Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?
     }
   }

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3.check
@@ -1,3 +1,3 @@
-DefDef("foo", Nil, Nil, Inferred(), None)
-ValDef("bar", Inferred(), None)
+DefDef("foo", Nil, Nil, Inferred(), EmptyTree())
+ValDef("bar", Inferred(), EmptyTree())
 Bind("x", Ident("_"))

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -8,7 +8,7 @@ object Foo {
   def inspectBodyImpl(x: Expr[Int])(using qctx: QuoteContext) : Expr[String] = {
     import qctx.reflect._
     Term.of(x) match {
-      case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.showExtractors)
+      case Inlined(EmptyTree(), Nil, arg) => Expr(arg.symbol.tree.showExtractors)
       case arg => Expr(arg.symbol.tree.showExtractors) // TODO should all by name parameters be in an inline node?
     }
   }

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners.check
@@ -1,27 +1,27 @@
 foo
-ValDef("macro", Inferred(), None)
+ValDef("macro", Inferred(), EmptyTree())
 
 bar
-DefDef("foo", Nil, Nil, Inferred(), None)
+DefDef("foo", Nil, Nil, Inferred(), EmptyTree())
 
 bar2
-DefDef("foo", Nil, Nil, Inferred(), None)
+DefDef("foo", Nil, Nil, Inferred(), EmptyTree())
 
 foo2
-ValDef("macro", Inferred(), None)
+ValDef("macro", Inferred(), EmptyTree())
 
 baz
-ValDef("foo2", Inferred(), None)
+ValDef("foo2", Inferred(), EmptyTree())
 
 baz2
-ValDef("foo2", Inferred(), None)
+ValDef("foo2", Inferred(), EmptyTree())
 
 <init>
-ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
+ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), EmptyTree()), ValDef("b2", Inferred(), EmptyTree())))
 
 b
-ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
+ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), EmptyTree()), ValDef("b2", Inferred(), EmptyTree())))
 
 b2
-ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
+ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), EmptyTree()), ValDef("b2", Inferred(), EmptyTree())))
 

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1.check
@@ -1,2 +1,2 @@
-DefDef("foo", Nil, Nil, TypeIdent("Int"), Some(Apply(Select(Literal(Constant.Int(1)), "+"), List(Literal(Constant.Int(2))))))
-ValDef("bar", TypeIdent("Int"), Some(Apply(Select(Literal(Constant.Int(2)), "+"), List(Literal(Constant.Int(3))))))
+DefDef("foo", Nil, Nil, TypeIdent("Int"), Apply(Select(Literal(Constant.Int(1)), "+"), List(Literal(Constant.Int(2)))))
+ValDef("bar", TypeIdent("Int"), Apply(Select(Literal(Constant.Int(2)), "+"), List(Literal(Constant.Int(3)))))

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -14,7 +14,7 @@ object Foo {
       else '{"NO DEFINTION"}
 
     Term.of(x) match {
-      case Inlined(None, Nil, arg) => definitionString(arg.symbol)
+      case Inlined(EmptyTree(), Nil, arg) => definitionString(arg.symbol)
       case arg => definitionString(arg.symbol) // TODO should all by name parameters be in an inline node
     }
   }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2.check
@@ -1,2 +1,2 @@
-DefDef("foo", Nil, Nil, Inferred(), None)
-ValDef("bar", Inferred(), None)
+DefDef("foo", Nil, Nil, Inferred(), EmptyTree())
+ValDef("bar", Inferred(), EmptyTree())

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -13,7 +13,7 @@ object Foo {
       else '{"NO DEFINTION"}
 
     Term.of(x) match {
-      case Inlined(None, Nil, arg) => definitionString(arg.symbol)
+      case Inlined(EmptyTree(), Nil, arg) => definitionString(arg.symbol)
       case arg => definitionString(arg.symbol) // TODO should all by name parameters be in an inline node
     }
   }

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
@@ -11,7 +11,7 @@ class TastyInterpreter extends TastyInspector {
 
       override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {
         // TODO: check the correct sig and object enclosement for main
-        case DefDef("main", _, _, _, Some(rhs)) =>
+        case DefDef("main", _, _, _, rhs: Term) =>
           val interpreter = new jvm.Interpreter
 
           interpreter.eval(rhs)(using Map.empty)

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -40,7 +40,7 @@ object Lens {
 
     object Function {
       def unapply(t: Term): Option[(List[ValDef], Term)] = t match {
-        case Inlined(None, Nil, Lambda(params, body)) => Some((params, body))
+        case Inlined(EmptyTree(), Nil, Lambda(params, body)) => Some((params, body))
         case _ => None
       }
     }

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -70,7 +70,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, body)), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
@@ -82,7 +82,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, body)), Closure(Ident("$anonfun"), _)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matching-open/Macro_1.scala
+++ b/tests/run-macros/quote-matching-open/Macro_1.scala
@@ -34,7 +34,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using qctx: QuoteContext)(f: Expr[Any]): (List[qctx.reflect.ValDef], Expr[R]) = {
     import qctx.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, body)), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/tasty-argument-tree-1.check
+++ b/tests/run-macros/tasty-argument-tree-1.check
@@ -1,42 +1,42 @@
 
-tree: Inlined(None, Nil, Literal(Constant.Int(3)))
+tree: Inlined(EmptyTree(), Nil, Literal(Constant.Int(3)))
 tree deref. vals: Literal(Constant.Int(3))
 
-tree: Inlined(None, Nil, Ident("v"))
+tree: Inlined(EmptyTree(), Nil, Ident("v"))
 tree deref. vals: Literal(Constant.Int(1))
 
-tree: Inlined(None, Nil, Ident("x$proxy1"))
+tree: Inlined(EmptyTree(), Nil, Ident("x$proxy1"))
 tree deref. vals: Literal(Constant.Int(2))
 
-tree: Inlined(None, Nil, Ident("l"))
+tree: Inlined(EmptyTree(), Nil, Ident("l"))
 tree deref. vals: Literal(Constant.Int(3))
 
-tree: Inlined(None, Nil, Ident("a"))
+tree: Inlined(EmptyTree(), Nil, Ident("a"))
 tree deref. vals: Ident("a")
 
-tree: Inlined(None, Nil, Ident("x$proxy2"))
+tree: Inlined(EmptyTree(), Nil, Ident("x$proxy2"))
 tree deref. vals: Ident("b")
 
-tree: Inlined(None, Nil, Ident("x$proxy3"))
+tree: Inlined(EmptyTree(), Nil, Ident("x$proxy3"))
 tree deref. vals: Apply(Ident("d2"), Nil)
 
-tree: Inlined(None, Nil, Ident("x$proxy4"))
+tree: Inlined(EmptyTree(), Nil, Ident("x$proxy4"))
 tree deref. vals: Apply(Ident("d3"), List(Literal(Constant.Int(3))))
 
-tree: Inlined(None, Nil, Ident("x$proxy5"))
+tree: Inlined(EmptyTree(), Nil, Ident("x$proxy5"))
 tree deref. vals: TypeApply(Ident("d4"), List(TypeIdent("Int")))
 
-tree: Inlined(None, Nil, Ident("vv"))
+tree: Inlined(EmptyTree(), Nil, Ident("vv"))
 tree deref. vals: Literal(Constant.Int(1))
 
-tree: Inlined(None, Nil, Ident("x$proxy6"))
+tree: Inlined(EmptyTree(), Nil, Ident("x$proxy6"))
 tree deref. vals: Literal(Constant.Int(1))
 
-tree: Inlined(None, Nil, Ident("vd"))
+tree: Inlined(EmptyTree(), Nil, Ident("vd"))
 tree deref. vals: Literal(Constant.Int(2))
 
-tree: Inlined(None, Nil, Ident("x$proxy7"))
+tree: Inlined(EmptyTree(), Nil, Ident("x$proxy7"))
 tree deref. vals: Literal(Constant.Int(2))
 
-tree: Inlined(None, Nil, Ident("x$proxy8"))
+tree: Inlined(EmptyTree(), Nil, Ident("x$proxy8"))
 tree deref. vals: Apply(TypeApply(Select(Ident("Tuple2"), "apply"), List(Inferred(), Inferred())), List(Literal(Constant.Int(1)), Literal(Constant.Int(2))))

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -20,7 +20,7 @@ object Macros {
       DefDef(sym1, {
         case List() => {
           case List(List(a, b)) =>
-            Some(Term.of('{ ${ a.asExpr.asInstanceOf[Expr[Int]] } - ${ b.asExpr.asInstanceOf[Expr[Int]] } }))
+            Term.of('{ ${ a.asExpr.asInstanceOf[Expr[Int]] } - ${ b.asExpr.asInstanceOf[Expr[Int]] } })
         }
       }),
       Term.of('{ assert(${ Apply(Ref(sym1), List(Literal(Constant.Int(2)), Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == -1) }))
@@ -36,7 +36,7 @@ object Macros {
       DefDef(sym2, {
         case List() => {
           case List() =>
-            Some(Literal(Constant.Int(2)))
+            Literal(Constant.Int(2))
         }
       }),
       Term.of('{ assert(${ Ref(sym2).asExpr.asInstanceOf[Expr[Int]] } == 2) }))
@@ -55,8 +55,7 @@ object Macros {
     val sym3Statements : List[Statement] = List(
       DefDef(sym3, {
         case List() => {
-          case List(List(a), List(b)) =>
-            Some(a)
+          case List(List(a), List(b)) => a
         }
       }),
       Term.of('{ assert(${ Apply(Apply(Ref(sym3), List(Literal(Constant.Int(3)))), List(Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == 3) }))
@@ -74,11 +73,11 @@ object Macros {
       DefDef(sym4, {
         case List() => {
           case List(List(x)) =>
-            Some(Term.of('{
+            Term.of('{
               if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
               then 0
               else ${ Apply(Ref(sym4), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
-            }))
+            })
         }
       }),
       Term.of('{ assert(${ Apply(Ref(sym4), List(Literal(Constant.Int(4)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }))
@@ -96,7 +95,6 @@ object Macros {
       DefDef(sym5, {
         case List() => {
           case List(List(x)) =>
-            Some {
               val sym51 : Symbol = Symbol.newMethod(
                 sym5,
                 "sym51",
@@ -108,11 +106,10 @@ object Macros {
                   DefDef(sym51, {
                     case List() => {
                       case List(List(xx)) =>
-                        Some(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - ${ xx.asExpr.asInstanceOf[Expr[Int]] } }))
+                        Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - ${ xx.asExpr.asInstanceOf[Expr[Int]] } })
                     }
                   })),
                 Closure(Ref(sym51), None))
-            }
         }
       }),
       Term.of('{ assert(${ Apply(Ref(sym5), List(Literal(Constant.Int(5)))).asExpr.asInstanceOf[Expr[Int=>Int]] }(4) == 1) }))
@@ -138,27 +135,23 @@ object Macros {
       DefDef(sym6_1, {
         case List() => {
           case List(List(x)) =>
-            Some {
               Term.of('{
                 println(s"sym6_1: ${ ${ x.asExpr.asInstanceOf[Expr[Int]] } }")
                 if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
                 then 0
                 else ${ Apply(Ref(sym6_2), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
               })
-            }
         }
       }),
       DefDef(sym6_2, {
         case List() => {
           case List(List(x)) =>
-            Some {
               Term.of('{
                 println(s"sym6_2: ${ ${ x.asExpr.asInstanceOf[Expr[Int]] } }")
                 if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
                 then 0
                 else ${ Apply(Ref(sym6_1), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
               })
-            }
         }
 
       }),
@@ -179,7 +172,7 @@ object Macros {
       DefDef(sym7, {
         case List(t) => {
           case List(List(x)) =>
-            Some(Typed(x, Inferred(t)))
+            Typed(x, Inferred(t))
         }
       }),
       Term.of('{ assert(${ Apply(TypeApply(Ref(sym7), List(Inferred(TypeRepr.of[Int]))), List(Literal(Constant.Int(7)))).asExpr.asInstanceOf[Expr[Int]] } == 7) }))

--- a/tests/run-macros/tasty-extractors-1.check
+++ b/tests/run-macros/tasty-extractors-1.check
@@ -1,120 +1,120 @@
-Inlined(None, Nil, Literal(Constant.Boolean(true)))
+Inlined(EmptyTree(), Nil, Literal(Constant.Boolean(true)))
 ConstantType(Constant.Boolean(true))
 
-Inlined(None, Nil, Literal(Constant.Int(1)))
+Inlined(EmptyTree(), Nil, Literal(Constant.Int(1)))
 ConstantType(Constant.Int(1))
 
-Inlined(None, Nil, Literal(Constant.Long(2L)))
+Inlined(EmptyTree(), Nil, Literal(Constant.Long(2L)))
 ConstantType(Constant.Long(2L))
 
-Inlined(None, Nil, Literal(Constant.Float(2.1f)))
+Inlined(EmptyTree(), Nil, Literal(Constant.Float(2.1f)))
 ConstantType(Constant.Float(2.1f))
 
-Inlined(None, Nil, Literal(Constant.Double(2.2d)))
+Inlined(EmptyTree(), Nil, Literal(Constant.Double(2.2d)))
 ConstantType(Constant.Double(2.2d))
 
-Inlined(None, Nil, Literal(Constant.String("abc")))
+Inlined(EmptyTree(), Nil, Literal(Constant.String("abc")))
 ConstantType(Constant.String("abc"))
 
-Inlined(None, Nil, Apply(Ident("println"), List(Literal(Constant.String("abc")))))
+Inlined(EmptyTree(), Nil, Apply(Ident("println"), List(Literal(Constant.String("abc")))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Typed(Literal(Constant.Int(8)), TypeIdent("Int")))
+Inlined(EmptyTree(), Nil, Typed(Literal(Constant.Int(8)), TypeIdent("Int")))
 TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")
 
-Inlined(None, Nil, Typed(Literal(Constant.Byte(8)), TypeIdent("Byte")))
+Inlined(EmptyTree(), Nil, Typed(Literal(Constant.Byte(8)), TypeIdent("Byte")))
 TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Byte")
 
-Inlined(None, Nil, Typed(Literal(Constant.Short(8)), TypeIdent("Short")))
+Inlined(EmptyTree(), Nil, Typed(Literal(Constant.Short(8)), TypeIdent("Short")))
 TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Short")
 
-Inlined(None, Nil, Literal(Constant.Char('a')))
+Inlined(EmptyTree(), Nil, Literal(Constant.Char('a')))
 ConstantType(Constant.Char('a'))
 
-Inlined(None, Nil, Block(List(Literal(Constant.Int(1)), Literal(Constant.Int(2))), Literal(Constant.Int(3))))
+Inlined(EmptyTree(), Nil, Block(List(Literal(Constant.Int(1)), Literal(Constant.Int(2))), Literal(Constant.Int(3))))
 ConstantType(Constant.Int(3))
 
-Inlined(None, Nil, If(Typed(Literal(Constant.Boolean(true)), TypeIdent("Boolean")), Literal(Constant.Int(1)), Literal(Constant.Int(2))))
+Inlined(EmptyTree(), Nil, If(Typed(Literal(Constant.Boolean(true)), TypeIdent("Boolean")), Literal(Constant.Int(1)), Literal(Constant.Int(2))))
 OrType(ConstantType(Constant.Int(1)), ConstantType(Constant.Int(2)))
 
-Inlined(None, Nil, Match(Literal(Constant.String("a")), List(CaseDef(Literal(Constant.String("a")), None, Block(Nil, Literal(Constant.Unit()))))))
+Inlined(EmptyTree(), Nil, Match(Literal(Constant.String("a")), List(CaseDef(Literal(Constant.String("a")), EmptyTree(), Block(Nil, Literal(Constant.Unit()))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Match(Literal(Constant.String("b")), List(CaseDef(Bind("n", Ident("_")), None, Block(Nil, Literal(Constant.Unit()))))))
+Inlined(EmptyTree(), Nil, Match(Literal(Constant.String("b")), List(CaseDef(Bind("n", Ident("_")), EmptyTree(), Block(Nil, Literal(Constant.Unit()))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Match(Literal(Constant.String("c")), List(CaseDef(Bind("n", Typed(Ident("_"), TypeIdent("String"))), None, Block(Nil, Literal(Constant.Unit()))))))
+Inlined(EmptyTree(), Nil, Match(Literal(Constant.String("c")), List(CaseDef(Bind("n", Typed(Ident("_"), TypeIdent("String"))), EmptyTree(), Block(Nil, Literal(Constant.Unit()))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Match(Literal(Constant.String("e")), List(CaseDef(Ident("_"), None, Block(Nil, Literal(Constant.Unit()))))))
+Inlined(EmptyTree(), Nil, Match(Literal(Constant.String("e")), List(CaseDef(Ident("_"), EmptyTree(), Block(Nil, Literal(Constant.Unit()))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Match(Literal(Constant.String("f")), List(CaseDef(Typed(Ident("_"), TypeIdent("String")), None, Block(Nil, Literal(Constant.Unit()))))))
+Inlined(EmptyTree(), Nil, Match(Literal(Constant.String("f")), List(CaseDef(Typed(Ident("_"), TypeIdent("String")), EmptyTree(), Block(Nil, Literal(Constant.Unit()))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Match(Typed(Literal(Constant.String("g")), TypeIdent("Any")), List(CaseDef(Alternative(List(Typed(Ident("_"), TypeIdent("String")), Typed(Ident("_"), TypeIdent("Int")))), None, Block(Nil, Literal(Constant.Unit()))))))
+Inlined(EmptyTree(), Nil, Match(Typed(Literal(Constant.String("g")), TypeIdent("Any")), List(CaseDef(Alternative(List(Typed(Ident("_"), TypeIdent("String")), Typed(Ident("_"), TypeIdent("Int")))), EmptyTree(), Block(Nil, Literal(Constant.Unit()))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Match(Literal(Constant.String("h")), List(CaseDef(Ident("_"), Some(Literal(Constant.Boolean(false))), Block(Nil, Literal(Constant.Unit()))))))
+Inlined(EmptyTree(), Nil, Match(Literal(Constant.String("h")), List(CaseDef(Ident("_"), Literal(Constant.Boolean(false)), Block(Nil, Literal(Constant.Unit()))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ValDef("a", Inferred(), Some(Literal(Constant.String("o"))))), Match(Literal(Constant.String("i")), List(CaseDef(Bind("a", Ident("_")), None, Block(Nil, Literal(Constant.Unit())))))))
+Inlined(EmptyTree(), Nil, Block(List(ValDef("a", Inferred(), Literal(Constant.String("o")))), Match(Literal(Constant.String("i")), List(CaseDef(Bind("a", Ident("_")), EmptyTree(), Block(Nil, Literal(Constant.Unit())))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Match(Ident("Nil"), List(CaseDef(Unapply(TypeApply(Select(Ident("List"), "unapplySeq"), List(Inferred())), Nil, List(Bind("a", Ident("_")), Bind("b", Ident("_")), Bind("c", Ident("_")))), None, Block(Nil, Literal(Constant.Unit()))))))
+Inlined(EmptyTree(), Nil, Match(Ident("Nil"), List(CaseDef(Unapply(TypeApply(Select(Ident("List"), "unapplySeq"), List(Inferred())), Nil, List(Bind("a", Ident("_")), Bind("b", Ident("_")), Bind("c", Ident("_")))), EmptyTree(), Block(Nil, Literal(Constant.Unit()))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Try(Literal(Constant.Int(1)), List(CaseDef(Ident("_"), None, Block(Nil, Literal(Constant.Unit())))), None))
+Inlined(EmptyTree(), Nil, Try(Literal(Constant.Int(1)), List(CaseDef(Ident("_"), EmptyTree(), Block(Nil, Literal(Constant.Unit())))), EmptyTree()))
 OrType(ConstantType(Constant.Int(1)), TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit"))
 
-Inlined(None, Nil, Try(Literal(Constant.Int(2)), Nil, Some(Literal(Constant.Unit()))))
+Inlined(EmptyTree(), Nil, Try(Literal(Constant.Int(2)), Nil, Literal(Constant.Unit())))
 ConstantType(Constant.Int(2))
 
-Inlined(None, Nil, Try(Literal(Constant.Int(3)), List(CaseDef(Ident("_"), None, Block(Nil, Literal(Constant.Unit())))), Some(Literal(Constant.Unit()))))
+Inlined(EmptyTree(), Nil, Try(Literal(Constant.Int(3)), List(CaseDef(Ident("_"), EmptyTree(), Block(Nil, Literal(Constant.Unit())))), Literal(Constant.Unit())))
 OrType(ConstantType(Constant.Int(3)), TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit"))
 
-Inlined(None, Nil, Apply(Select(Literal(Constant.String("a")), "=="), List(Literal(Constant.String("b")))))
+Inlined(EmptyTree(), Nil, Apply(Select(Literal(Constant.String("a")), "=="), List(Literal(Constant.String("b")))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Boolean")
 
-Inlined(None, Nil, Apply(Select(New(TypeIdent("Object")), "<init>"), Nil))
+Inlined(EmptyTree(), Nil, Apply(Select(New(TypeIdent("Object")), "<init>"), Nil))
 TypeRef(ThisType(TypeRef(NoPrefix(), "lang")), "Object")
 
-Inlined(None, Nil, Apply(Select(Ident("Int"), "box"), List(NamedArg("x", Literal(Constant.Int(9))))))
+Inlined(EmptyTree(), Nil, Apply(Select(Ident("Int"), "box"), List(NamedArg("x", Literal(Constant.Int(9))))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "lang")), "Integer")
 
-Inlined(None, Nil, Apply(TypeApply(Select(Ident("Ordering"), "apply"), List(TypeIdent("Int"))), List(Ident("Int"))))
+Inlined(EmptyTree(), Nil, Apply(TypeApply(Select(Ident("Ordering"), "apply"), List(TypeIdent("Int"))), List(Ident("Int"))))
 AppliedType(TypeRef(ThisType(TypeRef(NoPrefix(), "math")), "Ordering"), List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")))
 
-Inlined(None, Nil, Block(List(ValDef("a", TypeIdent("Int"), Some(Literal(Constant.Int(3))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ValDef("a", TypeIdent("Int"), Literal(Constant.Int(3)))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ValDef("b", TypeIdent("Int"), Some(Literal(Constant.Int(3))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ValDef("b", TypeIdent("Int"), Literal(Constant.Int(3)))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f1", Nil, Nil, TypeIdent("Int"), Some(Literal(Constant.Int(3))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f1", Nil, Nil, TypeIdent("Int"), Literal(Constant.Int(3)))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f2", Nil, Nil, TypeIdent("Int"), Some(Return(Literal(Constant.Int(4)), IsDefDefSymbol(<Test$._$_$f2>))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f2", Nil, Nil, TypeIdent("Int"), Return(Literal(Constant.Int(4)), IsDefDefSymbol(<Test$._$_$f2>)))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f3", Nil, List(List(ValDef("i", TypeIdent("Int"), None))), TypeIdent("Int"), Some(Ident("i")))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f3", Nil, List(List(ValDef("i", TypeIdent("Int"), EmptyTree()))), TypeIdent("Int"), Ident("i"))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f4", Nil, List(List(ValDef("i", TypeIdent("Int"), None)), List(ValDef("j", TypeIdent("Int"), None))), TypeIdent("Int"), Some(Apply(Select(Ident("i"), "+"), List(Ident("j")))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f4", Nil, List(List(ValDef("i", TypeIdent("Int"), EmptyTree())), List(ValDef("j", TypeIdent("Int"), EmptyTree()))), TypeIdent("Int"), Apply(Select(Ident("i"), "+"), List(Ident("j"))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f5", Nil, List(List(ValDef("i", TypeIdent("Int"), None))), TypeIdent("Int"), Some(Ident("i"))), DefDef("f5$default$1", Nil, Nil, Inferred(), Some(Literal(Constant.Int(9))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f5", Nil, List(List(ValDef("i", TypeIdent("Int"), EmptyTree()))), TypeIdent("Int"), Ident("i")), DefDef("f5$default$1", Nil, Nil, Inferred(), Literal(Constant.Int(9)))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f6", List(TypeDef("T", TypeBoundsTree(Inferred(), Inferred()))), List(List(ValDef("x", TypeIdent("T"), None))), TypeIdent("T"), Some(Ident("x")))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f6", List(TypeDef("T", TypeBoundsTree(Inferred(), Inferred()))), List(List(ValDef("x", TypeIdent("T"), EmptyTree()))), TypeIdent("T"), Ident("x"))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f7", List(TypeDef("T", TypeBoundsTree(Inferred(), Inferred()))), List(List(ValDef("x", TypeIdent("T"), None))), Singleton(Ident("x")), Some(Ident("x")))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f7", List(TypeDef("T", TypeBoundsTree(Inferred(), Inferred()))), List(List(ValDef("x", TypeIdent("T"), EmptyTree()))), Singleton(Ident("x")), Ident("x"))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f8", Nil, List(List(ValDef("i", Annotated(Applied(Inferred(), List(TypeIdent("Int"))), Apply(Select(New(Inferred()), "<init>"), Nil)), None))), TypeIdent("Int"), Some(Literal(Constant.Int(9))))), Apply(Ident("f8"), List(Typed(Repeated(List(Literal(Constant.Int(1)), Literal(Constant.Int(2)), Literal(Constant.Int(3))), Inferred()), Inferred())))))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f8", Nil, List(List(ValDef("i", Annotated(Applied(Inferred(), List(TypeIdent("Int"))), Apply(Select(New(Inferred()), "<init>"), Nil)), EmptyTree()))), TypeIdent("Int"), Literal(Constant.Int(9)))), Apply(Ident("f8"), List(Typed(Repeated(List(Literal(Constant.Int(1)), Literal(Constant.Int(2)), Literal(Constant.Int(3))), Inferred()), Inferred())))))
 TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")
 
-Inlined(None, Nil, Block(List(DefDef("f9", Nil, List(List(ValDef("i", ByName(TypeIdent("Int")), None))), TypeIdent("Int"), Some(Ident("i")))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("f9", Nil, List(List(ValDef("i", ByName(TypeIdent("Int")), EmptyTree()))), TypeIdent("Int"), Ident("i"))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 

--- a/tests/run-macros/tasty-extractors-2.check
+++ b/tests/run-macros/tasty-extractors-2.check
@@ -1,105 +1,105 @@
-Inlined(None, Nil, Block(List(ValDef("x", Inferred(), Some(Literal(Constant.Int(1))))), Assign(Ident("x"), Literal(Constant.Int(2)))))
+Inlined(EmptyTree(), Nil, Block(List(ValDef("x", Inferred(), Literal(Constant.Int(1)))), Assign(Ident("x"), Literal(Constant.Int(2)))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("$anonfun", Nil, List(List(ValDef("x", TypeIdent("Int"), None))), Inferred(), Some(Ident("x")))), Closure(Ident("$anonfun"), None)))
+Inlined(EmptyTree(), Nil, Block(List(DefDef("$anonfun", Nil, List(List(ValDef("x", TypeIdent("Int"), EmptyTree()))), Inferred(), Ident("x"))), Closure(Ident("$anonfun"), None)))
 AppliedType(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Function1"), List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int"), TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")))
 
-Inlined(None, Nil, Ident("???"))
+Inlined(EmptyTree(), Nil, Ident("???"))
 TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "scala")), "Predef"), "???")
 
-Inlined(None, Nil, Literal(Constant.Int(1)))
+Inlined(EmptyTree(), Nil, Literal(Constant.Int(1)))
 ConstantType(Constant.Int(1))
 
-Inlined(None, Nil, Typed(Literal(Constant.Int(1)), TypeIdent("Int")))
+Inlined(EmptyTree(), Nil, Typed(Literal(Constant.Int(1)), TypeIdent("Int")))
 TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")
 
-Inlined(None, Nil, Typed(Ident("Nil"), Applied(TypeIdent("List"), List(TypeIdent("Int")))))
+Inlined(EmptyTree(), Nil, Typed(Ident("Nil"), Applied(TypeIdent("List"), List(TypeIdent("Int")))))
 AppliedType(TypeRef(ThisType(TypeRef(NoPrefix(), "immutable")), "List"), List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")))
 
-Inlined(None, Nil, Typed(Apply(Select(New(TypeIdent("Baz")), "<init>"), Nil), Applied(TypeIdent("&"), List(TypeIdent("Foo"), TypeIdent("Bar")))))
+Inlined(EmptyTree(), Nil, Typed(Apply(Select(New(TypeIdent("Baz")), "<init>"), Nil), Applied(TypeIdent("&"), List(TypeIdent("Foo"), TypeIdent("Bar")))))
 AndType(TypeRef(ThisType(TypeRef(NoPrefix(), "<empty>")), "Foo"), TypeRef(ThisType(TypeRef(NoPrefix(), "<empty>")), "Bar"))
 
-Inlined(None, Nil, Typed(Literal(Constant.Int(1)), Applied(TypeIdent("|"), List(TypeIdent("Int"), TypeIdent("String")))))
+Inlined(EmptyTree(), Nil, Typed(Literal(Constant.Int(1)), Applied(TypeIdent("|"), List(TypeIdent("Int"), TypeIdent("String")))))
 OrType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int"), TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "scala")), "Predef"), "String"))
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, Nil)), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, Nil)), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ValDef("Foo", TypeIdent("Foo$"), Some(Apply(Select(New(TypeIdent("Foo$")), "<init>"), Nil))), ClassDef("Foo$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo")), None)), Nil)), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ValDef("Foo", TypeIdent("Foo$"), Apply(Select(New(TypeIdent("Foo$")), "<init>"), Nil)), ClassDef("Foo$", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo")), EmptyTree())), Nil)), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(TypeDef("Foo", TypeBoundsTree(Inferred(), Inferred()))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(TypeDef("Foo", TypeBoundsTree(Inferred(), Inferred()))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(TypeDef("Foo", TypeIdent("Int"))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(TypeDef("Foo", TypeIdent("Int"))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(TypeDef("Foo", TypeBoundsTree(TypeIdent("Null"), TypeIdent("Object")))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(TypeDef("Foo", TypeBoundsTree(TypeIdent("Null"), TypeIdent("Object")))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(Constant.Int(0)))), DefDef("a_=", Nil, List(List(ValDef("x$1", Inferred(), None))), Inferred(), Some(Literal(Constant.Unit())))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Literal(Constant.Int(0))), DefDef("a_=", Nil, List(List(ValDef("x$1", Inferred(), EmptyTree()))), Inferred(), Literal(Constant.Unit()))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Some(Literal(Constant.Int(0))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Literal(Constant.Int(0)))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Some(Literal(Constant.Int(0))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Literal(Constant.Int(0)))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Some(Literal(Constant.Int(0))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Literal(Constant.Int(0)))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil), TypeSelect(Select(Ident("_root_"), "scala"), "Product"), TypeSelect(Select(Ident("_root_"), "scala"), "Serializable")), Nil, None, List(DefDef("copy", Nil, List(Nil), Inferred(), Some(Apply(Select(New(Inferred()), "<init>"), Nil))))), ValDef("Foo", TypeIdent("Foo$"), Some(Apply(Select(New(TypeIdent("Foo$")), "<init>"), Nil))), ClassDef("Foo$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil), Applied(Inferred(), List(Inferred()))), Nil, Some(ValDef("_", Singleton(Ident("Foo")), None)), List(DefDef("apply", Nil, List(Nil), Inferred(), Some(Apply(Select(New(Inferred()), "<init>"), Nil))), DefDef("unapply", Nil, List(List(ValDef("x$1", Inferred(), None))), Singleton(Literal(Constant.Boolean(true))), Some(Literal(Constant.Boolean(true)))), DefDef("toString", Nil, Nil, Inferred(), Some(Literal(Constant.String("Foo"))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil), TypeSelect(Select(Ident("_root_"), "scala"), "Product"), TypeSelect(Select(Ident("_root_"), "scala"), "Serializable")), Nil, None, List(DefDef("copy", Nil, List(Nil), Inferred(), Apply(Select(New(Inferred()), "<init>"), Nil)))), ValDef("Foo", TypeIdent("Foo$"), Apply(Select(New(TypeIdent("Foo$")), "<init>"), Nil)), ClassDef("Foo$", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil), Applied(Inferred(), List(Inferred()))), Nil, Some(ValDef("_", Singleton(Ident("Foo")), EmptyTree())), List(DefDef("apply", Nil, List(Nil), Inferred(), Apply(Select(New(Inferred()), "<init>"), Nil)), DefDef("unapply", Nil, List(List(ValDef("x$1", Inferred(), EmptyTree()))), Singleton(Literal(Constant.Boolean(true))), Literal(Constant.Boolean(true))), DefDef("toString", Nil, Nil, Inferred(), Literal(Constant.String("Foo")))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo1", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None)))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo1", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), EmptyTree()))), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), EmptyTree())))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo2", DefDef("<init>", Nil, List(List(ValDef("b", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("b", Inferred(), None)))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo2", DefDef("<init>", Nil, List(List(ValDef("b", TypeIdent("Int"), EmptyTree()))), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("b", Inferred(), EmptyTree())))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo3", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None))), ValDef("Foo3", TypeIdent("Foo3$"), Some(Apply(Select(New(TypeIdent("Foo3$")), "<init>"), Nil))), ClassDef("Foo3$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo3")), None)), List(DefDef("$lessinit$greater$default$1", Nil, Nil, Inferred(), Some(Literal(Constant.Int(5))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo3", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), EmptyTree()))), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), EmptyTree()))), ValDef("Foo3", TypeIdent("Foo3$"), Apply(Select(New(TypeIdent("Foo3$")), "<init>"), Nil)), ClassDef("Foo3$", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo3")), EmptyTree())), List(DefDef("$lessinit$greater$default$1", Nil, Nil, Inferred(), Literal(Constant.Int(5)))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo4", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None)), List(ValDef("b", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None)))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo4", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), EmptyTree())), List(ValDef("b", TypeIdent("Int"), EmptyTree()))), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), EmptyTree()), ValDef("b", Inferred(), EmptyTree())))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo5", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None)), List(ValDef("b", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None))), ValDef("Foo5", TypeIdent("Foo5$"), Some(Apply(Select(New(TypeIdent("Foo5$")), "<init>"), Nil))), ClassDef("Foo5$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo5")), None)), List(DefDef("$lessinit$greater$default$2", Nil, List(List(ValDef("a", TypeIdent("Int"), None))), Inferred(), Some(Ident("a")))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo5", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), EmptyTree())), List(ValDef("b", TypeIdent("Int"), EmptyTree()))), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), EmptyTree()), ValDef("b", Inferred(), EmptyTree()))), ValDef("Foo5", TypeIdent("Foo5$"), Apply(Select(New(TypeIdent("Foo5$")), "<init>"), Nil)), ClassDef("Foo5$", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo5")), EmptyTree())), List(DefDef("$lessinit$greater$default$2", Nil, List(List(ValDef("a", TypeIdent("Int"), EmptyTree()))), Inferred(), Ident("a"))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo6", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None)), List(ValDef("b", Singleton(Ident("a")), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None)))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo6", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), EmptyTree())), List(ValDef("b", Singleton(Ident("a")), EmptyTree()))), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), EmptyTree()), ValDef("b", Inferred(), EmptyTree())))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo7", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), DefDef("<init>", Nil, List(Nil), Inferred(), Some(Block(List(Apply(Select(This(Some("Foo7")), "<init>"), List(Literal(Constant.Int(6))))), Literal(Constant.Unit()))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo7", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), EmptyTree()))), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), EmptyTree()), DefDef("<init>", Nil, List(Nil), Inferred(), Block(List(Apply(Select(This(Some("Foo7")), "<init>"), List(Literal(Constant.Int(6))))), Literal(Constant.Unit())))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo8", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(Apply(Ident("println"), List(Literal(Constant.Int(0))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo8", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(Apply(Ident("println"), List(Literal(Constant.Int(0))))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo10", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(Constant.Int(9))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo10", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Literal(Constant.Int(9)))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo11", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(Constant.Int(10)))), DefDef("a_=", Nil, List(List(ValDef("x$1", Inferred(), None))), Inferred(), Some(Literal(Constant.Unit())))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo11", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Literal(Constant.Int(10))), DefDef("a_=", Nil, List(List(ValDef("x$1", Inferred(), EmptyTree()))), Inferred(), Literal(Constant.Unit()))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo12", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(Constant.Int(11))))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo12", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Literal(Constant.Int(11)))))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, Nil), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(TypeIdent("Foo")), "<init>"), Nil)), Nil, None, Nil)), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, Nil), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(TypeIdent("Foo")), "<init>"), Nil)), Nil, None, Nil)), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo2", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Inferred()), Nil, None, Nil), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil), TypeIdent("Foo2")), Nil, None, Nil)), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo2", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Inferred()), Nil, None, Nil), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil), TypeIdent("Foo2")), Nil, None, Nil)), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(List(ValDef("i", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("i", Inferred(), None))), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(TypeIdent("Foo")), "<init>"), List(Literal(Constant.Int(1))))), Nil, None, Nil)), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(List(ValDef("i", TypeIdent("Int"), EmptyTree()))), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("i", Inferred(), EmptyTree()))), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(TypeIdent("Foo")), "<init>"), List(Literal(Constant.Int(1))))), Nil, None, Nil)), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(TypeDef("X", TypeIdent("Int")))), DefDef("f", Nil, List(List(ValDef("a", TypeIdent("Foo"), None))), TypeSelect(Ident("a"), "X"), Some(Ident("???")))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(TypeDef("X", TypeIdent("Int")))), DefDef("f", Nil, List(List(ValDef("a", TypeIdent("Foo"), EmptyTree()))), TypeSelect(Ident("a"), "X"), Ident("???"))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(TypeDef("X", TypeBoundsTree(Inferred(), Inferred())))), DefDef("f", Nil, List(List(ValDef("a", Refined(TypeIdent("Foo"), List(TypeDef("X", TypeIdent("Int")))), None))), TypeSelect(Ident("a"), "X"), Some(Ident("???")))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), EmptyTree()), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(TypeDef("X", TypeBoundsTree(Inferred(), Inferred())))), DefDef("f", Nil, List(List(ValDef("a", Refined(TypeIdent("Foo"), List(TypeDef("X", TypeIdent("Int")))), EmptyTree()))), TypeSelect(Ident("a"), "X"), Ident("???"))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ValDef("lambda", Applied(Inferred(), List(TypeIdent("Int"), TypeIdent("Int"))), Some(Block(List(DefDef("$anonfun", Nil, List(List(ValDef("x", Inferred(), None))), Inferred(), Some(Ident("x")))), Closure(Ident("$anonfun"), None))))), Literal(Constant.Unit())))
+Inlined(EmptyTree(), Nil, Block(List(ValDef("lambda", Applied(Inferred(), List(TypeIdent("Int"), TypeIdent("Int"))), Block(List(DefDef("$anonfun", Nil, List(List(ValDef("x", Inferred(), EmptyTree()))), Inferred(), Ident("x"))), Closure(Ident("$anonfun"), None)))), Literal(Constant.Unit())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 


### PR DESCRIPTION
* Add `EmptyTree`
* Add `Tree.{isEmpty, nonEmpty}`
* Remove `Option` boxing in API
* Make it simpler to evolve the API a new language feature uses empty trees where they were not expected before