### PR TITLE
fixed relativePath on Windows

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -343,7 +343,12 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
               val jpath = file.jpath
               val relativePath =
                 if jpath eq null then file.path // repl and other custom tests use abstract files with no path
-                else if jpath.isAbsolute then sourcerootPath.relativize(jpath.normalize).toString
+                else if jpath.isAbsolute then
+                  val cunitPath = jpath.normalize
+                  // On Windows we can only relativize paths if root component matches
+                  // (see implementation of sun.nio.fs.WindowsPath#relativize)
+                  try sourcerootPath.relativize(cunitPath).toString
+                  catch case _: IllegalArgumentException => cunitPath.toString
                 else jpath.normalize.toString
               sym.addAnnotation(Annotation.makeSourceFile(relativePath))
           else (tree.rhs, sym.info) match


### PR DESCRIPTION
The following tests currently fail on Windows with error `java.lang.IllegalArgumentException: 'other' has different root` if the drive letter of project directory is not `C:` :
```
[error]         dotty.tools.dottydoc.ConstructorsFromTastyTest
[error]         dotty.tools.dottydoc.SimpleCommentsFromTastyTest
[error]         dotty.tools.dottydoc.PackageStructureFromTastyTest
[error]         dotty.tools.dottydoc.UsecaseFromTastyTest
[error]         dotty.tools.dotc.core.tasty.CommentPicklingTest
```
The error messages look as follows:
```
[...]
[info] Test dotty.tools.dotc.core.tasty.CommentPicklingTest.commentOnClass started
java.lang.IllegalArgumentException: 'other' has different root while compiling C:\Users\michelou\AppData\Local\Temp\temp10392587893749294106\Src0.scala
[error] Test dotty.tools.dotc.core.tasty.CommentPicklingTest.commentOnClass failed: java.lang.IllegalArgumentException: 'other' has different root, took 0.047 sec
[error]     at sun.nio.fs.WindowsPath.relativize(WindowsPath.java:404)
[error]     at sun.nio.fs.WindowsPath.relativize(WindowsPath.java:42)
[error]     at dotty.tools.dotc.transform.PostTyper$PostTyperTransformer.transform(PostTyper.scala:347)
java.lang.IllegalArgumentException: 'other' has different root while compiling C:\Users\michelou\AppData\Local\Temp\temp148039820[error]     at dotty.tools.dotc.ast.Trees$Instance$TreeMap.transform$$anonfun$2(Trees.scala:1369)
82953363845\Src0.scala
[error]     at scala.collection.immutable.List.mapConserve(List.scala:472)
[error]     at dotty.tools.dotc.ast.Trees$Instance$TreeMap.transform(Trees.scala:1369)
[error]     at dotty.tools.dotc.ast.Trees$Instance$TreeMap.transformStats(Trees.scala:1367)
java.lang.IllegalArgumentException: 'other' has different root while compiling C:\Users\michelou\AppData\Local\Temp\temp167319318[error]     at dotty.tools.dotc.ast.Trees$Instance$TreeMap.transform(Trees.scala:1354)
01680058344\Src0.scala
[error]     at dotty.tools.dotc.transform.MacroTransform$Transformer.transform(MacroTransform.scala:54)
[error]     at dotty.tools.dotc.transform.PostTyper$PostTyperTransformer.transform(PostTyper.scala:419)
java.lang.IllegalArgumentException: 'other' has different root while compiling C:\Users\michelou\AppData\Local\Temp\temp205718549[error]     at dotty.tools.dotc.transform.MacroTransform.run(MacroTransform.scala:21)
2628177812\Src0.scala
[error]     at dotty.tools.dotc.core.Phases$Phase.runOn$$anonfun$1(Phases.scala:296)
[error]     at scala.collection.immutable.List.map(List.scala:246)
[error]     at dotty.tools.dotc.core.Phases$Phase.runOn(Phases.scala:297)
[error]     at dotty.tools.dotc.Run.runPhases$4$$anonfun$4(Run.scala:185)
[error]     at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
java.lang.IllegalArgumentException: 'other' has different root while compiling C:\Users\michelou\AppData\Local\Temp\temp873410303[error]     at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
5862574123\Src0.scala
[error]     at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
[error]     at dotty.tools.dotc.Run.runPhases$5(Run.scala:195)
[error]     at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:203)
[error]     at dotty.runtime.function.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
java.lang.IllegalArgumentException: 'other' has different root while compiling C:\Users\michelou\AppData\Local\Temp\temp177421563[error]     at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:67)
61800965759\Src0.scala
[error]     at dotty.tools.dotc.Run.compileUnits(Run.scala:210)
[error]     at dotty.tools.dotc.Run.compileSources(Run.scala:147)
[error]     at dotty.tools.dotc.Run.compile(Run.scala:129)
[error]     at dotty.tools.dotc.Driver.doCompile(Driver.scala:38)
[error]     at dotty.tools.dotc.Driver.process(Driver.scala:195)
[error]     at dotty.tools.dotc.Driver.process(Driver.scala:164)
java.lang.IllegalArgumentException: 'other' has different root while compiling C:\Users\michelou\AppData\Local\Temp\temp949694445[error]     at dotty.tools.dotc.core.tasty.CommentPicklingTest.compileAndUnpickle$$anonfun$1(CommentPicklingTest.scala:95)
030893565\Src0.scala
[error]     at dotty.tools.io.Directory$.inTempDirectory(Directory.scala:26)
[error]     at dotty.tools.dotc.core.tasty.CommentPicklingTest.compileAndUnpickle(CommentPicklingTest.scala:103)
[error]     at dotty.tools.dotc.core.tasty.CommentPicklingTest.compileAndCheckComment(CommentPicklingTest.scala:70)
[error]     at dotty.tools.dotc.core.tasty.CommentPicklingTest.commentOnClass(CommentPicklingTest.scala:47)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]     at java.lang.reflect.Method.invoke(Method.java:566)
[error]     ...
[info] Test dotty.tools.dotc.core.tasty.CommentPicklingTest.commentOnObject started
[error] Test dotty.tools.dotc.core.tasty.CommentPicklingTest.commentOnObject failed: java.lang.IllegalArgumentException: 'other' has different root, took 0.053 sec
[error]     at sun.nio.fs.WindowsPath.relativize(WindowsPath.java:404)
[error]     at sun.nio.fs.WindowsPath.relativize(WindowsPath.java:42)
[error]     at dotty.tools.dotc.transform.PostTyper$PostTyperTransformer.transform(PostTyper.scala:347)
[...]
```
This is a well-known ***implementation dependent*** issue reported in several forums (e.g. [Overflow](https://stackoverflow.com/questions/16299604/creating-a-path-between-two-paths-in-java-using-the-path-class/38169064), [CodeRanch](https://coderanch.com/t/662938/certification/relativize-implementation-dependent-Paths-root)) : on Unix file systems root is always `/` while on Windows there may be more than one root (in my case drive letters `C:` and `W:`).

**PS.** See also JDK 8 source code for [WindowsPath#relativize](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/7534523b4174/src/windows/classes/sun/nio/fs/WindowsPath.java).