### PR TITLE
Redner version below name and logo

### DIFF
--- a/scala3doc/src/dotty/renderers/ScalaHtmlRenderer.scala
+++ b/scala3doc/src/dotty/renderers/ScalaHtmlRenderer.scala
@@ -295,7 +295,9 @@ class ScalaHtmlRenderer(ctx: DokkaContext, args: Args) extends HtmlRenderer(ctx)
               div(id := "logo")(
                 projectLogo,
                 span(
-                  div(cls:="projectName")(args.name),
+                  div(cls:="projectName")(args.name)
+                ),
+                span(
                   args.projectVersion.map(v => div(cls:="projectVersion")(v)).toList
                 )
               ),


### PR DESCRIPTION
@TheElectronWill this is probably beyond my css skills so we need to have some css magic to render logo below project name if version is short and below image as well if it is longer.

Or some other, better. solution