### PR TITLE
Make sure that we handle relative link correctly

### DIFF
--- a/docs/blog/_posts/2017-07-12-second-dotty-milestone-release.md
+++ b/docs/blog/_posts/2017-07-12-second-dotty-milestone-release.md
@@ -10,7 +10,7 @@ Today, we are excited to release Dotty version 0.2.0-RC1. This release
 serves as a technology preview that demonstrates new language features
 and the compiler supporting them.
 
-This release is based on the [previous milestone](/blog/2017/05/31/first-dotty-milestone-release.html).
+This release is based on the [previous milestone](/blog/_posts/2017-05-31-first-dotty-milestone-release.html).
 The highlights of this release are:
  - substantial improvement of quality of generated code for pattern matching
  - improvements in VS Code IDE stability
@@ -24,7 +24,7 @@ The highlights of this release are:
 This is our second scheduled release according to our [6-week release schedule](https://dotty.epfl.ch/docs/usage/version-numbers.html).
 
 ## What’s in the 0.2.0-RC1 technology preview?
-The [previous technology preview](/blog/2017/05/31/first-dotty-milestone-release.html) has shipped new language features planned for Scala 3:
+The [previous technology preview](/blog/_posts/2017-05-31-first-dotty-milestone-release.html) has shipped new language features planned for Scala 3:
 [Intersection Types](https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html),
 [Union Types](https://dotty.epfl.ch/docs/reference/new-types/union-types.html),
 [Trait Parameters](https://dotty.epfl.ch/docs/reference/other-new-features/trait-parameters.html),

--- a/docs/blog/_posts/2017-09-07-third-dotty-milestone-release.md
+++ b/docs/blog/_posts/2017-09-07-third-dotty-milestone-release.md
@@ -20,7 +20,7 @@ You can learn more about Dotty on our [website](http://dotty.epfl.ch).
 <!--more-->
 
 This is our third scheduled release according to our [6-week release schedule](https://dotty.epfl.ch/docs/usage/version-numbers.html).
-The [previous technology preview](/blog/2017/07/12/second-dotty-milestone-release.html) improved
+The [previous technology preview](/blog/_posts/2017-07-12-second-dotty-milestone-release.html) improved
 stability and reliability:
 
  - substantial improvement of quality of generated code for pattern matching

--- a/docs/blog/_posts/2017-10-16-fourth-dotty-milestone-release.md
+++ b/docs/blog/_posts/2017-10-16-fourth-dotty-milestone-release.md
@@ -20,7 +20,7 @@ You can learn more about Dotty on our [website](http://dotty.epfl.ch).
 <!--more-->
 
 This is our fourth scheduled release according to our [6-week release schedule](https://dotty.epfl.ch/docs/usage/version-numbers.html).
-The [previous technology preview](/blog/2017/09/07/third-dotty-milestone-release.html) improved
+The [previous technology preview](/blog/_posts/2017-09-07-third-dotty-milestone-release.html) improved
 stability and reliability.
 
 ## What’s new in the 0.4.0-RC1 technology preview?

--- a/docs/blog/_posts/2017-12-01-fifth-dotty-milestone-release.md
+++ b/docs/blog/_posts/2017-12-01-fifth-dotty-milestone-release.md
@@ -20,7 +20,7 @@ You can learn more about Dotty on our [website](http://dotty.epfl.ch).
 <!--more-->
 
 This is our fifth scheduled release according to our [6-week release schedule](https://dotty.epfl.ch/docs/usage/version-numbers.html).
-The [previous technology preview](/blog/2017/10/16/fourth-dotty-milestone-release.html) added
+The [previous technology preview](/blog/_posts/2017-10-16-fourth-dotty-milestone-release.html) added
 support for Scala 2.12 and came with a brand new REPL.
 
 ## What’s new in the 0.5.0-RC1 technology preview?

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -155,7 +155,7 @@ map into `case class`es or `val`s.
    case C(ps) extends P1, ..., Pn
    ```
    are treated specially. A call `C(ts)` of the apply method is ascribed the underlying type
-   `P1 & ... & Pn` (dropping any [super traits](../other-new-features/super-traits.html))
+   `P1 & ... & Pn` (dropping any [super traits](../other-new-features/mixin-traits.md))
    as long as that type is still compatible with the expected type at the point of application.
    A call `t.copy(ts)` of `C`'s `copy` method is treated in the same way.
 

--- a/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
@@ -146,10 +146,14 @@ class StaticSiteContext(val root: File, sourceSets: Set[SourceSetWrapper], val a
 
   def driForLink(template: TemplateFile, link: String): Option[DRI] =
     val pathDri = Try {
-      val path =
+      val baseFile =
         if link.startsWith("/") then root.toPath.resolve(link.drop(1))
-        else template.file.toPath.getParent().resolve(link)
-      if Files.exists(path) then Some(driFor(path)) else None
+        else template.file.toPath.getParent().resolve(link).normalize()
+
+      val baseFileName = baseFile.getFileName.toString
+      val mdFile = baseFile.resolveSibling(baseFileName.stripSuffix(".html") + ".md")
+
+      Seq(baseFile, mdFile).find(Files.exists(_)).map(driFor)
     }.toOption.flatten
     pathDri.orElse(memberLinkResolver(link))
 

--- a/scala3doc/src/dotty/renderers/ScalaHtmlRenderer.scala
+++ b/scala3doc/src/dotty/renderers/ScalaHtmlRenderer.scala
@@ -245,6 +245,8 @@ class ScalaHtmlRenderer(ctx: DokkaContext, args: Args) extends HtmlRenderer(ctx)
       ).toString()
     )
 
+  private val HashRegex = "([^#]+)(#.+)".r
+
   override def buildPageContent(context: FlowContent, page: ContentPage): Unit =
     page match
       case s: StaticPageNode if !s.hasFrame() =>
@@ -252,13 +254,23 @@ class ScalaHtmlRenderer(ctx: DokkaContext, args: Args) extends HtmlRenderer(ctx)
 
     page.getContent match
       case prc: PartiallyRenderedContent =>
+        def tryAsDri(str: String) =
+          val (path, prefix) = str match
+            case HashRegex(path, prefix) => (path, prefix)
+            case _ => (str, "")
+
+          // TODO (https://github.com/lampepfl/scala3doc/issues/238) proper warnings about unresolved links
+          prc.context.driForLink(prc.template.templateFile, path)
+            .flatMap(dri => Option(getLocationProvider.resolve(dri, sourceSets, page)))
+            .map(_ + prefix)
+            .getOrElse {
+              println(s"[WARN] ${prc.template.file}: Unable to resolve link '$str'")
+              str
+            }
+
         def processLocalLink(str: String): String =
-          Try(URL(str)).map(_ => str).getOrElse{
-          // TODO (https://github.com/lampepfl/scala3doc/issues/238) error handling
-            prc.context.driForLink(prc.template.templateFile, str)
-              .flatMap(dri => Option(getLocationProvider.resolve(dri, sourceSets, page)))
-              .getOrElse(str)
-          }
+          if str.startsWith("#") || str.isEmpty then str
+          else Try(URL(str)).map(_ => str).getOrElse(tryAsDri(str))
 
         val html = prc.procsesHtml(processLocalLink, resolveLink(page))
         withHtml(context, html)


### PR DESCRIPTION
Add better warning message in case of missing link.

We still are missing some links:
```
[WARN] /home/krzysiek/workspace/dotty/scala3doc/scala3-docs/index.html: Unable to resolve link 'blog/index.html' <- this is false positive
[WARN] /home/krzysiek/workspace/dotty/scala3doc/scala3-docs/index.html: Unable to resolve link 'docs/index.html' <- this is false positive
[WARN] /home/krzysiek/workspace/dotty/scala3doc/scala3-docs/docs/release-notes/0.1.2.md: Unable to resolve link '../reference/contextual/implicit-function-types.html'
[WARN] /home/krzysiek/workspace/dotty/scala3doc/scala3-docs/docs/reference/features-classification.md: Unable to resolve link 'contextual/delegates.md'
[WARN] /home/krzysiek/workspace/dotty/scala3doc/scala3-docs/docs/reference/features-classification.md: Unable to resolve link 'contextual/given-clauses.md'
```

@b-studios we probably should sort out that paths during documentation migration