### PR TITLE
Change style of scala doc to fit docs.scala-lang

### DIFF
--- a/scala3doc/resources/dotty_res/styles/scalastyle.css
+++ b/scala3doc/resources/dotty_res/styles/scalastyle.css
@@ -61,10 +61,13 @@ body {
 main {
   min-height: calc(100vh - var(--footer-height) - 24px);
 }
-#content {
-  margin-left: var(--side-width);
-  padding: var(--content-padding);
-  padding-bottom: calc(24px + var(--footer-height));
+@media(min-width: 576px) {
+
+  #content {
+    margin-left: var(--side-width);
+    padding: var(--content-padding);
+    padding-bottom: calc(24px + var(--footer-height));
+  }
 }
 
 /* Text */

--- a/scala3doc/scala3-docs/_layouts/doc-page.html
+++ b/scala3doc/scala3-docs/_layouts/doc-page.html
@@ -1,15 +1,29 @@
 ---
 layout: main
 ---
-<main class="container">
-    <header>
+
+<section class="title-page">
+  <div class="wrap">
+    <div class="content-title-documentation">
+      <div class="titles">
         <h1>{{ page.title }}</h1>
-        <div class="byline">
-            <a href="{{ urls.editSource }}">
-                <i class="far fa-edit"></i>
-                Edit this page on GitHub
-            </a>
-        </div>
-    </header>
-    {{ content }}
-</main>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="wrap">
+    <div class="byline">
+        <a href="{{ urls.editSource }}">
+            <i class="far fa-edit"></i>
+            Edit this page on GitHub
+        </a>
+    </div>
+    <div class="content-primary">
+      <div class="inner-box">
+        {{ content }}
+      </div>
+    </div>
+  </div>
+</section>

--- a/scala3doc/scala3-docs/_layouts/main.html
+++ b/scala3doc/scala3-docs/_layouts/main.html
@@ -1,9 +1,11 @@
 ---
 layout: base
 ---
-<div id="content-wrapper">
+
+<main id="inner-main">
     {{ content }}
-</div>
+</main>
+
 <script>
   ((window.gitter = {}).chat = {}).options = {
     room: 'lampepfl/dotty'

--- a/scala3doc/scala3-docs/css/dottydoc.css
+++ b/scala3doc/scala3-docs/css/dottydoc.css
@@ -1,12 +1,199 @@
+@charset "UTF-8";
+@import url("https://fonts.googleapis.com/css?family=Lato:300,400,400i,700i,900");
+@import url("https://fonts.googleapis.com/css?family=Roboto+Slab:400,700");
+@import url("https://fonts.googleapis.com/css?family=Kalam:300,400,700");
+
+:root {
+  --leftbar-bg: #15414C;
+  --logo-bg: #15414C;
+  --content-padding: 0px;
+  --title-fg: #DC322F;
+  --pre-bg: #fdfdf7;
+  --active-tab-color: #5CC6E4;
+  --leftbar-fg: rgba(255, 255, 255, 0.5);
+  --leftbar-hover-bg: #002B3B;
+  --leftbar-hover-fg: #fff;
+}
+
 html, body {
   font-weight: 300;
   height: 100%;
+  font-family: "Lato", sans-serif;
+  font-weight: 400;
+  line-height: 1.6;
+  color: #4A5659;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* simulating container layout from docs.scala-lang */
+#logo {
+  padding: 1em 0.5em;
 }
 
 main.container {
   min-height: 100vh;
   padding: 15px 15px;
   padding-bottom: 45px; /* prevents the content to be hidden by the gitter sidecar */
+}
+
+#content {
+  padding-bottom: 0;
+}
+
+main .content {
+  position: relative;
+  top: -80px;
+}
+
+footer {
+  margin-top: 0;
+  /* background: #002B36; */
+}
+
+#inner-main .inner-box {
+  padding: 30px;
+}
+
+.title-page {
+  min-height: 200px;
+}
+
+.wrap {
+  max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 20px;
+}
+
+.byline {
+  margin-bottom: 0.5em;
+  margin-top: -0.5em;
+}
+
+/* adjusting colors to color scheme from docs.scala-lang */
+.title-page {
+  background: #5CC6E4;
+}
+
+#logo {
+  background: var(--logo-bg);
+}
+#logo .projectName {
+  color: #fff;
+}
+
+/* links and buttons */
+
+.content-primary a {
+  color: #23aad1;
+  text-decoration: none;
+  transition: all 350ms ease;
+}
+.content-primary a:active, .content-primary a:focus, .content-primary a:hover {
+  color: #DC322F;
+  text-decoration: underline;
+}
+
+.byline a {
+  color: #bfe9f5;
+}
+
+.search button {
+  background: rgba(0,0,0,0.1);
+  box-shadow: none;
+  position: absolute;
+  top: 1em;
+  right: 42px;
+}
+
+.search button:hover {
+  fill: rgba(255,255,255,0.8);
+  background: rgba(0,0,0,0.15);
+}
+
+.popup-wrapper {
+  top: 7em; /* this is the position where it _should_ be */
+}
+
+.sideMenuPart a {
+  font-weight: 700;
+  transition: all 350ms ease;
+}
+
+.sideMenuPart a:hover {
+  text-decoration: none;
+}
+
+#inner-main {
+  background: #F0F3F3;
+}
+
+#inner-main .inner-box {
+  background: #fff;
+  border-radius: 3px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -ms-border-radius: 3px;
+  -o-border-radius: 3px;
+  -webkit-box-shadow: rgba(0, 43, 54, 0.04) 0 2px 1px;
+  -moz-box-shadow: rgba(0, 43, 54, 0.04) 0 2px 1px;
+  box-shadow: rgba(0, 43, 54, 0.04) 0 2px 1px;
+}
+
+/* main text headers */
+main .content-primary h1,
+main .content-primary h2,
+main .content-primary h3 {
+  font-family: "Roboto Slab", serif;
+  line-height: 1.4;
+  font-weight: 400;
+}
+
+main .content-primary h1,
+main .content-primary h2 {
+  color: #DC322F;
+  margin-bottom: 24px;
+}
+
+main .content-primary h4 {
+  font-size: 1.063rem;
+  font-family: "Lato", sans-serif;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: #073642;
+  margin-bottom: 18px;
+}
+
+/* we do not have supertitles, so using for breadcrumbs instead */
+.breadcrumbs {
+  position: absolute;
+}
+.breadcrumbs a:hover {
+  color: #3094b0;
+  text-decoration: none;
+}
+.titles .supertitle, .breadcrumbs {
+  text-transform: uppercase;
+  font-weight: 900;
+  font-size: 20px;
+  color: #2c90ad;
+}
+
+.titles h1 {
+    font-size: 1.875rem;
+    font-weight: 900;
+    font-family: "Lato", sans-serif;
+    padding-top: 40px;
+    text-transform: uppercase;
+    text-shadow: rgba(0, 43, 54, 0.1) 2px 2px 0;
+    color: #fff;
+}
+
+main .content-primary h3 {
+  font-size: 1.25rem;
+  color: #073642;
+  margin-bottom: 18px;
 }
 
 .container img {
@@ -25,9 +212,6 @@ main > h1 {
   margin-bottom: 20px;
 }
 
-.byline, .byline a {
-  color: grey;
-}
 .byline .author {
   display: block;
 }
@@ -185,11 +369,12 @@ pre, code {
   font-variant-ligatures: none;
 }
 pre {
-  padding: 0;
+  padding: 20px;
   font-size: 13px;
   background: var(--pre-bg);
   border-radius: 2px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid #e7e7d6;
+  margin-bottom: 36px;
 }
 
 /* admonitions */

--- a/scala3doc/scala3-docs/css/dottydoc.css
+++ b/scala3doc/scala3-docs/css/dottydoc.css
@@ -179,7 +179,7 @@ main .content-primary h4 {
 .breadcrumbs {
   position: absolute;
 }
-.breadcrumbs a:hover {
+.breadcrumbs a:hover, .breadcrumbs a:active, .breadcrumbs a:focus {
   color: #3094b0;
   text-decoration: none;
 }

--- a/scala3doc/scala3-docs/css/dottydoc.css
+++ b/scala3doc/scala3-docs/css/dottydoc.css
@@ -4,15 +4,19 @@
 @import url("https://fonts.googleapis.com/css?family=Kalam:300,400,700");
 
 :root {
-  --leftbar-bg: #15414C;
+  /* Side bar */
   --logo-bg: #15414C;
-  --content-padding: 0px;
-  --title-fg: #DC322F;
-  --pre-bg: #fdfdf7;
-  --active-tab-color: #5CC6E4;
   --leftbar-fg: rgba(255, 255, 255, 0.5);
+  --leftbar-bg: #15414C;
   --leftbar-hover-bg: #002B3B;
   --leftbar-hover-fg: #fff;
+  --active-tab-color: #5CC6E4;
+
+  /* Main pane */
+  --title-fg: #DC322F;
+  --content-padding: 0px;
+  --pre-bg: #fdfdf7;
+  --link-fg: #23aad1;
 }
 
 html, body {
@@ -29,6 +33,12 @@ html, body {
 /* simulating container layout from docs.scala-lang */
 #logo {
   padding: 1em 0.5em;
+}
+
+#leftColumn {
+  -webkit-box-shadow: rgba(0, 43, 54, 0.1) 0.3em 0em 0.5em;
+  -moz-box-shadow: rgba(0, 43, 54, 0.1) 0.3em 0em 0.5em;
+  box-shadow: rgba(0, 43, 54, 0.2) 0.3em 0em 0.5em;
 }
 
 main.container {
@@ -260,14 +270,28 @@ h5:hover a.anchor:hover {
 
 /* footer */
 footer {
-  color: grey;
+  background: #D0D6D6;
 }
+
 footer img#author-img {
   width: auto;
   height: auto;
   max-width:100px;
   max-height:100px;
   border-radius: 50%;
+}
+
+footer span.go-to-top-icon {
+  background: none;
+}
+footer a {
+  color: #15414C;
+  font-weight: 600;
+  transition: color .4s ease-out;
+}
+footer a:hover {
+  color: #456c75;
+  text-decoration: none;
 }
 
 /* api docs */


### PR DESCRIPTION
@romanowski I started adjusting the style of scala3doc to fit the one of https://docs.scala-lang.org -- and I think it works quite nicely (optically).

There are a few things still to do:

- Make this style the default also for generated index pages.
- Use this style also for the API docs
- Fix header (the breadcrumb should be inside the page, not before it)
- Fix footer (mostly colors and styling to match scala-lang.org).