### PR TITLE
Revert to the old way of setting envvars in CI file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -374,7 +374,7 @@ jobs:
           ./project/scripts/sbt dist/packArchive
           sha256sum dist/target/scala3-* > dist/target/sha256sum.txt
           ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
-          echo "name=RELEASE_TAG::${GITHUB_REF#*refs/tags/}" >> $GITHUB_ENV
+          echo "::set-env name=RELEASE_TAG::${GITHUB_REF#*refs/tags/}"
 
       - name: Create GitHub Release
         id: create_gh_release


### PR DESCRIPTION
The new one specified here – https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable – does not work for some reason (see https://github.com/lampepfl/dotty/runs/1450211624?check_suite_focus=true ). I don't have the time to investigate why the new way fails, so reverting to the tried-and-true old way now.