### PR TITLE
Fix #9424: Add `releaseFence()` call when mixing in a trait `val`.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -562,6 +562,7 @@ object StdNames {
     val reflect: N              = "reflect"
     val reflectiveSelectable: N = "reflectiveSelectable"
     val reify : N               = "reify"
+    val releaseFence : N        = "releaseFence"
     val rootMirror : N          = "rootMirror"
     val run: N                  = "run"
     val runOrElse: N            = "runOrElse"

--- a/compiler/src/dotty/tools/dotc/transform/Memoize.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Memoize.scala
@@ -16,9 +16,16 @@ import NameKinds.TraitSetterName
 import NameOps._
 import Flags._
 import Decorators._
+import StdNames.nme
+
+import util.Store
 
 object Memoize {
   val name: String = "memoize"
+
+  private final class MyState {
+    val classesThatNeedReleaseFence = new util.HashSet[Symbol]
+  }
 }
 
 /** Provides the implementations of all getters and setters, introducing
@@ -37,9 +44,16 @@ object Memoize {
  *      --> <accessor> <mods> def x_=(y: T): Unit = x = y
  */
 class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
+  import Memoize.MyState
   import ast.tpd._
 
   override def phaseName: String = Memoize.name
+
+  private var MyState: Store.Location[MyState] = _
+  private def myState(using Context): MyState = ctx.store(MyState)
+
+  override def initContext(ctx: FreshContext): Unit =
+    MyState = ctx.addLocation[MyState]()
 
   /* Makes sure that, after getters and constructors gen, there doesn't
    * exist non-deferred definitions that are not implemented. */
@@ -68,6 +82,17 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
    *  that defines it.
    */
   override def runsAfter: Set[String] = Set(Mixin.name)
+
+  override def prepareForUnit(tree: Tree)(using Context): Context =
+    ctx.fresh.updateStore(MyState, new MyState())
+
+  override def transformTemplate(tree: Template)(using Context): Tree =
+    val cls = ctx.owner.asClass
+    if myState.classesThatNeedReleaseFence.contains(cls) then
+      val releaseFenceCall = ref(defn.staticsMethodRef(nme.releaseFence)).appliedToNone
+      cpy.Template(tree)(tree.constr, tree.parents, Nil, tree.self, tree.body :+ releaseFenceCall)
+    else
+      tree
 
   override def transformDefDef(tree: DefDef)(using Context): Tree = {
     val sym = tree.symbol
@@ -154,7 +179,11 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
           // See tests/run/traitValOverriddenByParamAccessor.scala
           tree
         else
-          field.setFlag(Mutable) // Necessary for vals mixed in from traits
+          if !field.is(Mutable) then
+            // This is a val mixed in from a trait.
+            // We make it mutable, and mark the class as needing a releaseFence() in the constructor
+            field.setFlag(Mutable)
+            myState.classesThatNeedReleaseFence += sym.owner
           val initializer =
             if (isErasableBottomField(field, tree.vparamss.head.head.tpt.tpe.classSymbol)) Literal(Constant(()))
             else Assign(ref(field), adaptToField(field, ref(tree.vparamss.head.head.symbol)))


### PR DESCRIPTION
This is a forward port of relevant parts of the upstream PR
https://github.com/scala/scala/pull/7028

---

Any idea how to test this? scala/scala used a jstress test for that, but it's outside my area of expertise at the moment. I "tested" it by inspection in a variety of cases (when it must appear and it must not appear), but that doesn't give much confidence.