### PR TITLE
Fix #8602: Do not create mixins for constant-expression final vals.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -208,7 +208,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
             } else
               dropped += sym
           case stat @ DefDef(name, _, _, tpt, _)
-              if stat.symbol.isGetter && stat.symbol.owner.is(Trait) && !stat.symbol.is(Lazy) =>
+              if stat.symbol.isGetter && stat.symbol.owner.is(Trait) && !stat.symbol.is(Lazy) && !stat.symbol.isConstExprFinalVal =>
             val sym = stat.symbol
             assert(isRetained(sym), sym)
             if !stat.rhs.isEmpty && !isWildcardArg(stat.rhs) then

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -16,6 +16,7 @@ import ValueClasses.isDerivedValueClass
 import Decorators._
 import Constants.Constant
 import Annotations.Annotation
+import Phases._
 import ast.tpd.Literal
 
 import language.implicitConversions
@@ -166,6 +167,11 @@ object SymUtils:
         else thisName.fieldName
       self.owner.info.decl(fieldName).suchThat(!_.is(Method)).symbol
     }
+
+    def isConstExprFinalVal(using Context): Boolean =
+      atPhaseNoLater(erasurePhase) {
+        self.is(Final) && self.info.resultType.isInstanceOf[ConstantType]
+      }
 
     def isField(using Context): Boolean =
       self.isTerm && !self.is(Method)

--- a/tests/run/i8602/ChildClass_2.java
+++ b/tests/run/i8602/ChildClass_2.java
@@ -1,0 +1,5 @@
+public class ChildClass_2 extends Object implements ParentTrait {
+  public int getFoo() {
+    return foo();
+  }
+}

--- a/tests/run/i8602/ParentTrait_1.scala
+++ b/tests/run/i8602/ParentTrait_1.scala
@@ -1,0 +1,3 @@
+trait ParentTrait {
+  final val foo = 5
+}

--- a/tests/run/i8602/Test_3.scala
+++ b/tests/run/i8602/Test_3.scala
@@ -1,0 +1,8 @@
+object Test {
+  def main(args: Array[String]): Unit =
+    val child = new ChildClass_2()
+    assert(child.foo == 5)
+    assert(child.getFoo() == 5)
+    val parent: ParentTrait = child
+    assert(parent.foo == 5)
+}


### PR DESCRIPTION
This matches what Scala 2 does (addressing binary compatibility with Scala 2) and allows a trait with only such `final val`s to be extended from Java.