### PR TITLE
Fix #8599: Emit trait init methods only as static methods.

### DIFF
--- a/tests/run/i8599/JavaClass_2.java
+++ b/tests/run/i8599/JavaClass_2.java
@@ -1,0 +1,5 @@
+public class JavaClass_2 extends ScalaClass {
+  public int c() {
+    return a() + b();
+  }
+}

--- a/tests/run/i8599/ScalaDefs_1.scala
+++ b/tests/run/i8599/ScalaDefs_1.scala
@@ -1,0 +1,9 @@
+trait A {
+  val a: Int = 1
+}
+
+trait B {
+  val b: Int = 2
+}
+
+class ScalaClass extends A with B

--- a/tests/run/i8599/Test_3.scala
+++ b/tests/run/i8599/Test_3.scala
@@ -1,0 +1,7 @@
+object Test {
+  def main(args: Array[String]): Unit =
+    val obj = new JavaClass_2
+    assert(obj.a == 1)
+    assert(obj.b == 2)
+    assert(obj.c() == 3)
+}

--- a/tests/run/junitForwarders/C_1.scala
+++ b/tests/run/junitForwarders/C_1.scala
@@ -18,6 +18,6 @@ object Test extends App {
   }
   check(classOf[C], "foo - @org.junit.Test()")
   // scala/scala-dev#213, scala/scala#5570: `foo$` should not have the @Test annotation
-  check(classOf[T], "$init$ - ;$init$ - ;foo - @org.junit.Test();foo$ - ")
+  check(classOf[T], "$init$ - ;foo - @org.junit.Test();foo$ - ")
   check(classOf[U], "bar - @org.junit.Test();bar$ - ")
 }

--- a/tests/run/traitNoInit.scala
+++ b/tests/run/traitNoInit.scala
@@ -9,21 +9,11 @@ trait WithInit {
 
 trait Bar(x: Int)
 
-class NoInitClass extends NoInit() with Bar(1) {
-  def meth(x: Int) = x
-}
-
-class WithInitClass extends WithInit() with Bar(1) {
-  def meth(x: Int) = x
-}
-
 object Test {
   def hasInit(cls: Class[_]) = cls.getMethods.map(_.toString).exists(_.contains("$init$"))
   def main(args: Array[String]): Unit = {
-    val noInit = new NoInitClass {}
-    val withInit = new WithInitClass {}
-
-    assert(!hasInit(noInit.getClass))
-    assert(hasInit(withInit.getClass))
+    assert(!hasInit(classOf[NoInit]))
+    assert(hasInit(classOf[WithInit]))
+    assert(!hasInit(classOf[Bar]))
   }
 }


### PR DESCRIPTION
Concrete trait methods are encoded as two methods in the back-end:

* a default method containing the real body, and
* a static forwarder, to use for super calls (due to JVM reasons).

Previously, we did that also for the trait initializer methods `$init$`. However, that causes unrelated default methods to be inherited by Scala classes that extend several traits. In turn, that prevents Java classes from extending such classes.

Now, for the `$init$` methods, instead of creating a static forwarder, we *move* the entire body to a static method. Therefore, we only create a static method, and no default method.

This corresponds to what scalac does as well (both what we do and how we do it), although the previous "discrepancy" was not causing any incompatibility between Scala 2 and 3 per se.