### PR TITLE
Move `Quotes` as last parameter in `ExprMap.transform`

### DIFF
--- a/tests/run-macros/expr-map-1/Macro_1.scala
+++ b/tests/run-macros/expr-map-1/Macro_1.scala
@@ -8,7 +8,7 @@ private def stringRewriter(e: Expr[Any])(using Quotes): Expr[Any] =
 
 private object StringRewriter extends ExprMap {
 
-  def transform[T](e: Expr[T])(using Quotes, Type[T]): Expr[T] = e match
+  def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] = e match
     case Const(s: String) =>
       Expr(s.reverse) match
         case '{ $x: T } => x

--- a/tests/run-macros/expr-map-2/Macro_1.scala
+++ b/tests/run-macros/expr-map-2/Macro_1.scala
@@ -8,7 +8,7 @@ private def stringRewriter(e: Expr[Any])(using Quotes): Expr[Any] =
 
 private object StringRewriter extends ExprMap {
 
-  def transform[T](e: Expr[T])(using Quotes, Type[T]): Expr[T] = e match
+  def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] = e match
     case '{ ($x: Foo).x } =>
       '{ new Foo(4).x } match
         case '{ $e: T } => e

--- a/tests/run-macros/flops-rewrite-2/Macro_1.scala
+++ b/tests/run-macros/flops-rewrite-2/Macro_1.scala
@@ -64,7 +64,7 @@ private object Rewriter {
 }
 
 private class Rewriter(preTransform: List[Transformation[_]] = Nil, postTransform: List[Transformation[_]] = Nil, fixPoint: Boolean) extends ExprMap {
-  def transform[T](e: Expr[T])(using Quotes, Type[T]): Expr[T] = {
+  def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] = {
     val e2 = preTransform.foldLeft(e)((ei, transform) => transform(ei))
     val e3 = transformChildren(e2)
     val e4 = postTransform.foldLeft(e3)((ei, transform) => transform(ei))

--- a/tests/run-macros/flops-rewrite-3/Macro_1.scala
+++ b/tests/run-macros/flops-rewrite-3/Macro_1.scala
@@ -101,7 +101,7 @@ private class Rewriter private (preTransform: List[Transformation] = Nil, postTr
   def withPost(transform: Transformation): Rewriter =
     new Rewriter(preTransform, transform :: postTransform, fixPoint)
 
-  def transform[T](e: Expr[T])(using Quotes, Type[T]): Expr[T] = {
+  def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] = {
     val e2 = preTransform.foldLeft(e)((ei, transform) => transform(ei))
     val e3 = transformChildren(e2)
     val e4 = postTransform.foldLeft(e3)((ei, transform) => transform(ei))

--- a/tests/run-macros/flops-rewrite/Macro_1.scala
+++ b/tests/run-macros/flops-rewrite/Macro_1.scala
@@ -29,7 +29,7 @@ private object Rewriter {
 }
 
 private class Rewriter(preTransform: Expr[Any] => Expr[Any], postTransform: Expr[Any] => Expr[Any], fixPoint: Boolean) extends ExprMap {
-  def transform[T](e: Expr[T])(using Quotes, Type[T]): Expr[T] = {
+  def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] = {
     val e2 = checkedTransform(e, preTransform)
     val e3 = transformChildren(e2)
     val e4 = checkedTransform(e3, postTransform)


### PR DESCRIPTION
All other methods in the `scala.quoted` do it this way. There are some situations where one might want to pass an explicit type but never the `Quotes`.