### PR TITLE
docs: add an example to `-Yindent-colons` section

### DIFF
--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -387,6 +387,17 @@ xs.map:
       y * y
 ```
 
-Colons at the end of lines are their own token, distinct from normal `:`.
-The Scala grammar is changed in this variant so that colons at end of lines are accepted at all points
-where an opening brace enclosing a function argument is legal. Special provisions are taken so that method result types can still use a colon on the end of a line, followed by the actual type on the next.
+The colon is usable not only for lambdas and by-name parameters, but
+also even for ordinary parameters:
+
+```scala
+credentials ++ :
+  val file = Path.userHome / ".credentials"
+  if file.exists
+  then Seq(Credentials(file))
+  else Seq()
+```
+
+How does this syntax variant work? Colons at the end of lines are their own token, distinct from normal `:`.
+The Scala grammar is changed so that colons at end of lines are accepted at all points
+where an opening brace enclosing an argument is legal. Special provisions are taken so that method result types can still use a colon on the end of a line, followed by the actual type on the next.


### PR DESCRIPTION
At least, I think this is the recommendation....... is it?

I admit this came up when I was intentionally expunging all braces from a repo of mine as an exercise, in an attempt to form an opinion on the future of `-Yindent-colons`

never using braces could be a pointless exercise, or it could be good pedagogically actually. it's simpler for learning if the answer to "do I ever actually _need_ braces?" is "no"

in any case, I like knowing I have the option with `locally`