### PR TITLE
Skip fast Windows job for master merges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,9 +91,9 @@ jobs:
 
   test_windows_fast:
     runs-on: [self-hosted, Windows]
-    if: "github.event_name == 'schedule'
-         || (
+    if: "(
            github.event_name == 'push'
+           && github.ref != 'master'
            && !startsWith(github.event.ref, 'refs/tags/sbt-dotty-')
          )
          || (


### PR DESCRIPTION
Skip fast Windows job for master merges

As the full Windows job is a superset

[skip ci]