### PR TITLE
Implement bean property generation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -890,6 +890,8 @@ class Definitions {
 
   // Annotation classes
   @tu lazy val AnnotationDefaultAnnot: ClassSymbol = requiredClass("scala.annotation.internal.AnnotationDefault")
+  @tu lazy val BeanPropertyAnnot: ClassSymbol = requiredClass("scala.beans.BeanProperty")
+  @tu lazy val BooleanBeanPropertyAnnot: ClassSymbol = requiredClass("scala.beans.BooleanBeanProperty")
   @tu lazy val BodyAnnot: ClassSymbol = requiredClass("scala.annotation.internal.Body")
   @tu lazy val ChildAnnot: ClassSymbol = requiredClass("scala.annotation.internal.Child")
   @tu lazy val ContextResultCountAnnot: ClassSymbol = requiredClass("scala.annotation.internal.ContextResultCount")

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -590,7 +590,7 @@ class TreeUnpickler(reader: TastyReader,
       val isScala2MacroDefinedInScala3 = flags.is(Macro, butNot = Inline) && flags.is(Erased)
       ctx.owner match {
         case cls: ClassSymbol if (!isScala2MacroDefinedInScala3 || cls == defn.StringContextClass) && !isSyntheticBeanAccessor  =>
-          // Enter all members of classes that are not Scala 2 macros or synthetic accessors.
+          // Enter all members of classes that are not Scala 2 macros or synthetic bean accessors.
           //
           // For `StringContext`, enter `s`, `f` and `raw`
           // These definitions will be entered when defined in Scala 2. It is fine to enter them

--- a/compiler/src/dotty/tools/dotc/transform/BeanProperties.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BeanProperties.scala
@@ -1,0 +1,61 @@
+package dotty.tools.dotc
+package transform
+
+import core._
+import ast.tpd._
+import Contexts.Context
+import SymDenotations._
+import Symbols.newSymbol
+import Decorators._
+import Flags._
+import Names._
+import Types._
+
+import DenotTransformers._
+
+class BeanProperties(thisPhase: DenotTransformer):
+  def addBeanMethods(impl: Template)(using Context): Template =
+    val origBody = impl.body
+    cpy.Template(impl)(body = impl.body.flatMap {
+      case v: ValDef => generateAccessors(v)
+      case _ => Nil
+    } ::: origBody)
+
+  def generateAccessors(valDef: ValDef)(using Context): List[Tree] =
+    import Symbols.defn
+
+    def generateGetter(valDef: ValDef)(using Context) : Tree =
+      val prefix = if valDef.symbol.denot.hasAnnotation(defn.BooleanBeanPropertyAnnot) then "is" else "get"
+      val meth = newSymbol(
+        owner = summon[Context].owner,
+        name = prefixedName(prefix, valDef.name),
+        flags = Method | Permanent | Synthetic,
+        info = MethodType(Nil, valDef.denot.info))
+        .enteredAfter(thisPhase).asTerm
+      meth.addAnnotations(valDef.symbol.annotations)
+      val body: Tree = ref(valDef.symbol)
+      DefDef(meth, body)
+
+    def maybeGenerateSetter(valDef: ValDef)(using Context): Option[Tree] =
+      Option.when(valDef.denot.asSymDenotation.flags.is(Mutable)) {
+        val owner = summon[Context].owner
+        val meth = newSymbol(
+          owner,
+          name = prefixedName("set", valDef.name),
+          flags = Method | Permanent | Synthetic,
+          info = MethodType(valDef.name :: Nil, valDef.denot.info :: Nil, defn.UnitType)
+        ).enteredAfter(thisPhase).asTerm
+        meth.addAnnotations(valDef.symbol.annotations)
+        def body(params: List[List[Tree]]): Tree = Assign(ref(valDef.symbol), params.head.head)
+        DefDef(meth, body)
+      }
+
+    def prefixedName(prefix: String, valName: Name) =
+      (prefix + valName.lastPart.toString.capitalize).toTermName
+
+    extension(a: SymDenotation) def isApplicable = a.hasAnnotation(defn.BeanPropertyAnnot) || a.hasAnnotation(defn.BooleanBeanPropertyAnnot)
+
+    if valDef.denot.symbol.isApplicable then
+      generateGetter(valDef) +: maybeGenerateSetter(valDef) ++: Nil
+    else Nil
+  end generateAccessors

--- a/compiler/src/dotty/tools/dotc/transform/BeanProperties.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BeanProperties.scala
@@ -45,7 +45,7 @@ class BeanProperties(thisPhase: DenotTransformer):
         val meth = newSymbol(
           owner,
           name = prefixedName("set", valDef.name),
-          flags = Method | Permanent | Synthetic,
+          flags = Method | Synthetic,
           info = MethodType(valDef.name :: Nil, valDef.denot.info :: Nil, defn.UnitType),
           coord = annot.tree.span
         ).enteredAfter(thisPhase).asTerm

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -75,6 +75,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
 
   val superAcc: SuperAccessors = new SuperAccessors(thisPhase)
   val synthMbr: SyntheticMembers = new SyntheticMembers(thisPhase)
+  val beanProps: BeanProperties = new BeanProperties(thisPhase)
 
   private def newPart(tree: Tree): Option[New] = methPart(tree) match {
     case Select(nu: New, _) => Some(nu)
@@ -322,8 +323,10 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
           withNoCheckNews(templ.parents.flatMap(newPart)) {
             forwardParamAccessors(templ)
             synthMbr.addSyntheticMembers(
+              beanProps.addBeanMethods(
                 superAcc.wrapTemplate(templ)(
                   super.transform(_).asInstanceOf[Template]))
+            )
           }
         case tree: ValDef =>
           val tree1 = cpy.ValDef(tree)(rhs = normalizeErasedRhs(tree.rhs, tree.symbol))

--- a/tests/neg/beanAccessorsLeaking/A_1.scala
+++ b/tests/neg/beanAccessorsLeaking/A_1.scala
@@ -1,0 +1,2 @@
+class A:
+  @scala.beans.BeanProperty val x = 6

--- a/tests/neg/beanAccessorsLeaking/B_2.scala
+++ b/tests/neg/beanAccessorsLeaking/B_2.scala
@@ -1,0 +1,2 @@
+class B(val a: A):
+  def x = a.getX() // error

--- a/tests/run/beans.check
+++ b/tests/run/beans.check
@@ -1,0 +1,5 @@
+4
+true
+[@beans.LibraryAnnotation_1()]
+some text
+other text

--- a/tests/run/beans.check
+++ b/tests/run/beans.check
@@ -1,5 +1,6 @@
 4
 true
+10
 [@beans.LibraryAnnotation_1()]
 some text
 other text

--- a/tests/run/beans/A_2.scala
+++ b/tests/run/beans/A_2.scala
@@ -1,4 +1,4 @@
-class A {
+class A:
   @scala.beans.BeanProperty val x = 4
   @scala.beans.BooleanBeanProperty val y = true
   @scala.beans.BeanProperty var mutableOneWithLongName = "some text"
@@ -6,4 +6,12 @@ class A {
   @scala.beans.BeanProperty
   @beans.LibraryAnnotation_1
   val retainingAnnotation = 5
-}
+
+trait T:
+  @scala.beans.BeanProperty val x: Int
+
+class T1 extends T:
+  override val x = 5
+
+class T2 extends T1:
+  override val x = 10

--- a/tests/run/beans/A_2.scala
+++ b/tests/run/beans/A_2.scala
@@ -1,0 +1,9 @@
+class A {
+  @scala.beans.BeanProperty val x = 4
+  @scala.beans.BooleanBeanProperty val y = true
+  @scala.beans.BeanProperty var mutableOneWithLongName = "some text"
+
+  @scala.beans.BeanProperty
+  @beans.LibraryAnnotation_1
+  val retainingAnnotation = 5
+}

--- a/tests/run/beans/LibraryAnnotation_1.java
+++ b/tests/run/beans/LibraryAnnotation_1.java
@@ -1,0 +1,7 @@
+package beans;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LibraryAnnotation_1 {}

--- a/tests/run/beans/Test_3.java
+++ b/tests/run/beans/Test_3.java
@@ -5,6 +5,7 @@ class JavaTest {
     A a = new A();
     System.out.println(a.getX());
     System.out.println(a.isY());
+    System.out.println(new T2().getX());
 
     System.out.println(Arrays.asList(a.getClass().getMethod("getRetainingAnnotation").getAnnotations()));
 

--- a/tests/run/beans/Test_3.java
+++ b/tests/run/beans/Test_3.java
@@ -1,0 +1,15 @@
+import java.util.Arrays;
+
+class JavaTest {
+  public A run() throws ReflectiveOperationException{
+    A a = new A();
+    System.out.println(a.getX());
+    System.out.println(a.isY());
+
+    System.out.println(Arrays.asList(a.getClass().getMethod("getRetainingAnnotation").getAnnotations()));
+
+    System.out.println(a.getMutableOneWithLongName());
+    a.setMutableOneWithLongName("other text");
+    return a;
+  }
+}

--- a/tests/run/beans/Test_4.scala
+++ b/tests/run/beans/Test_4.scala
@@ -1,0 +1,4 @@
+object Test:
+  def main(args: Array[String]) =
+    val a = JavaTest().run()
+    println(a.mutableOneWithLongName)


### PR DESCRIPTION
Fixes #10322.
This PR adds bean property accessors generation to the `PostTyper` phase of the compilation.
This is a draft as it needs some automated tests, but I wanted to get some feedback earlier. 

Open questions:
- should some flags from properties be attached to the generated accessors? I'm thinking mostly about `Abstract` and `Override`.
-  about the problem of synthetic methods being available depending on the compilation being incremental or not - should it be tackled now? How can it be tested? 