### PR TITLE
Fix #10563: Handle static methods in non-native JS classes.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSInterop.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSInterop.scala
@@ -22,10 +22,6 @@ object JSInterop {
   def isJSType(sym: Symbol)(using Context): Boolean =
     sym.isJSType
 
-  /** Is this symbol a Scala.js-defined JS class, i.e., a non-native JS class? */
-  def isScalaJSDefinedJSClass(sym: Symbol)(using Context): Boolean =
-    sym.isNonNativeJSClass
-
   /** Should this symbol be translated into a JS getter?
    *
    *  This is true for any parameterless method, i.e., defined without `()`.

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -3,11 +3,23 @@ package org.scalajs.testsuite.compiler
 import org.junit.Assert._
 import org.junit.Test
 
+import scala.scalajs.js
+
 class RegressionTestScala3 {
   import RegressionTestScala3._
 
   @Test def testRegressionDoubleDefinitionOfOuterPointerIssue10177(): Unit = {
     assertEquals(6, new OuterClassIssue10177().foo(5))
+  }
+
+  @Test def testRegressionJSClassWithSyntheticStaticMethodsIssue10563(): Unit = {
+    val obj1 = new JSClassWithSyntheticStaticMethodsIssue10563(Some(3))
+    assertEquals(3, obj1.y)
+    assertEquals(8, obj1.foo(5))
+
+    val obj2 = new JSClassWithSyntheticStaticMethodsIssue10563(None)
+    assertEquals(-1, obj2.y)
+    assertEquals(4, obj2.foo(5))
   }
 }
 
@@ -21,4 +33,11 @@ object RegressionTestScala3 {
 
     def foo(x: Int): Int = new ChildClass().concreteMethod(x)
   }
+}
+
+// This class needs to be at the top-level, not in an object, to reproduce the issue
+class JSClassWithSyntheticStaticMethodsIssue10563(x: Option[Int]) extends js.Object {
+  val y: Int = x.getOrElse(-1) // lambda in constructor
+
+  def foo(z: Int): Int = x.getOrElse(-1) + z // lambda in method
 }


### PR DESCRIPTION
Static methods can be generated in non-native JS classes for lambdas that do not refer to the enclosing `this` value.