### PR TITLE
Drop `as` in patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -630,7 +630,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
             }
         }
         compareTypeLambda
-      case tp2 as OrType(tp21, tp22) =>
+      case tp2 @ OrType(tp21, tp22) =>
         compareAtoms(tp1, tp2) match
           case Some(b) => return b
           case _ =>
@@ -970,7 +970,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
        *  corresponding arguments are subtypes relative to their variance (see `isSubArgs`).
        */
       def isMatchingApply(tp1: Type): Boolean = tp1 match {
-        case tp1 as AppliedType(tycon1, args1) =>
+        case tp1 @ AppliedType(tycon1, args1) =>
           // We intentionally do not automatically dealias `tycon1` or `tycon2` here.
           // `TypeApplications#appliedTo` already takes care of dealiasing type
           // constructors when this can be done without affecting type

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -150,7 +150,7 @@ object TypeOps:
         tp.derivedAlias(simplify(tp.alias, theMap))
       case AndType(l, r) if !ctx.mode.is(Mode.Type) =>
         simplify(l, theMap) & simplify(r, theMap)
-      case tp as OrType(l, r)
+      case tp @ OrType(l, r)
       if !ctx.mode.is(Mode.Type)
          && (tp.isSoft || l.isBottomType || r.isBottomType) =>
         // Normalize A | Null and Null | A to A even if the union is hard (i.e.

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2608,10 +2608,7 @@ object Parsers {
     /**  Pattern2    ::=  [id `as'] InfixPattern
      */
     val pattern2: () => Tree = () => infixPattern() match {
-      case p @ Ident(name) if in.token == AT || in.isIdent(nme.as) =>
-        if in.token == AT && sourceVersion.isAtLeast(`3.1`) then
-          deprecationWarning(s"`@` bindings have been deprecated; use `as` instead", in.offset)
-
+      case p @ Ident(name) if in.token == AT =>
         val offset = in.skipToken()
         infixPattern() match {
           case pt @ Ident(tpnme.WILDCARD_STAR) =>  // compatibility for Scala2 `x @ _*` syntax
@@ -2638,8 +2635,7 @@ object Parsers {
     /**  InfixPattern ::= SimplePattern {id [nl] SimplePattern}
      */
     def infixPattern(): Tree =
-      infixOps(simplePattern(), in.canStartExprTokens, simplePattern,
-        isOperator = in.name != nme.raw.BAR && in.name != nme.as)
+      infixOps(simplePattern(), in.canStartExprTokens, simplePattern, isOperator = in.name != nme.raw.BAR)
 
     /** SimplePattern    ::= PatVar
      *                    |  Literal

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -214,7 +214,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       // of AndType and OrType to account for associativity
       case AndType(tp1, tp2) =>
         toTextInfixType(tpnme.raw.AMP, tp1, tp2) { toText(tpnme.raw.AMP) }
-      case tp as OrType(tp1, tp2) =>
+      case tp @ OrType(tp1, tp2) =>
         toTextInfixType(tpnme.raw.BAR, tp1, tp2) {
           if tp.isSoft && printDebug then toText(tpnme.ZOR) else toText(tpnme.raw.BAR)
         }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -480,7 +480,7 @@ class SpaceEngine(using Context) extends SpaceLogic {
           else args.map(arg => erase(arg, inArray = false))
         tp.derivedAppliedType(erase(tycon, inArray), args2)
 
-      case tp as OrType(tp1, tp2) =>
+      case tp @ OrType(tp1, tp2) =>
         OrType(erase(tp1, inArray), erase(tp2, inArray), tp.isSoft)
 
       case AndType(tp1, tp2) =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -600,7 +600,7 @@ trait Applications extends Compatibility {
             args match {
               case arg :: Nil if isVarArg(arg) =>
                 addTyped(arg, formal)
-              case (arg as Typed(Literal(Constant(null)), _)) :: Nil if ctx.isAfterTyper =>
+              case (arg @ Typed(Literal(Constant(null)), _)) :: Nil if ctx.isAfterTyper =>
                 addTyped(arg, formal)
               case _ =>
                 val elemFormal = formal.widenExpr.argTypesLo.head

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -269,7 +269,7 @@ TypeCaseClause    ::=  ‘case’ InfixType ‘=>’ Type [nl]
 
 Pattern           ::=  Pattern1 { ‘|’ Pattern1 }                                Alternative(pats)
 Pattern1          ::=  Pattern2 [‘:’ RefinedType]                               Bind(name, Typed(Ident(wildcard), tpe))
-Pattern2          ::=  [id ‘as’] InfixPattern                                   Bind(name, pat)
+Pattern2          ::=  [id ‘@’] InfixPattern                                    Bind(name, pat)
 InfixPattern      ::=  SimplePattern { id [nl] SimplePattern }                  InfixOp(pat, op, pat)
 SimplePattern     ::=  PatVar                                                   Ident(wildcard)
                     |  Literal                                                  Bind(name, Ident(wildcard))

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -92,13 +92,13 @@ Since `mkAnnotations` is `transparent`, the type of an application is the type o
 
 ## Pattern-Bound Given Instances
 
-Given instances can also appear as pattern bound-variables. Example:
+Given instances can also appear in patterns. Example:
 
 ```scala
 for given Context <- applicationContexts do
 
 pair match
-  case (ctx as given Context, y) => ...
+  case (ctx @ given Context, y) => ...
 ```
 In the first fragment above, anonymous given instances for class `Context` are established by enumerating over `applicationContexts`. In the second fragment, a given `Context`
 instance named `ctx` is established by matching against the first half of the `pair` selector.

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -47,7 +47,7 @@ trait ExprMap:
           tree
         case Super(qual, mix) =>
           tree
-        case tree as Apply(fun, args) =>
+        case tree @ Apply(fun, args) =>
           val MethodType(_, tpes, _) = fun.tpe.widen
           Apply.copy(tree)(transformTerm(fun, TypeRepr.of[Any])(owner), transformTerms(args, tpes)(owner))
         case TypeApply(fun, args) =>

--- a/tests/init/crash/fors.scala
+++ b/tests/init/crash/fors.scala
@@ -26,7 +26,7 @@ object Test extends App {
     var n = 0
     for (_ <- xs) n += 1; println(n)
     for ((x, y) <- xs zip ys) print(x + " "); println()
-    for (p as (x, y) <- xs zip ys) print(p._1 + " "); println()
+    for (p @ (x, y) <- xs zip ys) print(p._1 + " "); println()
 
     // iterators
     for (x <- it) print(x + " "); println()
@@ -53,7 +53,7 @@ object Test extends App {
     var n = 0
     for (_ <- xs) n += 1; println(n)
     for ((x, y) <- xs zip ys) print(x + " "); println()
-    for (p as (x, y) <- xs zip ys) print(p._1 + " "); println()
+    for (p @ (x, y) <- xs zip ys) print(p._1 + " "); println()
 
     // iterators
     for (x <- it) print(x + " "); println()

--- a/tests/neg/Iter3.scala
+++ b/tests/neg/Iter3.scala
@@ -147,7 +147,7 @@ object Iter2 {
       flatten(map(f(_).buildIterator))
 
     override def ++[B >: A](that: IterableOnce[B]): ArrayIterator[B] = {
-      val thatIterator as ArrayIterator(elems2, len2) = fromIterator(that.iterator)
+      val thatIterator @ ArrayIterator(elems2, len2) = fromIterator(that.iterator)
       if (len == 0) thatIterator
       else if (len2 == 0) this.asInstanceOf[ArrayIterator[B]]
       else {

--- a/tests/neg/ensureReported.scala
+++ b/tests/neg/ensureReported.scala
@@ -1,6 +1,6 @@
 object AnonymousF {
   val f = {
-    case l as List(1) => // error: missing parameter type
+    case l @ List(1) => // error: missing parameter type
       Some(l)
   }
 }

--- a/tests/neg/i1716.scala
+++ b/tests/neg/i1716.scala
@@ -1,7 +1,7 @@
 object Fail {
   def f(m: Option[Int]): Unit = {
      m match {
-      case x as Some[_] =>       // error: unbound wildcard type
+      case x @ Some[_] =>       // error: unbound wildcard type
       case _           =>
     }
   }

--- a/tests/neg/i3200.scala
+++ b/tests/neg/i3200.scala
@@ -1,6 +1,6 @@
 object Test {
   case object Bob { override def equals(other: Any) = true }
   def main(args: Array[String]): Unit = {
-    val m : Bob.type = (5: Any) match { case x as Bob => x }  // error
+    val m : Bob.type = (5: Any) match { case x @ Bob => x }  // error
   }
 }

--- a/tests/neg/i3200b.scala
+++ b/tests/neg/i3200b.scala
@@ -1,8 +1,8 @@
 object Test {
   def main(args: Array[String]): Unit = {
-    val a: Nil.type = (Vector(): Any) match { case n as Nil => n } // error
-    val b: Nil.type = (Vector(): Any) match { case n as (m as Nil) => n } // error
-    val c: Int = (1.0: Any) match { case n as 1 => n } // error
-    val d: Int = (1.0: Any) match { case n as (m as 1) => n } // error
+    val a: Nil.type = (Vector(): Any) match { case n @ Nil => n } // error
+    val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error
+    val c: Int = (1.0: Any) match { case n @ 1 => n } // error
+    val d: Int = (1.0: Any) match { case n @ (m @ 1) => n } // error
   }
 }

--- a/tests/neg/i3332.scala
+++ b/tests/neg/i3332.scala
@@ -16,6 +16,6 @@ object Test {
     case _ => println("nope")
   }
   def test(x: Any) = x match {
-    case _: String | _ as A() => 1
+    case _: String | _ @ A() => 1
   }
 }

--- a/tests/neg/i3812b.scala
+++ b/tests/neg/i3812b.scala
@@ -19,9 +19,9 @@ object Test {
     Some(x) match { case Some(Z2.v)  => () } // ok
 
     Some(x) match { case Some(4) | Some(Z1.v) => () } // error
-    Some(x) match { case a as Some(Z1.v)       => () } // error
+    Some(x) match { case a @ Some(Z1.v)       => () } // error
 
     Some(x) match { case Some(4) | Some(Z2.v) => () } // ok
-    Some(x) match { case a as Some(Z2.v)       => () } // ok
+    Some(x) match { case a @ Some(Z2.v)       => () } // ok
   }
 }

--- a/tests/neg/i8407.scala
+++ b/tests/neg/i8407.scala
@@ -1,6 +1,6 @@
 object Test:
   val xs = List(1, 2, 3, 4, 5)
   xs match {
-    case List(1, 2, xs1 as xs2: _*) => println(xs2) // error // error
+    case List(1, 2, xs1 @ xs2: _*) => println(xs2) // error // error
     case _ => ()
   }

--- a/tests/neg/i8715.scala
+++ b/tests/neg/i8715.scala
@@ -1,2 +1,2 @@
 @main
-def Test = List(42) match { case List(xs as (ys: _*)) => xs }  // error
+def Test = List(42) match { case List(xs @ (ys: _*)) => xs }  // error

--- a/tests/neg/i9310.scala
+++ b/tests/neg/i9310.scala
@@ -1,5 +1,5 @@
 //AE-d101cfe6d25117a51897609e673f6c8e74d31e6e
-val foo as this = 0
+val foo @ this = 0
 class Foo {
   foo { } // error
 }

--- a/tests/neg/multi-patterns.scala
+++ b/tests/neg/multi-patterns.scala
@@ -1,4 +1,4 @@
 object Test {
   val (a :: as), bs = List(1, 2, 3) // error
-  val B as List(), C: List[Int] = List() // error
+  val B @ List(), C: List[Int] = List() // error
 }

--- a/tests/neg/patternUnsoundness.scala
+++ b/tests/neg/patternUnsoundness.scala
@@ -10,7 +10,7 @@ object patternUnsoundness extends App {
   val y: C[Object] = x
 
   y match {
-    case d as D(x) => d.s = new Integer(1) // error
+    case d @ D(x) => d.s = new Integer(1) // error
   }
 
   val z: String = x.s // used to throw ClassCast exception

--- a/tests/pos/Iter2.scala
+++ b/tests/pos/Iter2.scala
@@ -193,7 +193,7 @@ object Iter2 {
       flatten(map(f(_).buildIterator))
 
     override def ++[B >: A](that: IterableOnce[B]): ArrayIterator[B] = {
-      val thatIterator as ArrayIterator(elems2, len2) = fromIterator(that.iterator)
+      val thatIterator @ ArrayIterator(elems2, len2) = fromIterator(that.iterator)
       if (len == 0) thatIterator
       else if (len2 == 0) this
       else {

--- a/tests/pos/given-pattern.scala
+++ b/tests/pos/given-pattern.scala
@@ -6,17 +6,17 @@ class Test {
   transparent inline def trySummon[S, T](f: PartialFunction[S, T]): T = ???
 
   inline def setFor[T]: Set[T] = trySummon {
-    case ord as given Ordering[T] => new TreeSet[T]
-    case given Ordering[T]        => new TreeSet[T]
-    case _                        => new HashSet[T]
+    case ord @ given Ordering[T] => new TreeSet[T]
+    case given Ordering[T]       => new TreeSet[T]
+    case _                       => new HashSet[T]
   }
 
   def f1[T](x: Ordering[T]) = (x, x) match {
-    case (y as given Ordering[T], _) => new TreeSet[T]
+    case (y @ given Ordering[T], _) => new TreeSet[T]
   }
   def f2[T](x: Ordering[T]) = {
     val xs = List(x, x, x)
-    for y as given Ordering[T] <- xs
+    for y @ given Ordering[T] <- xs
     yield new TreeSet[T]
   }
   def f3[T](x: Ordering[T]) = (x, x) match {

--- a/tests/pos/i10087.scala
+++ b/tests/pos/i10087.scala
@@ -8,6 +8,6 @@ def f4[T](x: Ordering[T]) = {
   val xs = List(x, x, x)
   for given Ordering[T] <- xs
   yield new TreeSet[T]
-  for x as given Ordering[T] <- xs
+  for x @ given Ordering[T] <- xs
   yield new TreeSet[T]
 }

--- a/tests/pos/i1540.scala
+++ b/tests/pos/i1540.scala
@@ -8,7 +8,7 @@ object Casey1 { def unapply(a: Casey1) = a }
 
 object Test {
   def main(args: Array[String]): Unit = {
-    val c as Casey1(x) = new Casey1(0)
+    val c @ Casey1(x) = new Casey1(0)
     assert(x == c.get)
   }
 }

--- a/tests/pos/i1540b.scala
+++ b/tests/pos/i1540b.scala
@@ -8,7 +8,7 @@ object Casey1 { def unapply[T](a: Casey1[T]) = a }
 
 object Test {
   def main(args: Array[String]): Unit = {
-    val c as Casey1(x) = new Casey1(0)
+    val c @ Casey1(x) = new Casey1(0)
     assert(x == c.get)
   }
 }

--- a/tests/pos/i3412.scala
+++ b/tests/pos/i3412.scala
@@ -1,3 +1,3 @@
 class Test {
-  val A as List() = List()
+  val A @ List() = List()
 }

--- a/tests/pos/i4177.scala
+++ b/tests/pos/i4177.scala
@@ -6,7 +6,7 @@ class Test {
     val a: PartialFunction[Int, String] = { case Foo(x) => x }
     val b: PartialFunction[Int, String] = { case x => x.toString }
 
-    val e: PartialFunction[String, String] = { case x as "abc" => x }
+    val e: PartialFunction[String, String] = { case x @ "abc" => x }
     val f: PartialFunction[String, String] = x => x match { case "abc" => x }
     val g: PartialFunction[String, String] = x => x match { case "abc" if x.isEmpty => x }
 

--- a/tests/pos/i4564.scala
+++ b/tests/pos/i4564.scala
@@ -10,7 +10,7 @@ object ClashNoSig { // ok
   def unapply(x: ClashNoSig) = x
 
   ClashNoSig(2) match {
-    case c as ClashNoSig(y) => c.copy(y + c._1)
+    case c @ ClashNoSig(y) => c.copy(y + c._1)
   }
 }
 case class ClashNoSig private (x: Int) {

--- a/tests/pos/i5402.scala
+++ b/tests/pos/i5402.scala
@@ -9,7 +9,7 @@ object Main {
     case 1 => 1
     case 0 | 0 => 0
     case 2 | 2 | 2 | 3 | 2 | 3 => 0
-    case 4 | (_ as 4) => 0
+    case 4 | (_ @ 4) => 0
     case _ => -1
   }
 

--- a/tests/pos/reference/delegate-match.scala
+++ b/tests/pos/reference/delegate-match.scala
@@ -5,8 +5,8 @@ class Test extends App:
   import scala.compiletime.summonFrom
 
   transparent inline def setFor[T]: Set[T] = summonFrom {
-    case ord as given Ordering[T] => new TreeSet[T]
-    case _                        => new HashSet[T]
+    case ord @ given Ordering[T] => new TreeSet[T]
+    case _                       => new HashSet[T]
   }
 
   summon[Ordering[String]]

--- a/tests/pos/simpleExtractors-2.scala
+++ b/tests/pos/simpleExtractors-2.scala
@@ -1,7 +1,7 @@
 class Foo {
   def bar(x: Any): Unit = x match {
     case Some(Some(i: Int)) => println(i)
-    case Some(s as Some(i)) => println(s)
-    case s as Some(r as Some(i)) => println(s)
+    case Some(s @ Some(i)) => println(s)
+    case s @ Some(r @ Some(i)) => println(s)
   }
 }

--- a/tests/pos/t10533.scala
+++ b/tests/pos/t10533.scala
@@ -1,5 +1,5 @@
 object Foo {
-  val b as Bar(_) = Bar(1)(2)(3)
+  val b @ Bar(_) = Bar(1)(2)(3)
 }
 
 case class Bar(a: Int)(b: Int)(c: Int)

--- a/tests/pos/t3136.scala
+++ b/tests/pos/t3136.scala
@@ -13,7 +13,7 @@ object NullaryMethodType {
 object Test {
   def TEST(tp: Type): String =
     tp match {
-      case PolyType(ps1, PolyType(ps2, res as PolyType(a, b))) => "1" + tp // couldn't find a simpler version that still crashes
+      case PolyType(ps1, PolyType(ps2, res @ PolyType(a, b))) => "1" + tp // couldn't find a simpler version that still crashes
       case NullaryMethodType(meh) => "2" + meh
     }
 }

--- a/tests/pos/t6675.scala
+++ b/tests/pos/t6675.scala
@@ -7,7 +7,7 @@ object LeftOrRight {
 
 object Test {
   (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match {
-    case LeftOrRight(pair as (a, b)) => a // false -Xlint warning: "extractor pattern binds a single value to a Product2 of type (Int, Int)"
+    case LeftOrRight(pair @ (a, b)) => a // false -Xlint warning: "extractor pattern binds a single value to a Product2 of type (Int, Int)"
   }
 
   (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match {

--- a/tests/pos/trailingCommas/trailingCommas.scala
+++ b/tests/pos/trailingCommas/trailingCommas.scala
@@ -114,7 +114,7 @@ trait SimplePattern {
 
   // test '@' syntax in patterns
   Some(1) match {
-    case Some(x as 1,
+    case Some(x @ 1,
     ) => x
   }
 

--- a/tests/pos/virtpatmat_alts_subst.scala
+++ b/tests/pos/virtpatmat_alts_subst.scala
@@ -1,6 +1,6 @@
 case class Foo(s: String) {
   def appliedType(tycon: Any) =
     tycon match {
-        case Foo(sym as ("NothingClass" | "AnyClass")) => println(sym)
+        case Foo(sym @ ("NothingClass" | "AnyClass")) => println(sym)
     }
 }

--- a/tests/run/3179.scala
+++ b/tests/run/3179.scala
@@ -1,7 +1,7 @@
 object Test {
   def main(args: Array[String]): Unit = {
     ("": Any) match {
-      case a as Test => 1
+      case a @ Test => 1
       case _ => 2
     }
   }

--- a/tests/run/enums-serialization-compat.scala
+++ b/tests/run/enums-serialization-compat.scala
@@ -31,19 +31,19 @@ extension (ref: AnyRef) def aliases(compare: AnyRef) = assert(ref eq compare, co
   val read = use(ByteArrayInputStream(buf.toByteArray))
   val in   = use(ObjectInputStream(read))
 
-  val Seq(Red as _, Green as _, Blue as _, Indigo as _) = (1 to 4).map(_ => in.readObject)
+  val Seq(Red @ _, Green @ _, Blue @ _, Indigo @ _) = (1 to 4).map(_ => in.readObject)
   Red    aliases JColor.Red
   Green  aliases SColor.Green
   Blue   aliases SColorTagged.Blue
   Indigo aliases SColorTagged.Indigo
 
-  val Seq(A as _, C as _, G as _, T as _) = (1 to 4).map(_ => in.readObject)
+  val Seq(A @ _, C @ _, G @ _, T @ _) = (1 to 4).map(_ => in.readObject)
   A aliases Nucleobase.A
   C aliases Nucleobase.C
   G aliases Nucleobase.G
   T aliases Nucleobase.T
 
-  val Seq(IntTag as _, UnitTag as _) = (1 to 2).map(_ => in.readObject)
+  val Seq(IntTag @ _, UnitTag @ _) = (1 to 2).map(_ => in.readObject)
   IntTag  aliases MyClassTag.IntTag
   UnitTag aliases MyClassTag.UnitTag
 

--- a/tests/run/fors.scala
+++ b/tests/run/fors.scala
@@ -26,7 +26,7 @@ object Test extends App {
     var n = 0
     for (_ <- xs) n += 1; println(n)
     for ((x, y) <- xs zip ys) print(x + " "); println()
-    for (p as (x, y) <- xs zip ys) print(p._1 + " "); println()
+    for (p @ (x, y) <- xs zip ys) print(p._1 + " "); println()
 
     // iterators
     for (x <- it) print(x + " "); println()
@@ -53,7 +53,7 @@ object Test extends App {
     var n = 0
     for (_ <- xs) n += 1; println(n)
     for ((x, y) <- xs zip ys) print(x + " "); println()
-    for (p as (x, y) <- xs zip ys) print(p._1 + " "); println()
+    for (p @ (x, y) <- xs zip ys) print(p._1 + " "); println()
 
     // iterators
     for (x <- it) print(x + " "); println()

--- a/tests/run/fully-abstract-interface.scala
+++ b/tests/run/fully-abstract-interface.scala
@@ -20,7 +20,7 @@ object Test {
     const1 match {
       case AppliedOp(_, _, _) =>
         println("test1 fail")
-      case c as Constant(n) =>
+      case c @ Constant(n) =>
         println("test1 OK")
         println(s"$n = ${c.eval}")
     }
@@ -41,9 +41,9 @@ object Test {
     println(applied.eval)
 
     applied match {
-      case c as Constant(n) =>
+      case c @ Constant(n) =>
         println("test3 fail")
-      case a as AppliedOp(op, x, y) =>
+      case a @ AppliedOp(op, x, y) =>
         println("test3 OK")
         println(s"AppliedOp($op, $x, $y) = ${a.eval}")
     }
@@ -304,7 +304,7 @@ object ListImplementation extends Arithmetic {
   def opClassTag: ClassTag[Op] = new ClassTag[Constant] {
     def runtimeClass: Class[_] = classOf[List[_]]
     override def unapply(x: Any): Option[List[Any]] = x match {
-      case op as (("+" | "*") :: Nil) =>
+      case op @ (("+" | "*") :: Nil) =>
       // Test that it is:
       //   type Op <: List[Any] // List(id: "+" | "*")
       Some(op)

--- a/tests/run/fully-abstract-nat-1.scala
+++ b/tests/run/fully-abstract-nat-1.scala
@@ -32,7 +32,7 @@ object Test {
     }
 
     def divOpt(a: Nat, b: Nat): Option[(Nat, Nat)] = b match {
-      case s as Succ(_) =>
+      case s @ Succ(_) =>
         // s is of type Nat though we know it is a Succ
         Some(safeDiv(a, s.asInstanceOf[Succ]))
       case _ => None

--- a/tests/run/fully-abstract-nat-2.scala
+++ b/tests/run/fully-abstract-nat-2.scala
@@ -34,7 +34,7 @@ object Test {
     }
 
     def divOpt(a: Nat, b: Nat): Option[(Nat, Nat)] = b match {
-      case s as Succ(_) => Some(safeDiv(a, s))
+      case s @ Succ(_) => Some(safeDiv(a, s))
       case _ => None
     }
 

--- a/tests/run/fully-abstract-nat-3.scala
+++ b/tests/run/fully-abstract-nat-3.scala
@@ -32,7 +32,7 @@ object Test {
     }
 
     def divOpt(a: Nat, b: Nat): Option[(Nat, Nat)] = b match {
-      case SuccRefine(s as Succ(_)) => Some(safeDiv(a, s))
+      case SuccRefine(s @ Succ(_)) => Some(safeDiv(a, s))
       case _ => None
     }
 
@@ -97,7 +97,7 @@ object CaseNums extends Numbers {
 
   object SuccRefine extends SuccRefineExtractor {
     def unapply(nat: Nat): Option[Succ] = nat match {
-      case succ as SuccClass(_) => Some(succ)
+      case succ @ SuccClass(_) => Some(succ)
       case _ => None
     }
   }

--- a/tests/run/fully-abstract-nat-4.scala
+++ b/tests/run/fully-abstract-nat-4.scala
@@ -32,7 +32,7 @@ object Test {
     }
 
     def divOpt(a: Nat, b: Nat): Option[(Nat, Nat)] = b match {
-      case s as Succ(p) =>
+      case s @ Succ(p) =>
         Some(safeDiv(a, s.asInstanceOf[b.type & SuccOpt#Refined])) // safe unchecked cast inserted by the language extension
       case _ => None
     }

--- a/tests/run/fully-abstract-nat-5.scala
+++ b/tests/run/fully-abstract-nat-5.scala
@@ -32,7 +32,7 @@ object Test {
     }
 
     def divOpt(a: Nat, b: Nat): Option[(Nat, Nat)] = b match {
-      case s as Succ(p) =>
+      case s @ Succ(p) =>
         Some(safeDiv(a, s.asInstanceOf[Succ])) // cast should not be needed with extension
       case _ => None
     }

--- a/tests/run/fully-abstract-nat-6.scala
+++ b/tests/run/fully-abstract-nat-6.scala
@@ -32,7 +32,7 @@ object Test {
     }
 
     def divOpt(a: Nat, b: Nat): Option[(Nat, Nat)] = b match {
-      case s as Succ(p) =>
+      case s @ Succ(p) =>
         Some(safeDiv(a, s.asInstanceOf[Succ])) // this case will not be needed
       case _ => None
     }

--- a/tests/run/fully-abstract-nat-7.scala
+++ b/tests/run/fully-abstract-nat-7.scala
@@ -32,7 +32,7 @@ object Test {
     }
 
     def divOpt(a: Nat, b: Nat): Option[(Nat, Nat)] = b match {
-      case s as Succ(p) =>
+      case s @ Succ(p) =>
         Some(safeDiv(a, s.asInstanceOf[Succ])) // this case will not be needed
       case _ => None
     }

--- a/tests/run/fully-abstract-nat.scala
+++ b/tests/run/fully-abstract-nat.scala
@@ -22,7 +22,7 @@ object Test {
       val large = (BigInt(1) << 100).asInstanceOf[Succ]
       large match {
         case Zero() => println("test fail")
-        case s as Succ(pred) =>
+        case s @ Succ(pred) =>
           println("test OK")
           println(s"Succ(${pred.pred}) = $s")
       }
@@ -52,7 +52,7 @@ object Test {
 
     three match {
       case Zero() => println("test3 fail")
-      case s as Succ(pred) =>
+      case s @ Succ(pred) =>
         println("test3 OK")
         println(s"Succ($pred) = ${s.value}")
     }

--- a/tests/run/i1099.scala
+++ b/tests/run/i1099.scala
@@ -8,7 +8,7 @@ object Test {
   // This is what `foo` expands to
   def foo2[T](x: Any)(implicit ev: ClassTag[T]) =
     x match {
-      case t as ev(_) => true
+      case t @ ev(_) => true
       case _   => false
     }
   def main(args: Array[String]): Unit = {

--- a/tests/run/i1432.scala
+++ b/tests/run/i1432.scala
@@ -2,8 +2,8 @@ object Test {
 
   def main(args: Array[String]): Unit = {
     val someFoo = Some("foo")
-    val _ as bar = someFoo
-    val _ as Some(baz) = someFoo
+    val _ @ bar = someFoo
+    val _ @ Some(baz) = someFoo
     println(bar)
     println(baz)
   }

--- a/tests/run/i1463.scala
+++ b/tests/run/i1463.scala
@@ -8,7 +8,7 @@ object Test {
 
   def f0(x: Any) = x match { case Bob2 => Bob2 }
   def f1(x: Any) = x match { case Bob => Bob }
-  // def f2(x: Any): Bob.type = x match { case x as Bob => x } // should not type check
+  // def f2(x: Any): Bob.type = x match { case x @ Bob => x } // should not type check
 
   def main(args: Array[String]): Unit = {
     assert(f0(Bob2) eq Bob2)

--- a/tests/run/i1991.scala
+++ b/tests/run/i1991.scala
@@ -14,9 +14,9 @@ class A[Foo](implicit tag: ClassTag[Foo]) {
   def testBind(x: Any) = x match {
     case foo0: Foo =>
       (foo0: Foo)
-    case foo1 as (_: Foo) =>
+    case foo1 @ (_: Foo) =>
       (foo1: Foo)
-    case foo2 as ExtractFoo() =>
+    case foo2 @ ExtractFoo() =>
       (foo2: Foo)
   }
 }

--- a/tests/run/i3200c.scala
+++ b/tests/run/i3200c.scala
@@ -9,7 +9,7 @@ object Test {
   }
 
   def test2(x: X) = x match {
-    case y as (yy: Y.type) =>
+    case y @ (yy: Y.type) =>
       yIs1(y)
       yIs1(yy)
   }

--- a/tests/run/patmat-bind-typed.scala
+++ b/tests/run/patmat-bind-typed.scala
@@ -1,5 +1,5 @@
 object Test {
-  def f(xs: List[Any]) = for (key as (dummy: String) <- xs) yield key
+  def f(xs: List[Any]) = for (key @ (dummy: String) <- xs) yield key
 
   def main(args: Array[String]): Unit = {
     f("abc" :: Nil) foreach println

--- a/tests/run/patmat-spec.scala
+++ b/tests/run/patmat-spec.scala
@@ -6,7 +6,7 @@ object Test {
     }
 
     "even" match {
-      case s as Even() => println(s"$s has an even number of characters")
+      case s @ Even() => println(s"$s has an even number of characters")
       case s          => println(s"$s has an odd number of characters")
     }
     // even has an even number of characters

--- a/tests/run/patmatch-classtag.scala
+++ b/tests/run/patmatch-classtag.scala
@@ -38,7 +38,7 @@ object Test extends App {
       println(cdef)
   }
   x match {
-    case cdef as CaseDef(s) =>
+    case cdef @ CaseDef(s) =>
       val x: CaseDef = cdef
       println(s)
   }

--- a/tests/run/t6646.scala
+++ b/tests/run/t6646.scala
@@ -8,8 +8,8 @@ object Test {
     val l = List(PrimaryKey, NoNull, lower)
 
     // withFilter must be generated in these
-    for (option as NoNull <- l) println("Found " + option)
-    for (option as `lower` <- l) println("Found " + option)
+    for (option @ NoNull <- l) println("Found " + option)
+    for (option @ `lower` <- l) println("Found " + option)
     for ((`lower`, i) <- l.zipWithIndex) println("Found " + i)
 
     // no withFilter

--- a/tests/run/t8395.scala
+++ b/tests/run/t8395.scala
@@ -1,6 +1,6 @@
  object Test {
   def baz(x: Object) = {
-    val s as (_s: String) = x
+    val s @ (_s: String) = x
     x
   }
   def main(args: Array[String]): Unit = {

--- a/tests/run/unchecked-patterns.scala
+++ b/tests/run/unchecked-patterns.scala
@@ -3,7 +3,7 @@ object Test extends App {
   val (y1: Some[Int] @unchecked) = Some(1): Option[Int]
 
   val a :: as: @unchecked = List(1, 2, 3)
-  val lst as b :: bs: @unchecked = List(1, 2, 3)
+  val lst @ b :: bs: @unchecked = List(1, 2, 3)
   val (1, c): @unchecked = (1, 2)
 
   object Positive { def unapply(i: Int): Option[Int] = Some(i).filter(_ > 0) }


### PR DESCRIPTION
With the change in givens we lose a strong reason for having them _now_. Besides, it is  not clear whether `as` bindings in patterns should be prefix or postfix. So, it's prudent to drop them at this stage.
