### PR TITLE
Remove Unliftable[Unit]

### DIFF
--- a/library/src-bootstrapped/scala/quoted/Unliftable.scala
+++ b/library/src-bootstrapped/scala/quoted/Unliftable.scala
@@ -14,9 +14,6 @@ trait Unliftable[T] {
 
 object Unliftable {
 
-  /** Default unliftable for Unit */
-  given UnitUnliftable as Unliftable[Unit] = new PrimitiveUnliftable
-
   /** Default unliftable for Boolean */
   given BooleanUnliftable as Unliftable[Boolean] = new PrimitiveUnliftable
 
@@ -44,7 +41,7 @@ object Unliftable {
   /** Default unliftable for String */
   given StringUnliftable as Unliftable[String] = new PrimitiveUnliftable
 
-  private class PrimitiveUnliftable[T <: Unit | Null | Int | Boolean | Byte | Short | Int | Long | Float | Double | Char | String] extends Unliftable[T] {
+  private class PrimitiveUnliftable[T <: Int | Boolean | Byte | Short | Int | Long | Float | Double | Char | String] extends Unliftable[T] {
     /** Lift a quoted primitive value `'{ n }` into `n` */
     def fromExpr(x: Expr[T]) = Const.unapply(x)
   }

--- a/tests/run-staging/quote-valueof.check
+++ b/tests/run-staging/quote-valueof.check
@@ -1,4 +1,3 @@
-Some(())
 Some(true)
 Some(1)
 Some(2)

--- a/tests/run-staging/quote-valueof.scala
+++ b/tests/run-staging/quote-valueof.scala
@@ -6,7 +6,6 @@ object Test {
   given Toolbox = Toolbox.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
-    println(('{}).unlift)
     println(('{true}).unlift)
     println(('{1}).unlift)
     println(('{2: Byte}).unlift)


### PR DESCRIPTION
There is no real point to unlift the value of an `Expr[Unit]` as it is always `()`.
This also aligns with not having a `Liftable[Unit]`.

Extracted from #10516