### PR TITLE
Use `unlift`/`unliftOrError` in code examples

### DIFF
--- a/docs/docs/reference/changed-features/numeric-literals.md
+++ b/docs/docs/reference/changed-features/numeric-literals.md
@@ -207,8 +207,8 @@ method in the `FromDigits` given instance. That method is defined in terms of a 
 implementation method `fromDigitsImpl`. Here is its definition:
 ```scala
   private def fromDigitsImpl(digits: Expr[String])(using ctx: Quotes): Expr[BigFloat] =
-    digits match {
-      case Const(ds) =>
+    digits.unlift match {
+      case Some(ds) =>
         try {
           val BigFloat(m, e) = apply(ds)
           '{BigFloat(${Expr(m)}, ${Expr(e)})}
@@ -218,7 +218,7 @@ implementation method `fromDigitsImpl`. Here is its definition:
             ctx.error(ex.getMessage)
             '{BigFloat(0, 0)}
         }
-      case digits =>
+      case None =>
         '{apply($digits)}
     }
 } // end BigFloat

--- a/tests/neg-macros/BigFloat/BigFloatFromDigitsImpl_1.scala
+++ b/tests/neg-macros/BigFloat/BigFloatFromDigitsImpl_1.scala
@@ -5,13 +5,13 @@ import scala.quoted._
 
 object BigFloatFromDigitsImpl:
   def apply(digits: Expr[String])(using Quotes): Expr[BigFloat] =
-    digits match
-      case Const(ds) =>
+    digits.unlift match
+      case Some(ds) =>
         try
           val BigFloat(m, e) = BigFloat(ds)
           '{BigFloat(${Expr(m)}, ${Expr(e)})}
         catch case ex: FromDigits.FromDigitsException =>
           quotes.reflect.report.error(ex.getMessage)
           '{BigFloat(0, 0)}
-      case digits =>
+      case None =>
         '{BigFloat($digits)}

--- a/tests/neg-macros/GenericNumLits/EvenFromDigitsImpl_1.scala
+++ b/tests/neg-macros/GenericNumLits/EvenFromDigitsImpl_1.scala
@@ -4,8 +4,8 @@ import scala.quoted._
 import Even._
 
 object EvenFromDigitsImpl:
-  def apply(digits: Expr[String])(using Quotes): Expr[Even] = digits match {
-    case Const(ds) =>
+  def apply(digits: Expr[String])(using Quotes): Expr[Even] = digits.unlift match {
+    case Some(ds) =>
       val ev =
         try evenFromDigits(ds)
         catch {

--- a/tests/run-macros/BigFloat/BigFloatFromDigitsImpl_1.scala
+++ b/tests/run-macros/BigFloat/BigFloatFromDigitsImpl_1.scala
@@ -5,8 +5,8 @@ import scala.quoted._
 
 object BigFloatFromDigitsImpl:
   def apply(digits: Expr[String])(using Quotes): Expr[BigFloat] =
-    digits match
-      case Const(ds) =>
+    digits.unlift match
+      case Some(ds) =>
         try
           val BigFloat(m, e) = BigFloat(ds)
           '{BigFloat(${Expr(m)}, ${Expr(e)})}
@@ -14,5 +14,5 @@ object BigFloatFromDigitsImpl:
           import quotes.reflect.report
           report.error(ex.getMessage)
           '{BigFloat(0, 0)}
-      case digits =>
+      case None =>
         '{BigFloat($digits)}

--- a/tests/run-macros/enum-nat-macro/Macros_2.scala
+++ b/tests/run-macros/enum-nat-macro/Macros_2.scala
@@ -25,6 +25,6 @@ import Nat._
        case 0 => acc
        case n => inner[Succ[N]](n - 1, '{Succ($acc)})
 
-     val Const(i) = int
+     val i = int.unliftOrError
      require(i >= 0)
      inner[Zero.type](i, '{Zero})

--- a/tests/run-macros/flops-rewrite-2/Macro_1.scala
+++ b/tests/run-macros/flops-rewrite-2/Macro_1.scala
@@ -12,18 +12,18 @@ private def rewriteMacro[T: Type](x: Expr[T])(using Quotes): Expr[T] = {
     postTransform = List(
       Transformation[Int] {
         case '{ plus($x, $y) } =>
-          (x, y) match {
-            case (Const(0), _) => y
-            case (Const(a), Const(b)) => Expr(a + b)
-            case (_, Const(_)) =>  '{ $y + $x }
+          (x.unlift, y.unlift) match {
+            case (Some(0), _) => y
+            case (Some(a), Some(b)) => Expr(a + b)
+            case (_, Some(_)) =>  '{ $y + $x }
             case _ => '{ $x + $y }
           }
         case '{ times($x, $y) } =>
-          (x, y) match {
-            case (Const(0), _) => '{0}
-            case (Const(1), _) => y
-            case (Const(a), Const(b)) => Expr(a * b)
-            case (_, Const(_)) => '{ $y * $x }
+          (x.unlift, y.unlift) match {
+            case (Some(0), _) => '{0}
+            case (Some(1), _) => y
+            case (Some(a), Some(b)) => Expr(a * b)
+            case (_, Some(_)) => '{ $y * $x }
             case _ => '{ $x * $y }
           }
         case '{ power(${Const(x)}, ${Const(y)}) } =>

--- a/tests/run-macros/flops-rewrite-3/Macro_1.scala
+++ b/tests/run-macros/flops-rewrite-3/Macro_1.scala
@@ -11,18 +11,18 @@ private def rewriteMacro[T: Type](x: Expr[T])(using Quotes): Expr[T] = {
   val rewriter = Rewriter().withFixPoint.withPost(
     Transformation.safe[Int] {
       case '{ plus($x, $y) } =>
-        (x, y) match {
-          case (Const(0), _) => y
-          case (Const(a), Const(b)) => Expr(a + b)
-          case (_, Const(_)) =>  '{ $y + $x }
+        (x.unlift, y.unlift) match {
+          case (Some(0), _) => y
+          case (Some(a), Some(b)) => Expr(a + b)
+          case (_, Some(_)) =>  '{ $y + $x }
           case _ => '{ $x + $y }
         }
       case '{ times($x, $y) } =>
-        (x, y) match {
-          case (Const(0), _) => '{0}
-          case (Const(1), _) => y
-          case (Const(a), Const(b)) => Expr(a * b)
-          case (_, Const(_)) => '{ $y * $x }
+        (x.unlift, y.unlift) match {
+          case (Some(0), _) => '{0}
+          case (Some(1), _) => y
+          case (Some(a), Some(b)) => Expr(a * b)
+          case (_, Some(_)) => '{ $y * $x }
           case _ => '{ $x * $y }
         }
       case '{ power(${Const(x)}, ${Const(y)}) } =>

--- a/tests/run-macros/i8671/Macro_1.scala
+++ b/tests/run-macros/i8671/Macro_1.scala
@@ -13,8 +13,8 @@ object FileName {
 
   def createFileName(fileName: Expr[String])(using Quotes): Expr[FileName] =
     import quotes.reflect.report
-    fileName match {
-      case e@Const(s) =>
+    fileName.unlift match {
+      case Some(s) =>
         fileNameFromString(s) match {
             case Right(fn) =>
               '{FileName.unsafe(${Expr(fn.name)})} // Or `Expr(fn)` if there is a `Liftable[FileName]`

--- a/tests/run-macros/quote-matcher-string-interpolator-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-string-interpolator-2/quoted_1.scala
@@ -9,8 +9,8 @@ object Macros {
   private def impl(self: Expr[StringContext], args: Expr[Seq[String]])(using Quotes): Expr[String] = {
     (self, args) match {
       case ('{ StringContext(${Varargs(parts)}: _*) }, Varargs(args1)) =>
-        val strParts = parts.map { case Const(str) => str.reverse }
-        val strArgs = args1.map { case Const(str) => str }
+        val strParts = parts.map(_.unliftOrError.reverse)
+        val strArgs = args1.map(_.unliftOrError)
         Expr(StringContext(strParts: _*).s(strArgs: _*))
       case _ => ???
     }

--- a/tests/run-macros/quoted-matching-docs-2/Macro_1.scala
+++ b/tests/run-macros/quoted-matching-docs-2/Macro_1.scala
@@ -25,13 +25,7 @@ private def sumExpr(args1: Seq[Expr[Int]])(using Quotes): Expr[Int] = {
       case arg => Seq(arg)
     }
     val args2 = args1.flatMap(flatSumArgs)
-    val staticSum: Int = args2.map {
-      case Const(arg) => arg
-      case _ => 0
-    }.sum
-    val dynamicSum: Seq[Expr[Int]] = args2.filter {
-      case Const(_) => false
-      case arg => true
-    }
+    val staticSum: Int = args2.map(_.unlift.getOrElse(0)).sum
+    val dynamicSum: Seq[Expr[Int]] = args2.filter(_.unlift.isEmpty)
     dynamicSum.foldLeft(Expr(staticSum))((acc, arg) => '{ $acc + $arg })
 }

--- a/tests/run-macros/quoted-matching-docs/Macro_1.scala
+++ b/tests/run-macros/quoted-matching-docs/Macro_1.scala
@@ -12,14 +12,8 @@ private def sumExpr(argsExpr: Expr[Seq[Int]])(using Quotes) : Expr[Int] = {
     case Varargs(Consts(args)) => // args is of type Seq[Int]
       Expr(args.sum) // precompute result of sum
     case Varargs(argExprs) => // argExprs is of type Seq[Expr[Int]]
-      val staticSum: Int = argExprs.map {
-        case Const(arg) => arg
-        case _ => 0
-      }.sum
-      val dynamicSum: Seq[Expr[Int]] = argExprs.filter {
-        case Const(_) => false
-        case arg => true
-      }
+      val staticSum: Int = argExprs.map(_.unlift.getOrElse(0)).sum
+      val dynamicSum: Seq[Expr[Int]] = argExprs.filter(_.unlift.isEmpty)
       dynamicSum.foldLeft(Expr(staticSum))((acc, arg) => '{ $acc + $arg })
     case _ =>
       '{ $argsExpr.sum }

--- a/tests/run-macros/quoted-pattern-open-expr-simple-eval/Macro_1.scala
+++ b/tests/run-macros/quoted-pattern-open-expr-simple-eval/Macro_1.scala
@@ -7,8 +7,8 @@ private def evalExpr(using Quotes)(e: Expr[Int]): Expr[Int] = {
     case '{ val y: Int = $x; $body(y): Int } =>
       evalExpr(Expr.betaReduce('{$body(${evalExpr(x)})}))
     case '{ ($x: Int) * ($y: Int) } =>
-      (x, y) match
-        case (Const(a), Const(b)) => Expr(a * b)
+      (x.unlift, y.unlift) match
+        case (Some(a), Some(b)) => Expr(a * b)
         case _ => e
     case _ => e
   }

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -52,7 +52,7 @@ object Macro {
 
   private def fooCore(parts: Seq[Expr[String]], args: Seq[Expr[Any]], reporter: Reporter)(using Quotes): Expr[String] = {
     for ((part, idx) <- parts.zipWithIndex) {
-      val Const(v: String) = part
+      val v = part.unliftOrError
       if (v.contains("#"))
         reporter.errorOnPart("Cannot use #", idx)
     }


### PR DESCRIPTION
This way the code examples use the recomended way to unlift arguments.