### PR TITLE
Fix scala3doc GH actions

### DIFF
--- a/.github/workflows/scala3doc.yaml
+++ b/.github/workflows/scala3doc.yaml
@@ -2,29 +2,17 @@ name: CI for Scala3doc
 
 on:
   push:
-    branches:
-      - master
-  pull_request_target:
+  pull_request:
 jobs:
   build:
+    env:
+      AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
     runs-on: ubuntu-latest
+    if: "github.event_name == 'pull_request' || contains(github.event.ref, 'scala3doc') || contains(github.event.ref, 'master')"
 
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
-
-      - name: Checkout to PR code
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run : |
-          if [[ -z "${PR_NUMBER}" ]]; then
-            echo Not a pull request do not need to checkout
-          else
-            REF=refs/pull/$PR_NUMBER/merge
-            echo checking $REF
-            git fetch origin $REF:$REF
-            git checkout $REF
-          fi     
 
       - name: Cache Coursier
         uses: actions/cache@v1
@@ -68,12 +56,12 @@ jobs:
 
       - name: Upload documentation to server
         uses: azure/CLI@v1
-        env: 
-          AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
+        if: env.AZURE_STORAGE_SAS_TOKEN
+        env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           inlineScript: |
-            DOC_DEST=pr-${PR_NUMBER:-master}
+            DOC_DEST=pr-${PR_NUMBER:-${GITHUB_REF##*/}}
             echo uplading docs to https://scala3doc.virtuslab.com/$DOC_DEST
             az storage container create --name $DOC_DEST --account-name scala3docstorage --public-access container
             az storage blob sync -s scala3doc/output -c $DOC_DEST --account-name scala3docstorage


### PR DESCRIPTION
Now we run on pull_request as well as on push if branch contains master or scala3doc

This allows us to upload doc to remote storage from private forks that have secrets set