### PR TITLE
don't run schedule on forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    if: "github.event_name == 'schedule'
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'
          || (
            github.event_name == 'push'
            && !startsWith(github.event.ref, 'refs/tags/sbt-dotty-')
@@ -57,7 +57,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    if: "github.event_name == 'schedule'
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'
          || (
            github.event_name == 'push'
            && !startsWith(github.event.ref, 'refs/tags/sbt-dotty-')
@@ -115,7 +115,7 @@ jobs:
 
   test_windows_full:
     runs-on: [self-hosted, Windows]
-    if: "github.event_name == 'schedule'
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'
          || (
            github.event_name == 'push'
            && !startsWith(github.event.ref, 'refs/tags/sbt-dotty-')
@@ -141,7 +141,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    if: "github.event_name == 'schedule'
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'
          || github.event_name == 'push'
          || (
            github.event_name == 'pull_request'
@@ -176,7 +176,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    if: "github.event_name == 'schedule'
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'
          || github.event_name == 'push'
          || (
            github.event_name == 'pull_request'
@@ -211,7 +211,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    if: "github.event_name == 'schedule'
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'
          || (
            github.event_name == 'push'
            && startsWith(github.event.ref, 'refs/tags/')
@@ -247,7 +247,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
 
-    if: "github.event_name == 'schedule'
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'
          || (
            github.event_name == 'push'
            && startsWith(github.event.ref, 'refs/tags/')
@@ -289,7 +289,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
     needs: [test_non_bootstrapped, test, community_build_a, community_build_b, test_sbt, test_java8]
-    if: "github.event_name == 'schedule'"
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'"
     env:
       NIGHTLYBUILD: yes
       PGP_PW: ${{ secrets.PGP_PW }}  # PGP passphrase
@@ -323,7 +323,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
     needs: [publish_nightly]
-    if: "github.event_name == 'schedule'"
+    if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'"
     env:
       NIGHTLYBUILD: yes
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}  # If you need to change this:


### PR DESCRIPTION
I currently get an email each day because the schedule run fails (due to `No runner matching the specified labels was found: self-hosted, Windows` etc.). 
I guess it is unnecessary that the schedule runs in forks hence the additional condition