### PR TITLE
Patch implementation of `Const.unapply`

### DIFF
--- a/library/src-bootstrapped/scala/quoted/Unliftable.scala
+++ b/library/src-bootstrapped/scala/quoted/Unliftable.scala
@@ -83,7 +83,7 @@ object Unliftable {
     def fromExpr(expr: Expr[T]) =
       import quotes.reflect._
       def rec(tree: Term): Option[T] = tree match {
-        case Literal(c) => Some(c.value.asInstanceOf[T])
+        case Literal(c) if c.value != null => Some(c.value.asInstanceOf[T])
         case Block(Nil, e) => rec(e)
         case Typed(e, _) => rec(e)
         case Inlined(_, Nil, e) => rec(e)

--- a/library/src/scala/quoted/Const.scala
+++ b/library/src/scala/quoted/Const.scala
@@ -21,7 +21,12 @@ object Const {
   def unapply[T](expr: Expr[T])(using Quotes): Option[T] = {
     import quotes.reflect._
     def rec(tree: Term): Option[T] = tree match {
-      case Literal(c) => Some(c.value.asInstanceOf[T])
+      case Literal(c) =>
+        c match
+          case Constant.Null() => None
+          case Constant.Unit() => None
+          case Constant.ClassOf(_) => None
+          case _ => Some(c.value.asInstanceOf[T])
       case Block(Nil, e) => rec(e)
       case Typed(e, _) => rec(e)
       case Inlined(_, Nil, e) => rec(e)

--- a/tests/run-macros/tasty-extractors-constants-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-constants-1/quoted_1.scala
@@ -14,7 +14,7 @@ object Macros {
     Expr(3) match { case Const(n) => stagedPrintln(n) }
     '{4} match { case Const(n) => stagedPrintln(n) }
     '{"abc"} match { case Const(n) => stagedPrintln(n) }
-    '{null} match { case Const(n) => stagedPrintln(n) }
+    '{null} match { case '{null} => stagedPrintln(null) }
 
     '{new Object} match { case Const(n) => println(n); case _ => stagedPrintln("OK") }
 

--- a/tests/run-staging/unliftables.check
+++ b/tests/run-staging/unliftables.check
@@ -38,7 +38,7 @@ Some(Some(3))
 Some(None)
 Some(Some(3))
 Some(Some(3))
-Some(None)
+None
 
 Some(Left(1))
 Some(Right(2))


### PR DESCRIPTION
* Make sure the extrators does not match classes. This should be done using reflection.
* Do not match `'{null}` to avoid accidental NPEs.
* Do not match `'{}` as there is no value to extract.

```diff
- case Const(null) =>
+ case '{null} =>

- case Const(()) =>
+ case '{} =>
```

We specialize use the old, faster, implementation for `Unliftable` as there it correct by the construction of the available `Unliftable`s. We only need to add a null check for `StringUnliftable`.