### PR TITLE
Scala3doc: improve stdlib loading

### DIFF
--- a/.github/workflows/scala3doc.yaml
+++ b/.github/workflows/scala3doc.yaml
@@ -45,9 +45,6 @@ jobs:
       - name: Generate Scala 3 documentation
         run: ./project/scripts/sbt scala3doc/generateScala3Documentation
 
-      - name: Generate Scala 3 stdlib documentation
-        run: ./project/scripts/sbt scala3doc/generateScala3StdlibDocumentation
-
       - name: Generate documentation for example project using dotty-sbt
         run: ./project/scripts/sbt "sbt-dotty/scripted sbt-dotty/scala3doc"
 

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -176,6 +176,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *  +- Flags
    *
    *  ```
+   *
+   * @syntax markdown
    */
   trait Reflection { self: reflect.type =>
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1216,7 +1216,6 @@ object Build {
   val generateSelfDocumentation = taskKey[Unit]("Generate example documentation")
   // Note: the two tasks below should be one, but a bug in Tasty prevents that
   val generateScala3Documentation = inputKey[Unit]("Generate documentation for dotty lib")
-  val generateScala3StdlibDocumentation = taskKey[Unit]("Generate documentation for Scala3 standard library")
   val generateTestcasesDocumentation  = taskKey[Unit]("Generate documentation for testcases, usefull for debugging tests")
   lazy val `scala3doc` = project.in(file("scala3doc")).asScala3doc
   lazy val `scala3doc-testcases` = project.in(file("scala3doc-testcases")).asScala3docTestcases
@@ -1566,9 +1565,9 @@ object Build {
             val majorVersion = (scalaBinaryVersion in LocalProject("scala3-library-bootstrapped")).value
 
             val dottyJars: Seq[java.io.File] = Seq(
+              (`stdlib-bootstrapped`/Compile/products).value,
               (`scala3-interfaces`/Compile/products).value,
               (`tasty-core-bootstrapped`/Compile/products).value,
-              (`scala3-library-bootstrapped`/Compile/products).value,
             ).flatten
 
             val roots = joinProducts(dottyJars)
@@ -1583,23 +1582,6 @@ object Build {
               roots, "Scala 3", dest.getAbsolutePath, "master",
               "-siteroot scala3doc/scala3-docs -project-logo scala3doc/scala3-docs/logo.svg"))
           }.evaluated,
-
-
-          generateScala3StdlibDocumentation:= Def.taskDyn {
-            val dottyJars: Seq[java.io.File] = Seq(
-              (`stdlib-bootstrapped`/Compile/products).value,
-              (`scala3-interfaces`/Compile/products).value,
-              (`tasty-core-bootstrapped`/Compile/products).value,
-            ).flatten
-
-            val roots = joinProducts(dottyJars)
-
-            if (dottyJars.isEmpty) Def.task { streams.value.log.error("Dotty lib wasn't found") }
-            else generateDocumentation(
-              roots, "Scala 3", "scala3doc/output/scala3-stdlib", "maser",
-              "-siteroot scala3doc/scala3-docs -comment-syntax wiki -project-logo scala3doc/scala3-docs/logo.svg "
-            )
-          }.value,
 
           generateTestcasesDocumentation := Def.taskDyn {
             generateDocumentation(Build.testcasesOutputDir.in(Test).value, "Scala3doc testcases", "scala3doc/output/testcases", "master")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1580,7 +1580,7 @@ object Build {
               IO.write(dest / "CNAME", "dotty.epfl.ch")
             }.dependsOn(generateDocumentation(
               roots, "Scala 3", dest.getAbsolutePath, "master",
-              "-siteroot scala3doc/scala3-docs -project-logo scala3doc/scala3-docs/logo.svg"))
+              "-comment-syntax wiki -siteroot scala3doc/scala3-docs -project-logo scala3doc/scala3-docs/logo.svg"))
           }.evaluated,
 
           generateTestcasesDocumentation := Def.taskDyn {

--- a/scala3doc/src/dotty/dokka/tasty/comments/wiki/Converter.scala
+++ b/scala3doc/src/dotty/dokka/tasty/comments/wiki/Converter.scala
@@ -31,13 +31,16 @@ class Converter(val repr: Repr) extends BaseConverter {
     block match {
       case Title(text, level) =>
         val content = convertInline(text)
+        // NOTE: these aren't strictly necessary, but if you inline them, incremental compilation will break
+        val jContent = content.asJava : java.util.List[_ <: dkkd.DocTag]
+        val jAtt = kt.emptyMap[String, String]
         emit(level match {
-          case 1 => dkkd.H1(content.asJava, kt.emptyMap)
-          case 2 => dkkd.H2(content.asJava, kt.emptyMap)
-          case 3 => dkkd.H3(content.asJava, kt.emptyMap)
-          case 4 => dkkd.H4(content.asJava, kt.emptyMap)
-          case 5 => dkkd.H5(content.asJava, kt.emptyMap)
-          case 6 => dkkd.H6(content.asJava, kt.emptyMap)
+          case 1 => dkkd.H1(jContent, jAtt)
+          case 2 => dkkd.H2(jContent, jAtt)
+          case 3 => dkkd.H3(jContent, jAtt)
+          case 4 => dkkd.H4(jContent, jAtt)
+          case 5 => dkkd.H5(jContent, jAtt)
+          case 6 => dkkd.H6(jContent, jAtt)
         })
 
       case Paragraph(text) =>


### PR DESCRIPTION
This PR fixes the issue that prevented us from loading stdlib together w/ other artifacts, and makes the doctool aware of stdlib patching going on in the compiler.