### PR TITLE
Fix #10295: Require import qualifiers to be idempotent

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -723,6 +723,8 @@ trait Checking {
   def checkLegalImportPath(path: Tree)(using Context): Unit = {
     checkStable(path.tpe, path.srcPos, "import prefix")
     if (!ctx.isAfterTyper) Checking.checkRealizable(path.tpe, path.srcPos)
+    if !isIdempotentExpr(path) then
+      report.error(em"import prefix is not a pure expression", path.srcPos)
   }
 
  /**  Check that `tp` is a class type.

--- a/tests/neg/i10295.scala
+++ b/tests/neg/i10295.scala
@@ -1,0 +1,4 @@
+def get: 1 = { println("hi"); 1 }
+import get._ // error: import prefix is not a pure expression
+val x = get.toLong
+

--- a/tests/pos/i10295.scala
+++ b/tests/pos/i10295.scala
@@ -1,0 +1,36 @@
+trait M:
+  type X
+  object X:
+    def foo(): X = ???
+
+inline def m(using m: M): m.type = m
+
+def doSomething(body: M ?=> Unit) = body(using new M{})
+
+
+def Test1 =
+  given M = new M{}
+  import m._
+  val x: X = X.foo()
+  println(x)
+
+def Test2 =
+
+  doSomething {
+    val x: m.X = m.X.foo()
+    println(x)
+  }
+  // or with an import
+  doSomething {
+    import m._ // Concise and clear import of the same stable path `m`
+    val x: X = X.foo()
+    println(x)
+  }
+  // without this feature we would need an extra line in each call site
+  doSomething {
+    // not ideal
+    val myM = m // or summon[M]
+    import myM._
+    val x: X = X.foo()
+    println(x)
+  }


### PR DESCRIPTION
The use case for contextual abstractions is still supported if the function
returning an implicit parameter is declared `inline`.