### PR TITLE
Fix edge case in ReadTasty.scala

### DIFF
--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
@@ -69,7 +69,12 @@ class ReadTasty extends Phase {
           def moduleClass = clsd.owner.info.member(className.moduleClassName).symbol
           compilationUnit(clsd.classSymbol).orElse(compilationUnit(moduleClass))
         case _ =>
-          cannotUnpickle(s"no class file was found")
+          staticRef(className.moduleClassName) match {
+            case clsd: ClassDenotation =>
+              compilationUnit(clsd.classSymbol)
+            case denot =>
+              cannotUnpickle(s"no class file was found for denot: $denot")
+          }
       }
     case unit =>
      Some(unit)

--- a/scala3doc-testcases/src/example/typeAndObjects/package.scala
+++ b/scala3doc-testcases/src/example/typeAndObjects/package.scala
@@ -1,0 +1,12 @@
+package example
+
+// Ala fails Ola does not
+package object typeAndObjects:
+  type Ala
+
+package typeAndObjects {
+  object Ala
+}
+
+type Ola
+object Ola


### PR DESCRIPTION
It can happen that a module named `className` exists and no class with same exists, yet the module class name is still suffixed with `$` (see testcase).

Fixed #10499.