### PR TITLE
Remove Documentation type from Reflect

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2316,14 +2316,14 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def pos: Option[Position] =
           if self.exists then Some(self.sourcePos) else None
 
-        def documentation: Option[Documentation] =
+        def docstring: Option[String] =
           import dotc.core.Comments.CommentsContext
           val docCtx = ctx.docCtx.getOrElse {
             throw new RuntimeException(
               "DocCtx could not be found and documentations are unavailable. This is a compiler-internal error."
             )
           }
-          docCtx.docstring(self)
+          docCtx.docstring(self).map(_.raw)
 
         def tree: Tree = FromSymbol.definitionFromSym(self)
 
@@ -2651,19 +2651,6 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         dotc.report.warning(msg, pos)
 
     end report
-
-    type Documentation = dotc.core.Comments.Comment
-
-    object Documentation extends DocumentationModule
-
-    given DocumentationMethods: DocumentationMethods with
-      extension (self: Documentation):
-        def raw: String = self.raw
-        def expanded: Option[String] = self.expanded
-        def usecases: List[(String, Option[DefDef])] =
-          self.usecases.map { uc => (uc.code, uc.tpdCode) }
-      end extension
-    end DocumentationMethods
 
     private def optional[T <: dotc.ast.Trees.Tree[?]](tree: T): Option[tree.type] =
       if tree.isEmpty then None else Some(tree)

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -174,8 +174,6 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *
    *  +- SourceFile
    *
-   *  +- Documentation
-   *
    *  +- Constant
    *
    *  +- Symbol
@@ -3089,7 +3087,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def pos: Option[Position]
 
         /** The documentation for this symbol, if any */
-        def documentation: Option[Documentation]
+        def docstring: Option[String]
 
         /** Tree of this definition
         *
@@ -3752,36 +3750,6 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     }
 
 
-    ///////////////////
-    // DOCUMENTATION //
-    ///////////////////
-
-    /** Attachment representing the documentation of a definition */
-    type Documentation <: AnyRef
-
-    /** Module object of `type Documentation`  */
-    val Documentation: DocumentationModule
-
-    /** Methods of the module object `val Documentation` */
-    trait DocumentationModule { this: Documentation.type => }
-
-    /** Makes extension methods on `Documentation` available without any imports */
-    given DocumentationMethods: DocumentationMethods
-
-    /** Extension methods of `Documentation` */
-    trait DocumentationMethods {
-      extension (self: Documentation):
-        /** Raw documentation string */
-        def raw: String
-
-        /** Expanded documentation string, if any */
-        def expanded: Option[String]
-
-        /** List of usecases and their corresponding trees, if any */
-        def usecases: List[(String, Option[DefDef])]
-
-      end extension
-    }
 
     ///////////////
     //   UTILS   //

--- a/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
@@ -34,9 +34,9 @@ trait BasicSupport:
 
 
   extension (sym: Symbol):
-    def documentation = sym.documentation match
-      case Some(comment) =>
-          Map(ctx.sourceSet -> parseComment(comment, sym.tree))
+    def documentation = sym.docstring match
+      case Some(docstring) =>
+          Map(ctx.sourceSet -> parseComment(docstring, sym.tree))
       case None =>
           Map.empty
 

--- a/scala3doc/src/dotty/dokka/tasty/ScalaDocSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ScalaDocSupport.scala
@@ -12,10 +12,10 @@ trait ScaladocSupport { self: TastyParser =>
   import qctx.reflect._
 
   def parseComment(
-    commentPre: Documentation,
+    docstring: String,
     tree: Tree
   ): dkkd.DocumentationNode = {
-    val commentNode =
+    val commentString: String =
       if tree.symbol.isClassDef || tree.symbol.owner.isClassDef then
         import dotty.tools.dotc
         given ctx: dotc.core.Contexts.Context = qctx.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
@@ -23,11 +23,10 @@ trait ScaladocSupport { self: TastyParser =>
         val sym = tree.symbol.asInstanceOf[dotc.core.Symbols.Symbol]
 
         comments.CommentExpander.cookComment(sym)(using ctx)
-          .get.asInstanceOf[Documentation]
+          .get.expanded.get
       else
-        commentPre
+        docstring
 
-    val commentString = commentNode.expanded getOrElse commentNode.raw
     val preparsed =
       comments.Preparser.preparse(comments.Cleaner.clean(commentString))
 

--- a/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
+++ b/tests/run-custom-args/tasty-inspector/tasty-documentation-inspector/Test.scala
@@ -21,8 +21,8 @@ class DocumentationInspector extends TastyInspector {
 
       override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {
         case tree: Definition =>
-          tree.symbol.documentation match {
-            case Some(doc) => println(doc.raw)
+          tree.symbol.docstring match {
+            case Some(doc) => println(doc)
             case None => println()
           }
           super.traverseTree(tree)(owner)


### PR DESCRIPTION
Nothing but the .raw field is set when we load documentation from Tasty. Right now, it doesn't make sense to expose `Documentation` as a separate type.

It might make sense to expose it later when we decide how exactly we expose cooking comments.