### PR TITLE
Fix #10603: implicitNotFound message for T <: Function1[_, _]

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -334,6 +334,8 @@ class ImplicitSearchError(
    */
   private def userDefinedImplicitNotFoundTypeMessage: Option[String] =
     pt.baseClasses.iterator
+      // Don't inherit "No implicit view available..." message if subtypes of Function1 are not treated as implicit conversions anymore
+      .filter(sym => Feature.migrateTo3 || sym != defn.Function1)
       .map(userDefinedImplicitNotFoundTypeMessage(_))
       .find(_.isDefined).flatten
 

--- a/tests/neg/i10603a.check
+++ b/tests/neg/i10603a.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i10603a.scala:2:35 ---------------------------------------------------------------------------------
+2 |  val x = implicitly[List[Boolean]] // error
+  |                                   ^
+  |        no implicit argument of type List[Boolean] was found for parameter e of method implicitly in object Predef

--- a/tests/neg/i10603a.scala
+++ b/tests/neg/i10603a.scala
@@ -1,0 +1,3 @@
+object Test {
+  val x = implicitly[List[Boolean]] // error
+}

--- a/tests/neg/i10603b.check
+++ b/tests/neg/i10603b.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i10603b.scala:4:35 ---------------------------------------------------------------------------------
+4 |  val x = implicitly[List[Boolean]] // error
+  |                                   ^
+  |                                   No implicit view available from Int => Boolean.

--- a/tests/neg/i10603b.scala
+++ b/tests/neg/i10603b.scala
@@ -1,0 +1,5 @@
+import language.`3.0-migration`
+
+object Test {
+  val x = implicitly[List[Boolean]] // error
+}

--- a/tests/neg/summon-function.check
+++ b/tests/neg/summon-function.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/summon-function.scala:2:23 -------------------------------------------------------------------------
 2 |  summon[Int => String] // error
   |                       ^
-  |                       No implicit view available from Int => String.
+  |            no implicit argument of type Int => String was found for parameter x of method summon in object Predef


### PR DESCRIPTION
Don't display "No implicit view available ..." message when an given instance of a subtype of Function1 was not found