### PR TITLE
Do not re-highlight result of typeOf

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -382,7 +382,7 @@ class ReplDriver(settings: Array[String],
         case _  =>
           compiler.typeOf(expr)(newRun(state)).fold(
             displayErrors,
-            res => out.println(SyntaxHighlighting.highlight(res)(using state.context))
+            res => out.println(res)  // result has some highlights
           )
       }
       state


### PR DESCRIPTION
Literals in the result are highlighted:
```
scala> :type if true then 1.0 else if true then 10L else "bye"
(1.0 : Double) | ((10L : Long) | ("bye" : String))
```
Band aid for #10615 