### PR TITLE
Fix #10349: Use local ctx in Implicits.eligible

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -280,7 +280,7 @@ object Implicits:
     }
 
     /** The candidates that are eligible for expected type `tp` */
-    @threadUnsafe lazy val eligible: List[Candidate] =
+    def eligible(using Context): List[Candidate] =
       trace(i"eligible($tp), companions = ${companionRefs.showAsList}%, %", implicitsDetailed, show = true) {
         if (refs.nonEmpty && monitored) record(s"check eligible refs in tpe", refs.length)
         filterMatching(tp)

--- a/tests/pos/10349.scala
+++ b/tests/pos/10349.scala
@@ -1,0 +1,11 @@
+object Firsts:
+
+  type First[X] = X match
+    case Map[_, v] => First[Option[v]]
+
+  def first[X](x: X): First[X] = x match
+    case x: Map[_, _] => first(x.values.headOption)
+
+  @main
+  def runFirsts2(): Unit =
+    assert(first(Map.empty[Int, Int]) == None)


### PR DESCRIPTION
The NPE was caused by the (wrong?) use of an unpickling context in implicit search. By analyzing the context at each point in the stack trace of the NPE for 10349.scala (below), I noticed that `ctx.compilationUnit` becomes null starting from `eligible(Implicits.scala:285)` (it is not null just before, in `searchImplicit(Implicits.scala:1280)`).

<details><summary>stack trace</summary><pre>
java.lang.NullPointerException
  at dotty.tools.dotc.core.NameKinds$UniqueNameKind.fresh(NameKinds.scala:222)
  at dotty.tools.dotc.typer.ProtoTypes$.newTypeVar(ProtoTypes.scala:569)
  at dotty.tools.dotc.core.TypeOps$.$anonfun$4(TypeOps.scala:754)
  at scala.collection.immutable.List.map(List.scala:246)
  at dotty.tools.dotc.core.TypeOps$.instantiateToSubType(TypeOps.scala:754)
  at dotty.tools.dotc.core.TypeOps$.refineUsingParent(TypeOps.scala:656)
  at dotty.tools.dotc.core.TypeComparer.decompose$2$$anonfun$1(TypeComparer.scala:2418)
  at scala.collection.immutable.List.map(List.scala:250)
  at dotty.tools.dotc.core.TypeComparer.decompose$1(TypeComparer.scala:2418)
  at dotty.tools.dotc.core.TypeComparer.provablyDisjoint(TypeComparer.scala:2441)
  at dotty.tools.dotc.core.TypeComparer.provablyDisjoint(TypeComparer.scala:2511)
  at dotty.tools.dotc.core.TypeComparer.provablyDisjoint(TypeComparer.scala:2511)
  at dotty.tools.dotc.core.TrackingTypeComparer.matchCase$1(TypeComparer.scala:2804)
  at dotty.tools.dotc.core.TrackingTypeComparer.recur$2(TypeComparer.scala:2813)
  at dotty.tools.dotc.core.TrackingTypeComparer.op$proxy45$1(TypeComparer.scala:2834)
  at dotty.tools.dotc.core.TrackingTypeComparer.matchCases(TypeComparer.scala:2835)
  at dotty.tools.dotc.core.Types$MatchType.liftedTree1$2(Types.scala:4433)
  at dotty.tools.dotc.core.Types$MatchType.matchCases$1(Types.scala:4436)
  at dotty.tools.dotc.core.Types$MatchType.reduced$$anonfun$1(Types.scala:4437)
  at dotty.tools.dotc.core.TypeComparer.inSubComparer(TypeComparer.scala:2527)
  at dotty.tools.dotc.core.TypeComparer.tracked(TypeComparer.scala:2537)
  at dotty.tools.dotc.core.TypeComparer$.tracked(TypeComparer.scala:2687)
  at dotty.tools.dotc.core.Types$MatchType.reduced(Types.scala:4437)
  at dotty.tools.dotc.core.Types$MatchType.tryNormalize(Types.scala:4399)
  at dotty.tools.dotc.core.Types$AppliedType.tryMatchAlias$1(Types.scala:3931)
  at dotty.tools.dotc.core.Types$AppliedType.tryNormalize(Types.scala:3937)
  at dotty.tools.dotc.core.Types$Type.normalized(Types.scala:1328)
  at dotty.tools.dotc.core.Types$MatchType.tryNormalize(Types.scala:4399)
  at dotty.tools.dotc.core.Types$AppliedType.tryMatchAlias$1(Types.scala:3931)
  at dotty.tools.dotc.core.Types$AppliedType.tryNormalize(Types.scala:3937)
  at dotty.tools.dotc.core.SymDenotations$ClassDenotation.recur$1(SymDenotations.scala:1971)
  at dotty.tools.dotc.core.SymDenotations$ClassDenotation.baseTypeOf(SymDenotations.scala:2087)
  at dotty.tools.dotc.core.Types$Type.baseType(Types.scala:1051)
  at dotty.tools.dotc.core.TypeComparer.nonExprBaseType(TypeComparer.scala:1276)
  at dotty.tools.dotc.core.TypeComparer.tryBaseType$1(TypeComparer.scala:736)
  at dotty.tools.dotc.core.TypeComparer.thirdTryNamed$1(TypeComparer.scala:515)
  at dotty.tools.dotc.core.TypeComparer.thirdTry$1(TypeComparer.scala:554)
  at dotty.tools.dotc.core.TypeComparer.secondTry$1(TypeComparer.scala:479)
  at dotty.tools.dotc.core.TypeComparer.compareNamed$1(TypeComparer.scala:289)
  at dotty.tools.dotc.core.TypeComparer.firstTry$1(TypeComparer.scala:295)
  at dotty.tools.dotc.core.TypeComparer.recur(TypeComparer.scala:1257)
  at dotty.tools.dotc.core.TypeComparer.isSubType(TypeComparer.scala:177)
  at dotty.tools.dotc.core.TypeComparer.isSubType(TypeComparer.scala:187)
  at dotty.tools.dotc.core.TypeComparer.isSubArg$1(TypeComparer.scala:1468)
  at dotty.tools.dotc.core.TypeComparer.recurArgs$1(TypeComparer.scala:1473)
  at dotty.tools.dotc.core.TypeComparer.isSubArgs(TypeComparer.scala:1476)
  at dotty.tools.dotc.core.TypeComparer.loop$3(TypeComparer.scala:1067)
  at dotty.tools.dotc.core.TypeComparer.isMatchingApply$1(TypeComparer.scala:1082)
  at dotty.tools.dotc.core.TypeComparer.compareAppliedType2$1(TypeComparer.scala:1141)
  at dotty.tools.dotc.core.TypeComparer.thirdTry$1(TypeComparer.scala:552)
  at dotty.tools.dotc.core.TypeComparer.secondTry$1(TypeComparer.scala:479)
  at dotty.tools.dotc.core.TypeComparer.firstTry$1(TypeComparer.scala:366)
  at dotty.tools.dotc.core.TypeComparer.recur(TypeComparer.scala:1257)
  at dotty.tools.dotc.core.TypeComparer.isSubType(TypeComparer.scala:177)
  at dotty.tools.dotc.core.TypeComparer.tryBaseType$1(TypeComparer.scala:738)
  at dotty.tools.dotc.core.TypeComparer.compareAppliedType2$1(TypeComparer.scala:1149)
  at dotty.tools.dotc.core.TypeComparer.thirdTry$1(TypeComparer.scala:552)
  at dotty.tools.dotc.core.TypeComparer.secondTry$1(TypeComparer.scala:378)
  at dotty.tools.dotc.core.TypeComparer.firstTry$1(TypeComparer.scala:366)
  at dotty.tools.dotc.core.TypeComparer.recur(TypeComparer.scala:1257)
  at dotty.tools.dotc.core.TypeComparer.isSubType(TypeComparer.scala:177)
  at dotty.tools.dotc.core.TypeComparer.isSubType(TypeComparer.scala:187)
  at dotty.tools.dotc.core.TypeComparer.topLevelSubType(TypeComparer.scala:128)
  at dotty.tools.dotc.core.TypeComparer$.topLevelSubType(TypeComparer.scala:2587)
  at dotty.tools.dotc.core.Types$Type.$less$colon$less(Types.scala:961)
  at dotty.tools.dotc.core.Types$Type.relaxed_$less$colon$less(Types.scala:995)
  at dotty.tools.dotc.typer.ProtoTypes$Compatibility.isCompatible(ProtoTypes.scala:39)
  at dotty.tools.dotc.typer.ProtoTypes$Compatibility.isCompatible$(ProtoTypes.scala:26)
  at dotty.tools.dotc.typer.ProtoTypes$NoViewsAllowed$.isCompatible(ProtoTypes.scala:110)
  at dotty.tools.dotc.typer.Implicits$ImplicitRefs.candidateKind$1(Implicits.scala:240)
  at dotty.tools.dotc.typer.Implicits$ImplicitRefs.tryCandidate$1(Implicits.scala:254)
  at dotty.tools.dotc.typer.Implicits$ImplicitRefs.filterMatching$$anonfun$2(Implicits.scala:263)
  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
  at scala.collection.immutable.List.foreach(List.scala:333)
  at dotty.tools.dotc.typer.Implicits$ImplicitRefs.filterMatching(Implicits.scala:263)
  at dotty.tools.dotc.typer.Implicits$OfTypeImplicits.eligible(Implicits.scala:285)
  at dotty.tools.dotc.typer.Implicits$ImplicitSearch.searchImplicit(Implicits.scala:1280)
  at dotty.tools.dotc.typer.Implicits$ImplicitSearch.searchImplicit(Implicits.scala:1289)
  at dotty.tools.dotc.typer.Implicits$ImplicitSearch.bestImplicit(Implicits.scala:1314)
  at dotty.tools.dotc.typer.Implicits.inferImplicit(Implicits.scala:946)
  at dotty.tools.dotc.typer.Implicits.inferImplicit$(Implicits.scala:747)
  at dotty.tools.dotc.typer.Typer.inferImplicit(Typer.scala:92)
  at dotty.tools.dotc.typer.Implicits.inferImplicitArg(Implicits.scala:821)
  at dotty.tools.dotc.typer.Implicits.inferImplicitArg$(Implicits.scala:747)
  at dotty.tools.dotc.typer.Typer.inferImplicitArg(Typer.scala:92)
  at dotty.tools.dotc.typer.Implicits.implicitArgTree(Implicits.scala:831)
  at dotty.tools.dotc.typer.Implicits.implicitArgTree$(Implicits.scala:747)
  at dotty.tools.dotc.typer.Typer.implicitArgTree(Typer.scala:92)
  at dotty.tools.dotc.typer.Implicits.checkCanEqual(Implicits.scala:916)
  at dotty.tools.dotc.typer.Implicits.checkCanEqual$(Implicits.scala:747)
  at dotty.tools.dotc.typer.Typer.checkCanEqual(Typer.scala:92)
  at dotty.tools.dotc.typer.Applications.typedApply(Applications.scala:1031)
  at dotty.tools.dotc.typer.Applications.typedApply$(Applications.scala:236)
  at dotty.tools.dotc.typer.Typer.typedApply(Typer.scala:92)
  at dotty.tools.dotc.typer.Typer.typedInfixOp(Typer.scala:2362)
  at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:2509)
  at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:2532)
  at dotty.tools.dotc.typer.ProtoTypes$FunProto.$anonfun$2(ProtoTypes.scala:367)
  at dotty.tools.dotc.typer.ProtoTypes$FunProto.cacheTypedArg(ProtoTypes.scala:323)
  at dotty.tools.dotc.typer.ProtoTypes$FunProto.typedArg(ProtoTypes.scala:368)
  at dotty.tools.dotc.typer.Applications$ApplyToUntyped.typedArg(Applications.scala:825)
  at dotty.tools.dotc.typer.Applications$ApplyToUntyped.typedArg(Applications.scala:825)
  at dotty.tools.dotc.typer.Applications$Application.addTyped$1(Applications.scala:545)
  at dotty.tools.dotc.typer.Applications$Application.matchArgs(Applications.scala:616)
  at dotty.tools.dotc.typer.Applications$Application.init(Applications.scala:366)
  at dotty.tools.dotc.typer.Applications$TypedApply.<init>(Applications.scala:720)
  at dotty.tools.dotc.typer.Applications$ApplyToUntyped.<init>(Applications.scala:824)
  at dotty.tools.dotc.typer.Applications.ApplyTo(Applications.scala:1051)
  at dotty.tools.dotc.typer.Applications.ApplyTo$(Applications.scala:236)
  at dotty.tools.dotc.typer.Typer.ApplyTo(Typer.scala:92)
  at dotty.tools.dotc.typer.Applications.simpleApply$1(Applications.scala:898)
  at dotty.tools.dotc.typer.Applications.realApply$5$$anonfun$4(Applications.scala:977)
  at dotty.tools.dotc.typer.Typer.tryEither(Typer.scala:2728)
  at dotty.tools.dotc.typer.Applications.realApply$1(Applications.scala:988)
  at dotty.tools.dotc.typer.Applications.typedApply(Applications.scala:1026)
  at dotty.tools.dotc.typer.Applications.typedApply$(Applications.scala:236)
  at dotty.tools.dotc.typer.Typer.typedApply(Typer.scala:92)
  at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:2471)
  at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:2532)
  at dotty.tools.dotc.typer.Typer.typed(Typer.scala:2601)
  at dotty.tools.dotc.typer.Typer.typed(Typer.scala:2605)
  at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:2720)
  at dotty.tools.dotc.typer.Typer.$anonfun$33(Typer.scala:1987)
  at dotty.tools.dotc.typer.PrepareInlineable$.dropInlineIfError(PrepareInlineable.scala:216)
  at dotty.tools.dotc.typer.Typer.typedDefDef(Typer.scala:1987)
  at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:2448)
  at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:2531)
  at dotty.tools.dotc.typer.Typer.typed(Typer.scala:2601)
  at dotty.tools.dotc.typer.Typer.typed(Typer.scala:2605)
  at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:2627)
  at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:2676)
  at dotty.tools.dotc.typer.Typer.typedClassDef(Typer.scala:2131)
  at dotty.tools.dotc.typer.Typer.typedTypeOrClassDef$2(Typer.scala:2459)
  at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:2463)
  at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:2531)
  at dotty.tools.dotc.typer.Typer.typed(Typer.scala:2601)
  at dotty.tools.dotc.typer.Typer.typed(Typer.scala:2605)
  at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:2627)
  at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:2676)
  at dotty.tools.dotc.typer.Typer.typedPackageDef(Typer.scala:2256)
  at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:2503)
  at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:2532)
  at dotty.tools.dotc.typer.Typer.typed(Typer.scala:2601)
  at dotty.tools.dotc.typer.Typer.typed(Typer.scala:2605)
  at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:2720)
  at dotty.tools.dotc.typer.FrontEnd.liftedTree1$1(FrontEnd.scala:79)
  at dotty.tools.dotc.typer.FrontEnd.typeCheck$$anonfun$1(FrontEnd.scala:84)
  at dotty.runtime.function.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
  at dotty.tools.dotc.typer.FrontEnd.monitor(FrontEnd.scala:43)
  at dotty.tools.dotc.typer.FrontEnd.typeCheck(FrontEnd.scala:85)
  at dotty.tools.dotc.typer.FrontEnd.runOn$$anonfun$3(FrontEnd.scala:120)
  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
  at scala.collection.immutable.List.foreach(List.scala:333)
  at dotty.tools.dotc.typer.FrontEnd.runOn(FrontEnd.scala:120)
  at dotty.tools.dotc.Run.runPhases$4$$anonfun$4(Run.scala:185)
  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
  at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
  at dotty.tools.dotc.Run.runPhases$5(Run.scala:195)
  at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:203)
  at dotty.runtime.function.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
  at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:67)
  at dotty.tools.dotc.Run.compileUnits(Run.scala:210)
  at dotty.tools.dotc.Run.compileSources(Run.scala:147)
  at dotty.tools.dotc.Run.compile(Run.scala:129)
  at dotty.tools.dotc.Driver.doCompile(Driver.scala:38)
  at dotty.tools.dotc.Driver.process(Driver.scala:193)
  at dotty.tools.dotc.Driver.process(Driver.scala:162)
  at dotty.tools.dotc.Driver.process(Driver.scala:174)
  at dotty.tools.dotc.Driver.main(Driver.scala:201)
  at dotty.tools.dotc.Main.main(Main.scala)
