### PR TITLE
Update syntax in docs

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1091,6 +1091,8 @@ object Parsers {
     /** Singleton    ::=  SimpleRef
      *                 |  SimpleLiteral
      *                 |  Singleton ‘.’ id
+     * -- not yet      |  Singleton ‘(’ Singletons ‘)’
+     * -- not yet      |  Singleton ‘[’ Types ‘]’
      */
     def singleton(): Tree =
       if isSimpleLiteral then simpleLiteral()

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -157,7 +157,7 @@ AnnotType         ::=  SimpleType {Annotation}                                  
 
 SimpleType        ::=  SimpleLiteral                                            SingletonTypeTree(l)
                     |  ‘?’ TypeBounds
-                    |  SimpleType1 { ‘(’ Singletons ‘)’ }
+                    |  SimpleType1
 SimpleType1       ::=  id                                                       Ident(name)
                     |  Singleton ‘.’ id                                         Select(t, name)
                     |  Singleton ‘.’ ‘type’                                     SingletonTypeTree(p)
@@ -169,8 +169,6 @@ SimpleType1       ::=  id                                                       
 Singleton         ::=  SimpleRef
                     |  SimpleLiteral
                     |  Singleton ‘.’ id
--- not yet          |  Singleton ‘(’ Singletons ‘)’
--- not yet          |  Singleton ‘[’ Types ‘]’
 Singletons        ::=  Singleton { ‘,’ Singleton }
 FunArgType        ::=  Type
                     |  ‘=>’ Type                                                PrefixOp(=>, t)
@@ -205,11 +203,9 @@ Expr1             ::=  [‘inline’] ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[
                     |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
                     |  PostfixExpr [Ascription]
-                    |  StructuralInstance
                     |  ‘inline’ InfixExpr MatchClause
 Ascription        ::=  ‘:’ InfixType                                            Typed(expr, tp)
                     |  ‘:’ Annotation {Annotation}                              Typed(expr, Annotated(EmptyTree, annot)*)
-StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody        New templ
 Catches           ::=  ‘catch’ (Expr | ExprCaseClause)
 PostfixExpr       ::=  InfixExpr [id]                                           PostfixOp(expr, op)
 InfixExpr         ::=  PrefixExpr
@@ -400,6 +396,7 @@ ObjectDef         ::=  id [Template]                                            
 EnumDef           ::=  id ClassConstr InheritClauses EnumBody                   EnumDef(mods, name, tparams, template)
 GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | StructuralInstance)
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’       -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
+StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody
 Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’
                        {UsingParamClause}] ExtMethods
 ExtMethods        ::=  ExtMethod | [nl] ‘{’ ExtMethod {semi ExtMethod ‘}’

--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -371,6 +371,16 @@ ConstrApps        ::=  ConstrApp {‘with’ ConstrApp}
                     |  ConstrApp {‘,’ ConstrApp}
 ```
 
+Note: To align `extends` clauses and `derives` clauses, Scala 3 also allows multiple
+extended types to be separated by commas. So the following is now legal:
+```
+class A extends B, C { ... }
+```
+It is equivalent to the old form
+```
+class A extends B with C { ... }
+```
+
 ### Discussion
 
 This type class derivation framework is intentionally very small and low-level. There are essentially two pieces of

--- a/docs/docs/reference/other-new-features/control-syntax.md
+++ b/docs/docs/reference/other-new-features/control-syntax.md
@@ -26,16 +26,20 @@ for
   y <- ys
 do
   println(x + y)
+
+try body
+catch case ex: IOException => handle
 ```
 
 The rules in detail are:
 
- - The condition of an `if`-expression can be written without enclosing parentheses if it is followed by a `then`
-   or some [indented](./indentation.html) code on a following line.
+ - The condition of an `if`-expression can be written without enclosing parentheses if it is followed by a `then`.
  - The condition of a `while`-loop can be written without enclosing parentheses if it is followed by a `do`.
  - The enumerators of a `for`-expression can be written without enclosing parentheses or braces if they are followed by a `yield` or `do`.
  - A `do` in a `for`-expression expresses a `for`-loop.
-
+ - A `catch` can be followed by a single case on the same line.
+   If there are multiple cases, these have to be appear within braces (just like in Scala-2)
+   or an indented block.
 ### Rewrites
 
 The Dotty compiler can rewrite source code from old syntax to new syntax and back.


### PR DESCRIPTION
 - Update syntax.md to remove features that are unsupported or only supported by a -Y option.
 - Add clause on `catch case ...`
 - Add clause on extending with `,`

