### PR TITLE
Update reflect Symbol declarations API

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/FieldsImpl.scala
+++ b/community-build/src/scala/dotty/communitybuild/FieldsImpl.scala
@@ -9,9 +9,9 @@ object FieldsImpl:
   def fieldsImpl[V: Type, T: Type](from: Expr[V])(using Quotes): Expr[Seq[T]] =
     import quotes.reflect._
     val retType = TypeTree.of[T].tpe
-    def isProjectField(s: Symbol) = 
+    def isProjectField(s: Symbol) =
       s.isValDef && s.tree.asInstanceOf[ValDef].tpt.tpe <:< retType
     val projectsTree = Term.of(from)
-    val symbols = TypeTree.of[V].symbol.members.filter(isProjectField)
+    val symbols = TypeTree.of[V].symbol.memberMethods.filter(isProjectField)
     val selects = symbols.map(Select(projectsTree, _).asExprOf[T])
     '{ println(${Expr(retType.show)}); ${Varargs(selects)} }

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2344,34 +2344,44 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           val sym = self.unforcedDecls.find(sym => sym.name == name.toTermName)
           if (isField(sym)) sym else dotc.core.Symbols.NoSymbol
 
-        def classMethod(name: String): List[Symbol] =
+        def declaredMethod(name: String): List[Symbol] =
           self.typeRef.decls.iterator.collect {
             case sym if isMethod(sym) && sym.name.toString == name => sym.asTerm
           }.toList
 
-        def classMethods: List[Symbol] =
+        def declaredMethods: List[Symbol] =
           self.typeRef.decls.iterator.collect {
             case sym if isMethod(sym) => sym.asTerm
           }.toList
 
-        def members: List[Symbol] =
-          self.typeRef.info.decls.toList
+        def memberMethod(name: String): List[Symbol] =
+          appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
+            case sym if isMethod(sym) && sym.name.toString == name => sym.asTerm
+          }.toList
 
-        def typeMembers: List[Symbol] =
-          self.unforcedDecls.filter(_.isType)
+        def memberMethods: List[Symbol] =
+          appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
+            case sym if isMethod(sym) => sym.asTerm
+          }.toList
 
-        def typeMember(name: String): Symbol =
+        def declaredType(name: String): List[Symbol] =
+          self.typeRef.decls.iterator.collect {
+            case sym if sym.isType && sym.name.toString == name => sym.asType
+          }.toList
+
+        def declaredTypes: List[Symbol] =
+          self.typeRef.decls.iterator.collect {
+            case sym if sym.isType => sym.asType
+          }.toList
+
+        def memberType(name: String): Symbol =
           self.unforcedDecls.find(sym => sym.name == name.toTypeName)
 
-        def method(name: String): List[Symbol] =
-          appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
-            case sym if isMethod(sym) && sym.name.toString == name => sym.asTerm
-          }.toList
+        def memberTypes: List[Symbol] =
+          self.unforcedDecls.filter(_.isType)
 
-        def methods: List[Symbol] =
-          appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
-            case sym if isMethod(sym) => sym.asTerm
-          }.toList
+        def declarations: List[Symbol] =
+          self.typeRef.info.decls.toList
 
         def paramSymss: List[List[Symbol]] = self.denot.paramSymss
         def primaryConstructor: Symbol = self.denot.primaryConstructor

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3155,25 +3155,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def field(name: String): Symbol
 
         /** Get non-private named methods defined directly inside the class */
-        def classMethod(name: String): List[Symbol]
+        def declaredMethod(name: String): List[Symbol]
 
         /** Get all non-private methods defined directly inside the class, exluding constructors */
-        def classMethods: List[Symbol]
-
-        /** Type member directly declared in the class */
-        def typeMembers: List[Symbol]
-
-        /** Type member with the given name directly declared in the class */
-        def typeMember(name: String): Symbol
-
-        /** All members directly declared in the class */
-        def members: List[Symbol]
+        def declaredMethods: List[Symbol]
 
         /** Get named non-private methods declared or inherited */
-        def method(name: String): List[Symbol]
+        def memberMethod(name: String): List[Symbol]
 
         /** Get all non-private methods declared or inherited */
-        def methods: List[Symbol]
+        def memberMethods: List[Symbol]
+
+        /** Get non-private named methods defined directly inside the class */
+        def declaredType(name: String): List[Symbol]
+
+        /** Get all non-private methods defined directly inside the class, exluding constructors */
+        def declaredTypes: List[Symbol]
+
+        /** Type member with the given name directly declared in the class */
+        def memberType(name: String): Symbol
+
+        /** Type member directly declared in the class */
+        def memberTypes: List[Symbol]
+
+        /** All members directly declared in the class */
+        def declarations: List[Symbol]
 
         /** The symbols of each type parameter list and value parameter list of this
           *  method, or Nil if this isn't a method.

--- a/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -120,7 +120,7 @@ trait ClassLikeSupport:
         }
       // TODO check given methods?
       case dd: DefDef if !dd.symbol.isHiddenByVisibility && dd.symbol.isGiven =>
-        Some(dd.symbol.owner.typeMember(dd.name))
+        Some(dd.symbol.owner.memberType(dd.name))
           .filterNot(_.exists)
           .map { _ =>
             parseMethod(dd.symbol, kind = Kind.Given(getGivenInstance(dd).map(_.asSignature), None))
@@ -156,7 +156,7 @@ trait ClassLikeSupport:
       case vd: ValDef if !isSyntheticField(vd.symbol) && (!vd.symbol.flags.is(Flags.Case) || !vd.symbol.flags.is(Flags.Enum)) =>
         Some(parseValDef(vd))
 
-      case c: ClassDef if c.symbol.owner.method(c.name).exists(_.flags.is(Flags.Given)) =>
+      case c: ClassDef if c.symbol.owner.memberMethod(c.name).exists(_.flags.is(Flags.Given)) =>
         Some(parseGivenClasslike(c))
 
       case c: ClassDef if c.symbol.shouldDocumentClasslike &&  !c.symbol.isGiven =>

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -101,7 +101,7 @@ class SymOps[Q <: Quotes](val q: Q):
       else
         val pointsTo =
           if (!sym.isTypeDef) PointingToDeclaration.INSTANCE
-          else PointingToGenericParameters(sym.owner.typeMembers.indexOf(sym))
+          else PointingToGenericParameters(sym.owner.memberTypes.indexOf(sym))
 
         val method =
           if (sym.isDefDef) Some(sym)

--- a/scala3doc/test/dotty/dokka/tasty/comments/CommentExpanderTests.scala
+++ b/scala3doc/test/dotty/dokka/tasty/comments/CommentExpanderTests.scala
@@ -10,7 +10,7 @@ import dotty.dokka.tasty.TastyParser
 class CommentExpanderTests {
   def check(using quoted.Quotes)(): Unit =
     assertCommentEquals(
-      qr.Symbol.requiredClass("tests.B").method("otherMethod").head,
+      qr.Symbol.requiredClass("tests.B").memberMethod("otherMethod").head,
       "/** This is my foo: Bar, actually. */",
     )
     assertCommentEquals(
@@ -18,7 +18,7 @@ class CommentExpanderTests {
       "/** This is foo: Foo expanded. */",
     )
     assertCommentEquals(
-      qr.Symbol.requiredModule("tests.O").method("method").head,
+      qr.Symbol.requiredModule("tests.O").memberMethod("method").head,
       "/** This is foo: O's foo. */",
     )
 

--- a/scala3doc/test/dotty/dokka/tasty/comments/MemberLookupTests.scala
+++ b/scala3doc/test/dotty/dokka/tasty/comments/MemberLookupTests.scala
@@ -89,9 +89,9 @@ class LookupTestCases[Q <: Quotes](val q: Quotes) {
         if s.flags.is(q.reflect.Flags.Module) then s.moduleClass else s
       Sym(hackResolveModule(symbol.field(name)))
     def fun(name: String) =
-      val List(sym) = symbol.method(name)
+      val List(sym) = symbol.memberMethod(name)
       Sym(sym)
-    def tpe(name: String) = Sym(symbol.typeMember(name))
+    def tpe(name: String) = Sym(symbol.memberType(name))
   }
 
   def cls(fqn: String) = Sym(q.reflect.Symbol.classSymbol(fqn))

--- a/tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala
@@ -29,7 +29,7 @@ class Interpreter[Q <: Quotes & Singleton](using q0: Q) extends TreeInterpreter[
                 }
 
                 // println(method)
-                val symbol = sym.methods.find(_.name == method.getName).get
+                val symbol = sym.memberMethods.find(_.name == method.getName).get
 
                 if (symbol.isDefinedInCurrentRun) {
                   val argsList = if (args == null) Nil else args.toList

--- a/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
+++ b/tests/run-macros/gestalt-type-toolbox-reflect/Macro_1.scala
@@ -58,25 +58,25 @@ object TypeToolbox {
   inline def methodIn[T](inline mem: String): Seq[String] = ${methodInImpl[T]('mem)}
   private def methodInImpl[T: Type](mem: Expr[String])(using Quotes) : Expr[Seq[String]] = {
     import quotes.reflect._
-    Expr(TypeTree.of[T].symbol.classMethod(mem.valueOrError).map(_.name))
+    Expr(TypeTree.of[T].symbol.declaredMethod(mem.valueOrError).map(_.name))
   }
 
   inline def methodsIn[T]: Seq[String] = ${methodsInImpl[T]}
   private def methodsInImpl[T: Type](using Quotes) : Expr[Seq[String]] = {
     import quotes.reflect._
-    Expr(TypeTree.of[T].symbol.classMethods.map(_.name))
+    Expr(TypeTree.of[T].symbol.declaredMethods.map(_.name))
   }
 
   inline def method[T](inline mem: String): Seq[String] = ${methodImpl[T]('mem)}
   private def methodImpl[T: Type](mem: Expr[String])(using Quotes) : Expr[Seq[String]] = {
     import quotes.reflect._
-    Expr(TypeTree.of[T].symbol.method(mem.valueOrError).map(_.name))
+    Expr(TypeTree.of[T].symbol.memberMethod(mem.valueOrError).map(_.name))
   }
 
   inline def methods[T]: Seq[String] = ${methodsImpl[T]}
   private def methodsImpl[T: Type](using Quotes) : Expr[Seq[String]] = {
     import quotes.reflect._
-    Expr(TypeTree.of[T].symbol.methods.map(_.name))
+    Expr(TypeTree.of[T].symbol.memberMethods.map(_.name))
   }
 
   inline def typeTag[T](x: T): String = ${typeTagImpl[T]}

--- a/tests/run-macros/i6518/Macro_1.scala
+++ b/tests/run-macros/i6518/Macro_1.scala
@@ -7,10 +7,10 @@ object Macros {
   private def testImpl(using Quotes) : Expr[String] = {
     import quotes.reflect._
     val classSym = TypeRepr.of[Function1].classSymbol.get
-    classSym.classMethod("apply")
-    classSym.classMethods
-    classSym.method("apply")
-    Expr(classSym.methods.map(_.name).sorted.mkString("\n"))
+    classSym.declaredMethod("apply")
+    classSym.declaredMethods
+    classSym.memberMethod("apply")
+    Expr(classSym.memberMethods.map(_.name).sorted.mkString("\n"))
   }
 
 }

--- a/tests/run-macros/i8520/Macro_1.scala
+++ b/tests/run-macros/i8520/Macro_1.scala
@@ -8,6 +8,6 @@ def testExpr[T[_]: Type](using Quotes): Expr[Unit] = {
      if f.is(Flags.Covariant) then "+"
      else if f.is(Flags.Contravariant) then "-"
      else " "
-  val t = TypeRepr.of[T].typeSymbol.typeMembers.map(x => (x.name, variance(x.flags)))
+  val t = TypeRepr.of[T].typeSymbol.memberTypes.map(x => (x.name, variance(x.flags)))
   '{ println(${Expr(t.toString)}) }
 }

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -8,7 +8,7 @@ object Macros {
     val tree = Term.of(expr)
 
     val methods =
-      tree.tpe.classSymbol.get.classMethods.map { m =>
+      tree.tpe.classSymbol.get.declaredMethods.map { m =>
         val name = m.show
         m.tree match
           case ddef: DefDef =>


### PR DESCRIPTION
* Rename `classMethod` to `declaredMethod`
* Rename `classMethods` to `declaredMethods`
* Rename `method` to `memberMethod`
* Rename `methods` to `memberMethods`
* Add `declaredType` and `declaredTypes`
* Rename `typeMember` to `memberType`
* Rename `typeMembers` to `memberTypes`
* Rename `members` to `declarations`
