### PR TITLE
Fix documentation about indentation syntax

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/Fields.scala
+++ b/community-build/src/scala/dotty/communitybuild/Fields.scala
@@ -5,5 +5,5 @@ import scala.quoted.Type
 class FieldsDsl[V](v: V):
   inline def of[T]: Seq[T] = FieldsImpl.fieldsOfType[V, T](v)
 
-extension [V](on: V):
+extension [V](on: V)
   def fields = FieldsDsl(on)

--- a/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
@@ -275,7 +275,7 @@ class BTypesFromSymbols[I <: DottyBackendInterface](val int: I) extends BTypes {
    *   object T { def f { object U } }
    * the owner of U is T, so UModuleClass.isStatic is true. Phase travel does not help here.
    */
-  extension (sym: Symbol):
+  extension (sym: Symbol)
     private def isOriginallyStaticOwner: Boolean =
       sym.is(PackageClass) || sym.is(ModuleClass) && sym.originalOwner.originalLexicallyEnclosingClass.isOriginallyStaticOwner
 

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -125,7 +125,7 @@ object DottyBackendInterface {
   }
 
   given symExtensions: AnyRef with
-    extension (sym: Symbol):
+    extension (sym: Symbol)
 
       def isInterface(using Context): Boolean = (sym.is(PureInterface)) || sym.is(Trait)
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1145,7 +1145,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       !(sym.is(Method) && sym.info.isInstanceOf[MethodOrPoly]) // if is a method it is parameterless
   }
 
-  extension (xs: List[tpd.Tree]):
+  extension (xs: List[tpd.Tree])
     def tpes: List[Type] = xs match {
       case x :: xs1 => x.tpe :: xs1.tpes
       case nil => Nil

--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -9,7 +9,7 @@ import ast.untpd
 /** Extension methods for contexts where we want to keep the ctx.<methodName> syntax */
 object ContextOps:
 
-  extension (ctx: Context):
+  extension (ctx: Context)
 
     /** Enter symbol into current class, if current class is owner of current context,
     *  or into current scope, if not. Should always be called instead of scope.enter

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -650,7 +650,7 @@ object Contexts {
   }
 
   given ops: AnyRef with
-    extension (c: Context):
+    extension (c: Context)
       def addNotNullInfo(info: NotNullInfo) =
         c.withNotNullInfos(c.notNullInfos.extendWith(info))
 

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -28,7 +28,7 @@ object Decorators {
       case s: String => typeName(s)
       case n: Name => n.toTypeName
 
-  extension (s: String):
+  extension (s: String)
     def splitWhere(f: Char => Boolean, doDropIndex: Boolean): Option[(String, String)] =
       def splitAt(idx: Int, doDropIndex: Boolean): Option[(String, String)] =
         if (idx == -1) None
@@ -61,7 +61,7 @@ object Decorators {
   /** Implements a findSymbol method on iterators of Symbols that
    *  works like find but avoids Option, replacing None with NoSymbol.
    */
-  extension (it: Iterator[Symbol]):
+  extension (it: Iterator[Symbol])
     final def findSymbol(p: Symbol => Boolean): Symbol = {
       while (it.hasNext) {
         val sym = it.next()

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2571,7 +2571,7 @@ object TypeComparer {
      */
     val Fresh: Repr = 4
 
-    extension (approx: Repr):
+    extension (approx: Repr)
       def low: Boolean = (approx & LoApprox) != 0
       def high: Boolean = (approx & HiApprox) != 0
       def addLow: Repr = approx | LoApprox

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -241,7 +241,7 @@ object Completion {
             }
           }
 
-      // There are four possible ways for an extension method to be applicable:
+      // There are four possible ways for an extension method to be applicable
 
       // 1. The extension method is visible under a simple name, by being defined or inherited or imported in a scope enclosing the reference.
       val extMethodsInScope =

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -64,7 +64,7 @@ object Parsers {
     val Spliced = 2
   }
 
-  extension (buf: ListBuffer[Tree]):
+  extension (buf: ListBuffer[Tree])
     def +++=(x: Tree) = x match {
       case x: Thicket => buf ++= x.trees
       case x => buf += x
@@ -3563,8 +3563,6 @@ object Parsers {
       val tparams = typeParamClauseOpt(ParamOwner.Def)
       val extParams = paramClause(0, prefix = true)
       val givenParamss = paramClauses(givenOnly = true)
-      in.observeColonEOL()
-      if (in.token == COLONEOL) in.nextToken()
       val methods =
         if isDefIntro(modifierTokens) then
           extMethod() :: Nil

--- a/compiler/src/dotty/tools/dotc/printing/Texts.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Texts.scala
@@ -168,7 +168,7 @@ object Texts {
     /** The given texts `xs`, each on a separate line */
     def lines(xs: Traversable[Text]): Vertical = Vertical(xs.toList.reverse)
 
-    extension (text: => Text):
+    extension (text: => Text)
       def provided(cond: Boolean): Text = if (cond) text else Str("")
 
   }

--- a/compiler/src/dotty/tools/dotc/printing/package.scala
+++ b/compiler/src/dotty/tools/dotc/printing/package.scala
@@ -22,7 +22,7 @@ package object printing {
   val XprintMode: Key[Unit] = new Key
 
   /** @pre `nel` is non-empty list */
-  extension [A](nel: List[A]):
+  extension [A](nel: List[A])
     private[printing] def intersperse(a: A): List[A] =
       nel.flatMap(a :: _ :: Nil).tail
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -259,7 +259,7 @@ class ExtractSemanticDB extends Phase:
 
         case _ => None
 
-      extension (tpe: Types.Type):
+      extension (tpe: Types.Type)
         private inline def isAnnotatedByUnchecked(using Context) = tpe match
           case Types.AnnotatedType(_, annot) => annot.symbol == defn.UncheckedAnnot
           case _                             => false
@@ -490,12 +490,12 @@ class ExtractSemanticDB extends Phase:
       val start = if idx >= 0 then idx else span.start
       Span(start, start + sym.name.show.length, start)
 
-    extension (list: List[List[ValDef]]):
+    extension (list: List[List[ValDef]])
       private  inline def isSingleArg = list match
         case (_::Nil)::Nil => true
         case _             => false
 
-    extension (tree: DefDef):
+    extension (tree: DefDef)
       private def isSetterDef(using Context): Boolean =
         tree.name.isSetterName && tree.mods.is(Accessor) && tree.vparamss.isSingleArg
 
@@ -521,13 +521,13 @@ class ExtractSemanticDB extends Phase:
         else limit
       Span(start max limit, end)
 
-    extension (span: Span):
+    extension (span: Span)
       private def hasLength: Boolean = span.exists && !span.isZeroExtent
 
     /**Consume head while not an import statement.
      * Returns the rest of the list after the first import, or else the empty list
      */
-    extension (body: List[Tree]):
+    extension (body: List[Tree])
       @tailrec private def foreachUntilImport(op: Tree => Unit): List[Tree] = body match
         case ((_: Import) :: rest) => rest
         case stat :: rest =>
@@ -535,7 +535,7 @@ class ExtractSemanticDB extends Phase:
           rest.foreachUntilImport(op)
         case Nil => Nil
 
-    extension (sym: Symbol):
+    extension (sym: Symbol)
       private def adjustIfCtorTyparam(using Context) =
         if sym.isType && sym.owner.exists && sym.owner.isConstructor then
           matchingMemberType(sym, sym.owner.owner)

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -69,7 +69,7 @@ object Scala3:
 
 
   given NameOps: AnyRef with
-    extension (name: Name):
+    extension (name: Name)
       def isWildcard = name match
         case nme.WILDCARD | WILDCARDTypeName => true
         case _                               => name.is(NameKinds.WildcardParamName)
@@ -90,7 +90,7 @@ object Scala3:
   end NameOps
 
   given SymbolOps: AnyRef with
-    extension (sym: Symbol):
+    extension (sym: Symbol)
 
       def ifExists(using Context): Option[Symbol] = if sym.exists then Some(sym) else None
 
@@ -140,13 +140,13 @@ object Scala3:
 
   end LocalSymbol
 
-  extension (char: Char):
+  extension (char: Char)
     private inline def isGlobalTerminal = (char: @switch) match
       case '/' | '.' | '#' | ']' | ')' => true
       case _                           => false
 
   given StringOps: AnyRef with
-    extension (symbol: String):
+    extension (symbol: String)
       def isSymbol: Boolean = !symbol.isEmpty
       def isRootPackage: Boolean = RootPackage == symbol
       def isEmptyPackage: Boolean = EmptyPackage == symbol
@@ -170,7 +170,7 @@ object Scala3:
   end StringOps
 
   given InfoOps: AnyRef with
-    extension (info: SymbolInformation):
+    extension (info: SymbolInformation)
       def isAbstract: Boolean = (info.properties & SymbolInformation.Property.ABSTRACT.value) != 0
       def isFinal: Boolean = (info.properties & SymbolInformation.Property.FINAL.value) != 0
       def isSealed: Boolean = (info.properties & SymbolInformation.Property.SEALED.value) != 0
@@ -205,7 +205,7 @@ object Scala3:
   end InfoOps
 
   given RangeOps: AnyRef with
-    extension (range: Range):
+    extension (range: Range)
       def hasLength = range.endLine > range.startLine || range.endCharacter > range.startCharacter
   end RangeOps
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/Tools.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Tools.scala
@@ -144,5 +144,5 @@ object Tools:
     sb.append(if occ.role.isReference then " -> " else " <- ").append(occ.symbol).nl
   end processOccurrence
 
-  extension (sb: StringBuilder):
+  extension (sb: StringBuilder)
     private inline def nl = sb.append(System.lineSeparator)

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -190,7 +190,7 @@ object ExtensionMethods {
         // See the documentation of `memberSignature` to understand why `.stripPoly.ensureMethodic` is needed here.
         candidates filter (c => FullParameterization.memberSignature(c.info) == imeth.info.stripPoly.ensureMethodic.signature)
       assert(matching.nonEmpty,
-       i"""no extension method found for:
+       i"""no extension method found for
           |
           |  $imeth:${imeth.info.show} with signature ${imeth.info.signature} in ${companion.moduleClass}
           |

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -35,7 +35,7 @@ object ImportInfo {
 
     ImportInfo(sym, selectors, None, isRootImport = true)
 
-  extension (c: Context):
+  extension (c: Context)
     def withRootImports(rootRefs: List[RootRef])(using Context): Context =
       rootRefs.foldLeft(c)((ctx, ref) => ctx.fresh.setImportInfo(rootImport(ref)))
 

--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -339,7 +339,7 @@ object Nullables:
       }.traverse(tree)
   end extension
 
-  extension (tree: Assign):
+  extension (tree: Assign)
     def computeAssignNullable()(using Context): tree.type = tree.lhs match
       case TrackedRef(ref) =>
         val rhstp = tree.rhs.typeOpt

--- a/compiler/src/dotty/tools/dotc/util/LinearMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearMap.scala
@@ -15,7 +15,7 @@ object LinearMap:
   def empty[K <: AnyRef, V >: Null <: AnyRef]: LinearMap[K, V] =
     immutable.Map.empty[K, V]
 
-  extension [K <: AnyRef, V >: Null <: AnyRef](m: LinearMap[K, V]):
+  extension [K <: AnyRef, V >: Null <: AnyRef](m: LinearMap[K, V])
 
     def lookup(key: K): V /*| Null*/ = (m: @unchecked) match
       case m: immutable.AbstractMap[K, V] @unchecked =>

--- a/compiler/src/dotty/tools/dotc/util/LinearSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearSet.scala
@@ -12,7 +12,7 @@ object LinearSet:
 
   def empty[Elem >: Null <: AnyRef]: LinearSet[Elem] = immutable.Set.empty[Elem]
 
-  extension [Elem >: Null <: AnyRef](s: LinearSet[Elem]):
+  extension [Elem >: Null <: AnyRef](s: LinearSet[Elem])
 
     def contains(elem: Elem): Boolean = (s: @unchecked) match
       case s: immutable.AbstractSet[Elem] @unchecked => s.contains(elem)

--- a/compiler/src/dotty/tools/package.scala
+++ b/compiler/src/dotty/tools/package.scala
@@ -25,7 +25,7 @@ package object tools {
     throw new UnsupportedOperationException(methodName)
 
   /** Forward-ported from the explicit-nulls branch. */
-  extension [T](x: T | Null):
+  extension [T](x: T | Null)
 
     /** Assert `x` is non null and strip `Null` from type */
     inline def nn: T =

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -142,7 +142,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None) {
 
 object Rendering {
 
-  extension (s: Symbol):
+  extension (s: Symbol)
     def showUser(using Context): String = {
       val printer = new ReplPrinter(ctx)
       val text = printer.dclText(s)

--- a/compiler/src/dotty/tools/repl/results.scala
+++ b/compiler/src/dotty/tools/repl/results.scala
@@ -14,10 +14,10 @@ object results {
   /** Result is a type alias for an Either with left value `Errors` */
   type Result[+A] = scala.util.Either[Errors, A]
 
-  extension [A](a: A):
+  extension [A](a: A)
     def result: Result[A] = scala.util.Right(a)
 
-  extension [A](xs: Errors):
+  extension [A](xs: Errors)
     def errors: Result[A] = scala.util.Left(xs)
 
 }

--- a/compiler/src/scala/quoted/runtime/impl/Matcher.scala
+++ b/compiler/src/scala/quoted/runtime/impl/Matcher.scala
@@ -135,12 +135,12 @@ object Matcher {
       case _ => notMatched
     }
 
-    extension (scrutinees: List[Tree]):
+    extension (scrutinees: List[Tree])
       /** Check that all trees match with =?= and concatenate the results with &&& */
       private def =?= (patterns: List[Tree])(using Env): Matching =
         matchLists(scrutinees, patterns)(_ =?= _)
 
-    extension (scrutinee0: Tree):
+    extension (scrutinee0: Tree)
       /** Check that the trees match and return the contents from the pattern holes.
        *  Return None if the trees do not match otherwise return Some of a tuple containing all the contents in the holes.
        *
@@ -399,7 +399,7 @@ object Matcher {
     val matched: Matching = Some(Tuple())
     def matched(x: Any): Matching = Some(Tuple1(x))
 
-    extension (self: Matching):
+    extension (self: Matching)
       def asOptionOfTuple: Option[Tuple] = self
 
       /** Concatenates the contents of two successful matchings or return a `notMatched` */

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -46,7 +46,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
   private val yCheck: Boolean =
     ctx.settings.Ycheck.value(using ctx).exists(x => x == "all" || x == "macros")
 
-  extension [T](self: scala.quoted.Expr[T]):
+  extension [T](self: scala.quoted.Expr[T])
     def show: String =
       reflect.TreeMethodsImpl.show(reflect.Term.of(self))
 
@@ -58,7 +58,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
   end extension
 
-  extension [X](self: scala.quoted.Expr[Any]):
+  extension [X](self: scala.quoted.Expr[Any])
     /** Checks is the `quoted.Expr[?]` is valid expression of type `X` */
     def isExprOf(using scala.quoted.Type[X]): Boolean =
       reflect.TypeReprMethodsImpl.<:<(reflect.Term.of(self).tpe)(reflect.TypeRepr.of[X])
@@ -86,7 +86,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Tree
 
     object TreeMethodsImpl extends TreeMethods:
-      extension (self: Tree):
+      extension (self: Tree)
         def pos: Position = self.sourcePos
         def symbol: Symbol = self.symbol
         def showExtractors: String =
@@ -117,7 +117,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           QuotesImpl.this.asExprOf[T](self.asExpr)(using tp)
       end extension
 
-      extension [ThisTree <: Tree](self: ThisTree):
+      extension [ThisTree <: Tree](self: ThisTree)
         def changeOwner(newOwner: Symbol): ThisTree =
           tpd.TreeOps(self).changeNonLocalOwners(newOwner).asInstanceOf[ThisTree]
       end extension
@@ -142,7 +142,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end PackageClause
 
     object PackageClauseMethodsImpl extends PackageClauseMethods:
-      extension (self: PackageClause):
+      extension (self: PackageClause)
         def pid: Ref = self.pid
         def stats: List[Tree] = self.stats
       end extension
@@ -166,7 +166,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Import
 
     object ImportMethodsImpl extends ImportMethods:
-      extension (self: Import):
+      extension (self: Import)
         def expr: Term = self.expr
         def selectors: List[ImportSelector] = self.selectors
       end extension
@@ -193,7 +193,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     object Definition extends DefinitionModule
 
     object DefinitionMethodsImpl extends DefinitionMethods:
-      extension (self: Definition):
+      extension (self: Definition)
         def name: String = self match
           case self: tpd.MemberDef => self.name.toString
       end extension
@@ -218,7 +218,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ClassDef
 
     object ClassDefMethodsImpl extends ClassDefMethods:
-      extension (self: ClassDef):
+      extension (self: ClassDef)
         def constructor: DefDef =
           self.rhs.asInstanceOf[tpd.Template].constr
         def parents: List[Tree] =
@@ -250,7 +250,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end DefDef
 
     object DefDefMethodsImpl extends DefDefMethods:
-      extension (self: DefDef):
+      extension (self: DefDef)
         def typeParams: List[TypeDef] = self.tparams
         def paramss: List[List[ValDef]] = self.vparamss
         def returnTpt: TypeTree = self.tpt
@@ -287,7 +287,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ValDef
 
     object ValDefMethodsImpl extends ValDefMethods:
-      extension (self: ValDef):
+      extension (self: ValDef)
         def tpt: TypeTree = self.tpt
         def rhs: Option[Term] = optional(self.rhs)
       end extension
@@ -311,7 +311,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeDef
 
     object TypeDefMethodsImpl extends TypeDefMethods:
-      extension (self: TypeDef):
+      extension (self: TypeDef)
         def rhs: Tree = self.rhs
       end extension
     end TypeDefMethodsImpl
@@ -350,7 +350,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Term
 
     object TermMethodsImpl extends TermMethods:
-      extension (self: Term):
+      extension (self: Term)
         def seal: scala.quoted.Expr[Any] =
           if self.isExpr then new ExprImpl(self, QuotesImpl.this.hashCode)
           else throw new Exception("Cannot seal a partially applied Term. Try eta-expanding the term first.")
@@ -429,7 +429,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Ident
 
     object IdentMethodsImpl extends IdentMethods:
-      extension (self: Ident):
+      extension (self: Ident)
         def name: String = self.name.toString
       end extension
     end IdentMethodsImpl
@@ -461,7 +461,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Select
 
     object SelectMethodsImpl extends SelectMethods:
-      extension (self: Select):
+      extension (self: Select)
         def qualifier: Term = self.qualifier
         def name: String = self.name.toString
         def signature: Option[Signature] =
@@ -488,7 +488,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Literal
 
     object LiteralMethodsImpl extends LiteralMethods:
-      extension (self: Literal):
+      extension (self: Literal)
         def constant: Constant = self.const
       end extension
     end LiteralMethodsImpl
@@ -511,7 +511,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end This
 
     object ThisMethodsImpl extends ThisMethods:
-      extension (self: This):
+      extension (self: This)
         def id: Option[String] = optional(self.qual).map(_.name.toString)
       end extension
     end ThisMethodsImpl
@@ -533,7 +533,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end New
 
     object NewMethodsImpl extends NewMethods:
-      extension (self: New):
+      extension (self: New)
         def tpt: TypeTree = self.tpt
       end extension
     end NewMethodsImpl
@@ -556,7 +556,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end NamedArg
 
     object NamedArgMethodsImpl extends NamedArgMethods:
-      extension (self: NamedArg):
+      extension (self: NamedArg)
         def name: String = self.name.toString
         def value: Term = self.arg
       end extension
@@ -580,7 +580,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Apply
 
     object ApplyMethodsImpl extends ApplyMethods:
-      extension (self: Apply):
+      extension (self: Apply)
         def fun: Term = self.fun
         def args: List[Term] = self.args
       end extension
@@ -604,7 +604,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeApply
 
     object TypeApplyMethodsImpl extends TypeApplyMethods:
-      extension (self: TypeApply):
+      extension (self: TypeApply)
         def fun: Term = self.fun
         def args: List[TypeTree] = self.args
       end extension
@@ -628,7 +628,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Super
 
     object SuperMethodsImpl extends SuperMethods:
-      extension (self: Super):
+      extension (self: Super)
         def qualifier: Term = self.qual
         def id: Option[String] = optional(self.mix).map(_.name.toString)
         def idPos: Position = self.mix.sourcePos
@@ -653,7 +653,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Typed
 
     object TypedMethodsImpl extends TypedMethods:
-      extension (self: Typed):
+      extension (self: Typed)
         def expr: Term = self.expr
         def tpt: TypeTree = self.tpt
       end extension
@@ -677,7 +677,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Assign
 
     object AssignMethodsImpl extends AssignMethods:
-      extension (self: Assign):
+      extension (self: Assign)
         def lhs: Term = self.lhs
         def rhs: Term = self.rhs
       end extension
@@ -701,7 +701,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Block
 
     object BlockMethodsImpl extends BlockMethods:
-      extension (self: Block):
+      extension (self: Block)
         def statements: List[Statement] = self.stats
         def expr: Term = self.expr
       end extension
@@ -725,7 +725,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Closure
 
     object ClosureMethodsImpl extends ClosureMethods:
-      extension (self: Closure):
+      extension (self: Closure)
         def meth: Term = self.meth
         def tpeOpt: Option[TypeRepr] = optional(self.tpt).map(_.tpe)
       end extension
@@ -762,7 +762,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end If
 
     object IfMethodsImpl extends IfMethods:
-      extension (self: If):
+      extension (self: If)
         def cond: Term = self.cond
         def thenp: Term = self.thenp
         def elsep: Term = self.elsep
@@ -790,7 +790,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Match
 
     object MatchMethodsImpl extends MatchMethods:
-      extension (self: Match):
+      extension (self: Match)
         def scrutinee: Term = self.selector
         def cases: List[CaseDef] = self.cases
         def isInline: Boolean = self.isInline
@@ -815,7 +815,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end SummonFrom
 
     object SummonFromMethodsImpl extends SummonFromMethods:
-      extension (self: SummonFrom):
+      extension (self: SummonFrom)
         def cases: List[CaseDef] = self.cases
       end extension
     end SummonFromMethodsImpl
@@ -838,7 +838,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Try
 
     object TryMethodsImpl extends TryMethods:
-      extension (self: Try):
+      extension (self: Try)
         def body: Term = self.expr
         def cases: List[CaseDef] = self.cases
         def finalizer: Option[Term] = optional(self.finalizer)
@@ -863,7 +863,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Return
 
     object ReturnMethodsImpl extends ReturnMethods:
-      extension (self: Return):
+      extension (self: Return)
         def expr: Term = self.expr
         def from: Symbol = self.from.symbol
       end extension
@@ -887,7 +887,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Repeated
 
     object RepeatedMethodsImpl extends RepeatedMethods:
-      extension (self: Repeated):
+      extension (self: Repeated)
         def elems: List[Term] = self.elems
         def elemtpt: TypeTree = self.elemtpt
       end extension
@@ -911,7 +911,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Inlined
 
     object InlinedMethodsImpl extends InlinedMethods:
-      extension (self: Inlined):
+      extension (self: Inlined)
         def call: Option[Tree] = optional(self.call)
         def bindings: List[Definition] = self.bindings
         def body: Term = self.expansion
@@ -939,7 +939,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end SelectOuter
 
     object SelectOuterMethodsImpl extends SelectOuterMethods:
-      extension (self: SelectOuter):
+      extension (self: SelectOuter)
         def qualifier: Term = self.qualifier
         def name: String = self.name.toString
         def level: Int =
@@ -966,7 +966,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end While
 
     object WhileMethodsImpl extends WhileMethods:
-      extension (self: While):
+      extension (self: While)
         def cond: Term = self.cond
         def body: Term = self.body
       end extension
@@ -987,7 +987,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeTree
 
     object TypeTreeMethodsImpl extends TypeTreeMethods:
-      extension (self: TypeTree):
+      extension (self: TypeTree)
         def tpe: TypeRepr = self.tpe.stripTypeVar
       end extension
     end TypeTreeMethodsImpl
@@ -1025,7 +1025,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeIdent
 
     object TypeIdentMethodsImpl extends TypeIdentMethods:
-      extension (self: TypeIdent):
+      extension (self: TypeIdent)
         def name: String = self.name.toString
       end extension
     end TypeIdentMethodsImpl
@@ -1048,7 +1048,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeSelect
 
     object TypeSelectMethodsImpl extends TypeSelectMethods:
-      extension (self: TypeSelect):
+      extension (self: TypeSelect)
         def qualifier: Term = self.qualifier
         def name: String = self.name.toString
       end extension
@@ -1070,7 +1070,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeProjection
 
     object TypeProjectionMethodsImpl extends TypeProjectionMethods:
-      extension (self: TypeProjection):
+      extension (self: TypeProjection)
         def qualifier: TypeTree = self.qualifier
         def name: String = self.name.toString
       end extension
@@ -1094,7 +1094,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Singleton
 
     object SingletonMethodsImpl extends SingletonMethods:
-      extension (self: Singleton):
+      extension (self: Singleton)
         def ref: Term = self.ref
       end extension
     end SingletonMethodsImpl
@@ -1115,7 +1115,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Refined
 
     object RefinedMethodsImpl extends RefinedMethods:
-      extension (self: Refined):
+      extension (self: Refined)
         def tpt: TypeTree = self.tpt
         def refinements: List[Definition] = self.refinements.asInstanceOf[List[Definition]]
       end extension
@@ -1139,7 +1139,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Applied
 
     object AppliedMethodsImpl extends AppliedMethods:
-      extension (self: Applied):
+      extension (self: Applied)
         def tpt: TypeTree = self.tpt
         def args: List[Tree] = self.args
       end extension
@@ -1163,7 +1163,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Annotated
 
     object AnnotatedMethodsImpl extends AnnotatedMethods:
-      extension (self: Annotated):
+      extension (self: Annotated)
         def arg: TypeTree = self.arg
         def annotation: Term = self.annot
       end extension
@@ -1187,7 +1187,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end MatchTypeTree
 
     object MatchTypeTreeMethodsImpl extends MatchTypeTreeMethods:
-      extension (self: MatchTypeTree):
+      extension (self: MatchTypeTree)
         def bound: Option[TypeTree] = optional(self.bound)
         def selector: TypeTree = self.selector
         def cases: List[TypeCaseDef] = self.cases
@@ -1212,7 +1212,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ByName
 
     object ByNameMethodsImpl extends ByNameMethods:
-      extension (self: ByName):
+      extension (self: ByName)
         def result: TypeTree = self.result
       end extension
     end ByNameMethodsImpl
@@ -1235,7 +1235,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end LambdaTypeTree
 
     object LambdaTypeTreeMethodsImpl extends LambdaTypeTreeMethods:
-      extension (self: LambdaTypeTree):
+      extension (self: LambdaTypeTree)
         def tparams: List[TypeDef] = self.tparams
         def body: Tree = self.body
       end extension
@@ -1257,7 +1257,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeBind
 
     object TypeBindMethodsImpl extends TypeBindMethods:
-      extension (self: TypeBind):
+      extension (self: TypeBind)
         def name: String = self.name.toString
         def body: Tree = self.body
       end extension
@@ -1281,7 +1281,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeBlock
 
     object TypeBlockMethodsImpl extends TypeBlockMethods:
-      extension (self: TypeBlock):
+      extension (self: TypeBlock)
         def aliases: List[TypeDef] = self.stats.map { case alias: TypeDef => alias }
         def tpt: TypeTree = self.expr
       end extension
@@ -1309,7 +1309,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeBoundsTree
 
     object TypeBoundsTreeMethodsImpl extends TypeBoundsTreeMethods:
-      extension (self: TypeBoundsTree):
+      extension (self: TypeBoundsTree)
         def tpe: TypeBounds = self.tpe.asInstanceOf[Types.TypeBounds]
         def low: TypeTree = self match
           case self: tpd.TypeBoundsTree => self.lo
@@ -1334,7 +1334,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end WildcardTypeTree
 
     object WildcardTypeTreeMethodsImpl extends WildcardTypeTreeMethods:
-      extension (self: WildcardTypeTree):
+      extension (self: WildcardTypeTree)
         def tpe: TypeRepr = self.tpe.stripTypeVar
       end extension
     end WildcardTypeTreeMethodsImpl
@@ -1357,7 +1357,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end CaseDef
 
     object CaseDefMethodsImpl extends CaseDefMethods:
-      extension (self: CaseDef):
+      extension (self: CaseDef)
         def pattern: Tree = self.pat
         def guard: Option[Term] = optional(self.guard)
         def rhs: Term = self.body
@@ -1382,7 +1382,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeCaseDef
 
     object TypeCaseDefMethodsImpl extends TypeCaseDefMethods:
-      extension (self: TypeCaseDef):
+      extension (self: TypeCaseDef)
         def pattern: TypeTree = self.pat
         def rhs: TypeTree = self.body
       end extension
@@ -1406,7 +1406,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Bind
 
     object BindMethodsImpl extends BindMethods:
-      extension (self: Bind):
+      extension (self: Bind)
         def name: String = self.name.toString
         def pattern: Tree = self.body
       end extension
@@ -1430,7 +1430,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Unapply
 
     object UnapplyMethodsImpl extends UnapplyMethods:
-      extension (self: Unapply):
+      extension (self: Unapply)
         def fun: Term = selfUnApply(self).fun
         def implicits: List[Term] = selfUnApply(self).implicits
         def patterns: List[Tree] = effectivePatterns(selfUnApply(self).patterns)
@@ -1463,7 +1463,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Alternatives
 
     object AlternativesMethodsImpl extends AlternativesMethods:
-      extension (self: Alternatives):
+      extension (self: Alternatives)
         def patterns: List[Tree] = self.trees
       end extension
     end AlternativesMethodsImpl
@@ -1486,7 +1486,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
 
     object SimpleSelectorMethodsImpl extends SimpleSelectorMethods:
-      extension (self: SimpleSelector):
+      extension (self: SimpleSelector)
         def name: String = self.imported.name.toString
         def namePos: Position = self.imported.sourcePos
       end extension
@@ -1505,7 +1505,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end RenameSelector
 
     object RenameSelectorMethodsImpl extends RenameSelectorMethods:
-      extension (self: RenameSelector):
+      extension (self: RenameSelector)
         def fromName: String = self.imported.name.toString
         def fromPos: Position = self.imported.sourcePos
         def toName: String = self.renamed.asInstanceOf[untpd.Ident].name.toString
@@ -1530,7 +1530,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end OmitSelector
 
     object OmitSelectorMethodsImpl extends OmitSelectorMethods:
-      extension (self: OmitSelector):
+      extension (self: OmitSelector)
         def name: String = self.imported.toString
         def namePos: Position = self.imported.sourcePos
       end extension
@@ -1551,7 +1551,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end GivenSelector
 
     object GivenSelectorMethodsImpl extends GivenSelectorMethods:
-      extension (self: GivenSelector):
+      extension (self: GivenSelector)
         def bound: Option[TypeTree] =
           self.bound match
             case untpd.TypedSplice(tpt) => Some(tpt)
@@ -1587,7 +1587,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeRepr
 
     object TypeReprMethodsImpl extends TypeReprMethods:
-      extension (self: TypeRepr):
+      extension (self: TypeRepr)
         def showExtractors: String =
           Extractors.showType(using QuotesImpl.this)(self)
 
@@ -1673,7 +1673,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TermRef
 
     object TermRefMethodsImpl extends TermRefMethods:
-      extension (self: TermRef):
+      extension (self: TermRef)
         def qualifier: TypeRepr = self.prefix
         def name: String = self.name.toString
       end extension
@@ -1693,7 +1693,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeRef
 
     object TypeRefMethodsImpl extends TypeRefMethods:
-      extension (self: TypeRef):
+      extension (self: TypeRef)
         def qualifier: TypeRepr = self.prefix
         def name: String = self.name.toString
         def isOpaqueAlias: Boolean = self.symbol.isOpaqueAlias
@@ -1717,7 +1717,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end SuperType
 
     object SuperTypeMethodsImpl extends SuperTypeMethods:
-      extension (self: SuperType):
+      extension (self: SuperType)
         def thistpe: TypeRepr = self.thistpe
         def supertpe: TypeRepr = self.thistpe
       end extension
@@ -1743,7 +1743,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Refinement
 
     object RefinementMethodsImpl extends RefinementMethods:
-      extension (self: Refinement):
+      extension (self: Refinement)
         def parent: TypeRepr = self.parent
         def name: String = self.refinedName.toString
         def info: TypeRepr = self.refinedInfo
@@ -1764,7 +1764,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end AppliedType
 
     object AppliedTypeMethodsImpl extends AppliedTypeMethods:
-      extension (self: AppliedType):
+      extension (self: AppliedType)
         def tycon: TypeRepr = self.tycon
         def args: List[TypeRepr] = self.args
       end extension
@@ -1786,7 +1786,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end AnnotatedType
 
     object AnnotatedTypeMethodsImpl extends AnnotatedTypeMethods:
-      extension (self: AnnotatedType):
+      extension (self: AnnotatedType)
         def underlying: TypeRepr = self.underlying.stripTypeVar
         def annot: Term = self.annot.tree
       end extension
@@ -1806,7 +1806,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end AndType
 
     object AndTypeMethodsImpl extends AndTypeMethods:
-      extension (self: AndType):
+      extension (self: AndType)
         def left: TypeRepr = self.tp1.stripTypeVar
         def right: TypeRepr = self.tp2.stripTypeVar
       end extension
@@ -1826,7 +1826,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end OrType
 
     object OrTypeMethodsImpl extends OrTypeMethods:
-      extension (self: OrType):
+      extension (self: OrType)
         def left: TypeRepr = self.tp1.stripTypeVar
         def right: TypeRepr = self.tp2.stripTypeVar
       end extension
@@ -1848,7 +1848,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end MatchType
 
     object MatchTypeMethodsImpl extends MatchTypeMethods:
-      extension (self: MatchType):
+      extension (self: MatchType)
         def bound: TypeRepr = self.bound
         def scrutinee: TypeRepr = self.scrutinee
         def cases: List[TypeRepr] = self.cases
@@ -1869,7 +1869,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ByNameType
 
     object ByNameTypeMethodsImpl extends ByNameTypeMethods:
-      extension (self: ByNameType):
+      extension (self: ByNameType)
         def underlying: TypeRepr = self.resType.stripTypeVar
       end extension
     end ByNameTypeMethodsImpl
@@ -1889,7 +1889,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ParamRef
 
     object ParamRefMethodsImpl extends ParamRefMethods:
-      extension (self: ParamRef):
+      extension (self: ParamRef)
         def binder: LambdaType = self.binder.asInstanceOf[LambdaType] // Cast to tpd
         def paramNum: Int = self.paramNum
       end extension
@@ -1908,7 +1908,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ThisType
 
     object ThisTypeMethodsImpl extends ThisTypeMethods:
-      extension (self: ThisType):
+      extension (self: ThisType)
         def tref: TypeRepr = self.tref
       end extension
     end ThisTypeMethodsImpl
@@ -1927,7 +1927,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
 
     object RecursiveThisMethodsImpl extends RecursiveThisMethods:
-      extension (self: RecursiveThis):
+      extension (self: RecursiveThis)
         def binder: RecursiveType = self.binder
       end extension
     end RecursiveThisMethodsImpl
@@ -1947,7 +1947,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end RecursiveType
 
     object RecursiveTypeMethodsImpl extends RecursiveTypeMethods:
-      extension (self: RecursiveType):
+      extension (self: RecursiveType)
         def underlying: TypeRepr = self.underlying.stripTypeVar
         def recThis: RecursiveThis = self.recThis
       end extension
@@ -1971,7 +1971,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end MethodType
 
     object MethodTypeMethodsImpl extends MethodTypeMethods:
-      extension (self: MethodType):
+      extension (self: MethodType)
         def isErased: Boolean = self.isErasedMethod
         def isImplicit: Boolean = self.isImplicitMethod
         def param(idx: Int): TypeRepr = self.newParamRef(idx)
@@ -1997,7 +1997,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end PolyType
 
     object PolyTypeMethodsImpl extends PolyTypeMethods:
-      extension (self: PolyType):
+      extension (self: PolyType)
         def param(idx: Int): TypeRepr = self.newParamRef(idx)
         def paramNames: List[String] = self.paramNames.map(_.toString)
         def paramBounds: List[TypeBounds] = self.paramInfos
@@ -2021,7 +2021,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeLambda
 
     object TypeLambdaMethodsImpl extends TypeLambdaMethods:
-      extension (self: TypeLambda):
+      extension (self: TypeLambda)
         def paramNames: List[String] = self.paramNames.map(_.toString)
         def paramBounds: List[TypeBounds] = self.paramInfos
         def param(idx: Int): TypeRepr = self.newParamRef(idx)
@@ -2046,7 +2046,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeBounds
 
     object TypeBoundsMethodsImpl extends TypeBoundsMethods:
-      extension (self: TypeBounds):
+      extension (self: TypeBounds)
         def low: TypeRepr = self.lo.stripLazyRef
         def hi: TypeRepr = self.hi.stripLazyRef
       end extension
@@ -2154,7 +2154,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Constant
 
     object ConstantMethodsImpl extends ConstantMethods:
-      extension (self: Constant):
+      extension (self: Constant)
         def value: Any = self.value
         def showExtractors: String =
           Extractors.showConstant(using QuotesImpl.this)(self)
@@ -2184,7 +2184,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ImplicitSearchSuccessTypeTestImpl
 
     object ImplicitSearchSuccessMethodsImpl extends ImplicitSearchSuccessMethods:
-      extension (self: ImplicitSearchSuccess):
+      extension (self: ImplicitSearchSuccess)
         def tree: Term = self
       end extension
     end ImplicitSearchSuccessMethodsImpl
@@ -2199,7 +2199,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ImplicitSearchFailureTypeTestImpl
 
     object ImplicitSearchFailureMethodsImpl extends ImplicitSearchFailureMethods:
-      extension (self: ImplicitSearchFailure):
+      extension (self: ImplicitSearchFailure)
         def explanation: String =
           self.tpe.asInstanceOf[dotc.typer.Implicits.SearchFailureType].explanation
       end extension
@@ -2253,7 +2253,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Symbol
 
     object SymbolMethodsImpl extends SymbolMethods:
-      extension (self: Symbol):
+      extension (self: Symbol)
         def owner: Symbol = self.denot.owner
         def maybeOwner: Symbol = self.denot.maybeOwner
         def flags: Flags = self.denot.flags
@@ -2392,7 +2392,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Signature
 
     object SignatureMethodsImpl extends SignatureMethods:
-      extension (self: Signature):
+      extension (self: Signature)
         def paramSigs: List[String | Int] =
           self.paramsSig.map {
             case paramSig: dotc.core.Names.TypeName =>
@@ -2505,7 +2505,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Flags
 
     object FlagsMethodsImpl extends FlagsMethods:
-      extension (self: Flags):
+      extension (self: Flags)
         def is(that: Flags): Boolean = self.isAllOf(that)
         def |(that: Flags): Flags = dotc.core.Flags.or(self, that) // TODO: Replace with dotc.core.Flags.|(self)(that)  once extension names have stabilized
         def &(that: Flags): Flags = dotc.core.Flags.and(self, that)// TODO: Replace with dotc.core.Flags.&(self)(that)  once extension names have stabilized
@@ -2526,7 +2526,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Position
 
     object PositionMethodsImpl extends PositionMethods:
-      extension (self: Position):
+      extension (self: Position)
         def start: Int = self.start
         def end: Int = self.end
         def exists: Boolean = self.exists
@@ -2545,7 +2545,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     object SourceFile extends SourceFileModule
 
     object SourceFileMethodsImpl extends SourceFileMethods:
-      extension (self: SourceFile):
+      extension (self: SourceFile)
         def jpath: java.nio.file.Path = self.file.jpath
         def content: String = new String(self.content())
       end extension
@@ -2604,7 +2604,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     object Documentation extends DocumentationModule
 
     object DocumentationMethodsImpl extends DocumentationMethods:
-      extension (self: Documentation):
+      extension (self: Documentation)
         def raw: String = self.raw
         def expanded: Option[String] = self.expanded
         def usecases: List[(String, Option[DefDef])] =

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -47,7 +47,7 @@ class ReplTest(withStaging: Boolean = false, out: ByteArrayOutputStream = new By
   def fromInitialState[A](op: State => A): A =
     op(initialState)
 
-  extension [A](state: State):
+  extension [A](state: State)
     def andThen(op: State => A): A = op(state)
 
   def scripts(path: String): Array[JFile] = {

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -83,7 +83,7 @@ comment          ::=  ‘/*’ “any sequence of characters; nested comments ar
 
 nl               ::=  “new line character”
 semi             ::=  ‘;’ |  nl {nl}
-colonEol         ::=  ": at end of line that can start a tenmplate body"
+colonEol         ::=  ": at end of line that can start a template body"
 ```
 
 ## Keywords
@@ -151,7 +151,7 @@ FunParamClause    ::=  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’
 TypedFunParam     ::=  id ‘:’ Type
 MatchType         ::=  InfixType `match` ‘{’ TypeCaseClauses ‘}’
 InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
-RefinedType       ::=  WithType {[nl | colonEol] Refinement}                    RefinedTypeTree(t, ds)
+RefinedType       ::=  WithType {[nl] Refinement}                               RefinedTypeTree(t, ds)
 WithType          ::=  AnnotType {‘with’ AnnotType}                             (deprecated)
 AnnotType         ::=  SimpleType {Annotation}                                  Annotated(t, annot)
 
@@ -224,8 +224,9 @@ SimpleExpr        ::=  SimpleRef
                     |  ‘$’ ‘{’ Block ‘}’
                     |  Quoted
                     |  quoteId     // only inside splices
-                    |  ‘new’ ConstrApp {‘with’ ConstrApp} [TemplateBody]        New(constr | templ)
-                    |  ‘new’ TemplateBody
+                    |  ‘new’ ConstrApp {‘with’ ConstrApp}                       New(constr | templ)
+                       [[colonEol] TemplateBody
+                    |  ‘new’ [colonEol] TemplateBody
                     |  ‘(’ ExprsInParens ‘)’                                    Parens(exprs)
                     |  SimpleExpr ‘.’ id                                        Select(expr, id)
                     |  SimpleExpr ‘.’ MatchClause
@@ -397,14 +398,14 @@ ClassDef          ::=  id ClassConstr [Template]                                
 ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses        with DefDef(_, <init>, Nil, vparamss, EmptyTree, EmptyTree) as first stat
 ConstrMods        ::=  {Annotation} [AccessModifier]
 ObjectDef         ::=  id [Template]                                            ModuleDef(mods, name, template)  // no constructor
-EnumDef           ::=  id ClassConstr InheritClauses EnumBody                   EnumDef(mods, name, tparams, template)
+EnumDef           ::=  id ClassConstr InheritClauses [colonEol] EnumBody
 GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | StructuralInstance)
-GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’       -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
+GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’         -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
 Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’
                        {UsingParamClause}] ExtMethods
 ExtMethods        ::=  ExtMethod | [nl] ‘{’ ExtMethod {semi ExtMethod ‘}’
 ExtMethod         ::=  {Annotation [nl]} {Modifier} ‘def’ DefDef
-Template          ::=  InheritClauses [TemplateBody]                            Template(constr, parents, self, stats)
+Template          ::=  InheritClauses [colonEol] [TemplateBody]                 Template(constr, parents, self, stats)
 InheritClauses    ::=  [‘extends’ ConstrApps] [‘derives’ QualId {‘,’ QualId}]
 ConstrApps        ::=  ConstrApp {(‘,’ | ‘with’) ConstrApp}
 ConstrApp         ::=  SimpleType1 {Annotation} {ParArgumentExprs}              Apply(tp, args)
@@ -412,8 +413,7 @@ ConstrExpr        ::=  SelfInvocation
                     |  ‘{’ SelfInvocation {semi BlockStat} ‘}’
 SelfInvocation    ::=  ‘this’ ArgumentExprs {ArgumentExprs}
 
-TemplateBody      ::=  [nl | colonEol]
-                       ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’      (self, stats)
+TemplateBody      ::=  [nl] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
 TemplateStat      ::=  Import
                     |  Export
                     |  {Annotation [nl]} {Modifier} Def
@@ -425,8 +425,7 @@ TemplateStat      ::=  Import
 SelfType          ::=  id [‘:’ InfixType] ‘=>’                                  ValDef(_, name, tpt, _)
                     |  ‘this’ ‘:’ InfixType ‘=>’
 
-EnumBody          ::=  [nl | colonEol]
-                       ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
+EnumBody          ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
 EnumStat          ::=  TemplateStat
                     |  {Annotation [nl]} {Modifier} EnumCase
 EnumCase          ::=  ‘case’ (id ClassConstr [‘extends’ ConstrApps]] | ids)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -1,6 +1,6 @@
 ---
 layout: doc-page
-title: "Scala Syntax Summary"
+title: "Scala3 Syntax Summary"
 ---
 
 The following descriptions of Scala tokens uses literal characters `‘c’` when
@@ -265,8 +265,6 @@ Guard             ::=  ‘if’ PostfixExpr
 CaseClauses       ::=  CaseClause { CaseClause }                                Match(EmptyTree, cases)
 CaseClause        ::=  ‘case’ Pattern [Guard] ‘=>’ Block                        CaseDef(pat, guard?, block)   // block starts at =>
 ExprCaseClause    ::=  ‘case’ Pattern [Guard] ‘=>’ Expr
-ImplicitCaseClauses ::=  ImplicitCaseClause { ImplicitCaseClause }
-ImplicitCaseClause  ::=  ‘case’ PatVar [‘:’ RefinedType] [Guard] ‘=>’ Block
 TypeCaseClauses   ::=  TypeCaseClause { TypeCaseClause }
 TypeCaseClause    ::=  ‘case’ InfixType ‘=>’ Type [nl]
 
@@ -354,7 +352,7 @@ ImportSelectors   ::=  id [‘=>’ id | ‘=>’ ‘_’] [‘,’ ImportSelect
                     |  WildCardSelector {‘,’ WildCardSelector}
 WildCardSelector  ::=  ‘given’ [InfixType]
                     |  ‘_'
-Export            ::=  ‘export’ [‘given’] ImportExpr {‘,’ ImportExpr}
+Export            ::=  [‘given’] ImportExpr {‘,’ ImportExpr}
 
 EndMarker         ::=  ‘end’ EndMarkerTag    -- when followed by EOL
 EndMarkerTag      ::=  id | ‘if’ | ‘while’ | ‘for’ | ‘match’ | ‘try’

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -58,8 +58,8 @@ There are two rules:
 
     An indentation region can start
 
-     - after the condition of an `if-else`, or
      - after the leading parameters of an `extension`, or
+     - after a `with` in a given instance, or
      - after a ": at end of line" token (see below)
      - after one of the following tokens:
 
@@ -93,7 +93,7 @@ There are two rules:
 It is an error if the indentation width of the token following an `<outdent>` does not match the indentation of some previous line in the enclosing indentation region. For instance, the following would be rejected.
 
 ```scala
-if x < 0
+if x < 0 then
     -x
   else   // error: `else` does not align correctly
      x
@@ -104,14 +104,14 @@ at the toplevel, inside braces `{...}`, but not inside parentheses `(...)`, patt
 
 ### Optional Braces Around Template Bodies
 
-The Scala grammar uses the term _template body_ for the definitions of a class, trait, object or given instance that are normally enclosed in braces. The braces around a template body can also be omitted by means of the following rule
+The Scala grammar uses the term _template body_ for the definitions of a class, trait, or object that are normally enclosed in braces. The braces around a template body can also be omitted by means of the following rule
 
 If at the point where a template body can start there is a `:` that occurs at the end
 of a line, and that is followed by at least one indented statement, the recognized
 token is changed from ":" to ": at end of line". The latter token is one of the tokens
 that can start an indentation region. The Scala grammar is changed so an optional ": at end of line" is allowed in front of a template body.
 
-Analogous rules apply for enum bodies, type refinements, definitions in an instance creation expressions, and local packages containing nested definitions.
+Analogous rules apply for enum bodies and local packages containing nested definitions.
 
 With these new rules, the following constructs are all valid:
 
@@ -128,15 +128,6 @@ object O:
 enum Color:
   case Red, Green, Blue
 
-type T = A:
-  def f: Int
-
-given [T](using Ord[T]): Ord[List[T]] with
-  def compare(x: List[T], y: List[T]) = ???
-
-extension (xs: List[Int])
-  def second: Int = xs.tail.head
-
 new A:
   def f = 3
 
@@ -145,14 +136,15 @@ package p:
 package q:
   def b = 2
 ```
+In each case, the `:` at the end of line can be replaced without change of meaning by a pair of braces that enclose the following indented definition(s).
 
 The syntax changes allowing this are as follows:
 
 ```
-TemplateBody ::=  [colonEol] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
-EnumBody     ::=  [colonEol] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
-Packaging    ::=  ‘package’ QualId [colonEol] ‘{’ TopStatSeq ‘}’
-RefinedType  ::=  AnnotType {[colonEol] Refinement}
+Template    ::=  InheritClauses [colonEol] [TemplateBody]
+EnumDef     ::=  id ClassConstr InheritClauses [colonEol] EnumBody
+Packaging   ::=  ‘package’ QualId [nl | colonEol] ‘{’ TopStatSeq ‘}’
+SimpleExpr  ::=  ‘new’ ConstrApp {‘with’ ConstrApp} [[colonEol] TemplateBody]
 ```
 
 Here, `colonEol` stands for ": at end of line", as described above.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -185,6 +185,8 @@ sidebar:
               url: docs/reference/dropped-features/nonlocal-returns.html
             - title: "[this] Qualifier"
               url: docs/reference/dropped-features/this-qualifier.html
+        - title: Syntax Summary
+          url: doc/reference/syntax.html
     - title: Contributing
       subsection:
         - title: Contribute Knowledge

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -16,7 +16,7 @@ inline def quotes(using q: Quotes): q.type = q
 trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
   // Extension methods for `Expr[T]`
-  extension [T](self: Expr[T]):
+  extension [T](self: Expr[T])
     /** Show a source code like representation of this expression without syntax highlight */
     def show: String
 
@@ -55,7 +55,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
   end extension
 
   // Extension methods for `Expr[Any]` that take another explicit type parameter
-  extension [X](self: Expr[Any]):
+  extension [X](self: Expr[Any])
     /** Checks is the `quoted.Expr[?]` is valid expression of type `X` */
     def isExprOf(using Type[X]): Boolean
 
@@ -207,7 +207,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Tree` */
     trait TreeMethods {
 
-      extension (self: Tree):
+      extension (self: Tree)
         /** Position in the source code */
         def pos: Position
 
@@ -237,7 +237,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       extension [T](self: Tree)
         def asExprOf(using Type[T]): Expr[T]
 
-      extension [ThisTree <: Tree](self: ThisTree):
+      extension [ThisTree <: Tree](self: ThisTree)
         /** Changes the owner of the symbols in the tree */
         def changeOwner(newOwner: Symbol): ThisTree
       end extension
@@ -271,7 +271,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `PackageClause` */
     trait PackageClauseMethods:
-      extension (self: PackageClause):
+      extension (self: PackageClause)
         def pid: Ref
         def stats: List[Tree]
       end extension
@@ -304,7 +304,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Import` */
     trait ImportMethods:
-      extension (self: Import):
+      extension (self: Import)
         def expr: Term
         def selectors: List[ImportSelector]
       end extension
@@ -344,7 +344,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Definition` */
     trait DefinitionMethods:
-      extension (self: Definition):
+      extension (self: Definition)
         def name: String
       end extension
     end DefinitionMethods
@@ -378,7 +378,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ClassDef` */
     trait ClassDefMethods:
-      extension (self: ClassDef):
+      extension (self: ClassDef)
         def constructor: DefDef
         def parents: List[Tree /* Term | TypeTree */]
         def derived: List[TypeTree]
@@ -416,7 +416,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `DefDef` */
     trait DefDefMethods:
-      extension (self: DefDef):
+      extension (self: DefDef)
         def typeParams: List[TypeDef]
         def paramss: List[List[ValDef]]
         def returnTpt: TypeTree
@@ -463,7 +463,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ValDef` */
     trait ValDefMethods:
-      extension (self: ValDef):
+      extension (self: ValDef)
         def tpt: TypeTree
         def rhs: Option[Term]
       end extension
@@ -498,7 +498,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeDef` */
     trait TypeDefMethods:
-      extension (self: TypeDef):
+      extension (self: TypeDef)
         def rhs: Tree /*TypeTree | TypeBoundsTree*/
       end extension
     end TypeDefMethods
@@ -545,7 +545,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Term` */
     trait TermMethods {
-      extension (self: Term):
+      extension (self: Term)
 
         /** TypeRepr of this term */
         def tpe: TypeRepr
@@ -657,7 +657,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Ident` */
     trait IdentMethods:
-      extension (self: Ident):
+      extension (self: Ident)
         def name: String
       end extension
     end IdentMethods
@@ -707,7 +707,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Select` */
     trait SelectMethods:
-      extension (self: Select):
+      extension (self: Select)
         def qualifier: Term
         def name: String
         def signature: Option[Signature]
@@ -746,7 +746,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Literal` */
     trait LiteralMethods:
-      extension (self: Literal):
+      extension (self: Literal)
         def constant: Constant
       end extension
     end LiteralMethods
@@ -783,7 +783,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `This` */
     trait ThisMethods:
-      extension (self: This):
+      extension (self: This)
         def id: Option[String]
       end extension
     end ThisMethods
@@ -820,7 +820,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `New` */
     trait NewMethods:
-      extension (self: New):
+      extension (self: New)
         def tpt: TypeTree
       end extension
     end NewMethods
@@ -857,7 +857,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `NamedArg` */
     trait NamedArgMethods:
-      extension (self: NamedArg):
+      extension (self: NamedArg)
         def name: String
         def value: Term
       end extension
@@ -895,7 +895,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Apply` */
     trait ApplyMethods:
-      extension (self: Apply):
+      extension (self: Apply)
         def fun: Term
         def args: List[Term]
       end extension
@@ -933,7 +933,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeApply` */
     trait TypeApplyMethods:
-      extension (self: TypeApply):
+      extension (self: TypeApply)
         def fun: Term
         def args: List[TypeTree]
       end extension
@@ -971,7 +971,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Super` */
     trait SuperMethods:
-      extension (self: Super):
+      extension (self: Super)
         def qualifier: Term
         def id: Option[String]
         def idPos: Position
@@ -1010,7 +1010,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Typed` */
     trait TypedMethods:
-      extension (self: Typed):
+      extension (self: Typed)
         def expr: Term
         def tpt: TypeTree
       end extension
@@ -1048,7 +1048,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Assign` */
     trait AssignMethods:
-      extension (self: Assign):
+      extension (self: Assign)
         def lhs: Term
         def rhs: Term
       end extension
@@ -1086,7 +1086,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Block` */
     trait BlockMethods:
-      extension (self: Block):
+      extension (self: Block)
         def statements: List[Statement]
         def expr: Term
       end extension
@@ -1130,7 +1130,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Closure` */
     trait ClosureMethods:
-      extension (self: Closure):
+      extension (self: Closure)
         def meth: Term
         def tpeOpt: Option[TypeRepr]
       end extension
@@ -1204,7 +1204,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `If` */
     trait IfMethods:
-      extension (self: If):
+      extension (self: If)
         def cond: Term
         def thenp: Term
         def elsep: Term
@@ -1244,7 +1244,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Match` */
     trait MatchMethods:
-      extension (self: Match):
+      extension (self: Match)
         def scrutinee: Term
         def cases: List[CaseDef]
         def isInline: Boolean
@@ -1283,7 +1283,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SummonFrom` */
     trait SummonFromMethods:
-      extension (self: SummonFrom):
+      extension (self: SummonFrom)
         def cases: List[CaseDef]
       end extension
     end SummonFromMethods
@@ -1320,7 +1320,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Try` */
     trait TryMethods:
-      extension (self: Try):
+      extension (self: Try)
         def body: Term
         def cases: List[CaseDef]
         def finalizer: Option[Term]
@@ -1359,7 +1359,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Return` */
     trait ReturnMethods:
-      extension (self: Return):
+      extension (self: Return)
         def expr: Term
         def from: Symbol
       end extension
@@ -1392,7 +1392,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Repeated` */
     trait RepeatedMethods:
-      extension (self: Repeated):
+      extension (self: Repeated)
         def elems: List[Term]
         def elemtpt: TypeTree
       end extension
@@ -1425,7 +1425,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Inlined` */
     trait InlinedMethods:
-      extension (self: Inlined):
+      extension (self: Inlined)
         def call: Option[Tree /* Term | TypeTree */]
         def bindings: List[Definition]
         def body: Term
@@ -1459,7 +1459,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SelectOuter` */
     trait SelectOuterMethods:
-      extension (self: SelectOuter):
+      extension (self: SelectOuter)
         def qualifier: Term
         def name: String
         def level: Int
@@ -1498,7 +1498,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `While` */
     trait WhileMethods:
-      extension (self: While):
+      extension (self: While)
         def cond: Term
         def body: Term
       end extension
@@ -1532,7 +1532,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeTree` */
     trait TypeTreeMethods:
-      extension (self: TypeTree):
+      extension (self: TypeTree)
         /** TypeRepr of this type tree */
         def tpe: TypeRepr
       end extension
@@ -1584,7 +1584,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeIdent` */
     trait TypeIdentMethods:
-      extension (self: TypeIdent):
+      extension (self: TypeIdent)
         def name: String
       end extension
     end TypeIdentMethods
@@ -1616,7 +1616,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeSelect` */
     trait TypeSelectMethods:
-      extension (self: TypeSelect):
+      extension (self: TypeSelect)
         def qualifier: Term
         def name: String
       end extension
@@ -1649,7 +1649,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeProjection` */
     trait TypeProjectionMethods:
-      extension (self: TypeProjection):
+      extension (self: TypeProjection)
         def qualifier: TypeTree
         def name: String
       end extension
@@ -1682,7 +1682,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Singleton` */
     trait SingletonMethods:
-      extension (self: Singleton):
+      extension (self: Singleton)
         def ref: Term
       end extension
     end SingletonMethods
@@ -1714,7 +1714,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Refined` */
     trait RefinedMethods:
-      extension (self: Refined):
+      extension (self: Refined)
         def tpt: TypeTree
         def refinements: List[Definition]
       end extension
@@ -1747,7 +1747,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Applied` */
     trait AppliedMethods:
-      extension (self: Applied):
+      extension (self: Applied)
         def tpt: TypeTree
         def args: List[Tree /*TypeTree | TypeBoundsTree*/]
       end extension
@@ -1780,7 +1780,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Annotated` */
     trait AnnotatedMethods:
-      extension (self: Annotated):
+      extension (self: Annotated)
         def arg: TypeTree
         def annotation: Term
       end extension
@@ -1813,7 +1813,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `MatchTypeTree` */
     trait MatchTypeTreeMethods:
-      extension (self: MatchTypeTree):
+      extension (self: MatchTypeTree)
         def bound: Option[TypeTree]
         def selector: TypeTree
         def cases: List[TypeCaseDef]
@@ -1847,7 +1847,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ByName` */
     trait ByNameMethods:
-      extension (self: ByName):
+      extension (self: ByName)
         def result: TypeTree
       end extension
     end ByNameMethods
@@ -1879,7 +1879,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `LambdaTypeTree` */
     trait LambdaTypeTreeMethods:
-      extension (self: LambdaTypeTree):
+      extension (self: LambdaTypeTree)
         def tparams: List[TypeDef]
         def body: Tree /*TypeTree | TypeBoundsTree*/
       end extension
@@ -1912,7 +1912,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeBind` */
     trait TypeBindMethods:
-      extension (self: TypeBind):
+      extension (self: TypeBind)
         def name: String
         def body: Tree /*TypeTree | TypeBoundsTree*/
       end extension
@@ -1945,7 +1945,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeBlock` */
     trait TypeBlockMethods:
-      extension (self: TypeBlock):
+      extension (self: TypeBlock)
         def aliases: List[TypeDef]
         def tpt: TypeTree
       end extension
@@ -1980,7 +1980,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeBoundsTree` */
     trait TypeBoundsTreeMethods:
-      extension (self: TypeBoundsTree):
+      extension (self: TypeBoundsTree)
         def tpe: TypeBounds
         def low: TypeTree
         def hi: TypeTree
@@ -2017,7 +2017,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `WildcardTypeTree` */
     trait WildcardTypeTreeMethods:
-      extension (self: WildcardTypeTree):
+      extension (self: WildcardTypeTree)
         def tpe: TypeRepr
       end extension
     end WildcardTypeTreeMethods
@@ -2051,7 +2051,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `CaseDef` */
     trait CaseDefMethods:
-      extension (self: CaseDef):
+      extension (self: CaseDef)
         def pattern: Tree
         def guard: Option[Term]
         def rhs: Term
@@ -2085,7 +2085,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeCaseDef` */
     trait TypeCaseDefMethods:
-      extension (self: TypeCaseDef):
+      extension (self: TypeCaseDef)
         def pattern: TypeTree
         def rhs: TypeTree
       end extension
@@ -2120,7 +2120,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Bind` */
     trait BindMethods:
-      extension (self: Bind):
+      extension (self: Bind)
         def name: String
         def pattern: Tree
       end extension
@@ -2153,7 +2153,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Unapply` */
     trait UnapplyMethods:
-      extension (self: Unapply):
+      extension (self: Unapply)
         def fun: Term
         def implicits: List[Term]
         def patterns: List[Tree]
@@ -2187,7 +2187,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Alternatives` */
     trait AlternativesMethods:
-      extension (self: Alternatives):
+      extension (self: Alternatives)
         def patterns: List[Tree]
       end extension
     end AlternativesMethods
@@ -2235,7 +2235,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SimpleSelector` */
     trait SimpleSelectorMethods:
-      extension (self: SimpleSelector):
+      extension (self: SimpleSelector)
         def name: String
         def namePos: Position
       end extension
@@ -2266,7 +2266,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `RenameSelector` */
     trait RenameSelectorMethods:
-      extension (self: RenameSelector):
+      extension (self: RenameSelector)
         def fromName: String
         def fromPos: Position
         def toName: String
@@ -2299,7 +2299,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `OmitSelector` */
     trait OmitSelectorMethods:
-      extension (self: OmitSelector):
+      extension (self: OmitSelector)
         def name: String
         def namePos: Position
     end OmitSelectorMethods
@@ -2329,7 +2329,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `GivenSelector` */
     trait GivenSelectorMethods:
-      extension (self: GivenSelector):
+      extension (self: GivenSelector)
         def bound: Option[TypeTree]
     end GivenSelectorMethods
 
@@ -2362,7 +2362,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeRepr` */
     trait TypeReprMethods {
-      extension (self: TypeRepr):
+      extension (self: TypeRepr)
 
         /** Shows the tree as extractors */
         def showExtractors: String
@@ -2511,7 +2511,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ConstantType` */
     trait ConstantTypeMethods:
-      extension (self: ConstantType):
+      extension (self: ConstantType)
         def constant: Constant
       end extension
     end ConstantTypeMethods
@@ -2542,7 +2542,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TermRef` */
     trait TermRefMethods:
-      extension (self: TermRef):
+      extension (self: TermRef)
         def qualifier: TypeRepr
         def name: String
       end extension
@@ -2573,7 +2573,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeRef` */
     trait TypeRefMethods:
-      extension (self: TypeRef):
+      extension (self: TypeRef)
         def qualifier: TypeRepr
         def name: String
         def isOpaqueAlias: Boolean
@@ -2607,7 +2607,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SuperType` */
     trait SuperTypeMethods { this: SuperTypeMethods =>
-      extension (self: SuperType):
+      extension (self: SuperType)
         def thistpe: TypeRepr
         def supertpe: TypeRepr
       end extension
@@ -2639,7 +2639,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Refinement` */
     trait RefinementMethods:
-      extension (self: Refinement):
+      extension (self: Refinement)
         def parent: TypeRepr
         def name: String
         def info: TypeRepr
@@ -2671,7 +2671,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `AppliedType` */
     trait AppliedTypeMethods:
-      extension (self: AppliedType):
+      extension (self: AppliedType)
         def tycon: TypeRepr
         def args: List[TypeRepr]
       end extension
@@ -2703,7 +2703,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `AnnotatedType` */
     trait AnnotatedTypeMethods:
-      extension (self: AnnotatedType):
+      extension (self: AnnotatedType)
         def underlying: TypeRepr
         def annot: Term
       end extension
@@ -2735,7 +2735,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `AndType` */
     trait AndTypeMethods:
-      extension (self: AndType):
+      extension (self: AndType)
         def left: TypeRepr
         def right: TypeRepr
       end extension
@@ -2767,7 +2767,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `OrType` */
     trait OrTypeMethods:
-      extension (self: OrType):
+      extension (self: OrType)
         def left: TypeRepr
         def right: TypeRepr
       end extension
@@ -2799,7 +2799,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `MatchType` */
     trait MatchTypeMethods:
-      extension (self: MatchType):
+      extension (self: MatchType)
         def bound: TypeRepr
         def scrutinee: TypeRepr
         def cases: List[TypeRepr]
@@ -2832,7 +2832,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ByNameType` */
     trait ByNameTypeMethods:
-      extension (self: ByNameType):
+      extension (self: ByNameType)
         def underlying: TypeRepr
       end extension
     end ByNameTypeMethods
@@ -2862,7 +2862,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ParamRef` */
     trait ParamRefMethods:
-      extension (self: ParamRef):
+      extension (self: ParamRef)
         def binder: TypeRepr
         def paramNum: Int
       end extension
@@ -2893,7 +2893,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ThisType` */
     trait ThisTypeMethods:
-      extension (self: ThisType):
+      extension (self: ThisType)
         def tref: TypeRepr
       end extension
     end ThisTypeMethods
@@ -2923,7 +2923,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `RecursiveThis` */
     trait RecursiveThisMethods:
-      extension (self: RecursiveThis):
+      extension (self: RecursiveThis)
         def binder: RecursiveType
       end extension
     end RecursiveThisMethods
@@ -2964,7 +2964,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `RecursiveType` */
     trait RecursiveTypeMethods:
-      extension (self: RecursiveType):
+      extension (self: RecursiveType)
         def underlying: TypeRepr
         def recThis: RecursiveThis
       end extension
@@ -2996,7 +2996,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `MethodType` */
     trait MethodTypeMethods:
-      extension (self: MethodType):
+      extension (self: MethodType)
         def isImplicit: Boolean
         def isErased: Boolean
         def param(idx: Int): TypeRepr
@@ -3032,7 +3032,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `PolyType` */
     trait PolyTypeMethods:
-      extension (self: PolyType):
+      extension (self: PolyType)
         def param(idx: Int): TypeRepr
         def paramNames: List[String]
         def paramBounds: List[TypeBounds]
@@ -3066,7 +3066,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeLambda` */
     trait TypeLambdaMethods:
-      extension (self: TypeLambda):
+      extension (self: TypeLambda)
         def paramNames: List[String]
         def paramBounds: List[TypeBounds]
         def param(idx: Int) : TypeRepr
@@ -3105,7 +3105,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeBounds` */
     trait TypeBoundsMethods:
-      extension (self: TypeBounds):
+      extension (self: TypeBounds)
         def low: TypeRepr
         def hi: TypeRepr
       end extension
@@ -3292,7 +3292,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Constant` */
     trait ConstantMethods {
-      extension (self: Constant):
+      extension (self: Constant)
         /** Returns the value of the constant */
         def value: Any
 
@@ -3346,7 +3346,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ImplicitSearchSuccess` */
     trait ImplicitSearchSuccessMethods:
-      extension (self: ImplicitSearchSuccess):
+      extension (self: ImplicitSearchSuccess)
         def tree: Term
       end extension
     end ImplicitSearchSuccessMethods
@@ -3367,7 +3367,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ImplicitSearchFailure` */
     trait ImplicitSearchFailureMethods:
-      extension (self: ImplicitSearchFailure):
+      extension (self: ImplicitSearchFailure)
         def explanation: String
       end extension
     end ImplicitSearchFailureMethods
@@ -3494,7 +3494,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Symbol` */
     trait SymbolMethods {
-      extension (self: Symbol):
+      extension (self: Symbol)
 
         /** Owner of this symbol. The owner is the symbol in which this symbol is defined. Throws if this symbol does not have an owner. */
         def owner: Symbol
@@ -3686,7 +3686,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Signature` */
     trait SignatureMethods {
-      extension (self: Signature):
+      extension (self: Signature)
 
         /** The signatures of the method parameters.
           *
@@ -4030,7 +4030,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Flags` */
     trait FlagsMethods {
-      extension (self: Flags):
+      extension (self: Flags)
         /** Is the given flag set a subset of this flag sets */
         def is(that: Flags): Boolean
 
@@ -4077,7 +4077,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Position` */
     trait PositionMethods {
-      extension (self: Position):
+      extension (self: Position)
 
         /** The start offset in the source file */
         def start: Int
@@ -4126,7 +4126,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SourceFile` */
     trait SourceFileMethods {
-      extension (self: SourceFile):
+      extension (self: SourceFile)
         /** Path to this source file */
         def jpath: java.nio.file.Path
 
@@ -4220,7 +4220,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Documentation` */
     trait DocumentationMethods {
-      extension (self: Documentation):
+      extension (self: Documentation)
         /** Raw documentation string */
         def raw: String
 

--- a/scala3doc-testcases/src/tests/FilterTest.scala
+++ b/scala3doc-testcases/src/tests/FilterTest.scala
@@ -120,8 +120,8 @@ class FilterTest extends FilterTestBase with FilterTestBaseTrait:
   /** doc */
   protected given namedSeq: Seq[String | Int | Double] = List(1)
 
-extension (e: FilterTest):
+extension (e: FilterTest)
   def extensionMethod(name: FilterTest): FilterTest = ???
 
-extension (e: FilterTestBase):
+extension (e: FilterTestBase)
   def extensionMethodBase(name: FilterTest): FilterTest = ???

--- a/scala3doc-testcases/src/tests/extensionMethodSignatures.scala
+++ b/scala3doc-testcases/src/tests/extensionMethodSignatures.scala
@@ -4,7 +4,7 @@ package extensionMethodSignatures
 class ClassOne
 {
   // Commented cases won't work for now
-  // extension ClassTwoOps on (c: ClassTwo):
+  // extension ClassTwoOps on (c: ClassTwo)
   //     def getA() = c.a
   extension (c: ClassTwo)
     def getB(): String

--- a/scala3doc-testcases/src/tests/implicitMembers.scala
+++ b/scala3doc-testcases/src/tests/implicitMembers.scala
@@ -6,15 +6,15 @@ class OuterClass:
   class ImplicitMemberTarget
 
   object ImplicitMemberTarget:
-    extension (a: ImplicitMemberTarget):
+    extension (a: ImplicitMemberTarget)
       def extensionFromCompanion: String =
         "ImplicitMemberTarget"
 
   // does not work
-  extension (a: ImplicitMemberTarget):
+  extension (a: ImplicitMemberTarget)
     def extensionFromOuterClass: String =
       "ImplicitMemberTarget"
 
-extension (a: OuterClass#ImplicitMemberTarget):
+extension (a: OuterClass#ImplicitMemberTarget)
     def extensionFromPackage: String =
       "ImplicitMemberTarget"

--- a/tests/bench/string-interpolation-macro/Macro.scala
+++ b/tests/bench/string-interpolation-macro/Macro.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Macro {
 
-  extension (inline sc: StringContext):
+  extension (inline sc: StringContext)
     inline def x(inline args: Int*): String = ${ code('sc, 'args) }
 
   def code(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Int]])(using Quotes): Expr[String] =

--- a/tests/neg/gadt-approximation-interaction.scala
+++ b/tests/neg/gadt-approximation-interaction.scala
@@ -80,7 +80,7 @@ object ExtensionMethod {
   enum SUB[-A, +B]:
     case Refl[S]() extends SUB[S, S]
 
-  extension (x: Int):
+  extension (x: Int)
     def **(y: Int) = math.pow(x, y).toInt
 
   def foo[T](t: T, ev: T SUB Int) =

--- a/tests/neg/i5773.scala
+++ b/tests/neg/i5773.scala
@@ -23,7 +23,7 @@ object Main {
 21 |    println(1 appendS 2)
    |            ^^^^^^^^^
    |value appendS is not a member of Int.
-   |An extension method was tried, but could not be fully constructed:
+   |An extension method was tried, but could not be fully constructed
    |
    |    Semigroup.sumSemigroup[Any](/* ambiguous */implicitly[Numeric[Any]]).appendS()
 one error found

--- a/tests/neg/i6900.scala
+++ b/tests/neg/i6900.scala
@@ -1,7 +1,7 @@
 object Test2 {
 
   // Works with extension method
-  extension [A](a: A):
+  extension [A](a: A)
     def foo[C]: C => A = _ => a   // error: extension method cannot have type parameters
 
   1.foo.foo

--- a/tests/pos/i6900.scala
+++ b/tests/pos/i6900.scala
@@ -21,7 +21,7 @@ object Test1 {
 object Test2 {
 
   // Works with extension method
-  extension [A, C](a: A):
+  extension [A, C](a: A)
     def foo: C => A = _ => a
 
   1.foo.foo

--- a/tests/pos/typeclass-encoding3.scala
+++ b/tests/pos/typeclass-encoding3.scala
@@ -138,7 +138,7 @@ object Test {
   common
     val minimum = Int.MinValue
 
-  extension [T : Ord] for List[T] : Ord:
+  extension [T : Ord] for List[T] : Ord
     def compareTo(that: List[T]): Int = (this, that) match
       case (Nil, Nil) => 0
       case (Nil, _) => -1


### PR DESCRIPTION
The fixes omit documenting `:` in extension blocks. These will be disabled
in a separate commit.

There are two reasons for omitted in `:` in extensions:

 - they are not needed, and there should be one way to do things
 - they are confusing since everywhere else a `:` at eol starts a
   new scope, but here it doesn't.