### PR TITLE
Fix #10648: Fixes of syntax documentation

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/Fields.scala
+++ b/community-build/src/scala/dotty/communitybuild/Fields.scala
@@ -5,5 +5,5 @@ import scala.quoted.Type
 class FieldsDsl[V](v: V):
   inline def of[T]: Seq[T] = FieldsImpl.fieldsOfType[V, T](v)
 
-extension [V](on: V):
+extension [V](on: V)
   def reflectedFields = FieldsDsl(on)

--- a/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
@@ -275,7 +275,7 @@ class BTypesFromSymbols[I <: DottyBackendInterface](val int: I) extends BTypes {
    *   object T { def f { object U } }
    * the owner of U is T, so UModuleClass.isStatic is true. Phase travel does not help here.
    */
-  extension (sym: Symbol):
+  extension (sym: Symbol)
     private def isOriginallyStaticOwner: Boolean =
       sym.is(PackageClass) || sym.is(ModuleClass) && sym.originalOwner.originalLexicallyEnclosingClass.isOriginallyStaticOwner
 

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -125,7 +125,7 @@ object DottyBackendInterface {
   }
 
   given symExtensions: AnyRef with
-    extension (sym: Symbol):
+    extension (sym: Symbol)
 
       def isInterface(using Context): Boolean = (sym.is(PureInterface)) || sym.is(Trait)
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1148,7 +1148,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       !(sym.is(Method) && sym.info.isInstanceOf[MethodOrPoly]) // if is a method it is parameterless
   }
 
-  extension (xs: List[tpd.Tree]):
+  extension (xs: List[tpd.Tree])
     def tpes: List[Type] = xs match {
       case x :: xs1 => x.tpe :: xs1.tpes
       case nil => Nil

--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -9,7 +9,7 @@ import ast.untpd
 /** Extension methods for contexts where we want to keep the ctx.<methodName> syntax */
 object ContextOps:
 
-  extension (ctx: Context):
+  extension (ctx: Context)
 
     /** Enter symbol into current class, if current class is owner of current context,
     *  or into current scope, if not. Should always be called instead of scope.enter

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -650,7 +650,7 @@ object Contexts {
   }
 
   given ops: AnyRef with
-    extension (c: Context):
+    extension (c: Context)
       def addNotNullInfo(info: NotNullInfo) =
         c.withNotNullInfos(c.notNullInfos.extendWith(info))
 

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -28,7 +28,7 @@ object Decorators {
       case s: String => typeName(s)
       case n: Name => n.toTypeName
 
-  extension (s: String):
+  extension (s: String)
     def splitWhere(f: Char => Boolean, doDropIndex: Boolean): Option[(String, String)] =
       def splitAt(idx: Int, doDropIndex: Boolean): Option[(String, String)] =
         if (idx == -1) None
@@ -61,7 +61,7 @@ object Decorators {
   /** Implements a findSymbol method on iterators of Symbols that
    *  works like find but avoids Option, replacing None with NoSymbol.
    */
-  extension (it: Iterator[Symbol]):
+  extension (it: Iterator[Symbol])
     final def findSymbol(p: Symbol => Boolean): Symbol = {
       while (it.hasNext) {
         val sym = it.next()

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2571,7 +2571,7 @@ object TypeComparer {
      */
     val Fresh: Repr = 4
 
-    extension (approx: Repr):
+    extension (approx: Repr)
       def low: Boolean = (approx & LoApprox) != 0
       def high: Boolean = (approx & HiApprox) != 0
       def addLow: Repr = approx | LoApprox

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -241,7 +241,7 @@ object Completion {
             }
           }
 
-      // There are four possible ways for an extension method to be applicable:
+      // There are four possible ways for an extension method to be applicable
 
       // 1. The extension method is visible under a simple name, by being defined or inherited or imported in a scope enclosing the reference.
       val extMethodsInScope =

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -64,7 +64,7 @@ object Parsers {
     val Spliced = 2
   }
 
-  extension (buf: ListBuffer[Tree]):
+  extension (buf: ListBuffer[Tree])
     def +++=(x: Tree) = x match {
       case x: Thicket => buf ++= x.trees
       case x => buf += x
@@ -3565,8 +3565,6 @@ object Parsers {
       val tparams = typeParamClauseOpt(ParamOwner.Def)
       val extParams = paramClause(0, prefix = true)
       val givenParamss = paramClauses(givenOnly = true)
-      in.observeColonEOL()
-      if (in.token == COLONEOL) in.nextToken()
       val methods =
         if isDefIntro(modifierTokens) then
           extMethod() :: Nil

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3565,6 +3565,9 @@ object Parsers {
       val tparams = typeParamClauseOpt(ParamOwner.Def)
       val extParams = paramClause(0, prefix = true)
       val givenParamss = paramClauses(givenOnly = true)
+      if in.token == COLON then
+        syntaxError("no `:` expected here")
+        in.nextToken()
       val methods =
         if isDefIntro(modifierTokens) then
           extMethod() :: Nil

--- a/compiler/src/dotty/tools/dotc/printing/Texts.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Texts.scala
@@ -168,7 +168,7 @@ object Texts {
     /** The given texts `xs`, each on a separate line */
     def lines(xs: Traversable[Text]): Vertical = Vertical(xs.toList.reverse)
 
-    extension (text: => Text):
+    extension (text: => Text)
       def provided(cond: Boolean): Text = if (cond) text else Str("")
 
   }

--- a/compiler/src/dotty/tools/dotc/printing/package.scala
+++ b/compiler/src/dotty/tools/dotc/printing/package.scala
@@ -22,7 +22,7 @@ package object printing {
   val XprintMode: Key[Unit] = new Key
 
   /** @pre `nel` is non-empty list */
-  extension [A](nel: List[A]):
+  extension [A](nel: List[A])
     private[printing] def intersperse(a: A): List[A] =
       nel.flatMap(a :: _ :: Nil).tail
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -259,7 +259,7 @@ class ExtractSemanticDB extends Phase:
 
         case _ => None
 
-      extension (tpe: Types.Type):
+      extension (tpe: Types.Type)
         private inline def isAnnotatedByUnchecked(using Context) = tpe match
           case Types.AnnotatedType(_, annot) => annot.symbol == defn.UncheckedAnnot
           case _                             => false
@@ -490,12 +490,12 @@ class ExtractSemanticDB extends Phase:
       val start = if idx >= 0 then idx else span.start
       Span(start, start + sym.name.show.length, start)
 
-    extension (list: List[List[ValDef]]):
+    extension (list: List[List[ValDef]])
       private  inline def isSingleArg = list match
         case (_::Nil)::Nil => true
         case _             => false
 
-    extension (tree: DefDef):
+    extension (tree: DefDef)
       private def isSetterDef(using Context): Boolean =
         tree.name.isSetterName && tree.mods.is(Accessor) && tree.vparamss.isSingleArg
 
@@ -521,13 +521,13 @@ class ExtractSemanticDB extends Phase:
         else limit
       Span(start max limit, end)
 
-    extension (span: Span):
+    extension (span: Span)
       private def hasLength: Boolean = span.exists && !span.isZeroExtent
 
     /**Consume head while not an import statement.
      * Returns the rest of the list after the first import, or else the empty list
      */
-    extension (body: List[Tree]):
+    extension (body: List[Tree])
       @tailrec private def foreachUntilImport(op: Tree => Unit): List[Tree] = body match
         case ((_: Import) :: rest) => rest
         case stat :: rest =>
@@ -535,7 +535,7 @@ class ExtractSemanticDB extends Phase:
           rest.foreachUntilImport(op)
         case Nil => Nil
 
-    extension (sym: Symbol):
+    extension (sym: Symbol)
       private def adjustIfCtorTyparam(using Context) =
         if sym.isType && sym.owner.exists && sym.owner.isConstructor then
           matchingMemberType(sym, sym.owner.owner)

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -69,7 +69,7 @@ object Scala3:
 
 
   given NameOps: AnyRef with
-    extension (name: Name):
+    extension (name: Name)
       def isWildcard = name match
         case nme.WILDCARD | WILDCARDTypeName => true
         case _                               => name.is(NameKinds.WildcardParamName)
@@ -90,7 +90,7 @@ object Scala3:
   end NameOps
 
   given SymbolOps: AnyRef with
-    extension (sym: Symbol):
+    extension (sym: Symbol)
 
       def ifExists(using Context): Option[Symbol] = if sym.exists then Some(sym) else None
 
@@ -140,13 +140,13 @@ object Scala3:
 
   end LocalSymbol
 
-  extension (char: Char):
+  extension (char: Char)
     private inline def isGlobalTerminal = (char: @switch) match
       case '/' | '.' | '#' | ']' | ')' => true
       case _                           => false
 
   given StringOps: AnyRef with
-    extension (symbol: String):
+    extension (symbol: String)
       def isSymbol: Boolean = !symbol.isEmpty
       def isRootPackage: Boolean = RootPackage == symbol
       def isEmptyPackage: Boolean = EmptyPackage == symbol
@@ -170,7 +170,7 @@ object Scala3:
   end StringOps
 
   given InfoOps: AnyRef with
-    extension (info: SymbolInformation):
+    extension (info: SymbolInformation)
       def isAbstract: Boolean = (info.properties & SymbolInformation.Property.ABSTRACT.value) != 0
       def isFinal: Boolean = (info.properties & SymbolInformation.Property.FINAL.value) != 0
       def isSealed: Boolean = (info.properties & SymbolInformation.Property.SEALED.value) != 0
@@ -205,7 +205,7 @@ object Scala3:
   end InfoOps
 
   given RangeOps: AnyRef with
-    extension (range: Range):
+    extension (range: Range)
       def hasLength = range.endLine > range.startLine || range.endCharacter > range.startCharacter
   end RangeOps
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/Tools.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Tools.scala
@@ -144,5 +144,5 @@ object Tools:
     sb.append(if occ.role.isReference then " -> " else " <- ").append(occ.symbol).nl
   end processOccurrence
 
-  extension (sb: StringBuilder):
+  extension (sb: StringBuilder)
     private inline def nl = sb.append(System.lineSeparator)

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -190,7 +190,7 @@ object ExtensionMethods {
         // See the documentation of `memberSignature` to understand why `.stripPoly.ensureMethodic` is needed here.
         candidates filter (c => FullParameterization.memberSignature(c.info) == imeth.info.stripPoly.ensureMethodic.signature)
       assert(matching.nonEmpty,
-       i"""no extension method found for:
+       i"""no extension method found for
           |
           |  $imeth:${imeth.info.show} with signature ${imeth.info.signature} in ${companion.moduleClass}
           |

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -190,7 +190,7 @@ object ExtensionMethods {
         // See the documentation of `memberSignature` to understand why `.stripPoly.ensureMethodic` is needed here.
         candidates filter (c => FullParameterization.memberSignature(c.info) == imeth.info.stripPoly.ensureMethodic.signature)
       assert(matching.nonEmpty,
-       i"""no extension method found for
+       i"""no extension method found for:
           |
           |  $imeth:${imeth.info.show} with signature ${imeth.info.signature} in ${companion.moduleClass}
           |

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -35,7 +35,7 @@ object ImportInfo {
 
     ImportInfo(sym, selectors, None, isRootImport = true)
 
-  extension (c: Context):
+  extension (c: Context)
     def withRootImports(rootRefs: List[RootRef])(using Context): Context =
       rootRefs.foldLeft(c)((ctx, ref) => ctx.fresh.setImportInfo(rootImport(ref)))
 

--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -339,7 +339,7 @@ object Nullables:
       }.traverse(tree)
   end extension
 
-  extension (tree: Assign):
+  extension (tree: Assign)
     def computeAssignNullable()(using Context): tree.type = tree.lhs match
       case TrackedRef(ref) =>
         val rhstp = tree.rhs.typeOpt

--- a/compiler/src/dotty/tools/dotc/util/LinearMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearMap.scala
@@ -15,7 +15,7 @@ object LinearMap:
   def empty[K <: AnyRef, V >: Null <: AnyRef]: LinearMap[K, V] =
     immutable.Map.empty[K, V]
 
-  extension [K <: AnyRef, V >: Null <: AnyRef](m: LinearMap[K, V]):
+  extension [K <: AnyRef, V >: Null <: AnyRef](m: LinearMap[K, V])
 
     def lookup(key: K): V /*| Null*/ = (m: @unchecked) match
       case m: immutable.AbstractMap[K, V] @unchecked =>

--- a/compiler/src/dotty/tools/dotc/util/LinearSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearSet.scala
@@ -12,7 +12,7 @@ object LinearSet:
 
   def empty[Elem >: Null <: AnyRef]: LinearSet[Elem] = immutable.Set.empty[Elem]
 
-  extension [Elem >: Null <: AnyRef](s: LinearSet[Elem]):
+  extension [Elem >: Null <: AnyRef](s: LinearSet[Elem])
 
     def contains(elem: Elem): Boolean = (s: @unchecked) match
       case s: immutable.AbstractSet[Elem] @unchecked => s.contains(elem)

--- a/compiler/src/dotty/tools/package.scala
+++ b/compiler/src/dotty/tools/package.scala
@@ -25,7 +25,7 @@ package object tools {
     throw new UnsupportedOperationException(methodName)
 
   /** Forward-ported from the explicit-nulls branch. */
-  extension [T](x: T | Null):
+  extension [T](x: T | Null)
 
     /** Assert `x` is non null and strip `Null` from type */
     inline def nn: T =

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -142,7 +142,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None) {
 
 object Rendering {
 
-  extension (s: Symbol):
+  extension (s: Symbol)
     def showUser(using Context): String = {
       val printer = new ReplPrinter(ctx)
       val text = printer.dclText(s)

--- a/compiler/src/dotty/tools/repl/results.scala
+++ b/compiler/src/dotty/tools/repl/results.scala
@@ -14,10 +14,10 @@ object results {
   /** Result is a type alias for an Either with left value `Errors` */
   type Result[+A] = scala.util.Either[Errors, A]
 
-  extension [A](a: A):
+  extension [A](a: A)
     def result: Result[A] = scala.util.Right(a)
 
-  extension [A](xs: Errors):
+  extension [A](xs: Errors)
     def errors: Result[A] = scala.util.Left(xs)
 
 }

--- a/compiler/src/scala/quoted/runtime/impl/Matcher.scala
+++ b/compiler/src/scala/quoted/runtime/impl/Matcher.scala
@@ -135,12 +135,12 @@ object Matcher {
       case _ => notMatched
     }
 
-    extension (scrutinees: List[Tree]):
+    extension (scrutinees: List[Tree])
       /** Check that all trees match with =?= and concatenate the results with &&& */
       private def =?= (patterns: List[Tree])(using Env): Matching =
         matchLists(scrutinees, patterns)(_ =?= _)
 
-    extension (scrutinee0: Tree):
+    extension (scrutinee0: Tree)
       /** Check that the trees match and return the contents from the pattern holes.
        *  Return None if the trees do not match otherwise return Some of a tuple containing all the contents in the holes.
        *
@@ -408,7 +408,7 @@ object Matcher {
     val matched: Matching = Some(Tuple())
     def matched(x: Any): Matching = Some(Tuple1(x))
 
-    extension (self: Matching):
+    extension (self: Matching)
       def asOptionOfTuple: Option[Tuple] = self
 
       /** Concatenates the contents of two successful matchings or return a `notMatched` */

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -46,7 +46,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
   private val yCheck: Boolean =
     ctx.settings.Ycheck.value(using ctx).exists(x => x == "all" || x == "macros")
 
-  extension [T](self: scala.quoted.Expr[T]):
+  extension [T](self: scala.quoted.Expr[T])
     def show: String =
       reflect.Printer.TreeCode.show(reflect.asTerm(self))
 
@@ -55,7 +55,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
   end extension
 
-  extension [X](self: scala.quoted.Expr[Any]):
+  extension [X](self: scala.quoted.Expr[Any])
     /** Checks is the `quoted.Expr[?]` is valid expression of type `X` */
     def isExprOf(using scala.quoted.Type[X]): Boolean =
       reflect.TypeReprMethods.<:<(reflect.asTerm(self).tpe)(reflect.TypeRepr.of[X])
@@ -88,7 +88,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     object Tree extends TreeModule
 
     given TreeMethods: TreeMethods with
-      extension (self: Tree):
+      extension (self: Tree)
         def pos: Position = self.sourcePos
         def symbol: Symbol = self.symbol
         def show(using printer: Printer[Tree]): String = printer.show(self)
@@ -112,7 +112,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           QuotesImpl.this.asExprOf[T](self.asExpr)(using tp)
       end extension
 
-      extension [ThisTree <: Tree](self: ThisTree):
+      extension [ThisTree <: Tree](self: ThisTree)
         def changeOwner(newOwner: Symbol): ThisTree =
           tpd.TreeOps(self).changeNonLocalOwners(newOwner).asInstanceOf[ThisTree]
       end extension
@@ -137,7 +137,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end PackageClause
 
     given PackageClauseMethods: PackageClauseMethods with
-      extension (self: PackageClause):
+      extension (self: PackageClause)
         def pid: Ref = self.pid
         def stats: List[Tree] = self.stats
       end extension
@@ -161,7 +161,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Import
 
     given ImportMethods: ImportMethods with
-      extension (self: Import):
+      extension (self: Import)
         def expr: Term = self.expr
         def selectors: List[Selector] = self.selectors
       end extension
@@ -181,7 +181,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Export
 
     given ExportMethods: ExportMethods with
-      extension (self: Export):
+      extension (self: Export)
         def expr: Term = self.expr
         def selectors: List[Selector] = self.selectors
       end extension
@@ -208,7 +208,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     object Definition extends DefinitionModule
 
     given DefinitionMethods: DefinitionMethods with
-      extension (self: Definition):
+      extension (self: Definition)
         def name: String = self match
           case self: tpd.MemberDef => self.name.toString
       end extension
@@ -233,7 +233,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ClassDef
 
     given ClassDefMethods: ClassDefMethods with
-      extension (self: ClassDef):
+      extension (self: ClassDef)
         def constructor: DefDef =
           self.rhs.asInstanceOf[tpd.Template].constr
         def parents: List[Tree] =
@@ -265,7 +265,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end DefDef
 
     given DefDefMethods: DefDefMethods with
-      extension (self: DefDef):
+      extension (self: DefDef)
         def typeParams: List[TypeDef] = self.tparams
         def paramss: List[List[ValDef]] = self.vparamss
         def returnTpt: TypeTree = self.tpt
@@ -302,7 +302,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ValDef
 
     given ValDefMethods: ValDefMethods with
-      extension (self: ValDef):
+      extension (self: ValDef)
         def tpt: TypeTree = self.tpt
         def rhs: Option[Term] = optional(self.rhs)
       end extension
@@ -326,7 +326,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeDef
 
     given TypeDefMethods: TypeDefMethods with
-      extension (self: TypeDef):
+      extension (self: TypeDef)
         def rhs: Tree = self.rhs
       end extension
     end TypeDefMethods
@@ -360,7 +360,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Term
 
     given TermMethods: TermMethods with
-      extension (self: Term):
+      extension (self: Term)
         def seal: scala.quoted.Expr[Any] =
           if self.isExpr then new ExprImpl(self, QuotesImpl.this.hashCode)
           else throw new Exception("Cannot seal a partially applied Term. Try eta-expanding the term first.")
@@ -439,7 +439,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Ident
 
     given IdentMethods: IdentMethods with
-      extension (self: Ident):
+      extension (self: Ident)
         def name: String = self.name.toString
       end extension
     end IdentMethods
@@ -471,7 +471,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Select
 
     given SelectMethods: SelectMethods with
-      extension (self: Select):
+      extension (self: Select)
         def qualifier: Term = self.qualifier
         def name: String = self.name.toString
         def signature: Option[Signature] =
@@ -498,7 +498,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Literal
 
     given LiteralMethods: LiteralMethods with
-      extension (self: Literal):
+      extension (self: Literal)
         def constant: Constant = self.const
       end extension
     end LiteralMethods
@@ -521,7 +521,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end This
 
     given ThisMethods: ThisMethods with
-      extension (self: This):
+      extension (self: This)
         def id: Option[String] = optional(self.qual).map(_.name.toString)
       end extension
     end ThisMethods
@@ -543,7 +543,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end New
 
     given NewMethods: NewMethods with
-      extension (self: New):
+      extension (self: New)
         def tpt: TypeTree = self.tpt
       end extension
     end NewMethods
@@ -566,7 +566,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end NamedArg
 
     given NamedArgMethods: NamedArgMethods with
-      extension (self: NamedArg):
+      extension (self: NamedArg)
         def name: String = self.name.toString
         def value: Term = self.arg
       end extension
@@ -590,7 +590,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Apply
 
     given ApplyMethods: ApplyMethods with
-      extension (self: Apply):
+      extension (self: Apply)
         def fun: Term = self.fun
         def args: List[Term] = self.args
       end extension
@@ -614,7 +614,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeApply
 
     given TypeApplyMethods: TypeApplyMethods with
-      extension (self: TypeApply):
+      extension (self: TypeApply)
         def fun: Term = self.fun
         def args: List[TypeTree] = self.args
       end extension
@@ -638,7 +638,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Super
 
     given SuperMethods: SuperMethods with
-      extension (self: Super):
+      extension (self: Super)
         def qualifier: Term = self.qual
         def id: Option[String] = optional(self.mix).map(_.name.toString)
         def idPos: Position = self.mix.sourcePos
@@ -663,7 +663,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Typed
 
     given TypedMethods: TypedMethods with
-      extension (self: Typed):
+      extension (self: Typed)
         def expr: Term = self.expr
         def tpt: TypeTree = self.tpt
       end extension
@@ -687,7 +687,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Assign
 
     given AssignMethods: AssignMethods with
-      extension (self: Assign):
+      extension (self: Assign)
         def lhs: Term = self.lhs
         def rhs: Term = self.rhs
       end extension
@@ -711,7 +711,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Block
 
     given BlockMethods: BlockMethods with
-      extension (self: Block):
+      extension (self: Block)
         def statements: List[Statement] = self.stats
         def expr: Term = self.expr
       end extension
@@ -735,7 +735,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Closure
 
     given ClosureMethods: ClosureMethods with
-      extension (self: Closure):
+      extension (self: Closure)
         def meth: Term = self.meth
         def tpeOpt: Option[TypeRepr] = optional(self.tpt).map(_.tpe)
       end extension
@@ -772,7 +772,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end If
 
     given IfMethods: IfMethods with
-      extension (self: If):
+      extension (self: If)
         def cond: Term = self.cond
         def thenp: Term = self.thenp
         def elsep: Term = self.elsep
@@ -800,7 +800,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Match
 
     given MatchMethods: MatchMethods with
-      extension (self: Match):
+      extension (self: Match)
         def scrutinee: Term = self.selector
         def cases: List[CaseDef] = self.cases
         def isInline: Boolean = self.isInline
@@ -825,7 +825,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end SummonFrom
 
     given SummonFromMethods: SummonFromMethods with
-      extension (self: SummonFrom):
+      extension (self: SummonFrom)
         def cases: List[CaseDef] = self.cases
       end extension
     end SummonFromMethods
@@ -848,7 +848,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Try
 
     given TryMethods: TryMethods with
-      extension (self: Try):
+      extension (self: Try)
         def body: Term = self.expr
         def cases: List[CaseDef] = self.cases
         def finalizer: Option[Term] = optional(self.finalizer)
@@ -873,7 +873,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Return
 
     given ReturnMethods: ReturnMethods with
-      extension (self: Return):
+      extension (self: Return)
         def expr: Term = self.expr
         def from: Symbol = self.from.symbol
       end extension
@@ -897,7 +897,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Repeated
 
     given RepeatedMethods: RepeatedMethods with
-      extension (self: Repeated):
+      extension (self: Repeated)
         def elems: List[Term] = self.elems
         def elemtpt: TypeTree = self.elemtpt
       end extension
@@ -921,7 +921,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Inlined
 
     given InlinedMethods: InlinedMethods with
-      extension (self: Inlined):
+      extension (self: Inlined)
         def call: Option[Tree] = optional(self.call)
         def bindings: List[Definition] = self.bindings
         def body: Term = self.expansion
@@ -949,7 +949,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end SelectOuter
 
     given SelectOuterMethods: SelectOuterMethods with
-      extension (self: SelectOuter):
+      extension (self: SelectOuter)
         def qualifier: Term = self.qualifier
         def name: String = self.name.toString
         def level: Int =
@@ -976,7 +976,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end While
 
     given WhileMethods: WhileMethods with
-      extension (self: While):
+      extension (self: While)
         def cond: Term = self.cond
         def body: Term = self.body
       end extension
@@ -997,7 +997,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeTree
 
     given TypeTreeMethods: TypeTreeMethods with
-      extension (self: TypeTree):
+      extension (self: TypeTree)
         def tpe: TypeRepr = self.tpe.stripTypeVar
       end extension
     end TypeTreeMethods
@@ -1035,7 +1035,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeIdent
 
     given TypeIdentMethods: TypeIdentMethods with
-      extension (self: TypeIdent):
+      extension (self: TypeIdent)
         def name: String = self.name.toString
       end extension
     end TypeIdentMethods
@@ -1058,7 +1058,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeSelect
 
     given TypeSelectMethods: TypeSelectMethods with
-      extension (self: TypeSelect):
+      extension (self: TypeSelect)
         def qualifier: Term = self.qualifier
         def name: String = self.name.toString
       end extension
@@ -1080,7 +1080,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeProjection
 
     given TypeProjectionMethods: TypeProjectionMethods with
-      extension (self: TypeProjection):
+      extension (self: TypeProjection)
         def qualifier: TypeTree = self.qualifier
         def name: String = self.name.toString
       end extension
@@ -1104,7 +1104,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Singleton
 
     given SingletonMethods: SingletonMethods with
-      extension (self: Singleton):
+      extension (self: Singleton)
         def ref: Term = self.ref
       end extension
     end SingletonMethods
@@ -1125,7 +1125,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Refined
 
     given RefinedMethods: RefinedMethods with
-      extension (self: Refined):
+      extension (self: Refined)
         def tpt: TypeTree = self.tpt
         def refinements: List[Definition] = self.refinements.asInstanceOf[List[Definition]]
       end extension
@@ -1149,7 +1149,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Applied
 
     given AppliedMethods: AppliedMethods with
-      extension (self: Applied):
+      extension (self: Applied)
         def tpt: TypeTree = self.tpt
         def args: List[Tree] = self.args
       end extension
@@ -1173,7 +1173,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Annotated
 
     given AnnotatedMethods: AnnotatedMethods with
-      extension (self: Annotated):
+      extension (self: Annotated)
         def arg: TypeTree = self.arg
         def annotation: Term = self.annot
       end extension
@@ -1197,7 +1197,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end MatchTypeTree
 
     given MatchTypeTreeMethods: MatchTypeTreeMethods with
-      extension (self: MatchTypeTree):
+      extension (self: MatchTypeTree)
         def bound: Option[TypeTree] = optional(self.bound)
         def selector: TypeTree = self.selector
         def cases: List[TypeCaseDef] = self.cases
@@ -1222,7 +1222,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ByName
 
     given ByNameMethods: ByNameMethods with
-      extension (self: ByName):
+      extension (self: ByName)
         def result: TypeTree = self.result
       end extension
     end ByNameMethods
@@ -1245,7 +1245,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end LambdaTypeTree
 
     given LambdaTypeTreeMethods: LambdaTypeTreeMethods with
-      extension (self: LambdaTypeTree):
+      extension (self: LambdaTypeTree)
         def tparams: List[TypeDef] = self.tparams
         def body: Tree = self.body
       end extension
@@ -1267,7 +1267,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeBind
 
     given TypeBindMethods: TypeBindMethods with
-      extension (self: TypeBind):
+      extension (self: TypeBind)
         def name: String = self.name.toString
         def body: Tree = self.body
       end extension
@@ -1291,7 +1291,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeBlock
 
     given TypeBlockMethods: TypeBlockMethods with
-      extension (self: TypeBlock):
+      extension (self: TypeBlock)
         def aliases: List[TypeDef] = self.stats.map { case alias: TypeDef => alias }
         def tpt: TypeTree = self.expr
       end extension
@@ -1319,7 +1319,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeBoundsTree
 
     given TypeBoundsTreeMethods: TypeBoundsTreeMethods with
-      extension (self: TypeBoundsTree):
+      extension (self: TypeBoundsTree)
         def tpe: TypeBounds = self.tpe.asInstanceOf[Types.TypeBounds]
         def low: TypeTree = self match
           case self: tpd.TypeBoundsTree => self.lo
@@ -1344,7 +1344,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end WildcardTypeTree
 
     given WildcardTypeTreeMethods: WildcardTypeTreeMethods with
-      extension (self: WildcardTypeTree):
+      extension (self: WildcardTypeTree)
         def tpe: TypeRepr = self.tpe.stripTypeVar
       end extension
     end WildcardTypeTreeMethods
@@ -1367,7 +1367,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end CaseDef
 
     given CaseDefMethods: CaseDefMethods with
-      extension (self: CaseDef):
+      extension (self: CaseDef)
         def pattern: Tree = self.pat
         def guard: Option[Term] = optional(self.guard)
         def rhs: Term = self.body
@@ -1392,7 +1392,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeCaseDef
 
     given TypeCaseDefMethods: TypeCaseDefMethods with
-      extension (self: TypeCaseDef):
+      extension (self: TypeCaseDef)
         def pattern: TypeTree = self.pat
         def rhs: TypeTree = self.body
       end extension
@@ -1416,7 +1416,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Bind
 
     given BindMethods: BindMethods with
-      extension (self: Bind):
+      extension (self: Bind)
         def name: String = self.name.toString
         def pattern: Tree = self.body
       end extension
@@ -1440,7 +1440,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Unapply
 
     given UnapplyMethods: UnapplyMethods with
-      extension (self: Unapply):
+      extension (self: Unapply)
         def fun: Term = selfUnApply(self).fun
         def implicits: List[Term] = selfUnApply(self).implicits
         def patterns: List[Tree] = effectivePatterns(selfUnApply(self).patterns)
@@ -1473,7 +1473,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Alternatives
 
     given AlternativesMethods: AlternativesMethods with
-      extension (self: Alternatives):
+      extension (self: Alternatives)
         def patterns: List[Tree] = self.trees
       end extension
     end AlternativesMethods
@@ -1495,7 +1495,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end SimpleSelector
 
     given SimpleSelectorMethods: SimpleSelectorMethods with
-      extension (self: SimpleSelector):
+      extension (self: SimpleSelector)
         def name: String = self.imported.name.toString
         def namePos: Position = self.imported.sourcePos
       end extension
@@ -1514,7 +1514,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end RenameSelector
 
     given RenameSelectorMethods: RenameSelectorMethods with
-      extension (self: RenameSelector):
+      extension (self: RenameSelector)
         def fromName: String = self.imported.name.toString
         def fromPos: Position = self.imported.sourcePos
         def toName: String = self.renamed.asInstanceOf[untpd.Ident].name.toString
@@ -1539,7 +1539,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end OmitSelector
 
     given OmitSelectorMethods: OmitSelectorMethods with
-      extension (self: OmitSelector):
+      extension (self: OmitSelector)
         def name: String = self.imported.toString
         def namePos: Position = self.imported.sourcePos
       end extension
@@ -1560,7 +1560,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end GivenSelector
 
     given GivenSelectorMethods: GivenSelectorMethods with
-      extension (self: GivenSelector):
+      extension (self: GivenSelector)
         def bound: Option[TypeTree] =
           self.bound match
             case untpd.TypedSplice(tpt) => Some(tpt)
@@ -1596,7 +1596,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeRepr
 
     given TypeReprMethods: TypeReprMethods with
-      extension (self: TypeRepr):
+      extension (self: TypeRepr)
 
         def show(using printer: Printer[TypeRepr]): String = printer.show(self)
 
@@ -1701,7 +1701,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeRef
 
     given TypeRefMethods: TypeRefMethods with
-      extension (self: TypeRef):
+      extension (self: TypeRef)
         def isOpaqueAlias: Boolean = self.symbol.isOpaqueAlias
         def translucentSuperType: TypeRepr = self.translucentSuperType
       end extension
@@ -1723,7 +1723,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end SuperType
 
     given SuperTypeMethods: SuperTypeMethods with
-      extension (self: SuperType):
+      extension (self: SuperType)
         def thistpe: TypeRepr = self.thistpe
         def supertpe: TypeRepr = self.thistpe
       end extension
@@ -1749,7 +1749,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Refinement
 
     given RefinementMethods: RefinementMethods with
-      extension (self: Refinement):
+      extension (self: Refinement)
         def parent: TypeRepr = self.parent
         def name: String = self.refinedName.toString
         def info: TypeRepr = self.refinedInfo
@@ -1770,7 +1770,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end AppliedType
 
     given AppliedTypeMethods: AppliedTypeMethods with
-      extension (self: AppliedType):
+      extension (self: AppliedType)
         def tycon: TypeRepr = self.tycon
         def args: List[TypeRepr] = self.args
       end extension
@@ -1792,7 +1792,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end AnnotatedType
 
     given AnnotatedTypeMethods: AnnotatedTypeMethods with
-      extension (self: AnnotatedType):
+      extension (self: AnnotatedType)
         def underlying: TypeRepr = self.underlying.stripTypeVar
         def annotation: Term = self.annot.tree
       end extension
@@ -1855,7 +1855,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end MatchType
 
     given MatchTypeMethods: MatchTypeMethods with
-      extension (self: MatchType):
+      extension (self: MatchType)
         def bound: TypeRepr = self.bound
         def scrutinee: TypeRepr = self.scrutinee
         def cases: List[TypeRepr] = self.cases
@@ -1876,7 +1876,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ByNameType
 
     given ByNameTypeMethods: ByNameTypeMethods with
-      extension (self: ByNameType):
+      extension (self: ByNameType)
         def underlying: TypeRepr = self.resType.stripTypeVar
       end extension
     end ByNameTypeMethods
@@ -1896,7 +1896,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ParamRef
 
     given ParamRefMethods: ParamRefMethods with
-      extension (self: ParamRef):
+      extension (self: ParamRef)
         def binder: LambdaType = self.binder.asInstanceOf[LambdaType] // Cast to tpd
         def paramNum: Int = self.paramNum
       end extension
@@ -1915,7 +1915,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ThisType
 
     given ThisTypeMethods: ThisTypeMethods with
-      extension (self: ThisType):
+      extension (self: ThisType)
         def tref: TypeRepr = self.tref
       end extension
     end ThisTypeMethods
@@ -1934,7 +1934,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
 
     given RecursiveThisMethods: RecursiveThisMethods with
-      extension (self: RecursiveThis):
+      extension (self: RecursiveThis)
         def binder: RecursiveType = self.binder
       end extension
     end RecursiveThisMethods
@@ -1954,7 +1954,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end RecursiveType
 
     given RecursiveTypeMethods: RecursiveTypeMethods with
-      extension (self: RecursiveType):
+      extension (self: RecursiveType)
         def underlying: TypeRepr = self.underlying.stripTypeVar
         def recThis: RecursiveThis = self.recThis
       end extension
@@ -2000,7 +2000,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end MethodType
 
     given MethodTypeMethods: MethodTypeMethods with
-      extension (self: MethodType):
+      extension (self: MethodType)
         def isErased: Boolean = self.isErasedMethod
         def isImplicit: Boolean = self.isImplicitMethod
         def param(idx: Int): TypeRepr = self.newParamRef(idx)
@@ -2023,7 +2023,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end PolyType
 
     given PolyTypeMethods: PolyTypeMethods with
-      extension (self: PolyType):
+      extension (self: PolyType)
         def param(idx: Int): TypeRepr = self.newParamRef(idx)
         def paramBounds: List[TypeBounds] = self.paramInfos
       end extension
@@ -2045,7 +2045,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeLambda
 
     given TypeLambdaMethods: TypeLambdaMethods with
-      extension (self: TypeLambda):
+      extension (self: TypeLambda)
         def param(idx: Int): TypeRepr = self.newParamRef(idx)
         def paramBounds: List[TypeBounds] = self.paramInfos
       end extension
@@ -2068,7 +2068,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeBounds
 
     given TypeBoundsMethods: TypeBoundsMethods with
-      extension (self: TypeBounds):
+      extension (self: TypeBounds)
         def low: TypeRepr = self.lo.stripLazyRef
         def hi: TypeRepr = self.hi.stripLazyRef
       end extension
@@ -2176,7 +2176,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Constant
 
     given ConstantMethods: ConstantMethods with
-      extension (self: Constant):
+      extension (self: Constant)
         def value: Any = self.value
         def show: String = Extractors.showConstant(using QuotesImpl.this)(self)
       end extension
@@ -2199,7 +2199,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ImplicitSearchSuccessTypeTest
 
     given ImplicitSearchSuccessMethods: ImplicitSearchSuccessMethods with
-      extension (self: ImplicitSearchSuccess):
+      extension (self: ImplicitSearchSuccess)
         def tree: Term = self
       end extension
     end ImplicitSearchSuccessMethods
@@ -2214,7 +2214,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end ImplicitSearchFailureTypeTest
 
     given ImplicitSearchFailureMethods: ImplicitSearchFailureMethods with
-      extension (self: ImplicitSearchFailure):
+      extension (self: ImplicitSearchFailure)
         def explanation: String =
           self.tpe.asInstanceOf[dotc.typer.Implicits.SearchFailureType].explanation
       end extension
@@ -2268,7 +2268,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Symbol
 
     given SymbolMethods: SymbolMethods with
-      extension (self: Symbol):
+      extension (self: Symbol)
         def owner: Symbol = self.denot.owner
         def maybeOwner: Symbol = self.denot.maybeOwner
         def flags: Flags = self.denot.flags
@@ -2433,7 +2433,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Signature
 
     given SignatureMethods: SignatureMethods with
-      extension (self: Signature):
+      extension (self: Signature)
         def paramSigs: List[String | Int] =
           self.paramsSig.map {
             case paramSig: dotc.core.Names.TypeName =>
@@ -2546,7 +2546,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Flags
 
     given FlagsMethods: FlagsMethods with
-      extension (self: Flags):
+      extension (self: Flags)
         def is(that: Flags): Boolean = self.isAllOf(that)
         def |(that: Flags): Flags = dotc.core.Flags.or(self, that) // TODO: Replace with dotc.core.Flags.|(self)(that)  once extension names have stabilized
         def &(that: Flags): Flags = dotc.core.Flags.and(self, that)// TODO: Replace with dotc.core.Flags.&(self)(that)  once extension names have stabilized
@@ -2564,7 +2564,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end Position
 
     given PositionMethods: PositionMethods with
-      extension (self: Position):
+      extension (self: Position)
         def start: Int = self.start
         def end: Int = self.end
         def sourceFile: SourceFile = self.source
@@ -2585,7 +2585,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     }
 
     given SourceFileMethods: SourceFileMethods with
-      extension (self: SourceFile):
+      extension (self: SourceFile)
         def jpath: java.nio.file.Path = self.file.jpath
         def content: Option[String] =
           // TODO detect when we do not have a source and return None

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -76,7 +76,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
   object reflect extends reflectModule:
 
-    extension (expr: Expr[Any]):
+    extension (expr: Expr[Any])
       def asTerm: Term =
         val exprImpl = expr.asInstanceOf[ExprImpl]
         exprImpl.checkScopeId(QuotesImpl.this.hashCode)

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1666,7 +1666,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end NamedTypeTypeTest
 
     given NamedTypeMethods: NamedTypeMethods with
-      extension (self: NamedType):
+      extension (self: NamedType)
         def qualifier: TypeRepr = self.prefix
         def name: String = self.name.toString
       end extension
@@ -1807,7 +1807,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end AndOrTypeTypeTest
 
     given AndOrTypeMethods: AndOrTypeMethods with
-      extension (self: AndOrType):
+      extension (self: AndOrType)
         def left: TypeRepr = self.tp1.stripTypeVar
         def right: TypeRepr = self.tp2.stripTypeVar
       end extension
@@ -1969,7 +1969,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end LambdaTypeTypeTest
 
     given LambdaTypeMethods: LambdaTypeMethods with
-      extension (self: LambdaType):
+      extension (self: LambdaType)
         def paramNames: List[String] = self.paramNames.map(_.toString)
         def paramTypes: List[TypeRepr] = self.paramInfos
         def resType: TypeRepr = self.resType

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -47,7 +47,7 @@ class ReplTest(withStaging: Boolean = false, out: ByteArrayOutputStream = new By
   def fromInitialState[A](op: State => A): A =
     op(initialState)
 
-  extension [A](state: State):
+  extension [A](state: State)
     def andThen(op: State => A): A = op(state)
 
   def scripts(path: String): Array[JFile] = {

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -83,7 +83,7 @@ comment          ::=  ‘/*’ “any sequence of characters; nested comments ar
 
 nl               ::=  “new line character”
 semi             ::=  ‘;’ |  nl {nl}
-colonEol         ::=  ": at end of line that can start a tenmplate body"
+colonEol         ::=  ": at end of line that can start a template body"
 ```
 
 ## Keywords
@@ -151,7 +151,7 @@ FunParamClause    ::=  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’
 TypedFunParam     ::=  id ‘:’ Type
 MatchType         ::=  InfixType `match` ‘{’ TypeCaseClauses ‘}’
 InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
-RefinedType       ::=  WithType {[nl | colonEol] Refinement}                    RefinedTypeTree(t, ds)
+RefinedType       ::=  WithType {[nl] Refinement}                               RefinedTypeTree(t, ds)
 WithType          ::=  AnnotType {‘with’ AnnotType}                             (deprecated)
 AnnotType         ::=  SimpleType {Annotation}                                  Annotated(t, annot)
 
@@ -220,8 +220,9 @@ SimpleExpr        ::=  SimpleRef
                     |  ‘$’ ‘{’ Block ‘}’
                     |  Quoted
                     |  quoteId     // only inside splices
-                    |  ‘new’ ConstrApp {‘with’ ConstrApp} [TemplateBody]        New(constr | templ)
-                    |  ‘new’ TemplateBody
+                    |  ‘new’ ConstrApp {‘with’ ConstrApp}                       New(constr | templ)
+                       [[colonEol] TemplateBody
+                    |  ‘new’ [colonEol] TemplateBody
                     |  ‘(’ ExprsInParens ‘)’                                    Parens(exprs)
                     |  SimpleExpr ‘.’ id                                        Select(expr, id)
                     |  SimpleExpr ‘.’ MatchClause
@@ -393,15 +394,15 @@ ClassDef          ::=  id ClassConstr [Template]                                
 ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses        with DefDef(_, <init>, Nil, vparamss, EmptyTree, EmptyTree) as first stat
 ConstrMods        ::=  {Annotation} [AccessModifier]
 ObjectDef         ::=  id [Template]                                            ModuleDef(mods, name, template)  // no constructor
-EnumDef           ::=  id ClassConstr InheritClauses EnumBody                   EnumDef(mods, name, tparams, template)
+EnumDef           ::=  id ClassConstr InheritClauses [colonEol] EnumBody
 GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | StructuralInstance)
-GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’       -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
+GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’         -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
 StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody
 Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’
                        {UsingParamClause}] ExtMethods
 ExtMethods        ::=  ExtMethod | [nl] ‘{’ ExtMethod {semi ExtMethod ‘}’
 ExtMethod         ::=  {Annotation [nl]} {Modifier} ‘def’ DefDef
-Template          ::=  InheritClauses [TemplateBody]                            Template(constr, parents, self, stats)
+Template          ::=  InheritClauses [colonEol] [TemplateBody]                 Template(constr, parents, self, stats)
 InheritClauses    ::=  [‘extends’ ConstrApps] [‘derives’ QualId {‘,’ QualId}]
 ConstrApps        ::=  ConstrApp {(‘,’ | ‘with’) ConstrApp}
 ConstrApp         ::=  SimpleType1 {Annotation} {ParArgumentExprs}              Apply(tp, args)
@@ -409,8 +410,7 @@ ConstrExpr        ::=  SelfInvocation
                     |  ‘{’ SelfInvocation {semi BlockStat} ‘}’
 SelfInvocation    ::=  ‘this’ ArgumentExprs {ArgumentExprs}
 
-TemplateBody      ::=  [nl | colonEol]
-                       ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’      (self, stats)
+TemplateBody      ::=  [nl] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
 TemplateStat      ::=  Import
                     |  Export
                     |  {Annotation [nl]} {Modifier} Def
@@ -422,8 +422,7 @@ TemplateStat      ::=  Import
 SelfType          ::=  id [‘:’ InfixType] ‘=>’                                  ValDef(_, name, tpt, _)
                     |  ‘this’ ‘:’ InfixType ‘=>’
 
-EnumBody          ::=  [nl | colonEol]
-                       ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
+EnumBody          ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
 EnumStat          ::=  TemplateStat
                     |  {Annotation [nl]} {Modifier} EnumCase
 EnumCase          ::=  ‘case’ (id ClassConstr [‘extends’ ConstrApps]] | ids)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -1,6 +1,6 @@
 ---
 layout: doc-page
-title: "Scala3 Syntax Summary"
+title: "Scala 3 Syntax Summary"
 ---
 
 The following descriptions of Scala tokens uses literal characters `‘c’` when

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -1,6 +1,6 @@
 ---
 layout: doc-page
-title: "Scala Syntax Summary"
+title: "Scala3 Syntax Summary"
 ---
 
 The following descriptions of Scala tokens uses literal characters `‘c’` when
@@ -261,8 +261,6 @@ Guard             ::=  ‘if’ PostfixExpr
 CaseClauses       ::=  CaseClause { CaseClause }                                Match(EmptyTree, cases)
 CaseClause        ::=  ‘case’ Pattern [Guard] ‘=>’ Block                        CaseDef(pat, guard?, block)   // block starts at =>
 ExprCaseClause    ::=  ‘case’ Pattern [Guard] ‘=>’ Expr
-ImplicitCaseClauses ::=  ImplicitCaseClause { ImplicitCaseClause }
-ImplicitCaseClause  ::=  ‘case’ PatVar [‘:’ RefinedType] [Guard] ‘=>’ Block
 TypeCaseClauses   ::=  TypeCaseClause { TypeCaseClause }
 TypeCaseClause    ::=  ‘case’ InfixType ‘=>’ Type [nl]
 
@@ -350,7 +348,7 @@ ImportSelectors   ::=  id [‘=>’ id | ‘=>’ ‘_’] [‘,’ ImportSelect
                     |  WildCardSelector {‘,’ WildCardSelector}
 WildCardSelector  ::=  ‘given’ [InfixType]
                     |  ‘_'
-Export            ::=  ‘export’ [‘given’] ImportExpr {‘,’ ImportExpr}
+Export            ::=  [‘given’] ImportExpr {‘,’ ImportExpr}
 
 EndMarker         ::=  ‘end’ EndMarkerTag    -- when followed by EOL
 EndMarkerTag      ::=  id | ‘if’ | ‘while’ | ‘for’ | ‘match’ | ‘try’

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -99,11 +99,11 @@ By contrast, using clauses can be defined for the `extension` as well as per `de
 
 Sometimes, one wants to define several extension methods that share the same
 left-hand parameter type. In this case one can "pull out" the common parameters into
-a single extension and enclose all methods in braces or an indented region following a '`:`'.
+a single extension and enclose all methods in braces or an indented region.
 Example:
 
 ```scala
-extension (ss: Seq[String]):
+extension (ss: Seq[String])
 
   def longestStrings: Seq[String] =
     val maxLength = ss.map(_.length).max
@@ -144,7 +144,7 @@ extension (ss: Seq[String])
 Collective extensions also can take type parameters and have using clauses. Example:
 
 ```scala
-extension [T](xs: List[T])(using Ordering[T]):
+extension [T](xs: List[T])(using Ordering[T])
   def smallest(n: Int): List[T] = xs.sorted.take(n)
   def smallestIndices(n: Int): List[Int] =
     val limit = smallest(n).max

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -58,8 +58,8 @@ There are two rules:
 
     An indentation region can start
 
-     - after the condition of an `if-else`, or
      - after the leading parameters of an `extension`, or
+     - after a `with` in a given instance, or
      - after a ": at end of line" token (see below)
      - after one of the following tokens:
 
@@ -93,7 +93,7 @@ There are two rules:
 It is an error if the indentation width of the token following an `<outdent>` does not match the indentation of some previous line in the enclosing indentation region. For instance, the following would be rejected.
 
 ```scala
-if x < 0
+if x < 0 then
     -x
   else   // error: `else` does not align correctly
      x
@@ -104,14 +104,14 @@ at the toplevel, inside braces `{...}`, but not inside parentheses `(...)`, patt
 
 ### Optional Braces Around Template Bodies
 
-The Scala grammar uses the term _template body_ for the definitions of a class, trait, object or given instance that are normally enclosed in braces. The braces around a template body can also be omitted by means of the following rule
+The Scala grammar uses the term _template body_ for the definitions of a class, trait, or object that are normally enclosed in braces. The braces around a template body can also be omitted by means of the following rule
 
 If at the point where a template body can start there is a `:` that occurs at the end
 of a line, and that is followed by at least one indented statement, the recognized
 token is changed from ":" to ": at end of line". The latter token is one of the tokens
 that can start an indentation region. The Scala grammar is changed so an optional ": at end of line" is allowed in front of a template body.
 
-Analogous rules apply for enum bodies, type refinements, definitions in an instance creation expressions, and local packages containing nested definitions.
+Analogous rules apply for enum bodies and local packages containing nested definitions.
 
 With these new rules, the following constructs are all valid:
 
@@ -128,15 +128,6 @@ object O:
 enum Color:
   case Red, Green, Blue
 
-type T = A:
-  def f: Int
-
-given [T](using Ord[T]): Ord[List[T]] with
-  def compare(x: List[T], y: List[T]) = ???
-
-extension (xs: List[Int])
-  def second: Int = xs.tail.head
-
 new A:
   def f = 3
 
@@ -145,14 +136,15 @@ package p:
 package q:
   def b = 2
 ```
+In each case, the `:` at the end of line can be replaced without change of meaning by a pair of braces that enclose the following indented definition(s).
 
 The syntax changes allowing this are as follows:
 
 ```
-TemplateBody ::=  [colonEol] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
-EnumBody     ::=  [colonEol] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
-Packaging    ::=  ‘package’ QualId [colonEol] ‘{’ TopStatSeq ‘}’
-RefinedType  ::=  AnnotType {[colonEol] Refinement}
+Template    ::=  InheritClauses [colonEol] [TemplateBody]
+EnumDef     ::=  id ClassConstr InheritClauses [colonEol] EnumBody
+Packaging   ::=  ‘package’ QualId [nl | colonEol] ‘{’ TopStatSeq ‘}’
+SimpleExpr  ::=  ‘new’ ConstrApp {‘with’ ConstrApp} [[colonEol] TemplateBody]
 ```
 
 Here, `colonEol` stands for ": at end of line", as described above.

--- a/docs/docs/reference/syntax.md
+++ b/docs/docs/reference/syntax.md
@@ -42,7 +42,6 @@ plainid          ::=  alphaid
                    |  op
 id               ::=  plainid
                    |  ‘`’ { charNoBackQuoteOrNewline | UnicodeEscape | charEscapeSeq } ‘`’
-                   |  INT                           // interpolation id, only for quasi-quotes
 idrest           ::=  {letter | digit} [‘_’ op]
 quoteId          ::=  ‘'’ alphaid
 
@@ -138,81 +137,79 @@ ClassQualifier    ::=  ‘[’ id ‘]’
 ### Types
 ```ebnf
 Type              ::=  FunType
-                    |  HkTypeParamClause ‘=>>’ Type                             LambdaTypeTree(ps, t)
-                    |  FunParamClause ‘=>>’ Type                                TermLambdaTypeTree(ps, t)
+                    |  HkTypeParamClause ‘=>>’ Type
+                    |  FunParamClause ‘=>>’ Type
                     |  MatchType
                     |  InfixType
-FunType           ::=  FunArgTypes (‘=>’ | ‘?=>’) Type                          Function(ts, t)
-                    |  HKTypeParamClause '=>' Type                              PolyFunction(ps, t)
+FunType           ::=  FunArgTypes (‘=>’ | ‘?=>’) Type
+                    |  HKTypeParamClause '=>' Type
 FunArgTypes       ::=  InfixType
                     |  ‘(’ [ FunArgType {‘,’ FunArgType } ] ‘)’
                     |  FunParamClause
 FunParamClause    ::=  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’
 TypedFunParam     ::=  id ‘:’ Type
 MatchType         ::=  InfixType `match` ‘{’ TypeCaseClauses ‘}’
-InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
-RefinedType       ::=  WithType {[nl] Refinement}                               RefinedTypeTree(t, ds)
-WithType          ::=  AnnotType {‘with’ AnnotType}                             (deprecated)
-AnnotType         ::=  SimpleType {Annotation}                                  Annotated(t, annot)
+InfixType         ::=  RefinedType {id [nl] RefinedType}
+RefinedType       ::=  AnnotType {[nl] Refinement}
+AnnotType         ::=  SimpleType {Annotation}
 
-SimpleType        ::=  SimpleLiteral                                            SingletonTypeTree(l)
+SimpleType        ::=  SimpleLiteral
                     |  ‘?’ TypeBounds
-                    |  SimpleType1
-SimpleType1       ::=  id                                                       Ident(name)
-                    |  Singleton ‘.’ id                                         Select(t, name)
-                    |  Singleton ‘.’ ‘type’                                     SingletonTypeTree(p)
-                    |  ‘(’ Types ‘)’                                            Tuple(ts)
-                    |  Refinement                                               RefinedTypeTree(EmptyTree, refinement)
+                    |  id
+                    |  Singleton ‘.’ id
+                    |  Singleton ‘.’ ‘type’
+                    |  ‘(’ Types ‘)’
+                    |  Refinement
                     |  ‘$’ ‘{’ Block ‘}’
-                    |  SimpleType1 TypeArgs                                     AppliedTypeTree(t, args)
-                    |  SimpleType1 ‘#’ id                                       Select(t, name)
+                    |  SimpleType1 TypeArgs
+                    |  SimpleType1 ‘#’ id
 Singleton         ::=  SimpleRef
                     |  SimpleLiteral
                     |  Singleton ‘.’ id
-Singletons        ::=  Singleton { ‘,’ Singleton }
+
 FunArgType        ::=  Type
-                    |  ‘=>’ Type                                                PrefixOp(=>, t)
+                    |  ‘=>’ Type
 ParamType         ::=  [‘=>’] ParamValueType
-ParamValueType    ::=  Type [‘*’]                                               PostfixOp(t, "*")
-TypeArgs          ::=  ‘[’ Types ‘]’                                            ts
-Refinement        ::=  ‘{’ [RefineDcl] {semi [RefineDcl]} ‘}’                   ds
-TypeBounds        ::=  [‘>:’ Type] [‘<:’ Type]                                  TypeBoundsTree(lo, hi)
-TypeParamBounds   ::=  TypeBounds {‘:’ Type}                                    ContextBounds(typeBounds, tps)
+ParamValueType    ::=  Type [‘*’]
+TypeArgs          ::=  ‘[’ Types ‘]’
+Refinement        ::=  ‘{’ [RefineDcl] {semi [RefineDcl]} ‘}’
+TypeBounds        ::=  [‘>:’ Type] [‘<:’ Type]
+TypeParamBounds   ::=  TypeBounds {‘:’ Type}
 Types             ::=  Type {‘,’ Type}
 ```
 
 ### Expressions
 ```ebnf
-Expr              ::=  FunParams (‘=>’ | ‘?=>’) Expr                            Function(args, expr), Function(ValDef([implicit], id, TypeTree(), EmptyTree), expr)
+Expr              ::=  FunParams (‘=>’ | ‘?=>’) Expr
                     |  Expr1
 BlockResult       ::=  FunParams (‘=>’ | ‘?=>’) Block
                     |  Expr1
 FunParams         ::=  Bindings
                     |  id
                     |  ‘_’
-Expr1             ::=  [‘inline’] ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr] If(Parens(cond), thenp, elsep?)
-                    |  [‘inline’] ‘if’  Expr ‘then’ Expr [[semi] ‘else’ Expr]    If(cond, thenp, elsep?)
-                    |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr                           WhileDo(Parens(cond), body)
-                    |  ‘while’ Expr ‘do’ Expr                                   WhileDo(cond, body)
-                    |  ‘try’ Expr Catches [‘finally’ Expr]                      Try(expr, catches, expr?)
-                    |  ‘try’ Expr [‘finally’ Expr]                              Try(expr, Nil, expr?)
-                    |  ‘throw’ Expr                                             Throw(expr)
-                    |  ‘return’ [Expr]                                          Return(expr?)
+Expr1             ::=  [‘inline’] ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr]
+                    |  [‘inline’] ‘if’  Expr ‘then’ Expr [[semi] ‘else’ Expr]
+                    |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr
+                    |  ‘while’ Expr ‘do’ Expr
+                    |  ‘try’ Expr Catches [‘finally’ Expr]
+                    |  ‘try’ Expr [‘finally’ Expr]
+                    |  ‘throw’ Expr
+                    |  ‘return’ [Expr]
                     |  ForExpr
-                    |  HkTypeParamClause ‘=>’ Expr                              PolyFunction(ts, expr)
-                    |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
-                    |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
+                    |  HkTypeParamClause ‘=>’ Expr
+                    |  [SimpleExpr ‘.’] id ‘=’ Expr
+                    |  SimpleExpr1 ArgumentExprs ‘=’ Expr
                     |  PostfixExpr [Ascription]
                     |  ‘inline’ InfixExpr MatchClause
-Ascription        ::=  ‘:’ InfixType                                            Typed(expr, tp)
-                    |  ‘:’ Annotation {Annotation}                              Typed(expr, Annotated(EmptyTree, annot)*)
+Ascription        ::=  ‘:’ InfixType
+                    |  ‘:’ Annotation {Annotation}
 Catches           ::=  ‘catch’ (Expr | ExprCaseClause)
-PostfixExpr       ::=  InfixExpr [id]                                           PostfixOp(expr, op)
+PostfixExpr       ::=  InfixExpr [id]
 InfixExpr         ::=  PrefixExpr
-                    |  InfixExpr id [nl] InfixExpr                              InfixOp(expr, op, expr)
+                    |  InfixExpr id [nl] InfixExpr
                     |  InfixExpr MatchClause
-MatchClause       ::=  ‘match’ ‘{’ CaseClauses ‘}’                              Match(expr, cases)
-PrefixExpr        ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr                       PrefixOp(expr, op)
+MatchClause       ::=  ‘match’ ‘{’ CaseClauses ‘}’
+PrefixExpr        ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr
 SimpleExpr        ::=  SimpleRef
                     |  Literal
                     |  ‘_’
@@ -220,27 +217,24 @@ SimpleExpr        ::=  SimpleRef
                     |  ‘$’ ‘{’ Block ‘}’
                     |  Quoted
                     |  quoteId                                                  -- only inside splices
-                    |  ‘new’ ConstrApp {‘with’ ConstrApp}                       New(constr | templ)
-                       [[colonEol] TemplateBody
+                    |  ‘new’ ConstrApp {‘with’ ConstrApp} [[colonEol] TemplateBody
                     |  ‘new’ [colonEol] TemplateBody
-                    |  ‘(’ ExprsInParens ‘)’                                    Parens(exprs)
-                    |  SimpleExpr ‘.’ id                                        Select(expr, id)
+                    |  ‘(’ ExprsInParens ‘)’
+                    |  SimpleExpr ‘.’ id
                     |  SimpleExpr ‘.’ MatchClause
-                    |  SimpleExpr TypeArgs                                      TypeApply(expr, args)
-                    |  SimpleExpr ArgumentExprs                                 Apply(expr, args)
-                    |  SimpleExpr ‘_’                                           PostfixOp(expr, _) (to be dropped)
-                    |  XmlExpr													(to be dropped)
+                    |  SimpleExpr TypeArgs
+                    |  SimpleExpr ArgumentExprs
 Quoted            ::=  ‘'’ ‘{’ Block ‘}’
                     |  ‘'’ ‘[’ Type ‘]’
 ExprsInParens     ::=  ExprInParens {‘,’ ExprInParens}
-ExprInParens      ::=  PostfixExpr ‘:’ Type                                     -- normal Expr allows only RefinedType here
+ExprInParens      ::=  PostfixExpr ‘:’ Type
                     |  Expr
-ParArgumentExprs  ::=  ‘(’ [‘using’] ExprsInParens ‘)’                          exprs
-                    |  ‘(’ [ExprsInParens ‘,’] PostfixExpr ‘:’ ‘_’ ‘*’ ‘)’      exprs :+ Typed(expr, Ident(wildcardStar))
+ParArgumentExprs  ::=  ‘(’ [‘using’] ExprsInParens ‘)’
+                    |  ‘(’ [ExprsInParens ‘,’] PostfixExpr ‘:’ ‘_’ ‘*’ ‘)’
 ArgumentExprs     ::=  ParArgumentExprs
                     |  BlockExpr
 BlockExpr         ::=  ‘{’ (CaseClauses | Block) ‘}’
-Block             ::=  {BlockStat semi} [BlockResult]                           Block(stats, expr?)
+Block             ::=  {BlockStat semi} [BlockResult]
 BlockStat         ::=  Import
                     |  {Annotation {nl}} [‘implicit’ | ‘lazy’] Def
                     |  {Annotation {nl}} {LocalModifier} TmplDef
@@ -248,31 +242,29 @@ BlockStat         ::=  Import
                     |  Expr1
                     |  EndMarker
 
-ForExpr           ::=  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’)        ForYield(enums, expr)
-                       {nl} [‘yield’] Expr
-                    |  ‘for’ Enumerators (‘do’ Expr | ‘yield’ Expr)             ForDo(enums, expr)
+ForExpr           ::=  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’) {nl} [‘yield’] Expr
+                    |  ‘for’ Enumerators (‘do’ Expr | ‘yield’ Expr)
 Enumerators       ::=  Generator {semi Enumerator | Guard}
 Enumerator        ::=  Generator
                     |  Guard
-                    |  Pattern1 ‘=’ Expr                                        GenAlias(pat, expr)
-Generator         ::=  [‘case’] Pattern1 ‘<-’ Expr                                       GenFrom(pat, expr)
+                    |  Pattern1 ‘=’ Expr
+Generator         ::=  [‘case’] Pattern1 ‘<-’ Expr
 Guard             ::=  ‘if’ PostfixExpr
 
-CaseClauses       ::=  CaseClause { CaseClause }                                Match(EmptyTree, cases)
-CaseClause        ::=  ‘case’ Pattern [Guard] ‘=>’ Block                        CaseDef(pat, guard?, block)   // block starts at =>
+CaseClauses       ::=  CaseClause { CaseClause }
+CaseClause        ::=  ‘case’ Pattern [Guard] ‘=>’ Block
 ExprCaseClause    ::=  ‘case’ Pattern [Guard] ‘=>’ Expr
 TypeCaseClauses   ::=  TypeCaseClause { TypeCaseClause }
 TypeCaseClause    ::=  ‘case’ InfixType ‘=>’ Type [nl]
 
-Pattern           ::=  Pattern1 { ‘|’ Pattern1 }                                Alternative(pats)
-Pattern1          ::=  Pattern2 [‘:’ RefinedType]                               Bind(name, Typed(Ident(wildcard), tpe))
-Pattern2          ::=  [id ‘@’] InfixPattern                                    Bind(name, pat)
-InfixPattern      ::=  SimplePattern { id [nl] SimplePattern }                  InfixOp(pat, op, pat)
-SimplePattern     ::=  PatVar                                                   Ident(wildcard)
-                    |  Literal                                                  Bind(name, Ident(wildcard))
-                    |  ‘(’ [Patterns] ‘)’                                       Parens(pats) Tuple(pats)
+Pattern           ::=  Pattern1 { ‘|’ Pattern1 }
+Pattern1          ::=  Pattern2 [‘:’ RefinedType]
+Pattern2          ::=  [id ‘@’] InfixPattern
+InfixPattern      ::=  SimplePattern { id [nl] SimplePattern }
+SimplePattern     ::=  PatVar
+                    |  Literal
+                    |  ‘(’ [Patterns] ‘)’
                     |  Quoted
-                    |  XmlPattern												(to be dropped)
                     |  SimplePattern1 [TypeArgs] [ArgumentPatterns]
                     |  ‘given’ RefinedType
 SimplePattern1    ::=  SimpleRef
@@ -280,15 +272,14 @@ SimplePattern1    ::=  SimpleRef
 PatVar            ::=  varid
                     |  ‘_’
 Patterns          ::=  Pattern {‘,’ Pattern}
-ArgumentPatterns  ::=  ‘(’ [Patterns] ‘)’                                       Apply(fn, pats)
+ArgumentPatterns  ::=  ‘(’ [Patterns] ‘)’
                     |  ‘(’ [Patterns ‘,’] Pattern2 ‘:’ ‘_’ ‘*’ ‘)’
 ```
 
 ### Type and Value Parameters
 ```ebnf
 ClsTypeParamClause::=  ‘[’ ClsTypeParam {‘,’ ClsTypeParam} ‘]’
-ClsTypeParam      ::=  {Annotation} [‘+’ | ‘-’]                                 TypeDef(Modifiers, name, tparams, bounds)
-                       id [HkTypeParamClause] TypeParamBounds                   Bound(below, above, context)
+ClsTypeParam      ::=  {Annotation} [‘+’ | ‘-’] id [HkTypeParamClause] TypeParamBounds
 
 DefTypeParamClause::=  ‘[’ DefTypeParam {‘,’ DefTypeParam} ‘]’
 DefTypeParam      ::=  {Annotation} id [HkTypeParamClause] TypeParamBounds
@@ -297,28 +288,26 @@ TypTypeParamClause::=  ‘[’ TypTypeParam {‘,’ TypTypeParam} ‘]’
 TypTypeParam      ::=  {Annotation} id [HkTypeParamClause] TypeBounds
 
 HkTypeParamClause ::=  ‘[’ HkTypeParam {‘,’ HkTypeParam} ‘]’
-HkTypeParam       ::=  {Annotation} [‘+’ | ‘-’] (id [HkTypeParamClause] | ‘_’)
-                       TypeBounds
+HkTypeParam       ::=  {Annotation} [‘+’ | ‘-’] (id [HkTypeParamClause] | ‘_’) TypeBounds
 
 ClsParamClauses   ::=  {ClsParamClause} [[nl] ‘(’ [‘implicit’] ClsParams ‘)’]
 ClsParamClause    ::=  [nl] ‘(’ ClsParams ‘)’
                     |  [nl] ‘(’ ‘using’ (ClsParams | Types) ‘)’
 ClsParams         ::=  ClsParam {‘,’ ClsParam}
-ClsParam          ::=  {Annotation}                                             ValDef(mods, id, tpe, expr) -- point of mods on val/var
-                       [{Modifier} (‘val’ | ‘var’) | ‘inline’] Param
+ClsParam          ::=  {Annotation} [{Modifier} (‘val’ | ‘var’) | ‘inline’] Param
 Param             ::=  id ‘:’ ParamType [‘=’ Expr]
 
 DefParamClauses   ::=  {DefParamClause} [[nl] ‘(’ [‘implicit’] DefParams ‘)’]
 DefParamClause    ::=  [nl] ‘(’ DefParams ‘)’ | UsingParamClause
 UsingParamClause  ::=  [nl] ‘(’ ‘using’ (DefParams | Types) ‘)’
 DefParams         ::=  DefParam {‘,’ DefParam}
-DefParam          ::=  {Annotation} [‘inline’] Param                            ValDef(mods, id, tpe, expr) -- point of mods at id.
+DefParam          ::=  {Annotation} [‘inline’] Param
 ```
 
 ### Bindings and Imports
 ```ebnf
 Bindings          ::=  ‘(’ [Binding {‘,’ Binding}] ‘)’
-Binding           ::=  (id | ‘_’) [‘:’ Type]                                    ValDef(_, id, tpe, EmptyTree)
+Binding           ::=  (id | ‘_’) [‘:’ Type]
 
 Modifier          ::=  LocalModifier
                     |  AccessModifier
@@ -334,10 +323,10 @@ LocalModifier     ::=  ‘abstract’
 AccessModifier    ::=  (‘private’ | ‘protected’) [AccessQualifier]
 AccessQualifier   ::=  ‘[’ id ‘]’
 
-Annotation        ::=  ‘@’ SimpleType1 {ParArgumentExprs}                         Apply(tpe, args)
+Annotation        ::=  ‘@’ SimpleType1 {ParArgumentExprs}
 
 Import            ::=  ‘import’ ImportExpr {‘,’ ImportExpr}
-ImportExpr        ::=  SimpleRef {‘.’ id} ‘.’ ImportSpec                          Import(expr, sels)
+ImportExpr        ::=  SimpleRef {‘.’ id} ‘.’ ImportSpec
 ImportSpec        ::=  id
                     | ‘_’
                     | ‘given’
@@ -358,15 +347,13 @@ EndMarkerTag      ::=  id | ‘if’ | ‘while’ | ‘for’ | ‘match’ | �
 RefineDcl         ::=  ‘val’ ValDcl
                     |  ‘def’ DefDcl
                     |  ‘type’ {nl} TypeDcl
-                    |  INT
 Dcl               ::=  RefineDcl
                     |  ‘var’ VarDcl
-ValDcl            ::=  ids ‘:’ Type                                             PatDef(_, ids, tpe, EmptyTree)
-VarDcl            ::=  ids ‘:’ Type                                             PatDef(_, ids, tpe, EmptyTree)
-DefDcl            ::=  DefSig ‘:’ Type                                          DefDef(_, name, tparams, vparamss, tpe, EmptyTree)
+ValDcl            ::=  ids ‘:’ Type
+VarDcl            ::=  ids ‘:’ Type
+DefDcl            ::=  DefSig ‘:’ Type
 DefSig            ::=  id [DefTypeParamClause] DefParamClauses
-TypeDcl           ::=  id [TypeParamClause] {FunParamClause} TypeBounds         TypeDefTree(_, name, tparams, bound
-                       [‘=’ Type]
+TypeDcl           ::=  id [TypeParamClause] {FunParamClause} TypeBounds [‘=’ Type]
 
 Def               ::=  ‘val’ PatDef
                     |  ‘var’ VarDef
@@ -374,20 +361,20 @@ Def               ::=  ‘val’ PatDef
                     |  ‘type’ {nl} TypeDcl
                     |  TmplDef
 PatDef            ::=  ids [‘:’ Type] ‘=’ Expr
-                    |  Pattern2 [‘:’ Type | Ascription] ‘=’ Expr                PatDef(_, pats, tpe?, expr)
+                    |  Pattern2 [‘:’ Type | Ascription] ‘=’ Expr
 VarDef            ::=  PatDef
                     |  ids ‘:’ Type ‘=’ ‘_’
-DefDef            ::=  DefSig [‘:’ Type] ‘=’ Expr                               DefDef(_, name, tparams, vparamss, tpe, expr)
-                    |  ‘this’ DefParamClause DefParamClauses ‘=’ ConstrExpr     DefDef(_, <init>, Nil, vparamss, EmptyTree, expr | Block)
+DefDef            ::=  DefSig [‘:’ Type] ‘=’ Expr
+                    |  ‘this’ DefParamClause DefParamClauses ‘=’ ConstrExpr
 
 TmplDef           ::=  ([‘case’] ‘class’ | ‘trait’) ClassDef
                     |  [‘case’] ‘object’ ObjectDef
                     |  ‘enum’ EnumDef
                     |  ‘given’ GivenDef
-ClassDef          ::=  id ClassConstr [Template]                                ClassDef(mods, name, tparams, templ)
-ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses        with DefDef(_, <init>, Nil, vparamss, EmptyTree, EmptyTree) as first stat
+ClassDef          ::=  id ClassConstr [Template]
+ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses
 ConstrMods        ::=  {Annotation} [AccessModifier]
-ObjectDef         ::=  id [Template]                                            ModuleDef(mods, name, template)  // no constructor
+ObjectDef         ::=  id [Template]
 EnumDef           ::=  id ClassConstr InheritClauses [colonEol] EnumBody
 GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | StructuralInstance)
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’         -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
@@ -396,10 +383,10 @@ Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘
                        {UsingParamClause}] ExtMethods
 ExtMethods        ::=  ExtMethod | [nl] ‘{’ ExtMethod {semi ExtMethod ‘}’
 ExtMethod         ::=  {Annotation [nl]} {Modifier} ‘def’ DefDef
-Template          ::=  InheritClauses [colonEol] [TemplateBody]                 Template(constr, parents, self, stats)
+Template          ::=  InheritClauses [colonEol] [TemplateBody]
 InheritClauses    ::=  [‘extends’ ConstrApps] [‘derives’ QualId {‘,’ QualId}]
 ConstrApps        ::=  ConstrApp ({‘,’ ConstrApp} | {‘with’ ConstrApp})
-ConstrApp         ::=  SimpleType1 {Annotation} {ParArgumentExprs}              Apply(tp, args)
+ConstrApp         ::=  SimpleType1 {Annotation} {ParArgumentExprs}
 ConstrExpr        ::=  SelfInvocation
                     |  ‘{’ SelfInvocation {semi BlockStat} ‘}’
 SelfInvocation    ::=  ‘this’ ArgumentExprs {ArgumentExprs}
@@ -413,7 +400,7 @@ TemplateStat      ::=  Import
                     |  Expr1
                     |  EndMarker
                     |
-SelfType          ::=  id [‘:’ InfixType] ‘=>’                                  ValDef(_, name, tpt, _)
+SelfType          ::=  id [‘:’ InfixType] ‘=>’
                     |  ‘this’ ‘:’ InfixType ‘=>’
 
 EnumBody          ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
@@ -430,8 +417,8 @@ TopStat           ::=  Import
                     |  PackageObject
                     |  EndMarker
                     |
-Packaging         ::=  ‘package’ QualId [nl | colonEol] ‘{’ TopStatSeq ‘}’      Package(qid, stats)
-PackageObject     ::=  ‘package’ ‘object’ ObjectDef                             object with package in mods.
+Packaging         ::=  ‘package’ QualId [nl | colonEol] ‘{’ TopStatSeq ‘}’
+PackageObject     ::=  ‘package’ ‘object’ ObjectDef
 
-CompilationUnit   ::=  {‘package’ QualId semi} TopStatSeq                       Package(qid, stats)
+CompilationUnit   ::=  {‘package’ QualId semi} TopStatSeq
 ```

--- a/docs/docs/reference/syntax.md
+++ b/docs/docs/reference/syntax.md
@@ -1,6 +1,6 @@
 ---
 layout: doc-page
-title: "Scala3 Syntax Summary"
+title: "Scala 3 Syntax Summary"
 ---
 
 The following descriptions of Scala tokens uses literal characters `‘c’` when

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -187,6 +187,8 @@ sidebar:
               url: docs/reference/dropped-features/nonlocal-returns.html
             - title: "[this] Qualifier"
               url: docs/reference/dropped-features/this-qualifier.html
+        - title: Syntax Summary
+          url: doc/reference/syntax.html
     - title: Contributing
       subsection:
         - title: Contribute Knowledge

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -188,7 +188,7 @@ sidebar:
             - title: "[this] Qualifier"
               url: docs/reference/dropped-features/this-qualifier.html
         - title: Syntax Summary
-          url: doc/reference/syntax.html
+          url: docs/reference/syntax.html
     - title: Contributing
       subsection:
         - title: Contribute Knowledge

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -14,7 +14,7 @@ inline def quotes(using q: Quotes): q.type = q
 trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
   // Extension methods for `Expr[T]`
-  extension [T](self: Expr[T]):
+  extension [T](self: Expr[T])
     /** Show a source code like representation of this expression */
     def show: String
 
@@ -31,7 +31,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     @deprecated("Use `.value` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
     def unlift(using FromExpr[T]): Option[T] = self.value
 
-    @deprecated("Use `.unliftOrError` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
+    @deprecated("Use `.valueOrError` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
     def unliftOrError(using FromExpr[T]): T = self.valueOrError
 
     /** Return the value of this expression.
@@ -59,7 +59,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
   end extension
 
   // Extension methods for `Expr[Any]` that take another explicit type parameter
-  extension [X](self: Expr[Any]):
+  extension [X](self: Expr[Any])
     /** Checks is the `quoted.Expr[?]` is valid expression of type `X` */
     def isExprOf(using Type[X]): Boolean
 
@@ -228,7 +228,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Tree` */
     trait TreeMethods {
 
-      extension (self: Tree):
+      extension (self: Tree)
         /** Position in the source code */
         def pos: Position
 
@@ -249,7 +249,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       extension [T](self: Tree)
         def asExprOf(using Type[T]): Expr[T]
 
-      extension [ThisTree <: Tree](self: ThisTree):
+      extension [ThisTree <: Tree](self: ThisTree)
         /** Changes the owner of the symbols in the tree */
         def changeOwner(newOwner: Symbol): ThisTree
       end extension
@@ -277,7 +277,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `PackageClause` */
     trait PackageClauseMethods:
-      extension (self: PackageClause):
+      extension (self: PackageClause)
         def pid: Ref
         def stats: List[Tree]
       end extension
@@ -304,7 +304,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Import` */
     trait ImportMethods:
-      extension (self: Import):
+      extension (self: Import)
         def expr: Term
         def selectors: List[Selector]
       end extension
@@ -362,7 +362,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Definition` */
     trait DefinitionMethods:
-      extension (self: Definition):
+      extension (self: Definition)
         def name: String
       end extension
     end DefinitionMethods
@@ -390,7 +390,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ClassDef` */
     trait ClassDefMethods:
-      extension (self: ClassDef):
+      extension (self: ClassDef)
         def constructor: DefDef
         def parents: List[Tree /* Term | TypeTree */]
         def derived: List[TypeTree]
@@ -422,7 +422,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `DefDef` */
     trait DefDefMethods:
-      extension (self: DefDef):
+      extension (self: DefDef)
         def typeParams: List[TypeDef]
         def paramss: List[List[ValDef]]
         def returnTpt: TypeTree
@@ -463,7 +463,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ValDef` */
     trait ValDefMethods:
-      extension (self: ValDef):
+      extension (self: ValDef)
         def tpt: TypeTree
         def rhs: Option[Term]
       end extension
@@ -492,7 +492,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeDef` */
     trait TypeDefMethods:
-      extension (self: TypeDef):
+      extension (self: TypeDef)
         def rhs: Tree /*TypeTree | TypeBoundsTree*/
       end extension
     end TypeDefMethods
@@ -534,7 +534,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Term` */
     trait TermMethods {
-      extension (self: Term):
+      extension (self: Term)
 
         /** TypeRepr of this term */
         def tpe: TypeRepr
@@ -637,7 +637,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Ident` */
     trait IdentMethods:
-      extension (self: Ident):
+      extension (self: Ident)
         def name: String
       end extension
     end IdentMethods
@@ -681,7 +681,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Select` */
     trait SelectMethods:
-      extension (self: Select):
+      extension (self: Select)
         def qualifier: Term
         def name: String
         def signature: Option[Signature]
@@ -714,7 +714,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Literal` */
     trait LiteralMethods:
-      extension (self: Literal):
+      extension (self: Literal)
         def constant: Constant
       end extension
     end LiteralMethods
@@ -745,7 +745,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `This` */
     trait ThisMethods:
-      extension (self: This):
+      extension (self: This)
         def id: Option[String]
       end extension
     end ThisMethods
@@ -776,7 +776,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `New` */
     trait NewMethods:
-      extension (self: New):
+      extension (self: New)
         def tpt: TypeTree
       end extension
     end NewMethods
@@ -807,7 +807,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `NamedArg` */
     trait NamedArgMethods:
-      extension (self: NamedArg):
+      extension (self: NamedArg)
         def name: String
         def value: Term
       end extension
@@ -839,7 +839,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Apply` */
     trait ApplyMethods:
-      extension (self: Apply):
+      extension (self: Apply)
         def fun: Term
         def args: List[Term]
       end extension
@@ -871,7 +871,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeApply` */
     trait TypeApplyMethods:
-      extension (self: TypeApply):
+      extension (self: TypeApply)
         def fun: Term
         def args: List[TypeTree]
       end extension
@@ -903,7 +903,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Super` */
     trait SuperMethods:
-      extension (self: Super):
+      extension (self: Super)
         def qualifier: Term
         def id: Option[String]
         def idPos: Position
@@ -936,7 +936,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Typed` */
     trait TypedMethods:
-      extension (self: Typed):
+      extension (self: Typed)
         def expr: Term
         def tpt: TypeTree
       end extension
@@ -968,7 +968,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Assign` */
     trait AssignMethods:
-      extension (self: Assign):
+      extension (self: Assign)
         def lhs: Term
         def rhs: Term
       end extension
@@ -1000,7 +1000,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Block` */
     trait BlockMethods:
-      extension (self: Block):
+      extension (self: Block)
         def statements: List[Statement]
         def expr: Term
       end extension
@@ -1038,7 +1038,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Closure` */
     trait ClosureMethods:
-      extension (self: Closure):
+      extension (self: Closure)
         def meth: Term
         def tpeOpt: Option[TypeRepr]
       end extension
@@ -1106,7 +1106,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `If` */
     trait IfMethods:
-      extension (self: If):
+      extension (self: If)
         def cond: Term
         def thenp: Term
         def elsep: Term
@@ -1140,7 +1140,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Match` */
     trait MatchMethods:
-      extension (self: Match):
+      extension (self: Match)
         def scrutinee: Term
         def cases: List[CaseDef]
         def isInline: Boolean
@@ -1173,7 +1173,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SummonFrom` */
     trait SummonFromMethods:
-      extension (self: SummonFrom):
+      extension (self: SummonFrom)
         def cases: List[CaseDef]
       end extension
     end SummonFromMethods
@@ -1204,7 +1204,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Try` */
     trait TryMethods:
-      extension (self: Try):
+      extension (self: Try)
         def body: Term
         def cases: List[CaseDef]
         def finalizer: Option[Term]
@@ -1237,7 +1237,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Return` */
     trait ReturnMethods:
-      extension (self: Return):
+      extension (self: Return)
         def expr: Term
         def from: Symbol
       end extension
@@ -1264,7 +1264,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Repeated` */
     trait RepeatedMethods:
-      extension (self: Repeated):
+      extension (self: Repeated)
         def elems: List[Term]
         def elemtpt: TypeTree
       end extension
@@ -1291,7 +1291,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Inlined` */
     trait InlinedMethods:
-      extension (self: Inlined):
+      extension (self: Inlined)
         def call: Option[Tree /* Term | TypeTree */]
         def bindings: List[Definition]
         def body: Term
@@ -1319,7 +1319,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SelectOuter` */
     trait SelectOuterMethods:
-      extension (self: SelectOuter):
+      extension (self: SelectOuter)
         def qualifier: Term
         def name: String
         def level: Int
@@ -1352,7 +1352,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `While` */
     trait WhileMethods:
-      extension (self: While):
+      extension (self: While)
         def cond: Term
         def body: Term
       end extension
@@ -1380,7 +1380,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeTree` */
     trait TypeTreeMethods:
-      extension (self: TypeTree):
+      extension (self: TypeTree)
         /** TypeRepr of this type tree */
         def tpe: TypeRepr
       end extension
@@ -1423,7 +1423,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeIdent` */
     trait TypeIdentMethods:
-      extension (self: TypeIdent):
+      extension (self: TypeIdent)
         def name: String
       end extension
     end TypeIdentMethods
@@ -1449,7 +1449,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeSelect` */
     trait TypeSelectMethods:
-      extension (self: TypeSelect):
+      extension (self: TypeSelect)
         def qualifier: Term
         def name: String
       end extension
@@ -1476,7 +1476,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeProjection` */
     trait TypeProjectionMethods:
-      extension (self: TypeProjection):
+      extension (self: TypeProjection)
         def qualifier: TypeTree
         def name: String
       end extension
@@ -1503,7 +1503,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Singleton` */
     trait SingletonMethods:
-      extension (self: Singleton):
+      extension (self: Singleton)
         def ref: Term
       end extension
     end SingletonMethods
@@ -1529,7 +1529,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Refined` */
     trait RefinedMethods:
-      extension (self: Refined):
+      extension (self: Refined)
         def tpt: TypeTree
         def refinements: List[Definition]
       end extension
@@ -1556,7 +1556,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Applied` */
     trait AppliedMethods:
-      extension (self: Applied):
+      extension (self: Applied)
         def tpt: TypeTree
         def args: List[Tree /*TypeTree | TypeBoundsTree*/]
       end extension
@@ -1583,7 +1583,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Annotated` */
     trait AnnotatedMethods:
-      extension (self: Annotated):
+      extension (self: Annotated)
         def arg: TypeTree
         def annotation: Term
       end extension
@@ -1610,7 +1610,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `MatchTypeTree` */
     trait MatchTypeTreeMethods:
-      extension (self: MatchTypeTree):
+      extension (self: MatchTypeTree)
         def bound: Option[TypeTree]
         def selector: TypeTree
         def cases: List[TypeCaseDef]
@@ -1638,7 +1638,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ByName` */
     trait ByNameMethods:
-      extension (self: ByName):
+      extension (self: ByName)
         def result: TypeTree
       end extension
     end ByNameMethods
@@ -1664,7 +1664,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `LambdaTypeTree` */
     trait LambdaTypeTreeMethods:
-      extension (self: LambdaTypeTree):
+      extension (self: LambdaTypeTree)
         def tparams: List[TypeDef]
         def body: Tree /*TypeTree | TypeBoundsTree*/
       end extension
@@ -1691,7 +1691,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeBind` */
     trait TypeBindMethods:
-      extension (self: TypeBind):
+      extension (self: TypeBind)
         def name: String
         def body: Tree /*TypeTree | TypeBoundsTree*/
       end extension
@@ -1718,7 +1718,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeBlock` */
     trait TypeBlockMethods:
-      extension (self: TypeBlock):
+      extension (self: TypeBlock)
         def aliases: List[TypeDef]
         def tpt: TypeTree
       end extension
@@ -1747,7 +1747,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeBoundsTree` */
     trait TypeBoundsTreeMethods:
-      extension (self: TypeBoundsTree):
+      extension (self: TypeBoundsTree)
         def tpe: TypeBounds
         def low: TypeTree
         def hi: TypeTree
@@ -1778,7 +1778,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `WildcardTypeTree` */
     trait WildcardTypeTreeMethods:
-      extension (self: WildcardTypeTree):
+      extension (self: WildcardTypeTree)
         def tpe: TypeRepr
       end extension
     end WildcardTypeTreeMethods
@@ -1806,7 +1806,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `CaseDef` */
     trait CaseDefMethods:
-      extension (self: CaseDef):
+      extension (self: CaseDef)
         def pattern: Tree
         def guard: Option[Term]
         def rhs: Term
@@ -1834,7 +1834,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeCaseDef` */
     trait TypeCaseDefMethods:
-      extension (self: TypeCaseDef):
+      extension (self: TypeCaseDef)
         def pattern: TypeTree
         def rhs: TypeTree
       end extension
@@ -1863,7 +1863,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Bind` */
     trait BindMethods:
-      extension (self: Bind):
+      extension (self: Bind)
         def name: String
         def pattern: Tree
       end extension
@@ -1890,7 +1890,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Unapply` */
     trait UnapplyMethods:
-      extension (self: Unapply):
+      extension (self: Unapply)
         def fun: Term
         def implicits: List[Term]
         def patterns: List[Tree]
@@ -1918,7 +1918,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Alternatives` */
     trait AlternativesMethods:
-      extension (self: Alternatives):
+      extension (self: Alternatives)
         def patterns: List[Tree]
       end extension
     end AlternativesMethods
@@ -1960,7 +1960,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SimpleSelector` */
     trait SimpleSelectorMethods:
-      extension (self: SimpleSelector):
+      extension (self: SimpleSelector)
         def name: String
         def namePos: Position
       end extension
@@ -1985,7 +1985,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `RenameSelector` */
     trait RenameSelectorMethods:
-      extension (self: RenameSelector):
+      extension (self: RenameSelector)
         def fromName: String
         def fromPos: Position
         def toName: String
@@ -2012,7 +2012,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `OmitSelector` */
     trait OmitSelectorMethods:
-      extension (self: OmitSelector):
+      extension (self: OmitSelector)
         def name: String
         def namePos: Position
     end OmitSelectorMethods
@@ -2036,7 +2036,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `GivenSelector` */
     trait GivenSelectorMethods:
-      extension (self: GivenSelector):
+      extension (self: GivenSelector)
         def bound: Option[TypeTree]
     end GivenSelectorMethods
 
@@ -2066,7 +2066,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeRepr` */
     trait TypeReprMethods {
-      extension (self: TypeRepr):
+      extension (self: TypeRepr)
 
         /** Shows the type as a String */
         def show(using Printer[TypeRepr]): String
@@ -2200,7 +2200,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ConstantType` */
     trait ConstantTypeMethods:
-      extension (self: ConstantType):
+      extension (self: ConstantType)
         def constant: Constant
       end extension
     end ConstantTypeMethods
@@ -2256,7 +2256,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeRef` */
     trait TypeRefMethods:
-      extension (self: TypeRef):
+      extension (self: TypeRef)
         def isOpaqueAlias: Boolean
         def translucentSuperType: TypeRepr
       end extension
@@ -2282,7 +2282,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SuperType` */
     trait SuperTypeMethods { this: SuperTypeMethods =>
-      extension (self: SuperType):
+      extension (self: SuperType)
         def thistpe: TypeRepr
         def supertpe: TypeRepr
       end extension
@@ -2308,7 +2308,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Refinement` */
     trait RefinementMethods:
-      extension (self: Refinement):
+      extension (self: Refinement)
         def parent: TypeRepr
         def name: String
         def info: TypeRepr
@@ -2334,7 +2334,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `AppliedType` */
     trait AppliedTypeMethods:
-      extension (self: AppliedType):
+      extension (self: AppliedType)
         def tycon: TypeRepr
         def args: List[TypeRepr]
       end extension
@@ -2360,7 +2360,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `AnnotatedType` */
     trait AnnotatedTypeMethods:
-      extension (self: AnnotatedType):
+      extension (self: AnnotatedType)
         def underlying: TypeRepr
         def annotation: Term
       end extension
@@ -2434,7 +2434,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `MatchType` */
     trait MatchTypeMethods:
-      extension (self: MatchType):
+      extension (self: MatchType)
         def bound: TypeRepr
         def scrutinee: TypeRepr
         def cases: List[TypeRepr]
@@ -2461,7 +2461,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ByNameType` */
     trait ByNameTypeMethods:
-      extension (self: ByNameType):
+      extension (self: ByNameType)
         def underlying: TypeRepr
       end extension
     end ByNameTypeMethods
@@ -2485,7 +2485,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ParamRef` */
     trait ParamRefMethods:
-      extension (self: ParamRef):
+      extension (self: ParamRef)
         def binder: TypeRepr
         def paramNum: Int
       end extension
@@ -2510,7 +2510,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ThisType` */
     trait ThisTypeMethods:
-      extension (self: ThisType):
+      extension (self: ThisType)
         def tref: TypeRepr
       end extension
     end ThisTypeMethods
@@ -2534,7 +2534,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `RecursiveThis` */
     trait RecursiveThisMethods:
-      extension (self: RecursiveThis):
+      extension (self: RecursiveThis)
         def binder: RecursiveType
       end extension
     end RecursiveThisMethods
@@ -2569,7 +2569,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `RecursiveType` */
     trait RecursiveTypeMethods:
-      extension (self: RecursiveType):
+      extension (self: RecursiveType)
         def underlying: TypeRepr
         def recThis: RecursiveThis
       end extension
@@ -2619,7 +2619,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `MethodType` */
     trait MethodTypeMethods:
-      extension (self: MethodType):
+      extension (self: MethodType)
         def isImplicit: Boolean
         def isErased: Boolean
         def param(idx: Int): TypeRepr
@@ -2646,7 +2646,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `PolyType` */
     trait PolyTypeMethods:
-      extension (self: PolyType):
+      extension (self: PolyType)
         def param(idx: Int): TypeRepr
         def paramBounds: List[TypeBounds]
       end extension
@@ -2672,7 +2672,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeLambda` */
     trait TypeLambdaMethods:
-      extension (self: TypeLambda):
+      extension (self: TypeLambda)
         def param(idx: Int) : TypeRepr
         def paramBounds: List[TypeBounds]
       end extension
@@ -2703,7 +2703,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `TypeBounds` */
     trait TypeBoundsMethods:
-      extension (self: TypeBounds):
+      extension (self: TypeBounds)
         def low: TypeRepr
         def hi: TypeRepr
       end extension
@@ -2884,7 +2884,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Constant` */
     trait ConstantMethods {
-      extension (self: Constant):
+      extension (self: Constant)
         /** Returns the value of the constant */
         def value: Any
 
@@ -2924,7 +2924,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ImplicitSearchSuccess` */
     trait ImplicitSearchSuccessMethods:
-      extension (self: ImplicitSearchSuccess):
+      extension (self: ImplicitSearchSuccess)
         def tree: Term
       end extension
     end ImplicitSearchSuccessMethods
@@ -2939,7 +2939,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `ImplicitSearchFailure` */
     trait ImplicitSearchFailureMethods:
-      extension (self: ImplicitSearchFailure):
+      extension (self: ImplicitSearchFailure)
         def explanation: String
       end extension
     end ImplicitSearchFailureMethods
@@ -3054,7 +3054,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Symbol` */
     trait SymbolMethods {
-      extension (self: Symbol):
+      extension (self: Symbol)
 
         /** Owner of this symbol. The owner is the symbol in which this symbol is defined. Throws if this symbol does not have an owner. */
         def owner: Symbol
@@ -3258,7 +3258,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Signature` */
     trait SignatureMethods {
-      extension (self: Signature):
+      extension (self: Signature)
 
         /** The signatures of the method parameters.
           *
@@ -3599,7 +3599,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Flags` */
     trait FlagsMethods {
-      extension (self: Flags):
+      extension (self: Flags)
         /** Is the given flag set a subset of this flag sets */
         def is(that: Flags): Boolean
 
@@ -3640,7 +3640,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Position` */
     trait PositionMethods {
-      extension (self: Position):
+      extension (self: Position)
 
         /** The start offset in the source file */
         def start: Int
@@ -3686,7 +3686,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `SourceFile` */
     trait SourceFileMethods {
-      extension (self: SourceFile):
+      extension (self: SourceFile)
         /** Path to this source file */
         def jpath: java.nio.file.Path
 

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -331,7 +331,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `Export` */
     trait ExportMethods:
-      extension (self: Export):
+      extension (self: Export)
         def expr: Term
         def selectors: List[Selector]
       end extension

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -2216,7 +2216,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `NamedType` */
     trait NamedTypeMethods:
-      extension (self: NamedType):
+      extension (self: NamedType)
         def qualifier: TypeRepr
         def name: String
       end extension
@@ -2378,7 +2378,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `AndOrType` */
     trait AndOrTypeMethods:
-      extension (self: AndOrType):
+      extension (self: AndOrType)
         def left: TypeRepr
         def right: TypeRepr
       end extension
@@ -2586,7 +2586,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Extension methods of `LambdaType` */
     trait LambdaTypeMethods:
-      extension (self: LambdaType):
+      extension (self: LambdaType)
         def paramNames: List[String]
         def paramTypes: List[TypeRepr]
         def resType: TypeRepr

--- a/scala3doc-testcases/src/tests/FilterTest.scala
+++ b/scala3doc-testcases/src/tests/FilterTest.scala
@@ -120,8 +120,8 @@ class FilterTest extends FilterTestBase with FilterTestBaseTrait:
   /** doc */
   protected given namedSeq: Seq[String | Int | Double] = List(1)
 
-extension (e: FilterTest):
+extension (e: FilterTest)
   def extensionMethod(name: FilterTest): FilterTest = ???
 
-extension (e: FilterTestBase):
+extension (e: FilterTestBase)
   def extensionMethodBase(name: FilterTest): FilterTest = ???

--- a/scala3doc-testcases/src/tests/extensionMethodSignatures.scala
+++ b/scala3doc-testcases/src/tests/extensionMethodSignatures.scala
@@ -23,7 +23,7 @@ class ClassOne
       = ???
 
   extension (c:ClassTwo)
-  :
+
     def getString(a: String): String
        = a
 

--- a/scala3doc-testcases/src/tests/extensionMethodSignatures.scala
+++ b/scala3doc-testcases/src/tests/extensionMethodSignatures.scala
@@ -4,7 +4,7 @@ package extensionMethodSignatures
 class ClassOne
 {
   // Commented cases won't work for now
-  // extension ClassTwoOps on (c: ClassTwo):
+  // extension ClassTwoOps on (c: ClassTwo)
   //     def getA() = c.a
   extension (c: ClassTwo)
     def getB(): String

--- a/scala3doc-testcases/src/tests/implicitMembers.scala
+++ b/scala3doc-testcases/src/tests/implicitMembers.scala
@@ -6,15 +6,15 @@ class OuterClass:
   class ImplicitMemberTarget
 
   object ImplicitMemberTarget:
-    extension (a: ImplicitMemberTarget):
+    extension (a: ImplicitMemberTarget)
       def extensionFromCompanion: String =
         "ImplicitMemberTarget"
 
   // does not work
-  extension (a: ImplicitMemberTarget):
+  extension (a: ImplicitMemberTarget)
     def extensionFromOuterClass: String =
       "ImplicitMemberTarget"
 
-extension (a: OuterClass#ImplicitMemberTarget):
+extension (a: OuterClass#ImplicitMemberTarget)
     def extensionFromPackage: String =
       "ImplicitMemberTarget"

--- a/scala3doc/src/dotty/dokka/DocContext.scala
+++ b/scala3doc/src/dotty/dokka/DocContext.scala
@@ -57,7 +57,7 @@ private def createMessage(
       case throwable: Throwable =>
          s"$localizedMessage \ncaused by: ${throwableToString(throwable)}"
 
-extension (r: report.type):
+extension (r: report.type)
   def error(m: String, f: File, e: Throwable | Null = null)(using CompilerContext): Unit =
     r.error(createMessage(m, f, e), sourcePostionFor(f))
 

--- a/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
+++ b/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
@@ -170,7 +170,7 @@ class DottyDokkaPlugin extends DokkaJavaPlugin:
   )
 
 // TODO (https://github.com/lampepfl/scala3doc/issues/232): remove once problem is fixed in Dokka
-extension [T]  (builder: ExtensionBuilder[T]):
+extension [T]  (builder: ExtensionBuilder[T])
   def ordered(before: Seq[Extension[_, _, _]], after: Seq[Extension[_, _, _]]): ExtensionBuilder[T] =
     val byDsl = new OrderingKind.ByDsl(dsl => {
       dsl.after(after:_*)

--- a/scala3doc/src/dotty/dokka/Scala3docArgs.scala
+++ b/scala3doc/src/dotty/dokka/Scala3docArgs.scala
@@ -46,7 +46,7 @@ object Scala3docArgs:
       processArguments(initialSummary, processAll = true, skipped = Nil)
     val newContext = rootCtx.fresh
 
-    extension[T](arg: Setting[T]):
+    extension[T](arg: Setting[T])
       def get = arg.valueIn(summary.sstate)
       def withDefault(default: => T) =
         if arg.get == arg.default then default else arg.get

--- a/scala3doc/src/dotty/dokka/compat.scala
+++ b/scala3doc/src/dotty/dokka/compat.scala
@@ -34,37 +34,37 @@ val topLevelDri = org.jetbrains.dokka.links.DRI.Companion.getTopLevel
 type SourceSetWrapper = DokkaConfiguration$DokkaSourceSet
 type DokkaSourceSet = DokkaConfiguration.DokkaSourceSet
 
-extension [T] (wrapper: SourceSetWrapper):
+extension [T] (wrapper: SourceSetWrapper)
     def toSet: JSet[DokkaConfiguration$DokkaSourceSet] = JSet(wrapper)
     def toMap(value: T): JMap[DokkaConfiguration$DokkaSourceSet, T] = JMap(wrapper -> value)
 
-extension [T] (wrapper: DokkaSourceSet):
+extension [T] (wrapper: DokkaSourceSet)
     // when named `toSet` fails in runtime -- TODO: create a minimal!
     // def toSet: JSet[DokkaConfiguration$DokkaSourceSet] = JSet(wrapper.asInstanceOf[SourceSetWrapper])
     def asSet: JSet[DokkaConfiguration$DokkaSourceSet] = JSet(wrapper.asInstanceOf[SourceSetWrapper])
     def asMap(value: T): JMap[DokkaConfiguration$DokkaSourceSet, T] = JMap(wrapper.asInstanceOf[SourceSetWrapper] -> value)
 
-extension (sourceSets: JList[DokkaSourceSet]):
+extension (sourceSets: JList[DokkaSourceSet])
   def asDokka: JSet[SourceSetWrapper] = sourceSets.asScala.toSet.asJava.asInstanceOf[JSet[SourceSetWrapper]]
   def toDisplaySourceSet = sourceSets.asScala.map(ss => DisplaySourceSet(ss.asInstanceOf[SourceSetWrapper])).toSet.asJava
 
-extension (sourceSets: Set[SourceSetWrapper]):
+extension (sourceSets: Set[SourceSetWrapper])
   def toDisplay = sourceSets.map(DisplaySourceSet(_)).asJava
 
-extension [V] (a: WithExtraProperties[_]):
+extension [V] (a: WithExtraProperties[_])
   def get(key: ExtraProperty.Key[_, V]): V = a.getExtra().getMap().get(key).asInstanceOf[V]
 
-extension [E <: WithExtraProperties[E]] (a: E):
+extension [E <: WithExtraProperties[E]] (a: E)
   def put(value: ExtraProperty[_ >: E]): E = a.withNewExtras(a.getExtra plus value)
 
-extension [V] (map: JMap[SourceSetWrapper, V]):
+extension [V] (map: JMap[SourceSetWrapper, V])
   def defaultValue: V = map.values.asScala.head
 
-extension [V](jlist: JList[V]):
+extension [V](jlist: JList[V])
   def ++ (other: JList[V]): JList[V] =
     Stream.of(jlist, other).flatMap(_.stream).collect(Collectors.toList())
 
-extension [V](jset: JSet[V]):
+extension [V](jset: JSet[V])
   def ++ (other: JSet[V]): JSet[V] =
     Stream.of(jset, other).flatMap(_.stream).collect(Collectors.toSet())
 

--- a/scala3doc/src/dotty/dokka/model/api/api.scala
+++ b/scala3doc/src/dotty/dokka/model/api/api.scala
@@ -94,7 +94,7 @@ type Signature = Seq[String | Link]
 object Signature:
   def apply(names: (String | Link)*): Signature = names // TO batter dotty shortcommings in union types
 
-extension (s: Signature):
+extension (s: Signature)
   def join(a: Signature): Signature = s ++ a
 
 case class LinkToType(signature: Signature, dri: DRI, kind: Kind)
@@ -116,7 +116,7 @@ object Member:
   def unapply(d: Documentable): Option[(String, DRI, Visibility, Kind, Origin)] =
     d.memberExt.map(v => (d.getName, d.getDri, v.visibility, v.kind, v.origin))
 
-extension[T] (member: Member):
+extension[T] (member: Member)
 
   private[api] def memberExt = MemberExtension.getFrom(member)
 
@@ -145,7 +145,7 @@ extension[T] (member: Member):
   def membersBy(op: Member => Boolean): (Seq[Member], Seq[Member]) = allMembers.filter(op).partition(_.origin == Origin.DefinedWithin)
 
 
-extension (module: DModule):
+extension (module: DModule)
   def driMap: Map[DRI, Member] = ModuleExtension.getFrom(module).fold(Map.empty)(_.driMap)
 
 case class TastyDocumentableSource(val path: String, val lineNumber: Int)

--- a/scala3doc/src/dotty/dokka/model/api/internalExtensions.scala
+++ b/scala3doc/src/dotty/dokka/model/api/internalExtensions.scala
@@ -50,7 +50,7 @@ object CompositeMemberExtension extends BaseKey[Documentable, CompositeMemberExt
     new MergeStrategy$Replace(left.copy(members = left.members ++ right.members))
       .asInstanceOf[MergeStrategy[Documentable]]
 
-extension (member: Member):
+extension (member: Member)
   private def putInMember(ext: MemberExtension) =
     val memberWithExtra = member.asInstanceOf[WithExtraProperties[Member]]
     memberWithExtra.withNewExtras(memberWithExtra.getExtra plus ext).asInstanceOf[Member]
@@ -93,7 +93,7 @@ extension (member: Member):
 
   def updateRecusivly(op: Member => Member) = op(member).withMembers(member.allMembers.map(op))
 
-extension (bound: Bound):
+extension (bound: Bound)
   def asSignature: Signature = bound match
     case tc: TypeConstructor =>
       tc.getProjections.asScala.toSeq.map {
@@ -102,7 +102,7 @@ extension (bound: Bound):
           Link(link.getName, link.getDri)
       }
 
-extension (m: DModule):
+extension (m: DModule)
   def updatePackages(op: Seq[DPackage] => Seq[DPackage]): DModule =
     m.copy(
             m.getName,

--- a/scala3doc/src/dotty/dokka/model/api/membersUtils.scala
+++ b/scala3doc/src/dotty/dokka/model/api/membersUtils.scala
@@ -5,7 +5,7 @@ import scala.jdk.CollectionConverters.{ListHasAsScala, SeqHasAsJava}
 import dotty.dokka.model.api._
 
 extension (m: DModule)
-  def visitMembers(callback: Member => Unit): Unit = 
+  def visitMembers(callback: Member => Unit): Unit =
     def visitClasslike(c: Member): Unit =
       callback(c)
       c.allMembers.foreach(visitClasslike(_))
@@ -16,12 +16,12 @@ extension (s: Signature)
     s.map {
       case s: String => s
       case l: Link => l.name
-    }.mkString 
+    }.mkString
 
-extension (m: Member):
+extension (m: Member)
   def getDirectParentsAsStrings: Seq[String] =
     m.directParents.map(_.getName).sorted
   def getParentsAsStrings: Seq[String] =
     m.parents.map(_.signature.getName).sorted
-  def getKnownChildrenAsStrings: Seq[String] =   
+  def getKnownChildrenAsStrings: Seq[String] =
     m.knownChildren.map(_.signature.getName).sorted

--- a/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
@@ -34,7 +34,7 @@ trait BasicSupport:
     Annotation(dri, params)
 
 
-  extension (sym: Symbol):
+  extension (sym: Symbol)
     def documentation = sym.docstring match
       case Some(docstring) =>
           Map(ctx.sourceSet -> parseComment(docstring, sym.tree))

--- a/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -188,7 +188,7 @@ trait ClassLikeSupport:
     case other => parseMember(other)
   ).map(_.withOrigin(Origin.InheritedFrom(s.symbol.owner.normalizedName, s.symbol.owner.dri)))
 
-  extension (c: ClassDef):
+  extension (c: ClassDef)
     def membersToDocument = c.body.filterNot(_.symbol.isHiddenByVisibility)
 
     def getNonTrivialInheritedMemberTrees =

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -14,7 +14,7 @@ class SymOps[Q <: Quotes](val q: Q):
   import q.reflect._
 
   given Q = q
-  extension (sym: Symbol):
+  extension (sym: Symbol)
     def packageName: String =
       if (sym.isPackageDef) sym.fullName
       else sym.maybeOwner.packageName

--- a/scala3doc/src/dotty/dokka/tasty/SyntheticSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SyntheticSupport.scala
@@ -7,7 +7,7 @@ trait SyntheticsSupport:
 
   import qctx.reflect._
 
-  extension (t: TypeRepr):
+  extension (t: TypeRepr)
     def isTupleType: Boolean = hackIsTupleType(using qctx)(t)
 
     def isCompiletimeAppliedType: Boolean = hackIsCompiletimeAppliedType(using qctx)(t)
@@ -24,7 +24,7 @@ trait SyntheticsSupport:
       val tpe = rtpe.asInstanceOf[dotc.core.Types.Type]
       ctx.definitions.isCompiletimeAppliedType(tpe.typeSymbol)
 
-  extension (s: Symbol):
+  extension (s: Symbol)
     def isSyntheticFunc: Boolean = s.flags.is(Flags.Synthetic) || s.flags.is(Flags.FieldAccessor) || isDefaultHelperMethod
 
     def isSuperBridgeMethod: Boolean = s.name.contains("$super$")

--- a/scala3doc/src/dotty/dokka/tasty/TypesSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/TypesSupport.scala
@@ -36,7 +36,7 @@ trait TypesSupport:
   }
 
   given TreeSyntax: AnyRef with
-    extension (tpeTree: Tree):
+    extension (tpeTree: Tree)
       def dokkaType: Bound =
         val data = tpeTree match
           case TypeBoundsTree(low, high) => typeBound(low.tpe, low = true) ++ typeBound(high.tpe, low = false)
@@ -46,7 +46,7 @@ trait TypesSupport:
         new GenericTypeConstructor(tpeTree.symbol.dri, data.asJava, null)
 
   given TypeSyntax: AnyRef with
-    extension (tpe: TypeRepr):
+    extension (tpe: TypeRepr)
       def dokkaType: Bound =
         val data = inner(tpe)
         val dri = data.collect{

--- a/scala3doc/src/dotty/dokka/translators/ScalaPageCreator.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaPageCreator.scala
@@ -159,7 +159,7 @@ class ScalaPageCreator(
 
   override def contentForFunction(f: DFunction) = contentForMember(f)
 
-  extension (b: DocBuilder):
+  extension (b: DocBuilder)
     def descriptionIfNotEmpty(d: Documentable): DocBuilder = {
       val desc = this.contentForDescription(d).asScala.toSeq
       val res = if desc.isEmpty then b else b

--- a/scala3doc/src/dotty/dokka/utils.scala
+++ b/scala3doc/src/dotty/dokka/utils.scala
@@ -31,7 +31,7 @@ def getFromExtra[V](e: WithExtraProperties[_], k: ExtraProperty.Key[_, V]): Opti
   Option(e.getExtra.getMap.get(k)).asInstanceOf[Option[V]]
 
 
-extension (f: DFunction):
+extension (f: DFunction)
   def isRightAssociative(): Boolean = f.getName.endsWith(":")
 
 def modifyContentGroup(originalContentNodeWithParents: Seq[ContentGroup], modifiedContentNode: ContentGroup): ContentGroup =

--- a/scala3doc/test/dotty/dokka/ScaladocTest.scala
+++ b/scala3doc/test/dotty/dokka/ScaladocTest.scala
@@ -59,7 +59,7 @@ enum Assertion:
   case AfterPagesTransformation(fn: RootPageNode => Unit)
   case AfterRendering(fn: (RootPageNode, DokkaContext) => Unit)
 
-extension (s: Seq[Assertion]):
+extension (s: Seq[Assertion])
   def asTestMethods: TestMethods =
     import Assertion._
     TestMethods(
@@ -74,5 +74,5 @@ extension (s: Seq[Assertion]):
       ((root, context) => s.collect { case AfterRendering(fn) => fn(root, context)}.kUnit)
     )
 
-extension [T] (s: T):
+extension [T] (s: T)
   private def kUnit = kotlin.Unit.INSTANCE

--- a/scala3doc/test/dotty/dokka/SignatureTest.scala
+++ b/scala3doc/test/dotty/dokka/SignatureTest.scala
@@ -75,7 +75,7 @@ abstract class SignatureTest(
   private def findMissingSingatures(expected: Seq[String], actual: Seq[String]): Set[String] =
     expected.toSet &~ actual.toSet
 
-  extension (s: String):
+  extension (s: String)
     private def startWithAnyOfThese(c: String*) = c.exists(s.startsWith)
     private def compactWhitespaces = whitespaceRegex.replaceAllIn(s, " ")
 

--- a/tests/bench/string-interpolation-macro/Macro.scala
+++ b/tests/bench/string-interpolation-macro/Macro.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Macro {
 
-  extension (inline sc: StringContext):
+  extension (inline sc: StringContext)
     inline def x(inline args: Int*): String = ${ code('sc, 'args) }
 
   def code(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Int]])(using Quotes): Expr[String] =

--- a/tests/neg/extension-colon.check
+++ b/tests/neg/extension-colon.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/extension-colon.scala:1:18 -------------------------------------------------------------------------
+1 |extension (x: Int): // error
+  |                  ^
+  |                  no `:` expected here

--- a/tests/neg/extension-colon.scala
+++ b/tests/neg/extension-colon.scala
@@ -1,0 +1,2 @@
+extension (x: Int): // error
+  def foo = x

--- a/tests/neg/gadt-approximation-interaction.scala
+++ b/tests/neg/gadt-approximation-interaction.scala
@@ -80,7 +80,7 @@ object ExtensionMethod {
   enum SUB[-A, +B]:
     case Refl[S]() extends SUB[S, S]
 
-  extension (x: Int):
+  extension (x: Int)
     def **(y: Int) = math.pow(x, y).toInt
 
   def foo[T](t: T, ev: T SUB Int) =

--- a/tests/neg/i5773.scala
+++ b/tests/neg/i5773.scala
@@ -23,7 +23,7 @@ object Main {
 21 |    println(1 appendS 2)
    |            ^^^^^^^^^
    |value appendS is not a member of Int.
-   |An extension method was tried, but could not be fully constructed:
+   |An extension method was tried, but could not be fully constructed
    |
    |    Semigroup.sumSemigroup[Any](/* ambiguous */implicitly[Numeric[Any]]).appendS()
 one error found

--- a/tests/neg/i5773.scala
+++ b/tests/neg/i5773.scala
@@ -23,7 +23,7 @@ object Main {
 21 |    println(1 appendS 2)
    |            ^^^^^^^^^
    |value appendS is not a member of Int.
-   |An extension method was tried, but could not be fully constructed
+   |An extension method was tried, but could not be fully constructed:
    |
    |    Semigroup.sumSemigroup[Any](/* ambiguous */implicitly[Numeric[Any]]).appendS()
 one error found

--- a/tests/neg/i6900.scala
+++ b/tests/neg/i6900.scala
@@ -1,7 +1,7 @@
 object Test2 {
 
   // Works with extension method
-  extension [A](a: A):
+  extension [A](a: A)
     def foo[C]: C => A = _ => a   // error: extension method cannot have type parameters
 
   1.foo.foo

--- a/tests/pos/i6900.scala
+++ b/tests/pos/i6900.scala
@@ -21,7 +21,7 @@ object Test1 {
 object Test2 {
 
   // Works with extension method
-  extension [A, C](a: A):
+  extension [A, C](a: A)
     def foo: C => A = _ => a
 
   1.foo.foo

--- a/tests/pos/package-indented.scala
+++ b/tests/pos/package-indented.scala
@@ -1,0 +1,8 @@
+
+package p:
+  def f = 10
+
+package q:
+  def g = 20
+
+def Test = p.f + q.g

--- a/tests/pos/typeclass-encoding3.scala
+++ b/tests/pos/typeclass-encoding3.scala
@@ -138,7 +138,7 @@ object Test {
   common
     val minimum = Int.MinValue
 
-  extension [T : Ord] for List[T] : Ord:
+  extension [T : Ord] for List[T] : Ord
     def compareTo(that: List[T]): Int = (this, that) match
       case (Nil, Nil) => 0
       case (Nil, _) => -1


### PR DESCRIPTION
Fix documentation about indentation syntax. Also fix syntax summary (globally).

The fixes omit documenting : in extension blocks. These are disabled
in a separate commit.

There are two reasons for omitted in : in extensions:

 - they are not needed, and there should be one way to do things
 - they are confusing since everywhere else a : at eol starts a
new scope, but here it doesn't.