### PR TITLE
MIgrate away from Kotlin Documentable

### DIFF
--- a/docs/docs/reference/new-types/polymorphic-function-types.md
+++ b/docs/docs/reference/new-types/polymorphic-function-types.md
@@ -80,7 +80,7 @@ println(e1) // Apply(Apply(Var(wrap),Var(f)),Apply(Var(wrap),Var(a)))
 ### Relationship With Type Lambdas
 
 Polymorphic function types are not to be confused with
-[_type lambdas_](new-types/type-lambdas.md).
+[_type lambdas_](type-lambdas.md).
 While the former describes the _type_ of a polymorphic _value_,
 the latter is an actual function value _at the type level_.
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1565,7 +1565,17 @@ object Build {
             generateDocumentation(
               classDirectory.in(Compile).value.getAbsolutePath,
               "scala3doc", "scala3doc/output/self", VersionUtil.gitHash,
-              "-siteroot scala3doc/documentation -project-logo scala3doc/documentation/logo.svg")
+              "-siteroot scala3doc/documentation -project-logo scala3doc/documentation/logo.svg " +
+              "-external-mappings " + raw".*scala\/quoted.*" + "::" +
+                "scala3doc" + "::" +
+                "http://dotty.epfl.ch/api/" + ":::" +
+                raw".*java.*" + "::" +
+                "javadoc" + "::" +
+                "https://docs.oracle.com/javase/8/docs/api/" + ":::" +
+                raw".*scala.*" + "::" +
+                "scaladoc" + "::" +
+                "https://www.scala-lang.org/api/current/"
+            )
           }.value,
 
           generateScala3Documentation := Def.inputTaskDyn {
@@ -1589,7 +1599,14 @@ object Build {
               IO.write(dest / "CNAME", "dotty.epfl.ch")
             }.dependsOn(generateDocumentation(
               roots, "Scala 3", dest.getAbsolutePath, "master",
-              "-comment-syntax wiki -siteroot scala3doc/scala3-docs -project-logo scala3doc/scala3-docs/logo.svg"))
+              "-comment-syntax wiki -siteroot scala3doc/scala3-docs -project-logo scala3doc/scala3-docs/logo.svg " +
+              "-external-mappings " + raw".*java.*" + "::" +
+                "javadoc" + "::" +
+                "https://docs.oracle.com/javase/8/docs/api/" + ":::" +
+                raw".*scala.*" + "::" +
+                "scaladoc" + "::" +
+                "https://www.scala-lang.org/api/current/"
+              ))
           }.evaluated,
 
           generateTestcasesDocumentation := Def.taskDyn {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1566,15 +1566,12 @@ object Build {
               classDirectory.in(Compile).value.getAbsolutePath,
               "scala3doc", "scala3doc/output/self", VersionUtil.gitHash,
               "-siteroot scala3doc/documentation -project-logo scala3doc/documentation/logo.svg " +
-              "-external-mappings " + raw".*scala\/quoted.*" + "::" +
+              "-external-mappings " + raw".*scala.*" + "::" +
                 "scala3doc" + "::" +
                 "http://dotty.epfl.ch/api/" + ":::" +
                 raw".*java.*" + "::" +
                 "javadoc" + "::" +
-                "https://docs.oracle.com/javase/8/docs/api/" + ":::" +
-                raw".*scala.*" + "::" +
-                "scaladoc" + "::" +
-                "https://www.scala-lang.org/api/current/"
+                "https://docs.oracle.com/javase/8/docs/api/"
             )
           }.value,
 
@@ -1602,10 +1599,7 @@ object Build {
               "-comment-syntax wiki -siteroot scala3doc/scala3-docs -project-logo scala3doc/scala3-docs/logo.svg " +
               "-external-mappings " + raw".*java.*" + "::" +
                 "javadoc" + "::" +
-                "https://docs.oracle.com/javase/8/docs/api/" + ":::" +
-                raw".*scala.*" + "::" +
-                "scaladoc" + "::" +
-                "https://www.scala-lang.org/api/current/"
+                "https://docs.oracle.com/javase/8/docs/api/"
               ))
           }.evaluated,
 

--- a/scala3doc-testcases/src/tests/extensionMethodSignatures.scala
+++ b/scala3doc-testcases/src/tests/extensionMethodSignatures.scala
@@ -17,6 +17,8 @@ class ClassOne
   extension (c: ClassTwo)
     def |||:(a: Int, b: Int, d: Int)(e: String): Int
       = 56
+    def ++:(a: Int): Int
+      = 45
 
   extension (b: Int)
     def secondGroup(): String

--- a/scala3doc-testcases/src/tests/givenSignatures.scala
+++ b/scala3doc-testcases/src/tests/givenSignatures.scala
@@ -2,43 +2,15 @@ package tests
 
 package givenSignatures
 
+object Obj
 
+given Seq[String] = Nil
 
-class GivenClass {
-    trait B
-    trait C[T]
-    val r: Int = 5
-    type R = Int
-    given R = r
-    trait Ord[T] {
-        def compare(x: T, y: T): Int
-        extension (x: T) def < (y: T) = compare(x, y) < 0
-        extension (x: T) def > (y: T) = compare(x, y) > 0
-    }
-    given intOrd: Ord[Int] with {
-        def compare(x: Int, y: Int) =
-            if (x < y) -1 else if (x > y) +1 else 0
-    }
+given GivenType = GivenType()
 
-    given asd(using int: Int): B with {}
+class GivenType
 
-    given asd2[T]: C[T] with {}
+trait Ord[T]
 
-    given listOrd[T](using ord: Ord[T]): Ord[List[T]] with {
-
-        def compare(xs: List[T], ys: List[T]): Int = (xs, ys) match
-            case (Nil, Nil) => 0
-            case (Nil, _) => -1
-            case (_, Nil) => +1
-            case (x :: xs1, y :: ys1) =>
-                val fst = ord.compare(x, y)
-                if (fst != 0) fst else compare(xs1, ys1)
-    }
-
-    given IntOps: Int.type = Int
-
-    given GivenType = GivenType()
-
-    class GivenType
-}
-
+given listOrd[T](using ord: Ord[T]): Ord[List[T]]
+  = ???

--- a/scala3doc-testcases/src/tests/givenSignaturesPg.scala
+++ b/scala3doc-testcases/src/tests/givenSignaturesPg.scala
@@ -1,0 +1,44 @@
+package tests
+
+package givenSignaturesPg
+
+
+
+class GivenClass {
+    trait B
+    trait C[T]
+    val r: Int = 5
+    type R = Int
+    given R = r
+    trait Ord[T] {
+        def compare(x: T, y: T): Int
+        extension (x: T) def < (y: T) = compare(x, y) < 0
+        extension (x: T) def > (y: T) = compare(x, y) > 0
+    }
+    given intOrd: Ord[Int] with {
+        def compare(x: Int, y: Int) =
+            if (x < y) -1 else if (x > y) +1 else 0
+    }
+
+    given asd(using int: Int): B with {}
+
+    given asd2[T]: C[T] with {}
+
+    given listOrd[T](using ord: Ord[T]): Ord[List[T]] with {
+
+        def compare(xs: List[T], ys: List[T]): Int = (xs, ys) match
+            case (Nil, Nil) => 0
+            case (Nil, _) => -1
+            case (_, Nil) => +1
+            case (x :: xs1, y :: ys1) =>
+                val fst = ord.compare(x, y)
+                if (fst != 0) fst else compare(xs1, ys1)
+    }
+
+    given IntOps: Int.type = Int
+
+    given GivenType = GivenType()
+
+    class GivenType
+}
+

--- a/scala3doc-testcases/src/tests/methodsAndConstructors.scala
+++ b/scala3doc-testcases/src/tests/methodsAndConstructors.scala
@@ -47,3 +47,10 @@ class Methods:
 
  def arrays(a: Array[String], b: Array[Int]): Array[Double]
  = ???
+
+ def rightA1(a: Int): Int
+ = ???
+
+ def ++:(a: Int)(b: Double): Int
+ = ???
+

--- a/scala3doc-testcases/src/tests/modifiersSignatureTestSource.scala
+++ b/scala3doc-testcases/src/tests/modifiersSignatureTestSource.scala
@@ -24,6 +24,9 @@ abstract class Methods()
 
   implicit def toImplicitString(): String
    = "asd"
+
+  inline def method2(inline name: String): String
+  = "ala"
 }
 
 class ImplementedMethods() extends Methods/*<-*/()/*->*/

--- a/scala3doc-testcases/src/tests/nestingDRI.scala
+++ b/scala3doc-testcases/src/tests/nestingDRI.scala
@@ -1,0 +1,16 @@
+package tests.nestingDRI
+
+trait TestClass
+
+class A:
+  class B
+  object B:
+    object C
+    class C:
+      object D
+
+
+class AA:
+  object B:
+    class C:
+      object D

--- a/scala3doc-testcases/src/toplevel.scala
+++ b/scala3doc-testcases/src/toplevel.scala
@@ -1,0 +1,3 @@
+def toplevelDef = 123
+
+class ToplevelClass

--- a/scala3doc/resources/dotty_res/scripts/ux.js
+++ b/scala3doc/resources/dotty_res/scripts/ux.js
@@ -15,6 +15,14 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+
+  if (location.hash) {
+    var selected = document.getElementById(location.hash.substring(1));
+    if (selected){
+      selected.classList.toggle("expand");
+    }
+  }
+
   var logo = document.getElementById("logo");
   if (logo) {
     logo.onclick = function() {

--- a/scala3doc/resources/dotty_res/scripts/ux.js
+++ b/scala3doc/resources/dotty_res/scripts/ux.js
@@ -5,6 +5,16 @@ window.addEventListener("DOMContentLoaded", () => {
       document.getElementById("leftColumn").classList.toggle("open");
     };
   }
+
+  var elements = document.getElementsByClassName("documentableElement")
+  if (elements) {
+    for (i = 0; i < elements.length; i++) {
+      elements[i].onclick = function(){
+        this.classList.toggle("expand")
+      }
+    }
+  }
+
   var logo = document.getElementById("logo");
   if (logo) {
     logo.onclick = function() {

--- a/scala3doc/resources/dotty_res/styles/scalastyle.css
+++ b/scala3doc/resources/dotty_res/styles/scalastyle.css
@@ -12,6 +12,9 @@
   --inactive-fg: #777;
   --title-fg: #00485E;
 
+  --link-sig-fd: #7c99a5;
+  --link-sig-hover-fd: #7c99a5;
+
   --leftbar-bg: #003048;
   --leftbar-fg: #fff;
   --leftbar-current-bg: #0090BB;
@@ -364,7 +367,7 @@ dl.attributes > dt.implicit {
 }
 dl.attributes > dd {
   display: block;
-  padding-left: 10em;
+  padding-left: 5em;
   margin-bottom: 5px;
   min-height: 15px;
 }
@@ -437,11 +440,43 @@ footer .pull-right {
   margin-left: auto;
 }
 
+
 .modifiers {
-  width: 12em;
   display: table-cell;
-  text-align: right;
   padding-right: 0.5em;
+  min-width: 10em;
+  max-width: 10em;
+  overflow: hidden;
+  direction: rtl;
+  white-space: nowrap;
+  text-indent: 0em;
+}
+
+.modifiers .other-modifiers {
+  color: gray;
+}
+
+.other-modifiers a, .other-modifiers a:visited, .other-modifiers span[data-unresolved-link] {
+  color: var(--link-sig-fd);
+}
+
+.expand .modifiers {
+  display: inline-table;
+  min-width: 4em;
+}
+
+.signature {
+  color: gray;
+  display: table-cell;
+  padding-left: 0.5em;
+}
+
+.signature a, .signature a:visited, .signature span[data-unresolved-link] {
+  color: var(--link-sig-fd);
+}
+
+.expand .signature {
+  display: inline;
 }
 
 .documentableElement {
@@ -454,15 +489,50 @@ footer .pull-right {
   font-weight: 500;
   font-size: 12px;
   background: var(--code-bg);
+  border: 0.25em solid white;
 }
 
 .documentableElement>div {
   display: table;
 }
 
-.annotations {
-  margin-left: 9em;
+.expand.documentableElement>div {
+  display: block;
+  padding-left: 3em;
 }
+
+.expand.documentableElement>div.header {
+  display: block;
+  padding-left: 7.5em;
+  text-indent: -4.5em;
+}
+
+.documentableElement>div .cover {
+  display: none;
+}
+
+.documentableElement.expand>div .cover {
+  display: block;
+}
+
+.expand .doc {
+  margin-left: 6.5em;
+}
+
+.documentableElement:hover {
+  cursor: pointer;
+  border-left: 0.25em solid var(--leftbar-bg);
+}
+
+.annotations {
+  color: gray;
+  display: none;
+}
+
+.expand .annotations {
+  display: inline-block;
+}
+
 .documentableAnchor {
   position: absolute;
   width: 24px;

--- a/scala3doc/resources/dotty_res/styles/scalastyle.css
+++ b/scala3doc/resources/dotty_res/styles/scalastyle.css
@@ -528,6 +528,9 @@ footer .pull-right {
   border-left: 0.25em solid var(--leftbar-bg);
 }
 
+.expand.documentableElement {
+  border-left: 0.25em solid var(--leftbar-bg);
+}
 .annotations {
   color: gray;
   display: none;

--- a/scala3doc/resources/dotty_res/styles/scalastyle.css
+++ b/scala3doc/resources/dotty_res/styles/scalastyle.css
@@ -367,7 +367,7 @@ dl.attributes > dt.implicit {
 }
 dl.attributes > dd {
   display: block;
-  padding-left: 5em;
+  padding-left: 6em;
   margin-bottom: 5px;
   min-height: 15px;
 }
@@ -462,7 +462,7 @@ footer .pull-right {
 
 .expand .modifiers {
   display: inline-table;
-  min-width: 4em;
+  min-width: 7em;
 }
 
 .signature {
@@ -517,6 +517,10 @@ footer .pull-right {
 
 .expand .doc {
   margin-left: 6.5em;
+}
+
+.doc code {
+  padding: 0;
 }
 
 .documentableElement:hover {

--- a/scala3doc/src/dotty/dokka/DocContext.scala
+++ b/scala3doc/src/dotty/dokka/DocContext.scala
@@ -141,24 +141,6 @@ case class DocContext(args: Scala3doc.Args, compilerContext: CompilerContext)
       res
     }
 
-    //val externalDocumentationLinks: List[Scala3docExternalDocumentationLink] = List(
-      // Scala3docExternalDocumentationLink(
-      //   List(raw".*scala\/quoted.*".r),
-      //   new URL("http://127.0.0.1:5500/scala3doc/output/scala3/"),
-      //   DocumentationKind.Scala3doc
-      // ).withPackageList(new URL("http://127.0.0.1:5500/scala3doc/output/scala3/-scala%203/package-list")),
-      // Scala3docExternalDocumentationLink(
-      //   List(raw".*java.*".r),
-      //   new URL("https://docs.oracle.com/javase/8/docs/api/"),
-      //   DocumentationKind.Javadoc
-      // ).withPackageList(new URL("https://docs.oracle.com/javase/8/docs/api/package-list")),
-      // Scala3docExternalDocumentationLink(
-      //   List(raw".*scala.*".r),
-      //   new URL("https://www.scala-lang.org/api/current/"),
-      //   DocumentationKind.Scaladoc
-      // )
-    //)
-
     override def getPluginsConfiguration: JList[DokkaConfiguration.PluginConfiguration] =
       JNil
 

--- a/scala3doc/src/dotty/dokka/DocContext.scala
+++ b/scala3doc/src/dotty/dokka/DocContext.scala
@@ -18,6 +18,7 @@ import dotty.tools.dotc.util.Spans
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import scala.io.Codec
+import java.net.URL
 
 type CompilerContext = dotty.tools.dotc.core.Contexts.Context
 
@@ -92,6 +93,24 @@ case class DocContext(args: Scala3doc.Args, compilerContext: CompilerContext)
         args,
         sourceLinks
       )(using compilerContext))
+
+    val externalDocumentationLinks: List[Scala3docExternalDocumentationLink] = List(
+      Scala3docExternalDocumentationLink(
+        List(raw".*scala\/quoted.*".r),
+        new URL("http://127.0.0.1:5500/scala3doc/output/scala3/"),
+        DocumentationKind.Scala3doc
+      ).withPackageList(new URL("http://127.0.0.1:5500/scala3doc/output/scala3/-scala%203/package-list")),
+      Scala3docExternalDocumentationLink(
+        List(raw".*java.*".r),
+        new URL("https://docs.oracle.com/javase/8/docs/api/"),
+        DocumentationKind.Javadoc
+      ).withPackageList(new URL("https://docs.oracle.com/javase/8/docs/api/package-list")),
+      Scala3docExternalDocumentationLink(
+        List(raw".*scala.*".r),
+        new URL("https://www.scala-lang.org/api/current/"),
+        DocumentationKind.Scaladoc
+      )
+    )
 
     override def getPluginsConfiguration: JList[DokkaConfiguration.PluginConfiguration] =
       JNil

--- a/scala3doc/src/dotty/dokka/DocContext.scala
+++ b/scala3doc/src/dotty/dokka/DocContext.scala
@@ -75,8 +75,8 @@ case class DocContext(args: Scala3doc.Args, compilerContext: CompilerContext)
     override def getOfflineMode: Boolean = false
     override def getFailOnWarning: Boolean = false
     override def getSourceSets: JList[DokkaSourceSet] = JList(mkSourceSet)
-    override def getModules: JList[DokkaConfiguration.DokkaModuleDescription] = JList()
-    override def getPluginsClasspath: JList[File] = JList()
+    override def getModules: JList[DokkaConfiguration.DokkaModuleDescription] = JNil
+    override def getPluginsClasspath: JList[File] = JNil
     override def getModuleName(): String = "ModuleName"
     override def getModuleVersion(): String = ""
 
@@ -94,13 +94,13 @@ case class DocContext(args: Scala3doc.Args, compilerContext: CompilerContext)
       )(using compilerContext))
 
     override def getPluginsConfiguration: JList[DokkaConfiguration.PluginConfiguration] =
-      JList()
+      JNil
 
     val mkSourceSet: DokkaSourceSet =
       new DokkaSourceSetImpl(
         /*displayName=*/ args.name,
         /*sourceSetID=*/ new DokkaSourceSetID(args.name, "main"),
-        /*classpath=*/ JList(),
+        /*classpath=*/ JNil,
         /*sourceRoots=*/ JSet(),
         /*dependentSourceSets=*/ JSet(),
         /*samples=*/ JSet(),

--- a/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
+++ b/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
@@ -187,7 +187,7 @@ class DottyDokkaPlugin extends DokkaJavaPlugin:
       .overrideExtension(dokkaBase.getDokkaLocationProvider)
   )
 
-extension (ctx: DokkaContext):
+extension (ctx: DokkaContext)
   def siteContext: Option[StaticSiteContext] = ctx.getConfiguration.asInstanceOf[DocContext].staticSiteContext
   def args: Scala3doc.Args = ctx.getConfiguration.asInstanceOf[DocContext].args
 

--- a/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
+++ b/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
@@ -120,8 +120,9 @@ class DottyDokkaPlugin extends DokkaJavaPlugin:
 
   val implicitMembersExtensionTransformer = extend(
     _.extensionPoint(CoreExtensions.INSTANCE.getDocumentableTransformer)
-      .fromRecipe(ImplicitMembersExtensionTransformer(_))
-      .name("implicitMembersExtensionTransformer")
+      .fromRecipe { case ctx @ given DokkaContext =>
+        new ImplicitMembersExtensionTransformer
+      }.name("implicitMembersExtensionTransformer")
   )
 
   val customDocumentationProvider = extend(

--- a/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
+++ b/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
@@ -187,10 +187,6 @@ class DottyDokkaPlugin extends DokkaJavaPlugin:
       .overrideExtension(dokkaBase.getDokkaLocationProvider)
   )
 
-extension (ctx: DokkaContext)
-  def siteContext: Option[StaticSiteContext] = ctx.getConfiguration.asInstanceOf[DocContext].staticSiteContext
-  def args: Scala3doc.Args = ctx.getConfiguration.asInstanceOf[DocContext].args
-
 // TODO (https://github.com/lampepfl/scala3doc/issues/232): remove once problem is fixed in Dokka
 extension [T]  (builder: ExtensionBuilder[T])
   def ordered(before: Seq[Extension[_, _, _]], after: Seq[Extension[_, _, _]]): ExtensionBuilder[T] =

--- a/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
+++ b/scala3doc/src/dotty/dokka/DottyDokkaPlugin.scala
@@ -183,7 +183,7 @@ class DottyDokkaPlugin extends DokkaJavaPlugin:
 
   val scalaExternalLocationProviderFactory = extend(
     _.extensionPoint(dokkaBase.getExternalLocationProviderFactory)
-      .fromRecipe{ case c as given DokkaContext => new ScalaExternalLocationProviderFactory }
+      .fromRecipe{ case c @ given DokkaContext => new ScalaExternalLocationProviderFactory }
       .overrideExtension(dokkaBase.getDokkaLocationProvider)
   )
 

--- a/scala3doc/src/dotty/dokka/Scala3doc.scala
+++ b/scala3doc/src/dotty/dokka/Scala3doc.scala
@@ -65,7 +65,7 @@ object Scala3doc:
     defaultSyntax: CommentSyntax = CommentSyntax.Markdown,
     sourceLinks: List[String] = Nil,
     revision: Option[String] = None,
-    externalMappings: List[List[String]]
+    externalMappings: List[List[String]] = List.empty
   )
 
   def run(args: Array[String], rootContext: CompilerContext): Reporter =

--- a/scala3doc/src/dotty/dokka/Scala3doc.scala
+++ b/scala3doc/src/dotty/dokka/Scala3doc.scala
@@ -64,7 +64,8 @@ object Scala3doc:
     projectLogo: Option[String] = None,
     defaultSyntax: CommentSyntax = CommentSyntax.Markdown,
     sourceLinks: List[String] = Nil,
-    revision: Option[String] = None
+    revision: Option[String] = None,
+    externalMappings: List[List[String]]
   )
 
   def run(args: Array[String], rootContext: CompilerContext): Reporter =

--- a/scala3doc/src/dotty/dokka/Scala3docArgs.scala
+++ b/scala3doc/src/dotty/dokka/Scala3docArgs.scala
@@ -34,7 +34,10 @@ class Scala3docArgs extends SettingGroup with CommonScalaSettings:
   val revision: Setting[String] =
     StringSetting("-revision", "revision", "Revision (branch or ref) used to build project project", "")
 
-  def scala3docSpecificSettings: Set[Setting[_]] = Set(sourceLinks, syntax, revision)
+  val externalDocumentationMappings: Setting[String] =
+    StringSetting("-external-mappings", "external-mappings", "Mapping between regex matching class file and external documentation", "")
+
+  def scala3docSpecificSettings: Set[Setting[_]] = Set(sourceLinks, syntax, revision, externalDocumentationMappings)
 
 object Scala3docArgs:
   def extract(args: List[String], rootCtx: CompilerContext):(Scala3doc.Args, CompilerContext) =
@@ -95,6 +98,7 @@ object Scala3docArgs:
         CommentSyntax.default
       }
     }
+    val externalMappings = externalDocumentationMappings.get.split(":::").map(_.split("::").toList).toList
 
     unsupportedSettings.filter(s => s.get != s.default).foreach { s =>
       report.warning(s"Setting ${s.name} is currently not supported.")
@@ -115,6 +119,7 @@ object Scala3docArgs:
       projectLogo.nonDefault,
       parseSyntax,
       sourceLinks.nonDefault.fold(Nil)(_.split(",").toList),
-      revision.nonDefault
+      revision.nonDefault,
+      externalMappings
     )
     (docArgs, newContext)

--- a/scala3doc/src/dotty/dokka/compat.scala
+++ b/scala3doc/src/dotty/dokka/compat.scala
@@ -14,8 +14,6 @@ import java.util.stream.Collectors
 import org.jetbrains.dokka.plugability._
 import kotlin.jvm.JvmClassMappingKt.getKotlinClass
 
-def mkDRI(packageName: String = null, extra: String = null) = new DRI(packageName, null, null, PointingToDeclaration.INSTANCE, extra)
-
 val U: kotlin.Unit = kotlin.Unit.INSTANCE
 
 def JList[T](e: T*): JList[T] = e.asJava

--- a/scala3doc/src/dotty/dokka/compat.scala
+++ b/scala3doc/src/dotty/dokka/compat.scala
@@ -28,6 +28,12 @@ type JMap[K, V] = java.util.Map[K, V]
 type JHashMap[K, V] = java.util.HashMap[K, V]
 type JMapEntry[K, V] = java.util.Map.Entry[K, V]
 
+private val emptyListInst = JList()
+def JNil[A] = emptyListInst.asInstanceOf[JList[A]]
+
+private val emptyMapInst = JMap()
+def emptyJMap[A, B] = emptyMapInst.asInstanceOf[JMap[A, B]]
+
 type DRI = org.jetbrains.dokka.links.DRI
 val topLevelDri = org.jetbrains.dokka.links.DRI.Companion.getTopLevel
 

--- a/scala3doc/src/dotty/dokka/externalDocumentationLinks.scala
+++ b/scala3doc/src/dotty/dokka/externalDocumentationLinks.scala
@@ -1,0 +1,18 @@
+package dotty.dokka
+
+import org.jetbrains.dokka._
+import java.net.URL
+import scala.util.matching._
+
+case class Scala3docExternalDocumentationLink(
+  originRegexes: List[Regex],
+  documentationUrl: URL,
+  kind: DocumentationKind,
+  packageListUrl: Option[URL] = None
+):
+  def withPackageList(url: URL): Scala3docExternalDocumentationLink = copy(packageListUrl = Some(url))
+
+enum DocumentationKind:
+  case Javadoc extends DocumentationKind
+  case Scaladoc extends DocumentationKind
+  case Scala3doc extends DocumentationKind

--- a/scala3doc/src/dotty/dokka/location/ScalaExternalLocationProvider.scala
+++ b/scala3doc/src/dotty/dokka/location/ScalaExternalLocationProvider.scala
@@ -8,6 +8,7 @@ import org.jetbrains.dokka.base.resolvers.anchors._
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.DisplaySourceSet
 import org.jetbrains.dokka.pages.RootPageNode
+import dotty.dokka.model.api._
 import org.jetbrains.dokka.plugability._
 import collection.JavaConverters._
 import java.util.{Set => JSet}
@@ -34,20 +35,20 @@ class ScalaExternalLocationProvider(
   }
 
   private def constructPathForJavadoc(dri: DRI): String = {
-    val packagePrefix = dri.getPackageName.replace(".","/")
-    val origin = originRegex.findFirstIn(dri.getExtra)
-    val className = origin match {
-      case Some(path) =>
-        path.split("/").last.stripSuffix(".class")
-      case None => dri.getClassNames
-    }
-    getDocURL + packagePrefix + "/" + className + extension
+    val location = "\\$+".r.replaceAllIn(dri.location.replace(".","/"), _ => ".")
+    val origin = originRegex.findFirstIn(dri.extra)
+    val anchor = dri.anchor
+    getDocURL + location + extension + anchor.fold("")(a => s"#$a")
   }
 
   private def constructPathForScaladoc(dri: DRI): String = {
-    val packagePrefix = dri.getPackageName.replace(".","/")
-    val className = dri.getClassNames
-    getDocURL + packagePrefix + "/" + className + extension
+    val location = dri.location.replace(".","/")
+    val anchor = dri.anchor
+    getDocURL + location + extension + anchor.fold("")(a => s"#$a")
   }
 
-  private def constructPathForScala3doc(dri: DRI): String = super.constructPath(dri)
+  private def constructPathForScala3doc(dri: DRI): String = {
+    val location = dri.location.replace(".","/")
+    val anchor = dri.anchor
+    getDocURL + location + anchor.fold(extension)(a => s"/$a$extension")
+  }

--- a/scala3doc/src/dotty/dokka/location/ScalaExternalLocationProvider.scala
+++ b/scala3doc/src/dotty/dokka/location/ScalaExternalLocationProvider.scala
@@ -1,0 +1,53 @@
+package dotty.dokka
+
+import org.jetbrains.dokka.base.resolvers.local._
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.resolvers.external._
+import org.jetbrains.dokka.base.resolvers.shared._
+import org.jetbrains.dokka.base.resolvers.anchors._
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.DisplaySourceSet
+import org.jetbrains.dokka.pages.RootPageNode
+import org.jetbrains.dokka.plugability._
+import collection.JavaConverters._
+import java.util.{Set => JSet}
+
+
+class ScalaExternalLocationProvider(
+  externalDocumentation: ExternalDocumentation,
+  extension: String,
+  kind: DocumentationKind
+)(using ctx: DokkaContext) extends DefaultExternalLocationProvider(externalDocumentation, extension, ctx):
+  override def resolve(dri: DRI): String =
+    Option(externalDocumentation.getPackageList).map(_.getLocations.asScala.toMap).flatMap(_.get(dri.toString))
+      .fold(constructPath(dri))( l => {
+        this.getDocURL + l
+      }
+    )
+
+  private val originRegex = raw"\[origin:(.*)\]".r
+
+  override def constructPath(dri: DRI): String = kind match {
+    case DocumentationKind.Javadoc => constructPathForJavadoc(dri)
+    case DocumentationKind.Scaladoc => constructPathForScaladoc(dri)
+    case DocumentationKind.Scala3doc => constructPathForScala3doc(dri)
+  }
+
+  private def constructPathForJavadoc(dri: DRI): String = {
+    val packagePrefix = dri.getPackageName.replace(".","/")
+    val origin = originRegex.findFirstIn(dri.getExtra)
+    val className = origin match {
+      case Some(path) =>
+        path.split("/").last.stripSuffix(".class")
+      case None => dri.getClassNames
+    }
+    getDocURL + packagePrefix + "/" + className + extension
+  }
+
+  private def constructPathForScaladoc(dri: DRI): String = {
+    val packagePrefix = dri.getPackageName.replace(".","/")
+    val className = dri.getClassNames
+    getDocURL + packagePrefix + "/" + className + extension
+  }
+
+  private def constructPathForScala3doc(dri: DRI): String = super.constructPath(dri)

--- a/scala3doc/src/dotty/dokka/location/ScalaExternalLocationProviderFactory.scala
+++ b/scala3doc/src/dotty/dokka/location/ScalaExternalLocationProviderFactory.scala
@@ -1,0 +1,17 @@
+package dotty.dokka
+
+import org.jetbrains.dokka.base.resolvers.local._
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.resolvers.external._
+import org.jetbrains.dokka.base.resolvers.shared._
+import org.jetbrains.dokka.base.resolvers.anchors._
+import org.jetbrains.dokka.links.DRI
+import org.jetbrains.dokka.model.DisplaySourceSet
+import org.jetbrains.dokka.pages.RootPageNode
+import org.jetbrains.dokka.plugability._
+import collection.JavaConverters._
+import java.util.{Set => JSet}
+
+class ScalaExternalLocationProviderFactory(using ctx: DokkaContext) extends ExternalLocationProviderFactory:
+  override def getExternalLocationProvider(doc: ExternalDocumentation): ExternalLocationProvider =
+    ScalaExternalLocationProvider(doc, ".html", DocumentationKind.Scala3doc)

--- a/scala3doc/src/dotty/dokka/location/ScalaPackageListService.scala
+++ b/scala3doc/src/dotty/dokka/location/ScalaPackageListService.scala
@@ -7,7 +7,7 @@ import org.jetbrains.dokka.links._
 import org.jetbrains.dokka.pages._
 import org.jetbrains.dokka.plugability._
 import collection.JavaConverters._
-import dotty.dokka.model.api.withNoOrigin
+import dotty.dokka.withNoOrigin
 
 object ScalaPackageListService:
   val DOKKA_PARAM_PREFIX = "$dokka"

--- a/scala3doc/src/dotty/dokka/location/ScalaPackageListService.scala
+++ b/scala3doc/src/dotty/dokka/location/ScalaPackageListService.scala
@@ -1,0 +1,46 @@
+package dotty.dokka
+
+import org.jetbrains.dokka.base.renderers._
+import org.jetbrains.dokka.base.resolvers.local._
+import org.jetbrains.dokka.base._
+import org.jetbrains.dokka.links._
+import org.jetbrains.dokka.pages._
+import org.jetbrains.dokka.plugability._
+import collection.JavaConverters._
+import dotty.dokka.model.api.withNoOrigin
+
+object ScalaPackageListService:
+  val DOKKA_PARAM_PREFIX = "$dokka"
+
+class ScalaPackageListService(context: DokkaContext, rootPage: RootPageNode):
+  import ScalaPackageListService._  //Why I need to do this?
+
+  val locationProvider = PluginUtils.querySingle[DokkaBase, LocationProviderFactory](context, _.getLocationProviderFactory)
+    .getLocationProvider(rootPage)
+
+  def createPackageList(format: String, linkExtension: String): String = {
+    val packages = retrievePackageInfo(rootPage)
+    val relocations = getRelocations(rootPage)
+    s"$DOKKA_PARAM_PREFIX.format:$format\n" ++
+    s"$DOKKA_PARAM_PREFIX.linkExtenstion:$linkExtension\n" ++
+    relocations.map( (dri, link) =>
+      s"$DOKKA_PARAM_PREFIX.location:${dri.withNoOrigin.toString}\u001f$link.$linkExtension"
+    ).mkString("","\n","\n") ++
+    packages.mkString("","\n","\n")
+  }
+
+  private def retrievePackageInfo(current: PageNode): Set[String] = current match {
+    case p: PackagePageNode => p.getChildren.asScala.toSet.flatMap(retrievePackageInfo) ++ Option(p.getDocumentable.getDri.getPackageName)
+    case other => other.getChildren.asScala.toSet.flatMap(retrievePackageInfo)
+  }
+
+  private def getRelocations(current: PageNode): List[(DRI, String)] = current match {
+    case c: ContentPage => getRelocation(c.getDri.asScala.toList, c) ++ c.getChildren.asScala.toList.flatMap(getRelocations)
+    case other => other.getChildren.asScala.toList.flatMap(getRelocations)
+  }
+
+  private def getRelocation(dris: List[DRI], node: ContentPage): List[(DRI, String)] =
+    val link = locationProvider.resolve(node, rootPage, true)
+    dris.map( dri =>
+      if locationProvider.expectedLocationForDri(dri) != link then Some(dri, link) else None
+    ).flatten

--- a/scala3doc/src/dotty/dokka/model/api/api.scala
+++ b/scala3doc/src/dotty/dokka/model/api/api.scala
@@ -8,6 +8,7 @@ import collection.JavaConverters._
 import org.jetbrains.dokka.model.doc._
 import org.jetbrains.dokka.model.properties._
 import org.jetbrains.dokka.pages._
+import dotty.dokka.tasty.comments.Comment
 
 enum Visibility(val name: String):
   case Unrestricted extends Visibility("")
@@ -161,6 +162,7 @@ extension[T] (member: Member)
   def inheritedFrom: Option[InheritedFrom] = memberExt.fold(None)(_.inheritedFrom)
   def annotations: List[Annotation] = memberExt.fold(Nil)(_.annotations)
   def sources: Option[TastyDocumentableSource] = memberExt.fold(None)(_.sources)
+  def docs: Option[Comment] = memberExt.fold(None)(_.rawDoc)
   def name = member.getName
   def dri = member.getDri
 
@@ -180,3 +182,5 @@ extension (module: DModule)
   def driMap: Map[DRI, Member] = ModuleExtension.getFrom(module).fold(Map.empty)(_.driMap)
 
 case class TastyDocumentableSource(val path: String, val lineNumber: Int)
+
+type DocPart = DocTag

--- a/scala3doc/src/dotty/dokka/model/api/api.scala
+++ b/scala3doc/src/dotty/dokka/model/api/api.scala
@@ -181,6 +181,15 @@ extension (members: Seq[Member]) def byInheritance =
 extension (module: DModule)
   def driMap: Map[DRI, Member] = ModuleExtension.getFrom(module).fold(Map.empty)(_.driMap)
 
+extension (dri: DRI):
+  def withNoOrigin = DRI(
+    dri.getPackageName,
+    dri.getClassNames,
+    dri.getCallable,
+    dri.getTarget,
+    Option(dri.getExtra).fold(null)(e => raw"\[origin:(.*)\]".r.replaceAllIn(e, ""))
+  )
+
 case class TastyDocumentableSource(val path: String, val lineNumber: Int)
 
 type DocPart = DocTag

--- a/scala3doc/src/dotty/dokka/model/api/api.scala
+++ b/scala3doc/src/dotty/dokka/model/api/api.scala
@@ -182,7 +182,7 @@ extension (members: Seq[Member]) def byInheritance =
 extension (module: DModule)
   def driMap: Map[DRI, Member] = ModuleExtension.getFrom(module).fold(Map.empty)(_.driMap)
 
-extension (dri: DRI):
+extension (dri: DRI)
   def withNoOrigin = dri._copy(
     extra = Option(dri.getExtra).fold(null)(e => raw"\[origin:(.*)\]".r.replaceAllIn(e, ""))
   )

--- a/scala3doc/src/dotty/dokka/model/api/api.scala
+++ b/scala3doc/src/dotty/dokka/model/api/api.scala
@@ -9,7 +9,6 @@ import org.jetbrains.dokka.model.doc._
 import org.jetbrains.dokka.model.properties._
 import org.jetbrains.dokka.pages._
 import dotty.dokka.tasty.comments.Comment
-import org.jetbrains.dokka.links._
 
 enum Visibility(val name: String):
   case Unrestricted extends Visibility("")
@@ -181,34 +180,6 @@ extension (members: Seq[Member]) def byInheritance =
 
 extension (module: DModule)
   def driMap: Map[DRI, Member] = ModuleExtension.getFrom(module).fold(Map.empty)(_.driMap)
-
-extension (dri: DRI)
-  def withNoOrigin = dri._copy(
-    extra = Option(dri.getExtra).fold(null)(e => raw"\[origin:(.*)\]".r.replaceAllIn(e, ""))
-  )
-
-  def location: String = dri.getPackageName
-
-  def anchor: Option[String] = Option(dri.getClassNames).filterNot(_.isEmpty)
-
-  def extra: String = dri.getExtra
-
-  def target: DriTarget = dri.getTarget
-
-  def _copy(
-    location: String = dri.location,
-    anchor: Option[String] = dri.anchor,
-    target: DriTarget = dri.target,
-    extra: String = dri.extra
-  ) = new DRI(location, anchor.getOrElse(""), null, target, extra)
-
-object DRI:
-  def apply(
-    location: String = "",
-    anchor: Option[String] = None,
-    target: DriTarget = PointingToDeclaration.INSTANCE,
-    extra: String = ""
-  ) = new DRI(location, anchor.getOrElse(""), null, target, extra)
 
 case class TastyDocumentableSource(val path: String, val lineNumber: Int)
 

--- a/scala3doc/src/dotty/dokka/model/api/api.scala
+++ b/scala3doc/src/dotty/dokka/model/api/api.scala
@@ -53,20 +53,26 @@ trait ImplicitConversionProvider { def conversion: Option[ImplicitConversion] }
 trait Classlike
 
 enum Kind(val name: String){
-  case Class extends Kind("class") with Classlike
+  case Class(typeParams: Seq[TypeParameter], argsLists: Seq[Seq[Parameter]])
+    extends Kind("class") with Classlike
   case Object extends Kind("object") with Classlike
-  case Trait extends Kind("trait") with Classlike
+  case Trait(typeParams: Seq[TypeParameter], argsLists: Seq[Seq[Parameter]])
+    extends Kind("trait") with Classlike
   case Enum extends Kind("enum") with Classlike
-  case EnumCase extends Kind("case")
-  case Def extends Kind("def")
-  case Extension(on: ExtensionTarget) extends Kind("def")
-  case Constructor extends Kind("def")
+  case EnumCase(kind: Object.type | Type | Val.type) extends Kind("case")
+  case Def(typeParams: Seq[TypeParameter], argsLists: Seq[Seq[Parameter]])
+    extends Kind("def")
+  case Extension(on: ExtensionTarget, m: Kind.Def) extends Kind("def")
+  case Constructor(base: Kind.Def) extends Kind("def")
   case Var extends Kind("var")
   case Val extends Kind("val")
-  case Exported extends Kind("export")
-  case Type(concreate: Boolean, opaque: Boolean) extends Kind("Type") // should we handle opaque as modifier?
-  case Given(as: Option[Signature], conversion: Option[ImplicitConversion]) extends Kind("Given") with ImplicitConversionProvider
-  case Implicit(kind: Kind, conversion: Option[ImplicitConversion]) extends Kind(kind.name)  with ImplicitConversionProvider
+  case Exported(m: Kind.Def) extends Kind("export")
+  case Type(concreate: Boolean, opaque: Boolean, typeParams: Seq[TypeParameter])
+    extends Kind("Type") // should we handle opaque as modifier?
+  case Given(kind: Def | Class, as: Option[Signature], conversion: Option[ImplicitConversion])
+    extends Kind("Given") with ImplicitConversionProvider
+  case Implicit(kind: Kind.Def | Kind.Val.type, conversion: Option[ImplicitConversion])
+    extends Kind(kind.name)  with ImplicitConversionProvider
   case Unknown extends Kind("Unknown")
 }
 
@@ -91,6 +97,23 @@ object Annotation:
   case class LinkParameter(name: Option[String] = None, dri: DRI, value: String) extends AnnotationParameter
   case class UnresolvedParameter(name: Option[String] = None, unresolvedText: String) extends AnnotationParameter
 
+case class Parameter(
+  annotations: Seq[Annotation],
+  modifiers: String,
+  name: String,
+  dri: DRI,
+  signature: Signature,
+  isExtendedSymbol: Boolean = false,
+  isGrouped: Boolean = false
+)
+
+case class TypeParameter(
+  variance: "" | "+" | "-",
+  name: String,
+  dri: DRI,
+  signature: Signature
+)
+
 // TODO (longterm) properly represent signatures
 case class Link(name: String, dri: DRI)
 type Signature = Seq[String | Link]
@@ -114,7 +137,7 @@ object HierarchyGraph:
   def withEdges(edges: Seq[(LinkToType, LinkToType)]) = HierarchyGraph.empty ++ edges
 
 
-type Member = Documentable // with WithExtraProperty[_] // Kotlin does not add generics to ExtraProperty implemented by e.g. DFunction
+type Member = Documentable
 
 object Member:
   def unapply(d: Documentable): Option[(String, DRI, Visibility, Kind, Origin)] =
@@ -146,10 +169,12 @@ extension[T] (member: Member)
   def parents: Seq[LinkToType] = compositeMemberExt.fold(Nil)(_.parents)
   def directParents: Seq[Signature] = compositeMemberExt.fold(Nil)(_.directParents)
   def knownChildren: Seq[LinkToType] = compositeMemberExt.fold(Nil)(_.knownChildren)
+  def companion: Option[DRI] = compositeMemberExt.fold(None)(_.companion)
 
   def membersBy(op: Member => Boolean): Seq[Member] = allMembers.filter(op)
-  def membersByWithInheritancePartition(op: Member => Boolean): (Seq[Member], Seq[Member]) = membersBy(op).partition(_.inheritedFrom.isEmpty)
 
+extension (members: Seq[Member]) def byInheritance =
+  members.partition(_.inheritedFrom.isEmpty)
 
 extension (module: DModule)
   def driMap: Map[DRI, Member] = ModuleExtension.getFrom(module).fold(Map.empty)(_.driMap)

--- a/scala3doc/src/dotty/dokka/model/api/internalExtensions.scala
+++ b/scala3doc/src/dotty/dokka/model/api/internalExtensions.scala
@@ -19,6 +19,7 @@ import org.jetbrains.dokka.model.DModule
 import collection.JavaConverters._
 import org.jetbrains.dokka.model.doc.DocumentationNode
 import org.jetbrains.dokka.model.properties._
+import dotty.dokka.tasty.comments.Comment
 
 case class MemberExtension(
   visibility: Visibility,
@@ -30,6 +31,7 @@ case class MemberExtension(
   origin: Origin = Origin.RegularlyDefined,
   inheritedFrom: Option[InheritedFrom] = None,
   graph: HierarchyGraph = HierarchyGraph.empty,
+  rawDoc: Option[Comment] = None
 ) extends ExtraProperty[Documentable]:
  override def getKey = MemberExtension
 

--- a/scala3doc/src/dotty/dokka/model/api/internalExtensions.scala
+++ b/scala3doc/src/dotty/dokka/model/api/internalExtensions.scala
@@ -20,7 +20,7 @@ import collection.JavaConverters._
 import org.jetbrains.dokka.model.doc.DocumentationNode
 import org.jetbrains.dokka.model.properties._
 
-private [model] case class MemberExtension(
+case class MemberExtension(
   visibility: Visibility,
   modifiers: Seq[dotty.dokka.model.api.Modifier],
   kind: Kind,
@@ -40,7 +40,8 @@ case class CompositeMemberExtension(
   members : Seq[Member] = Nil,
   directParents: Seq[Signature] = Nil,
   parents: Seq[LinkToType] = Nil,
-  knownChildren: Seq[LinkToType] = Nil
+  knownChildren: Seq[LinkToType] = Nil,
+  companion: Option[DRI] = None,
 ) extends ExtraProperty[Documentable]:
   override def getKey = CompositeMemberExtension
 

--- a/scala3doc/src/dotty/dokka/model/extras.scala
+++ b/scala3doc/src/dotty/dokka/model/extras.scala
@@ -13,26 +13,3 @@ case class ModuleExtension(driMap: Map[DRI, Member]) extends ExtraProperty[DModu
   override def getKey = ModuleExtension
 
 object ModuleExtension extends BaseKey[DModule, ModuleExtension]
-
-case class MethodExtension(parametersListSizes: Seq[Int]) extends ExtraProperty[DFunction]:
-  override def getKey = MethodExtension
-
-object MethodExtension extends BaseKey[DFunction, MethodExtension]
-
-case class ParameterExtension(isExtendedSymbol: Boolean, isGrouped: Boolean) extends ExtraProperty[DParameter]:
-  override def getKey = ParameterExtension
-
-object ParameterExtension extends BaseKey[DParameter, ParameterExtension]
-
-case class ClasslikeExtension(
-  constructor: Option[DFunction], // will be replaced by signature
-  companion: Option[DRI], // moved to kind?
-) extends ExtraProperty[DClasslike]:
-  override def getKey = ClasslikeExtension
-
-object ClasslikeExtension extends BaseKey[DClasslike, ClasslikeExtension]
-
-case class IsInherited(flag: Boolean) extends ExtraProperty[Documentable]:
-  override def getKey = IsInherited
-
-object IsInherited extends BaseKey[Documentable, IsInherited]

--- a/scala3doc/src/dotty/dokka/model/scalaModel.scala
+++ b/scala3doc/src/dotty/dokka/model/scalaModel.scala
@@ -8,6 +8,7 @@ import org.jetbrains.dokka.model.properties._
 import org.jetbrains.dokka.pages._
 import dotty.dokka.model.api.Signature
 import dotty.dokka.model.api.HierarchyGraph
+import dotty.dokka.model.api.Member
 
 enum TableStyle extends org.jetbrains.dokka.pages.Style:
   case Borderless
@@ -30,15 +31,15 @@ case class HtmlContentNode(
   override def getExtra = extra
   override def withNewExtras(p: PropertyContainer[ContentNode]) = copy(extra = p)
 
-class ScalaTagWrapper(root: DocTag) extends TagWrapper(null):
+class ScalaTagWrapper(root: DocTag, val name: String) extends TagWrapper(null):
   override def getRoot = root
 
 object ScalaTagWrapper {
 
-  case class See(root: DocTag) extends ScalaTagWrapper(root)
-  case class Todo(root: DocTag) extends ScalaTagWrapper(root)
-  case class Note(root: DocTag) extends ScalaTagWrapper(root)
-  case class Example(root: DocTag) extends ScalaTagWrapper(root)
+  case class See(root: DocTag) extends ScalaTagWrapper(root, "See")
+  case class Todo(root: DocTag) extends ScalaTagWrapper(root, "Todo")
+  case class Note(root: DocTag) extends ScalaTagWrapper(root, "Note")
+  case class Example(root: DocTag) extends ScalaTagWrapper(root, "Example")
   case class NestedNamedTag(
     name: String,
     subname: String,
@@ -101,7 +102,8 @@ case class DocumentableElement(
   brief: Seq[ContentNode],
   originInfo: Signature,
   attributes: Map[String, String],
-  params: ContentNodeParams
+  params: ContentNodeParams,
+  member: Member
 ) extends ScalaContentNode(params):
   override def newInstance(params: ContentNodeParams) = copy(params = params)
 
@@ -125,3 +127,7 @@ case class DocumentableList(
 
 case class DocumentableFilter(params: ContentNodeParams) extends ScalaContentNode(params):
   override def newInstance(params: ContentNodeParams) = copy(params = params)
+
+case class MemberInfo(member: Member, params: ContentNodeParams)
+  extends ScalaContentNode(params):
+    override def newInstance(params: ContentNodeParams) = copy(params = params)

--- a/scala3doc/src/dotty/dokka/preprocessors/ScalaPackageListCreator.scala
+++ b/scala3doc/src/dotty/dokka/preprocessors/ScalaPackageListCreator.scala
@@ -1,0 +1,38 @@
+package dotty.dokka
+
+import org.jetbrains.dokka.transformers.pages.{PageTransformer}
+import org.jetbrains.dokka.base.renderers._
+import org.jetbrains.dokka.base.resolvers.local._
+import org.jetbrains.dokka.base.resolvers.shared._
+import org.jetbrains.dokka.base._
+import org.jetbrains.dokka.links._
+import org.jetbrains.dokka.pages._
+import org.jetbrains.dokka.plugability._
+import collection.JavaConverters._
+
+class ScalaPackageListCreator(
+  context: DokkaContext,
+  format: LinkFormat,
+  outputFileNames: List[String] = List("package-list"),
+  removeModulePrefix: Boolean = true
+) extends PageTransformer:
+  override def invoke(input: RootPageNode) = {
+    input.modified(input.getName, (input.getChildren.asScala ++ packageList(input)).asJava)
+  }
+
+  private def processPage(page: PageNode, input: RootPageNode): PageNode = page
+
+  private def packageList(rootPageNode: RootPageNode): List[RendererSpecificPage] = {
+    val content = ScalaPackageListService(context, rootPageNode).createPackageList(
+      format.getFormatName,
+      format.getLinkExtension
+    )
+    outputFileNames.map( name => {
+      RendererSpecificResourcePage(
+          s"${rootPageNode.getName}/${name}",
+          JList(),
+          RenderingStrategy.Write(content)
+      )
+    }
+    )
+  }

--- a/scala3doc/src/dotty/dokka/site/SitePagesCreator.scala
+++ b/scala3doc/src/dotty/dokka/site/SitePagesCreator.scala
@@ -10,6 +10,8 @@ import org.jetbrains.dokka.pages._
 
 import scala.collection.JavaConverters._
 
+import dotty.dokka.model.api._
+
 class SitePagesCreator(using ctx: DocContext) extends BaseStaticSiteProcessor:
   private def mkRootPage(input: RootPageNode, children: List[PageNode]): AContentPage =
     input match
@@ -44,7 +46,7 @@ class SitePagesCreator(using ctx: DocContext) extends BaseStaticSiteProcessor:
       val msg = s"ERROR: Multiple index pages for doc found ${indexes.map(_.template.file)}"
       report.error(msg)
 
-    def emptyContent = ctx.asContent(Text(), mkDRI(extra = "root_content")).get(0)
+    def emptyContent = ctx.asContent(Text(), DRI(extra = "root_content")).get(0)
 
     val root = ctx.indexPage().toList.map(_.copy(getDri = JSet(docsRootDRI)))
     val docsRoot = AContentPage(

--- a/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
@@ -17,8 +17,7 @@ import org.jetbrains.dokka.plugability.DokkaContext
 import org.jetbrains.dokka.pages.Style
 import org.jetbrains.dokka.model.DisplaySourceSet
 import util.Try
-
-import scala.collection.JavaConverters._
+import collection.JavaConverters._
 
 import dotty.dokka.model.api._
 
@@ -168,7 +167,8 @@ class StaticSiteContext(
     }.toOption
     pathsDri.getOrElse(memberLinkResolver(link).toList)
 
-  def driFor(dest: Path): DRI = DRI(location = s"_.${root.toPath.relativize(dest)}")
+  def driFor(dest: Path): DRI =
+    DRI(location = root.toPath.relativize(dest).iterator.asScala.mkString("."))
 
   def relativePath(myTemplate: LoadedTemplate) = root.toPath.relativize(myTemplate.file.toPath)
 

--- a/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
+++ b/scala3doc/src/dotty/dokka/site/StaticSiteContext.scala
@@ -20,6 +20,8 @@ import util.Try
 
 import scala.collection.JavaConverters._
 
+import dotty.dokka.model.api._
+
 class StaticSiteContext(
   val root: File,
   sourceSets: Set[SourceSetWrapper],
@@ -166,7 +168,7 @@ class StaticSiteContext(
     }.toOption
     pathsDri.getOrElse(memberLinkResolver(link).toList)
 
-  def driFor(dest: Path): DRI = mkDRI(s"_.${root.toPath.relativize(dest)}")
+  def driFor(dest: Path): DRI = DRI(location = s"_.${root.toPath.relativize(dest)}")
 
   def relativePath(myTemplate: LoadedTemplate) = root.toPath.relativize(myTemplate.file.toPath)
 

--- a/scala3doc/src/dotty/dokka/site/common.scala
+++ b/scala3doc/src/dotty/dokka/site/common.scala
@@ -23,8 +23,8 @@ import org.jetbrains.dokka.pages._
 
 import scala.collection.JavaConverters._
 
-val docsRootDRI: DRI = DRI(location = "_.index.md")
-val docsDRI: DRI = DRI(location = "_.docs/index.md")
+val docsRootDRI: DRI = DRI(location = "index.md")
+val docsDRI: DRI = DRI(location = "docs.index.md")
 val apiPageDRI: DRI = DRI(location = "api", extra = "__api__")
 
 val defaultMarkdownOptions: DataHolder =

--- a/scala3doc/src/dotty/dokka/site/common.scala
+++ b/scala3doc/src/dotty/dokka/site/common.scala
@@ -3,6 +3,7 @@ package site
 
 import java.io.File
 import java.nio.file.Files
+import dotty.dokka.model.api._
 
 import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension
@@ -22,9 +23,9 @@ import org.jetbrains.dokka.pages._
 
 import scala.collection.JavaConverters._
 
-val docsRootDRI: DRI = mkDRI("_.index.md")
-val docsDRI: DRI = mkDRI("_.docs/index.md")
-val apiPageDRI: DRI = mkDRI(packageName = "api", extra = "__api__")
+val docsRootDRI: DRI = DRI(location = "_.index.md")
+val docsDRI: DRI = DRI(location = "_.docs/index.md")
+val apiPageDRI: DRI = DRI(location = "api", extra = "__api__")
 
 val defaultMarkdownOptions: DataHolder =
   new MutableDataSet()

--- a/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
@@ -41,6 +41,8 @@ trait BasicSupport:
       case None =>
           Map.empty
 
+    def documentation2 = sym.docstring.map(preparseComment(_, sym.tree))
+
     def source =
       val path = Some(sym.pos.get.sourceFile.jpath).filter(_ != null).map(_.toAbsolutePath).map(_.toString)
       path.map(TastyDocumentableSource(_, sym.pos.get.startLine))

--- a/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/BasicSupport.scala
@@ -48,4 +48,6 @@ trait BasicSupport:
     def getAnnotations(): List[Annotation] =
       sym.annotations.filterNot(_.symbol.packageName.startsWith("scala.annotation.internal")).map(parseAnnotation).reverse
 
+    def isLeftAssoc: Boolean = !sym.name.endsWith(":")
+
 

--- a/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -1,6 +1,6 @@
 package dotty.dokka.tasty
 
-import org.jetbrains.dokka.model.{TypeConstructor => DTypeConstructor, _}
+import org.jetbrains.dokka.model.{TypeConstructor => DTypeConstructor, TypeParameter => _, _}
 import org.jetbrains.dokka.model.doc._
 import org.jetbrains.dokka.DokkaConfiguration$DokkaSourceSet
 import collection.JavaConverters._
@@ -20,82 +20,94 @@ trait ClassLikeSupport:
   private val placeholderVisibility = JMap(ctx.sourceSet -> KotlinVisibility.Public.INSTANCE)
   private val placeholderModifier = JMap(ctx.sourceSet -> KotlinModifier.Empty.INSTANCE)
 
-  private def kindForClasslike(sym: Symbol): Kind =
-        if sym.flags.is(Flags.Module) then Kind.Object
-        else if sym.flags.is(Flags.Trait) then Kind.Trait
-        else if sym.flags.is(Flags.Enum) then Kind.Enum
-        else Kind.Class
+  private def bareClasslikeKind(symbol: Symbol): Kind =
+     if symbol.flags.is(Flags.Module) then Kind.Object
+        else if symbol.flags.is(Flags.Trait) then  Kind.Trait(Nil, Nil)
+        else if symbol.flags.is(Flags.Enum) then Kind.Enum
+        else Kind.Class(Nil, Nil)
 
-  object DClass:
-    def apply[T >: DClass](classDef: ClassDef)(
-      dri: DRI = classDef.symbol.dri,
-      name: String = classDef.symbol.normalizedName,
-      signatureOnly: Boolean = false,
-      modifiers: Seq[Modifier] = classDef.symbol.getExtraModifiers(),
-    ): DClass =
+  private def kindForClasslike(classDef: ClassDef): Kind =
+        def typeArgs = classDef.getTypeParams.map(mkTypeArgument)
 
-      // This Try is here because of problem that code compiles, but at runtime fails claiming
-      // java.lang.ClassCastException: class dotty.tools.dotc.ast.Trees$DefDef cannot be cast to class dotty.tools.dotc.ast.Trees$TypeDef (dotty.tools.dotc.ast.Trees$DefDef and dotty.tools.dotc.ast.Trees$TypeDef are in unnamed module of loader 'app')
-      // It is probably bug in Tasty
-      def hackGetParents(classDef: ClassDef): Option[List[Tree]] = scala.util.Try(classDef.parents).toOption
+        def parameterModifier(parameter: Symbol): String =
+          val fieldSymbol = classDef.symbol.field(parameter.normalizedName)
+          def isVal = fieldSymbol.flags.is(Flags.ParamAccessor) &&
+            !classDef.symbol.flags.is(Flags.Case) &&
+            !fieldSymbol.flags.is(Flags.Private)
 
-      def getSupertypesGraph(classDef: ClassDef, link: LinkToType): Seq[(LinkToType, LinkToType)] =
-        val smbl = classDef.symbol
-        val parents = if smbl.exists then hackGetParents(smbl.tree.asInstanceOf[ClassDef]) else None
-        parents.fold(Seq())(_.flatMap { case tree =>
-            val symbol = if tree.symbol.isClassConstructor then tree.symbol.owner else tree.symbol
-            val superLink = LinkToType(tree.dokkaType.asSignature, symbol.dri, kindForClasslike(symbol))
-            Seq(link -> superLink) ++ getSupertypesGraph(tree.asInstanceOf[ClassDef], superLink)
-          }
+          if fieldSymbol.flags.is(Flags.Mutable) then "var "
+          else if isVal then "val "
+          else ""
+
+        def args = if constructorWithoutParamLists(classDef) then Nil else
+          val constr =
+            Some(classDef.constructor.symbol)
+              .filter(s => s.exists && !s.isHiddenByVisibility)
+              .map( _.tree.asInstanceOf[DefDef])
+          constr.fold(Nil)(
+            _.paramss.map(_.map(mkParameter(_, parameterModifier)))
+            )
+
+        if classDef.symbol.flags.is(Flags.Module) then Kind.Object
+        else if classDef.symbol.flags.is(Flags.Trait) then
+          Kind.Trait(typeArgs, args)
+        else if classDef.symbol.flags.is(Flags.Enum) then Kind.Enum
+        else Kind.Class(typeArgs, args)
+
+  def mkClass[T >: DClass](classDef: ClassDef)(
+    dri: DRI = classDef.symbol.dri,
+    name: String = classDef.symbol.normalizedName,
+    signatureOnly: Boolean = false,
+    modifiers: Seq[Modifier] = classDef.symbol.getExtraModifiers(),
+  ): Member =
+
+    // This Try is here because of problem that code compiles, but at runtime fails claiming
+    // java.lang.ClassCastException: class dotty.tools.dotc.ast.Trees$DefDef cannot be cast to class dotty.tools.dotc.ast.Trees$TypeDef (dotty.tools.dotc.ast.Trees$DefDef and dotty.tools.dotc.ast.Trees$TypeDef are in unnamed module of loader 'app')
+    // It is probably bug in Tasty
+    def hackGetParents(classDef: ClassDef): Option[List[Tree]] = scala.util.Try(classDef.parents).toOption
+
+    def getSupertypesGraph(classDef: ClassDef, link: LinkToType): Seq[(LinkToType, LinkToType)] =
+      val smbl = classDef.symbol
+      val parents = if smbl.exists then hackGetParents(smbl.tree.asInstanceOf[ClassDef]) else None
+      parents.fold(Seq())(_.flatMap { case tree =>
+          val symbol = if tree.symbol.isClassConstructor then tree.symbol.owner else tree.symbol
+          val superLink = LinkToType(tree.dokkaType.asSignature, symbol.dri, bareClasslikeKind(symbol))
+          Seq(link -> superLink) ++ getSupertypesGraph(tree.asInstanceOf[ClassDef], superLink)
+        }
+      )
+
+    val supertypes = getSupertypes(using qctx)(classDef).map {
+      case (symbol, tpe) =>
+        LinkToType(tpe.dokkaType.asSignature, symbol.dri, bareClasslikeKind(symbol))
+    }
+    val selfSiangture: DSignature = typeForClass(classDef).dokkaType.asSignature
+
+    val graph = HierarchyGraph.withEdges(getSupertypesGraph(classDef,
+      LinkToType(selfSiangture, classDef.symbol.dri, bareClasslikeKind(classDef.symbol))))
+
+    val compositeExt =
+      if signatureOnly then CompositeMemberExtension.empty
+      else CompositeMemberExtension(
+          classDef.extractPatchedMembers,
+          classDef.getParents.map(_.dokkaType.asSignature),
+          supertypes,
+          Nil,
+          classDef.getCompanion
         )
 
-      val supertypes = getSupertypes(using qctx)(classDef).map {
-        case (symbol, tpe) => LinkToType(tpe.dokkaType.asSignature, symbol.dri, kindForClasslike(symbol))
-      }
-      val selfSiangture: DSignature = typeForClass(classDef).dokkaType.asSignature
-
-      val graph = HierarchyGraph.withEdges(getSupertypesGraph(classDef, LinkToType(selfSiangture, classDef.symbol.dri, kindForClasslike(classDef.symbol))))
-      val baseExtra = PropertyContainer.Companion.empty()
-            .plus(ClasslikeExtension(classDef.getConstructorMethod(), classDef.getCompanion))
-            .plus(MemberExtension(
-              classDef.symbol.getVisibility(),
-              modifiers,
-              kindForClasslike( classDef.symbol),
-              classDef.symbol.getAnnotations(),
-              selfSiangture,
-              classDef.symbol.source,
-              graph = graph
-            ))
-
-      val fullExtra =
-        if (signatureOnly) baseExtra
-        else
-          baseExtra.plus(CompositeMemberExtension(
-            classDef.extractPatchedMembers,
-            classDef.getParents.map(_.dokkaType.asSignature),
-            supertypes,
-            Nil))
-        end if
-
-      new DClass(
-          dri,
-          name,
-          (if(signatureOnly) Nil else classDef.getConstructors.map(parseMethod(_))).asJava,
-          JList(),
-          JList(),
-          JList(),
-          JMap(),
-          placeholderVisibility,
-          null,
-          /*generics =*/classDef.getTypeParams.map(parseTypeArgument).asJava,
-          Map.empty.asJava,
-          classDef.symbol.documentation.asJava,
-          null,
-          placeholderModifier,
-          ctx.sourceSet.toSet,
-          /*isExpectActual =*/ false,
-          fullExtra.asInstanceOf[PropertyContainer[DClass]]
-      )
+    mkMember(
+      classDef.symbol,
+      MemberExtension(
+          classDef.symbol.getVisibility(),
+          modifiers,
+          kindForClasslike(classDef),
+          classDef.symbol.getAnnotations(),
+          selfSiangture,
+          classDef.symbol.source,
+          graph = graph
+        ),
+        compositeExt
+    )
 
   private val conversionSymbol = Symbol.requiredClass("scala.Conversion")
 
@@ -107,8 +119,11 @@ trait ClassLikeSupport:
           None
       else None
 
+  private def isDocumentableExtension(s: Symbol) =
+    !s.isHiddenByVisibility && !s.isSyntheticFunc && s.isExtensionMethod
+
   private def parseMember(s: Tree): Option[Member] = processTreeOpt(s)(s match
-      case dd: DefDef if !dd.symbol.isHiddenByVisibility && !dd.symbol.isSyntheticFunc && dd.symbol.isExtensionMethod =>
+      case dd: DefDef if isDocumentableExtension(dd.symbol) =>
         dd.symbol.extendedSymbol.map { extSym =>
           val target = ExtensionTarget(
             extSym.symbol.normalizedName,
@@ -116,14 +131,16 @@ trait ClassLikeSupport:
             extSym.tpt.symbol.dri,
             extSym.symbol.pos.get.start
           )
-          parseMethod(dd.symbol, kind = Kind.Extension(target))
+          parseMethod(dd.symbol,specificKind = Kind.Extension(target, _))
         }
       // TODO check given methods?
       case dd: DefDef if !dd.symbol.isHiddenByVisibility && dd.symbol.isGiven =>
         Some(dd.symbol.owner.memberType(dd.name))
           .filterNot(_.exists)
           .map { _ =>
-            parseMethod(dd.symbol, kind = Kind.Given(getGivenInstance(dd).map(_.asSignature), None))
+            parseMethod(dd.symbol, specificKind =
+              Kind.Given(_, getGivenInstance(dd).map(_.asSignature), None)
+            )
           }
 
       case dd: DefDef if !dd.symbol.isHiddenByVisibility && dd.symbol.isExported =>
@@ -139,7 +156,9 @@ trait ClassLikeSupport:
         val dri = dd.rhs.collect {
           case s: Select if s.symbol.isDefDef => s.symbol.dri
         }.orElse(exportedTarget.map(_.qualifier.tpe.typeSymbol.dri))
-        Some(parseMethod(dd.symbol, kind = Kind.Exported).withOrigin(Origin.ExportedFrom(s"$instanceName.$functionName", dri)))
+
+        Some(parseMethod(dd.symbol, specificKind = Kind.Exported(_))
+          .withOrigin(Origin.ExportedFrom(s"$instanceName.$functionName", dri)))
 
       case dd: DefDef if !dd.symbol.isHiddenByVisibility && !dd.symbol.isGiven && !dd.symbol.isSyntheticFunc && !dd.symbol.isExtensionMethod =>
         Some(parseMethod(dd.symbol))
@@ -167,19 +186,24 @@ trait ClassLikeSupport:
 
   private def parseGivenClasslike(c: ClassDef): Member = {
     val parsedClasslike = parseClasslike(c)
+
     val parentTpe = c.parents(0) match {
       case t: TypeTree => Some(t.tpe)
       case t: Term => Some(t.tpe)
       case _ => None
     }
-    val modifiedClasslikeExtension = ClasslikeExtension.getFrom(parsedClasslike).map(_.copy(
-        constructor = c.getConstructorMethod(Some(_ => "using "))
-      )
-    ).get
-    parsedClasslike.withNewExtras(
-      parsedClasslike.getExtra.plus(modifiedClasslikeExtension)
-    ).withKind(
-      Kind.Given(parsedClasslike.directParents.headOption, parentTpe.flatMap(extractImplicitConversion))
+
+    val givenParents = parsedClasslike.directParents.headOption
+    val cls: Kind.Class = parsedClasslike.kind match
+      case Kind.Object => Kind.Class(Nil, Nil)
+      case Kind.Trait(tps, args) => Kind.Class(tps, args)
+      case cls: Kind.Class => cls
+      case other =>
+        report.warning("Unrecoginzed kind for given: $other", c.pos)
+        Kind.Class(Nil, Nil)
+
+    parsedClasslike.withKind(
+      Kind.Given(cls, givenParents, parentTpe.flatMap(extractImplicitConversion))
     )
   }
 
@@ -248,32 +272,28 @@ trait ClassLikeSupport:
       else if fieldSymbol.flags.is(Flags.ParamAccessor) && !c.symbol.flags.is(Flags.Case) && !fieldSymbol.flags.is(Flags.Private) then "val "
       else ""
 
-    def getTypeParams: List[TypeDef] = c.body.collect { case targ: TypeDef => targ  }.filter(_.symbol.isTypeParam)
+    def getTypeParams: List[TypeDef] =
+      c.body.collect { case targ: TypeDef => targ  }.filter(_.symbol.isTypeParam)
 
     def getCompanion: Option[DRI] = c.symbol.getCompanionSymbol
       .filter(!_.flags.is(Flags.Synthetic))
       .filterNot(_.isHiddenByVisibility)
       .map(_.dri)
 
-    def getConstructorMethod(paramModifierFunc: Option[Symbol => String] = None): Option[DFunction] =
-      Some(c.constructor.symbol).filter(_.exists).filterNot(_.isHiddenByVisibility).map( d =>
-        parseMethod(d, constructorWithoutParamLists(c), paramModifierFunc.getOrElse(s => c.getParameterModifier(s)))
-      )
 
-  def parseClasslike(classDef: ClassDef, signatureOnly: Boolean = false): DClass = classDef match
+  def parseClasslike(classDef: ClassDef, signatureOnly: Boolean = false): Member = classDef match
     case c: ClassDef if classDef.symbol.flags.is(Flags.Module) => parseObject(c, signatureOnly)
     case c: ClassDef if classDef.symbol.flags.is(Flags.Enum) => parseEnum(c, signatureOnly)
-    case clazz => DClass(classDef)(signatureOnly = signatureOnly)
+    case clazz => mkClass(classDef)(signatureOnly = signatureOnly)
 
-  def parseObject(classDef: ClassDef, signatureOnly: Boolean = false): DClass =
-    DClass(classDef)(
-      // All objects are final so we do not need final modifer!
+  def parseObject(classDef: ClassDef, signatureOnly: Boolean = false): Member =
+    mkClass(classDef)(
+      // All objects are final so we do not need final modifier!
       modifiers = classDef.symbol.getExtraModifiers().filter(_ != Modifier.Final),
       signatureOnly = signatureOnly
     )
 
-    // TODO check withNewExtras?
-  def parseEnum(classDef: ClassDef, signatureOnly: Boolean = false): DClass =
+  def parseEnum(classDef: ClassDef, signatureOnly: Boolean = false): Member =
     val extraModifiers = classDef.symbol.getExtraModifiers().filter(_ != Modifier.Sealed).filter(_ != Modifier.Abstract)
     val companion = classDef.symbol.getCompanionSymbol.map(_.tree.asInstanceOf[ClassDef]).get
 
@@ -289,165 +309,159 @@ trait ClassLikeSupport:
       case c: ClassDef if c.symbol.flags.is(Flags.Case) && c.symbol.flags.is(Flags.Enum) => processTree(c)(parseClasslike(c))
     }.flatten
 
-    val classlikie = DClass(classDef)(modifiers = extraModifiers, signatureOnly = signatureOnly)
-    classlikie.withNewMembers((enumVals ++ enumTypes ++ enumNested).map(_.withKind(Kind.EnumCase))).asInstanceOf[DClass]
+    val classlikie = mkClass(classDef)(modifiers = extraModifiers, signatureOnly = signatureOnly)
+    val cases =
+      enumNested.map(_.withKind(Kind.EnumCase(Kind.Object))) ++
+      enumTypes.map(et => et.withKind(Kind.EnumCase(et.kind.asInstanceOf[Kind.Type]))) ++
+      enumVals.map(_.withKind(Kind.EnumCase(Kind.Val)))
+
+    classlikie.withNewMembers(cases).asInstanceOf[DClass]
 
   def parseMethod(
       methodSymbol: Symbol,
       emptyParamsList: Boolean = false,
       paramPrefix: Symbol => String = _ => "",
-      kind: Kind = Kind.Def
-    ): DFunction =
+      specificKind: (Kind.Def => Kind) = identity
+    ): Member =
     val method = methodSymbol.tree.asInstanceOf[DefDef]
-    val paramLists = if emptyParamsList then Nil else method.paramss
+    val paramLists =
+      if emptyParamsList then Nil
+      else if methodSymbol.isExtensionMethod then
+        val params = method.paramss
+        if methodSymbol.isLeftAssoc || params.size == 1 then params.tail
+        else params.head :: params.tail.drop(1)
+      else method.paramss
     val genericTypes = if (methodSymbol.isClassConstructor) Nil else method.typeParams
 
+    val basicKind: Kind.Def = Kind.Def(
+      genericTypes.map(mkTypeArgument),
+      paramLists.map(_.map(mkParameter(_, paramPrefix)))
+    )
+
     val methodKind =
-      if methodSymbol.isClassConstructor then Kind.Constructor
+      if methodSymbol.isClassConstructor then Kind.Constructor(basicKind)
       else if methodSymbol.flags.is(Flags.Implicit) then extractImplicitConversion(method.returnTpt.tpe) match
         case Some(conversion) if paramLists.size == 0 || (paramLists.size == 1 && paramLists.head.size == 0) =>
-          Kind.Implicit(Kind.Def, Some(conversion))
+          Kind.Implicit(basicKind, Some(conversion))
         case None if paramLists.size == 1 && paramLists(0).size == 1 =>
-          Kind.Implicit(Kind.Def, Some(
+          Kind.Implicit(basicKind, Some(
             ImplicitConversion(
               paramLists(0)(0).tpt.tpe.typeSymbol.dri,
               method.returnTpt.tpe.typeSymbol.dri
             )
           ))
         case _ =>
-          Kind.Implicit(Kind.Def, None)
-      else kind
+          Kind.Implicit(basicKind, None)
+      else specificKind(basicKind)
 
-    val name = method.symbol.normalizedName
+    val origin = if !methodSymbol.isOverriden then Origin.RegularlyDefined else
+      val overridenSyms = methodSymbol.allOverriddenSymbols.map(_.owner)
+      Origin.Overrides(overridenSyms.map(s => Overriden(s.name, s.dri)).toSeq)
 
-    val memberExtension = MemberExtension(
-      methodSymbol.getVisibility(),
-      methodSymbol.getExtraModifiers(),
-      methodKind,
-      methodSymbol.getAnnotations(),
-      method.returnTpt.dokkaType.asSignature,
-      methodSymbol.source
+    mkMember(
+      method.symbol,
+      MemberExtension(
+        methodSymbol.getVisibility(),
+        methodSymbol.getExtraModifiers(),
+        methodKind,
+        methodSymbol.getAnnotations(),
+        method.returnTpt.dokkaType.asSignature,
+        methodSymbol.source,
+        origin
+      )
     )
 
-    val memberExtensionWithOrigin = 
-      if methodSymbol.isOverriden then memberExtension.copy(
-        origin = Origin.Overrides(methodSymbol.allOverriddenSymbols.map(_.owner).map(s => Overriden(s.name, s.dri)).toSeq)
-      ) else memberExtension
+  def mkParameter(argument: ValDef,
+    prefix: Symbol => String = _ => "",
+    isExtendedSymbol: Boolean = false,
+    isGrouped: Boolean = false) =
+      val inlinePrefix = if argument.symbol.flags.is(Flags.Inline) then "inline " else ""
+      // TODO (https://github.com/lampepfl/dotty/issues/10525): Add using flag
 
-    new DFunction(
-      methodSymbol.dri,
-      name,
-      /*isConstructor =*/ methodSymbol.isClassConstructor,
-      /*parameters =*/ paramLists.flatten.map(parseArgument(_, paramPrefix)).asJava, // TODO add support for parameters
-      /*documentation =*/ methodSymbol.documentation.asJava,
-      /*expectPresentInSet =*/ null, // unused
-      /*sources =*/ JMap(),
-      /*visibility =*/ placeholderVisibility,
-      /*type =*/ method.returnTpt.dokkaType,
-      /*generics =*/ genericTypes.map(parseTypeArgument).asJava,
-      /*receiver =*/ null, // Not used
-      /*modifier =*/ placeholderModifier,
-      ctx.sourceSet.toSet,
-       /*isExpectActual =*/ false,
-      PropertyContainer.Companion.empty()
-        plus MethodExtension(paramLists.map(_.size))
-        plus(memberExtensionWithOrigin)
-    )
+      Parameter(
+        argument.symbol.getAnnotations(),
+        inlinePrefix + prefix(argument.symbol),
+        argument.symbol.normalizedName,
+        argument.symbol.dri,
+        argument.tpt.dokkaType.asSignature,
+        isExtendedSymbol,
+        isGrouped
+      )
 
-  def parseArgument(argument: ValDef, prefix: Symbol => String, isExtendedSymbol: Boolean = false, isGrouped: Boolean = false): DParameter =
-    new DParameter(
-      argument.symbol.dri,
-      prefix(argument.symbol) + argument.symbol.normalizedName,
-      argument.symbol.documentation.asJava,
-      null,
-      argument.tpt.dokkaType,
-      ctx.sourceSet.toSet,
-      PropertyContainer.Companion.empty()
-        .plus(ParameterExtension(isExtendedSymbol, isGrouped))
-        .plus(MemberExtension.empty.copy(annotations = argument.symbol.getAnnotations()))
-    )
-
-  def parseTypeArgument(argument: TypeDef): DTypeParameter =
-    // Not sure if we should have such hacks...
-    val variancePrefix =
+  def mkTypeArgument(argument: TypeDef): TypeParameter =
+    val variancePrefix: "+" | "-" | "" =
       if  argument.symbol.flags.is(Flags.Covariant) then "+"
       else if argument.symbol.flags.is(Flags.Contravariant) then "-"
       else ""
 
-    new DTypeParameter(
-      Invariance(TypeParameter(argument.symbol.dri, variancePrefix + argument.symbol.normalizedName, null)),
-      argument.symbol.documentation.asJava,
-      null,
-      JList(argument.rhs.dokkaType),
-      ctx.sourceSet.toSet,
-      PropertyContainer.Companion.empty()
+    TypeParameter(
+      variancePrefix,
+      argument.symbol.normalizedName,
+      argument.symbol.dri,
+      argument.rhs.dokkaType.asSignature
     )
 
-  def parseTypeDef(typeDef: TypeDef): DProperty =
-
+  def parseTypeDef(typeDef: TypeDef): Member =
     def isTreeAbstract(typ: Tree): Boolean = typ match {
       case TypeBoundsTree(_, _) => true
       case LambdaTypeTree(params, body) => isTreeAbstract(body)
       case _ => false
     }
 
-
     val (generics, tpeTree) = typeDef.rhs match
-      case LambdaTypeTree(params, body) => (params.map(parseTypeArgument), body)
+      case LambdaTypeTree(params, body) => (params.map(mkTypeArgument), body)
       case tpe => (Nil, tpe)
 
-    new DProperty(
-      typeDef.symbol.dri,
-      typeDef.symbol.normalizedName,
-      /*documentation =*/ typeDef.symbol.documentation.asJava,
-      /*expectPresentInSet =*/ null, // unused
-      /*sources =*/ JMap(),
-      /*visibility =*/ placeholderVisibility,
-      /*type =*/ tpeTree.dokkaType, // TODO this may be hard...
-      /*receiver =*/ null, // Not used
-      /*setter =*/ null,
-      /*getter =*/ null,
-      /*modifier =*/ placeholderModifier,
-      ctx.sourceSet.toSet,
-      /*generics =*/ generics.asJava, // TODO
-       /*isExpectActual =*/ false,
-      PropertyContainer.Companion.empty() plus MemberExtension(
+    mkMember(
+      typeDef.symbol,
+      MemberExtension(
         typeDef.symbol.getVisibility(),
         typeDef.symbol.getExtraModifiers(),
-        Kind.Type(!isTreeAbstract(typeDef.rhs), typeDef.symbol.isOpaque),
+        Kind.Type(!isTreeAbstract(typeDef.rhs), typeDef.symbol.isOpaque, generics),
         typeDef.symbol.getAnnotations(),
         tpeTree.dokkaType.asSignature,
         typeDef.symbol.source
         )
     )
 
-  def parseValDef(valDef: ValDef): DProperty =
+  def parseValDef(valDef: ValDef): Member =
     def defaultKind = if valDef.symbol.flags.is(Flags.Mutable) then Kind.Var else Kind.Val
     val kind = if valDef.symbol.flags.is(Flags.Implicit) then
         Kind.Implicit(Kind.Val, extractImplicitConversion(valDef.tpt.tpe))
         else defaultKind
 
-    new DProperty(
-      valDef.symbol.dri,
-      valDef.symbol.normalizedName,
-      /*documentation =*/ valDef.symbol.documentation.asJava,
-      /*expectPresentInSet =*/ null, // unused
-      /*sources =*/ JMap(),
-      /*visibility =*/ placeholderVisibility,
-      /*type =*/ valDef.tpt.dokkaType,
-      /*receiver =*/ null, // Not used
-      /*setter =*/ null,
-      /*getter =*/ null,
-      /*modifier =*/ placeholderModifier,
-      ctx.sourceSet.toSet,
-      /*generics =*/ JList(),
-       /*isExpectActual =*/ false,
-      PropertyContainer.Companion.empty().plus(MemberExtension(
+    mkMember(
+      valDef.symbol,
+      MemberExtension(
           valDef.symbol.getVisibility(),
           valDef.symbol.getExtraModifiers(),
           kind,
           valDef.symbol.getAnnotations(),
           valDef.tpt.tpe.dokkaType.asSignature,
           valDef.symbol.source
-      ))
+      )
+    )
+
+  def mkMember[T <: Kind](
+    symbol: Symbol,
+    member: MemberExtension,
+    compositeExt: CompositeMemberExtension = CompositeMemberExtension.empty): Member =
+      new DClass(
+        symbol.dri,
+        symbol.normalizedName,
+        JNil,
+        JNil,
+        JNil,
+        JNil,
+        emptyJMap,
+        placeholderVisibility,
+        null,
+        JNil,
+        emptyJMap,
+        symbol.documentation.asJava,
+        null,
+        placeholderModifier,
+        ctx.sourceSet.toSet,
+        /*isExpectActual =*/ false,
+        PropertyContainer.Companion.empty().plus(member).plus(compositeExt)
     )

--- a/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -30,7 +30,7 @@ trait ClassLikeSupport:
         def typeArgs = classDef.getTypeParams.map(mkTypeArgument)
 
         def parameterModifier(parameter: Symbol): String =
-          val fieldSymbol = classDef.symbol.field(parameter.normalizedName)
+          val fieldSymbol = classDef.symbol.declaredField(parameter.normalizedName)
           def isVal = fieldSymbol.flags.is(Flags.ParamAccessor) &&
             !classDef.symbol.flags.is(Flags.Case) &&
             !fieldSymbol.flags.is(Flags.Private)
@@ -458,10 +458,10 @@ trait ClassLikeSupport:
         null,
         JNil,
         emptyJMap,
-        symbol.documentation.asJava,
+        emptyJMap,
         null,
         placeholderModifier,
         ctx.sourceSet.toSet,
         /*isExpectActual =*/ false,
-        PropertyContainer.Companion.empty().plus(member).plus(compositeExt)
+        PropertyContainer.Companion.empty().plus(member.copy(rawDoc = symbol.documentation2)).plus(compositeExt)
     )

--- a/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ClassLikeSupport.scala
@@ -27,32 +27,32 @@ trait ClassLikeSupport:
         else Kind.Class(Nil, Nil)
 
   private def kindForClasslike(classDef: ClassDef): Kind =
-        def typeArgs = classDef.getTypeParams.map(mkTypeArgument)
+    def typeArgs = classDef.getTypeParams.map(mkTypeArgument)
 
-        def parameterModifier(parameter: Symbol): String =
-          val fieldSymbol = classDef.symbol.declaredField(parameter.normalizedName)
-          def isVal = fieldSymbol.flags.is(Flags.ParamAccessor) &&
-            !classDef.symbol.flags.is(Flags.Case) &&
-            !fieldSymbol.flags.is(Flags.Private)
+    def parameterModifier(parameter: Symbol): String =
+      val fieldSymbol = classDef.symbol.declaredField(parameter.normalizedName)
+      def isVal = fieldSymbol.flags.is(Flags.ParamAccessor) &&
+        !classDef.symbol.flags.is(Flags.Case) &&
+        !fieldSymbol.flags.is(Flags.Private)
 
-          if fieldSymbol.flags.is(Flags.Mutable) then "var "
-          else if isVal then "val "
-          else ""
+      if fieldSymbol.flags.is(Flags.Mutable) then "var "
+      else if isVal then "val "
+      else ""
 
-        def args = if constructorWithoutParamLists(classDef) then Nil else
-          val constr =
-            Some(classDef.constructor.symbol)
-              .filter(s => s.exists && !s.isHiddenByVisibility)
-              .map( _.tree.asInstanceOf[DefDef])
-          constr.fold(Nil)(
-            _.paramss.map(_.map(mkParameter(_, parameterModifier)))
-            )
+    def args = if constructorWithoutParamLists(classDef) then Nil else
+      val constr =
+        Some(classDef.constructor.symbol)
+          .filter(s => s.exists && !s.isHiddenByVisibility)
+          .map( _.tree.asInstanceOf[DefDef])
+      constr.fold(Nil)(
+        _.paramss.map(_.map(mkParameter(_, parameterModifier)))
+        )
 
-        if classDef.symbol.flags.is(Flags.Module) then Kind.Object
-        else if classDef.symbol.flags.is(Flags.Trait) then
-          Kind.Trait(typeArgs, args)
-        else if classDef.symbol.flags.is(Flags.Enum) then Kind.Enum
-        else Kind.Class(typeArgs, args)
+    if classDef.symbol.flags.is(Flags.Module) then Kind.Object
+    else if classDef.symbol.flags.is(Flags.Trait) then
+      Kind.Trait(typeArgs, args)
+    else if classDef.symbol.flags.is(Flags.Enum) then Kind.Enum
+    else Kind.Class(typeArgs, args)
 
   def mkClass[T >: DClass](classDef: ClassDef)(
     dri: DRI = classDef.symbol.dri,

--- a/scala3doc/src/dotty/dokka/tasty/PackageSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/PackageSupport.scala
@@ -34,7 +34,7 @@ trait PackageSupport:
         parseClasslike(pckObj) match {
           case clazz: DClass =>
             DPackage(
-              new DRI(pckObj.symbol.dri.getPackageName, null, null, PointingToDeclaration.INSTANCE, null),
+              new DRI(pckObj.symbol.packageName, null, null, PointingToDeclaration.INSTANCE, null),
               clazz.getFunctions,
               clazz.getProperties,
               JList(),

--- a/scala3doc/src/dotty/dokka/tasty/ScalaDocSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/ScalaDocSupport.scala
@@ -7,9 +7,49 @@ import org.jetbrains.dokka.model.{doc => dkkd}
 import dotty.dokka.Scala3doc.CommentSyntax
 import dotty.dokka.ScalaTagWrapper
 import comments.{kt, dkk}
+import dotty.dokka.tasty.comments.Comment
 
 trait ScaladocSupport { self: TastyParser =>
   import qctx.reflect._
+
+  def preparseComment(
+    docstring: String,
+    tree: Tree
+  ): Comment =
+    val commentString: String =
+      if tree.symbol.isClassDef || tree.symbol.owner.isClassDef then
+        import dotty.tools.dotc
+        given ctx: dotc.core.Contexts.Context = qctx.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+
+        val sym = tree.symbol.asInstanceOf[dotc.core.Symbols.Symbol]
+
+        comments.CommentExpander.cookComment(sym)(using ctx)
+          .get.expanded.get
+      else
+        docstring
+
+    val preparsed =
+      comments.Preparser.preparse(comments.Cleaner.clean(commentString))
+
+    val commentSyntax =
+      preparsed.syntax.headOption match {
+        case Some(commentSetting) =>
+          CommentSyntax.parse(commentSetting).getOrElse {
+            val msg = s"not a valid comment syntax: $commentSetting, defaulting to Markdown syntax."
+            // we should update pos with span from documentation
+            report.warning(msg, tree.pos)
+            CommentSyntax.default
+          }
+        case None => ctx.args.defaultSyntax
+      }
+
+    val parser = commentSyntax match {
+      case CommentSyntax.Wiki =>
+        comments.WikiCommentParser(comments.Repr(qctx)(tree.symbol))
+      case CommentSyntax.Markdown =>
+        comments.MarkdownCommentParser(comments.Repr(qctx)(tree.symbol))
+    }
+    parser.parse(preparsed)
 
   def parseComment(
     docstring: String,

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -111,6 +111,14 @@ class SymOps[Q <: Quotes](val q: Q):
           else if (sym.maybeOwner.isDefDef) Some(sym.owner)
           else None
 
+        val originPath = {
+            import q.reflect._
+            import dotty.tools.dotc
+            given ctx as dotc.core.Contexts.Context = q.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+            val csym = sym.asInstanceOf[dotc.core.Symbols.Symbol]
+            Option(csym.associatedFile).map(_.path).fold("")(p => s"[origin:$p]")
+        }
+
         new DRI(
           sym.packageName,
           sym.topLevelEntryName.orNull, // TODO do we need any of this fields?
@@ -118,5 +126,5 @@ class SymOps[Q <: Quotes](val q: Q):
           pointsTo,
           // sym.show returns the same signature for def << = 1 and def >> = 2.
           // For some reason it contains `$$$` instrad of symbol name
-          s"${sym.name}${sym.fullName}/${sym.signature.resultSig}/[${sym.signature.paramSigs.mkString("/")}]"
+          s"${sym.name}${sym.fullName}/${sym.signature.resultSig}/[${sym.signature.paramSigs.mkString("/")}]$originPath"
         )

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -14,7 +14,7 @@ class SymOps[Q <: Quotes](val q: Q):
   import q.reflect._
 
   given Q = q
-  extension (sym: Symbol):
+  extension (sym: Symbol)
     def packageName: String = (
       if (sym.isPackageDef) sym.fullName
       else sym.maybeOwner.packageName

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -114,7 +114,7 @@ class SymOps[Q <: Quotes](val q: Q):
         val originPath = {
             import q.reflect._
             import dotty.tools.dotc
-            given ctx as dotc.core.Contexts.Context = q.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+            given ctx: dotc.core.Contexts.Context = q.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
             val csym = sym.asInstanceOf[dotc.core.Symbols.Symbol]
             Option(csym.associatedFile).map(_.path).fold("")(p => s"[origin:$p]")
         }

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -128,8 +128,11 @@ class SymOps[Q <: Quotes](val q: Q):
             val csym = sym.asInstanceOf[dotc.core.Symbols.Symbol]
             Option(csym.associatedFile).map(_.path).fold("")(p => s"[origin:$p]")
         }
+        // We want package object to point to package
+        val className = sym.className.filter(_ != "package$")
+
         DRI(
-          sym.className.fold(sym.packageName)(cn => s"${sym.packageName}.${cn}"),
+          className.fold(sym.packageName)(cn => s"${sym.packageName}.${cn}"),
           sym.anchor.getOrElse(""), // TODO do we need any of this fields?
           null,
           pointsTo,

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -14,13 +14,23 @@ class SymOps[Q <: Quotes](val q: Q):
   import q.reflect._
 
   given Q = q
-  extension (sym: Symbol)
-    def packageName: String =
+  extension (sym: Symbol):
+    def packageName: String = (
       if (sym.isPackageDef) sym.fullName
       else sym.maybeOwner.packageName
+    )
 
-    def topLevelEntryName: Option[String] = if (sym.isPackageDef) None else
-      if (sym.owner.isPackageDef) Some(sym.name) else sym.owner.topLevelEntryName
+    def className: Option[String] =
+      if (sym.isClassDef && !sym.flags.is(Flags.Package)) Some(
+        Some(sym.maybeOwner).filter(s => s.exists).flatMap(_.className).fold("")(cn => cn + "$") + sym.name
+      )
+      else if (sym.isPackageDef) None
+      else sym.maybeOwner.className
+
+    def anchor: Option[String] =
+      if (!sym.isClassDef && !sym.isPackageDef) Some(sym.name)
+      else None
+    //TODO: Retrieve string that will match scaladoc anchors
 
     def getVisibility(): Visibility =
       import VisibilityScope._
@@ -118,11 +128,10 @@ class SymOps[Q <: Quotes](val q: Q):
             val csym = sym.asInstanceOf[dotc.core.Symbols.Symbol]
             Option(csym.associatedFile).map(_.path).fold("")(p => s"[origin:$p]")
         }
-
-        new DRI(
-          sym.packageName,
-          sym.topLevelEntryName.orNull, // TODO do we need any of this fields?
-          method.map(s => new org.jetbrains.dokka.links.Callable(s.name, null, JList())).orNull,
+        DRI(
+          sym.className.fold(sym.packageName)(cn => s"${sym.packageName}.${cn}"),
+          sym.anchor.getOrElse(""), // TODO do we need any of this fields?
+          null,
           pointsTo,
           // sym.show returns the same signature for def << = 1 and def >> = 2.
           // For some reason it contains `$$$` instrad of symbol name

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -91,10 +91,11 @@ class SymOps[Q <: Quotes](val q: Q):
     def isLeftAssoc(d: Symbol): Boolean = !d.name.endsWith(":")
 
     def extendedSymbol: Option[ValDef] =
-      Option.when(sym.isExtensionMethod)(
-        if(isLeftAssoc(sym)) sym.tree.asInstanceOf[DefDef].paramss(0)(0)
-        else sym.tree.asInstanceOf[DefDef].paramss(1)(0)
-      )
+      Option.when(sym.isExtensionMethod){
+        val params = sym.tree.asInstanceOf[DefDef].paramss
+        if isLeftAssoc(sym) || params.size == 1 then params(0)(0)
+        else params(1)(0)
+      }
 
     // TODO #22 make sure that DRIs are unique plus probably reuse semantic db code?
     def dri: DRI =

--- a/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
@@ -474,6 +474,8 @@ class ScalaPageContentBuilder(
 
     type Self = ScalaPageContentBuilder#ScalaDocumentableContentBuilder
 
+    def memberInfo(m: Member) = addChild(MemberInfo(m, asParams(m.dri)))
+
     def documentableTab(name: String)(children: DocumentableGroup*): Self =
       def buildSignature(d: Documentable) =
         ScalaSignatureProvider.rawSignature(d, InlineSignatureBuilder()).asInstanceOf[InlineSignatureBuilder]
@@ -507,7 +509,8 @@ class ScalaPageContentBuilder(
           docs.fold(Nil)(d => reset().rawComment(d.getRoot)),
           originInfo,
           FilterAttributes.attributesFor(documentable),
-          asParams(documentable.getDri)
+          asParams(documentable.getDri),
+          documentable
         )
 
       def element(e: Documentable | DocumentableSubGroup): DocumentableElement | DocumentableElementGroup = e match

--- a/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
@@ -346,7 +346,7 @@ class ScalaPageContentBuilder(
     } else this
 
     def list[T](
-      elements: List[T],
+      elements: Seq[T],
       prefix: String = "",
       suffix: String = "",
       separator: String = ", ",
@@ -487,7 +487,7 @@ class ScalaPageContentBuilder(
         val originInfo = documentable.origin match {
           case Origin.ImplicitlyAddedBy(name, dri) => Signature("Implicitly added by ", SLink(name, dri))
           case Origin.ExtensionFrom(name, dri) => Signature("Extension method from ", SLink(name, dri))
-          case Origin.ExportedFrom(name, dri) => 
+          case Origin.ExportedFrom(name, dri) =>
             val signatureName: String | dotty.dokka.model.api.Link = dri match
               case Some(dri: DRI) => SLink(name, dri)
               case None => name

--- a/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaContentBuilder.scala
@@ -494,10 +494,6 @@ class ScalaPageContentBuilder(
               case Some(dri: DRI) => SLink(name, dri)
               case None => name
             Signature("Exported from ", signatureName)
-          case Origin.Overrides(overridenMembers) => 
-            def intersperse(xs: Seq[SLink]): Seq[(String | SLink)] = 
-              xs.flatMap(Seq(_, " -> ")).dropRight(1).asInstanceOf[Seq[(String | SLink)]] // dropRight returns `Seq[Object]`
-            Signature("Definition classes: ").join(Signature(intersperse(overridenMembers.map(SLink(_, _))):_*))
           case _ => Nil
         }
         val styles: Set[Style] = if documentable.deprecated.isDefined then Set(TextStyle.Strikethrough) else Set.empty

--- a/scala3doc/src/dotty/dokka/translators/ScalaPageCreator.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaPageCreator.scala
@@ -50,8 +50,6 @@ class ScalaPageCreator(
       JNil
     )
 
-  override def pageForClasslike(c: DClasslike): ClasslikePageNode = ???
-
   def pageForMember(c: Member): ClasslikePageNode = {
     val name =
       if c.kind == Kind.Object && c.companion.isDefined then

--- a/scala3doc/src/dotty/dokka/translators/ScalaPageCreator.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaPageCreator.scala
@@ -35,7 +35,9 @@ class ScalaPageCreator(
   override def pageForModule(m: DModule): ModulePageNode = super.pageForModule(m)
 
   private def pagesForMembers(member: Member): JList[PageNode] =
-    val (all, _) = member.membersBy(_.kind.isInstanceOf[Classlike])
+    val all = member
+      .membersBy(_.kind.isInstanceOf[Classlike])
+      .filter(m => m.origin == Origin.RegularlyDefined && m.inheritedFrom.isEmpty)
     all.map(pageForMember(_)).asJava
 
   override def pageForPackage(p: DPackage): PackagePageNode =
@@ -142,180 +144,7 @@ class ScalaPageCreator(
       res
     }
 
-    def contentForComments(d: Documentable) = b
-
-    def contentForDescription(d: Documentable) = {
-      val specialTags = Set[Class[_]](classOf[Description])
-
-      type SourceSet = DokkaConfiguration$DokkaSourceSet
-
-      val tags: List[(SourceSet, TagWrapper)] =
-        d.getDocumentation.asScala.toList.flatMap( (pd, doc) => doc.getChildren.asScala.map(pd -> _).toList )
-
-      val platforms = d.getSourceSets.asScala.toSet
-
-      val description = tags.collect{ case (pd, d: Description) => (pd, d) }.drop(1).groupBy(_(0)).map( (key, value) => key -> value.map(_(1)))
-
-      /** Collect the key-value pairs from `iter` into a `Map` with a `cleanup` step,
-        * keeping the original order of the pairs.
-        */
-      def collectInMap[K, E, V](
-        iter: Iterator[(K, E)]
-      )(
-        cleanup: List[E] => V
-      ): collection.Map[K, V] = {
-        val lhm = mutable.LinkedHashMap.empty[K, ListBuffer[E]]
-        iter.foreach { case (k, e) =>
-          lhm.updateWith(k) {
-            case None => Some(ListBuffer.empty.append(e))
-            case Some(buf) =>
-              buf.append(e)
-              Some(buf)
-          }
-        }
-        lhm.iterator.map { case (key, buf) => key -> cleanup(buf.result)}.to(mutable.LinkedHashMap)
-      }
-
-      val unnamedTags: collection.Map[(SourceSet, Class[_]), List[TagWrapper]] =
-        collectInMap {
-          tags.iterator
-            .filterNot { t =>
-              t(1).isInstanceOf[NamedTagWrapper] || specialTags.contains(t(1).getClass)
-            }.map { t =>
-              (t(0), t(1).getClass) -> t(1)
-            }
-        }(cleanup = identity)
-
-      val namedTags: collection.Map[
-        String,
-        Either[
-          collection.Map[SourceSet, NamedTagWrapper],
-          collection.Map[(SourceSet, String), ScalaTagWrapper.NestedNamedTag],
-        ],
-      ] = {
-        val grouped = collectInMap {
-          tags.iterator.collect {
-            case (sourcesets, n: NamedTagWrapper) =>
-              (n.getName, n.isInstanceOf[ScalaTagWrapper.NestedNamedTag]) -> (sourcesets, n)
-          }
-        }(cleanup = identity)
-
-        grouped.iterator.map {
-          case ((name, true), values) =>
-            val groupedValues =
-              values.iterator.map {
-                case (sourcesets, t) =>
-                  val tag = t.asInstanceOf[ScalaTagWrapper.NestedNamedTag]
-                  (sourcesets, tag.subname) -> tag
-              }.to(mutable.LinkedHashMap)
-            name -> Right(groupedValues)
-          case ((name, false), values) =>
-            name -> Left(values.to(mutable.LinkedHashMap))
-        }.to(mutable.LinkedHashMap)
-      }
-
-      b.group(Set(d.getDri), styles = Set(TextStyle.Block, TableStyle.Borderless)) { bdr =>
-        val b1 = description.foldLeft(bdr){
-          case (bdr, (key, value)) => bdr
-              .group(sourceSets = Set(key)){ gbdr =>
-                value.foldLeft(gbdr) { (gbdr, tag) => gbdr
-                  .comment(tag.getRoot)
-                }
-              }
-        }
-
-        b1.table(kind = ContentKind.Comment, styles = Set(TableStyle.DescriptionList)){ tbdr =>
-          val withUnnamedTags = unnamedTags.foldLeft(tbdr){ case (bdr, (key, value) ) => bdr
-            .cell(sourceSets = Set(key(0))){ b => b
-              .text(key(1).getSimpleName, styles = Set(TextStyle.Bold))
-            }
-            .cell(sourceSets = Set(key(0))) { b => b
-              .list(value, separator = ""){ (bdr, elem) => bdr
-                .comment(elem.getRoot)
-              }
-            }
-          }
-
-          val withNamedTags = namedTags.foldLeft(withUnnamedTags){
-            case (bdr, (key, Left(value))) =>
-              value.foldLeft(bdr){ case (bdr, (sourceSets, v)) => bdr
-                .cell(sourceSets = Set(sourceSets)){ b => b
-                  .text(key)
-                }
-                .cell(sourceSets = Set(sourceSets)){ b => b
-                  .comment(v.getRoot)
-                }
-              }
-            case (bdr, (key, Right(groupedValues))) => bdr
-              .cell(sourceSets = d.getSourceSets.asScala.toSet){ b => b
-                .text(key)
-              }
-              .cell(sourceSets = d.getSourceSets.asScala.toSet)(_.table(kind = ContentKind.Comment, styles = Set(TableStyle.NestedDescriptionList)){ tbdr =>
-                groupedValues.foldLeft(tbdr){ case (bdr, ((sourceSets, _), v)) => bdr
-                  .cell(sourceSets = Set(sourceSets)){ b => b
-                    .comment(v.identTag)
-                  }
-                  .cell(sourceSets = Set(sourceSets)){ b => b
-                    .comment(v.descTag)
-                  }
-                }
-              })
-          }
-
-          val withCompanion = d.companion.fold(withNamedTags){ co => withNamedTags
-                .cell(sourceSets = d.getSourceSets.asScala.toSet){ b => b
-                  .text("Companion")
-                }
-                .cell(sourceSets = d.getSourceSets.asScala.toSet){ b => b
-                  .driLink(
-                    d.kind match {
-                      case Kind.Object => "class"
-                      case _ => "object"
-                    },
-                    co
-                  )
-                }
-              }
-
-          val withExtensionInformation = d.kind match {
-            case Kind.Extension(on, _) =>
-              val sourceSets = d.getSourceSets.asScala.toSet
-              withCompanion.cell(sourceSets = sourceSets)(_.text("Extension"))
-                .cell(sourceSets = sourceSets)(_.text(s"This function is an extension on (${on.name}: ").inlineSignature(d, on.signature).text(")"))
-            case _ => withCompanion
-          }
-
-          val withSource = d match
-            case null => withExtensionInformation
-            case m: Member =>
-              ctx.sourceLinks.pathTo(m).fold(withCompanion){ link =>
-                val sourceSets = m.getSourceSets.asScala.toSet
-                withExtensionInformation.cell(sourceSets = sourceSets)(_.text("Source"))
-                  .cell(sourceSets = sourceSets)(_.resolvedLink("(source)", link))
-
-              }
-
-          d.deprecated match
-            case None => withSource
-            case Some(a) =>
-              extension (b: ScalaPageContentBuilder#ScalaDocumentableContentBuilder)
-                def annotationParameter(p: Option[Annotation.AnnotationParameter]): ScalaPageContentBuilder#ScalaDocumentableContentBuilder =
-                  p match
-                    case Some(Annotation.PrimitiveParameter(_, value)) => b.text(value.stripPrefix("\"").stripSuffix("\""))
-                    case Some(Annotation.LinkParameter(_, dri, text)) => b.driLink(text.stripPrefix("\"").stripSuffix("\""), dri)
-                    case Some(Annotation.UnresolvedParameter(_, value)) => b.text(value.stripPrefix("\"").stripSuffix("\""))
-                    case _ => b
-              val since = a.params.find(_.name.contains("since"))
-              val message = a.params.find(_.name.contains("message"))
-              val sourceSets = d.getSourceSets.asScala.toSet
-              withSource.cell(sourceSets = sourceSets)(_.text("Deprecated"))
-                .cell(sourceSets = sourceSets) { b =>
-                  val withPossibleSince = if (since.isDefined) b.text("(Since version ").annotationParameter(since).text(") ") else b
-                  withPossibleSince.annotationParameter(message)
-                }
-        }
-      }
-    }
+    def contentForDescription(m: Member) = b.memberInfo(m)
 
     def contentForScope(s: Documentable & WithScope & WithExtraProperties[_]) =
       def groupExtensions(extensions: Seq[Member]): Seq[DocumentableSubGroup] =
@@ -336,7 +165,6 @@ class ScalaPageCreator(
       val (definedImplicits, inheritedImplicits) = s.membersBy(_.kind.isInstanceOf[Kind.Implicit]).byInheritance
 
       b
-        .contentForComments(s)
         .documentableTab("Type members")(
           DocumentableGroup(Some("Types"), definedTypes),
           DocumentableGroup(Some("Classlikes"), definedClasslikes),

--- a/scala3doc/src/dotty/dokka/translators/ScalaPageCreator.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaPageCreator.scala
@@ -205,7 +205,7 @@ class ScalaPageCreator(
 
     def contentForConstructors(c: DClass) =
        b.documentableTab("Constructors")(
-        DocumentableGroup(None, c.membersBy(_.kind.isInstanceOf[Kind.Constructor])._1)
+        DocumentableGroup(None, c.membersBy(_.kind.isInstanceOf[Kind.Constructor]))
       )
 
 

--- a/scala3doc/src/dotty/dokka/translators/ScalaSignatureProvider.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaSignatureProvider.scala
@@ -50,178 +50,159 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter)(using
 
 object ScalaSignatureProvider:
   def rawSignature(documentable: Documentable, builder: SignatureBuilder): SignatureBuilder =
-    documentable match
-      case extension: DFunction if extension.kind.isInstanceOf[Kind.Extension] =>
-        extensionSignature(extension, builder)
-      case method: DFunction if method.kind.isInstanceOf[Kind.Given] =>
-        givenMethodSignature(method, builder)
-      case exprt: DFunction if exprt.kind == Kind.Exported =>
-        exportedMethodSignature(exprt, builder)
-      case method: DFunction =>
-        methodSignature(method, builder)
-      case enumEntry: DClass if enumEntry.kind == Kind.EnumCase =>
-        enumEntrySignature(enumEntry, builder)
-      case givenClazz: DClass if givenClazz.kind.isInstanceOf[Kind.Given] =>
-        givenClassSignature(givenClazz, builder)
-      case clazz: DClass =>
-        classSignature(clazz, builder)
-      case enumProperty: DProperty if enumProperty.kind == Kind.EnumCase =>
-        enumPropertySignature(enumProperty, builder)
-      case property: DProperty =>
-        propertySignature(property, builder)
-      case parameter: DParameter =>
-        parameterSignature(parameter, builder)
-      case _ =>
+    documentable.kind match
+      case Kind.Extension(_, m) =>
+        extensionSignature(documentable, m, builder)
+      case Kind.Exported(d) =>
+         methodSignature(documentable, d, builder)
+      case d: Kind.Def =>
+        methodSignature(documentable, d, builder)
+      case Kind.Constructor(d) =>
+        methodSignature(documentable, d, builder)
+      case Kind.Implicit(d: Kind.Def, _) =>
+        methodSignature(documentable, d, builder)
+      case Kind.EnumCase(cls: Kind.Class) =>
+        enumEntrySignature(documentable, cls, builder)
+      case Kind.EnumCase(_) =>
+       enumPropertySignature(documentable, builder)
+      case Kind.Given(cls: Kind.Class, _, _) =>
+        givenClassSignature(documentable, cls, builder)
+      case Kind.Given(d: Kind.Def, _, _) =>
+        givenMethodSignature(documentable, d, builder)
+      case Kind.Given(Kind.Val, _, _) =>
+        givenPropertySignature(documentable, builder)
+      case cls: Kind.Class =>
+        classSignature(documentable, cls, builder)
+      case Kind.Object | Kind.Enum =>
+        objectSignature(documentable, builder)
+      case trt: Kind.Trait =>
+        traitSignature(documentable, trt, builder)
+      case Kind.Val | Kind.Var | Kind.Implicit(Kind.Val, _) =>
+        fieldSignature(documentable, documentable.kind.name, builder)
+      case tpe: Kind.Type =>
+        typeSignature(tpe, documentable, builder)
+      case Kind.Unknown =>
         ???
 
-
-  private def enumEntrySignature(entry: DClass, bdr: SignatureBuilder): SignatureBuilder =
-    val ext = entry.get(ClasslikeExtension)
+  private def enumEntrySignature(member: Member, cls: Kind.Class, bdr: SignatureBuilder): SignatureBuilder =
     val withPrefixes: SignatureBuilder = bdr
       .text("case ")
-      .name(entry.getName, entry.getDri)
-      .generics(entry)
+      .memberName(member.name, member.dri)
+      .generics(cls.typeParams)
 
-    val withParameters = ext.constructor.toSeq.foldLeft(withPrefixes){ (bdr, elem) =>
-      bdr.functionParameters(elem)
+    val withParameters = withPrefixes.functionParameters(cls.argsLists)
+    parentsSignature(member, withParameters)
+
+  private def enumPropertySignature(entry: Member, builder: SignatureBuilder): SignatureBuilder =
+    val modifiedType = entry.signature.map {
+      case " & " => " with "
+      case o => o
     }
-    parentsSignature(entry, withParameters)
-
-  private def enumPropertySignature(entry: DProperty, builder: SignatureBuilder): SignatureBuilder =
-    val modifiedType = entry.getType match
-      case t: TypeConstructor => GenericTypeConstructor(
-        t.getDri,
-        t.getProjections.asScala.map{
-          case t: UnresolvedBound if t.getName == " & " => UnresolvedBound(" with ");
-          case other => other
-        }.asJava,
-        null
-      )
-      case other => other
 
     builder
       .text("case ")
-      .name(entry.getName, entry.getDri)
+      .name(entry.name, entry.dri)
       .text(" extends ")
-      .typeSignature(modifiedType)
+      .signature(modifiedType)
 
-  private def parentsSignature(d: DClass, builder: SignatureBuilder): SignatureBuilder =
-    d.directParents match
+  private def parentsSignature(member: Member, builder: SignatureBuilder): SignatureBuilder =
+    member.directParents match
       case Nil => builder
       case extendType :: withTypes =>
         val extendPart = builder.text(" extends ").signature(extendType)
         withTypes.foldLeft(extendPart)((bdr, tpe) => bdr.text(" with ").signature(tpe))
 
-  private def givenClassSignature(clazz: DClass, builder: SignatureBuilder): SignatureBuilder =
-    val ext = clazz.get(ClasslikeExtension)
+  private def givenClassSignature(member: Member, cls: Kind.Class, builder: SignatureBuilder): SignatureBuilder =
     val prefixes = builder
-      .modifiersAndVisibility(clazz, "given")
-      .name(clazz.getName, clazz.getDri)
-      .generics(clazz)
+      .modifiersAndVisibility(member, "given")
+      .name(member.name, member.dri)
+      .generics(cls.typeParams)
+      .functionParameters(cls.argsLists)
 
-    val withGenerics = ext.constructor.toSeq.foldLeft(prefixes){ (bdr, elem) =>
-      bdr.functionParameters(elem)
-    }
-    clazz.kind match
-      case Kind.Given(Some(instance), _) => withGenerics
-        .text(" as ")
+    member.kind match
+      case Kind.Given(_, Some(instance), _) => prefixes
+        .text(": ")
         .signature(instance)
-      case _ => withGenerics
+      case _ => prefixes
 
-  private def classSignature(clazz: DClass, builder: SignatureBuilder): SignatureBuilder =
-    val ext = clazz.get(ClasslikeExtension)
-    val prefixes = builder
+  private def classSignature(clazz: Member, cls: Kind.Class, builder: SignatureBuilder): SignatureBuilder =
+    val selfSignature = builder
       .modifiersAndVisibility(clazz, clazz.kind.name)
       .name(clazz.getName, clazz.getDri)
-      .generics(clazz)
+      .generics(cls.typeParams)
+      .functionParameters(cls.argsLists)
 
-    val withGenerics = ext.constructor.toSeq.foldLeft(prefixes){ (bdr, elem) =>
-      bdr.functionParameters(elem)
-    }
-    parentsSignature(clazz, withGenerics)
+    parentsSignature(clazz, selfSignature)
 
-  private def extensionSignature(extension: DFunction, builder: SignatureBuilder): SignatureBuilder =
-    val extendedSymbol = if (extension.isRightAssociative()) {
-      extension.getParameters.asScala(extension.get(MethodExtension).parametersListSizes(0))
-    } else {
-      extension.getParameters.asScala(0)
-    }
+  private def objectSignature(clazz: Member, builder: SignatureBuilder): SignatureBuilder =
+    val selfSignature = builder
+      .modifiersAndVisibility(clazz, clazz.kind.name)
+      .name(clazz.getName, clazz.getDri)
+
+    parentsSignature(clazz, selfSignature)
+
+  private def traitSignature(clazz: Member, cls: Kind.Trait, builder: SignatureBuilder): SignatureBuilder =
+    val selfSignature = builder
+      .modifiersAndVisibility(clazz, clazz.kind.name)
+      .name(clazz.getName, clazz.getDri)
+      .generics(cls.typeParams)
+      .functionParameters(cls.argsLists)
+
+    parentsSignature(clazz, selfSignature)
+
+  private def extensionSignature(extension: Member, fun: Kind.Def, builder: SignatureBuilder): SignatureBuilder =
     val withSignature = builder
       .modifiersAndVisibility(extension, "def")
       .name(extension.getName, extension.getDri)
-      .generics(extension)
-      .functionParameters(extension)
+      .generics(fun.typeParams)
+      .functionParameters(fun.argsLists)
 
-    if extension.isConstructor then withSignature
-    else withSignature.text(":").text(" ").typeSignature(extension.getType)
+      withSignature.text(":").text(" ").signature(extension.signature)
 
-  private def givenMethodSignature(method: DFunction, builder: SignatureBuilder): SignatureBuilder = method.kind match
-    case Kind.Given(Some(instance), _) =>
+  private def givenMethodSignature(method: Member, body: Kind.Def, builder: SignatureBuilder): SignatureBuilder = method.kind match
+    case Kind.Given(_, Some(instance), _) =>
       builder.text("given ")
-        .name(method.getName, method.getDri)
-        .text(" as ")
+        .name(method.name, method.dri)
+        .text(": ")
         .signature(instance)
     case _ =>
-      builder.text("given ").name(method.getName, method.getDri)
+      builder.text("given ").name(method.name, method.dri)
 
-  private def exportedMethodSignature(method: DFunction, builder: SignatureBuilder): SignatureBuilder = 
-    methodSignature(method, builder)
-
-  private def methodSignature(method: DFunction, builder: SignatureBuilder): SignatureBuilder =
+  private def methodSignature(method: Member, cls: Kind.Def, builder: SignatureBuilder): SignatureBuilder =
     val bdr = builder
     .modifiersAndVisibility(method, "def")
     .name(method.getName, method.getDri)
-    .generics(method)
-    .functionParameters(method)
-    if !method.isConstructor then
-      bdr
-        .text(":")
-        .text(" ")
-        .typeSignature(method.getType)
+    .generics(cls.typeParams)
+    .functionParameters(cls.argsLists)
+    if !method.kind.isInstanceOf[Kind.Constructor] then
+      bdr.text(": ").signature(method.signature)
     else bdr
 
-
-  private def propertySignature(property: DProperty, builder: SignatureBuilder): SignatureBuilder =
-    property.kind match
-      case _: Kind.Given => givenPropertySignature(property, builder)
-      case tpe: Kind.Type => typeSignature(tpe, property, builder)
-      case other => fieldSignature(property, other.name, builder)
-
-
-  private def typeSignature(tpe: Kind.Type, typeDef: DProperty, builder: SignatureBuilder): SignatureBuilder =
+  private def typeSignature(tpe: Kind.Type, typeDef: Member, builder: SignatureBuilder): SignatureBuilder =
     val bdr = builder
       .modifiersAndVisibility(typeDef, if tpe.opaque then "opaque type" else "type")
       .name(typeDef.getName, typeDef.getDri)
-      .generics(typeDef)
+      .generics(tpe.typeParams)
     if(!tpe.opaque){
       (if tpe.concreate then bdr.text(" = ") else bdr)
-        .typeSignature(typeDef.getType)
+        .signature(typeDef.signature)
     } else bdr
 
 
-  private def givenPropertySignature(property: DProperty, builder: SignatureBuilder): SignatureBuilder =
+  private def givenPropertySignature(property: Member, builder: SignatureBuilder): SignatureBuilder =
     val bdr = builder
       .text("given ")
-      .name(property.getName, property.getDri)
+      .name(property.name, property.dri)
 
     property.kind match
-      case Kind.Given(Some(instance), _) =>
+      case Kind.Given(_, Some(instance), _) =>
          bdr.text(" as ").signature(instance)
       case _ => bdr
 
-  private def fieldSignature(property: DProperty, kind: String, builder: SignatureBuilder): SignatureBuilder =
+  private def fieldSignature(member: Member, kind: String, builder: SignatureBuilder): SignatureBuilder =
     builder
-      .modifiersAndVisibility(property, kind)
-      .name(property.getName, property.getDri)
+      .modifiersAndVisibility(member, kind)
+      .name(member.name, member.dri)
       .text(":")
       .text(" ")
-      .typeSignature(property.getType)
-
-  private def parameterSignature(parameter: DParameter, builder: SignatureBuilder): SignatureBuilder =
-    val ext = parameter.get(ParameterExtension)
-    builder
-      .text(if ext.isGrouped then "extension (" else "(")
-      .text(parameter.getName)
-      .text(": ")
-      .typeSignature(parameter.getType)
-      .text(")")
+      .signature(member.signature)

--- a/scala3doc/src/dotty/dokka/translators/ScalaSignatureProvider.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaSignatureProvider.scala
@@ -22,7 +22,7 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter)(using
 
   private def signatureContent(d: Documentable)(
     func: ScalaPageContentBuilder#ScalaDocumentableContentBuilder => ScalaPageContentBuilder#ScalaDocumentableContentBuilder
-  ) = 
+  ) =
     val styles = stylesIfDeprecated(d)
     contentBuilder.contentForDocumentable(d, kind = ContentKind.Symbol, styles = styles, buildBlock = func)
 
@@ -46,7 +46,7 @@ class ScalaSignatureProvider(contentConverter: CommentsToContentConverter)(using
 
   private def stylesIfDeprecated(m: Member): Set[Style] =
     if m.deprecated.isDefined then styles ++ Set(TextStyle.Strikethrough) else styles
-    
+
 
 object ScalaSignatureProvider:
   def rawSignature(documentable: Documentable, builder: SignatureBuilder): SignatureBuilder =

--- a/scala3doc/src/dotty/dokka/translators/ScalaSignatureUtils.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaSignatureUtils.scala
@@ -50,7 +50,7 @@ trait SignatureBuilder extends ScalaSignatureUtils {
         d.annotations.foldLeft(this){ (bdr, annotation) => bdr.buildAnnotation(annotation) }
 
     private def buildAnnotation(a: Annotation): SignatureBuilder =
-       text("@").driLink(a.dri.getClassNames, a.dri).buildAnnotationParams(a).text(" ")
+       text("@").driLink(a.dri.location.split('.').last, a.dri).buildAnnotationParams(a).text(" ")
 
     private def buildAnnotationParams(a: Annotation): SignatureBuilder =
       if !a.params.isEmpty then

--- a/scala3doc/src/dotty/dokka/translators/ScalaSignatureUtils.scala
+++ b/scala3doc/src/dotty/dokka/translators/ScalaSignatureUtils.scala
@@ -2,7 +2,7 @@ package dotty.dokka
 
 import org.jetbrains.dokka.base.signatures._
 import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder
-import org.jetbrains.dokka.model._
+import org.jetbrains.dokka.model.{ TypeParameter => _, _ }
 import org.jetbrains.dokka.model.properties.WithExtraProperties
 import org.jetbrains.dokka.pages._
 import collection.JavaConverters._
@@ -12,6 +12,7 @@ case class InlineSignatureBuilder(names: Signature = Nil, preName: Signature = N
   override def text(str: String): SignatureBuilder = copy(names = str +: names)
   override def name(str: String, dri: DRI): SignatureBuilder = copy(names = Nil, preName = names)
   override def driLink(text: String, dri: DRI): SignatureBuilder = copy(names = Link(text, dri) +: names)
+  override def signature(s: Signature): SignatureBuilder = copy(names = s.reverse ++ names)
 
 object InlineSignatureBuilder:
   def typeSignatureFor(d: Documentable): Signature =
@@ -21,14 +22,16 @@ trait SignatureBuilder extends ScalaSignatureUtils {
   def text(str: String): SignatureBuilder
   def name(str: String, dri: DRI) = driLink(str, dri)
   def driLink(text: String, dri: DRI): SignatureBuilder
-
-  def signature(s: Signature) = s.foldLeft(this){ (b, e) => e match
-    case Link(name, dri) => b.driLink(name, dri)
-    case txt: String => b.text(txt)
+  def signature(s: Signature): SignatureBuilder = s.foldLeft(this){
+    case (bld, s: String) => bld.text(s)
+    case (bld, Link(text: String, dri: DRI)) => bld.driLink(text, dri)
   }
 
+  // Support properly once we rewrite signature builder
+  def memberName(name: String, dri: DRI) = text(name)
+
   def list[E](
-      elements: List[E],
+      elements: Seq[E],
       prefix: String = "",
       suffix: String = "",
       separator: String = ", ",
@@ -43,7 +46,7 @@ trait SignatureBuilder extends ScalaSignatureUtils {
   def annotationsBlock(d: Member): SignatureBuilder =
       d.annotations.foldLeft(this){ (bdr, annotation) => bdr.buildAnnotation(annotation)}
 
-    def annotationsInline(d: Documentable with WithExtraProperties[_]): SignatureBuilder =
+    def annotationsInline(d: Parameter): SignatureBuilder =
         d.annotations.foldLeft(this){ (bdr, annotation) => bdr.buildAnnotation(annotation) }
 
     private def buildAnnotation(a: Annotation): SignatureBuilder =
@@ -68,51 +71,28 @@ trait SignatureBuilder extends ScalaSignatureUtils {
         addParameterName(name).text(value)
     }
 
-    def modifiersAndVisibility(t: Documentable with WithAbstraction with WithVisibility with WithExtraProperties[_], kind: String) =
-      import org.jetbrains.dokka.model.properties._
-      val extras = t.getExtra.getMap()
+    def modifiersAndVisibility(t: Member, kind: String) =
       val (prefixMods, suffixMods) = t.modifiers.partition(_.prefix)
       val all = prefixMods.map(_.name) ++ Seq(t.visibility.asSignature) ++ suffixMods.map(_.name)
 
       text(all.toSignatureString()).text(kind + " ")
 
-    def typeSignature(b: Projection): SignatureBuilder = b match {
-      case tc: TypeConstructor =>
-        tc.getProjections.asScala.foldLeft(this) { (bdr, elem) => elem match {
-          case text: UnresolvedBound => bdr.text(text.getName)
-          case link: TypeParameter =>
-            bdr.driLink(link.getName, link.getDri)
-          case other =>
-            bdr.text(s"TODO($other)")
+    def generics(on: Seq[TypeParameter]) = list(on.toList, "[", "]"){ (bdr, e) =>
+      bdr.text(e.variance).memberName(e.name, e.dri).signature(e.signature)
+    }
+
+    def functionParameters(params: Seq[Seq[Parameter]]) =
+      if params.isEmpty then this.text("")
+      else if params == List(Nil) then this.text("()")
+      else this.list(params, separator = ""){ (bld, pList) =>
+        bld.list(pList, "(", ")"){ (bld, p) =>
+            bld.annotationsInline(p)
+              .text(p.modifiers)
+              .memberName(p.name, p.dri)
+              .text(": ")
+              .signature(p.signature)
         }
       }
-      case other =>
-        text(s"TODO: $other")
-    }
-
-    def generics(on: WithGenerics) = list(on.getGenerics.asScala.toList, "[", "]"){ (bdr, e) =>
-      val bldr = bdr.text(e.getName)
-      e.getBounds.asScala.foldLeft(bldr)( (b, bound) => b.typeSignature(bound))
-    }
-
-    def functionParameters(method: DFunction) =
-      val methodExtension = method.get(MethodExtension)
-      val receiverPos = if method.isRightAssociative() then methodExtension.parametersListSizes(0) else 0
-      val (bldr, index) = methodExtension.parametersListSizes.foldLeft(this, 0){
-        case ((builder, from), size) =>
-          val toIndex = from + size
-          if from == toIndex then (builder.text("()"), toIndex)
-          else if !method.kind.isInstanceOf[Kind.Extension] || from != receiverPos then
-            val b = builder.list(method.getParameters.subList(from, toIndex).asScala.toList, "(", ")"){ (bdr, param) => bdr
-              .annotationsInline(param)
-              .text(param.getName)
-              .text(": ")
-              .typeSignature(param.getType)
-            }
-            (b, toIndex)
-          else (builder, toIndex)
-      }
-      bldr
 }
 
 trait ScalaSignatureUtils:

--- a/scala3doc/src/dotty/renderers/DotDiagramBuilder.scala
+++ b/scala3doc/src/dotty/renderers/DotDiagramBuilder.scala
@@ -8,7 +8,15 @@ import HTML._
 import dotty.dokka.model.api._
 
 object DotDiagramBuilder:
-  def build(diagram: HierarchyGraph, renderer: SignatureRenderer): String =
+  def build(diagram: HierarchyGraph, renderer: SignatureRenderer)(using DocContext): String =
+    def getStyle(vertex: LinkToType) = vertex.kind match
+      case _ : Kind.Class => "fill: #45AD7D;"
+      case Kind.Object => "fill: #285577;"
+      case _ : Kind.Trait => "fill: #1CAACF;"
+      case Kind.Enum => "fill: #B66722;"
+      case _ : Kind.EnumCase => "fill: #B66722;"
+      case other => report.error(s"unexpected value: $other")
+
     val vWithId = diagram.verteciesWithId
     val vertecies = vWithId.map { (vertex, id) =>
       s"""node${id} [label="${getHtmlLabel(vertex, renderer)}", style="${getStyle(vertex)}"];\n"""
@@ -24,16 +32,6 @@ object DotDiagramBuilder:
     | $edges
     |}
     |""".stripMargin
-
-
-  private def getStyle(vertex: LinkToType) = vertex.kind match
-    case Kind.Class => "fill: #45AD7D;"
-    case Kind.Object => "fill: #285577;"
-    case Kind.Trait => "fill: #1CAACF;"
-    case Kind.Enum => "fill: #B66722;"
-    case Kind.EnumCase => "fill: #B66722;"
-    case other => sys.error(s"unexpected value: $other")
-
 
   private def getHtmlLabel(vertex: LinkToType, renderer: SignatureRenderer): String =
     span(style := "color: #FFFFFF;")(

--- a/scala3doc/src/dotty/renderers/MemberRenderer.scala
+++ b/scala3doc/src/dotty/renderers/MemberRenderer.scala
@@ -29,6 +29,15 @@ class MemberRenderer(signatureRenderer: SignatureRenderer, buildNode: ContentNod
 
   def tableRow(name: String, content: AppliedTag) = Seq(dt(name), dd(content))
 
+  def defintionClasses(m: Member) = m.origin match
+    case Origin.Overrides(defs) =>
+      def renderDef(d: Overriden): Seq[TagArg] =
+        Seq(signatureRenderer.renderLink(d.name, d.dri), " -> ")
+
+      val nodes: Seq[TagArg] = defs.flatMap(renderDef).dropRight(1) // drop trailing arrow
+      tableRow("Definition Classes", div(nodes:_*))
+
+    case _ => Nil
 
   def docAttributes(m: Member): Seq[AppliedTag] =
 
@@ -102,6 +111,7 @@ class MemberRenderer(signatureRenderer: SignatureRenderer, buildNode: ContentNod
           docAttributes(m),
           companion(m),
           deprecation(m),
+          defintionClasses(m),
           source(m),
         )
       )

--- a/scala3doc/src/dotty/renderers/MemberRenderer.scala
+++ b/scala3doc/src/dotty/renderers/MemberRenderer.scala
@@ -1,0 +1,108 @@
+package dotty.dokka
+
+import dotty.dokka.model.api._
+import scala.collection.immutable.SortedMap
+import dotty.dokka.HTML._
+import org.jetbrains.dokka.base.transformers.pages.comments.DocTagToContentConverter
+import org.jetbrains.dokka.pages.{DCI, ContentKind, ContentNode}
+import org.jetbrains.dokka.model.properties.PropertyContainer
+import collection.JavaConverters._
+
+class MemberRenderer(signatureRenderer: SignatureRenderer, buildNode: ContentNode => String)(using DocContext):
+
+  private val converter = new DocTagToContentConverter()
+
+  def renderDocPart(d: DocPart): AppliedTag =
+    val sb  = StringBuilder()
+    converter.buildContent(
+      d,
+      DCI(JSet(), ContentKind.Comment),
+      JSet(),
+      JSet(),
+      PropertyContainer.Companion.empty()
+    ).forEach(c => sb.append(buildNode(c)))
+    raw(sb)
+
+  def fullSignature(m: Member): AppliedTag = raw("signature: TODO!")
+
+  def doc(m: Member): Seq[AppliedTag] =  m.docs.fold(Nil)(d => Seq(renderDocPart(d.body)))
+
+  def tableRow(name: String, content: AppliedTag) = Seq(dt(name), dd(content))
+
+
+  def docAttributes(m: Member): Seq[AppliedTag] =
+
+    def nested(name: String, on: SortedMap[String, DocPart]): Seq[AppliedTag] = if on.isEmpty then Nil else
+      tableRow(name, dl(cls := "attributes")(
+        on.map { case (name, value) => tableRow(name, renderDocPart(value))}.toList:_*
+      ))
+
+    def list(name: String, on: List[DocPart]): Seq[AppliedTag] = if on.isEmpty then Nil else
+      tableRow(name, div(on.map(e => div(renderDocPart(e)))))
+
+    def opt(name: String, on: Option[DocPart]): Seq[AppliedTag] = if on.isEmpty then Nil else
+      tableRow(name, renderDocPart(on.get))
+
+    m.docs.fold(Nil)(d =>
+      nested("Type Params", d.typeParams) ++
+      nested("Value Params", d.valueParams) ++
+      opt("Returns", d.result) ++
+      nested("Throws", d.throws.transform((_, v) => v._1)) ++
+      opt("Constructor", d.constructor) ++
+      list("Authors", d.authors) ++
+      list("See also", d.see) ++
+      opt("Version", d.version) ++
+      opt("Since", d.since) ++
+      list("Todo", d.todo) ++
+      list("Note", d.note) ++
+      list("Example", d.example)
+    )
+
+  def companion(m: Member): Seq[AppliedTag] = m.companion.fold(Nil){dri =>
+    val kindName = if m.kind == Kind.Object then "class" else "object"
+    tableRow("Companion", signatureRenderer.renderLink(kindName, dri))
+  }
+
+  def source(m: Member): Seq[AppliedTag] =
+    summon[DocContext].sourceLinks.pathTo(m).fold(Nil){ link =>
+      tableRow("Source", a(href := link)("(source)"))
+    }
+
+  def deprecation(m: Member): Seq[AppliedTag] = m.deprecated.fold(Nil){ a =>
+    def stripQuotes(s: String) = s.stripPrefix("\"").stripSuffix("\"")
+    def parameter(p: Annotation.AnnotationParameter): TagArg = p match
+      case Annotation.PrimitiveParameter(_, value) => stripQuotes(value)
+      case Annotation.LinkParameter(_, dri, text) =>
+        signatureRenderer.renderLink(stripQuotes(text), dri)
+      case Annotation.UnresolvedParameter(_, value) => stripQuotes(value)
+
+    val (named, unnamed) = a.params.partition(_.name.nonEmpty)
+    val message = named.find(_.name.get == "message").orElse(unnamed.headOption)
+    val since = named.find(_.name.get == "since").orElse(unnamed.drop(1).headOption)
+
+    val content =
+      since.fold(Nil)(since =>
+        Seq(code("[Since version ", parameter(since), "] ")) ++
+          message.fold(Nil)(m => Seq(parameter(m))) ++
+          m.docs.fold(Nil)(_.deprecated.toSeq.map(renderDocPart))
+      )
+    Seq(dt("Deprecated"), dd(content:_*))
+  }
+
+  def memberInfo(m: Member): Seq[AppliedTag] =
+    val bodyContents = m.docs.fold(Nil)(d =>
+      if d.body.getChildren.isEmpty then Seq(d.body) else d.body.getChildren.asScala.toList
+    ).map(renderDocPart)
+
+    Seq(
+      div(cls := "documentableBrief doc")(bodyContents.take(1)),
+      div(cls := "cover")(
+        div(cls := "doc")(bodyContents.drop(1)),
+        dl(cls := "attributes")(
+          docAttributes(m),
+          companion(m),
+          deprecation(m),
+          source(m),
+        )
+      )
+    )

--- a/scala3doc/src/dotty/renderers/ScalaHtmlRenderer.scala
+++ b/scala3doc/src/dotty/renderers/ScalaHtmlRenderer.scala
@@ -123,9 +123,14 @@ class ScalaHtmlRenderer(using ctx: DokkaContext) extends HtmlRenderer(ctx) {
     import renderer._
 
     def buildDocumentable(element: DocumentableElement) =
-      def topLevelAttr = Seq(cls := "documentableElement") ++ element.attributes.map{ case (n, v) => Attr(s"data-f-$n") := v }
+      def topLevelAttr = Seq(cls := "documentableElement")
+        ++ element.params.dri.anchor.map(id := _)
+        ++ element.attributes.map{ case (n, v) => Attr(s"data-f-$n") := v }
       val kind = element.modifiers.takeRight(1)
       val otherModifiers = element.modifiers.dropRight(1)
+
+      val nameStyles = element.nameWithStyles.styles.map(_.toString.toLowerCase).mkString(" ")
+      val nameClasses = cls := s"documentableName monospace ${nameStyles.mkString(" ")}"
 
       div(topLevelAttr:_*)(
         a(href:=link(element.params.dri).getOrElse("#"), cls := "documentableAnchor"),
@@ -135,7 +140,7 @@ class ScalaHtmlRenderer(using ctx: DokkaContext) extends HtmlRenderer(ctx) {
             span(cls := "other-modifiers")(otherModifiers.map(renderElement)),
             span(cls := "kind")(kind.map(renderElement)),
           ),
-          renderLink(element.nameWithStyles.name, element.params.dri, cls := s"documentableName monospace ${element.nameWithStyles.styles.map(_.toString.toLowerCase).mkString(" ")}"),
+          renderLink(element.nameWithStyles.name, element.params.dri, nameClasses),
           span(cls := "signature monospace")(element.signature.map(renderElement)),
         ),
         div(cls := "docs")(

--- a/scala3doc/src/dotty/renderers/html.scala
+++ b/scala3doc/src/dotty/renderers/html.scala
@@ -77,6 +77,10 @@ object HTML:
   val body = Tag("body")
   val nav = Tag("nav")
   val img = Tag("img")
+  val ul = Tag("ul")
+  val li = Tag("li")
+  val code = Tag("code")
+
 
   val cls = Attr("class")
   val href = Attr("href")
@@ -94,4 +98,4 @@ object HTML:
   val alt = Attr("alt")
 
   def raw(content: String): AppliedTag = AppliedTag(content)
-
+  def raw(content: StringBuilder): AppliedTag = content

--- a/scala3doc/src/dotty/renderers/html.scala
+++ b/scala3doc/src/dotty/renderers/html.scala
@@ -31,7 +31,7 @@ object HTML:
             case a: AppliedTag =>
               sb.append(a)
             case s: String =>
-            sb.append(s.escapeReservedTokens)
+              sb.append(s.escapeReservedTokens)
           }
       }
       sb.append(s"</$name>")

--- a/scala3doc/test/dotty/dokka/SignatureTestCases.scala
+++ b/scala3doc/test/dotty/dokka/SignatureTestCases.scala
@@ -50,7 +50,7 @@ class StructuralTypes extends SignatureTest("structuralTypes", SignatureTest.mem
 
 class OpaqueTypes extends SignatureTest("opaqueTypes", SignatureTest.all)
 
-// class GivenSignatures extends SignatureTest("givenSignatures", SignatureTest.all)
+class GivenSignatures extends SignatureTest("givenSignatures", SignatureTest.all)
 
 class Annotations extends SignatureTest("annotations", SignatureTest.all)
 

--- a/scala3doc/test/dotty/dokka/SourceLinksTests.scala
+++ b/scala3doc/test/dotty/dokka/SourceLinksTests.scala
@@ -83,16 +83,16 @@ class SourceLinksTest:
   @Test
   def testBasicPaths =
     testLink(Seq("github://lampepfl/dotty"), Some("develop"))(
-      "project/Build.scala" -> "https://github.com/lampepfl/dotty/blob/develop/project/Build.scala#L",
+      "project/Build.scala" -> "https://github.com/lampepfl/dotty/blob/develop/project/Build.scala",
       ("project/Build.scala", 54) -> "https://github.com/lampepfl/dotty/blob/develop/project/Build.scala#L54",
-      ("project/Build.scala", edit) -> "https://github.com/lampepfl/dotty/edit/develop/project/Build.scala#L",
+      ("project/Build.scala", edit) -> "https://github.com/lampepfl/dotty/edit/develop/project/Build.scala",
       ("project/Build.scala", 54, edit) -> "https://github.com/lampepfl/dotty/edit/develop/project/Build.scala#L54",
     )
 
     testLink(Seq("gitlab://lampepfl/dotty"), Some("develop"))(
-      "project/Build.scala" -> "https://gitlab.com/lampepfl/dotty/-/blob/develop/project/Build.scala#L",
+      "project/Build.scala" -> "https://gitlab.com/lampepfl/dotty/-/blob/develop/project/Build.scala",
       ("project/Build.scala", 54) -> "https://gitlab.com/lampepfl/dotty/-/blob/develop/project/Build.scala#L54",
-      ("project/Build.scala", edit) -> "https://gitlab.com/lampepfl/dotty/-/edit/develop/project/Build.scala#L",
+      ("project/Build.scala", edit) -> "https://gitlab.com/lampepfl/dotty/-/edit/develop/project/Build.scala",
       ("project/Build.scala", 54, edit) -> "https://gitlab.com/lampepfl/dotty/-/edit/develop/project/Build.scala#L54",
     )
 
@@ -113,7 +113,7 @@ class SourceLinksTest:
   @Test
   def testBasicPrefixedPaths =
     testLink(Seq("src=gitlab://lampepfl/dotty"), Some("develop"))(
-      "src/lib/core.scala" -> "https://gitlab.com/lampepfl/dotty/-/blob/develop/src/lib/core.scala#L",
+      "src/lib/core.scala" -> "https://gitlab.com/lampepfl/dotty/-/blob/develop/src/lib/core.scala",
       ("src/lib/core.scala", 33, edit) -> "https://gitlab.com/lampepfl/dotty/-/edit/develop/src/lib/core.scala#L33",
       ("src/lib/core.scala", 33, edit) -> "https://gitlab.com/lampepfl/dotty/-/edit/develop/src/lib/core.scala#L33",
       "build.sbt" -> None

--- a/scala3doc/test/dotty/dokka/linking/DriTestCases.scala
+++ b/scala3doc/test/dotty/dokka/linking/DriTestCases.scala
@@ -1,5 +1,6 @@
 package dotty.dokka
 package linking
+import org.junit.Assert.assertTrue
 
 import org.junit.Ignore
 
@@ -10,6 +11,13 @@ class GivenTest extends DriTest("givenDRI")
 class GenericTest extends DriTest("genericDRI")
 
 class FunctionTest extends DriTest("functionDRI")
+
+class NestingTest extends DriTest("nestingDRI"):
+  override def assertOnDRIs(dris: Seq[DRI]) =
+    println(dris.groupBy(_.location).map(_._1))
+    dris.groupBy(_.location).foreach{ case (location, dris) =>
+      assertTrue(s"Location $location has multiple dris assigned: $dris", dris.size == 1)
+    }
 
 @Ignore class ShadowingTest extends DriTest("shadowingDRI"):
   override def assertOnDRIs(dris: Seq[DRI]) =

--- a/scala3doc/test/dotty/dokka/testUtils.scala
+++ b/scala3doc/test/dotty/dokka/testUtils.scala
@@ -53,7 +53,7 @@ class TestReporter extends ConsoleReporter:
 def testArgs(files: Seq[File] = Nil, dest: File = new File("notUsed")) = Scala3doc.Args(
           name = "Test Project Name",
           output = dest,
-          tastyFiles = files
+          tastyFiles = files,
         )
 
 def testContext = (new ContextBase).initialCtx.fresh.setReporter(new TestReporter)


### PR DESCRIPTION
Scala3doc was only loosly using dokka model and it has started to blocking us.

This PR standarize over Member and expand semantic of Kind. This allow us to have more typesafe way to reason about code.

It will also make migration away from dokka easier if needed.

This PR contains #10702 that allow to link to external APIs as well as refactor linking.

Beside that this PR document correctly all members as well as allows to link to given ones.

Signature are rendered correctly (no problem with annotations etc.)