### PR TITLE
Warn when matching against an opaque type

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/PickleBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/PickleBuffer.scala
@@ -241,10 +241,10 @@ object PickleBuffer {
     val termMap, typeMap = new Array[Long](64)
     for (idx <- 0 until ScalaFlagEnd)
       corr get (1L << idx) match {
-        case Some((termFlag: FlagSet, typeFlag: FlagSet)) =>
+        case Some((termFlag: FlagSet @unchecked, typeFlag: FlagSet @unchecked)) =>
           termMap(idx) |= termFlag.bits
           typeMap(idx) |= typeFlag.bits
-        case Some(commonFlag: FlagSet) =>
+        case Some(commonFlag: FlagSet @unchecked) =>
           termMap(idx) |= commonFlag.toTermFlags.bits
           typeMap(idx) |= commonFlag.toTypeFlags.bits
         case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -53,7 +53,8 @@ object TypeTestsCasts {
    *  7. if `P` is a refinement type, FALSE
    *  8. otherwise, TRUE
    */
-  def checkable(X: Type, P: Type, span: Span)(using Context): Boolean = {
+  def checkable(X: Type, P: Type, span: Span)(using Context): Boolean = atPhase(Phases.refchecksPhase.next) {
+    // Run just before ElimOpaque transform (which follows RefChecks)
     def isAbstract(P: Type) = !P.dealias.typeSymbol.isClass
 
     def replaceP(tp: Type)(using Context) = new TypeMap {
@@ -71,7 +72,7 @@ object TypeTestsCasts {
         case tref: TypeRef if tref.typeSymbol.isPatternBound =>
           if (variance == 1) tref.info.hiBound
           else if (variance == -1) tref.info.loBound
-          else OrType(defn.AnyType, defn.NothingType, soft = true)
+          else OrType(defn.AnyType, defn.NothingType, soft = true) // TODO: what does this line do?
         case _ => mapOver(tp)
       }
     }.apply(tp)

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -216,7 +216,7 @@ object Tuple {
   /** Convert an immutable array into a tuple of unknown arity and types */
   def fromIArray[T](xs: IArray[T]): Tuple = {
     val xs2: IArray[Object] = xs match {
-      case xs: IArray[Object] => xs
+      case xs: IArray[Object] @unchecked => xs
       case xs =>
         // TODO support IArray.map
         xs.asInstanceOf[Array[T]].map(_.asInstanceOf[Object]).asInstanceOf[IArray[Object]]

--- a/tests/neg-custom-args/fatal-warnings/opaque-match.scala
+++ b/tests/neg-custom-args/fatal-warnings/opaque-match.scala
@@ -1,0 +1,22 @@
+case class C()
+
+object O:
+  opaque type T <: C = C
+  val x: T = C()
+
+def Test[T] =
+  O.x match
+    case _: C => ???   // ok
+  C() match
+    case _: O.T => ???  // error
+  C() match
+    case _: T => ???   // error
+
+  (??? : Any) match
+    case _: List[O.T] => ???  // error
+  (??? : Any) match
+    case _: List[T] => ???  // error
+
+
+
+

--- a/tests/neg-custom-args/fatal-warnings/opaque-match.scala
+++ b/tests/neg-custom-args/fatal-warnings/opaque-match.scala
@@ -3,6 +3,8 @@ case class C()
 object O:
   opaque type T <: C = C
   val x: T = C()
+  (??? : Any) match
+    case _: T => ??? // OK
 
 def Test[T] =
   O.x match
@@ -14,6 +16,8 @@ def Test[T] =
 
   (??? : Any) match
     case _: List[O.T] => ???  // error
+  (??? : Any) match
+    case _: List[O.T @unchecked] => ???  // OK 
   (??? : Any) match
     case _: List[T] => ???  // error
 


### PR DESCRIPTION
This is really analogous to matching against an abstract type, and should be
handled the same way.