### PR TITLE
Scala3doc: handle escaped backslash when splitting wiki links

### DIFF
--- a/scala3doc/src/dotty/dokka/tasty/comments/MarkdownConverter.scala
+++ b/scala3doc/src/dotty/dokka/tasty/comments/MarkdownConverter.scala
@@ -195,7 +195,7 @@ class MarkdownConverter(val repr: Repr) extends BaseConverter {
 object MarkdownConverter {
   def splitWikiLink(chars: String): (String, String) =
     // split on a space which is not backslash escaped (regex uses "zero-width negative lookbehind")
-    chars.split("(?<!\\\\) ", /*max*/ 2) match {
+    chars.split("(?<!(?<!\\\\)\\\\) ", /*max*/ 2) match {
       case Array(target) => (target, "")
       case Array(target, userText) => (target, userText)
     }

--- a/scala3doc/test/dotty/dokka/tasty/comments/MarkdownConverterTests.scala
+++ b/scala3doc/test/dotty/dokka/tasty/comments/MarkdownConverterTests.scala
@@ -8,5 +8,6 @@ class MarkdownConverterTests {
     assertEquals(("a", "b c d"), MarkdownConverter.splitWikiLink("a b c d"))
     assertEquals(("a", "b\\ c d"), MarkdownConverter.splitWikiLink("a b\\ c d"))
     assertEquals(("a\\ b", "c d"), MarkdownConverter.splitWikiLink("a\\ b c d"))
+    assertEquals(("a\\\\", "b c d"), MarkdownConverter.splitWikiLink("a\\\\ b c d"))
   }
 }


### PR DESCRIPTION
What the title says; trivial fix.