### PR TITLE
Fix #5077: avoid pattern-bound type for selectors

### DIFF
--- a/tests/run/i5077.check
+++ b/tests/run/i5077.check
@@ -1,0 +1,3 @@
+A String with length 4
+A String with length 4
+A String with length 4

--- a/tests/run/i5077.scala
+++ b/tests/run/i5077.scala
@@ -1,0 +1,33 @@
+trait Is[A]
+case object IsInt extends Is[Int]
+case object IsString extends Is[String]
+case class C[A](is: Is[A], value: A)
+
+@main
+def Test = {
+  val c_string: C[String] = C(IsString, "name")
+  val c_any: C[_] = c_string
+  val any: Any = c_string
+
+  // Case 1: no error
+  // `IsInt.equals` might be overridden to match a value of `C[String]`
+  c_string match {
+    case C(IsInt, _) => println(s"An Int") // Can't possibly happen!
+    case C(IsString, s) => println(s"A String with length ${s.length}")
+    case _ => println("No match")
+  }
+
+  // Case 2: Should match the second case and print the length of the string
+  c_any match {
+    case C(IsInt, i) if i < 10 => println(s"An Int less than 10")
+    case C(IsString, s) => println(s"A String with length ${s.length}")
+    case _ => println("No match")
+  }
+
+  // Case 3: Same as above; should match the second case and print the length of the string
+  any match {
+    case C(IsInt, i) if i < 10 => println(s"An Int less than 10")
+    case C(IsString, s) => println(s"A String with length ${s.length}")
+    case _ => println("No match")
+  }
+}


### PR DESCRIPTION
Fix #5077: avoid pattern-bound type for selectors

Given the following definition:

    trait Is[A]
    case object IsInt extends Is[Int]
    case object IsString extends Is[String]
    case class C[A](is: Is[A], value: A)

and the pattern match:

    (x: C[_]) match
    case C(IsInt, i) => ...

The typer (enhanced with GADT) will infer `C[A$1]` as the type of the
pattern, where `A$1 =:= Int`.

The patternMatcher generates the following code:

    case val x15: C[A$1] =
      C.unapply[A$1 @ A$1](x9.$asInstanceOf$[C[A$1]])
    case val x16: Is[A$1] = x15._1
    case val x17: A$1 = x15._2        // erase to `Int`
    if IsInt.==(x16) then
      {
        case val i: A$1 = x17
	...
      }

Note that `x17` will have the erased type `Int`. This is incorrect: it
may only assume the type `Int` if the test is true inside the block.
If the test is false, we will get an type cast exception at runtime.

To fix the problem, we replace pattern-bound types by `Any` for
selector results:

    case val x15: C[A$1] =
      C.unapply[A$1 @ A$1](x9.$asInstanceOf$[C[A$1]])
    case val x16: Is[A$1] = x15._1
    case val x17: Any = x15._2
    if IsInt.==(x16) then
      {
        case val i: A$1 = x17.$asInstanceOf$[A$1]
        ...
      }

The patternMatcher will then use a type cast to pass the selector
value for nested unapplys or assign it to bound variables.