### PR TITLE
Remove `Expr.StringContext.unapply`

### DIFF
--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -236,15 +236,4 @@ object Expr {
     }
   }
 
-  object StringContext {
-    /** Matches a `StringContext(part0, part1, ...)` and extracts the parts of a call to if the
-     *  parts are passed explicitly. Returns the equvalent to `Seq('{part0}, '{part1}, ...)`.
-     */
-    def unapply(sc: Expr[StringContext])(using Quotes): Option[Seq[Expr[String]]] =
-      sc match
-        case '{ scala.StringContext(${Varargs(parts)}: _*) } => Some(parts)
-        case '{ new scala.StringContext(${Varargs(parts)}: _*) } => Some(parts)
-        case _ => None
-  }
-
 }


### PR DESCRIPTION
We already have a `FromExpr[StringContext]` that provides the `StringContext` directly.
Other uses of `StringContext` where the `Expr` of each argument natuarally tended to use pattern matching on quotes and `Varargs`.