### PR TITLE
Help scala.quoted migration from 3.0.0-M2 to 3.0.0-M3

### DIFF
--- a/library/src-bootstrapped/scala/quoted/Unlifted.scala
+++ b/library/src-bootstrapped/scala/quoted/Unlifted.scala
@@ -1,0 +1,14 @@
+package scala.quoted
+
+@deprecated("Use `scala.quoted.Expr` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
+object Unlifted:
+
+  @deprecated("Use `scala.quoted.Expr.unapply` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
+  def apply[T](expr: Expr[T])(using FromExpr[T])(using Quotes): Option[T] =
+    Expr.unapply(expr)
+
+  @deprecated("Use `scala.quoted.Exprs.unapply` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
+  def unapply[T](exprs: Seq[Expr[T]])(using FromExpr[T])(using Quotes): Option[Seq[T]] =
+    Exprs.unapply(exprs)
+
+end Unlifted

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -33,6 +33,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     */
     def matches(that: Expr[Any]): Boolean
 
+    @deprecated("Use `.value` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
+    def unlift(using FromExpr[T]): Option[T] = self.value
+
+    @deprecated("Use `.unliftOrError` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
+    def unliftOrError(using FromExpr[T]): T = self.valueOrError
+
     /** Return the value of this expression.
      *
      *  Returns `None` if the expression does not represent a value or possibly contains side effects.


### PR DESCRIPTION
Add back deprecated `Unlifted`, `unlift` and `unliftOrError`