### PR TITLE
Deprecate old `Expr` value extractors

### DIFF
--- a/library/src-bootstrapped/scala/quoted/FromExpr.scala
+++ b/library/src-bootstrapped/scala/quoted/FromExpr.scala
@@ -136,8 +136,8 @@ object FromExpr {
    */
   given StringContextFromExpr: FromExpr[StringContext] with {
     def unapply(x: Expr[StringContext])(using Quotes) = x match {
-      case '{ new StringContext(${Varargs(Consts(args))}: _*) } => Some(StringContext(args: _*))
-      case '{     StringContext(${Varargs(Consts(args))}: _*) } => Some(StringContext(args: _*))
+      case '{ new StringContext(${Varargs(Exprs(args))}: _*) } => Some(StringContext(args: _*))
+      case '{     StringContext(${Varargs(Exprs(args))}: _*) } => Some(StringContext(args: _*))
       case _ => None
     }
   }

--- a/library/src/scala/quoted/Const.scala
+++ b/library/src/scala/quoted/Const.scala
@@ -1,6 +1,7 @@
 package scala.quoted
 
 /** Literal constant values */
+@deprecated("Use `scala.quoted.Expr` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
 object Const {
 
   /** Matches expressions containing literal constant values and extracts the value.
@@ -18,6 +19,7 @@ object Const {
    *
    *  To directly unlift an expression `expr: Expr[T]` consider using `expr.value`/`expr.valueOrError` insead.
    */
+  @deprecated("Use `scala.quoted.Expr.unapply` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
   def unapply[T](expr: Expr[T])(using Quotes): Option[T] = {
     import quotes.reflect._
     def rec(tree: Term): Option[T] = tree match {

--- a/library/src/scala/quoted/Consts.scala
+++ b/library/src/scala/quoted/Consts.scala
@@ -1,6 +1,7 @@
 package scala.quoted
 
 /** Literal constant values */
+@deprecated("Use `scala.quoted.Exprs` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
 object Consts {
 
   /** Matches literal sequence of literal constant value expressions and return a sequence of values.
@@ -17,6 +18,7 @@ object Consts {
    *
    *  To directly unlift all expressions in a sequence `exprs: Seq[Expr[T]]` consider using `exprs.map(_.value)`/`exprs.map(_.valueOrError)` insead.
    */
+  @deprecated("Use `scala.quoted.Exprs.unapply` instead. This will be removed in 3.0.0-RC1", "3.0.0-M3")
   def unapply[T](exprs: Seq[Expr[T]])(using Quotes): Option[Seq[T]] =
     exprs.foldRight(Option(List.empty[T])) { (elem, acc) =>
       (elem, acc) match {


### PR DESCRIPTION
* Now we use `expr.value`, `expr.valueOrError`, `Expr.unapply` and `Exprs.unapply`
* We keep them to help migration between 3.0.0-M2 to 3.0.0-M3