### PR TITLE
Enforce indentation off-side rule

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -447,6 +447,13 @@ object Parsers {
       finally strictIndent = saved
     }
 
+    private def withoutStrictIndent[T](body: => T): T = {
+      val saved = strictIndent
+      strictIndent = false
+      try body
+      finally strictIndent = saved
+    }
+
 /* ---------- TREE CONSTRUCTION ------------------------------------------- */
 
     /** Convert tree to formal parameter list
@@ -1301,7 +1308,7 @@ object Parsers {
           true
         else
           newLineOptWhenFollowedBy(LBRACE)
-          false
+          in.next.token == LBRACE
       if indented then withStrictIndent(rest)
       else rest
 

--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -38,6 +38,10 @@ trait DottyTest extends ContextEscapeDetection {
   override def clearCtx() = {
     ctx = null
   }
+  def resetCtx() = {
+    clearCtx()
+    ctx = initialCtx
+  }
 
   protected def initializeCtx(fc: FreshContext): Unit = {
     fc.setSetting(fc.settings.encoding, "UTF8")

--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -13,7 +13,8 @@ import dotc.printing.Texts._
 import dotc.reporting.ConsoleReporter
 import dotc.core.Decorators._
 import dotc.ast.tpd
-import dotc.Compiler
+import dotc.{CompilationUnit,Compiler}
+import dotc.util.SourceFile
 
 import dotc.core.Phases.Phase
 
@@ -38,9 +39,11 @@ trait DottyTest extends ContextEscapeDetection {
   override def clearCtx() = {
     ctx = null
   }
-  def resetCtx() = {
+  def resetCtx(sourceFile: SourceFile) = {
     clearCtx()
-    ctx = initialCtx
+    val c = initialCtx
+    c.setCompilationUnit(CompilationUnit(sourceFile, mustExist = false))
+    ctx = c
   }
 
   protected def initializeCtx(fc: FreshContext): Unit = {

--- a/compiler/test/dotty/tools/dotc/parsing/DottyScannerTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/DottyScannerTest.scala
@@ -1,0 +1,45 @@
+package dotty.tools
+package dotc
+package parsing
+
+import dotty.tools.io._
+import scala.io.Codec
+import util._
+import Tokens._, Scanners._
+import org.junit.Test
+
+class DottyScannerTest extends ScannerTest {
+
+  val blackList = List(
+      "/scaladoc/scala/tools/nsc/doc/html/page/Index.scala",
+      "/scaladoc/scala/tools/nsc/doc/html/page/Template.scala"
+    )
+
+  def scanDir(path: String): Unit = scanDir(Directory(path))
+
+  def scanDir(dir: Directory): Unit = {
+    if (blackList exists (dir.jpath.toString endsWith _))
+      println(s"blacklisted package: ${dir.toAbsolute.jpath}")
+    else
+      for (f <- dir.files)
+        if (f.name.endsWith(".scala"))
+          if (blackList exists (f.jpath.toString endsWith _))
+            println(s"blacklisted file: ${f.toAbsolute.jpath}")
+          else
+            scan(new PlainFile(f))
+    for (d <- dir.dirs)
+      scanDir(d.path)
+  }
+
+  @Test
+  def scanList() = {
+    println(System.getProperty("user.dir"))
+    scan("compiler/src/dotty/tools/dotc/core/Symbols.scala")
+    scan("compiler/src/dotty/tools/dotc/core/Symbols.scala")
+  }
+
+  @Test
+  def scanDotty() = {
+    scanDir("compiler/src")
+  }
+}

--- a/compiler/test/dotty/tools/dotc/parsing/IndentTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/IndentTest.scala
@@ -5,7 +5,7 @@ package parsing
 import ast.untpd._
 import org.junit.Test
 
-class IndentTest extends ScannerTest:
+class IndentTest extends ParserTest:
 
   @Test
   def parseBraces: Unit =
@@ -14,15 +14,25 @@ class IndentTest extends ScannerTest:
       |  val x = 1
       |    val y = 2
       |}""".stripMargin
-    assert(scanTextEither(code).isRight)
+    assert(parseTextEither(code).isRight)
 
   @Test
   def parseIndents: Unit =
     val code = s"""
       |class A:
       |  val x = 1
+      |  val y = 2
       |""".stripMargin
-    assert(scanTextEither(code).isRight)
+    assert(parseTextEither(code).isRight)
+
+  @Test
+  def innerClassIndents: Unit =
+    val code = s"""
+      |class A:
+      |  class B:
+      |    val x = 1
+      |""".stripMargin
+    assert(parseTextEither(code).isRight)
 
   @Test
   def superfluousIndents: Unit =
@@ -31,4 +41,13 @@ class IndentTest extends ScannerTest:
       |  val x = 1
       |    val y = 2
       |""".stripMargin
-    assert(scanTextEither(code).isLeft)
+    assert(parseTextEither(code).isLeft)
+
+  @Test
+  def superfluousIndents2: Unit =
+    val code = s"""
+      |class Test:
+      |  test("hello")
+      |    assert(1 == 1)
+      |""".stripMargin
+    assert(parseTextEither(code).isLeft)

--- a/compiler/test/dotty/tools/dotc/parsing/IndentTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/IndentTest.scala
@@ -2,7 +2,6 @@ package dotty.tools
 package dotc
 package parsing
 
-import ast.untpd._
 import org.junit.Test
 
 class IndentTest extends ParserTest:
@@ -31,6 +30,15 @@ class IndentTest extends ParserTest:
       |class A:
       |  class B:
       |    val x = 1
+      |""".stripMargin
+    assert(parseTextEither(code).isRight)
+
+  @Test
+  def extendsClassIndents: Unit =
+    val code = s"""
+      |class A extends B:
+      |  override def hasUnreportedErrors: Boolean =
+      |    infos.exists(_.isInstanceOf[Error])
       |""".stripMargin
     assert(parseTextEither(code).isRight)
 

--- a/compiler/test/dotty/tools/dotc/parsing/IndentTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/IndentTest.scala
@@ -1,0 +1,34 @@
+package dotty.tools
+package dotc
+package parsing
+
+import ast.untpd._
+import org.junit.Test
+
+class IndentTest extends ScannerTest:
+
+  @Test
+  def parseBraces: Unit =
+    val code = s"""
+      |class A {
+      |  val x = 1
+      |    val y = 2
+      |}""".stripMargin
+    assert(scanTextEither(code).isRight)
+
+  @Test
+  def parseIndents: Unit =
+    val code = s"""
+      |class A:
+      |  val x = 1
+      |""".stripMargin
+    assert(scanTextEither(code).isRight)
+
+  @Test
+  def superfluousIndents: Unit =
+    val code = s"""
+      |class A:
+      |  val x = 1
+      |    val y = 2
+      |""".stripMargin
+    assert(scanTextEither(code).isLeft)

--- a/compiler/test/dotty/tools/dotc/parsing/IndentWidthTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/IndentWidthTest.scala
@@ -1,0 +1,18 @@
+package dotty.tools
+package dotc
+package parsing
+
+import org.junit.Test
+
+class IndentWidthTest extends ScannerTest:
+
+  @Test
+  def innerObjectIndents: Unit =
+    val code = s"""
+      |object A:
+      |  object B
+      |  end B
+      |
+      |  object C
+      |""".stripMargin
+    assert(scanTextEither(code).isRight)

--- a/compiler/test/dotty/tools/dotc/parsing/ParserTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ParserTest.scala
@@ -23,18 +23,23 @@ class ParserTest extends DottyTest {
   def reset() = {
     parsed = 0
     parsedTrees.clear()
-    resetCtx()
+  }
+
+  def reset(source: SourceFile) = {
+    parsed = 0
+    parsedTrees.clear()
+    resetCtx(source)
   }
 
   def parse(file: PlainFile): Tree = parseSourceEither(new SourceFile(file, Codec.UTF8)).toTry.get
 
   private def parseSourceEither(source: SourceFile): Either[ParserError, Tree] = {
     //println("***** parsing " + source.file)
+    reset(source)
     val parser = new Parser(source)
     val tree = parser.parse()
     if (getCtx.reporter.hasErrors) {
       val result = Left(ParserError(getCtx.reporter.allErrors))
-      reset()
       result
     }
     else {

--- a/compiler/test/dotty/tools/dotc/parsing/ScannerTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ScannerTest.scala
@@ -15,9 +15,10 @@ trait ScannerTest extends DottyTest:
 
   def scan(file: PlainFile): Unit = scanSourceEither(new SourceFile(file, Codec.UTF8)).toTry.get
 
-  def reset() = resetCtx()
+  def reset(source: SourceFile) = resetCtx(source)
 
   private def scanSourceEither(source: SourceFile): Either[ParserError, Unit] =
+    reset(source)
     //println("***** scanning " + file)
     val scanner = new Scanner(source)
     var i = 0
@@ -29,7 +30,6 @@ trait ScannerTest extends DottyTest:
 
     if getCtx.reporter.hasErrors || getCtx.reporter.hasWarnings then
       val result = Left(ParserError(getCtx.reporter.allErrors))
-      reset()
       result
     else Right(())
 


### PR DESCRIPTION
Ref https://github.com/lampepfl/dotty/issues/10671

Currently

```scala
class A:
  val x = 1
    val y = 2
```

is admitted. This becomes confusing since this looseness ends up not
catching things like

```scala
class Test:
  test("hello")
    assert(1 == 1)
```

where `assert(1 == 1)` is actually not passed into `test(...)(...)`.

Following the convention of indentation languages like Python, we should reject superfluous indentation, which can be defined as having two or more indentation widths within a region.

### Test output

```scala
[info] Test run started
[info] Test dotty.tools.dotc.parsing.IndentTest.superfluousIndents2 started
-- Error: <code>:4:4 -----------------------------------------------------------
4 |    assert(1 == 1)
  |    ^^^^^^
  |    unexpected indent: found 4 spaces
[info] Test dotty.tools.dotc.parsing.IndentTest.parseBraces started
[info] Test dotty.tools.dotc.parsing.IndentTest.parseIndents started
[info] Test dotty.tools.dotc.parsing.IndentTest.superfluousIndents started
-- Error: <code>:4:4 -----------------------------------------------------------
4 |    val y = 2
  |    ^^^
  |    unexpected indent: found 4 spaces
[info] Test dotty.tools.dotc.parsing.IndentTest.innerClassIndents started
```
