### PR TITLE
Add `Expr.asTerm`

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/FieldsImpl.scala
+++ b/community-build/src/scala/dotty/communitybuild/FieldsImpl.scala
@@ -11,7 +11,7 @@ object FieldsImpl:
     val retType = TypeTree.of[T].tpe
     def isProjectField(s: Symbol) =
       s.isValDef && s.tree.asInstanceOf[ValDef].tpt.tpe <:< retType
-    val projectsTree = Term.of(from)
+    val projectsTree = from.asTerm
     val symbols = TypeTree.of[V].symbol.fields.filter(isProjectField)
     val selects = symbols.map(Select(projectsTree, _).asExprOf[T])
     '{ println(${Expr(retType.show)}); ${Varargs(selects)} }

--- a/docs/docs/reference/metaprogramming/tasty-reflect.md
+++ b/docs/docs/reference/metaprogramming/tasty-reflect.md
@@ -42,7 +42,7 @@ trees. For example the `Literal(_)` extractor used below.
 ```scala
 def natConstImpl(x: Expr[Int])(using Quotes): Expr[Int] = {
   import quotes.reflect._
-  val xTree: Term = Term.of(x)
+  val xTree: Term = x.asTerm
   xTree match {
     case Inlined(_, _, Literal(Constant(n: Int))) =>
       if (n <= 0) {

--- a/library/src-bootstrapped/scala/quoted/Expr.scala
+++ b/library/src-bootstrapped/scala/quoted/Expr.scala
@@ -19,7 +19,7 @@ object Expr {
    */
   def betaReduce[T](expr: Expr[T])(using Quotes): Expr[T] =
     import quotes.reflect._
-    Term.betaReduce(Term.of(expr)) match
+    Term.betaReduce(expr.asTerm) match
       case Some(expr1) => expr1.asExpr.asInstanceOf[Expr[T]]
       case _ => expr
 
@@ -29,7 +29,7 @@ object Expr {
    */
   def block[T](statements: List[Expr[Any]], expr: Expr[T])(using Quotes): Expr[T] = {
     import quotes.reflect._
-    Block(statements.map(Term.of), Term.of(expr)).asExpr.asInstanceOf[Expr[T]]
+    Block(statements.map(asTerm), expr.asTerm).asExpr.asInstanceOf[Expr[T]]
   }
 
   /** Creates an expression that will construct the value `x` */

--- a/library/src-bootstrapped/scala/quoted/FromExpr.scala
+++ b/library/src-bootstrapped/scala/quoted/FromExpr.scala
@@ -90,7 +90,7 @@ object FromExpr {
         case Inlined(_, Nil, e) => rec(e)
         case _  => None
       }
-      rec(Term.of(expr))
+      rec(expr.asTerm)
   }
 
   /** Default implementation of `FromExpr[Option]`

--- a/library/src/scala/quoted/Const.scala
+++ b/library/src/scala/quoted/Const.scala
@@ -34,7 +34,7 @@ object Const {
       case Inlined(_, Nil, e) => rec(e)
       case _  => None
     }
-    rec(Term.of(expr))
+    rec(expr.asTerm)
   }
 
 }

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -100,13 +100,13 @@ trait ExprMap:
             transformTermChildren(tree, tpe)(owner)
           case _ if tree.isExpr =>
             // WARNING: Never do a cast like this in user code (accepable within the stdlib).
-            // In theory we should use `tree.asExpr match { case '{ $expr: t } => Term.of(transform(expr)) }`
+            // In theory we should use `tree.asExpr match { case '{ $expr: t } => transform(expr).asTerm }`
             // This is to avoid conflicts when re-boostrapping the library.
             type X
             val expr = tree.asExpr.asInstanceOf[Expr[X]]
             val t = tpe.asType.asInstanceOf[Type[X]]
             val transformedExpr = transform(expr)(using t)
-            Term.of(transformedExpr)
+            transformedExpr.asTerm
           case _ =>
             transformTermChildren(tree, tpe)(owner)
 
@@ -145,7 +145,7 @@ trait ExprMap:
         trees.mapConserve(x => transformTypeCaseDef(x)(owner))
 
     }
-    new MapChildren().transformTermChildren(Term.of(e), TypeRepr.of[T])(Symbol.spliceOwner).asExprOf[T]
+    new MapChildren().transformTermChildren(e.asTerm, TypeRepr.of[T])(Symbol.spliceOwner).asExprOf[T]
   }
 
 end ExprMap

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -76,7 +76,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *  import scala.quoted._
    *  def f(expr: Expr[Int])(using Quotes) =
    *    import quotes.reflect._
-   *    val tree: Tree = Term.of(expr)
+   *    val ast: Term = expr.asTerm
    *    ...
    *  ```
    *
@@ -201,10 +201,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    */
   trait reflectModule { self: reflect.type =>
 
+    /** Returns the `Term` representation this expression */
+    extension (expr: Expr[Any])
+      def asTerm: Term
+
     ///////////////
     //   TREES   //
     ///////////////
-
 
     /** Tree representing code written in the source */
     type Tree <: AnyRef
@@ -215,7 +218,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Methods of the module object `val Tree` */
     trait TreeModule { this: Tree.type =>
       /** Returns the Term representation this expression */
-      def of(expr: Expr[Any]): Tree
+      @deprecated("Use `expr.asTerm` instead (must `import quotes.reflect._`). This will be removed in 3.0.0-RC1", "3.0.0-M3")
+      def of(expr: Expr[Any]): Tree = expr.asTerm
     }
 
     /** Makes extension methods on `Tree` available without any imports */
@@ -509,7 +513,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     trait TermModule { this: Term.type =>
 
       /** Returns the Term representation this expression */
-      def of(expr: Expr[Any]): Term
+      @deprecated("Use `expr.asTerm` instead (must `import quotes.reflect._`). This will be removed in 3.0.0-RC1", "3.0.0-M3")
+      def of(expr: Expr[Any]): Term = expr.asTerm
 
       /** Returns a term that is functionally equivalent to `t`,
       *  however if `t` is of the form `((y1, ..., yn) => e2)(e1, ..., en)`

--- a/library/src/scala/quoted/Varargs.scala
+++ b/library/src/scala/quoted/Varargs.scala
@@ -21,7 +21,7 @@ object Varargs {
    */
   def apply[T](xs: Seq[Expr[T]])(using Type[T])(using Quotes): Expr[Seq[T]] = {
     import quotes.reflect._
-    Repeated(xs.map(Term.of).toList, TypeTree.of[T]).asExpr.asInstanceOf[Expr[Seq[T]]]
+    Repeated(xs.map(_.asTerm).toList, TypeTree.of[T]).asExpr.asInstanceOf[Expr[Seq[T]]]
   }
 
   /** Matches a literal sequence of expressions and return a sequence of expressions.
@@ -44,7 +44,7 @@ object Varargs {
       case Inlined(_, Nil, e) => rec(e)
       case _  => None
     }
-    rec(Term.of(expr))
+    rec(expr.asTerm)
   }
 
 }

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)
-          report.error(s, Term.of(part).pos)
+          report.error(s, part.asTerm.pos)
     }
     '{}
   }

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
     sc match {
       case '{ StringContext(${Varargs(parts)}: _*) } =>
         for (part @ Const(s) <- parts)
-          report.error(s, Term.of(part).pos)
+          report.error(s, part.asTerm.pos)
     }
     '{}
   }

--- a/tests/neg-macros/i6976/Macro_1.scala
+++ b/tests/neg-macros/i6976/Macro_1.scala
@@ -7,6 +7,6 @@ object macros {
 
   def mcrImpl(body: Expr[Any])(using ctx: Quotes) : Expr[Any] = {
     import ctx.reflect._
-    Term.of(body) match { case Block(_, _) => '{2} }
+    body.asTerm match { case Block(_, _) => '{2} }
   }
 }

--- a/tests/neg-macros/i7698.scala
+++ b/tests/neg-macros/i7698.scala
@@ -6,7 +6,7 @@ trait Show[T] {
 
 def showInterpolatorImpl(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes): Expr[String] =
   import quotes.reflect._
-  Term.of(argsExpr) match
+  argsExpr.asTerm match
     case '{ $arg: $t } => // error
     case '[ Int ] => // error
   ???

--- a/tests/neg-macros/i9801/Macro_1.scala
+++ b/tests/neg-macros/i9801/Macro_1.scala
@@ -16,6 +16,6 @@ def impl(prog: Expr[Double])(using Quotes) : Expr[Double] =
     triggerStackOverflow(0)
   } catch {
     case e =>
-      quotes.reflect.report.error(e.getMessage, Term.of(prog).pos)
+      quotes.reflect.report.error(e.getMessage, prog.asTerm.pos)
       '{ 42.0 }
   }

--- a/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-1/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    val tree = Term.of(cond)
+    val tree = cond.asTerm
 
     def isOps(tpe: TypeRepr): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts

--- a/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-assert-2/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    val tree = Term.of(cond)
+    val tree = cond.asTerm
 
     def isOps(tpe: TypeRepr): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts

--- a/tests/neg-macros/tasty-macro-error/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-error/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def impl(x: Expr[Any])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
-    report.error("here is the the argument is " + Term.of(x).underlyingArgument.show, Term.of(x).underlyingArgument.pos)
+    report.error("here is the the argument is " + x.asTerm.underlyingArgument.show, x.asTerm.underlyingArgument.pos)
     '{}
   }
 

--- a/tests/neg-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/neg-macros/tasty-macro-positions/quoted_1.scala
@@ -6,9 +6,9 @@ object Macros {
 
   def impl(x: Expr[Any])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
-    val pos = Term.of(x).underlyingArgument.pos
-    report.error("here is the the argument is " + Term.of(x).underlyingArgument.show, pos)
-    report.error("here (+5) is the the argument is " + Term.of(x).underlyingArgument.show, Position(pos.sourceFile, pos.start + 5, pos.end + 5))
+    val pos = x.asTerm.underlyingArgument.pos
+    report.error("here is the the argument is " + x.asTerm.underlyingArgument.show, pos)
+    report.error("here (+5) is the the argument is " + x.asTerm.underlyingArgument.show, Position(pos.sourceFile, pos.start + 5, pos.end + 5))
     '{}
   }
 

--- a/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-a/Macro_1.scala
@@ -11,7 +11,7 @@ object FIntepolator {
 
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) : Expr[String] = {
     import quotes.reflect._
-    report.error("there are no parts", Term.of(strCtxExpr).underlyingArgument.pos)
+    report.error("there are no parts", strCtxExpr.asTerm.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }
 

--- a/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
+++ b/tests/neg-macros/tasty-string-interpolator-position-b/Macro_1.scala
@@ -10,7 +10,7 @@ object Macro {
 object FIntepolator {
   def apply(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) : Expr[String] = {
     import quotes.reflect._
-    report.error("there are no args", Term.of(argsExpr).underlyingArgument.pos)
+    report.error("there are no args", argsExpr.asTerm.underlyingArgument.pos)
     '{ ($strCtxExpr).s($argsExpr: _*) }
   }
 

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -17,10 +17,10 @@ object Lens {
     import util._
     // obj.copy(field = value)
     def setterBody(obj: Expr[S], value: Expr[T], field: String): Expr[S] =
-      Select.overloaded(Term.of(obj), "copy", Nil, NamedArg(field, Term.of(value)) :: Nil, TypeBounds.empty).asExprOf[S]
+      Select.overloaded(obj.asTerm, "copy", Nil, NamedArg(field, value.asTerm) :: Nil, TypeBounds.empty).asExprOf[S]
 
     // exception: Term.of(getter).underlyingArgument
-    Term.of(getter) match {
+    getter.asTerm match {
       case Inlined(
         None, Nil,
         Block(

--- a/tests/pending/run/tasty-comments/quoted_1.scala
+++ b/tests/pending/run/tasty-comments/quoted_1.scala
@@ -9,7 +9,7 @@ object Macros {
   def impl[T](x: Expr[T])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    val tree = Term.of(x)
+    val tree = x.asTerm
     tree.symbol.comment.map(_.raw) match {
       case Some(str) => '{ println(${str}) }
       case None => '{ println() }

--- a/tests/pos-macros/i10151/Macro_1.scala
+++ b/tests/pos-macros/i10151/Macro_1.scala
@@ -60,7 +60,7 @@ object X:
         case l@Literal(x) =>
            l.asExpr match
              case '{ $l: lit } =>
-                Term.of('{ CBM.pure(${term.asExprOf[lit]}) })
+                '{ CBM.pure(${term.asExprOf[lit]}) }.asTerm
         case other =>
              throw RuntimeException(s"Not supported $other")
 
@@ -89,5 +89,5 @@ object X:
          }
          changes.transformTerm(body)(Symbol.spliceOwner)
 
-   val r = transform(Term.of(f)).asExprOf[CB[T]]
+   val r = transform(f.asTerm).asExprOf[CB[T]]
    r

--- a/tests/pos-macros/i10211/Macro_1.scala
+++ b/tests/pos-macros/i10211/Macro_1.scala
@@ -67,11 +67,11 @@ object X:
              val tb = transform(b).asExprOf[CB[Int]]
              val mt = MethodType(List("p"))(_ => List(b.tpe.widen), _ => TypeRepr.of[Boolean])
              val mapLambda = Lambda(Symbol.spliceOwner, mt, (_, x) => Select.overloaded(obj,"==",List(),List(x.head.asInstanceOf[Term]))).asExprOf[Int=>Boolean]
-             Term.of('{ CBM.map($tb)($mapLambda) })
+             '{ CBM.map($tb)($mapLambda) }.asTerm
         case Block(stats, last) => Block(stats, transform(last))
         case Inlined(x,List(),body) => transform(body)
         case l@Literal(x) =>
-             Term.of('{ CBM.pure(${term.asExpr}) })
+             '{ CBM.pure(${term.asExpr}) }.asTerm
         case other =>
              throw RuntimeException(s"Not supported $other")
 
@@ -99,4 +99,4 @@ object X:
          }
          changes.transformTerm(body)(Symbol.spliceOwner)
 
-   transform(Term.of(f)).asExprOf[CB[T]]
+   transform(f.asTerm).asExprOf[CB[T]]

--- a/tests/pos-macros/i6171/Macro_1.scala
+++ b/tests/pos-macros/i6171/Macro_1.scala
@@ -6,7 +6,7 @@ object scalatest {
 
   def assertImpl(x: Expr[Any])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
-    Term.of(x).underlyingArgument
+    x.asTerm.underlyingArgument
     '{ () }
   }
 }

--- a/tests/pos-macros/i6535/Macro_1.scala
+++ b/tests/pos-macros/i6535/Macro_1.scala
@@ -9,7 +9,7 @@ object scalatest {
     import util._
     import ValDef.let
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         let(Symbol.spliceOwner, lhs) { left =>
           let(Symbol.spliceOwner, rhs) { right =>
@@ -19,7 +19,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]

--- a/tests/pos-macros/i7011/Macros_1.scala
+++ b/tests/pos-macros/i7011/Macros_1.scala
@@ -5,7 +5,7 @@ inline def mcr(body: => Any): Unit = ${mcrImpl('body)}
 def mcrImpl[T](body: Expr[Any])(using Quotes) : Expr[Any] = {
   import quotes.reflect._
 
-  val bTree = Term.of(body)
+  val bTree = body.asTerm
   val under = bTree.underlyingArgument
 
   val res = '{Box(${under.asInstanceOf[Term].asExpr})}

--- a/tests/pos-macros/i7030/Macros_1.scala
+++ b/tests/pos-macros/i7030/Macros_1.scala
@@ -7,5 +7,5 @@ def innerImpl(exprs: Expr[Any])(using Quotes): Expr[Any] =
 inline def outer(expr: => Any): Any = ${outerImpl('expr)}
 def outerImpl(body: Expr[Any])(using Quotes): Expr[Any] = {
   import quotes.reflect._
-  Term.of(body).underlyingArgument.asExpr
+  body.asTerm.underlyingArgument.asExpr
 }

--- a/tests/pos-macros/i8325/Macro_1.scala
+++ b/tests/pos-macros/i8325/Macro_1.scala
@@ -13,7 +13,7 @@ object A:
 
   def transformImplExpr[A:Type](using Quotes)(expr: Expr[A]): Expr[A] = {
      import quotes.reflect._
-     Term.of(expr) match {
+     expr.asTerm match {
          case Inlined(x,y,z) => transformImplExpr(z.asExpr.asInstanceOf[Expr[A]])
          case Apply(fun,args) =>  '{  A.pure(${Apply(fun,args).asExpr.asInstanceOf[Expr[A]]}) }
          case other => expr

--- a/tests/pos-macros/i8325b/Macro_1.scala
+++ b/tests/pos-macros/i8325b/Macro_1.scala
@@ -13,7 +13,7 @@ object A:
 
   def transformImplExpr[A:Type](using Quotes)(expr: Expr[A]): Expr[A] = {
      import quotes.reflect._
-     Term.of(expr) match {
+     expr.asTerm match {
          case Inlined(x,y,z) => transformImplExpr(z.asExpr.asInstanceOf[Expr[A]])
          case r@Apply(fun,args) =>  '{
               A.pure(${r.asExpr.asInstanceOf[Expr[A]]}) }

--- a/tests/pos-macros/i8866/Macro_1.scala
+++ b/tests/pos-macros/i8866/Macro_1.scala
@@ -17,7 +17,7 @@ object Macro {
     ValDef.let(
       Symbol.spliceOwner,
       Select.unique(
-        Term.of('{ OtherMacro }),
+        '{ OtherMacro }.asTerm,
         "apply"
       )
     )(identity).asExprOf[Int]

--- a/tests/pos-macros/i8866b/Macro_1.scala
+++ b/tests/pos-macros/i8866b/Macro_1.scala
@@ -12,7 +12,7 @@ object Macro {
     ValDef.let(
       Symbol.spliceOwner,
       Select.unique(
-        Term.of('{ Other }),
+        '{ Other }.asTerm,
         "apply"
       )
     )(identity).asExprOf[Int]

--- a/tests/pos-macros/i9251/Macro_1.scala
+++ b/tests/pos-macros/i9251/Macro_1.scala
@@ -21,7 +21,7 @@ object Async {
   def checkPrintTypeImpl[F[_]:Type,T:Type](f: Expr[T])(using Quotes): Expr[Unit] =
     import quotes.reflect._
 
-    val fu = Term.of(f)
+    val fu = f.asTerm
     fu match
       case Inlined(_,_,Block(_,Apply(TypeApply(Select(q,n),tparams),List(param)))) =>
         param.tpe match

--- a/tests/pos-macros/i9518/Macro_1.scala
+++ b/tests/pos-macros/i9518/Macro_1.scala
@@ -7,7 +7,7 @@ inline def shift : Unit = ${ shiftTerm }
 
 def shiftTerm(using Quotes): Expr[Unit] = {
   import quotes.reflect._
-  val nTree = Term.of('{ ??? : CB[Int] })
+  val nTree = '{ ??? : CB[Int] }.asTerm
   val tp1 = TypeRepr.of[CB[Int]]
   val tp2 = TypeRepr.of[([X] =>> CB[X])[Int]]
   val ta = Type.of[[X] =>> CB[X]]

--- a/tests/pos-macros/i9687/Macro_1.scala
+++ b/tests/pos-macros/i9687/Macro_1.scala
@@ -24,8 +24,8 @@ object X {
 
  def transformImpl[A:Type](x:Expr[A])(using Quotes):Expr[A] = {
     import quotes.reflect._
-    val slowPath = Term.of('{ SlowPath })
-    val fastPath = Term.of('{ FastPath })
+    val slowPath = '{ SlowPath }.asTerm
+    val fastPath = '{ FastPath }.asTerm
     val transformer = new TreeMap() {
       override def transformTerm(term:Term)(owner: Symbol):Term = {
         term match
@@ -37,7 +37,7 @@ object X {
           case _ => super.transformTerm(term)(owner)
       }
     }
-    val r = transformer.transformTerm(Term.of(x))(Symbol.spliceOwner).asExprOf[A]
+    val r = transformer.transformTerm(x.asTerm)(Symbol.spliceOwner).asExprOf[A]
     s"result: ${r.show}"
     r
  }

--- a/tests/pos-macros/i9894/Macro_1.scala
+++ b/tests/pos-macros/i9894/Macro_1.scala
@@ -36,7 +36,7 @@ object X:
         case Block(stats, last) => Block(stats, transform(last))
         case Inlined(x,List(),body) => transform(body)
         case l@Literal(x) =>
-          Term.of('{ CBM.pure(${term.asExpr}) })
+          '{ CBM.pure(${term.asExpr}) }.asTerm
         case other =>
              throw RuntimeException(s"Not supported $other")
 
@@ -64,4 +64,4 @@ object X:
          }
          changes.transformTerm(body)(Symbol.spliceOwner)
 
-   transform(Term.of(f)).asExprOf[CB[T]]
+   transform(f.asTerm).asExprOf[CB[T]]

--- a/tests/pos-macros/treemap-unapply/Macro.scala
+++ b/tests/pos-macros/treemap-unapply/Macro.scala
@@ -3,6 +3,6 @@ import scala.quoted._
 inline def mcr(x: => Unit): Unit = ${mcrImpl('x)}
 def mcrImpl(x: Expr[Unit])(using Quotes) : Expr[Unit] =
   import quotes.reflect._
-  val tr: Term = Term.of(x)
+  val tr: Term = x.asTerm
   object m extends TreeMap
   m.transformTerm(tr)(Symbol.spliceOwner).asExprOf[Unit]

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2/Macro_1.scala
@@ -7,7 +7,7 @@ object Foo {
 
   def inspectBodyImpl(x: Expr[Int])(using Quotes) : Expr[String] = {
     import quotes.reflect._
-    Term.of(x) match {
+    x.asTerm match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.show(using Printer.TreeStructure))
       case arg => Expr(arg.symbol.tree.show(using Printer.TreeStructure)) // TODO should all by name parameters be in an inline node?
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3/Macro_1.scala
@@ -7,7 +7,7 @@ object Foo {
 
   def inspectBodyImpl(x: Expr[Int])(using Quotes) : Expr[String] = {
     import quotes.reflect._
-    Term.of(x) match {
+    x.asTerm match {
       case Inlined(None, Nil, arg) => Expr(arg.symbol.tree.show(using Printer.TreeStructure))
       case arg => Expr(arg.symbol.tree.show(using Printer.TreeStructure)) // TODO should all by name parameters be in an inline node?
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -12,7 +12,7 @@ object Macros {
 
     val output = myTraverser(buff)
 
-    val tree = Term.of(x)
+    val tree = x.asTerm
     output.traverseTree(tree)(Symbol.spliceOwner)
     '{print(${Expr(buff.result())})}
   }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1/quoted_1.scala
@@ -13,7 +13,7 @@ object Foo {
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.show(using Printer.TreeStructure))
       else '{"NO DEFINTION"}
 
-    Term.of(x) match {
+    x.asTerm match {
       case Inlined(None, Nil, arg) => definitionString(arg.symbol)
       case arg => definitionString(arg.symbol) // TODO should all by name parameters be in an inline node
     }

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2/quoted_1.scala
@@ -12,7 +12,7 @@ object Foo {
       if sym.isClassDef || sym.isDefDef || sym.isValDef then Expr(sym.tree.show(using Printer.TreeStructure))
       else '{"NO DEFINTION"}
 
-    Term.of(x) match {
+    x.asTerm match {
       case Inlined(None, Nil, arg) => definitionString(arg.symbol)
       case arg => definitionString(arg.symbol) // TODO should all by name parameters be in an inline node
     }

--- a/tests/run-macros/exports/Macro_2.scala
+++ b/tests/run-macros/exports/Macro_2.scala
@@ -14,15 +14,15 @@ private def visitExportsExprMapImpl[T: Type](e: Expr[T], f: Expr[T => Any])(usin
 private def visitExportsTreeMapImpl[T: Type](e: Expr[T], f: Expr[T => Any])(using Quotes): Expr[Any] =
   import quotes.reflect._
   object m extends TreeMap
-  '{$f(${m.transformTerm(Term.of(e))(Symbol.spliceOwner).asExprOf})}
+  '{$f(${m.transformTerm(e.asTerm)(Symbol.spliceOwner).asExprOf})}
 
 private def visitExportsShowImpl[T: Type](e: Expr[T])(using Quotes): Expr[Any] =
   import quotes.reflect._
-  '{println(${Expr(Term.of(e).show)})}
+  '{println(${Expr(e.asTerm.show)})}
 
 private def visitExportsShowExtractImpl[T: Type](e: Expr[T])(using Quotes): Expr[Any] =
   import quotes.reflect._
-  '{println(${Expr(Term.of(e).show(using Printer.TreeStructure))})}
+  '{println(${Expr(e.asTerm.show(using Printer.TreeStructure))})}
 
 private object IdempotentExprMap extends ExprMap {
 
@@ -43,7 +43,7 @@ private def traverseExportsImpl(e: Expr[Any], f: Expr[String => Any])(using Quot
   }
 
   val res =
-    ExportAccumulator.foldTree(mutable.Buffer.empty, Term.of(e))(Symbol.spliceOwner).mkString(", ")
+    ExportAccumulator.foldTree(mutable.Buffer.empty, e.asTerm)(Symbol.spliceOwner).mkString(", ")
 
   '{ $f(${Expr(res)}) }
 }

--- a/tests/run-macros/f-interpolation-1/FQuote_1.scala
+++ b/tests/run-macros/f-interpolation-1/FQuote_1.scala
@@ -31,7 +31,7 @@ object FQuote {
       tree.symbol.fullName == "scala.StringContext$.apply"
 
     // FQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts = Term.of(receiver).underlyingArgument match {
+    val parts = receiver.asTerm.underlyingArgument match {
       case Apply(conv, List(Apply(fun, List(Typed(Repeated(values, _), _)))))
           if isSCOpsConversion(conv) &&
              isStringContextApply(fun) &&
@@ -43,7 +43,7 @@ object FQuote {
     }
 
     // [a0, ...]: Any*
-    val Typed(Repeated(allArgs, _), _) = Term.of(args).underlyingArgument
+    val Typed(Repeated(allArgs, _), _) = args.asTerm.underlyingArgument
 
     for ((arg, part) <- allArgs.zip(parts.tail)) {
       if (part.startsWith("%d") && !(arg.tpe <:< TypeRepr.of[Int])) {

--- a/tests/run-macros/i10011/Macro_1.scala
+++ b/tests/run-macros/i10011/Macro_1.scala
@@ -5,5 +5,5 @@ inline def printPos[T](inline expr: T): (Int, Int) =
 
 private def printPos[T](expr: Expr[T])(using Quotes): Expr[(Int, Int)] =
   import quotes.reflect._
-  val pos = Term.of(expr).pos
+  val pos = expr.asTerm.pos
   Expr((pos.start, pos.end))

--- a/tests/run-macros/i5119/Macro_1.scala
+++ b/tests/run-macros/i5119/Macro_1.scala
@@ -8,6 +8,6 @@ object Macro {
   def impl(sc: Expr[StringContext], args: Expr[Seq[Any]])(using q: Quotes) : Expr[String] = {
     import q.reflect._
     given Printer[Tree] = Printer.TreeStructure
-    Expr(Term.of(sc).underlyingArgument.show + "\n" + Term.of(args).underlyingArgument.show)
+    Expr(sc.asTerm.underlyingArgument.show + "\n" + args.asTerm.underlyingArgument.show)
   }
 }

--- a/tests/run-macros/i5119b/Macro_1.scala
+++ b/tests/run-macros/i5119b/Macro_1.scala
@@ -8,6 +8,6 @@ object Macro {
   def impl(arg1: Expr[Any], arg2: Expr[Any])(using q: Quotes) : Expr[String] =
     import q.reflect._
     given Printer[Tree] = Printer.TreeStructure
-    Expr(Term.of(arg1).underlyingArgument.show + "\n" + Term.of(arg2).underlyingArgument.show)
+    Expr(arg1.asTerm.underlyingArgument.show + "\n" + arg2.asTerm.underlyingArgument.show)
 
 }

--- a/tests/run-macros/i5533/Macro_1.scala
+++ b/tests/run-macros/i5533/Macro_1.scala
@@ -10,7 +10,7 @@ object scalatest {
   def assertImpl(condition: Expr[Boolean])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    val tree = Term.of(condition)
+    val tree = condition.asTerm
 
     val expr = tree.asExprOf[Boolean]
 

--- a/tests/run-macros/i5533b/Macro_1.scala
+++ b/tests/run-macros/i5533b/Macro_1.scala
@@ -8,7 +8,7 @@ object scalatest {
 
   def assertImpl(condition: Expr[Boolean])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
-    val tree = Term.of(condition)
+    val tree = condition.asTerm
     def exprStr: String = condition.show
 
     tree.underlyingArgument match {

--- a/tests/run-macros/i5536/Macro_1.scala
+++ b/tests/run-macros/i5536/Macro_1.scala
@@ -5,7 +5,7 @@ object scalatest {
 
   def assertImpl(condition: Expr[Boolean])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
-    val tree = Term.of(condition)
+    val tree = condition.asTerm
     def exprStr: String = condition.show
 
     tree.underlyingArgument match {

--- a/tests/run-macros/i5629/Macro_1.scala
+++ b/tests/run-macros/i5629/Macro_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
-    val b = Term.of(cond).underlyingArgument.asExprOf[Boolean]
+    val b = cond.asTerm.underlyingArgument.asExprOf[Boolean]
     '{ scala.Predef.assert($b) }
   }
 

--- a/tests/run-macros/i5715/Macro_1.scala
+++ b/tests/run-macros/i5715/Macro_1.scala
@@ -7,7 +7,7 @@ object scalatest {
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case app @ Apply(select @ Select(lhs, op), rhs :: Nil) =>
         val cond = Apply(Select.copy(select)(lhs, "exists"), rhs :: Nil).asExprOf[Boolean]
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/i5941/macro_1.scala
+++ b/tests/run-macros/i5941/macro_1.scala
@@ -45,11 +45,11 @@ object Lens {
       }
     }
 
-    // exception: Term.of(getter).underlyingArgument
-    Term.of(getter) match {
+    // exception: getter.asTerm.underlyingArgument
+    getter.asTerm match {
       case Function(param :: Nil, Path(o, parts)) if o.symbol == param.symbol =>
         '{
-          val setter = (t: T) => (s: S) => ${ setterBody(Term.of('s), Term.of('t), parts).asExprOf[S] }
+          val setter = (t: T) => (s: S) => ${ setterBody('s.asTerm, 't.asTerm, parts).asExprOf[S] }
           apply($getter)(setter)
         }
       case _ =>
@@ -116,9 +116,9 @@ object Iso {
       '{???}
     } else '{
       // (p: S) => p._1
-      val to = (p: S) =>  ${ Select.unique(Term.of('p), "_1").asExprOf[A] }
+      val to = (p: S) =>  ${ Select.unique('p.asTerm, "_1").asExprOf[A] }
       // (p: A) => S(p)
-      val from = (p: A) =>  ${ Select.overloaded(Ident(companion), "apply", Nil, Term.of('p) :: Nil).asExprOf[S] }
+      val from = (p: A) =>  ${ Select.overloaded(Ident(companion), "apply", Nil, 'p.asTerm :: Nil).asExprOf[S] }
       apply(from)(to)
     }
   }

--- a/tests/run-macros/i6171/Macro_1.scala
+++ b/tests/run-macros/i6171/Macro_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         ValDef.let(Symbol.spliceOwner, lhs) { left =>
           ValDef.let(Symbol.spliceOwner, rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/i6679/Macro_1.scala
+++ b/tests/run-macros/i6679/Macro_1.scala
@@ -4,7 +4,7 @@ def makeMatch[A: Type](head : Expr[A])(using qctx : Quotes) : Expr[Unit] = {
   import quotes.reflect._
 
   val sacrifice = '{ $head match { case _ => ??? } }
-  Term.of(sacrifice)
+  sacrifice.asTerm
 
   '{ println("Ok") }
 }

--- a/tests/run-macros/i7887/Macro_1.scala
+++ b/tests/run-macros/i7887/Macro_1.scala
@@ -1,10 +1,10 @@
 def myMacroImpl(a: quoted.Expr[_])(using qctx: quoted.Quotes) = {
   import scala.quoted.quotes.reflect._
   def typed[A] = {
-    implicit val t: quoted.Type[A] = Term.of(a).tpe.widen.asType.asInstanceOf[quoted.Type[A]]
+    implicit val t: quoted.Type[A] = a.asTerm.tpe.widen.asType.asInstanceOf[quoted.Type[A]]
     '{
       type T = A
-      ${Term.of(a).asExprOf[T]}
+      ${a.asTerm.asExprOf[T]}
     }
   }
 

--- a/tests/run-macros/i7898/Macro_1.scala
+++ b/tests/run-macros/i7898/Macro_1.scala
@@ -4,7 +4,7 @@ object Main {
 
   def myMacroImpl(body: Expr[_])(using Quotes) : Expr[_] = {
     import quotes.reflect._
-    val bodyTerm = Term.of(underlyingArgument(body))
+    val bodyTerm = underlyingArgument(body).asTerm
     val showed = bodyTerm.show
     '{
       println(${Expr(showed)})
@@ -18,5 +18,5 @@ object Main {
 
   def underlyingArgument[T](expr: Expr[T])(using Quotes): Expr[T] =
     import quotes.reflect._
-    Term.of(expr).underlyingArgument.asExpr.asInstanceOf[Expr[T]]
+    expr.asTerm.underlyingArgument.asExpr.asInstanceOf[Expr[T]]
 }

--- a/tests/run-macros/i8007/Macro_2.scala
+++ b/tests/run-macros/i8007/Macro_2.scala
@@ -30,7 +30,7 @@ object Macro2 {
 
       val body: Expr[T] => Expr[String] = elem =>
         fields.reverse.foldLeft(Expr("")){ (acc, field) =>
-          val res = Select.unique(Term.of(elem), field).asExpr
+          val res = Select.unique(elem.asTerm, field).asExpr
           '{ $res.toString + " " + $acc }
         }
 

--- a/tests/run-macros/inferred-repeated-result/test_1.scala
+++ b/tests/run-macros/inferred-repeated-result/test_1.scala
@@ -5,7 +5,7 @@ object Macros {
   def impl[T](expr: Expr[T])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    val tree = Term.of(expr)
+    val tree = expr.asTerm
 
     val methods =
       tree.tpe.classSymbol.get.declaredMethods.map { m =>

--- a/tests/run-macros/paramSymss/Macro_1.scala
+++ b/tests/run-macros/paramSymss/Macro_1.scala
@@ -6,7 +6,7 @@ inline def showParamSyms(inline x: Any): String =
 def showParamSymsExpr(using Quotes)(x: Expr[Any]): Expr[String] =
   import quotes.reflect._
   val '{ $y: Any } = x // Drop Inlined not to access the symbol
-  val sym = Term.of(y).symbol
+  val sym = y.asTerm.symbol
   Expr(
     s"""sym: ${sym.fullName}
        |paramSymss: ${sym.paramSymss.map(_.map(_.fullName))}

--- a/tests/run-macros/quote-matcher-runtime/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-runtime/quoted_1.scala
@@ -17,8 +17,8 @@ object Macros {
     }
 
     '{
-      println("Scrutinee: " + ${Expr(Term.of(a).show)})
-      println("Pattern: " + ${Expr(Term.of(b).show)})
+      println("Scrutinee: " + ${Expr(a.asTerm.show)})
+      println("Pattern: " + ${Expr(b.asTerm.show)})
       println("Result: " + ${Expr(res.toString)})
       println()
     }

--- a/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-1/quoted_1.scala
@@ -21,7 +21,7 @@ object Macros {
 
       case _ =>
         import quotes.reflect._
-        report.error("Expected explicit DSL", Term.of(e).pos)
+        report.error("Expected explicit DSL", e.asTerm.pos)
         '{ ??? }
 
     }

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -39,7 +39,7 @@ object Macros {
 
       case _ =>
         import quotes.reflect._
-        report.error("Expected explicit DSL " + e.show, Term.of(e).pos)
+        report.error("Expected explicit DSL " + e.show, e.asTerm.pos)
         ???
     }
 
@@ -53,7 +53,7 @@ object Macros {
         )
       case _ =>
         import quotes.reflect._
-        report.error("Expected explicit DSL => DSL "  + e.show, Term.of(e).pos)
+        report.error("Expected explicit DSL => DSL "  + e.show, e.asTerm.pos)
         ???
     }
 
@@ -66,11 +66,11 @@ object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using Quotes): X = {
     import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.asTerm, params, List(v.asTerm)).asExpr.asInstanceOf[Expr[t]])
   }
   private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
     import quotes.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
@@ -79,11 +79,11 @@ object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using Quotes): X = {
     import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.asTerm, params, List(v.asTerm)).asExpr.asInstanceOf[Expr[t]])
   }
   private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
     import quotes.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matching-open/Macro_1.scala
+++ b/tests/run-macros/quote-matching-open/Macro_1.scala
@@ -19,22 +19,22 @@ object UnsafeExpr {
   def open[T1, R, X](f: Expr[T1 => R])(content: (Expr[R], [t] => Expr[t] => Expr[T1] => Expr[t]) => X)(using Quotes): X = {
     import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](Term.of(e), params, List(Term.of(v))).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v: Expr[T1]) => bodyFn[t](e.asTerm, params, List(v.asTerm)).asExpr.asInstanceOf[Expr[t]])
   }
   def open[T1, T2, R, X](f: Expr[(T1, T2) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2]) => Expr[t]) => X)(using Quotes)(using DummyImplicit): X = {
     import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2]) => bodyFn[t](Term.of(e), params, List(Term.of(v1), Term.of(v2))).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2]) => bodyFn[t](e.asTerm, params, List(v1.asTerm, v2.asTerm)).asExpr.asInstanceOf[Expr[t]])
   }
 
   def open[T1, T2, T3, R, X](f: Expr[(T1, T2, T3) => R])(content: (Expr[R], [t] => Expr[t] => (Expr[T1], Expr[T2], Expr[T3]) => Expr[t]) => X)(using Quotes)(using DummyImplicit, DummyImplicit): X = {
     import quotes.reflect._
     val (params, bodyExpr) = paramsAndBody[R](f)
-    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](Term.of(e), params, List(Term.of(v1), Term.of(v2), Term.of(v3))).asExpr.asInstanceOf[Expr[t]])
+    content(bodyExpr, [t] => (e: Expr[t]) => (v1: Expr[T1], v2: Expr[T2], v3: Expr[T3]) => bodyFn[t](e.asTerm, params, List(v1.asTerm, v2.asTerm, v3.asTerm)).asExpr.asInstanceOf[Expr[t]])
   }
   private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
     import quotes.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = Term.of(f).etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quoted-matching-docs/Macro_1.scala
+++ b/tests/run-macros/quoted-matching-docs/Macro_1.scala
@@ -23,5 +23,5 @@ private def sumExpr(argsExpr: Expr[Seq[Int]])(using Quotes) : Expr[Int] = {
 object UnsafeExpr {
   def underlyingArgument[T](expr: Expr[T])(using Quotes): Expr[T] =
     import quotes.reflect._
-    Term.of(expr).underlyingArgument.asExpr.asInstanceOf[Expr[T]]
+    expr.asTerm.underlyingArgument.asExpr.asInstanceOf[Expr[T]]
 }

--- a/tests/run-macros/refined-selectable-macro/Macro_1.scala
+++ b/tests/run-macros/refined-selectable-macro/Macro_1.scala
@@ -17,7 +17,7 @@ object Macro {
   private def toTupleImpl(s: Expr[Selectable])(using qctx:Quotes) : Expr[Tuple] = {
     import quotes.reflect._
 
-    val repr = Term.of(s).tpe.widenTermRefExpr.dealias
+    val repr = s.asTerm.tpe.widenTermRefExpr.dealias
 
     def rec(tpe: TypeRepr): List[(String, TypeRepr)] = {
       tpe match {
@@ -51,7 +51,7 @@ object Macro {
   private def fromTupleImpl[T: Type](s: Expr[Tuple], newRecord: Expr[Array[(String, Any)] => T])(using qctx:Quotes) : Expr[Any] = {
     import quotes.reflect._
 
-    val repr = Term.of(s).tpe.widenTermRefExpr.dealias
+    val repr = s.asTerm.tpe.widenTermRefExpr.dealias
 
     def isTupleCons(sym: Symbol): Boolean = sym.owner == defn.ScalaPackageClass && sym.name == "*:"
 

--- a/tests/run-macros/reflect-dsl/assert_1.scala
+++ b/tests/run-macros/reflect-dsl/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         ValDef.let(Symbol.spliceOwner, lhs) { left =>
           ValDef.let(Symbol.spliceOwner, rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-lambda/assert_1.scala
+++ b/tests/run-macros/reflect-lambda/assert_1.scala
@@ -8,7 +8,7 @@ object lib {
     import quotes.reflect._
     import util._
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), Lambda(param :: Nil, Apply(Select(a, "=="), b :: Nil)) :: Nil)
       if a.symbol == param.symbol || b.symbol == param.symbol =>
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/reflect-pos-fun/assert_1.scala
+++ b/tests/run-macros/reflect-pos-fun/assert_1.scala
@@ -8,13 +8,13 @@ object scalatest {
     import quotes.reflect._
     import util._
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(TypeApply(Select(lhs, op), targs), rhs) =>
         ValDef.let(Symbol.spliceOwner, lhs) { left =>
           ValDef.let(Symbol.spliceOwner, rhs) { rs =>
             val app = Select.overloaded(left, op, targs.map(_.tpe), rs)
             val b = app.asExprOf[Boolean]
-            Term.of('{ scala.Predef.assert($b) })
+            '{ scala.Predef.assert($b) }.asTerm
           }
         }.asExprOf[Unit]
     }

--- a/tests/run-macros/reflect-select-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-constructor/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         ValDef.let(Symbol.spliceOwner, lhs) { left =>
           ValDef.let(Symbol.spliceOwner, rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-select-copy-2/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy-2/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         ValDef.let(Symbol.spliceOwner, lhs) { left =>
           ValDef.let(Symbol.spliceOwner, rhs) { right =>
@@ -21,7 +21,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert(${b}) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]
@@ -34,7 +34,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert(${b}) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-select-copy/assert_1.scala
+++ b/tests/run-macros/reflect-select-copy/assert_1.scala
@@ -7,7 +7,7 @@ object scalatest {
   def assertImpl(cond: Expr[Boolean], clue: Expr[Any])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case Apply(select @ Select(lhs, op), rhs :: Nil) =>
         val cond = Apply(Select.copy(select)(lhs, ">"), rhs :: Nil).asExprOf[Boolean]
         '{ scala.Predef.assert($cond) }

--- a/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
+++ b/tests/run-macros/reflect-select-symbol-constructor/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(sel @ Select(lhs, op), rhs :: Nil) =>
         ValDef.let(Symbol.spliceOwner, lhs) { left =>
           ValDef.let(Symbol.spliceOwner, rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-select-value-class/assert_1.scala
+++ b/tests/run-macros/reflect-select-value-class/assert_1.scala
@@ -12,7 +12,7 @@ object scalatest {
       case tp: MethodType => tp.isImplicit
       case _ => false
 
-    Term.of(cond).underlyingArgument match {
+    cond.asTerm.underlyingArgument match {
       case t @ Apply(Select(lhs, op), rhs :: Nil) =>
         ValDef.let(Symbol.spliceOwner, lhs) { left =>
           ValDef.let(Symbol.spliceOwner, rhs) { right =>
@@ -22,7 +22,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]
@@ -36,7 +36,7 @@ object scalatest {
               val r = right.asExpr
               val b = result.asExprOf[Boolean]
               val code = '{ scala.Predef.assert($b) }
-              Term.of(code)
+              code.asTerm
             }
           }
         }.asExprOf[Unit]

--- a/tests/run-macros/reflect-sourceCode/Macro_1.scala
+++ b/tests/run-macros/reflect-sourceCode/Macro_1.scala
@@ -6,6 +6,6 @@ object api {
 
   private def reflImpl[T](x: Expr[T])(implicit qctx: Quotes): Expr[String] = {
     import quotes.reflect._
-    Expr(Term.of(x).pos.sourceCode.get)
+    Expr(x.asTerm.pos.sourceCode.get)
   }
 }

--- a/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
+++ b/tests/run-macros/tasty-argument-tree-1/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def impl[T](x: Expr[T])(using q: Quotes) : Expr[Unit] = {
     import q.reflect._
-    val tree = Term.of(x)
+    val tree = x.asTerm
     given Printer[Tree] = Printer.TreeStructure
     '{
       println()

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -27,7 +27,7 @@ object Macros {
         "T",
         TypeBounds(TypeRepr.of[Int], TypeRepr.of[Int]))
     val x6T = TypeRepr.of[List].appliedTo(List(TypeRepr.of[Int]))
-    val x7T = AnnotatedType(ConstantType(Constant.Int(7)), Term.of('{ new TestAnnotation }))
+    val x7T = AnnotatedType(ConstantType(Constant.Int(7)), '{ new TestAnnotation }.asTerm)
     val x8T =
       MatchType(
         TypeRepr.of[Int],

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -20,10 +20,10 @@ object Macros {
       DefDef(sym1, {
         case List() => {
           case List(List(a, b)) =>
-            Some(Term.of('{ ${ a.asExpr.asInstanceOf[Expr[Int]] } - ${ b.asExpr.asInstanceOf[Expr[Int]] } }))
+            Some('{ ${ a.asExpr.asInstanceOf[Expr[Int]] } - ${ b.asExpr.asInstanceOf[Expr[Int]] } }.asTerm)
         }
       }),
-      Term.of('{ assert(${ Apply(Ref(sym1), List(Literal(Constant.Int(2)), Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == -1) }))
+      '{ assert(${ Apply(Ref(sym1), List(Literal(Constant.Int(2)), Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == -1) }.asTerm)
 
     // test for no argument list (no Apply node)
     val sym2 : Symbol = Symbol.newMethod(
@@ -39,7 +39,7 @@ object Macros {
             Some(Literal(Constant.Int(2)))
         }
       }),
-      Term.of('{ assert(${ Ref(sym2).asExpr.asInstanceOf[Expr[Int]] } == 2) }))
+      '{ assert(${ Ref(sym2).asExpr.asInstanceOf[Expr[Int]] } == 2) }.asTerm)
 
    // test for multiple argument lists
    val sym3 : Symbol = Symbol.newMethod(
@@ -59,7 +59,7 @@ object Macros {
             Some(a)
         }
       }),
-      Term.of('{ assert(${ Apply(Apply(Ref(sym3), List(Literal(Constant.Int(3)))), List(Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == 3) }))
+      '{ assert(${ Apply(Apply(Ref(sym3), List(Literal(Constant.Int(3)))), List(Literal(Constant.Int(3)))).asExpr.asInstanceOf[Expr[Int]] } == 3) }.asTerm)
 
     // test for recursive references
     val sym4 : Symbol = Symbol.newMethod(
@@ -74,14 +74,14 @@ object Macros {
       DefDef(sym4, {
         case List() => {
           case List(List(x)) =>
-            Some(Term.of('{
+            Some('{
               if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
               then 0
-              else ${ Apply(Ref(sym4), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
-            }))
+              else ${ Apply(Ref(sym4), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.asTerm)).asExpr.asInstanceOf[Expr[Int]] }
+            }.asTerm)
         }
       }),
-      Term.of('{ assert(${ Apply(Ref(sym4), List(Literal(Constant.Int(4)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }))
+      '{ assert(${ Apply(Ref(sym4), List(Literal(Constant.Int(4)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }.asTerm)
 
     // test for nested functions (one symbol is the other's parent, and we use a Closure)
     val sym5 : Symbol = Symbol.newMethod(
@@ -108,14 +108,14 @@ object Macros {
                   DefDef(sym51, {
                     case List() => {
                       case List(List(xx)) =>
-                        Some(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - ${ xx.asExpr.asInstanceOf[Expr[Int]] } }))
+                        Some('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - ${ xx.asExpr.asInstanceOf[Expr[Int]] } }.asTerm)
                     }
                   })),
                 Closure(Ref(sym51), None))
             }
         }
       }),
-      Term.of('{ assert(${ Apply(Ref(sym5), List(Literal(Constant.Int(5)))).asExpr.asInstanceOf[Expr[Int=>Int]] }(4) == 1) }))
+      '{ assert(${ Apply(Ref(sym5), List(Literal(Constant.Int(5)))).asExpr.asInstanceOf[Expr[Int=>Int]] }(4) == 1) }.asTerm)
 
     // test mutually recursive definitions
     val sym6_1 : Symbol = Symbol.newMethod(
@@ -139,12 +139,12 @@ object Macros {
         case List() => {
           case List(List(x)) =>
             Some {
-              Term.of('{
+              '{
                 println(s"sym6_1: ${ ${ x.asExpr.asInstanceOf[Expr[Int]] } }")
                 if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
                 then 0
-                else ${ Apply(Ref(sym6_2), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
-              })
+                else ${ Apply(Ref(sym6_2), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.asTerm)).asExpr.asInstanceOf[Expr[Int]] }
+              }.asTerm
             }
         }
       }),
@@ -152,17 +152,17 @@ object Macros {
         case List() => {
           case List(List(x)) =>
             Some {
-              Term.of('{
+              '{
                 println(s"sym6_2: ${ ${ x.asExpr.asInstanceOf[Expr[Int]] } }")
                 if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
                 then 0
-                else ${ Apply(Ref(sym6_1), List(Term.of('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }))).asExpr.asInstanceOf[Expr[Int]] }
-              })
+                else ${ Apply(Ref(sym6_1), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.asTerm)).asExpr.asInstanceOf[Expr[Int]] }
+              }.asTerm
             }
         }
 
       }),
-      Term.of('{ assert(${ Apply(Ref(sym6_2), List(Literal(Constant.Int(6)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }))
+      '{ assert(${ Apply(Ref(sym6_2), List(Literal(Constant.Int(6)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }.asTerm)
 
     // test polymorphic methods by synthesizing an identity method
     val sym7 : Symbol = Symbol.newMethod(
@@ -182,7 +182,7 @@ object Macros {
             Some(Typed(x, Inferred(t)))
         }
       }),
-      Term.of('{ assert(${ Apply(TypeApply(Ref(sym7), List(Inferred(TypeRepr.of[Int]))), List(Literal(Constant.Int(7)))).asExpr.asInstanceOf[Expr[Int]] } == 7) }))
+      '{ assert(${ Apply(TypeApply(Ref(sym7), List(Inferred(TypeRepr.of[Int]))), List(Literal(Constant.Int(7)))).asExpr.asInstanceOf[Expr[Int]] } == 7) }.asTerm)
 
     Block(
       sym1Statements ++
@@ -192,7 +192,7 @@ object Macros {
       sym5Statements ++
       sym6Statements ++
       sym7Statements ++
-      List(Term.of('{ println("Ok") })),
+      List('{ println("Ok") }.asTerm),
       Literal(Constant.Unit())).asExpr.asInstanceOf[Expr[Unit]]
   }
 }

--- a/tests/run-macros/tasty-eval/quoted_1.scala
+++ b/tests/run-macros/tasty-eval/quoted_1.scala
@@ -19,7 +19,7 @@ object Macros {
     override def value(e: Expr[Int])(using Quotes) : Option[Int] = {
       import quotes.reflect._
 
-      Term.of(e).tpe match {
+      e.asTerm.tpe match {
         case pre: TermRef if pre.termSymbol.isValDef =>
           pre.termSymbol.tree match
             case t: ValDef =>

--- a/tests/run-macros/tasty-extractors-1/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-1/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
   def impl[T](x: Expr[T])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    val tree = Term.of(x)
+    val tree = x.asTerm
     val treeStr = Expr(tree.show(using Printer.TreeStructure))
     val treeTpeStr = Expr(tree.tpe.show(using Printer.TypeReprStructure))
 

--- a/tests/run-macros/tasty-extractors-2/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-2/quoted_1.scala
@@ -8,7 +8,7 @@ object Macros {
   def impl[T](x: Expr[T])(using q: Quotes) : Expr[Unit] = {
     import q.reflect._
 
-    val tree = Term.of(x)
+    val tree = x.asTerm
 
     val treeStr = Expr(tree.show(using Printer.TreeStructure))
     val treeTpeStr = Expr(tree.tpe.show(using Printer.TypeReprStructure))

--- a/tests/run-macros/tasty-extractors-3/quoted_1.scala
+++ b/tests/run-macros/tasty-extractors-3/quoted_1.scala
@@ -25,7 +25,7 @@ object Macros {
       }
     }
 
-    val tree = Term.of(x)
+    val tree = x.asTerm
     traverser.traverseTree(tree)(Symbol.spliceOwner)
     '{print(${Expr(buff.result())})}
   }

--- a/tests/run-macros/tasty-interpolation-1/Macro.scala
+++ b/tests/run-macros/tasty-interpolation-1/Macro.scala
@@ -56,7 +56,7 @@ abstract class MacroStringInterpolator[T] {
 
   protected def getStaticStringContext(strCtxExpr: Expr[StringContext])(using Quotes) : StringContext = {
     import quotes.reflect._
-    Term.of(strCtxExpr).underlyingArgument match {
+    strCtxExpr.asTerm.underlyingArgument match {
       case Select(Typed(Apply(_, List(Apply(_, List(Typed(Repeated(strCtxArgTrees, _), Inferred()))))), _), _) =>
         val strCtxArgs = strCtxArgTrees.map {
           case Literal(Constant.String(str)) => str
@@ -70,7 +70,7 @@ abstract class MacroStringInterpolator[T] {
 
   protected def getArgsList(argsExpr: Expr[Seq[Any]])(using Quotes) : List[Expr[Any]] = {
     import quotes.reflect._
-    Term.of(argsExpr).underlyingArgument match {
+    argsExpr.asTerm.underlyingArgument match {
       case Typed(Repeated(args, _), _) => args.map(_.asExpr)
       case tree => throw new NotStaticlyKnownError("Expected statically known argument list", tree.asExpr)
     }

--- a/tests/run-macros/tasty-macro-assert/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-assert/quoted_1.scala
@@ -15,7 +15,7 @@ object Asserts {
   def impl(cond: Expr[Boolean])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    val tree = Term.of(cond)
+    val tree = cond.asTerm
 
     def isOps(tpe: TypeRepr): Boolean = tpe match {
       case tpe: TermRef => tpe.termSymbol.isDefDef && tpe.name == "Ops"// TODO check that the parent is Asserts

--- a/tests/run-macros/tasty-macro-const/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-const/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   def natConstImpl(x: Expr[Int])(using Quotes) : Expr[Int] = {
     import quotes.reflect._
-    val xTree: Term = Term.of(x)
+    val xTree: Term = x.asTerm
     xTree match {
       case Inlined(_, _, Literal(Constant.Int(n))) =>
         if (n <= 0) {

--- a/tests/run-macros/tasty-macro-positions/quoted_1.scala
+++ b/tests/run-macros/tasty-macro-positions/quoted_1.scala
@@ -10,8 +10,8 @@ object Macros {
 
   def impl(x: Expr[Any])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
-    val pos = posStr(Term.of(x).underlyingArgument.pos)
-    val code = Term.of(x).underlyingArgument.show
+    val pos = posStr(x.asTerm.underlyingArgument.pos)
+    val code = x.asTerm.underlyingArgument.show
     '{
       println($pos)
       println(${Expr(code)})

--- a/tests/run-macros/tasty-original-source/Macros_1.scala
+++ b/tests/run-macros/tasty-original-source/Macros_1.scala
@@ -6,7 +6,7 @@ object Macros {
 
   private def impl(arg: Expr[Any])(using Quotes) : Expr[(String, Any)] = {
     import quotes.reflect._
-    val source = Expr(Term.of(arg).underlyingArgument.pos.sourceCode.get.toString)
+    val source = Expr(arg.asTerm.underlyingArgument.pos.sourceCode.get.toString)
     '{Tuple2($source, $arg)}
   }
 

--- a/tests/run-macros/tasty-overload-secondargs/Macro_1.scala
+++ b/tests/run-macros/tasty-overload-secondargs/Macro_1.scala
@@ -21,14 +21,14 @@ object Macro:
        mThenImpl[A,B,PartialFunction[A,B],Option[B]]('x)
     }
 
-    def mThenImpl[A:Type, B:Type, S<:(A=>B) :Type, R:Type](x:Expr[S])(using Quotes):Expr[R]=
+    def mThenImpl[A:Type, B:Type, S<:(A=>B) :Type, R:Type](x:Expr[S])(using Quotes):Expr[R] =
        import quotes.reflect._
-       val fun = Term.of('{X})
+       val fun = '{X}.asTerm
        val returnType = TypeRepr.of[(S) => ?]
        val firstPart = Select.overloaded(fun,"andThen",
                                  List(TypeIdent(defn.IntClass).tpe, TypeIdent(defn.IntClass).tpe),
                                  List(Literal(Constant.Int(1))),
                                  TypeRepr.of[(S) => R]
                        )
-       val r = Apply(firstPart,List(Term.of(x)))
+       val r = Apply(firstPart,List(x.asTerm))
        r.asExprOf[R]

--- a/tests/run-macros/tasty-seal-method/quoted_1.scala
+++ b/tests/run-macros/tasty-seal-method/quoted_1.scala
@@ -9,7 +9,7 @@ object Asserts {
   def zeroLastArgsImpl(x: Expr[Int])(using Quotes) : Expr[Int] = {
     import quotes.reflect._
     // For simplicity assumes that all parameters are Int and parameter lists have no more than 3 elements
-    Term.of(x).underlyingArgument match {
+    x.asTerm.underlyingArgument match {
       case Apply(fn, args) =>
         fn.tpe.widen match {
           case _: MethodType =>
@@ -35,15 +35,15 @@ object Asserts {
       case Apply(fn, args) =>
         val pre = rec(fn)
         args.size match {
-          case 0 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[() => Any]}() }))
-          case 1 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[Int => Any]}(0) }))
-          case 2 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[(Int, Int) => Any]}(0, 0) }))
-          case 3 => Term.of(Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }))
+          case 0 => Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[() => Any]}() }).asTerm
+          case 1 => Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[Int => Any]}(0) }).asTerm
+          case 2 => Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[(Int, Int) => Any]}(0, 0) }).asTerm
+          case 3 => Expr.betaReduce('{ ${pre.etaExpand(Symbol.spliceOwner).asExprOf[(Int, Int, Int) => Any]}(0, 0, 0) }).asTerm
         }
       case _ => term
     }
 
-    rec(Term.of(x).underlyingArgument).asExprOf[Int]
+    rec(x.asTerm.underlyingArgument).asExprOf[Int]
   }
 
 }

--- a/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
+++ b/tests/run-macros/tasty-string-interpolation-reporter-test/Macros_1.scala
@@ -24,7 +24,7 @@ object Macro {
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
             import quotes.reflect._
-            report.error(msg, Term.of(parts(partIdx)).pos)
+            report.error(msg, parts(partIdx).asTerm.pos)
           }
         }
         fooCore(parts, args, reporter)
@@ -38,7 +38,7 @@ object Macro {
         val reporter = new Reporter {
           def errorOnPart(msg: String, partIdx: Int): Unit = {
             import quotes.reflect._
-            val pos = Term.of(parts(partIdx)).pos
+            val pos = parts(partIdx).asTerm.pos
             errors += '{ Tuple4(${Expr(partIdx)}, ${Expr(pos.start)}, ${Expr(pos.end)}, ${Expr(msg)}) }
           }
         }

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -7,6 +7,6 @@ object MacrosImpl:
   def impl[T: Type](x: Expr[T])(using Quotes) : Expr[T] = {
     import quotes.reflect._
     val identityMap = new TreeMap { }
-    val transformed = identityMap.transformTerm(Term.of(x))(Symbol.spliceOwner).asExprOf[T]
+    val transformed = identityMap.transformTerm(x.asTerm)(Symbol.spliceOwner).asExprOf[T]
     transformed
   }

--- a/tests/run-macros/tasty-unsafe-let/quoted_1.scala
+++ b/tests/run-macros/tasty-unsafe-let/quoted_1.scala
@@ -8,11 +8,11 @@ object Macros {
   private def impl[T: Type](rhs: Expr[T], body: Expr[T => Unit])(using Quotes) : Expr[Unit] = {
     import quotes.reflect._
 
-    val rhsTerm = Term.of(rhs)
+    val rhsTerm = rhs.asTerm
 
     import quotes.reflect._
     ValDef.let(Symbol.spliceOwner, rhsTerm) { rhsId =>
-      Term.of(Expr.betaReduce('{$body(${rhsId.asExpr.asInstanceOf[Expr[T]]})})) // Dangerous uncheked cast!
+      Expr.betaReduce('{$body(${rhsId.asExpr.asInstanceOf[Expr[T]]})}).asTerm // Dangerous uncheked cast!
     }.asExprOf[Unit]
   }
 

--- a/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-1/XmlQuote_1.scala
@@ -41,7 +41,7 @@ object XmlQuote {
       tree.symbol.fullName == "scala.StringContext$.apply"
 
     // XmlQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts = Term.of(receiver).underlyingArgument match {
+    val parts = receiver.asTerm.underlyingArgument match {
       case Apply(conv, List(Apply(fun, List(Typed(Repeated(values, _), _)))))
           if isSCOpsConversion(conv) &&
              isStringContextApply(fun) &&
@@ -53,7 +53,7 @@ object XmlQuote {
     }
 
     // [a0, ...]: Any*
-    val Typed(Repeated(args0, _), _) = Term.of(args).underlyingArgument
+    val Typed(Repeated(args0, _), _) = args.asTerm.underlyingArgument
 
     val string = parts.mkString("??")
     '{new Xml(${Expr(string)}, ${liftListOfAny(args0)})}

--- a/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
+++ b/tests/run-macros/xml-interpolation-2/XmlQuote_1.scala
@@ -36,7 +36,7 @@ object XmlQuote {
     }
 
     // XmlQuote.SCOps(StringContext.apply([p0, ...]: String*)
-    val parts: List[String] = stripTyped(Term.of(receiver).underlying) match {
+    val parts: List[String] = stripTyped(receiver.asTerm.underlying) match {
       case Apply(conv, List(ctx1)) if isSCOpsConversion(conv) =>
         ctx1 match {
           case Apply(fun, List(Typed(Repeated(values, _), _))) if isStringContextApply(fun) =>
@@ -56,7 +56,7 @@ object XmlQuote {
     }
 
     // [a0, ...]: Any*
-    val args2: Expr[List[Any]] = Term.of(args).underlyingArgument match {
+    val args2: Expr[List[Any]] = args.asTerm.underlyingArgument match {
       case Typed(Repeated(args0, _), _) => // statically known args, make list directly
         Expr.ofList(args0.map(_.asExpr))
       case _ =>


### PR DESCRIPTION
* Add `Expr.asTerm` under `reflect`
* Deprecate `Tree.of` and `Term.of` for simpler migration from M2 to M3

This change make the intent of the operation clearer. We call `asTerm` to see the expression as a `Term` just like we call `asExpr` make the `Term` and `Expr[Any]`.
It will simplify code that needs to access the trees.

As these are extension methods, they can also be accessed explicitly using `reflect.asTerm(expr)` or `reflect.asTree(expr)` which can be useful in some situations.