### PR TITLE
CI: each job can only use 4 cores

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -53,6 +54,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -137,6 +139,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -172,6 +175,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -207,6 +211,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -242,6 +247,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -284,6 +290,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -318,6 +325,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -359,6 +367,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
@@ -441,6 +450,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2020-11-19
+      options: --cpus=4
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache

--- a/project/scripts/sbt
+++ b/project/scripts/sbt
@@ -7,8 +7,7 @@ set -e
 CMD="${1:?Missing sbt command}"
 
 # run sbt with the supplied arg
-sbt -J-Xmx4096m \
-    -J-XX:ReservedCodeCacheSize=512m \
+sbt -J-XX:ReservedCodeCacheSize=512m \
     -DSBT_PGP_USE_GPG=false \
     -no-colors \
     "$CMD"


### PR DESCRIPTION
This should allow us to massively increase the number of jobs we can run
in parallel.

It also means we don't need to run sbt with so much ram so we can remove
the max heap size setting in projects/script/sbt.