### PR TITLE
Add trailing colon to extension block

### DIFF
--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -134,7 +134,7 @@ type T = A:
 given [T](using Ord[T]): Ord[List[T]] with
   def compare(x: List[T], y: List[T]) = ???
 
-extension (xs: List[Int])
+extension (xs: List[Int]):
   def second: Int = xs.tail.head
 
 new A:


### PR DESCRIPTION
I believe this is mandatory, right?