### PR TITLE
Remove the -Yemit-tasty-in-class option, along with handling of .hasTasty.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.DS_Store
 *.class
 *.tasty
-*.hasTasty
 *.log
 *.swp
 *~

--- a/.vscode-template/settings.json
+++ b/.vscode-template/settings.json
@@ -7,7 +7,7 @@
 
   "search.exclude": {
     "**/*.class": true,
-    "**/*.hasTasty": true,
+    "**/*.tasty": true,
     "**/target/": true,
     "community-build/community-projects": true
   }

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -154,7 +154,6 @@ class ScalaSettings extends Settings.SettingGroup with CommonScalaSettings {
   val YdebugError: Setting[Boolean] = BooleanSetting("-Ydebug-error", "Print the stack trace when any error is caught.", false)
   val YtermConflict: Setting[String] = ChoiceSetting("-Yresolve-term-conflict", "strategy", "Resolve term conflicts", List("package", "object", "error"), "error")
   val Ylog: Setting[List[String]] = PhasesSetting("-Ylog", "Log operations during")
-  val YemitTastyInClass: Setting[Boolean] = BooleanSetting("-Yemit-tasty-in-class", "Generate tasty in the .class file and add an empty *.hasTasty file.")
   val YlogClasspath: Setting[Boolean] = BooleanSetting("-Ylog-classpath", "Output information about what classpath is being applied.")
   val YdisableFlatCpCaching: Setting[Boolean] = BooleanSetting("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
 

--- a/compiler/src/dotty/tools/dotc/fromtasty/Debug.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/Debug.scala
@@ -36,10 +36,9 @@ object Debug {
 
     val fromTastyOut = Files.createDirectory(tmpOut.resolve("from-tasty"))
 
-    val extensions = List("tasty", "hasTasty").map(_.toLowerCase)
     val tastyFiles =
       Directory(fromSourcesOut).walk
-        .filter(x => x.isFile && extensions.exists(_ == x.extension.toLowerCase))
+        .filter(x => x.isFile && "tasty".equalsIgnoreCase(x.extension))
         .map(_.toString)
         .toList
 

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -57,7 +57,7 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
 
   // Presence of a file with one of these suffixes indicates that the
   // corresponding class has been pickled with TASTY.
-  private val tastySuffixes = List(".hasTasty", ".tasty")
+  private val tastySuffix = ".tasty"
 
   // FIXME: All the code doing classpath handling is very fragile and ugly,
   // improving this requires changing the dotty classpath APIs to handle our usecases.
@@ -220,11 +220,8 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
       while (entries.hasMoreElements) {
         val entry = entries.nextElement()
         val name = entry.getName
-        tastySuffixes.find(name.endsWith) match {
-          case Some(tastySuffix) =>
-            buffer += name.replace("/", ".").stripSuffix(tastySuffix).toTypeName
-          case _ =>
-        }
+        if name.endsWith(tastySuffix) then
+          buffer += name.replace("/", ".").stripSuffix(tastySuffix).toTypeName
       }
     }
     finally zipFile.close()
@@ -237,13 +234,8 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
         override def visitFile(path: Path, attrs: BasicFileAttributes) = {
           if (!attrs.isDirectory) {
             val name = path.getFileName.toString
-            for {
-              tastySuffix <- tastySuffixes
-              if name.endsWith(tastySuffix)
-            }
-            {
+            if name.endsWith(tastySuffix) then
               buffer += dir.relativize(path).toString.replace("/", ".").stripSuffix(tastySuffix).toTypeName
-            }
           }
           FileVisitResult.CONTINUE
         }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -232,7 +232,7 @@ class CompilationTests {
         Properties.compilerInterface, Properties.scalaLibrary, Properties.scalaAsm,
         Properties.dottyInterfaces, Properties.jlineTerminal, Properties.jlineReader,
       ).mkString(File.pathSeparator),
-      Array("-Ycheck-reentrant", "-Yemit-tasty-in-class", "-language:postfixOps", "-Ysemanticdb")
+      Array("-Ycheck-reentrant", "-language:postfixOps", "-Ysemanticdb")
     )
 
     val libraryDirs = List(Paths.get("library/src"), Paths.get("library/src-bootstrapped"))

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1369,5 +1369,5 @@ object ParallelTesting {
   }
 
   def isTastyFile(f: JFile): Boolean =
-    f.getName.endsWith(".hasTasty") || f.getName.endsWith(".tasty")
+    f.getName.endsWith(".tasty")
 }

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -136,15 +136,18 @@ object DottyPlugin extends AutoPlugin {
   override def requires: Plugins = plugins.JvmPlugin
   override def trigger = allRequirements
 
-  /** Patches the IncOptions so that .tasty and .hasTasty files are pruned as needed.
+  /** Patches the IncOptions so that .tasty files are pruned as needed.
    *
    *  This code is adapted from `scalaJSPatchIncOptions` in Scala.js, which needs
-   *  to do the exact same thing but for classfiles.
+   *  to do the exact same thing but for .sjsir files.
    *
    *  This complicated logic patches the ClassfileManager factory of the given
-   *  IncOptions with one that is aware of .tasty and .hasTasty files emitted by the Dotty
+   *  IncOptions with one that is aware of .tasty files emitted by the Dotty
    *  compiler. This makes sure that, when a .class file must be deleted, the
-   *  corresponding .tasty or .hasTasty file is also deleted.
+   *  corresponding .tasty file is also deleted.
+   *
+   *  To support older versions of dotty, this also takes care of .hasTasty
+   *  files, although they are not used anymore.
    */
   def dottyPatchIncOptions(incOptions: IncOptions): IncOptions = {
     val tastyFileManager = new TastyFileManager

--- a/sbt-dotty/src/dotty/tools/sbtplugin/TastyFileManager.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/TastyFileManager.scala
@@ -9,15 +9,18 @@ import xsbti.compile.ClassFileManager
 import scala.collection.mutable
 
 
-/** A class file manger that prunes .tasty and .hasTasty as needed.
+/** A class file manger that prunes .tasty as needed.
  *
  *  This makes sure that, when a .class file must be deleted, the
- *  corresponding .tasty or .hasTasty file is also deleted.
+ *  corresponding .tasty file is also deleted.
  *
  *  This code is adapted from Zinc `TransactionalClassFileManager`.
  *  We need to duplicate the logic since forwarding to the default class
  *  file manager doesn't work: we need to backup tasty files in a different
  *  temporary directory as class files.
+ *
+ *  To support older versions of dotty, this also takes care of .hasTasty
+ *  files, although they are not used anymore.
  */
 final class TastyFileManager extends ClassFileManager {
   private[this] var _tempDir: File = null


### PR DESCRIPTION
The default was flipped in a6455665fa30b760051238df52c05de5e6ccd5b1 in July 2018. Since then, it has not been really tested.

Completely removing it will allow the tooling not to worry about `.hasTasty` and the need to read TASTy from class files.

We keep the support of `.hasTasty` files in sbt-dotty for now, so that it still supports older versions of dotty.