### PR TITLE
REPL force module load as last resort

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -309,7 +309,9 @@ class ReplDriver(settings: Array[String],
         defs.map(rendering.renderMethod) ++
         vals.flatMap(rendering.renderVal)
 
-      (state.copy(valIndex = state.valIndex - vals.count(resAndUnit)), formattedMembers)
+      val diagnostics = if formattedMembers.isEmpty then rendering.forceModule(symbol) else formattedMembers
+
+      (state.copy(valIndex = state.valIndex - vals.count(resAndUnit)), diagnostics)
     }
     else (state, Seq.empty)
 

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -203,6 +203,22 @@ class ReplCompilerTests extends ReplTest {
     run("val a: 1 | 0 = 1")
     assertEquals("val a: 1 | 0 = 1", storedOutput().trim)
   }
+
+  @Test def `i10214 must show classic MatchError` = fromInitialState { implicit state =>
+    run("val 1 = 2")
+    assertEquals("scala.MatchError: 2 (of class java.lang.Integer)", storedOutput().linesIterator.next())
+  }
+  @Test def `i10214 must show useful regex MatchError` =
+    fromInitialState { implicit state =>
+      run("""val r = raw"\d+".r""")
+    } andThen { implicit state =>
+      run("""val r() = "abc"""")
+      assertEquals("scala.MatchError: abc (of class java.lang.String)", storedOutput().linesIterator.drop(2).next())
+    }
+  @Test def `i10214 must show MatchError on literal type` = fromInitialState { implicit state =>
+    run("val (x: 1) = 2")
+    assertEquals("scala.MatchError: 2 (of class java.lang.Integer)", storedOutput().linesIterator.next())
+  }
 }
 
 object ReplCompilerTests {


### PR DESCRIPTION
If there are no members, and it's not a template,
forcibly initialize the enclosing class.

Fixes https://github.com/lampepfl/dotty/issues/10214

Earlier I was in the neighborhood of REPL & Stack, so I dropped by for a visit.

This will need rebasing on the other commit.