### PR TITLE
Slightly Improved Varargs Extractor

### DIFF
--- a/library/src/scala/quoted/Varargs.scala
+++ b/library/src/scala/quoted/Varargs.scala
@@ -39,7 +39,8 @@ object Varargs {
   def unapply[T](expr: Expr[Seq[T]])(using Quotes): Option[Seq[Expr[T]]] = {
     import quotes.reflect._
     def rec(tree: Term): Option[Seq[Expr[T]]] = tree match {
-      case Typed(Repeated(elems, _), _) => Some(elems.map(x => x.asExpr.asInstanceOf[Expr[T]]))
+      case Repeated(elems, _) => Some(elems.map(x => x.asExpr.asInstanceOf[Expr[T]]))
+      case Typed(e, _) => rec(e)
       case Block(Nil, e) => rec(e)
       case Inlined(_, Nil, e) => rec(e)
       case _  => None


### PR DESCRIPTION
A small change to `scala.quoted.Varargs.unapply` to make it apply in more circumstances when inlining is involved, as (as far as I can tell/recall) sometimes varargs end up being encoded as ```Typed(Inlined(EmptyTree, List(), Repeated(elems, _)), _)``` not ```Typed(Repeated(elems, _), _)``` or ```Inlined(EmptyTree, List(), Typed(Repeated(elems, _), _))``` in corner cases, which means the old implementation fails to match in a confusing manner. This improves things substantially in my wacky heavily-inlining macro expansions, and I'm pretty sure it doesn't break anything.