### PR TITLE
Add unsafeToArray to IArray

### DIFF
--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -247,6 +247,13 @@ object opaques:
     extension [T](arr: IArray[T]) def takeWhile(p: T => Boolean): IArray[T] =
       genericArrayOps(arr).takeWhile(p)
 
+    /** Returns the underlying _mutable_ array; use with caution. Like `unsafeFromArray`,
+     *  the returned array must _not_ be mutated after this or the guaranteed immutablity
+     *  of IArray will be violated.
+     */
+    extension [T](arr: IArray[T]) def unsafeToArray: Array[T] =
+      arr.asInstanceOf[Array[T]]
+
     /** Converts an array of pairs into an array of first elements and an array of second elements. */
     extension [U: ClassTag, V: ClassTag](arr: IArray[(U, V)]) def unzip: (IArray[U], IArray[V]) =
       genericArrayOps(arr).unzip

--- a/tests/run/iarrays.scala
+++ b/tests/run/iarrays.scala
@@ -70,4 +70,9 @@ object Test extends App {
   val cs: Array[Double] = bs.asInstanceOf[Array[Double]]
   cs(1) = 3.0
   assert(bs(1) == 3.0)
+
+  // Check unsafeFromArray andThen unsafeToArray is an identity
+  val ds: Array[Double] = Array(1.0, 2.0)
+  val es: Array[Double] = IArray.unsafeFromArray(ds).unsafeToArray
+  assert(ds eq es)
 }


### PR DESCRIPTION
This came up when integrating `IArray` with fs2, where I needed access to `copyToArray`. Rather than add `copyToArray` as an extension method to `IArray`, this PR provides an escape hatch to access the underlying mutable array without needing an explicit `asInstanceOf`.