### PR TITLE
Fix an example of covariant type

### DIFF
--- a/docs/docs/reference/new-types/type-lambdas-spec.md
+++ b/docs/docs/reference/new-types/type-lambdas-spec.md
@@ -89,7 +89,7 @@ is treated as a shorthand for
 ```
 Abstract types and opaque type aliases remember the variances they were created with. So the type
 ```scala
-def F2[-A, +B]
+type F2[-A, +B]
 ```
 is known to be contravariant in `A` and covariant in `B` and can be instantiated only
 with types that satisfy these constraints. Likewise


### PR DESCRIPTION
From the context of the document, it looks like a `type`, not a `def`, should be put here.