### PR TITLE
Add reflect `MatchCase` `TypeRepr`

### DIFF
--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -175,6 +175,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *               +- LambdaType -+- MethodOrPoly -+- MethodType
    *               |              |                +- PolyType
    *               |              +- TypeLambda
+   *               +- MatchCase
    *               +- TypeBounds
    *               +- NoPrefix
    *
@@ -2677,6 +2678,40 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def paramBounds: List[TypeBounds]
       end extension
     end TypeLambdaMethods
+
+    /** Case of a `MatchType` containing pattern `case P => R`.
+     *
+     *  Note: cases with type bindings are represented nested in a `TypeLambda`.
+     */
+    type MatchCase <: TypeRepr
+
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MatchCase` */
+    given MatchCaseTypeTest: TypeTest[TypeRepr, MatchCase]
+
+    /** Module object of `type MatchCase`  */
+    val MatchCase: MatchCaseModule
+
+    /** Methods of the module object `val MatchCase` */
+    trait MatchCaseModule { this: MatchCase.type =>
+      /* Create match type case `case <pattern> => <rhs>` */
+      def apply(pattern: TypeRepr, rhs: TypeRepr): MatchCase
+      /* Matches a match type case `case <pattern> => <rhs>` */
+      def unapply(x: MatchCase): (TypeRepr, TypeRepr)
+    }
+
+    /** Makes extension methods on `MatchCase` available without any imports */
+    given MatchCaseMethods: MatchCaseMethods
+
+    /** Extension methods of `MatchCase` */
+    trait MatchCaseMethods:
+      extension (self: MatchCase)
+        /** Pattern `P` of `case P => R` in a `MatchType` */
+        def pattern: TypeRepr
+        /** RHS `R` of `case P => R` in a `MatchType` */
+        def rhs: TypeRepr
+      end extension
+    end MatchCaseMethods
+
 
     // ----- TypeBounds -----------------------------------------------
 

--- a/scala3doc/src/dotty/dokka/tasty/SyntheticSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SyntheticSupport.scala
@@ -96,13 +96,3 @@ trait SyntheticsSupport:
     given dotc.core.Contexts.Context = qctx.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
     val cSym = c.symbol.asInstanceOf[dotc.core.Symbols.Symbol]
     cSym.typeRef.appliedTo(cSym.typeParams.map(_.typeRef)).asInstanceOf[TypeRepr]
-
-  object MatchTypeCase:
-    def unapply(tpe: TypeRepr): Option[(TypeRepr, TypeRepr)] =
-      tpe match
-        case AppliedType(t, Seq(from, to)) /*if t == MatchCaseType*/ =>
-            Some((from, to))
-        case TypeLambda(paramNames, paramTypes, AppliedType(t, Seq(from, to))) /*if t == MatchCaseType*/ =>
-            Some((from, to))
-        case _ =>
-          None

--- a/scala3doc/src/dotty/dokka/tasty/TypesSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/TypesSupport.scala
@@ -240,7 +240,9 @@ trait TypesSupport:
 
       case MatchType(bond, sc, cases) =>
         val casesTexts = cases.flatMap {
-          case MatchTypeCase(from, to) =>
+          case MatchCase(from, to) =>
+            texts("  case ") ++ inner(from) ++ texts(" => ") ++ inner(to) ++ texts("\n")
+          case TypeLambda(_, _, MatchCase(from, to)) =>
             texts("  case ") ++ inner(from) ++ texts(" => ") ++ inner(to) ++ texts("\n")
         }
         inner(sc) ++ texts(" match {\n") ++ casesTexts ++ texts("}")

--- a/tests/run-macros/tasty-construct-types/Macro_1.scala
+++ b/tests/run-macros/tasty-construct-types/Macro_1.scala
@@ -36,7 +36,9 @@ object Macros {
           TypeLambda(
             List("t"),
             _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
-            tl => TypeRepr.of[scala.runtime.MatchCase].appliedTo(List(TypeRepr.of[List].appliedTo(tl.param(0)), tl.param(0)))))
+            tl => MatchCase(TypeRepr.of[List].appliedTo(tl.param(0)), tl.param(0))),
+          MatchCase(TypeRepr.of[Int], TypeRepr.of[Int])
+        )
       )
 
     assert(x1T =:= TypeRepr.of[1])
@@ -46,7 +48,10 @@ object Macros {
     assert(x5T =:= TypeRepr.of[RefineMe { type T = Int }])
     assert(x6T =:= TypeRepr.of[List[Int]])
     assert(x7T =:= TypeRepr.of[7 @TestAnnotation])
-    assert(x8T =:= TypeRepr.of[List[8] match { case List[t] => t }])
+    assert(x8T =:= TypeRepr.of[List[8] match {
+      case List[t] => t
+      case Int => Int
+    }])
 
     '{
       println("Ok")


### PR DESCRIPTION
This represents the `MATCHCASEtype` type in `TastyFormat` and hides the `scala.runtime.MatchCase` internal encoding.

This is an alternative to  #10690