### PR TITLE
Make -explain-types a -Y option as -Yexplain-types.

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -203,7 +203,7 @@ class ScalaSettings extends Settings.SettingGroup with CommonScalaSettings {
 
   /** Area-specific debug output */
   val YexplainLowlevel: Setting[Boolean] = BooleanSetting("-Yexplain-lowlevel", "When explaining type errors, show types at a lower level.")
-  val YexplainTypes: Setting[Boolean] = BooleanSetting("-Yexplain-types", "Explain type errors in more detail.")
+  val YexplainTypes: Setting[Boolean] = BooleanSetting("-Yexplain-types", "Explain type errors in more detail.").withAbbreviation("-explain-types")
   val YnoDoubleBindings: Setting[Boolean] = BooleanSetting("-Yno-double-bindings", "Assert no namedtype is bound twice (should be enabled only if program is error-free).")
   val YshowVarBounds: Setting[Boolean] = BooleanSetting("-Yshow-var-bounds", "Print type variables with their bounds.")
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -77,7 +77,6 @@ class ScalaSettings extends Settings.SettingGroup with CommonScalaSettings {
   val semanticdbTarget: Setting[String] = PathSetting("-semanticdb-target", "Specify an alternative output directory for SemanticDB files.", "")
 
   val deprecation: Setting[Boolean] = BooleanSetting("-deprecation", "Emit warning and location for usages of deprecated APIs.") withAbbreviation "--deprecation"
-  val explainTypes: Setting[Boolean] = BooleanSetting("-explain-types", "Explain type errors in more detail.") withAbbreviation "--explain-types"
   val explain: Setting[Boolean] = BooleanSetting("-explain", "Explain errors in more detail.") withAbbreviation "--explain"
   val feature: Setting[Boolean] = BooleanSetting("-feature", "Emit warning and location for usages of features that should be imported explicitly.") withAbbreviation "--feature"
   val help: Setting[Boolean] = BooleanSetting("-help", "Print a synopsis of standard options.") withAbbreviation "--help"
@@ -204,6 +203,7 @@ class ScalaSettings extends Settings.SettingGroup with CommonScalaSettings {
 
   /** Area-specific debug output */
   val YexplainLowlevel: Setting[Boolean] = BooleanSetting("-Yexplain-lowlevel", "When explaining type errors, show types at a lower level.")
+  val YexplainTypes: Setting[Boolean] = BooleanSetting("-Yexplain-types", "Explain type errors in more detail.")
   val YnoDoubleBindings: Setting[Boolean] = BooleanSetting("-Yno-double-bindings", "Assert no namedtype is bound twice (should be enabled only if program is error-free).")
   val YshowVarBounds: Setting[Boolean] = BooleanSetting("-Yshow-var-bounds", "Print type variables with their bounds.")
 

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -123,7 +123,7 @@ object ErrorReporting {
       if ((found1 eq found) != (expected eq expected1) && (found1 <:< expected1))
         i"""
            |(Note that Scala's and Java's representation of this type differs)"""
-      else if (ctx.settings.explainTypes.value)
+      else if (ctx.settings.YexplainTypes.value)
         i"""
            |${ctx.typerState.constraint}
            |${TypeComparer.explained(_.isSubType(found, expected))}"""


### PR DESCRIPTION
It prints compiler implementation details about constraint solving.