### PR TITLE
Add perspective to the community build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -177,3 +177,7 @@
 [submodule "community-build/community-projects/izumi-reflect"]
 	path = community-build/community-projects/izumi-reflect
 	url = https://github.com/dotty-staging/izumi-reflect.git
+[submodule "community-build/community-projects/perspective"]
+	path = community-build/community-projects/perspective
+	url = https://github.com/dotty-staging/perspective.git
+	branch = dotty/nightly

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -627,6 +627,14 @@ object projects:
     sbtPublishCommand = "publishLocal",
     dependencies = List(scalatest)
   )
+  
+  lazy val perspective = SbtCommunityProject(
+    project = "perspective",
+    // No library with easy typeclasses to verify data against exist for Dotty, so no tests yet
+    // Until then I guess this mainly serves to check that it still compiles at all
+    sbtTestCommand = "dottyPerspectiveExamples/compile",
+    dependencies = List(cats)
+  )
 
 end projects
 
@@ -691,6 +699,7 @@ def allProjects = List(
   projects.scalaSTM,
   projects.scissLucre,
   projects.izumiReflect,
+  projects.perspective,
 )
 
 lazy val projectMap = allProjects.map(p => p.project -> p).toMap

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -148,6 +148,7 @@ class CommunityBuildTestB extends CommunityBuildTest:
   @Test def simulacrumScalafixAnnotations = projects.simulacrumScalafixAnnotations.run()
   @Test def verify = projects.verify.run()
   @Test def xmlInterpolator = projects.xmlInterpolator.run()
+  @Test def perspective = projects.perspective.run()
 
 end CommunityBuildTestB
 


### PR DESCRIPTION
No idea if I've done this correctly, but let's hope so :P

This will add [perspective](https://github.com/Katrix/perspective) to the community build. perspective is a generic programming library like shapeless, but taking a different paradigm instead (functional instead of logic based, value level instead of type level). Reason why I thought perspective might fit in well in the community build is that it is probably one of the projects that uses polymorphic function types the most as of now. I've already come across a few bugs in relation to this, which I have already submitted.

No tests for now, as I don't know if there are any other libraries updated to Dotty which includes typeclasses that are easy to test. (Using circe currently for the scala 2 part of the project). Just the fact that it compiles should at least provide some confidence that nothing broke in terms of typechecking or similar which perspective relies upon.