### PR TITLE
indent text to not restart list numbering

### DIFF
--- a/docs/docs/reference/other-new-features/export.md
+++ b/docs/docs/reference/other-new-features/export.md
@@ -139,7 +139,7 @@ Export clauses are processed when the type information of the enclosing object o
     on demand.
  5. Determine the types of all parents of the class.
 
-With export clauses, the following steps are added:
+    With export clauses, the following steps are added:
 
  6. Compute the types of all paths in export clauses in a context logically
     inside the class but not considering any imports or exports in that class.


### PR DESCRIPTION
The current version of the doc restarts the list numbering after `With export clauses, the following steps are added:`, making items 1 and 2, instead of 6 and 7, and making the following paragraph invalid.