### PR TITLE
Default to Scala3doc

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -155,7 +155,10 @@ final case class SbtCommunityProject(
     ++ s"++$compilerVersion!; "
 
   override val testCommand = s"$baseCommand$sbtTestCommand"
-  override val publishCommand = if sbtPublishCommand eq null then null else s"$baseCommand$sbtPublishCommand"
+  override val publishCommand = if sbtPublishCommand eq null then null else
+    val disableDocCommand =
+      if sbtDocCommand eq null then "" else "set every useScala3doc := false;"
+    s"$baseCommand$disableDocCommand$sbtPublishCommand"
   override val docCommand =
     if sbtDocCommand eq null then null else
       val cmd = if sbtDocCommand.startsWith(";") then sbtDocCommand else s";$sbtDocCommand"

--- a/sbt-dotty/sbt-test/sbt-dotty/scala3doc/build.sbt
+++ b/sbt-dotty/sbt-test/sbt-dotty/scala3doc/build.sbt
@@ -1,3 +1,7 @@
 scalaVersion := sys.props("plugin.scalaVersion")
 
-useScala3doc := true
+lazy val assertUsingScala3doc = taskKey[Unit]("")
+
+assertUsingScala3doc := {
+  assert(useScala3doc.value)
+}

--- a/sbt-dotty/sbt-test/sbt-dotty/scala3doc/test
+++ b/sbt-dotty/sbt-test/sbt-dotty/scala3doc/test
@@ -1,2 +1,3 @@
+> assertUsingScala3doc
 > doc
 

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -362,7 +362,10 @@ object DottyPlugin extends AutoPlugin {
 
       // Configuration for the doctool
       resolvers ++= (if(!useScala3doc.value) Nil else Seq(Resolver.jcenterRepo)),
-      useScala3doc := false,
+      useScala3doc := {
+        val v = scalaVersion.value
+        v.startsWith("3.0.0") && !v.startsWith("3.0.0-M1") && !v.startsWith("3.0.0-M2")
+      },
       // We need to add doctool classes to the classpath so they can be called
       scalaInstance in doc := Def.taskDyn {
         if (isDotty.value)


### PR DESCRIPTION
Default to `useScala3doc := true`.

We should leave it there for now I guess for compat reasons.