### PR TITLE
sbt-dotty: Require sbt >= 1.4, bump version to 0.5.0-SNAPSHOT

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -56,7 +56,7 @@ object Build {
   val referenceVersion = "3.0.0-RC1-bin-20201202-67d9790-NIGHTLY"
 
   val baseVersion = "3.0.0-M3"
-  val baseSbtDottyVersion = "0.4.7"
+  val baseSbtDottyVersion = "0.5.0"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -169,7 +169,7 @@ object DottyPlugin extends AutoPlugin {
   override val globalSettings: Seq[Def.Setting[_]] = Seq(
     onLoad in Global := onLoad.in(Global).value.andThen { state =>
 
-      val requiredVersion = ">=1.3.6"
+      val requiredVersion = ">=1.4.4"
 
       val sbtV = sbtVersion.value
       if (!VersionNumber(sbtV).matchesSemVer(SemanticSelector(requiredVersion)))


### PR DESCRIPTION
Because we're building sbt-dotty using sbt 1.4, we cannot guarantee that
it works with older sbt versions (and in fact it doesn't), since this is
a compatibility, we also bump the version number of sbt-dotty.

[test_sbt]]