### PR TITLE
Try to fix paths in TastyInspector

### DIFF
--- a/scala3doc/test/dotty/dokka/tasty/comments/CommentExpanderTests.scala
+++ b/scala3doc/test/dotty/dokka/tasty/comments/CommentExpanderTests.scala
@@ -42,7 +42,7 @@ class CommentExpanderTests {
 
       def processCompilationUnit(using quoted.Quotes)(root: quotes.reflect.Tree): Unit = ()
 
-      override def postProcess(using quoted.Quotes): Unit =
+      override def postProcess(using quoted.Quotes)(): Unit =
         check()
 
     Inspector().inspectTastyFiles(TestUtils.listOurClasses())


### PR DESCRIPTION
Right now `postProcess` is way less useful than it should be, since the path-dependent types interfere with gathering `Tree`s. This PR is to try and see if we can still fix that.