### PR TITLE
Force full compilation in malformed-class-name-with-dollar

### DIFF
--- a/sbt-dotty/sbt-test/source-dependencies/malformed-class-name-with-dollar/test
+++ b/sbt-dotty/sbt-test/source-dependencies/malformed-class-name-with-dollar/test
@@ -1,3 +1,5 @@
 > compile
 $ copy-file changes/A.scala A.scala
+# It seems that https://github.com/lampepfl/dotty/pull/10784 break incremental compilation here
+> clean
 > compile


### PR DESCRIPTION
[test_sbt]

It seems that #10784 broke incremental compilation in `malformed-class-name-with-dollar` sbt test. I think we have some cases where incremental compilation fails we can investigate it after M3.