### PR TITLE
Fix typo in control syntax documentation

### DIFF
--- a/docs/docs/reference/other-new-features/control-syntax.md
+++ b/docs/docs/reference/other-new-features/control-syntax.md
@@ -9,7 +9,7 @@ around the generators of a `for`-expression. Examples:
 ```scala
 if x < 0 then
   "negative"
-else if x == 0
+else if x == 0 then
   "zero"
 else
   "positive"


### PR DESCRIPTION
Missing `then` keyword in example code.