### PR TITLE
Add a way to skip scala3docs CI

### DIFF
--- a/.github/workflows/scala3doc.yaml
+++ b/.github/workflows/scala3doc.yaml
@@ -8,7 +8,12 @@ jobs:
     env:
       AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
     runs-on: ubuntu-latest
-    if: "github.event_name == 'pull_request' || contains(github.event.ref, 'scala3doc') || contains(github.event.ref, 'master')"
+    if: "(    github.event_name == 'pull_request'
+           && !contains(github.event.pull_request.body, '[skip ci]')
+           && !contains(github.event.pull_request.body, '[skip docs]')
+         )
+         || contains(github.event.ref, 'scala3doc')
+         || contains(github.event.ref, 'master')"
 
     steps:
       - name: Git Checkout
@@ -67,7 +72,12 @@ jobs:
     env:
       AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
     runs-on: ubuntu-latest
-    if: "github.event_name == 'pull_request' || contains(github.event.ref, 'scala3doc') || contains(github.event.ref, 'master')"
+    if: "(    github.event_name == 'pull_request'
+           && !contains(github.event.pull_request.body, '[skip ci]')
+           && !contains(github.event.pull_request.body, '[skip docs]')
+         )
+         || contains(github.event.ref, 'scala3doc')
+         || contains(github.event.ref, 'master')"
 
     steps:
       - name: Git Checkout


### PR DESCRIPTION
Now we can skip the docs CI using `[skip ci]` or `[skip docs]`.