### PR TITLE
Parsing indentation cleanup

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -74,6 +74,9 @@ object Scanners {
 
     def isNestedStart = token == LBRACE || token == INDENT
     def isNestedEnd = token == RBRACE || token == OUTDENT
+
+    /** Is current token first one after a newline? */
+    def isAfterLineEnd: Boolean = lineOffset >= 0
   }
 
   abstract class ScannerCommon(source: SourceFile)(using Context) extends CharArrayReader with TokenData {
@@ -512,15 +515,12 @@ object Scanners {
          |Previous indent : $lastWidth
          |Latest indent   : $nextWidth"""
 
-    private def switchAtEOL(testToken: Token, eolToken: Token): Unit =
-      if token == testToken then
+    def observeColonEOL(): Unit =
+      if token == COLON then
         lookAhead()
         val atEOL = isAfterLineEnd || token == EOF
         reset()
-        if atEOL then token = eolToken
-
-    def observeColonEOL(): Unit = switchAtEOL(COLON, COLONEOL)
-    def observeWithEOL(): Unit = switchAtEOL(WITH, WITHEOL)
+        if atEOL then token = COLONEOL
 
     def observeIndented(): Unit =
       if indentSyntax && isNewLine then
@@ -609,9 +609,6 @@ object Scanners {
         case _ =>
       }
     }
-
-    /** Is current token first one after a newline? */
-    def isAfterLineEnd: Boolean = lineOffset >= 0
 
     /** Is there a blank line between the current token and the last one?
      *  A blank line consists only of characters <= ' '.

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -276,8 +276,7 @@ object Tokens extends TokensCommon {
   final val closingRegionTokens = BitSet(RBRACE, RPAREN, RBRACKET, CASE) | statCtdTokens
 
   final val canStartIndentTokens: BitSet =
-    statCtdTokens | BitSet(COLONEOL, WITH, EQUALS, ARROW, LARROW, WHILE, TRY, FOR, IF)
-    // TODO: add THROW, CTXARROW
+    statCtdTokens | BitSet(COLONEOL, WITH, EQUALS, ARROW, CTXARROW, LARROW, WHILE, TRY, FOR, IF, THROW)
 
   /** Faced with the choice between a type and a formal parameter, the following
    *  tokens determine it's a formal parameter.
@@ -286,7 +285,7 @@ object Tokens extends TokensCommon {
 
   final val scala3keywords = BitSet(ENUM, ERASED, GIVEN)
 
-  final val endMarkerTokens = identifierTokens | BitSet(IF, WHILE, FOR, MATCH, TRY, NEW, GIVEN, VAL, THIS)
+  final val endMarkerTokens = identifierTokens | BitSet(IF, WHILE, FOR, MATCH, TRY, NEW, THROW, GIVEN, VAL, THIS)
 
   final val softModifierNames = Set(nme.inline, nme.opaque, nme.open, nme.transparent, nme.infix)
 }

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -204,8 +204,7 @@ object Tokens extends TokensCommon {
   final val QUOTE = 87;            enter(QUOTE, "'")
 
   final val COLONEOL = 88;         enter(COLONEOL, ":", ": at eol")
-  final val WITHEOL = 89;          enter(WITHEOL, "with", "with at eol")
-  final val SELFARROW = 90;        enter(SELFARROW, "=>") // reclassified ARROW following self-type
+  final val SELFARROW = 89;        enter(SELFARROW, "=>") // reclassified ARROW following self-type
 
   /** XML mode */
   final val XMLSTART = 99;         enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate
@@ -277,8 +276,8 @@ object Tokens extends TokensCommon {
   final val closingRegionTokens = BitSet(RBRACE, RPAREN, RBRACKET, CASE) | statCtdTokens
 
   final val canStartIndentTokens: BitSet =
-    statCtdTokens | BitSet(COLONEOL, WITHEOL, EQUALS, ARROW, LARROW, WHILE, TRY, FOR, IF)
-      // `if` is excluded because it often comes after `else` which makes for awkward indentation rules  TODO: try to do without the exception
+    statCtdTokens | BitSet(COLONEOL, WITH, EQUALS, ARROW, LARROW, WHILE, TRY, FOR, IF)
+    // TODO: add THROW, CTXARROW
 
   /** Faced with the choice between a type and a formal parameter, the following
    *  tokens determine it's a formal parameter.

--- a/docs/docs/reference/changed-features/match-syntax.md
+++ b/docs/docs/reference/changed-features/match-syntax.md
@@ -6,42 +6,41 @@ title: Match Expressions
 The syntactical precedence of match expressions has been changed.
 `match` is still a keyword, but it is used like an alphabetical operator. This has several consequences:
 
-1. `match` expressions can be chained:
-
-   ```scala
-   xs match {
-      case Nil => "empty"
-      case x :: xs1 => "nonempty"
-   } match {
-      case "empty" => 0
-      case "nonempty" => 1
-   }
-   ```
-
-   (or, dropping the optional braces)
-
-   ```scala
-   xs match
-      case Nil => "empty"
-      case x :: xs1 => "nonempty"
-   match
-      case "empty" => 0
-      case "nonempty" => 1
-   ```
-
-2. `match` may follow a period:
+ 1. `match` expressions can be chained:
 
     ```scala
-    if xs.match
-       case Nil => false
-       case _ => true
-    then "nonempty"
-    else "empty"
+    xs match {
+       case Nil => "empty"
+       case x :: xs1 => "nonempty"
+    } match {
+       case "empty" => 0
+       case "nonempty" => 1
+    }
     ```
 
-3. The scrutinee of a match expression must be an `InfixExpr`. Previously the scrutinee could be
-   followed by a type ascription `: T`, but this is no longer supported. So `x : T match { ... }`
-   now has to be written `(x: T) match { ... }`.
+    (or, dropping the optional braces)
+
+    ```scala
+    xs match
+       case Nil => "empty"
+       case x :: xs1 => "nonempty"
+    match
+       case "empty" => 0
+       case "nonempty" => 1
+    ```
+
+ 2. `match` may follow a period:
+
+     ```scala
+     if xs.match
+        case Nil => false
+        case _ => true
+     then "nonempty"
+     else "empty"
+     ```
+
+ 3. The scrutinee of a match expression must be an `InfixExpr`. Previously the scrutinee could be followed by a type ascription `: T`, but this is no longer supported. So `x : T match { ... }` now has to be
+ written `(x: T) match { ... }`.
 
 ## Syntax
 

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -64,8 +64,8 @@ There are two rules:
      - after one of the following tokens:
 
        ```
-       =  =>  <-  catch  do  else  finally  for
-       if  match  return  then  try  while  yield
+       =  =>  ?=>  <-  catch  do  else  finally  for
+       if  match  return  then  throw  try  while  yield
        ```
 
     If an `<indent>` is inserted, the indentation width of the token on the next line

--- a/tests/pos/indent.scala
+++ b/tests/pos/indent.scala
@@ -51,6 +51,10 @@ object Test:
       y * y
   }
 
+  val gg = (x: Int) ?=>
+    val y = x + 1
+    y
+
   xs.map {
     x =>
     val y = x * x
@@ -80,11 +84,15 @@ object Test:
 
 class Test2:
   self =>
-  def foo = 1
+  def foo(x: Int) =
+    if x < 0 then throw
+      val ex = new AssertionError()
+      ex
+    x
 
   val x =
     new Test2 {
-      override def foo = 2
+      override def foo(x: Int) = 2
     }
   end x
 end Test2


### PR DESCRIPTION
- [x] Eliminate WITHEOL token: Change parsing algorithm so that we do not need a separate WITHEOL token. The grammar remains unaffected.

- [x] Make indentation significant after `throw` and `?=>`
