### PR TITLE
fix #10724: adapt vararg parameters

### DIFF
--- a/tests/run/i10724.scala
+++ b/tests/run/i10724.scala
@@ -1,0 +1,15 @@
+object Exporter {
+  object Exportee {
+    inline def foo(args: String*): String = args.mkString(" ")
+
+    inline def bar(l: Option[Int])()(i: Int)(b: Boolean, args: String*): String =
+      s"$l-$i-$b-${args.mkString("-")}"
+  }
+  export Exportee._
+}
+
+import Exporter._
+
+@main def Test =
+  println(foo("a", "b", "c"))
+  println(bar(Some(1))()(2)(true, "a", "b", "c"))


### PR DESCRIPTION
fixes #10724 

A follow up PR would be needed to adapt exports of java varargs which are already broken