### PR TITLE
Fix #9965: Properly handle class type parameters when copying symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -185,11 +185,11 @@ class TreeTypeMap(
    *  and mapped symbols `mapped`. Also goes into mapped classes
    *  and substitutes their declarations.
    */
-  def withMappedSyms(syms: List[Symbol], mapped: List[Symbol]): TreeTypeMap = {
+  def withMappedSyms(syms: List[Symbol], mapped: List[Symbol]): TreeTypeMap =
     val symsChanged = syms ne mapped
     val substMap = withSubstitution(syms, mapped)
     lazy val origCls = mapped.zip(syms).filter(_._1.isClass).toMap
-    val fullMap = mapped.filter(_.isClass).foldLeft(substMap) { (tmap, cls) =>
+    mapped.filter(_.isClass).foldLeft(substMap) { (tmap, cls) =>
       val origDcls = cls.info.decls.toList.filterNot(_.is(TypeParam))
       val mappedDcls = mapSymbols(origDcls, tmap)
       val tmap1 = tmap.withMappedSyms(
@@ -199,7 +199,4 @@ class TreeTypeMap(
         origDcls.lazyZip(mappedDcls).foreach(cls.asClass.replace)
       tmap1
     }
-    if symsChanged || (fullMap eq substMap) then fullMap
-    else withMappedSyms(syms, mapAlways = true)
-  }
 }

--- a/tests/pos/i9965.scala
+++ b/tests/pos/i9965.scala
@@ -1,0 +1,19 @@
+class D[T]
+
+class C {
+  def f() = {
+    locally {
+      class dd[U] extends D[U] {
+        val xx = 1
+      }
+      class ee[V] extends dd[(V, V)]
+      def d[V]: dd[V] = new dd[V]
+      g[D[Int]](d[Int])
+      g[D[(Int, Int)]](new ee[Int])
+    }
+  }
+
+  inline def locally[T](inline body: T): T = body
+
+  def g[T](x: T): T = x
+}


### PR DESCRIPTION
Fixes #9965
 