### PR TITLE
Fix #10605: Avoid mismatched constraints when prototypes are context …

### DIFF
--- a/tests/neg/i10605.scala
+++ b/tests/neg/i10605.scala
@@ -1,0 +1,9 @@
+def xa[A, B, X, Y](f: X => ((A, B) ?=> Y)) =
+  (z: X) => (a: A, b: B) => f(z)(using a, b)
+
+def superxa1(using String, Int): Nothing = ???
+def superxa2(using String, Int): Unit = ???
+
+def main =
+  xa(Function.const(superxa1)(_: Int)) // error
+  xa(Function.const(superxa2)(_: Int)) // error


### PR DESCRIPTION
…functions

Fixes #10605