### PR TITLE
Improve docs

### DIFF
--- a/docs/docs/reference/changed-features/match-syntax.md
+++ b/docs/docs/reference/changed-features/match-syntax.md
@@ -6,45 +6,47 @@ title: Match Expressions
 The syntactical precedence of match expressions has been changed.
 `match` is still a keyword, but it is used like an alphabetical operator. This has several consequences:
 
- 1. `match` expressions can be chained:
+1. `match` expressions can be chained:
+
+   ```scala
+   xs match {
+      case Nil => "empty"
+      case x :: xs1 => "nonempty"
+   } match {
+      case "empty" => 0
+      case "nonempty" => 1
+   }
+   ```
+
+   (or, dropping the optional braces)
+
+   ```scala
+   xs match
+      case Nil => "empty"
+      case x :: xs1 => "nonempty"
+   match
+      case "empty" => 0
+      case "nonempty" => 1
+   ```
+
+2. `match` may follow a period:
 
     ```scala
-    xs match {
-       case Nil => "empty"
-       case x :: xs1 => "nonempty"
-    } match {
-       case "empty" => 0
-       case "nonempty" => 1
-    }
+    if xs.match
+       case Nil => false
+       case _ => true
+    then "nonempty"
+    else "empty"
     ```
 
-  (or, dropping the optional braces)
-
-    ```scala
-    xs match
-       case Nil => "empty"
-       case x :: xs1 => "nonempty"
-    match
-       case "empty" => 0
-       case "nonempty" => 1
-    ```
-
- 2. `match` may follow a period:
-
-     ```scala
-     if xs.match
-        case Nil => false
-        case _ => true
-     then "nonempty"
-     else "empty"
-     ```
-
- 3. The scrutinee of a match expression must be an `InfixExpr`. Previously the scrutinee could be followed by a type ascription `: T`, but this is no longer supported. So `x : T match { ... }` now has to be
- written `(x: T) match { ... }`.
+3. The scrutinee of a match expression must be an `InfixExpr`. Previously the scrutinee could be
+   followed by a type ascription `: T`, but this is no longer supported. So `x : T match { ... }`
+   now has to be written `(x: T) match { ... }`.
 
 ## Syntax
 
 The new syntax of match expressions is as follows.
+
 ```
 InfixExpr    ::=  ...
                |  InfixExpr MatchClause

--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -295,7 +295,7 @@ given derived$Eq[T](using eqT: Eq[T]): Eq[Opt[T]] =
    eqSum(
       summon[Mirror[Opt[T]]],
       List(
-         eqProduct(summon[Mirror[Sm[T]]], List(summon[Eq[T]]))
+         eqProduct(summon[Mirror[Sm[T]]], List(summon[Eq[T]])),
          eqProduct(summon[Mirror[Nn.type]], Nil)
       )
    )

--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -123,7 +123,7 @@ Note the following properties of `Mirror` types,
 + Properties are encoded using types rather than terms. This means that they have no runtime footprint unless used and
   also that they are a compile time feature for use with Scala 3's metaprogramming facilities.
 + The kinds of `MirroredType` and `MirroredElemTypes` match the kind of the data type the mirror is an instance for.
-  This allows `Mirrors` to support ADTs of all kinds.
+  This allows `Mirror`s to support ADTs of all kinds.
 + There is no distinct representation type for sums or products (ie. there is no `HList` or `Coproduct` type as in
   Scala 2 versions of Shapeless). Instead the collection of child types of a data type is represented by an ordinary,
   possibly parameterized, tuple type. Scala 3's metaprogramming facilities can be used to work with these tuple types
@@ -167,7 +167,6 @@ The low-level method we will use to implement a type class `derived` method in t
 type-level constructs in Scala 3: inline methods, inline matches, and implicit searches via  `summonInline` or `summonFrom`. Given this definition of the
 `Eq` type class,
 
-
 ```scala
 trait Eq[T]:
    def eqv(x: T, y: T): Boolean
@@ -194,7 +193,6 @@ implementation of `summonAll` is `inline` and uses Scala 3's `summonInline` cons
 `List`,
 
 ```scala
-
 inline def summonAll[T <: Tuple]: List[Eq[_]] =
    inline erasedValue[T] match
       case _: EmptyTuple => Nil
@@ -357,10 +355,13 @@ ConstrApps        ::=  ConstrApp {‘with’ ConstrApp}
 
 Note: To align `extends` clauses and `derives` clauses, Scala 3 also allows multiple
 extended types to be separated by commas. So the following is now legal:
+
 ```scala
 class A extends B, C { ... }
 ```
+
 It is equivalent to the old form
+
 ```scala
 class A extends B with C { ... }
 ```

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -27,6 +27,7 @@ given listOrd[T](using ord: Ord[T]): Ord[List[T]] with
          if fst != 0 then fst else compare(xs1, ys1)
 
 ```
+
 This code defines a trait `Ord` with two given instances. `intOrd` defines
 a given for the type `Ord[Int]` whereas `listOrd[T]` defines givens
 for `Ord[List[T]]` for all types `T` that come with a given instance for `Ord[T]`
@@ -39,20 +40,24 @@ parameters](./using-clauses.md).
 
 The name of a given can be left out. So the definitions
 of the last section can also be expressed like this:
+
 ```scala
 given Ord[Int] with
    ...
 given [T](using Ord[T]): Ord[List[T]] with
    ...
 ```
+
 If the name of a given is missing, the compiler will synthesize a name from
 the implemented type(s).
 
 **Note** The name synthesized by the compiler is chosen to be readable and reasonably concise. For instance, the two instances above would get the names:
+
 ```scala
 given_Ord_Int
 given_Ord_List_T
 ```
+
 The precise rules for synthesizing names are found [here](./relationship-implicits.html#anonymous-given-instances). These rules do not guarantee absence of name conflicts between
 given instances of types that are "too similar". To avoid conflicts one can
 use named instances.
@@ -62,15 +67,18 @@ use named instances.
 ## Alias Givens
 
 An alias can be used to define a given instance that is equal to some expression. E.g.:
+
 ```scala
 given global: ExecutionContext = ForkJoinPool()
 ```
+
 This creates a given `global` of type `ExecutionContext` that resolves to the right
 hand side `ForkJoinPool()`.
 The first time `global` is accessed, a new `ForkJoinPool` is created, which is then
 returned for this and all subsequent accesses to `global`. This operation is thread-safe.
 
 Alias givens can be anonymous as well, e.g.
+
 ```scala
 given Position = enclosingTree.position
 given (using config: Config): Factory = MemoizingFactory(config)
@@ -83,11 +91,13 @@ but it can only implement a single type.
 
 Given aliases can have the `inline` and `transparent` modifiers.
 Example:
+
 ```scala
 transparent inline given mkAnnotations[A, T]: Annotations[A, T] = ${
   // code producing a value of a subtype of Annotations
 }
 ```
+
 Since `mkAnnotations` is `transparent`, the type of an application is the type of its right hand side, which can be a proper subtype of the declared result type `Annotations[A, T]`.
 
 ## Pattern-Bound Given Instances
@@ -100,6 +110,7 @@ for given Context <- applicationContexts do
 pair match
    case (ctx @ given Context, y) => ...
 ```
+
 In the first fragment above, anonymous given instances for class `Context` are established by enumerating over `applicationContexts`. In the second fragment, a given `Context`
 instance named `ctx` is established by matching against the first half of the `pair` selector.
 
@@ -107,7 +118,9 @@ In each case, a pattern-bound given instance consists of `given` and a type `T`.
 
 ## Negated Givens
 
-Scala 2's somewhat puzzling behavior with respect to ambiguity has been exploited to implement the analogue of a "negated" search in implicit resolution, where a query Q1 fails if some other query Q2 succeeds and Q1 succeeds if Q2 fails. With the new cleaned up behavior these techniques no longer work. But the new special type `scala.util.NotGiven` now implements negation directly.
+Scala 2's somewhat puzzling behavior with respect to ambiguity has been exploited to implement the analogue of a "negated" search in implicit resolution,
+where a query Q1 fails if some other query Q2 succeeds and Q1 succeeds if Q2 fails. With the new cleaned up behavior these techniques no longer work.
+But the new special type `scala.util.NotGiven` now implements negation directly.
 
 For any query type `Q`, `NotGiven[Q]` succeeds if and only if the implicit
 search for `Q` fails, for example:
@@ -124,8 +137,8 @@ object Foo:
 
 @main def test() =
    given Tagged[Int] with {}
-   assert(implicitly[Foo[Int]].value) // fooTagged is found
-   assert(!implicitly[Foo[String]].value) // fooNotTagged is found
+   assert(summon[Foo[Int]].value) // fooTagged is found
+   assert(!summon[Foo[String]].value) // fooNotTagged is found
 ```
 
 ## Given Instance Initialization
@@ -152,7 +165,7 @@ A given instance starts with the reserved word `given` and an optional _signatur
 defines a name and/or parameters for the instance. It is followed by `:`. There are three kinds
 of given instances:
 
- - A _structural instance_ contains one or more types or constructor applications, followed by `with` and a template body
-that contains member definitions of the instance.
- - An _alias instance_ contains a type, followed by `=` and a right hand side expression.
- - An _abstract instance_ contains just the type, which is not followed by anything.
+- A _structural instance_ contains one or more types or constructor applications,
+  followed by `with` and a template body that contains member definitions of the instance.
+- An _alias instance_ contains a type, followed by `=` and a right hand side expression.
+- An _abstract instance_ contains just the type, which is not followed by anything.

--- a/docs/docs/reference/dropped-features/limit22.md
+++ b/docs/docs/reference/dropped-features/limit22.md
@@ -3,12 +3,14 @@ layout: doc-page
 title: "Dropped: Limit 22"
 ---
 
-The limits of 22 for the maximal number of parameters of function types
-and the maximal number of fields in tuple types have been dropped.
+The limits of 22 for the maximal number of parameters of function types and the
+maximal number of fields in tuple types have been dropped.
 
-Functions can now have an arbitrary number of
-parameters. Functions beyond `Function22` are erased to a new trait
-`scala.FunctionXXL` and tuples beyond `Tuple22` are erased to a new trait `scala.TupleXXL`.
+* Functions can now have an arbitrary number of parameters. Functions beyond
+  `Function22` are erased to a new trait `scala.FunctionXXL`
+
+* Tuples can also have an arbitrary number of fields. Tuples beyond `Tuple22`
+  are erased to a new trait `scala.TupleXXL`. Furthermore, they support generic
+  operation such as concatenation and indexing.
+
 Both of these are implemented using arrays.
-
-Tuples can also have an arbitrary number of fields. Furthermore, they support generic operation such as concatenation and indexing.

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -331,7 +331,7 @@ a `List` is liftable if its element type is:
 given [T: ToExpr : Type]: ToExpr[List[T]] with
    def toExpr(xs: List[T]) = xs match
       case head :: tail => '{ ${ Expr(head) } :: ${ toExpr(tail) } }
-      case Nil => '{ Nil: List[T] }
+      case Nil          => '{ Nil: List[T] }
 ```
 
 In the end, `ToExpr` resembles very much a serialization
@@ -762,7 +762,7 @@ trait Show[-T]:
    def show(x: T): String
 
 // in a different file
-given Show[Boolean]:
+given Show[Boolean] with
    def show(b: Boolean) = "boolean!"
 
 println(showMe"${true}")

--- a/docs/docs/reference/other-new-features/creator-applications.md
+++ b/docs/docs/reference/other-new-features/creator-applications.md
@@ -3,9 +3,11 @@ layout: doc-page
 title: "Universal Apply Methods"
 ---
 
-Scala case classes generate apply methods, so that values of case classes can be created using simple function application, without needing to write `new`.
+Scala case classes generate apply methods, so that values of case classes can be created using simple
+function application, without needing to write `new`.
 
 Scala 3 generalizes this scheme to all concrete classes. Example:
+
 ```scala
 class StringBuilder(s: String):
    def this() = this("")
@@ -13,28 +15,35 @@ class StringBuilder(s: String):
 StringBuilder("abc")  // same as new StringBuilder("abc")
 StringBuilder()       // same as new StringBuilder()
 ```
-This works since a companion object with two apply methods
+
+This works since a companion object with two `apply` methods
 is generated together with the class. The object looks like this:
+
 ```scala
 object StringBuilder:
    inline def apply(s: String): StringBuilder = new StringBuilder(s)
    inline def apply(): StringBuilder = new StringBuilder()
 ```
+
 The synthetic object `StringBuilder` and its `apply` methods are called _constructor proxies_.
 Constructor proxies are generated even for Java classes and classes coming from Scala 2.
 The precise rules are as follows:
 
- 1. A constructor proxy companion object `object C` is created for a concrete class `C`, provided the class does not have already a companion, and there is also no other value or method named `C` defined or inherited in the scope where `C` is defined.
+ 1. A constructor proxy companion object `object C` is created for a concrete class `C`,
+    provided the class does not have already a companion, and there is also no other value
+    or method named `C` defined or inherited in the scope where `C` is defined.
 
  2. Constructor proxy `apply` methods are generated for a concrete class provided
 
-   - the class has a companion object (which might have been generated in step 1), and
-   - that companion object does not already define a member named `apply`.
+    - the class has a companion object (which might have been generated in step 1), and
+    - that companion object does not already define a member named `apply`.
 
-   Each generated `apply` method forwards to one constructor of the class. It has the
-   same type and value parameters as the constructor.
+    Each generated `apply` method forwards to one constructor of the class. It has the
+    same type and value parameters as the constructor.
 
-Constructor proxy companions cannot be used as values by themselves. A proxy companion object must be selected with `apply` (or be applied to arguments, in which case the `apply` is implicitly inserted).
+Constructor proxy companions cannot be used as values by themselves. A proxy companion object must
+be selected with `apply` (or be applied to arguments, in which case the `apply` is implicitly
+inserted).
 
 Constructor proxies are also not allowed to shadow normal definitions. That is,
 if an identifier resolves to a constructor proxy, and the same identifier is also
@@ -42,4 +51,6 @@ defined or imported in some other scope, an ambiguity is reported.
 
 ### Motivation
 
-Leaving out `new` hides an implementation detail and makes code more pleasant to read. Even though it requires a new rule, it will likely increase the perceived regularity of the language, since case classes already provide function call creation syntax (and are often defined for this reason alone).
+Leaving out `new` hides an implementation detail and makes code more pleasant to read. Even though
+it requires a new rule, it will likely increase the perceived regularity of the language, since case
+classes already provide function call creation syntax (and are often defined for this reason alone).

--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -61,6 +61,7 @@ l / l2                  // error: `/` is not a member of Logarithm
 ### Bounds For Opaque Type Aliases
 
 Opaque type aliases can also come with bounds. Example:
+
 ```scala
 object Access:
 
@@ -85,11 +86,12 @@ object Access:
 
 end Access
 ```
+
 The `Access` object defines three opaque type aliases:
 
- - `Permission`, representing a single permission,
- - `Permissions`, representing a set of permissions with the meaning "all of these permissions granted",
- - `PermissionChoice`, representing a set of permissions with the meaning "at least one of these permissions granted".
+- `Permission`, representing a single permission,
+- `Permissions`, representing a set of permissions with the meaning "all of these permissions granted",
+- `PermissionChoice`, representing a set of permissions with the meaning "at least one of these permissions granted".
 
 Outside the `Access` object, values of type `Permissions` may be combined using the `&` operator,
 where `x & y` means "all permissions in `x` *and* in `y` granted".
@@ -106,6 +108,7 @@ All three opaque type aliases have the same underlying representation type `Int`
 `Permission` type has an upper bound `Permissions & PermissionChoice`. This makes
 it known outside the `Access` object that `Permission` is a subtype of the other
 two types.  Hence, the following usage scenario type-checks.
+
 ```scala
 object User:
    import Access._
@@ -116,16 +119,17 @@ object User:
    val rwItem = Item(ReadWrite)
    val noItem = Item(NoPermission)
 
-   assert( roItem.rights.is(ReadWrite) == false )
-   assert( roItem.rights.isOneOf(ReadOrWrite) == true )
+   assert(!roItem.rights.is(ReadWrite))
+   assert(roItem.rights.isOneOf(ReadOrWrite))
 
-   assert( rwItem.rights.is(ReadWrite) == true )
-   assert( rwItem.rights.isOneOf(ReadOrWrite) == true )
+   assert(rwItem.rights.is(ReadWrite))
+   assert(rwItem.rights.isOneOf(ReadOrWrite))
 
-   assert( noItem.rights.is(ReadWrite) == false )
-   assert( noItem.rights.isOneOf(ReadOrWrite) == false )
+   assert(!noItem.rights.is(ReadWrite))
+   assert(!noItem.rights.isOneOf(ReadOrWrite))
 end User
 ```
+
 On the other hand, the call `roItem.rights.isOneOf(ReadWrite)` would give a type error
 since `Permissions` and `PermissionChoice` are different, unrelated types outside `Access`.
 


### PR DESCRIPTION
Since in some files I inserted some empty lines to separate code examples and its surrounding context paragraphs,
to check what I changed besides white spaces, please turn on "Hide whitespace changes".

* Current view of an ordered list in the match-syntax.md  is wrong, and I adjust the indentation to fix it.
* Since `NotGiven` is new in Scala 3, I think in its example code use the new `summon` is better than `implicitly`, and I did this replacement.
* Add missing `with` in the declaration of given instances.
* Use `inline` instead of `final` to declare constant expressions.