### PR TITLE
More careful instantation of wildcards when solving constraints

### DIFF
--- a/tests/pos/i10161.scala
+++ b/tests/pos/i10161.scala
@@ -1,0 +1,9 @@
+object Incompat2 {
+  trait Context { type Out }
+
+  object Context {
+    def foo(implicit ctx: Context): Option[ctx.Out] = ???
+
+    def bar(implicit ctx: Context): (Option[ctx.Out], String) = (foo, "foo")
+  }
+}


### PR DESCRIPTION
The previous treatment could instantiate a wildcard type to a type that violated
constraint satisfiability.

Fixes #10161