### PR TITLE
Properly report clashes between classes and objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -168,7 +168,8 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     CannotExtendJavaEnumID,
     InvalidReferenceInImplicitNotFoundAnnotationID,
     TraitMayNotDefineNativeMethodID,
-    JavaEnumParentArgsID
+    JavaEnumParentArgsID,
+    AlreadyDefinedID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1847,6 +1847,19 @@ import transform.SymUtils._
     def explain = ""
   }
 
+  class AlreadyDefined(name: Name, owner: Symbol, conflicting: Symbol)(using Context) extends NamingMsg(AlreadyDefinedID):
+    private def where: String =
+      if conflicting.effectiveOwner.is(Package) && conflicting.associatedFile != null then
+        i" in ${conflicting.associatedFile}"
+      else if conflicting.owner == owner then ""
+      else i" in ${conflicting.owner}"
+    def msg =
+      if conflicting.isTerm != name.isTermName then
+        em"$name clashes with $conflicting$where; the two must be defined together"
+      else
+        em"$name is already defined as $conflicting$where"
+    def explain = ""
+
   class PackageNameAlreadyDefined(pkg: Symbol)(using Context) extends NamingMsg(PackageNameAlreadyDefinedID) {
     lazy val (where, or) =
       if pkg.associatedFile == null then ("", "")

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -136,11 +136,10 @@ class Namer { typer: Typer =>
     var conflictsDetected = false
 
     def conflict(conflicting: Symbol) =
-      val where: String =
-        if conflicting.owner == owner then ""
-        else if conflicting.owner.isPackageObject then i" in ${conflicting.associatedFile}"
-        else i" in ${conflicting.owner}"
-      report.error(i"$name is already defined as $conflicting$where", ctx.source.atSpan(span))
+      val other =
+        if conflicting.is(ConstructorProxy) then conflicting.companionClass
+        else conflicting
+      report.error(AlreadyDefined(name, owner, other), ctx.source.atSpan(span))
       conflictsDetected = true
 
     def checkNoConflictIn(owner: Symbol) =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1979,6 +1979,7 @@ class Typer extends Namer
     val ValDef(name, tpt, _) = vdef
     completeAnnotations(vdef, sym)
     if (sym.isOneOf(GivenOrImplicit)) checkImplicitConversionDefOK(sym)
+    if sym.is(Module) then checkNoModuleClash(sym)
     val tpt1 = checkSimpleKinded(typedType(tpt))
     val rhs1 = vdef.rhs match {
       case rhs @ Ident(nme.WILDCARD) => rhs withType tpt1.tpe

--- a/tests/neg/i9472a.check
+++ b/tests/neg/i9472a.check
@@ -1,0 +1,4 @@
+-- [E161] Naming Error: tests/neg/i9472a/B.scala:3:0 -------------------------------------------------------------------
+3 |object Reproduction // error
+  |^
+  |Reproduction clashes with class Reproduction in tests/neg/i9472a/A.scala; the two must be defined together

--- a/tests/neg/i9472a/A.scala
+++ b/tests/neg/i9472a/A.scala
@@ -1,0 +1,4 @@
+package example.reproduction
+
+class Reproduction
+

--- a/tests/neg/i9472a/B.scala
+++ b/tests/neg/i9472a/B.scala
@@ -1,0 +1,5 @@
+package example.reproduction
+
+object Reproduction // error
+
+

--- a/tests/neg/i9472b.check
+++ b/tests/neg/i9472b.check
@@ -1,0 +1,4 @@
+-- [E161] Naming Error: tests/neg/i9472b/A.scala:3:0 -------------------------------------------------------------------
+3 |object Reproduction // error
+  |^
+  |Reproduction clashes with class Reproduction in tests/neg/i9472b/B.scala; the two must be defined together

--- a/tests/neg/i9472b/A.scala
+++ b/tests/neg/i9472b/A.scala
@@ -1,0 +1,4 @@
+package example.reproduction
+
+object Reproduction // error
+

--- a/tests/neg/i9472b/B.scala
+++ b/tests/neg/i9472b/B.scala
@@ -1,0 +1,4 @@
+package example.reproduction
+
+class Reproduction
+

--- a/tests/neg/trailingCommas.scala
+++ b/tests/neg/trailingCommas.scala
@@ -7,9 +7,9 @@ trait ArgumentExprs2 { validMethod(23, "bar")(Ev0, Ev1, ) } // error // error
 trait ArgumentExprs3 { new ValidClass(23, "bar", )(Ev0, Ev1) } // error // error
 trait ArgumentExprs4 { new ValidClass(23, "bar")(Ev0, Ev1, ) } // error // error
 
-trait Params1 { def f(foo: Int, bar: String, )(implicit ev0: Ev0, ev1: Ev1, ) = 1 } // error // error // error
+trait Params1 { def f(foo: Int, bar: String, )(implicit ev0: Ev0, ev1: Ev1, ) = 1 } // error // error
 
-trait Params2 { def f(foo: Int, bar: String, )(implicit ev0: Ev0, ev1: Ev1, ) = 1 } // error // error // error
+trait Params2 { def f(foo: Int, bar: String, )(implicit ev0: Ev0, ev1: Ev1, ) = 1 } // error // error
 
 trait ClassParams1 { final class C(foo: Int, bar: String, )(implicit ev0: Ev0, ev1: Ev1) } // error
 trait ClassParams2 { final class C(foo: Int, bar: String)(implicit ev0: Ev0, ev1: Ev1, ) } // error


### PR DESCRIPTION
Properly report clashes between classes and objects defined in
different source files.

Fixes #9472