### PR TITLE
Scala3doc: fix syntax highlighting

### DIFF
--- a/scala3doc/resources/dotty_res/scripts/hljs-scala3.js
+++ b/scala3doc/resources/dotty_res/scripts/hljs-scala3.js
@@ -255,11 +255,11 @@ function highlightDotty(hljs) {
     ]
   }
 
-  // Given instances (for the soft keyword 'as')
+  // Given instances
   const GIVEN = {
     begin: /given/, end: /[=;\n]/,
     excludeEnd: true,
-    keywords: 'as given using',
+    keywords: 'given using with',
     contains: [
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
@@ -316,8 +316,8 @@ function highlightDotty(hljs) {
 
   const CLASS = {
     className: 'class',
-    begin: `((${modifiers}|open|case) +)*class|trait|enum|object|package object`, end: templateDeclEnd,
-    keywords: withSoftKeywords('open'),
+    begin: `((${modifiers}|open|case|transparent) +)*(class|trait|enum|object|package object)`, end: templateDeclEnd,
+    keywords: withSoftKeywords('open transparent'),
     contains: [
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,

--- a/scala3doc/scala3-docs/css/color-brewer.css
+++ b/scala3doc/scala3-docs/css/color-brewer.css
@@ -15,14 +15,14 @@ Ported by Fabrício Tavares de Oliveira
   color: #000;
 }
 
-.hljs-string,
+/*.hljs-string,
 .hljs-meta,
 .hljs-symbol,
 .hljs-template-tag,
 .hljs-template-variable,
 .hljs-addition {
   color: #756bb1;
-}
+}*/
 
 .hljs-comment,
 .hljs-quote {
@@ -42,7 +42,7 @@ Ported by Fabrício Tavares de Oliveira
   color: #88f;
 }
 
-.hljs-keyword,
+/*.hljs-keyword,
 .hljs-selector-tag,
 .hljs-title,
 .hljs-section,
@@ -55,7 +55,7 @@ Ported by Fabrício Tavares de Oliveira
 .hljs-selector-class,
 .hljs-strong {
   color: #3182bd;
-}
+}*/
 
 .hljs-emphasis {
   font-style: italic;


### PR DESCRIPTION
This is an ad-hoc fix. For some reason, we have two files with CSS for hljs, and I'm not certain why that's the case and which one should actually be used.

Fixes #10911.

[skip ci]