### PR TITLE
Complete owners of type parameters before parameters themselves

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -211,9 +211,13 @@ class TypeApplications(val self: Type) extends AnyVal {
 
   /** If `self` is a generic class, its type parameter symbols, otherwise Nil */
   final def typeParamSymbols(using Context): List[TypeSymbol] = typeParams match {
-    case (_: Symbol) :: _ =>
-      assert(typeParams.forall(_.isInstanceOf[Symbol]))
-      typeParams.asInstanceOf[List[TypeSymbol]]
+    case tparams @ (_: Symbol) :: _ =>
+      assert(tparams.forall(_.isInstanceOf[Symbol]))
+      tparams.asInstanceOf[List[TypeSymbol]]
+        // Note: Two successive calls to typeParams can yield different results here because
+        // of different completion status. I.e. the first call might produce some symbols,
+        // whereas the second call gives some LambdaParams. This was observed
+        // for ticket0137.scala
     case _ => Nil
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -841,6 +841,20 @@ class Namer { typer: Typer =>
     private var nestedCtx: Context = null
     assert(!original.isClassDef)
 
+    /** If completion of the owner of the to be completed symbol has not yet started,
+     *  complete the owner first and check again. This prevents cyclic references
+     *  where we need to copmplete a type parameter that has an owner that is not
+     *  yet completed. Test case is pos/i10967.scala.
+     */
+    override def needsCompletion(symd: SymDenotation)(using Context): Boolean =
+      val owner = symd.owner
+      !owner.exists
+      || owner.is(Touched)
+      || {
+        owner.ensureCompleted()
+        !symd.isCompleted
+      }
+
     override def completerTypeParams(sym: Symbol)(using Context): List[TypeSymbol] =
       if myTypeParams == null then
         //println(i"completing type params of $sym in ${sym.owner}")

--- a/tests/pos/i10638.scala
+++ b/tests/pos/i10638.scala
@@ -1,0 +1,9 @@
+package woes
+
+trait Txn[T <: Txn[T]]
+
+trait Impl[Repr[~ <: Txn[~]]] {
+  final type Ext = Extension[Repr]  // Huh!
+}
+
+trait Extension[Repr[~ <: Txn[~]]]

--- a/tests/pos/i10967.scala
+++ b/tests/pos/i10967.scala
@@ -1,0 +1,9 @@
+trait SomeTrait
+
+trait CollBase[A <: SomeTrait, +CC1[A2 <: SomeTrait]] {
+  val companion: CollCompanion[CC1]
+}
+
+trait Coll[A <: SomeTrait] extends CollBase[A, Coll]
+
+trait CollCompanion[+CC2[A <: SomeTrait]]


### PR DESCRIPTION
Fixes #10967
Fixes #10638

I minimized #10967 further to:
```scala
trait SomeTrait

trait CollBase[CC1[A2 <: SomeTrait]] {
  val companion: CollCompanion[CC1]
}

trait CollCompanion[CC2[A <: SomeTrait]]
```
What happened was:

 1. the compiler tries to typecheck `companion`
 2. this means needs to check `CollCompanion[CC1]`
 3. this means it needs to complete the type parameter `CC2` of CollCompanion in order to make sure the argument is CC1 is kind correct.
 4. this means we complete type parameter `A` of `CC2`
 4. checking the type parameter requires checking the owner class `CollCompanion`.
 5. And this leads back to `CC2`, hence the cycle.

Note that if the definitions of `CollBase` and `CollCompanion` appear in reverse order,
no cycle results, since then `CollCompanion` and its type parameters were completed before
completing `companion`.

To break the cycle, we can complete the owner of a type parameter before starting
completion of the parameter. Furthermore, we need to do this only in Namer, which is
where the complex checking patterns are. I have not tried to also treat symbols that
are not type definitions that way. It's not necessary to fix #10967 but it might help
for other cycles (or it might cause them, these things are tricky!). I did try to
make the behavior universal for all completers, not just Namers, but that caused
crashes immediately.