### PR TITLE
Fixes involving SAM types

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -61,9 +61,9 @@ class Compiler {
          new CookComments,           // Cook the comments: expand variables, doc, etc.
          new CheckStatic,            // Check restrictions that apply to @static members
          new BetaReduce,             // Reduce closure applications
+         new ExpandSAMs,             // Expand single abstract method closures to anonymous classes
          new init.Checker) ::        // Check initialization of objects
     List(new ElimRepeated,           // Rewrite vararg parameters and arguments
-         new ExpandSAMs,             // Expand single abstract method closures to anonymous classes
          new ProtectedAccessors,     // Add accessors for protected members
          new ExtensionMethods,       // Expand methods of value classes with extension methods
          new UncacheGivenAliases,    // Avoid caching RHS of simple parameterless given aliases

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -350,7 +350,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     val constr = newConstructor(cls, Synthetic, Nil, Nil).entered
     def forwarder(fn: TermSymbol, name: TermName) = {
       val fwdMeth = fn.copy(cls, name, Synthetic | Method | Final).entered.asTerm
-      if (fwdMeth.allOverriddenSymbols.exists(!_.is(Deferred))) fwdMeth.setFlag(Override)
+      for overridden <- fwdMeth.allOverriddenSymbols do
+        if overridden.is(Extension) then fwdMeth.setFlag(Extension)
+        if !overridden.is(Deferred) then fwdMeth.setFlag(Override)
       polyDefDef(fwdMeth, tprefs => prefss => ref(fn).appliedToTypes(tprefs).appliedToArgss(prefss))
     }
     val forwarders = fns.lazyZip(methNames).map(forwarder)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5006,7 +5006,9 @@ object Types {
                     mapOver(tp)
                 }
               }
-              val approx = approxParams(mt).asInstanceOf[MethodType]
+              val approx =
+                if ctx.owner.isContainedIn(cls) then mt
+                else approxParams(mt).asInstanceOf[MethodType]
               Some(approx)
             case _ =>
               None

--- a/compiler/src/dotty/tools/dotc/transform/ByNameClosures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ByNameClosures.scala
@@ -26,6 +26,10 @@ class ByNameClosures extends TransformByNameApply with IdentityDenotTransformer 
 
   override def phaseName: String = ByNameClosures.name
 
+  override def runsAfterGroupsOf: Set[String] = Set(ExpandSAMs.name)
+    // ExpanSAMs applied to partial functions creates methods that need
+    // to be fully defined before converting. Test case is pos/i9391.scala.
+
   override def mkByNameClosure(arg: Tree, argType: Type)(using Context): Tree = {
     val meth = newSymbol(
       ctx.owner, nme.ANON_FUN, Synthetic | Method, MethodType(Nil, Nil, argType))

--- a/tests/pos/i9391.scala
+++ b/tests/pos/i9391.scala
@@ -1,0 +1,3 @@
+def g(x: => Any): Any = x
+
+val a: PartialFunction[Any => Any, Any] = (f => g(f(0)) match { case v => v })    // was an error, now OK


### PR DESCRIPTION
First, move ExpandSAMs to a group before HoistSuperArgs

Fixes #9391

This also uncovered two follow-on errors which were previously not detected, and which are fixed in the 2nd and 3rd commit.
