### PR TITLE
Early return from resolveOverloaded in case arguments are erroneous

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -332,6 +332,16 @@ object Types {
     /** Is this type produced as a repair for an error? */
     final def isError(using Context): Boolean = stripTypeVar.isInstanceOf[ErrorType]
 
+    def hasErrors(using Context): Boolean = widenDealias match
+      case _: NamedType => false
+      case AppliedType(tycon, args) => tycon.hasErrors || args.exists(_.hasErrors)
+      case RefinedType(parent, _, rinfo) => parent.hasErrors || rinfo.hasErrors
+      case TypeBounds(lo, hi) => lo.hasErrors || hi.hasErrors
+      case tp: AndOrType => tp.tp1.hasErrors || tp.tp2.hasErrors
+      case tp: TypeProxy => tp.underlying.hasErrors
+      case _: ErrorType => true
+      case _ => false
+
     /** Is some part of the widened version of this type produced as a repair for an error? */
     def isErroneous(using Context): Boolean =
       widen.existsPart(_.isError, forceLazy = false)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -212,6 +212,107 @@ object Applications {
     overwriteType(app.tpe)
       // ExtMethodApply always has wildcard type in order not to prompt any further adaptations
       // such as eta expansion before the method is fully applied.
+  }
+
+  /** Find reference to default parameter getter for parameter #n in current
+    *  parameter list, or NoType if none was found
+    */
+  def findDefaultGetter(fn: Tree, n: Int, testOnly: Boolean)(using Context): Tree = {
+    if fn.symbol.isTerm then
+      val meth = fn.symbol.asTerm
+      val receiver: Tree = methPart(fn) match {
+        case Select(receiver, _) => receiver
+        case mr => mr.tpe.normalizedPrefix match {
+          case mr: TermRef => ref(mr)
+          case mr =>
+            if testOnly then
+              // In this case it is safe to skolemize now; we will produce a stable prefix for the actual call.
+              ref(mr.narrow)
+            else
+              EmptyTree
+        }
+      }
+      val getterPrefix =
+        if (meth.is(Synthetic) && meth.name == nme.apply) nme.CONSTRUCTOR else meth.name
+      def getterName = DefaultGetterName(getterPrefix, n + numArgs(fn))
+      if !meth.hasDefaultParams then
+        EmptyTree
+      else if (receiver.isEmpty) {
+        def findGetter(cx: Context): Tree =
+          if (cx eq NoContext) EmptyTree
+          else if (cx.scope != cx.outer.scope &&
+            cx.denotNamed(meth.name).hasAltWith(_.symbol == meth)) {
+            val denot = cx.denotNamed(getterName)
+            if (denot.exists) ref(TermRef(cx.owner.thisType, getterName, denot))
+            else findGetter(cx.outer)
+          }
+          else findGetter(cx.outer)
+        findGetter(ctx)
+      }
+      else {
+        def selectGetter(qual: Tree): Tree = {
+          val getterDenot = qual.tpe.member(getterName)
+          if (getterDenot.exists) qual.select(TermRef(qual.tpe, getterName, getterDenot))
+          else EmptyTree
+        }
+        if (!meth.isClassConstructor)
+          selectGetter(receiver)
+        else {
+          // default getters for class constructors are found in the companion object
+          val cls = meth.owner
+          val companion = cls.companionModule
+          if (companion.isTerm) {
+            val prefix = receiver.tpe.baseType(cls).normalizedPrefix
+            if (prefix.exists) selectGetter(ref(TermRef(prefix, companion.asTerm)))
+            else EmptyTree
+          }
+          else EmptyTree
+        }
+      }
+    else EmptyTree // structural applies don't have symbols or defaults
+  }//.showing(i"find getter $fn, $n = $result")
+  end findDefaultGetter
+
+  /** Splice new method reference `meth` into existing application `app` */
+  private def spliceMeth(meth: Tree, app: Tree)(using Context): Tree = app match {
+    case Apply(fn, args) =>
+      spliceMeth(meth, fn).appliedToArgs(args)
+    case TypeApply(fn, targs) =>
+      // Note: It is important that the type arguments `targs` are passed in new trees
+      // instead of being spliced in literally. Otherwise, a type argument to a default
+      // method could be constructed as the definition site of the type variable for
+      // that default constructor. This would interpolate type variables too early,
+      // causing lots of tests (among them tasty_unpickleScala2) to fail.
+      //
+      // The test case is in i1757.scala. Here we have a variable `s` and a method `cpy`
+      // defined like this:
+      //
+      //      var s
+      //      def cpy[X](b: List[Int] = b): B[X] = new B[X](b)
+      //
+      // The call `s.cpy()` then gets expanded to
+      //
+      //      { val $1$: B[Int] = this.s
+      //        $1$.cpy[X']($1$.cpy$default$1[X']
+      //      }
+      //
+      // A type variable gets interpolated if it does not appear in the type
+      // of the current tree and the current tree contains the variable's "definition".
+      // Previously, the polymorphic function tree to which the variable was first added
+      // was taken as the variable's definition. But that fails here because that
+      // tree was `s.cpy` but got transformed into `$1$.cpy`. We now take the type argument
+      // [X'] of the variable as its definition tree, which is more robust. But then
+      // it's crucial that the type tree is not copied directly as argument to
+      // `cpy$default$1`. If it was, the variable `X'` would already be interpolated
+      // when typing the default argument, which is too early.
+      spliceMeth(meth, fn).appliedToTypes(targs.tpes)
+    case _ => meth
+  }
+
+  def defaultArgument(fn: Tree, n: Int, testOnly: Boolean)(using Context): Tree =
+    val getter = findDefaultGetter(fn, n, testOnly)
+    if getter.isEmpty then getter
+    else spliceMeth(getter.withSpan(fn.span), fn)
 }
 
 trait Applications extends Compatibility {
@@ -412,98 +513,6 @@ trait Applications extends Compatibility {
       handlePositional(methodType.paramNames, args)
     }
 
-    /** Splice new method reference into existing application */
-    def spliceMeth(meth: Tree, app: Tree): Tree = app match {
-      case Apply(fn, args) =>
-        spliceMeth(meth, fn).appliedToTermArgs(args)
-      case TypeApply(fn, targs) =>
-        // Note: It is important that the type arguments `targs` are passed in new trees
-        // instead of being spliced in literally. Otherwise, a type argument to a default
-        // method could be constructed as the definition site of the type variable for
-        // that default constructor. This would interpolate type variables too early,
-        // causing lots of tests (among them tasty_unpickleScala2) to fail.
-        //
-        // The test case is in i1757.scala. Here we have a variable `s` and a method `cpy`
-        // defined like this:
-        //
-        //      var s
-        //      def cpy[X](b: List[Int] = b): B[X] = new B[X](b)
-        //
-        // The call `s.cpy()` then gets expanded to
-        //
-        //      { val $1$: B[Int] = this.s
-        //        $1$.cpy[X']($1$.cpy$default$1[X']
-        //      }
-        //
-        // A type variable gets interpolated if it does not appear in the type
-        // of the current tree and the current tree contains the variable's "definition".
-        // Previously, the polymorphic function tree to which the variable was first added
-        // was taken as the variable's definition. But that fails here because that
-        // tree was `s.cpy` but got transformed into `$1$.cpy`. We now take the type argument
-        // [X'] of the variable as its definition tree, which is more robust. But then
-        // it's crucial that the type tree is not copied directly as argument to
-        // `cpy$default$1`. If it was, the variable `X'` would already be interpolated
-        // when typing the default argument, which is too early.
-        spliceMeth(meth, fn).appliedToTypes(targs.tpes)
-      case _ => meth
-    }
-
-    /** Find reference to default parameter getter for parameter #n in current
-     *  parameter list, or NoType if none was found
-     */
-    def findDefaultGetter(n: Int)(using Context): Tree = {
-      val meth = methRef.symbol.asTerm
-      val receiver: Tree = methPart(normalizedFun) match {
-        case Select(receiver, _) => receiver
-        case mr => mr.tpe.normalizedPrefix match {
-          case mr: TermRef => ref(mr)
-          case mr =>
-            if (this.isInstanceOf[TestApplication[?]])
-              // In this case it is safe to skolemize now; we will produce a stable prefix for the actual call.
-              ref(mr.narrow)
-            else
-              EmptyTree
-        }
-      }
-      val getterPrefix =
-        if (meth.is(Synthetic) && meth.name == nme.apply) nme.CONSTRUCTOR else meth.name
-      def getterName = DefaultGetterName(getterPrefix, n)
-      if (!meth.hasDefaultParams)
-        EmptyTree
-      else if (receiver.isEmpty) {
-        def findGetter(cx: Context): Tree =
-          if (cx eq NoContext) EmptyTree
-          else if (cx.scope != cx.outer.scope &&
-            cx.denotNamed(meth.name).hasAltWith(_.symbol == meth)) {
-            val denot = cx.denotNamed(getterName)
-            if (denot.exists) ref(TermRef(cx.owner.thisType, getterName, denot))
-            else findGetter(cx.outer)
-          }
-          else findGetter(cx.outer)
-        findGetter(ctx)
-      }
-      else {
-        def selectGetter(qual: Tree): Tree = {
-          val getterDenot = qual.tpe.member(getterName)
-          if (getterDenot.exists) qual.select(TermRef(qual.tpe, getterName, getterDenot))
-          else EmptyTree
-        }
-        if (!meth.isClassConstructor)
-          selectGetter(receiver)
-        else {
-          // default getters for class constructors are found in the companion object
-          val cls = meth.owner
-          val companion = cls.companionModule
-          if (companion.isTerm) {
-            val prefix = receiver.tpe.baseType(cls).normalizedPrefix
-            if (prefix.exists) selectGetter(ref(TermRef(prefix, companion.asTerm)))
-            else EmptyTree
-          }
-          else EmptyTree
-        }
-      }
-    }
-
     /** Is `sym` a constructor of a Java-defined annotation? */
     def isJavaAnnotConstr(sym: Symbol): Boolean =
       sym.is(JavaDefined) && sym.isConstructor && sym.owner.derivesFrom(defn.AnnotationClass)
@@ -554,18 +563,7 @@ trait Applications extends Compatibility {
                 else
                   EmptyTree
               }
-              else {
-                val getter =
-                  if (sym.exists) // `sym` doesn't exist for structural calls
-                    findDefaultGetter(n + numArgs(normalizedFun))
-                  else
-                    EmptyTree
-
-                if (!getter.isEmpty)
-                  spliceMeth(getter.withSpan(normalizedFun.span), normalizedFun)
-                else
-                  EmptyTree
-              }
+              else defaultArgument(normalizedFun, n, this.isInstanceOf[TestApplication[?]])
 
             def implicitArg = implicitArgTree(formal, appPos.span)
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1927,10 +1927,10 @@ trait Applications extends Compatibility {
       case _ => false
 
     record("resolveOverloaded.narrowedApplicable", candidates.length)
-    if pt.isErroneous then
+    if pt.hasErrors then
       // `pt` might have become erroneous by typing arguments of FunProtos.
       // If `pt` is erroneous, don't try to go further; report the error in `pt` instead.
-      candidates 
+      candidates
     else
       val found = narrowMostSpecific(candidates)
       if found.length <= 1 then found

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -212,12 +212,11 @@ object Applications {
     overwriteType(app.tpe)
       // ExtMethodApply always has wildcard type in order not to prompt any further adaptations
       // such as eta expansion before the method is fully applied.
-  }
 
   /** Find reference to default parameter getter for parameter #n in current
     *  parameter list, or NoType if none was found
     */
-  def findDefaultGetter(fn: Tree, n: Int, testOnly: Boolean)(using Context): Tree = {
+  def findDefaultGetter(fn: Tree, n: Int, testOnly: Boolean)(using Context): Tree =
     if fn.symbol.isTerm then
       val meth = fn.symbol.asTerm
       val receiver: Tree = methPart(fn) match {
@@ -270,7 +269,6 @@ object Applications {
         }
       }
     else EmptyTree // structural applies don't have symbols or defaults
-  }//.showing(i"find getter $fn, $n = $result")
   end findDefaultGetter
 
   /** Splice new method reference `meth` into existing application `app` */

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -456,7 +456,7 @@ trait Applications extends Compatibility {
 
     protected def methodType: MethodType = methType.asInstanceOf[MethodType]
     private def methString: String =
-      def infoStr = if methType.hasErrors then "" else i": $methType"
+      def infoStr = if methType.isErroneous then "" else i": $methType"
       i"${err.refStr(methRef)}$infoStr"
 
     /** Re-order arguments to correctly align named arguments */
@@ -1927,7 +1927,7 @@ trait Applications extends Compatibility {
       case _ => false
 
     record("resolveOverloaded.narrowedApplicable", candidates.length)
-    if pt.hasErrors then
+    if pt.unusableForInference then
       // `pt` might have become erroneous by typing arguments of FunProtos.
       // If `pt` is erroneous, don't try to go further; report the error in `pt` instead.
       candidates

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -455,7 +455,9 @@ trait Applications extends Compatibility {
     def success: Boolean = ok
 
     protected def methodType: MethodType = methType.asInstanceOf[MethodType]
-    private def methString: String = i"${err.refStr(methRef)}: ${methType.show}"
+    private def methString: String =
+      def infoStr = if methType.hasErrors then "" else i": $methType"
+      i"${err.refStr(methRef)}$infoStr"
 
     /** Re-order arguments to correctly align named arguments */
     def reorder[T >: Untyped](args: List[Trees.Tree[T]]): List[Trees.Tree[T]] = {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -955,8 +955,9 @@ trait Implicits:
         if (argument.isEmpty) i"missing implicit parameter of type $pt after typer"
         else i"type error: ${argument.tpe} does not conform to $pt${err.whyNoMatchStr(argument.tpe, pt)}")
 
-      if pt.hasErrors || !argument.isEmpty && argument.tpe.hasErrors then
-        return NoMatchingImplicitsFailure
+      if pt.unusableForInference
+         || !argument.isEmpty && argument.tpe.unusableForInference
+      then return NoMatchingImplicitsFailure
 
       val result0 =
         try ImplicitSearch(pt, argument, span).bestImplicit

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -954,6 +954,10 @@ trait Implicits:
       assert(ctx.phase.allowsImplicitSearch,
         if (argument.isEmpty) i"missing implicit parameter of type $pt after typer"
         else i"type error: ${argument.tpe} does not conform to $pt${err.whyNoMatchStr(argument.tpe, pt)}")
+
+      if pt.hasErrors || !argument.isEmpty && argument.tpe.hasErrors then
+        return NoMatchingImplicitsFailure
+
       val result0 =
         try ImplicitSearch(pt, argument, span).bestImplicit
         catch case ce: CyclicReference =>

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -193,6 +193,8 @@ object ProtoTypes {
       if ((name eq this.name) && (memberProto eq this.memberProto) && (compat eq this.compat)) this
       else SelectionProto(name, memberProto, compat, privateOK)
 
+    override def hasErrors(using Context): Boolean = memberProto.hasErrors
+
     def map(tm: TypeMap)(using Context): SelectionProto = derivedSelectionProto(name, tm(memberProto), compat)
     def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T = ta(x, memberProto)
 
@@ -403,6 +405,8 @@ object ProtoTypes {
     override def isErroneous(using Context): Boolean =
       state.typedArgs.tpes.exists(_.isErroneous)
 
+    override def hasErrors(using Context): Boolean = state.typedArgs.exists(_.tpe.hasErrors)
+
     override def toString: String = s"FunProto(${args mkString ","} => $resultType)"
 
     def map(tm: TypeMap)(using Context): FunProto =
@@ -453,6 +457,8 @@ object ProtoTypes {
       if ((argType eq this.argType) && (resultType eq this.resultType)) this
       else ViewProto(argType, resultType)
 
+    override def hasErrors(using Context): Boolean = argType.hasErrors || resType.hasErrors
+
     def map(tm: TypeMap)(using Context): ViewProto = derivedViewProto(tm(argType), tm(resultType))
 
     def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T =
@@ -495,6 +501,8 @@ object ProtoTypes {
     def derivedPolyProto(targs: List[Tree], resultType: Type): PolyProto =
       if ((targs eq this.targs) && (resType eq this.resType)) this
       else PolyProto(targs, resType)
+
+    override def hasErrors(using Context): Boolean = targs.exists(_.tpe.hasErrors)
 
     def map(tm: TypeMap)(using Context): PolyProto =
       derivedPolyProto(targs, tm(resultType))

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -193,7 +193,11 @@ object ProtoTypes {
       if ((name eq this.name) && (memberProto eq this.memberProto) && (compat eq this.compat)) this
       else SelectionProto(name, memberProto, compat, privateOK)
 
-    override def hasErrors(using Context): Boolean = memberProto.hasErrors
+    override def isErroneous(using Context): Boolean =
+      memberProto.isErroneous
+
+    override def unusableForInference(using Context): Boolean =
+      memberProto.unusableForInference
 
     def map(tm: TypeMap)(using Context): SelectionProto = derivedSelectionProto(name, tm(memberProto), compat)
     def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T = ta(x, memberProto)
@@ -405,7 +409,8 @@ object ProtoTypes {
     override def isErroneous(using Context): Boolean =
       state.typedArgs.tpes.exists(_.isErroneous)
 
-    override def hasErrors(using Context): Boolean = state.typedArgs.exists(_.tpe.hasErrors)
+    override def unusableForInference(using Context): Boolean =
+      state.typedArgs.exists(_.tpe.unusableForInference)
 
     override def toString: String = s"FunProto(${args mkString ","} => $resultType)"
 
@@ -457,7 +462,11 @@ object ProtoTypes {
       if ((argType eq this.argType) && (resultType eq this.resultType)) this
       else ViewProto(argType, resultType)
 
-    override def hasErrors(using Context): Boolean = argType.hasErrors || resType.hasErrors
+    override def isErroneous(using Context): Boolean =
+      argType.isErroneous || resType.isErroneous
+
+    override def unusableForInference(using Context): Boolean =
+      argType.unusableForInference || resType.unusableForInference
 
     def map(tm: TypeMap)(using Context): ViewProto = derivedViewProto(tm(argType), tm(resultType))
 
@@ -502,7 +511,11 @@ object ProtoTypes {
       if ((targs eq this.targs) && (resType eq this.resType)) this
       else PolyProto(targs, resType)
 
-    override def hasErrors(using Context): Boolean = targs.exists(_.tpe.hasErrors)
+    override def isErroneous(using Context): Boolean =
+      targs.exists(_.tpe.isErroneous)
+
+    override def unusableForInference(using Context): Boolean =
+      targs.exists(_.tpe.unusableForInference)
 
     def map(tm: TypeMap)(using Context): PolyProto =
       derivedPolyProto(targs, tm(resultType))

--- a/tests/neg/i7750a.scala
+++ b/tests/neg/i7750a.scala
@@ -1,5 +1,5 @@
 def foo: Unit = {
     val a = (x: Int, y: String) => x + + y  // error
     implicit def f[X](x: (X,  String) => String) = (z: X) => (z, null) // error
-    a(1)
+    a(1) // error
 }

--- a/tests/neg/i9344.scala
+++ b/tests/neg/i9344.scala
@@ -1,0 +1,4 @@
+
+object Test {
+  val I1: Int = 0 * * * 8 * 1 - 1 + 1 + // error
+}

--- a/tests/pos/i5427.scala
+++ b/tests/pos/i5427.scala
@@ -27,11 +27,14 @@ object Test2 {
 
 object Test3 {
   def fooInt: Foo[Int] { type Out = String } = ???
-  implicit def str: String = ???
+  implicit def istr: String = ???
+  implicit def iint: Int = ???
 
   def test5[A](implicit f1: Foo[A] = fooInt, f2: f1.Out) = f2
 
   val t5 = test5
+    // used to succeed with just one local implicit `istr`
+    // but failed if a competing implicit `iint` was added.
   t5: String
 }
 

--- a/tests/run-bootstrapped/typeCheckErrors.check
+++ b/tests/run-bootstrapped/typeCheckErrors.check
@@ -1,2 +1,1 @@
 Error(Not found: abc,            1 + abc,16,Typer)
-Error(Not found: abc,            1 + abc,16,Typer)


### PR DESCRIPTION
Fixes #9344
Fixes #10983

This was more involved than I anticipated. I originally thought we could use `isErroneous` to flag types as not fit for inference. 
But it turned out that was not exactly what we needed, and that in fact we need another predicate `unusableForInference` instead. This work also uncovered a failure to correctly treat parameter-dependent using clauses with defaults, which has
been fixed as well.