### PR TITLE
Fix #11061: stop accidentally supported auto-tupling for case classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -31,7 +31,7 @@ import TypeComparer.CompareResult
 import util.Spans._
 import util.common._
 import util.{Property, SimpleIdentityMap, SrcPos}
-import Applications.{productSelectorTypes, wrapDefs, defaultArgument}
+import Applications.{tupleComponentTypes, wrapDefs, defaultArgument}
 
 import collection.mutable
 import annotation.tailrec
@@ -1273,8 +1273,8 @@ class Typer extends Namer
     /** Is `formal` a product type which is elementwise compatible with `params`? */
     def ptIsCorrectProduct(formal: Type) =
       isFullyDefined(formal, ForceDegree.flipBottom) &&
-      (defn.isProductSubType(formal) || formal.derivesFrom(defn.PairClass)) &&
-      productSelectorTypes(formal, tree.srcPos).corresponds(params) {
+      defn.isProductSubType(formal) &&
+      tupleComponentTypes(formal).corresponds(params) {
         (argType, param) =>
           param.tpt.isEmpty || argType.widenExpr <:< typedAheadType(param.tpt).tpe
       }

--- a/scala3doc/src/dotty/renderers/MemberRenderer.scala
+++ b/scala3doc/src/dotty/renderers/MemberRenderer.scala
@@ -33,7 +33,7 @@ class MemberRenderer(signatureRenderer: SignatureRenderer, buildNode: ContentNod
     case Origin.Overrides(defs) =>
       def renderDef(d: Overriden): Seq[TagArg] =
         Seq(" -> ", signatureRenderer.renderLink(d.name, d.dri))
-      val headNode = m.inheritedFrom.map(signatureRenderer.renderLink(_, _))
+      val headNode = m.inheritedFrom.map(form => signatureRenderer.renderLink(form.name, form.dri))
       val tailNodes = defs.flatMap(renderDef)
       val nodes = headNode.fold(tailNodes.drop(1))(_ +: tailNodes)
       tableRow("Definition Classes", div(nodes:_*))

--- a/tests/neg/i11061.scala
+++ b/tests/neg/i11061.scala
@@ -1,0 +1,7 @@
+case class Foo(a: Int, b: Int)
+
+object Test {
+  def foo(x: Foo) = List(x).map(_ + _) // error
+
+  def main(args: Array[String]): Unit = println(foo(Foo(3, 4)))
+}

--- a/tests/pos/i6199a.scala
+++ b/tests/pos/i6199a.scala
@@ -3,6 +3,6 @@ case class ValueWithEncoder[T](value: T, encoder: Encoder[T])
 
 object Test {
   val a: Seq[ValueWithEncoder[_]] = Seq.empty
-  val b = a.map((value, encoder) => encoder.encode(value))
+  val b = a.map(ve => ve.encoder.encode(ve.value))
   val c: Seq[String] = b
 }


### PR DESCRIPTION
Fix #11061: stop accidentally supported auto-tupling for case classes

This commit refactor the PR #5259 so that it will not impact pattern
matching code.