### PR TITLE
Fix #10355: Run PostTyper before Staging in REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -35,6 +35,8 @@ class Staging extends MacroTransform {
 
   override def phaseName: String = Staging.name
 
+  override def runsAfter: Set[String] = Set(PostTyper.name)
+
   override def allowsImplicitSearch: Boolean = true
 
   override def checkPostCondition(tree: Tree)(using Context): Unit =

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -34,8 +34,8 @@ class ReplCompiler extends Compiler {
   override protected def frontendPhases: List[List[Phase]] = List(
     List(new REPLFrontEnd),
     List(new CollectTopLevelImports),
+    List(new PostTyper),
     List(new Staging),
-    List(new PostTyper)
   )
 
   def newRun(initCtx: Context, state: State): Run = new Run(this, initCtx) {

--- a/compiler/test-resources/repl/i10355
+++ b/compiler/test-resources/repl/i10355
@@ -1,0 +1,5 @@
+scala> import scala.quoted._
+scala> def foo(expr: Expr[Any])(using Quotes) = expr match { case '{ $x: t } => '{ $x: Any } }
+def foo(expr: quoted.Expr[Any])(using x$2: quoted.Quotes): quoted.Expr[Any]
+scala> def bar(expr: Expr[Any])(using Quotes) = expr match { case '{ $x: t } => '{ val a: t = ??? ; ???} }
+def bar(expr: quoted.Expr[Any])(using x$2: quoted.Quotes): quoted.Expr[Nothing]


### PR DESCRIPTION
PostTyper marks compilation units with `needsStaging` to enable this phase.

Fixes #10355.