### PR TITLE
fix #10247: skip deprecation warnings in synthetic definitions

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -55,6 +55,7 @@ class CompilationTests {
       compileFile("tests/pos-special/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/run/i5606.scala", defaultOptions.and("-Yretain-trees")),
       compileFile("tests/pos-custom-args/i5498-postfixOps.scala", defaultOptions withoutLanguageFeature "postfixOps"),
+      compileFilesInDir("tests/pos-custom-args/deprecation", defaultOptions.and("-deprecation", "-Xfatal-warnings")),
       compileFile("tests/pos-custom-args/i8875.scala", defaultOptions.and("-Xprint:getters")),
       compileFile("tests/pos-custom-args/i9267.scala", defaultOptions.and("-Ystop-after:erasure")),
       compileFile("tests/pos-special/extend-java-enum.scala", defaultOptions.and("-source", "3.0-migration")),

--- a/tests/neg-custom-args/deprecation/i10247.scala
+++ b/tests/neg-custom-args/deprecation/i10247.scala
@@ -1,0 +1,5 @@
+def usered = Color.Red // error: value Red is deprecated
+
+enum Color {
+  @deprecated("no Red", "0.1") case Red
+}

--- a/tests/pos-custom-args/deprecation/i10247.scala
+++ b/tests/pos-custom-args/deprecation/i10247.scala
@@ -1,0 +1,20 @@
+// check that deprecation warnings of Red are not caught in its enclosing scope
+enum Color(rgb: Int) {
+
+  @deprecated("stop using Red", "0.1")
+  case Red extends Color(0xff0000)
+
+  case Green extends Color(0x00ff00)
+
+  case Blue  extends Color(0x0000ff)
+
+  final def colorCode: Option[Int] = this match {
+    case Red => None
+    case _   => Some(rgb)
+  }
+
+}
+
+object Color {
+  val deprecatedMembers = Set(Red)
+}


### PR DESCRIPTION
fixes #10247 

In this change we avoid all deprecation warnings when directly within a synthetic definition.

perhaps this is too permissive? i.e. Is there a place desirable for a synthetic def to warn about calling a deprecated member?

e.g. in this example in issue #10247 the enum case `Red` is deprecated, but is used to define both the `values` array and the `valueOf` lookup method, but these should not cause warnings