### PR TITLE
Do not warn on canceled splices in quoted patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -43,7 +43,7 @@ trait QuotesAndSplices {
   def typedQuote(tree: untpd.Quote, pt: Type)(using Context): Tree = {
     record("typedQuote")
     tree.quoted match {
-      case untpd.Splice(innerExpr) if tree.isTerm =>
+      case untpd.Splice(innerExpr) if tree.isTerm && !ctx.mode.is(Mode.Pattern) =>
         report.warning("Canceled splice directly inside a quote. '{ ${ XYZ } } is equivalent to XYZ.", tree.srcPos)
       case untpd.TypSplice(innerType) if tree.isType =>
         report.warning("Canceled splice directly inside a quote. '[ ${ XYZ } ] is equivalent to XYZ.", tree.srcPos)

--- a/tests/pos-special/fatal-warnings/i9804.scala
+++ b/tests/pos-special/fatal-warnings/i9804.scala
@@ -1,0 +1,5 @@
+import scala.quoted._
+
+def f[A: Type](e: Expr[A])(using Quotes): Expr[A] = e match {
+  case '{ $e2 } => e2
+}


### PR DESCRIPTION
The following is a valid and minimal quoted patten: `case '{ $x } =>`

Fixes #9804