### PR TITLE
Fix #10888: Avoid A.this.B for Java inner classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -349,7 +349,10 @@ class ClassfileParser(
       val tag = sig(index); index += 1
       (tag: @switch) match {
         case 'L' =>
-          /** A type representation where inner classes become `A#B` instead of `A.this.B` (like with `typeRef`) */
+          /** A type representation where inner classes become `A#B` instead of `A.this.B` (like with `typeRef`)
+           *
+           *  Note: the symbol must not be nested in a generic class.
+           */
           def innerType(symbol: Symbol): Type =
             if symbol.is(Flags.Package) then
               symbol.thisType
@@ -358,7 +361,7 @@ class ClassfileParser(
             else
               throw new RuntimeException("unexpected term symbol " + symbol)
 
-          def processClassType(tp: Type): Type = tp match {
+          def processTypeArgs(tp: Type): Type = tp match {
             case tp: TypeRef =>
               if (sig(index) == '<') {
                 accept('<')
@@ -392,12 +395,12 @@ class ClassfileParser(
 
           val classSym = classNameToSymbol(subName(c => c == ';' || c == '<'))
           val classTpe = if (classSym eq defn.ObjectClass) defn.FromJavaObjectType else innerType(classSym)
-          var tpe = processClassType(classTpe)
+          var tpe = processTypeArgs(classTpe)
           while (sig(index) == '.') {
             accept('.')
             val name = subName(c => c == ';' || c == '<' || c == '.').toTypeName
-            val clazz = tpe.member(name).symbol
-            tpe = processClassType(innerType(clazz))
+            val tp = tpe.select(name)
+            tpe = processTypeArgs(tp)
           }
           accept(';')
           tpe
@@ -435,15 +438,15 @@ class ClassfileParser(
             paramtypes += {
               if isRepeatedParam(index) then
                 index += 1
-                val elemType = sig2type(tparams, skiptvs)
+                val elemType = sig2type(tparams, skiptvs = false)
                 // `ElimRepeated` is responsible for correctly erasing this.
                 defn.RepeatedParamType.appliedTo(elemType)
               else
-                sig2type(tparams, skiptvs)
+                sig2type(tparams, skiptvs = false)
             }
 
           index += 1
-          val restype = sig2type(tparams, skiptvs)
+          val restype = sig2type(tparams, skiptvs = false)
           JavaMethodType(paramnames.toList, paramtypes.toList, restype)
         case 'T' =>
           val n = subName(';'.==).toTypeName


### PR DESCRIPTION
Fix #10888: Avoid A.this.B for Java inner classes

For Java inner classes, we should use `A#B` instead of `A.this.B`.

Co-authored-by: Guillaume Martres <smarter@ubuntu.com>