### PR TITLE
Disallow type lambdas as F-bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1386,7 +1386,11 @@ import transform.SymUtils._
 
   class TypeDoesNotTakeParameters(tpe: Type, params: List[Trees.Tree[Trees.Untyped]])(using Context)
     extends TypeMsg(TypeDoesNotTakeParametersID) {
-    def msg = em"$tpe does not take type parameters"
+    private def fboundsAddendum =
+      if tpe.typeSymbol.isAllOf(Provisional | TypeParam) then
+        "\n(Note that F-bounds of type parameters may not be type lambdas)"
+      else ""
+    def msg = em"$tpe does not take type parameters$fboundsAddendum"
     def explain =
       val ps =
         if (params.size == 1) s"a type parameter ${params.head}"

--- a/tests/neg/i8752.check
+++ b/tests/neg/i8752.check
@@ -1,0 +1,11 @@
+-- [E053] Type Error: tests/neg/i8752.scala:3:41 -----------------------------------------------------------------------
+3 |trait Arround1[C <:[X]=>>IterableOps[X,C,C[X]] ] // error // error
+  |                                         ^^^^
+  |                                         C does not take type parameters
+  |                                         (Note that F-bounds of type parameters may not be type lambdas)
+
+longer explanation available when compiling with `-explain`
+-- Error: tests/neg/i8752.scala:3:39 -----------------------------------------------------------------------------------
+3 |trait Arround1[C <:[X]=>>IterableOps[X,C,C[X]] ] // error // error
+  |                                       ^
+  |                                       Type argument C does not have the same kind as its bound [_]

--- a/tests/neg/i8752.scala
+++ b/tests/neg/i8752.scala
@@ -1,0 +1,3 @@
+import scala.collection.IterableOps
+
+trait Arround1[C <:[X]=>>IterableOps[X,C,C[X]] ] // error // error


### PR DESCRIPTION
Given parameter
```
C <: [Y] => ... C[T] ...
```
change error message for `C[T]` to explain that type lambdas are not supported
as F-bounds.

Fixes #8752 

by making the error message ckearer.


