### PR TITLE
Update dotty landing page

### DIFF
--- a/scala3doc/scala3-docs/css/frontpage.css
+++ b/scala3doc/scala3-docs/css/frontpage.css
@@ -60,6 +60,12 @@ section.page {
   min-height: 100vh;
   width: 100%;
   padding: 0;
+  padding-bottom: 2em;
+}
+
+section.page strong {
+  font-weight: bold;
+  color: rgba(255,255,255,0.6);
 }
 
 section .container {

--- a/scala3doc/scala3-docs/index.html
+++ b/scala3doc/scala3-docs/index.html
@@ -26,6 +26,11 @@ extraCSS:
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="docs/index.html">
+                            Reference
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="https://docs.scala-lang.org/scala3/">
                             Docs
                         </a>
                     </li>

--- a/scala3doc/scala3-docs/index.html
+++ b/scala3doc/scala3-docs/index.html
@@ -80,5 +80,14 @@ extraCSS:
       <pre><code>sbt new <a href="https://github.com/lampepfl/dotty-cross.g8">lampepfl/dotty-cross.g8</a></code></pre>
 
       <p>For documentation see the <a href="https://github.com/lampepfl/dotty-example-project">Scala 3 Example Project</a>.</p>
+
+      <h1 id="documentation">Learn more about Scala 3</h1>
+      <p>You can find much more information about Scala 3 in ...</p>
+      <ul>
+        <li>... the <a href="https://docs.scala-lang.org/scala3/">Scala 3 documentation</a>,</li>
+        <li>... the <a href="https://docs.scala-lang.org/scala3/scala3-book">Scala 3 book</a>,</li>
+        <li>... the <a href="docs/index.html">Scala 3 reference docs</a>,</li>
+        <li>... the <a href="https://docs.scala-lang.org/scala3/guides.html">Scala 3 guides</a>.</li>
+      </ul>
   </div>
 </section>

--- a/scala3doc/scala3-docs/index.html
+++ b/scala3doc/scala3-docs/index.html
@@ -47,7 +47,7 @@ extraCSS:
         <div class="scala-logo-container">
             <img src="images/dotty-logo-white.svg" alt="logo" />
             <div class="subtitle text-center">
-                <h1 id="dotty" class="above-byline">Dotty</h1>
+                <h1 id="dotty" class="above-byline">Scala 3</h1>
                 <p>A next-generation compiler for Scala</p>
                 <p>(scroll down for more info)</p>
             </div>
@@ -57,8 +57,8 @@ extraCSS:
 <section class="page bg-blue bg-dark">
   <div class="container">
 
-      <h1 id="getting-started">Try Dotty</h1>
-      <p>If you are a Mac user, you can install Dotty with <a href="https://brew.sh/">brew</a>:</p>
+      <h1 id="getting-started">Try Scala 3</h1>
+      <p>If you are a Mac user, you can install Scala 3 with <a href="https://brew.sh/">brew</a>:</p>
       <pre><code>brew install lampepfl/brew/dotty</code></pre>
 
       <p>If you are a Linux or Windows user, download the <a href="https://github.com/lampepfl/dotty/releases">latest release</a>. Optionally add path of the folder <code>bin/</code> to the system environment variable <code>PATH</code>. </p>
@@ -68,17 +68,17 @@ extraCSS:
 
       <p>To start the REPL, run: <code>scala</code>.</p>
 
-      <p>Or, you can try Dotty in your browser with <a href="https://scastie.scala-lang.org/?target=dotty">Scastie</a>.</p>
+      <p>Or, you can try Scala 3 in your browser with <a href="https://scastie.scala-lang.org/?target=dotty">Scastie</a>.</p>
 
-      <h1 id="getting-started-with-a-project">Create a Dotty Project</h1>
-      <p>The fastest way to create a new project in Dotty is using <a href="http://www.scala-sbt.org/">sbt (1.1.4+)</a>.</p>
+      <h1 id="getting-started-with-a-project">Create a Scala 3 Project</h1>
+      <p>The fastest way to create a new project in Scala 3 is using <a href="http://www.scala-sbt.org/">sbt (1.1.4+)</a>.</p>
 
-      <p>Create a Dotty project:</p>
+      <p>Create a Scala 3 project:</p>
       <pre><code>sbt new <a href="https://github.com/lampepfl/dotty.g8">lampepfl/dotty.g8</a></code></pre>
 
-      <p>Or a Dotty project that cross compiles with Scala 2:</p>
+      <p>Or a Scala 3 project that cross compiles with Scala 2:</p>
       <pre><code>sbt new <a href="https://github.com/lampepfl/dotty-cross.g8">lampepfl/dotty-cross.g8</a></code></pre>
 
-      <p>For documentation see the <a href="https://github.com/lampepfl/dotty-example-project">Dotty Example Project</a>.</p>
+      <p>For documentation see the <a href="https://github.com/lampepfl/dotty-example-project">Scala 3 Example Project</a>.</p>
   </div>
 </section>

--- a/scala3doc/scala3-docs/index.html
+++ b/scala3doc/scala3-docs/index.html
@@ -1,5 +1,5 @@
 ---
-title: Dotty
+title: Scala 3
 layout: main
 hasFrame: false
 extraCSS:
@@ -58,17 +58,28 @@ extraCSS:
   <div class="container">
 
       <h1 id="getting-started">Try Scala 3</h1>
-      <p>If you are a Mac user, you can install Scala 3 with <a href="https://brew.sh/">brew</a>:</p>
+      <p>There are multiple ways of <a href="https://docs.scala-lang.org/scala3/getting-started.html">getting started</a> with Scala 3.</p>
+      <ol>
+          <li>You can try Scala 3 in your browser with <a href="https://scastie.scala-lang.org/?target=dotty">Scastie</a>.</li>
+          <li>If you already have sbt installed, you can <a href="#getting-started-with-a-project">create a Scala 3 project</a> and sbt will take care of the rest.</li>
+          <li>You can install all necessary dependencies with <a href="https://get-coursier.io/">coursier</a> by running <code>cs setup</code>. You can also run <code>cs install scala3-compiler</code> or <code>cs install scala3-repl</code> to install command-line commands for the compiler and repl, correspondingly.</li>
+          <li>You can <a href="#install">manually install Scala 3</a> on your computer.</li>
+      </ol>
+
+      <h1 id="install">Install Scala 3</h1>
+      <p>If you are a <strong>Mac</strong> user, you can install Scala 3 with <a href="https://brew.sh/">brew</a>:</p>
       <pre><code>brew install lampepfl/brew/dotty</code></pre>
 
-      <p>If you are a Linux or Windows user, download the <a href="https://github.com/lampepfl/dotty/releases">latest release</a>. Optionally add path of the folder <code>bin/</code> to the system environment variable <code>PATH</code>. </p>
+      <p>
+        If you are a <strong>Linux</strong> or <strong>Windows</strong> user, as a prerequisite you need a JDK 8 or later properly installed on your system. The environment variable <code>JAVA_HOME</code> should point to your Java installation.<br/>
+        For <strong>Windows</strong> users, we recommend using <a href="https://docs.microsoft.com/en-us/windows/wsl/install-win10">the Windows subsystem for linux</a> or some other bash shell like <a href="https://gitforwindows.org/">git bash</a>.<br/>
+        Then download the <a href="https://github.com/lampepfl/dotty/releases">latest release</a>. Optionally add the path of the folder <code>bin/</code> to the system environment variable <code>PATH</code>.
+      </p>
 
       <p>Now you can compile Scala source code:</p>
       <pre><code>scalac hello.scala</code></pre>
 
       <p>To start the REPL, run: <code>scala</code>.</p>
-
-      <p>Or, you can try Scala 3 in your browser with <a href="https://scastie.scala-lang.org/?target=dotty">Scastie</a>.</p>
 
       <h1 id="getting-started-with-a-project">Create a Scala 3 Project</h1>
       <p>The fastest way to create a new project in Scala 3 is using <a href="http://www.scala-sbt.org/">sbt (1.1.4+)</a>.</p>


### PR DESCRIPTION
This PR updates the landing page and
1. renames occurrences of dotty to Scala 3
2. mentions coursier
3. details the installation instructions for Windows to address #10300
4. adds a link to docs.scala-lang.org in the header
5. adds links to additional resources at the bottom of the page 