### PR TITLE
typedSelect refactorings

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -645,8 +645,6 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         keywordStr("${") ~ toTextGlobal(dropBlock(tree)) ~ keywordStr("}")
       case TypSplice(tree) =>
         keywordStr("${") ~ toTextGlobal(dropBlock(tree)) ~ keywordStr("}")
-      case tree: Applications.ExtMethodApply =>
-        toText(tree.app) ~ Str("(ext method apply)").provided(printDebug)
       case Thicket(trees) =>
         "Thicket {" ~~ toTextGlobal(trees, "\n") ~~ "}"
       case MacroTree(call) =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -196,23 +196,6 @@ object Applications {
   def wrapDefs(defs: mutable.ListBuffer[Tree], tree: Tree)(using Context): Tree =
     if (defs != null && defs.nonEmpty) tpd.Block(defs.toList, tree) else tree
 
-  abstract class AppProxy(implicit @constructorOnly src: SourceFile) extends ProxyTree {
-    def app: Tree
-    override def span = app.span
-
-    def forwardTo = app
-    def canEqual(that: Any): Boolean = app.canEqual(that)
-    def productArity: Int = app.productArity
-    def productElement(n: Int): Any = app.productElement(n)
-  }
-
-  /** A wrapper indicating that its argument is an application of an extension method.
-   */
-  class ExtMethodApply(val app: Tree)(implicit @constructorOnly src: SourceFile) extends AppProxy:
-    overwriteType(app.tpe)
-      // ExtMethodApply always has wildcard type in order not to prompt any further adaptations
-      // such as eta expansion before the method is fully applied.
-
   /** Find reference to default parameter getter for parameter #n in current
     *  parameter list, or NoType if none was found
     */

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -648,6 +648,11 @@ object Checking {
           else "Cannot override non-inline parameter with an inline parameter",
           p1.srcPos)
 
+  def checkConversionsSpecific(to: Type, pos: SrcPos)(using Context): Unit =
+    if to.isRef(defn.AnyValClass, skipRefined = false)
+       || to.isRef(defn.ObjectClass, skipRefined = false)
+    then
+      report.error(em"the result of an implicit conversion must be more specific than $to", pos)
 }
 
 trait Checking {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -492,12 +492,14 @@ object Implicits:
   class AmbiguousImplicits(val alt1: SearchSuccess, val alt2: SearchSuccess, val expectedType: Type, val argument: Tree) extends SearchFailureType {
     def explanation(using Context): String =
       em"both ${err.refStr(alt1.ref)} and ${err.refStr(alt2.ref)} $qualify"
-    override def whyNoConversion(using Context): String = {
-      val what = if (expectedType.isInstanceOf[SelectionProto]) "extension methods" else "conversions"
-      i"""
-         |Note that implicit $what cannot be applied because they are ambiguous;
-         |$explanation"""
-    }
+    override def whyNoConversion(using Context): String =
+      if !argument.isEmpty && argument.tpe.widen.isRef(defn.NothingClass) then
+        ""
+      else
+        val what = if (expectedType.isInstanceOf[SelectionProto]) "extension methods" else "conversions"
+        i"""
+           |Note that implicit $what cannot be applied because they are ambiguous;
+           |$explanation"""
   }
 
   class MismatchedImplicit(ref: TermRef,

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -38,6 +38,9 @@ object Inferencing {
     result
   }
 
+  /** Try to fully define `tp`. Return whether constraint has changed.
+   *  Any changed constraint is kept.
+   */
   def canDefineFurther(tp: Type)(using Context): Boolean =
     val prevConstraint = ctx.typerState.constraint
     isFullyDefined(tp, force = ForceDegree.all)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -38,6 +38,11 @@ object Inferencing {
     result
   }
 
+  def canDefineFurther(tp: Type)(using Context): Boolean =
+    val prevConstraint = ctx.typerState.constraint
+    isFullyDefined(tp, force = ForceDegree.all)
+    && (ctx.typerState.constraint ne prevConstraint)
+
   /** The fully defined type, where all type variables are forced.
    *  Throws an error if type contains wildcards.
    */

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -16,7 +16,7 @@ import transform.SymUtils._
 import Contexts._
 import Names.{Name, TermName}
 import NameKinds.{InlineAccessorName, InlineBinderName, InlineScrutineeName, BodyRetainerName}
-import ProtoTypes.selectionProto
+import ProtoTypes.shallowSelectionProto
 import Annotations.Annotation
 import SymDenotations.SymDenotation
 import Inferencing.isFullyDefined
@@ -1240,7 +1240,7 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
 
     override def typedSelect(tree: untpd.Select, pt: Type)(using Context): Tree = {
       assert(tree.hasType, tree)
-      val qual1 = typed(tree.qualifier, selectionProto(tree.name, pt, this))
+      val qual1 = typed(tree.qualifier, shallowSelectionProto(tree.name, pt, this))
       val resNoReduce = untpd.cpy.Select(tree)(qual1, tree.name).withType(tree.typeOpt)
       val resMaybeReduced = constToLiteral(reducer.reduceProjection(resNoReduce))
       if (resNoReduce ne resMaybeReduced)

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -235,12 +235,11 @@ object ProtoTypes {
   /** Create a selection proto-type, but only one level deep;
    *  treat constructors specially
    */
-  def selectionProto(name: Name, tp: Type, typer: Typer)(using Context): TermType =
+  def shallowSelectionProto(name: Name, tp: Type, typer: Typer)(using Context): TermType =
     if (name.isConstructorName) WildcardType
-    else tp match {
+    else tp match
       case tp: UnapplyFunProto => new UnapplySelectionProto(name)
       case tp => SelectionProto(name, IgnoredProto(tp), typer, privateOK = true)
-    }
 
   /** A prototype for expressions [] that are in some unspecified selection operation
    *

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2957,8 +2957,7 @@ class Typer extends Namer
             if isExtension then return found
             else
               checkImplicitConversionUseOK(found)
-              val qual1 = withoutMode(Mode.ImplicitsEnabled)(adapt(found, selProto, locked))
-              return typedSelect(tree, pt, qual1)
+              return typedSelect(tree, pt, found)
           case failure: SearchFailure =>
             if failure.isAmbiguous then
               return (

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -570,10 +570,11 @@ class Typer extends Namer
       else if qual.tpe.derivesFrom(defn.DynamicClass)
         && selName.isTermName && !isDynamicExpansion(tree)
       then
+        val tree2 = cpy.Select(tree0)(untpd.TypedSplice(qual), selName)
         if pt.isInstanceOf[FunOrPolyProto] || pt == AssignProto then
-          assignType(tree, TryDynamicCallType)
+          assignType(tree2, TryDynamicCallType)
         else
-          typedDynamicSelect(tree0, Nil, pt)
+          typedDynamicSelect(tree2, Nil, pt)
       else
         assignType(tree,
           rawType match

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -55,3 +55,6 @@ annot-bootstrap.scala
 # interaction with Scala-2's implicitly
 i9793.scala
 
+# lazy_implicit symbol has different position after pickling
+i8182.scala
+

--- a/tests/neg/enum-values.check
+++ b/tests/neg/enum-values.check
@@ -20,8 +20,8 @@
    |
    |                                             example.Extensions.values(ListLike)    failed with
    |
-   |                                                 Found:    example.ListLike.type
-   |                                                 Required: Nothing
+   |                                                 Found:    Array[example.Tag[?]]
+   |                                                 Required: Array[example.ListLike[?]]
 -- [E008] Not Found Error: tests/neg/enum-values.scala:34:52 -----------------------------------------------------------
 34 |  val typeCtorsK: Array[TypeCtorsK[?]] = TypeCtorsK.values // error
    |                                         ^^^^^^^^^^^^^^^^^
@@ -32,8 +32,8 @@
    |
    |                                             example.Extensions.values(TypeCtorsK)    failed with
    |
-   |                                                 Found:    example.TypeCtorsK.type
-   |                                                 Required: Nothing
+   |                                                 Found:    Array[example.Tag[?]]
+   |                                                 Required: Array[example.TypeCtorsK[?[_$1]]]
 -- [E008] Not Found Error: tests/neg/enum-values.scala:36:6 ------------------------------------------------------------
 36 |  Tag.valueOf("Int") // error
    |  ^^^^^^^^^^^

--- a/tests/neg/i6779.check
+++ b/tests/neg/i6779.check
@@ -3,11 +3,16 @@
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^
    |                             Found:    F[T]
    |                             Required: F[G[T]]
--- [E007] Type Mismatch Error: tests/neg/i6779.scala:12:31 -------------------------------------------------------------
+-- [E008] Not Found Error: tests/neg/i6779.scala:12:31 -----------------------------------------------------------------
 12 |  def g2[T](x: T): F[G[T]] = x.f // error
    |                             ^^^
-   |                             Found:    F[T]
-   |                             Required: F[G[T]]
+   |                             value f is not a member of T.
+   |                             An extension method was tried, but could not be fully constructed:
+   |
+   |                                 Test.f[G[T]](x)(given_Stuff)    failed with
+   |
+   |                                     Found:    (x : T)
+   |                                     Required: G[T]
 -- [E007] Type Mismatch Error: tests/neg/i6779.scala:14:38 -------------------------------------------------------------
 14 |  def g3[T](x: T): F[G[T]] = this.f(x)(using summon[Stuff]) // error
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/neg/i8032.check
+++ b/tests/neg/i8032.check
@@ -1,9 +1,0 @@
--- [E007] Type Mismatch Error: tests/neg/i8032.scala:1:15 --------------------------------------------------------------
-1 |val x: 1 | 2 = 3 // error
-  |               ^
-  |               Found:    (3 : Int)
-  |               Required: (1 : Int) | (2 : Int)
--- [E008] Not Found Error: tests/neg/i8032.scala:3:12 ------------------------------------------------------------------
-3 |val y = ???.map // error
-  |        ^^^^^^^
-  |        value map is not a member of Nothing

--- a/tests/neg/i8032.scheck
+++ b/tests/neg/i8032.scheck
@@ -1,0 +1,9 @@
+-- [E007] Type Mismatch Error: tests/neg/i8032.scala:1:15 --------------------------------------------------------------
+1 |val x: 1 | 2 = 3 // error
+  |               ^
+  |               Found:    (3 : Int)
+  |               Required: (1 : Int) | (2 : Int)
+-- [E008] Not Found Error: tests/neg/i8032.scala:3:12 ------------------------------------------------------------------
+3 |val y = ???.map // error
+  |        ^^^^^^^
+  |        value map is not a member of Nothing

--- a/tests/pos/i8182.scala
+++ b/tests/pos/i8182.scala
@@ -1,0 +1,10 @@
+package example
+
+trait Show[-A]:
+  extension (a: A) def show: String
+
+given (using rec: Show[String]): Show[String] = ??? // must be Show[String] as the argument
+
+given (using rec: => Show[String]): Show[Option[String]] = ??? // must be byname argument
+
+def test = Option("").show

--- a/tests/semanticdb/expect/Enums.expect.scala
+++ b/tests/semanticdb/expect/Enums.expect.scala
@@ -52,7 +52,7 @@ object Enums/*<-_empty_::Enums.*/:
   extension [A/*<-_empty_::Enums.unwrap().[A]*/, B/*<-_empty_::Enums.unwrap().[B]*/](opt/*<-_empty_::Enums.unwrap().(opt)*/: Option/*->scala::Option#*/[A/*->_empty_::Enums.unwrap().[A]*/]) def unwrap/*<-_empty_::Enums.unwrap().*/(using ev/*<-_empty_::Enums.unwrap().(ev)*/: A/*->_empty_::Enums.unwrap().[A]*/ <:</*->_empty_::Enums.`<:<`#*/ Option/*->scala::Option#*/[B/*->_empty_::Enums.unwrap().[B]*/]): Option/*->scala::Option#*/[B/*->_empty_::Enums.unwrap().[B]*/] = ev/*->_empty_::Enums.unwrap().(ev)*/ match
     case Refl/*->_empty_::Enums.`<:<`.Refl.*//*->_empty_::Enums.`<:<`.Refl.unapply().*/() => opt/*->_empty_::Enums.unwrap().(opt)*/.flatMap/*->scala::Option#flatMap().*/(identity/*->scala::Predef.identity().*//*->local0*/[Option/*->scala::Option#*/[B/*->_empty_::Enums.unwrap().[B]*/]])
 
-  val some1/*<-_empty_::Enums.some1.*/ = /*->_empty_::Enums.unwrap().*/Some/*->scala::Some.*//*->scala::Some.apply().*/(Some/*->scala::Some.*//*->scala::Some.apply().*/(1))/*->_empty_::Enums.`<:<`.given_T().*/.unwrap
+  val some1/*<-_empty_::Enums.some1.*/ = /*->_empty_::Enums.unwrap().*/Some/*->scala::Some.*//*->scala::Some.apply().*/(Some/*->scala::Some.*//*->scala::Some.apply().*/(1)).unwrap/*->_empty_::Enums.`<:<`.given_T().*/
 
   enum Planet/*<-_empty_::Enums.Planet#*/(mass/*<-_empty_::Enums.Planet#mass.*/: Double/*->scala::Double#*/, radius/*<-_empty_::Enums.Planet#radius.*/: Double/*->scala::Double#*/) extends Enum/*->java::lang::Enum#*/[Planet/*->_empty_::Enums.Planet#*/]/*->java::lang::Enum#`<init>`().*/:
     private final val G/*<-_empty_::Enums.Planet#G.*/ = 6.67300E-11

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -971,7 +971,7 @@ Occurrences:
 [54:18..54:18): -> scala/Some.apply().
 [54:19..54:23): Some -> scala/Some.
 [54:23..54:23): -> scala/Some.apply().
-[54:27..54:27): -> _empty_/Enums.`<:<`.given_T().
+[54:34..54:34): -> _empty_/Enums.`<:<`.given_T().
 [56:7..56:13): Planet <- _empty_/Enums.Planet#
 [56:13..56:13): <- _empty_/Enums.Planet#`<init>`().
 [56:14..56:18): mass <- _empty_/Enums.Planet#mass.


### PR DESCRIPTION
The aim of the refactoring is to be clearer and to be able to drop ExtMethodApply.

Two main strategies:

 1. Move some code out of adapt and assignType into typedSelect.
 2. Concentrate extension method expansion and conversions for selections in a
    method `tryExtensionOrConversion. The method is called from `typedSelect`
    and `tryInsertImplicitOnQualifier`.

The aim of the refactoring is to move all select-dependent adaptations and re-tries into
typedSelect. Right now some are in adapt and some are in assignType. This is awkward
since it means that

 - we do too much in TypeAssigner. Since it aims to be minimal TypeAssigner should have no business doing adaptations
and retries.
 - we do some adaptations too early in adapt. This means we need the kludge of wrapping
trees in ExtMethodApply which causes #8182, among others.

Fixes #8182
