### PR TITLE
Revert "Update opaques.md"

### DIFF
--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -70,7 +70,7 @@ object Access:
    opaque type Permission <: Permissions & PermissionChoice = Int
 
    extension (x: Permissions)
-      def & (y: Permissions): Permissions = x & y
+      def & (y: Permissions): Permissions = x | y
    extension (x: PermissionChoice)
       def | (y: PermissionChoice): PermissionChoice = x | y
    extension (granted: Permissions)


### PR DESCRIPTION
Reverts lampepfl/dotty#10976

This was not a typo.

> The `Access` object defines three opaque type aliases:
> 
> - `Permission`, representing a single permission,
> - `Permissions`, representing a set of permissions with the meaning "all of these permissions granted",
> - `PermissionChoice`, representing a set of permissions with the meaning "at least one of these permissions granted".

`permissionSetX & permissionSetY` is supposed to be the union of `permissionSetX` and `permissionSetY`, not the intersection of them.

It's also clear that `def & (y: Permissions): Permissions = x | y` was intentional from this text:
> Also, the definition of ReadWrite must use |, even though an equivalent definition outside Access would use &.

What is meant by this is that the real method `&` would take precedent over the extension method `&`, so `|` must be called manually instead of `&` in the `Access` object.

The idea with this example is to show that it's useful that a single permission has the same representation as the equivalent singleton `Permissions` set or the equivalent `PermissionChoice` set.

If one wanted to, the subtyping relation could be changed to this:

```
//"All permissions in X granted" implies "At least one permission in X granted"
opaque type Permissions <: PermissionsChoice = Int
//At least one of these permissions granted
opaque type PermissionChoice = Int
//"A single permission granted" implies "All permissions in this singleton set granted"
opaque type Permission <: Permissions = Int
```

The example demos how opaque types behaves in many ways at the same time, perhaps even too much in too little text, hence why it's a bit confusing.