### PR TITLE
fix #10997: check accessible from sealed parent not companion

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -91,7 +91,7 @@ object SymUtils:
     *  It must satisfy the following conditions:
     *   - it has at least one child class or object
     *   - none of its children are anonymous classes
-    *   - all of its children are addressable through a path from its companion object
+    *   - all of its children are addressable through a path from the parent class
     *   - all of its children are generic products or singletons
     */
     def whyNotGenericSum(using Context): String =
@@ -99,11 +99,10 @@ object SymUtils:
         s"it is not a sealed ${self.kindString}"
       else {
         val children = self.children
-        val companion = self.linkedClass
         def problem(child: Symbol) = {
 
           def isAccessible(sym: Symbol): Boolean =
-            companion.isContainedIn(sym) || sym.is(Module) && isAccessible(sym.owner)
+            self.isContainedIn(sym) || sym.is(Module) && isAccessible(sym.owner)
 
           if (child == self) "it has anonymous or inaccessible subclasses"
           else if (!isAccessible(child.owner)) i"its child $child is not accessible"

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -87,22 +87,28 @@ object SymUtils:
 
     def isGenericProduct(using Context): Boolean = whyNotGenericProduct.isEmpty
 
+    def useCompanionAsMirror(using Context): Boolean = self.linkedClass.exists && !self.is(Scala2x)
+
     /** Is this a sealed class or trait for which a sum mirror is generated?
     *  It must satisfy the following conditions:
     *   - it has at least one child class or object
     *   - none of its children are anonymous classes
     *   - all of its children are addressable through a path from the parent class
+    *     and also the location of the generated mirror.
     *   - all of its children are generic products or singletons
     */
-    def whyNotGenericSum(using Context): String =
+    def whyNotGenericSum(declScope: Symbol)(using Context): String =
       if (!self.is(Sealed))
         s"it is not a sealed ${self.kindString}"
       else {
         val children = self.children
+        val companionMirror = self.useCompanionAsMirror
+        assert(!(companionMirror && (declScope ne self.linkedClass)))
         def problem(child: Symbol) = {
 
           def isAccessible(sym: Symbol): Boolean =
-            self.isContainedIn(sym) || sym.is(Module) && isAccessible(sym.owner)
+            (self.isContainedIn(sym) && (companionMirror || declScope.isContainedIn(sym)))
+            || sym.is(Module) && isAccessible(sym.owner)
 
           if (child == self) "it has anonymous or inaccessible subclasses"
           else if (!isAccessible(child.owner)) i"its child $child is not accessible"
@@ -117,7 +123,7 @@ object SymUtils:
         else children.map(problem).find(!_.isEmpty).getOrElse("")
       }
 
-    def isGenericSum(using Context): Boolean = whyNotGenericSum.isEmpty
+    def isGenericSum(declScope: Symbol)(using Context): Boolean = whyNotGenericSum(declScope).isEmpty
 
     /** If this is a constructor, its owner: otherwise this. */
     final def skipConstructor(using Context): Symbol =

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -584,9 +584,9 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     if (clazz.is(Module)) {
       if (clazz.is(Case)) makeSingletonMirror()
       else if (linked.isGenericProduct) makeProductMirror(linked)
-      else if (linked.isGenericSum) makeSumMirror(linked)
+      else if (linked.isGenericSum(clazz)) makeSumMirror(linked)
       else if (linked.is(Sealed))
-        derive.println(i"$linked is not a sum because ${linked.whyNotGenericSum}")
+        derive.println(i"$linked is not a sum because ${linked.whyNotGenericSum(clazz)}")
     }
     else if (impl.removeAttachment(ExtendsSingletonMirror).isDefined)
       makeSingletonMirror()

--- a/tests/neg/i10997.scala
+++ b/tests/neg/i10997.scala
@@ -1,0 +1,9 @@
+sealed trait Parent
+
+trait Wrapper {
+
+  case class Foo(x: Int, y: Int, s: String) extends Parent
+  case class Bar(x: Int, y: Int) extends Parent
+
+  println(summon[deriving.Mirror.Of[Parent]]) // error
+}

--- a/tests/neg/i10997.scala
+++ b/tests/neg/i10997.scala
@@ -7,3 +7,12 @@ trait Wrapper {
 
   println(summon[deriving.Mirror.Of[Parent]]) // error
 }
+
+class ClassWrapper {
+  sealed trait Base
+  case class Foo(x: Int) extends Base
+}
+
+@main def Test =
+  val cw = new ClassWrapper()
+  val mirrorParent = summon[deriving.Mirror.Of[cw.Base]] // error: code gen for Mirror can not access each case

--- a/tests/pos/i10997.scala
+++ b/tests/pos/i10997.scala
@@ -1,0 +1,24 @@
+class Test {
+
+  sealed trait Parent
+  case class Foo(x: Int, y: Int, s: String) extends Parent
+  case class Bar(x: Int, y: Int) extends Parent
+
+  println(summon[deriving.Mirror.Of[Parent]])
+}
+
+object Test2 {
+
+  case class Foo(x: Int, y: Int, s: String) extends i.Parent
+  case class Bar(x: Int, y: Int) extends i.Parent
+
+  val i = Inner()
+
+  class Inner {
+
+    sealed trait Parent
+
+    println(summon[deriving.Mirror.Of[Parent]])
+  }
+
+}

--- a/tests/run/deriving-constructor-order.scala
+++ b/tests/run/deriving-constructor-order.scala
@@ -7,7 +7,7 @@ object Test extends App {
       case _: T => ()
     }
 
-  sealed trait Base1
+  sealed trait Base1 // Base1 MUST NOT have a companion here!
   case class Foo() extends Base1
   case object Bar extends Base1
   case class Qux(i: Int) extends Base1

--- a/tests/run/deriving.scala
+++ b/tests/run/deriving.scala
@@ -4,7 +4,7 @@ object T
 case class A(x: Int, y: Int) extends T
 case object B extends T
 
-sealed trait U
+sealed trait U // U MUST NOT have a companion here!
 case class C() extends U
 
 object Test extends App {

--- a/tests/run/i10997.scala
+++ b/tests/run/i10997.scala
@@ -1,0 +1,37 @@
+class ClassWrapper {
+
+  sealed trait Parent
+  case class Foo(x: Int, y: Int, s: String) extends Parent
+  case class Bar(x: Int, y: Int) extends Parent
+  case object Qux extends Parent
+
+  def testcase(): Unit =
+
+    val mirrorParent = summon[deriving.Mirror.Of[Parent]]
+    val mirrorFoo    = summon[deriving.Mirror.Of[Foo]]
+    val mirrorBar    = summon[deriving.Mirror.Of[Bar]]
+    val mirrorQux    = summon[deriving.Mirror.Of[Qux.type]]
+
+    val fooShapedTuple: (Int, Int, String) = (23, 47, "ok")
+    val barShapedTuple: (Int, Int)         = (57, 71)
+    val quxShapedTuple: EmptyTuple         = EmptyTuple
+
+    val foo: Foo      = mirrorFoo.fromProduct(fooShapedTuple)
+    val bar: Bar      = mirrorBar.fromProduct(barShapedTuple)
+    val qux: Qux.type = mirrorQux.fromProduct(quxShapedTuple)
+
+    assert(foo == Foo(23, 47, "ok"))
+    assert(bar == Bar(57, 71))
+    assert(qux == Qux)
+
+    val fooOrd = mirrorParent.ordinal(foo)
+    val barOrd = mirrorParent.ordinal(bar)
+    val quxOrd = mirrorParent.ordinal(qux)
+
+    assert(fooOrd == 0)
+    assert(barOrd == 1)
+    assert(quxOrd == 2)
+}
+
+@main def Test =
+  ClassWrapper().testcase()


### PR DESCRIPTION
fixes #10997 

given the commit https://github.com/lampepfl/dotty/commit/275a0a96bdb1f28300ca8e0f045226e1e99b3df1 I am unclear why the accessibilty test in `whyNotGenericSum` needs to check for the companion.

I believe that it was a lucky coincidence that `whyNotGenericSum` passes for traits without a companion, i.e. if you trace the owners of any definition up to the root package then eventually you get the owner `NoSymbol`, which then succeeds in the case there is no companion, which breaks the criterion "all of its children are addressable through a path from its companion object".

The motivation for the change in this PR is that we use `whyNotGenericSum` to implement `isGenericSum`. Then `isGenericSum` is used by `Synthesizer.sumMirror` to decide if something gets a synthesized `Mirror.Sum`. 

Since `Synthesizer.sumMirror` still generates a mirror even if there is no companion, I can not see a reason to fail `whyNotGenericSum` if there is no companion.