### PR TITLE
Fix 11018 - consistency of trait parameters

### DIFF
--- a/tests/neg/i11018.scala
+++ b/tests/neg/i11018.scala
@@ -1,0 +1,21 @@
+trait Foo {
+  def name: String
+}
+class Bar
+
+trait CClass[+A](val a: A) {
+  val b = a
+}
+
+trait CTrait[+A](val a: A) {
+  val b = a
+}
+trait DTrait[+B] extends CTrait[B]
+trait DClass[+B] extends CClass[B]
+
+final class F1 extends DTrait[Foo] with CTrait[Bar](new Bar) // error: illegal parameter
+final class F2 extends CTrait[Bar](new Bar) with DTrait[Foo] // error: illegal parameter
+final class F3 extends DClass[Foo] with CClass[Bar](new Bar) // error: illegal parameter
+final class F4 extends CClass[Bar](new Bar) with DClass[Foo] // error: illegal parameter
+
+final class F5 extends DTrait[Foo] with CTrait[Foo & Bar](new Bar with Foo { def name = "hello"}) // ok

--- a/tests/neg/i3989f.scala
+++ b/tests/neg/i3989f.scala
@@ -3,7 +3,7 @@ object Test extends App {
   class B[+X](val y: X) extends A[X](y)
   class C extends B(5) with A[String] // error: illegal inheritance
 
-  class D extends B(5) with A[Any] // ok
+  class D extends B(5) with A[Any] // error: illegal parameter
 
   def f(a: A[Int]): String = a match {
     case c: C => c.x


### PR DESCRIPTION
Check conformance of trait and class parameters of base types. This PR attempts to solve #11018 by incorporating an additional check.

However, it might be too conservative as it also rules out a positive example of #3989.