### PR TITLE
Generalize isArgPrefixOf

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -289,14 +289,15 @@ object Types {
     def isFromJavaObject(using Context): Boolean = typeSymbol eq defn.FromJavaObjectSymbol
 
     /** True iff `symd` is a denotation of a class type parameter and the reference
-     *  `<this> . <symd>` is an actual argument reference, i.e. `this` is different
-     *  from the ThisType of `symd`'s owner.
+     *  `<pre> . <symd>` is an actual argument reference, i.e. `pre` is not the
+     *  ThisType of `symd`'s owner, or a reference to `symd`'s owner.'
      */
     def isArgPrefixOf(symd: SymDenotation)(using Context): Boolean =
       symd.exists && !symd.owner.is(Package) && // Early exit if possible because the next check would force SymbolLoaders
       symd.isAllOf(ClassTypeParam) && {
         this match {
           case tp: ThisType => tp.cls ne symd.owner
+          case tp: TypeRef => tp.symbol ne symd.owner
           case _ => true
         }
       }
@@ -2212,7 +2213,8 @@ object Types {
           throw new TypeError(
             i"""bad parameter reference $this at ${ctx.phase}
                |the parameter is ${param.showLocated} but the prefix $prefix
-               |does not define any corresponding arguments.""")
+               |does not define any corresponding arguments.
+               |idx = $idx, args = $args""")
         NoDenotation
       }
     }

--- a/tests/pos/i11057.scala
+++ b/tests/pos/i11057.scala
@@ -1,0 +1,20 @@
+object data {
+
+    trait OfType[T]
+    case object IntT extends OfType[Int]
+    case object DoubleT extends OfType[Double]
+    case object FloatT extends OfType[Float]
+
+    type DSeq[X] = scala.collection.immutable.AbstractSeq[X]
+
+    case class ColumnName[T](n:String, t: OfType[T])
+    case class Column[T,F[_]<:DSeq[_]](n:F[T], of: ColumnName[T])
+  }
+
+  def min4[T,F[_]<:data.DSeq[T]](col: data.Column[T,F])(using Ordering[T]): T = {
+    col match {
+      case c:data.Column[Int,_] => c.n.min[T](Ordering[T])
+      case _:data.Column[Double,_] => ???
+      case _:data.Column[Float,_] => ???
+    }
+  }


### PR DESCRIPTION
Fixes #11057

We had a case of getting the info of C#F at pattern matching, where `F`
as a paremeter of `C`. In this case, no recomputation of the argument
via argInfo is needed; the info is the info of `F` directly.