### PR TITLE
Fix hoisting supercall arguments from primary constructor

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -67,7 +67,7 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
       val constr = cdef.symbol
       lazy val origParams = // The parameters that can be accessed in the supercall
         if (constr == cls.primaryConstructor)
-          cls.info.decls.filter(d => d.is(TypeParam) || d.is(ParamAccessor))
+          cls.info.decls.filter(d => d.is(TypeParam) || d.is(ParamAccessor) && !d.isSetter)
         else
           allParamSyms(cdef)
 

--- a/tests/pos/i11045.scala
+++ b/tests/pos/i11045.scala
@@ -1,0 +1,2 @@
+abstract class Foo(x: Any)
+class Boom(var x: Unit, y: Unit) extends Foo((x: Int) => x)


### PR DESCRIPTION
Fix hoisting of supercall arguments from primary constructor of a class
with var parameters.

Fixes #11045