### PR TITLE
Reduce noise in community build logs

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -156,7 +156,10 @@ final case class SbtCommunityProject(
     ++ s"""set dependencyOverrides in ThisBuild ++= ${dependencyOverrides.mkString("Seq(", ", ", ")")}; """
     ++ s"++$compilerVersion!; "
 
-  override val testCommand = s"$baseCommand$sbtTestCommand"
+  override val testCommand =
+    """set testOptions in Global += Tests.Argument(TestFramework("munit.Framework"), "+l"); """
+    ++ s"$baseCommand$sbtTestCommand"
+
   override val publishCommand = if sbtPublishCommand eq null then null else
     val disableDocCommand =
       if sbtDocCommand eq null then "" else "set every useScala3doc := false;"


### PR DESCRIPTION
Use the sbt logger for the munit test framework, bringing it in line with others such as scalatest and scalacheck.

This means that output from munit-based tests will be affected by the sbt `logLevel` setting for the community build (currently set to `Level.Error`):

https://github.com/lampepfl/dotty/blob/0f1d350a3b521b80759ddf4307977c5193756493/community-build/src/scala/dotty/communitybuild/projects.scala#L155

In particular, several projects in `community_build_b` have munit test suites that generate a tremendous amount of output at "info" level, which will now be filtered out by the above setting.

Extracted from #10731
