### PR TITLE
Upgrade to Scala.js 1.4.0.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -1420,7 +1420,7 @@ class JSCodeGen()(using genCtx: Context) {
             /* This is a default parameter whose assignment was moved to
              * a local variable. Put an undefined param instead.
              */
-            js.Transient(UndefinedParam)(toIRType(sym.info))
+            js.Transient(UndefinedParam)
           } else {
             js.VarRef(encodeLocalSym(sym))(toIRType(sym.info))
           }
@@ -1691,7 +1691,7 @@ class JSCodeGen()(using genCtx: Context) {
 
     fun match {
       case _ if sym.isJSDefaultParam =>
-        js.Transient(UndefinedParam)(toIRType(sym.info.finalResultType))
+        js.Transient(UndefinedParam)
 
       case Select(Super(_, _), _) =>
         genSuperCall(tree, isStat)
@@ -4306,6 +4306,15 @@ object JSCodeGen {
    *  To be used inside a `js.Transient` node.
    */
   case object UndefinedParam extends js.Transient.Value {
+    val tpe: jstpe.Type = jstpe.UndefType
+
+    def traverse(traverser: ir.Traversers.Traverser): Unit = ()
+
+    def transform(transformer: ir.Transformers.Transformer, isStat: Boolean)(
+        implicit pos: ir.Position): js.Tree = {
+      js.Transient(this)
+    }
+
     def printIR(out: ir.Printers.IRTreePrinter): Unit =
       out.print("<undefined-param>")
   }

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -753,7 +753,10 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
 
     if (targetSym.isJSType) {
       if (defaultGetter.owner.isNonNativeJSClass) {
-        genApplyJSClassMethod(targetTree, defaultGetter, defaultGetterArgs)
+        if (defaultGetter.hasAnnotation(jsdefn.JSOptionalAnnot))
+          js.Undefined()
+        else
+          genApplyJSClassMethod(targetTree, defaultGetter, defaultGetterArgs)
       } else {
         report.error(
             "When overriding a native method with default arguments, " +

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1148,12 +1148,14 @@ object Build {
       },
 
       managedSources in Compile ++= {
-        val dir = fetchScalaJSSource.value / "test-suite/js/src/main/scala"
-        val filter = (
-          ("*.scala": FileFilter)
+        val dir = fetchScalaJSSource.value
+        (
+          (dir / "test-suite/js/src/main/scala" ** (("*.scala": FileFilter)
             -- "Typechecking*.scala" // defines a Scala 2 macro
+            )).get
+
+          ++ (dir / "junit-async/js/src/main/scala" ** "*.scala").get
         )
-        (dir ** filter).get
       },
 
       // A first blacklist of tests for those that do not compile or do not link

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 //
 // e.g. addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.6")
 


### PR DESCRIPTION
The changes in `JSExportsGen` are ported from the upstream PR https://github.com/scala-js/scala-js/pull/4334

The changes in the build add the sources of `org.scalajs.junit.async._` to the Compile configuration of the JUnit test suite. This contains helpers for asynchronous tests that are internally used by the JUnit test suite.