### PR TITLE
Add ParamClause to allow multiple type param clauses

### DIFF
--- a/compiler/src-non-bootstrapped/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src-non-bootstrapped/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -261,14 +261,14 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         }))
       def copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term]): DefDef =
         tpd.cpy.DefDef(original)(name.toTermName, tpd.joinParams(typeParams, paramss), tpt, yCheckedOwners(rhs, original.symbol).getOrElse(tpd.EmptyTree))
-      def unapply(ddef: DefDef): (String, List[TypeDef], List[List[ValDef]], TypeTree, Option[Term]) =
-        (ddef.name.toString, ddef.typeParams, ddef.termParamss, ddef.tpt, optional(ddef.rhs))
+      // def unapply(ddef: DefDef): (String, List[TypeDef], List[List[ValDef]], TypeTree, Option[Term]) =
+      //   (ddef.name.toString, ddef.typeParams, ddef.termParamss, ddef.tpt, optional(ddef.rhs))
     end DefDef
 
     given DefDefMethods: DefDefMethods with
       extension (self: DefDef)
         def typeParams: List[TypeDef] = self.leadingTypeParams // TODO: adapt to multiple type parameter clauses
-        def paramss: List[List[ValDef]] = self.termParamss
+        // def paramss: List[List[ValDef]] = self.termParamss
         def returnTpt: TypeTree = self.tpt
         def rhs: Option[Term] = optional(self.rhs)
       end extension
@@ -747,12 +747,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         val meth = dotc.core.Symbols.newSymbol(owner, nme.ANON_FUN, Synthetic | Method, tpe)
         tpd.Closure(meth, tss => yCheckedOwners(rhsFn(meth, tss.head), meth))
 
-      def unapply(tree: Block): Option[(List[ValDef], Term)] = tree match {
-        case Block((ddef @ DefDef(_, _, params :: Nil, _, Some(body))) :: Nil, Closure(meth, _))
-        if ddef.symbol == meth.symbol =>
-          Some((params, body))
-        case _ => None
-      }
+      def unapply(tree: Block): Option[(List[ValDef], Term)] = ???
     end Lambda
 
     type If = tpd.If

--- a/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
@@ -117,8 +117,8 @@ object Extractors {
         this += ", " ++= bindings += ", " += expansion += ")"
       case ValDef(name, tpt, rhs) =>
         this += "ValDef(\"" += name += "\", " += tpt += ", " += rhs += ")"
-      case DefDef(name, typeParams, paramss, returnTpt, rhs) =>
-        this += "DefDef(\"" += name += "\", " ++= typeParams += ", " +++= paramss += ", " += returnTpt += ", " += rhs += ")"
+      case DefDef(name, paramsClauses, returnTpt, rhs) =>
+        this += "DefDef(\"" += name += "\", " ++= paramsClauses += ", " += returnTpt += ", " += rhs += ")"
       case TypeDef(name, rhs) =>
         this += "TypeDef(\"" += name += "\", " += rhs += ")"
       case ClassDef(name, constr, parents, derived, self, body) =>
@@ -256,6 +256,11 @@ object Extractors {
       else if x.isTypeDef then this += "IsTypeDefSymbol(<" += x.fullName += ">)"
       else { assert(x.isNoSymbol); this += "NoSymbol()" }
 
+    def visitParamClause(x: ParamClause): this.type =
+      x match
+        case TermParamClause(params) => this += "TermParamClause(" ++= params += ")"
+        case TypeParamClause(params) => this += "TypeParamClause(" ++= params += ")"
+
     def +=(x: Boolean): this.type = { sb.append(x); this }
     def +=(x: Byte): this.type = { sb.append(x); this }
     def +=(x: Short): this.type = { sb.append(x); this }
@@ -299,6 +304,10 @@ object Extractors {
 
     private implicit class SymbolOps(buff: self.type) {
       def +=(x: Symbol): self.type = { visitSymbol(x); buff }
+    }
+
+    private implicit class ParamClauseOps(buff: self.type) {
+      def ++=(x: List[ParamClause]): self.type = { visitList(x, visitParamClause); buff }
     }
 
     private def visitOption[U](opt: Option[U], visit: U => this.type): this.type = opt match {

--- a/library/src-bootstrapped/scala/quoted/Quotes.scala
+++ b/library/src-bootstrapped/scala/quoted/Quotes.scala
@@ -150,6 +150,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *           +- Unapply
    *           +- Alternatives
    *
+   *  +- ParamClause -+- TypeParamClause
+   *                  +- TermParamClause
    *
    *  +- TypeRepr -+- NamedType -+- TermRef
    *               |             +- TypeRef
@@ -414,9 +416,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val DefDef` */
     trait DefDefModule { this: DefDef.type =>
-      def apply(symbol: Symbol, rhsFn: List[TypeRepr] => List[List[Term]] => Option[Term]): DefDef
-      def copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term]): DefDef
-      def unapply(ddef: DefDef): (String, List[TypeDef], List[List[ValDef]], TypeTree, Option[Term])
+      def apply(symbol: Symbol, rhsFn: List[List[Tree]] => Option[Term]): DefDef
+      def copy(original: Tree)(name: String, paramss: List[ParamClause], tpt: TypeTree, rhs: Option[Term]): DefDef
+      def unapply(ddef: DefDef): (String, List[ParamClause], TypeTree, Option[Term])
     }
 
     /** Makes extension methods on `DefDef` available without any imports */
@@ -425,9 +427,37 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `DefDef` */
     trait DefDefMethods:
       extension (self: DefDef)
-        def typeParams: List[TypeDef]
-        def paramss: List[List[ValDef]]
+        /** List of type and term parameter clauses */
+        def paramss: List[ParamClause]
+
+        /** List of leading type paramters or Nil if the method does not have leading type paramters.
+         *
+         *  Note: Non leading type parameters can be found in extension methods such as
+         *  ```scala
+         *  extension (a: A) def f[T]() = ...
+         *  ```
+         */
+        def leadingTypeParams: List[TypeDef]
+
+        /** List of parameter clauses following the leading type parameters or all clauses.
+         *  Return all parameter clauses if there are no leading type paramters.
+         *
+         *  Non leading type parameters can be found in extension methods such as
+         *  ```scala
+         *  extension (a: A) def f[T]() = ...
+         *  ```
+         */
+        def trailingParamss: List[ParamClause]
+
+        /** List of term parameter clauses */
+        def termParamss: List[TermParamClause]
+
+        /** The tree of the return type of the method */
         def returnTpt: TypeTree
+
+        /** The tree of the implementation of the method.
+         *  Returns `None` if the method does not hava an implemetation.
+         */
         def rhs: Option[Term]
       end extension
     end DefDefMethods
@@ -1921,6 +1951,90 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end AlternativesMethods
 
+    /** A parameter clause `[X1, ..., Xn]` or `(x1: X1, ..., xn: Xx)`
+     *
+     *  `[X1, ..., Xn]` are reresented with `TypeParamClause` and `(x1: X1, ..., xn: Xx)` are represented with `TermParamClause`
+     *
+     *  `ParamClause` encodes the following enumeration
+     *  ```scala
+     *  enum ParamClause:
+     *    case TypeParamClause(params: List[TypeDef])
+     *    case TermParamClause(params: List[ValDef])
+     *  ```
+     */
+    type ParamClause <: AnyRef
+
+    /** Module object of `type ParamClause`  */
+    val ParamClause: ParamClauseModule
+
+    /** Methods of the module object `val ParamClause` */
+    trait ParamClauseModule { this: ParamClause.type =>
+    }
+
+    /** Makes extension methods on `ParamClause` available without any imports */
+    given ParamClauseMethods: ParamClauseMethods
+
+    /** Extension methods of `ParamClause` */
+    trait ParamClauseMethods:
+      extension (self: ParamClause)
+        /** List of parameters of the clause */
+        def params: List[ValDef] | List[TypeDef]
+    end ParamClauseMethods
+
+    /** A term parameter clause `(x1: X1, ..., xn: Xx)`
+     *  Can also be `(implicit X1, ..., Xn)`, `(given X1, ..., Xn)` or `(given x1: X1, ..., xn: Xn)`
+     */
+    type TermParamClause <: ParamClause
+
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `ParamClause` is a `TermParamClause` */
+    given TermParamClauseTypeTest: TypeTest[ParamClause, TermParamClause]
+
+    /** Module object of `type TermParamClause`  */
+    val TermParamClause: TermParamClauseModule
+
+    /** Methods of the module object `val TermParamClause` */
+    trait TermParamClauseModule { this: TermParamClause.type =>
+      def apply(params: List[ValDef]): TermParamClause
+      def unapply(x: TermParamClause): Some[List[ValDef]]
+    }
+
+    /** Makes extension methods on `TermParamClause` available without any imports */
+    given TermParamClauseMethods: TermParamClauseMethods
+
+    /** Extension methods of `TermParamClause` */
+    trait TermParamClauseMethods:
+      extension (self: TermParamClause)
+        /** List of parameters of the clause */
+        def params: List[ValDef]
+        /** Is this a given parameter clause `(implicit X1, ..., Xn)`, `(given X1, ..., Xn)` or `(given x1: X1, ..., xn: Xn)` */
+        def isImplicit: Boolean
+    end TermParamClauseMethods
+
+    /** A type parameter clause `[X1, ..., Xn]` */
+    type TypeParamClause <: ParamClause
+
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `ParamClause` is a `TypeParamClause` */
+    given TypeParamClauseTypeTest: TypeTest[ParamClause, TypeParamClause]
+
+    /** Module object of `type TypeParamClause`  */
+    val TypeParamClause: TypeParamClauseModule
+
+    /** Methods of the module object `val TypeParamClause` */
+    trait TypeParamClauseModule { this: TypeParamClause.type =>
+      def apply(params: List[TypeDef]): TypeParamClause
+      def unapply(x: TypeParamClause): Some[List[TypeDef]]
+    }
+
+    /** Makes extension methods on `TypeParamClause` available without any imports */
+    given TypeParamClauseMethods: TypeParamClauseMethods
+
+    /** Extension methods of `TypeParamClause` */
+    trait TypeParamClauseMethods:
+      extension (self: TypeParamClause)
+        /** List of parameters of the clause */
+        def params: List[TypeDef]
+    end TypeParamClauseMethods
+
     //////////////////////
     //    SELECTORS     //
     /////////////////////
@@ -2629,6 +2743,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `MethodType` */
     trait MethodTypeMethods:
       extension (self: MethodType)
+        /** Is this the type of given parameter clause `(implicit X1, ..., Xn)`, `(given X1, ..., Xn)` or `(given x1: X1, ..., xn: Xn)` */
         def isImplicit: Boolean
         def isErased: Boolean
         def param(idx: Int): TypeRepr
@@ -3911,9 +4026,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           case vdef @ ValDef(_, tpt, rhs) =>
             val owner = vdef.symbol
             foldTrees(foldTree(x, tpt)(owner), rhs)(owner)
-          case ddef @ DefDef(_, tparams, vparamss, tpt, rhs) =>
+          case ddef @ DefDef(_, paramss, tpt, rhs) =>
             val owner = ddef.symbol
-            foldTrees(foldTree(vparamss.foldLeft(foldTrees(x, tparams)(owner))((acc, y) => foldTrees(acc, y)(owner)), tpt)(owner), rhs)(owner)
+            foldTrees(foldTree(paramss.foldLeft(x)((acc, y) => foldTrees(acc, y.params)(owner)), tpt)(owner), rhs)(owner)
           case tdef @ TypeDef(_, rhs) =>
             val owner = tdef.symbol
             foldTree(x, rhs)(owner)
@@ -4022,7 +4137,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
             ValDef.copy(tree)(tree.name, tpt1, rhs1)
           case tree: DefDef =>
             val owner = tree.symbol
-            DefDef.copy(tree)(tree.name, transformSubTrees(tree.typeParams)(owner), tree.paramss mapConserve (x => transformSubTrees(x)(owner)), transformTypeTree(tree.returnTpt)(owner), tree.rhs.map(x => transformTerm(x)(owner)))
+            val newParamClauses = tree.paramss.mapConserve {
+              case TypeParamClause(params) => TypeParamClause(transformSubTrees(params)(owner))
+              case TermParamClause(params) => TermParamClause(transformSubTrees(params)(owner))
+            }
+            DefDef.copy(tree)(tree.name, newParamClauses, transformTypeTree(tree.returnTpt)(owner), tree.rhs.map(x => transformTerm(x)(owner)))
           case tree: TypeDef =>
             val owner = tree.symbol
             TypeDef.copy(tree)(tree.name, transformTree(tree.rhs)(owner))

--- a/library/src-non-bootstrapped/scala/quoted/Quotes.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Quotes.scala
@@ -183,15 +183,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     trait DefDefModule { this: DefDef.type =>
       def apply(symbol: Symbol, rhsFn: List[TypeRepr] => List[List[Term]] => Option[Term]): DefDef
       def copy(original: Tree)(name: String, typeParams: List[TypeDef], paramss: List[List[ValDef]], tpt: TypeTree, rhs: Option[Term]): DefDef
-      def unapply(ddef: DefDef): (String, List[TypeDef], List[List[ValDef]], TypeTree, Option[Term])
+      def copy(original: Tree)(name: String, paramss: List[ParamClause], tpt: TypeTree, rhs: Option[Term]): DefDef = ???
+      // def unapply(ddef: DefDef): (String, List[TypeDef], List[List[ValDef]], TypeTree, Option[Term])
+      def unapply(ddef: DefDef): (String, List[ParamClause], TypeTree, Option[Term]) = ???
     }
 
     given DefDefMethods: DefDefMethods
 
     trait DefDefMethods:
       extension (self: DefDef)
+        def paramss: List[ParamClause] = ???
         def typeParams: List[TypeDef]
-        def paramss: List[List[ValDef]]
         def returnTpt: TypeTree
         def rhs: Option[Term]
       end extension
@@ -1260,6 +1262,37 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def patterns: List[Tree]
       end extension
     end AlternativesMethods
+
+    type ParamClause <: AnyRef
+
+    given ParamClauseMethods: ParamClauseMethods = ???
+
+    trait ParamClauseMethods:
+      extension (self: ParamClause)
+        def params: List[ValDef] | List[TypeDef]
+    end ParamClauseMethods
+
+    type TermParamClause <: ParamClause
+
+    given TermParamClauseTypeTest: TypeTest[ParamClause, TermParamClause] = ???
+
+    val TermParamClause: TermParamClauseModule = ???
+
+    trait TermParamClauseModule { this: TermParamClause.type =>
+      def apply(params: List[ValDef]): TermParamClause
+      def unapply(x: TermParamClause): Some[List[ValDef]]
+    }
+
+    type TypeParamClause <: AnyRef
+
+    given TypeParamClauseTypeTest: TypeTest[ParamClause, TypeParamClause] = ???
+
+    val TypeParamClause: TypeParamClauseModule = ???
+
+    trait TypeParamClauseModule { this: TypeParamClause.type =>
+      def apply(params: List[TypeDef]): TypeParamClause
+      def unapply(x: TypeParamClause): Some[List[TypeDef]]
+    }
 
     type Selector <: AnyRef
 
@@ -2518,9 +2551,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           case vdef @ ValDef(_, tpt, rhs) =>
             val owner = vdef.symbol
             foldTrees(foldTree(x, tpt)(owner), rhs)(owner)
-          case ddef @ DefDef(_, tparams, vparamss, tpt, rhs) =>
+          case ddef @ DefDef(_, paramss, tpt, rhs) =>
             val owner = ddef.symbol
-            foldTrees(foldTree(vparamss.foldLeft(foldTrees(x, tparams)(owner))((acc, y) => foldTrees(acc, y)(owner)), tpt)(owner), rhs)(owner)
+            // foldTrees(foldTree(vparamss.foldLeft(foldTrees(x, tparams)(owner))((acc, y) => foldTrees(acc, y)(owner)), tpt)(owner), rhs)(owner)
+            ???
           case tdef @ TypeDef(_, rhs) =>
             val owner = tdef.symbol
             foldTree(x, rhs)(owner)
@@ -2608,7 +2642,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
             ValDef.copy(tree)(tree.name, tpt1, rhs1)
           case tree: DefDef =>
             val owner = tree.symbol
-            DefDef.copy(tree)(tree.name, transformSubTrees(tree.typeParams)(owner), tree.paramss mapConserve (x => transformSubTrees(x)(owner)), transformTypeTree(tree.returnTpt)(owner), tree.rhs.map(x => transformTerm(x)(owner)))
+            // DefDef.copy(tree)(tree.name, transformSubTrees(tree.typeParams)(owner), tree.paramss mapConserve (x => transformSubTrees(x)(owner)), transformTypeTree(tree.returnTpt)(owner), tree.rhs.map(x => transformTerm(x)(owner)))
+            ???
           case tree: TypeDef =>
             val owner = tree.symbol
             TypeDef.copy(tree)(tree.name, transformTree(tree.rhs)(owner))

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -29,7 +29,7 @@ trait ExprMap:
             ValDef.copy(tree)(tree.name, tree.tpt, rhs1)
           case tree: DefDef =>
             val owner = tree.symbol
-            DefDef.copy(tree)(tree.name, tree.typeParams, tree.paramss, tree.returnTpt, tree.rhs.map(x => transformTerm(x, tree.returnTpt.tpe)(owner)))
+            DefDef.copy(tree)(tree.name, tree.paramss, tree.returnTpt, tree.rhs.map(x => transformTerm(x, tree.returnTpt.tpe)(owner)))
           case tree: TypeDef =>
             tree
           case tree: ClassDef =>

--- a/scala3doc/src/dotty/dokka/tasty/SymOps.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SymOps.scala
@@ -102,9 +102,9 @@ class SymOps[Q <: Quotes](val q: Q):
 
     def extendedSymbol: Option[ValDef] =
       Option.when(sym.isExtensionMethod){
-        val params = sym.tree.asInstanceOf[DefDef].paramss
-        if isLeftAssoc(sym) || params.size == 1 then params(0)(0)
-        else params(1)(0)
+        val termParamss = sym.tree.asInstanceOf[DefDef].termParamss
+        if isLeftAssoc(sym) || termParamss.size == 1 then termParamss(0).params(0)
+        else termParamss(1).params(0)
       }
 
     // TODO #22 make sure that DRIs are unique plus probably reuse semantic db code?

--- a/scala3doc/src/dotty/dokka/tasty/SyntheticSupport.scala
+++ b/scala3doc/src/dotty/dokka/tasty/SyntheticSupport.scala
@@ -46,9 +46,9 @@ trait SyntheticsSupport:
   def constructorWithoutParamLists(c: ClassDef): Boolean =
     !isValidPos(c.constructor.pos)  || {
       val end = c.constructor.pos.end
-      val typesEnd =  c.constructor.typeParams.lastOption.fold(end - 1)(_.pos.end)
+      val typesEnd =  c.constructor.leadingTypeParams.lastOption.fold(end - 1)(_.pos.end)
       val classDefTree = c.constructor.show
-      c.constructor.typeParams.nonEmpty && end <= typesEnd + 1
+      c.constructor.leadingTypeParams.nonEmpty && end <= typesEnd + 1
     }
 
   // TODO: #49 Remove it after TASTY-Reflect release with published flag Extension

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -24,7 +24,7 @@ object Lens {
       case Inlined(
         None, Nil,
         Block(
-          DefDef(_, Nil, (param :: Nil) :: Nil, _, Some(Select(o, field))) :: Nil,
+          DefDef(_, TermParamClause(param :: Nil) :: Nil, _, Some(Select(o, field))) :: Nil,
           Lambda(meth, _)
         )
       ) if o.symbol == param.symbol =>

--- a/tests/pos-special/i7592/Macros_1.scala
+++ b/tests/pos-special/i7592/Macros_1.scala
@@ -12,7 +12,7 @@ def compileImpl[T](expr : Expr[T])(using Quotes) : Expr[T] = {
       case s : (Select|Ident) => {
         if( s.symbol.isDefDef ) {
           s.symbol.tree match {
-            case DefDef(name, typeParams, params, returnTp, Some(rhs)) => proc(rhs)
+            case DefDef(name, paramss, returnTp, Some(rhs)) => proc(rhs)
           }
         } else {
           ???

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-2.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-2.check
@@ -1,3 +1,3 @@
-DefDef("foo", Nil, Nil, TypeIdent("Int"), Some(Apply(Select(Literal(IntConstant(1)), "+"), List(Literal(IntConstant(2))))))
+DefDef("foo", Nil, TypeIdent("Int"), Some(Apply(Select(Literal(IntConstant(1)), "+"), List(Literal(IntConstant(2))))))
 ValDef("bar", TypeIdent("Int"), Some(Apply(Select(Literal(IntConstant(2)), "+"), List(Literal(IntConstant(3))))))
 Bind("x", Ident("_"))

--- a/tests/run-custom-args/Yretain-trees/tasty-definitions-3.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-definitions-3.check
@@ -1,3 +1,3 @@
-DefDef("foo", Nil, Nil, Inferred(), None)
+DefDef("foo", Nil, Inferred(), None)
 ValDef("bar", Inferred(), None)
 Bind("x", Ident("_"))

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners.check
@@ -2,10 +2,10 @@ foo
 ValDef("macro", Inferred(), None)
 
 bar
-DefDef("foo", Nil, Nil, Inferred(), None)
+DefDef("foo", Nil, Inferred(), None)
 
 bar2
-DefDef("foo", Nil, Nil, Inferred(), None)
+DefDef("foo", Nil, Inferred(), None)
 
 foo2
 ValDef("macro", Inferred(), None)
@@ -17,11 +17,11 @@ baz2
 ValDef("foo2", Inferred(), None)
 
 <init>
-ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
+ClassDef("A", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
 
 b
-ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
+ClassDef("A", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
 
 b2
-ClassDef("A", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
+ClassDef("A", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Inferred()), Nil, None, List(TypeDef("B", TypeBoundsTree(Inferred(), Inferred())), DefDef("b", Nil, Inferred(), None), ValDef("b2", Inferred(), None)))
 

--- a/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
+++ b/tests/run-custom-args/Yretain-trees/tasty-extractors-owners/quoted_1.scala
@@ -22,7 +22,7 @@ object Macros {
     import quotes.reflect._
     override def traverseTree(tree: Tree)(owner: Symbol): Unit = {
       tree match {
-        case tree @ DefDef(name, _, _, _, _) =>
+        case tree @ DefDef(name, _, _, _) =>
           buff.append(name)
           buff.append("\n")
           buff.append(tree.symbol.owner.tree.show(using Printer.TreeStructure))

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-1.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-1.check
@@ -1,2 +1,2 @@
-DefDef("foo", Nil, Nil, TypeIdent("Int"), Some(Apply(Select(Literal(IntConstant(1)), "+"), List(Literal(IntConstant(2))))))
+DefDef("foo", Nil, TypeIdent("Int"), Some(Apply(Select(Literal(IntConstant(1)), "+"), List(Literal(IntConstant(2))))))
 ValDef("bar", TypeIdent("Int"), Some(Apply(Select(Literal(IntConstant(2)), "+"), List(Literal(IntConstant(3))))))

--- a/tests/run-custom-args/Yretain-trees/tasty-load-tree-2.check
+++ b/tests/run-custom-args/Yretain-trees/tasty-load-tree-2.check
@@ -1,2 +1,2 @@
-DefDef("foo", Nil, Nil, Inferred(), None)
+DefDef("foo", Nil, Inferred(), None)
 ValDef("bar", Inferred(), None)

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TastyInterpreter.scala
@@ -11,7 +11,7 @@ class TastyInterpreter extends TastyInspector {
 
       override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match {
         // TODO: check the correct sig and object enclosement for main
-        case DefDef("main", _, _, _, Some(rhs)) =>
+        case DefDef("main", _, _, Some(rhs)) =>
           val interpreter = new jvm.Interpreter
 
           interpreter.eval(rhs)(using Map.empty)

--- a/tests/run-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
+++ b/tests/run-custom-args/tasty-interpreter/interpreter/TreeInterpreter.scala
@@ -28,7 +28,7 @@ abstract class TreeInterpreter[Q <: Quotes & Singleton](using val q: Q) {
     // withLocalValue(`this`, inst) {
       sym.tree match
         case ddef: DefDef =>
-          val syms = ddef.paramss.headOption.getOrElse(Nil).map(_.symbol)
+          val syms = ddef.termParamss.headOption.map(_.params).getOrElse(Nil).map(_.symbol)
           withLocalValues(syms, args.map(LocalValue.valFrom(_))) {
             eval(ddef.rhs.get)
           }
@@ -45,7 +45,7 @@ abstract class TreeInterpreter[Q <: Quotes & Singleton](using val q: Q) {
     val evaluatedArgs = argss.flatten.map(arg => LocalValue.valFrom(eval(arg)))
     fn.symbol.tree match
       case ddef: DefDef =>
-        val syms = ddef.paramss.headOption.getOrElse(Nil).map(_.symbol)
+        val syms = ddef.termParamss.headOption.map(_.params).getOrElse(Nil).map(_.symbol)
         withLocalValues(syms, evaluatedArgs) {
           eval(ddef.rhs.get)
         }
@@ -75,7 +75,7 @@ abstract class TreeInterpreter[Q <: Quotes & Singleton](using val q: Q) {
           else LocalValue.valFrom(evalRhs)
 
         accEnv.updated(stat.symbol, evalRef)
-      case DefDef(_, _, _, _, _) =>
+      case DefDef(_, _, _, _) =>
         // TODO: record the environment for closure purposes
         accEnv
       case stat =>

--- a/tests/run-macros/exports.check
+++ b/tests/run-macros/exports.check
@@ -11,6 +11,6 @@ reflection show:
   ()
 }
 reflection show extractors:
-Inlined(None, Nil, Block(List(ValDef("Observer", TypeIdent("Observer$"), Some(Apply(Select(New(TypeIdent("Observer$")), "<init>"), Nil))), ClassDef("Observer$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Observer")), None)), List(Export(Ident("Messages"), List(SimpleSelector(count))), DefDef("count", Nil, Nil, Inferred(), Some(Select(Ident("Messages"), "count")))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ValDef("Observer", TypeIdent("Observer$"), Some(Apply(Select(New(TypeIdent("Observer$")), "<init>"), Nil))), ClassDef("Observer$", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Observer")), None)), List(Export(Ident("Messages"), List(SimpleSelector(count))), DefDef("count", Nil, Inferred(), Some(Select(Ident("Messages"), "count")))))), Literal(UnitConstant())))
 visited exports with splice
 visited exports with splice inverted

--- a/tests/run-macros/i6988/FirstArg_1.scala
+++ b/tests/run-macros/i6988/FirstArg_1.scala
@@ -19,7 +19,7 @@ object Macros {
       if owner.isClassDef then
         owner.tree match
           case tdef: ClassDef =>
-            tdef.constructor.paramss map { _ map {_.symbol }}
+            tdef.constructor.paramss map { _.params map {_.symbol }}
       else enclosingParamList(owner.owner)
 
     def literal(value: String): Expr[String] =

--- a/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-2/quoted_1.scala
@@ -70,7 +70,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
     import quotes.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", List(TermParamClause(params)), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
+++ b/tests/run-macros/quote-matcher-symantics-3/quoted_1.scala
@@ -83,7 +83,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
     import quotes.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", List(TermParamClause(params)), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/quote-matching-open/Macro_1.scala
+++ b/tests/run-macros/quote-matching-open/Macro_1.scala
@@ -34,7 +34,7 @@ object UnsafeExpr {
   }
   private def paramsAndBody[R](using Quotes)(f: Expr[Any]): (List[quotes.reflect.ValDef], Expr[R]) = {
     import quotes.reflect._
-    val Block(List(DefDef("$anonfun", Nil, List(params), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
+    val Block(List(DefDef("$anonfun", List(TermParamClause(params)), _, Some(body))), Closure(Ident("$anonfun"), None)) = f.asTerm.etaExpand(Symbol.spliceOwner)
     (params, body.asExpr.asInstanceOf[Expr[R]])
   }
 

--- a/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
+++ b/tests/run-macros/tasty-create-method-symbol/Macro_1.scala
@@ -18,11 +18,10 @@ object Macros {
     assert(sym1.name == "sym1")
     val sym1Statements : List[Statement] = List(
       DefDef(sym1, {
-        case List() => {
           case List(List(a, b)) =>
             Some('{ ${ a.asExpr.asInstanceOf[Expr[Int]] } - ${ b.asExpr.asInstanceOf[Expr[Int]] } }.asTerm)
         }
-      }),
+      ),
       '{ assert(${ Apply(Ref(sym1), List(Literal(IntConstant(2)), Literal(IntConstant(3)))).asExpr.asInstanceOf[Expr[Int]] } == -1) }.asTerm)
 
     // test for no argument list (no Apply node)
@@ -34,11 +33,10 @@ object Macros {
     assert(sym2.name == "sym2")
     val sym2Statements : List[Statement] = List(
       DefDef(sym2, {
-        case List() => {
           case List() =>
             Some(Literal(IntConstant(2)))
         }
-      }),
+      ),
       '{ assert(${ Ref(sym2).asExpr.asInstanceOf[Expr[Int]] } == 2) }.asTerm)
 
    // test for multiple argument lists
@@ -54,11 +52,10 @@ object Macros {
     assert(sym3.name == "sym3")
     val sym3Statements : List[Statement] = List(
       DefDef(sym3, {
-        case List() => {
-          case List(List(a), List(b)) =>
+          case List(List(a: Term), List(b)) =>
             Some(a)
         }
-      }),
+      ),
       '{ assert(${ Apply(Apply(Ref(sym3), List(Literal(IntConstant(3)))), List(Literal(IntConstant(3)))).asExpr.asInstanceOf[Expr[Int]] } == 3) }.asTerm)
 
     // test for recursive references
@@ -72,7 +69,6 @@ object Macros {
     assert(sym4.name == "sym4")
     val sym4Statements : List[Statement] = List(
       DefDef(sym4, {
-        case List() => {
           case List(List(x)) =>
             Some('{
               if ${ x.asExpr.asInstanceOf[Expr[Int]] } == 0
@@ -80,7 +76,7 @@ object Macros {
               else ${ Apply(Ref(sym4), List('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - 1 }.asTerm)).asExpr.asInstanceOf[Expr[Int]] }
             }.asTerm)
         }
-      }),
+      ),
       '{ assert(${ Apply(Ref(sym4), List(Literal(IntConstant(4)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }.asTerm)
 
     // test for nested functions (one symbol is the other's parent, and we use a Closure)
@@ -94,7 +90,6 @@ object Macros {
     assert(sym5.name == "sym5")
     val sym5Statements : List[Statement] = List(
       DefDef(sym5, {
-        case List() => {
           case List(List(x)) =>
             Some {
               val sym51 : Symbol = Symbol.newMethod(
@@ -106,15 +101,14 @@ object Macros {
               Block(
                 List(
                   DefDef(sym51, {
-                    case List() => {
                       case List(List(xx)) =>
                         Some('{ ${ x.asExpr.asInstanceOf[Expr[Int]] } - ${ xx.asExpr.asInstanceOf[Expr[Int]] } }.asTerm)
                     }
-                  })),
+                  )),
                 Closure(Ref(sym51), None))
             }
         }
-      }),
+      ),
       '{ assert(${ Apply(Ref(sym5), List(Literal(IntConstant(5)))).asExpr.asInstanceOf[Expr[Int=>Int]] }(4) == 1) }.asTerm)
 
     // test mutually recursive definitions
@@ -136,7 +130,6 @@ object Macros {
     assert(sym6_2.name == "sym6_2")
     val sym6Statements : List[Statement] = List(
       DefDef(sym6_1, {
-        case List() => {
           case List(List(x)) =>
             Some {
               '{
@@ -147,9 +140,8 @@ object Macros {
               }.asTerm
             }
         }
-      }),
+      ),
       DefDef(sym6_2, {
-        case List() => {
           case List(List(x)) =>
             Some {
               '{
@@ -161,7 +153,7 @@ object Macros {
             }
         }
 
-      }),
+      ),
       '{ assert(${ Apply(Ref(sym6_2), List(Literal(IntConstant(6)))).asExpr.asInstanceOf[Expr[Int]] } == 0) }.asTerm)
 
     // test polymorphic methods by synthesizing an identity method
@@ -177,11 +169,10 @@ object Macros {
     assert(sym7.name == "sym7")
     val sym7Statements : List[Statement] = List(
       DefDef(sym7, {
-        case List(t) => {
-          case List(List(x)) =>
-            Some(Typed(x, Inferred(t)))
+          case List(List(t: TypeTree), List(x: Term)) =>
+            Some(Typed(x, t))
         }
-      }),
+      ),
       '{ assert(${ Apply(TypeApply(Ref(sym7), List(Inferred(TypeRepr.of[Int]))), List(Literal(IntConstant(7)))).asExpr.asInstanceOf[Expr[Int]] } == 7) }.asTerm)
 
     Block(

--- a/tests/run-macros/tasty-extractors-1.check
+++ b/tests/run-macros/tasty-extractors-1.check
@@ -91,30 +91,30 @@ TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 Inlined(None, Nil, Block(List(ValDef("b", TypeIdent("Int"), Some(Literal(IntConstant(3))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f1", Nil, Nil, TypeIdent("Int"), Some(Literal(IntConstant(3))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(DefDef("f1", Nil, TypeIdent("Int"), Some(Literal(IntConstant(3))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f2", Nil, Nil, TypeIdent("Int"), Some(Return(Literal(IntConstant(4)), IsDefDefSymbol(<Test$._$_$f2>))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(DefDef("f2", Nil, TypeIdent("Int"), Some(Return(Literal(IntConstant(4)), IsDefDefSymbol(<Test$._$_$f2>))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f3", Nil, List(List(ValDef("i", TypeIdent("Int"), None))), TypeIdent("Int"), Some(Ident("i")))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(DefDef("f3", List(TermParamClause(List(ValDef("i", TypeIdent("Int"), None)))), TypeIdent("Int"), Some(Ident("i")))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f4", Nil, List(List(ValDef("i", TypeIdent("Int"), None)), List(ValDef("j", TypeIdent("Int"), None))), TypeIdent("Int"), Some(Apply(Select(Ident("i"), "+"), List(Ident("j")))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(DefDef("f4", List(TermParamClause(List(ValDef("i", TypeIdent("Int"), None))), TermParamClause(List(ValDef("j", TypeIdent("Int"), None)))), TypeIdent("Int"), Some(Apply(Select(Ident("i"), "+"), List(Ident("j")))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f5", Nil, List(List(ValDef("i", TypeIdent("Int"), None))), TypeIdent("Int"), Some(Ident("i"))), DefDef("f5$default$1", Nil, Nil, Inferred(), Some(Literal(IntConstant(9))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(DefDef("f5", List(TermParamClause(List(ValDef("i", TypeIdent("Int"), None)))), TypeIdent("Int"), Some(Ident("i"))), DefDef("f5$default$1", Nil, Inferred(), Some(Literal(IntConstant(9))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f6", List(TypeDef("T", TypeBoundsTree(Inferred(), Inferred()))), List(List(ValDef("x", TypeIdent("T"), None))), TypeIdent("T"), Some(Ident("x")))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(DefDef("f6", List(TypeParamClause(List(TypeDef("T", TypeBoundsTree(Inferred(), Inferred())))), TermParamClause(List(ValDef("x", TypeIdent("T"), None)))), TypeIdent("T"), Some(Ident("x")))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f7", List(TypeDef("T", TypeBoundsTree(Inferred(), Inferred()))), List(List(ValDef("x", TypeIdent("T"), None))), Singleton(Ident("x")), Some(Ident("x")))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(DefDef("f7", List(TypeParamClause(List(TypeDef("T", TypeBoundsTree(Inferred(), Inferred())))), TermParamClause(List(ValDef("x", TypeIdent("T"), None)))), Singleton(Ident("x")), Some(Ident("x")))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("f8", Nil, List(List(ValDef("i", Annotated(Applied(Inferred(), List(TypeIdent("Int"))), Apply(Select(New(Inferred()), "<init>"), Nil)), None))), TypeIdent("Int"), Some(Literal(IntConstant(9))))), Apply(Ident("f8"), List(Typed(Repeated(List(Literal(IntConstant(1)), Literal(IntConstant(2)), Literal(IntConstant(3))), Inferred()), Inferred())))))
+Inlined(None, Nil, Block(List(DefDef("f8", List(TermParamClause(List(ValDef("i", Annotated(Applied(Inferred(), List(TypeIdent("Int"))), Apply(Select(New(Inferred()), "<init>"), Nil)), None)))), TypeIdent("Int"), Some(Literal(IntConstant(9))))), Apply(Ident("f8"), List(Typed(Repeated(List(Literal(IntConstant(1)), Literal(IntConstant(2)), Literal(IntConstant(3))), Inferred()), Inferred())))))
 TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")
 
-Inlined(None, Nil, Block(List(DefDef("f9", Nil, List(List(ValDef("i", ByName(TypeIdent("Int")), None))), TypeIdent("Int"), Some(Ident("i")))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(DefDef("f9", List(TermParamClause(List(ValDef("i", ByName(TypeIdent("Int")), None)))), TypeIdent("Int"), Some(Ident("i")))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 

--- a/tests/run-macros/tasty-extractors-2.check
+++ b/tests/run-macros/tasty-extractors-2.check
@@ -1,7 +1,7 @@
 Inlined(None, Nil, Block(List(ValDef("x", Inferred(), Some(Literal(IntConstant(1))))), Assign(Ident("x"), Literal(IntConstant(2)))))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(DefDef("$anonfun", Nil, List(List(ValDef("x", TypeIdent("Int"), None))), Inferred(), Some(Ident("x")))), Closure(Ident("$anonfun"), None)))
+Inlined(None, Nil, Block(List(DefDef("$anonfun", List(TermParamClause(List(ValDef("x", TypeIdent("Int"), None)))), Inferred(), Some(Ident("x")))), Closure(Ident("$anonfun"), None)))
 AppliedType(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Function1"), List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int"), TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")))
 
 Inlined(None, Nil, Ident("???"))
@@ -22,10 +22,10 @@ AndType(TypeRef(ThisType(TypeRef(NoPrefix(), "<empty>")), "Foo"), TypeRef(ThisTy
 Inlined(None, Nil, Typed(Literal(IntConstant(1)), Applied(TypeIdent("|"), List(TypeIdent("Int"), TypeIdent("String")))))
 OrType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int"), TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "scala")), "Predef"), "String"))
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, Nil)), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, Nil)), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ValDef("Foo", TypeIdent("Foo$"), Some(Apply(Select(New(TypeIdent("Foo$")), "<init>"), Nil))), ClassDef("Foo$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo")), None)), Nil)), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ValDef("Foo", TypeIdent("Foo$"), Some(Apply(Select(New(TypeIdent("Foo$")), "<init>"), Nil))), ClassDef("Foo$", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo")), None)), Nil)), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
 Inlined(None, Nil, Block(List(TypeDef("Foo", TypeBoundsTree(Inferred(), Inferred()))), Literal(UnitConstant())))
@@ -37,69 +37,69 @@ TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 Inlined(None, Nil, Block(List(TypeDef("Foo", TypeBoundsTree(TypeIdent("Null"), TypeIdent("Object")))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(IntConstant(0)))), DefDef("a_=", Nil, List(List(ValDef("x$1", Inferred(), None))), Inferred(), Some(Literal(UnitConstant())))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(IntConstant(0)))), DefDef("a_=", List(TermParamClause(List(ValDef("x$1", Inferred(), None)))), Inferred(), Some(Literal(UnitConstant())))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Some(Literal(IntConstant(0))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Inferred(), Some(Literal(IntConstant(0))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Some(Literal(IntConstant(0))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Inferred(), Some(Literal(IntConstant(0))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Nil, Inferred(), Some(Literal(IntConstant(0))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(DefDef("a", Nil, Inferred(), Some(Literal(IntConstant(0))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil), TypeSelect(Select(Ident("_root_"), "scala"), "Product"), TypeSelect(Select(Ident("_root_"), "scala"), "Serializable")), Nil, None, List(DefDef("copy", Nil, List(Nil), Inferred(), Some(Apply(Select(New(Inferred()), "<init>"), Nil))))), ValDef("Foo", TypeIdent("Foo$"), Some(Apply(Select(New(TypeIdent("Foo$")), "<init>"), Nil))), ClassDef("Foo$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo")), None)), List(DefDef("apply", Nil, List(Nil), Inferred(), Some(Apply(Select(New(Inferred()), "<init>"), Nil))), DefDef("unapply", Nil, List(List(ValDef("x$1", Inferred(), None))), Singleton(Literal(BooleanConstant(true))), Some(Literal(BooleanConstant(true)))), DefDef("toString", Nil, Nil, Inferred(), Some(Literal(StringConstant("Foo"))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil), TypeSelect(Select(Ident("_root_"), "scala"), "Product"), TypeSelect(Select(Ident("_root_"), "scala"), "Serializable")), Nil, None, List(DefDef("copy", List(TermParamClause(Nil)), Inferred(), Some(Apply(Select(New(Inferred()), "<init>"), Nil))))), ValDef("Foo", TypeIdent("Foo$"), Some(Apply(Select(New(TypeIdent("Foo$")), "<init>"), Nil))), ClassDef("Foo$", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo")), None)), List(DefDef("apply", List(TermParamClause(Nil)), Inferred(), Some(Apply(Select(New(Inferred()), "<init>"), Nil))), DefDef("unapply", List(TermParamClause(List(ValDef("x$1", Inferred(), None)))), Singleton(Literal(BooleanConstant(true))), Some(Literal(BooleanConstant(true)))), DefDef("toString", Nil, Inferred(), Some(Literal(StringConstant("Foo"))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo1", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None)))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo1", DefDef("<init>", List(TermParamClause(List(ValDef("a", TypeIdent("Int"), None)))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None)))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo2", DefDef("<init>", Nil, List(List(ValDef("b", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("b", Inferred(), None)))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo2", DefDef("<init>", List(TermParamClause(List(ValDef("b", TypeIdent("Int"), None)))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("b", Inferred(), None)))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo3", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None))), ValDef("Foo3", TypeIdent("Foo3$"), Some(Apply(Select(New(TypeIdent("Foo3$")), "<init>"), Nil))), ClassDef("Foo3$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo3")), None)), List(DefDef("$lessinit$greater$default$1", Nil, Nil, Inferred(), Some(Literal(IntConstant(5))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo3", DefDef("<init>", List(TermParamClause(List(ValDef("a", TypeIdent("Int"), None)))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None))), ValDef("Foo3", TypeIdent("Foo3$"), Some(Apply(Select(New(TypeIdent("Foo3$")), "<init>"), Nil))), ClassDef("Foo3$", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo3")), None)), List(DefDef("$lessinit$greater$default$1", Nil, Inferred(), Some(Literal(IntConstant(5))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo4", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None)), List(ValDef("b", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None)))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo4", DefDef("<init>", List(TermParamClause(List(ValDef("a", TypeIdent("Int"), None))), TermParamClause(List(ValDef("b", TypeIdent("Int"), None)))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None)))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo5", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None)), List(ValDef("b", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None))), ValDef("Foo5", TypeIdent("Foo5$"), Some(Apply(Select(New(TypeIdent("Foo5$")), "<init>"), Nil))), ClassDef("Foo5$", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo5")), None)), List(DefDef("$lessinit$greater$default$2", Nil, List(List(ValDef("a", TypeIdent("Int"), None))), Inferred(), Some(Ident("a")))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo5", DefDef("<init>", List(TermParamClause(List(ValDef("a", TypeIdent("Int"), None))), TermParamClause(List(ValDef("b", TypeIdent("Int"), None)))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None))), ValDef("Foo5", TypeIdent("Foo5$"), Some(Apply(Select(New(TypeIdent("Foo5$")), "<init>"), Nil))), ClassDef("Foo5$", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, Some(ValDef("_", Singleton(Ident("Foo5")), None)), List(DefDef("$lessinit$greater$default$2", List(TermParamClause(List(ValDef("a", TypeIdent("Int"), None)))), Inferred(), Some(Ident("a")))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo6", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None)), List(ValDef("b", Singleton(Ident("a")), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None)))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo6", DefDef("<init>", List(TermParamClause(List(ValDef("a", TypeIdent("Int"), None))), TermParamClause(List(ValDef("b", Singleton(Ident("a")), None)))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), ValDef("b", Inferred(), None)))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo7", DefDef("<init>", Nil, List(List(ValDef("a", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), DefDef("<init>", Nil, List(Nil), Inferred(), Some(Block(List(Apply(Select(This(Some("Foo7")), "<init>"), List(Literal(IntConstant(6))))), Literal(UnitConstant()))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo7", DefDef("<init>", List(TermParamClause(List(ValDef("a", TypeIdent("Int"), None)))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), None), DefDef("<init>", List(TermParamClause(Nil)), Inferred(), Some(Block(List(Apply(Select(This(Some("Foo7")), "<init>"), List(Literal(IntConstant(6))))), Literal(UnitConstant()))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo8", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(Apply(Ident("println"), List(Literal(IntConstant(0))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo8", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(Apply(Ident("println"), List(Literal(IntConstant(0))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo10", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(IntConstant(9))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo10", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(IntConstant(9))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo11", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(IntConstant(10)))), DefDef("a_=", Nil, List(List(ValDef("x$1", Inferred(), None))), Inferred(), Some(Literal(UnitConstant())))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo11", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(IntConstant(10)))), DefDef("a_=", List(TermParamClause(List(ValDef("x$1", Inferred(), None)))), Inferred(), Some(Literal(UnitConstant())))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo12", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(IntConstant(11))))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo12", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("a", Inferred(), Some(Literal(IntConstant(11))))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, Nil), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(TypeIdent("Foo")), "<init>"), Nil)), Nil, None, Nil)), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, Nil), ClassDef("Bar", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(TypeIdent("Foo")), "<init>"), Nil)), Nil, None, Nil)), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo2", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Inferred()), Nil, None, Nil), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil), TypeIdent("Foo2")), Nil, None, Nil)), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo2", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Inferred()), Nil, None, Nil), ClassDef("Bar", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil), TypeIdent("Foo2")), Nil, None, Nil)), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(List(ValDef("i", TypeIdent("Int"), None))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("i", Inferred(), None))), ClassDef("Bar", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(TypeIdent("Foo")), "<init>"), List(Literal(IntConstant(1))))), Nil, None, Nil)), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(List(ValDef("i", TypeIdent("Int"), None)))), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(ValDef("i", Inferred(), None))), ClassDef("Bar", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(TypeIdent("Foo")), "<init>"), List(Literal(IntConstant(1))))), Nil, None, Nil)), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(TypeDef("X", TypeIdent("Int")))), DefDef("f", Nil, List(List(ValDef("a", TypeIdent("Foo"), None))), TypeSelect(Ident("a"), "X"), Some(Ident("???")))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(TypeDef("X", TypeIdent("Int")))), DefDef("f", List(TermParamClause(List(ValDef("a", TypeIdent("Foo"), None)))), TypeSelect(Ident("a"), "X"), Some(Ident("???")))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", Nil, List(Nil), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(TypeDef("X", TypeBoundsTree(Inferred(), Inferred())))), DefDef("f", Nil, List(List(ValDef("a", Refined(TypeIdent("Foo"), List(TypeDef("X", TypeIdent("Int")))), None))), TypeSelect(Ident("a"), "X"), Some(Ident("???")))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ClassDef("Foo", DefDef("<init>", List(TermParamClause(Nil)), Inferred(), None), List(Apply(Select(New(Inferred()), "<init>"), Nil)), Nil, None, List(TypeDef("X", TypeBoundsTree(Inferred(), Inferred())))), DefDef("f", List(TermParamClause(List(ValDef("a", Refined(TypeIdent("Foo"), List(TypeDef("X", TypeIdent("Int")))), None)))), TypeSelect(Ident("a"), "X"), Some(Ident("???")))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 
-Inlined(None, Nil, Block(List(ValDef("lambda", Applied(Inferred(), List(TypeIdent("Int"), TypeIdent("Int"))), Some(Block(List(DefDef("$anonfun", Nil, List(List(ValDef("x", Inferred(), None))), Inferred(), Some(Ident("x")))), Closure(Ident("$anonfun"), None))))), Literal(UnitConstant())))
+Inlined(None, Nil, Block(List(ValDef("lambda", Applied(Inferred(), List(TypeIdent("Int"), TypeIdent("Int"))), Some(Block(List(DefDef("$anonfun", List(TermParamClause(List(ValDef("x", Inferred(), None)))), Inferred(), Some(Ident("x")))), Closure(Ident("$anonfun"), None))))), Literal(UnitConstant())))
 TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Unit")
 


### PR DESCRIPTION
Reflects the changes done in #10940

~Based on~ Subsumes #11082


Introduces `ParamClause`
```scala
    /** A parameter clause `[X1, ..., Xn]` or `(x1: X1, ..., xn: Xx)`
     *
     *  `[X1, ..., Xn]` are reresented with `TypeParamClause` and `(x1: X1, ..., xn: Xx)` are represented with `TermParamClause`
     *
     *  `ParamClause` encodes the following enumeration
     *  ```scala
     *  enum ParamClause:
     *    case TypeParamClause(params: List[TypeDef])
     *    case TermParamClause(params: List[ValDef])
     *  ```
     */
    type ParamClause <: AnyRef
```

Technically, `ParamClause` is like an opaque type on `List[ValDef] | List[TypeDef]` with some extra invariants that we need to ensure.