### PR TITLE
Take type bounds into account for overloading resolution

### DIFF
--- a/tests/neg/tcpoly_overloaded.scala
+++ b/tests/neg/tcpoly_overloaded.scala
@@ -21,5 +21,5 @@ trait Test {
     def flatMap[S]
             (f: T => List[S], foo: Int): List[S]  = sys.error("foo")
   }
-  val l: MList[String] = moo.flatMap[String, List, Any, MList]((x: Int) => new MList("String"))
+  val l: MList[String] = moo.flatMap[String, List, Any, MList]((x: Int) => new MList("String")) // error: no alternative matches
 }

--- a/tests/pos/i11015.scala
+++ b/tests/pos/i11015.scala
@@ -1,0 +1,6 @@
+import annotation.targetName
+object Foo:
+   def apply[A <: Int]: Int = 0
+   @targetName("applyS") def apply[B <: String]: String = "0"
+
+def test = Foo[Int]


### PR DESCRIPTION
When resolving overloaded polymorphic variants with explicit type
arguments, discard those variants where the given argument does not
fit the type parameter bounds.

Fixes #11015