### PR TITLE
Allow literals as given types

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3534,7 +3534,9 @@ object Parsers {
         newLinesOpt()
         val noParams = tparams.isEmpty && vparamss.isEmpty
         if !(name.isEmpty && noParams) then accept(COLON)
-        val parents = constrApp() :: withConstrApps()
+        val parents =
+          if isSimpleLiteral then toplevelTyp() :: Nil
+          else constrApp() :: withConstrApps()
         val parentsIsType = parents.length == 1 && parents.head.isType
         if in.token == EQUALS && parentsIsType then
           accept(EQUALS)

--- a/tests/pos/i11102.scala
+++ b/tests/pos/i11102.scala
@@ -1,0 +1,3 @@
+given s: "literal" = "literal" // compile error
+given "foo" = "foo"
+given x: 1 = 1


### PR DESCRIPTION
It's a weird use case, but the grammar allows it.

Fixes #11102