### PR TITLE
Eliminate `newNakedSymbol` methods

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -661,7 +661,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
      */
     private def makeStatifiedDefDef(dd: DefDef): DefDef =
       val origSym = dd.symbol.asTerm
-      val newSym = makeStatifiedDefSymbol(origSym, origSym.name)
+      val newSym = makeStatifiedDefSymbol(origSym, origSym.symName)
       tpd.DefDef(newSym, { paramRefss =>
         val selfParamRef :: regularParamRefs = paramRefss.head
         val enclosingClass = origSym.owner.asClass

--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -236,7 +236,7 @@ final class JSDefinitions()(using Context) {
 
   /** If `cls` is a class in the scala package, its name, otherwise EmptyTypeName */
   private def scalajsClassName(cls: Symbol)(using Context): TypeName =
-    if (cls.isClass && cls.owner == ScalaJSJSPackageClass) cls.asClass.name
+    if (cls.isClass && cls.owner == ScalaJSJSPackageClass) cls.name.asTypeName
     else EmptyTypeName
 
   /** Is the given `cls` a class of the form `scala.scalajs.js.prefixN` where

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -133,7 +133,7 @@ object desugar {
   /** A derived type definition watching `sym` */
   def derivedTypeParamWithVariance(sym: TypeSymbol)(using Context): TypeDef =
     val variance = VarianceFlags & sym.flags
-    TypeDef(sym.name, DerivedFromParamTree().watching(sym)).withFlags(TypeParam | Synthetic | variance)
+    TypeDef(sym.symName, DerivedFromParamTree().watching(sym)).withFlags(TypeParam | Synthetic | variance)
 
   /** A value definition copied from `vdef` with a tpt typetree derived from it */
   def derivedTermParam(vdef: ValDef)(using Context): ValDef =

--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -50,7 +50,7 @@ class TreeTypeMap(
   private val mapOwnerThis = new TypeMap {
     private def mapPrefix(from: List[Symbol], to: List[Symbol], tp: Type): Type = from match {
       case Nil => tp
-      case (cls: ClassSymbol) :: from1 => mapPrefix(from1, to.tail, tp.substThis(cls, to.head.thisType))
+      case (cls: ClassSymbol @unchecked) :: from1 => mapPrefix(from1, to.tail, tp.substThis(cls, to.head.thisType))
       case _ :: from1 => mapPrefix(from1, to.tail, tp)
     }
     def apply(tp: Type): Type = tp match {

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -201,7 +201,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   }
 
   def ValDef(sym: TermSymbol, rhs: LazyTree = EmptyTree)(using Context): ValDef =
-    ta.assignType(untpd.ValDef(sym.name, TypeTree(sym.info), rhs), sym)
+    ta.assignType(untpd.ValDef(sym.symName, TypeTree(sym.info), rhs), sym)
 
   def SyntheticValDef(name: TermName, rhs: Tree)(using Context): ValDef =
     ValDef(newSymbol(ctx.owner, name, Synthetic, rhs.tpe.widen, coord = rhs.span), rhs)
@@ -211,7 +211,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     sym.setParamss(paramss)
     ta.assignType(
       untpd.DefDef(
-        sym.name,
+        sym.symName,
         paramss.map {
           case TypeSymbols(params) => params.map(param => TypeDef(param).withSpan(param.span))
           case TermSymbols(params) => params.map(param => ValDef(param).withSpan(param.span))
@@ -284,7 +284,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   end DefDef
 
   def TypeDef(sym: TypeSymbol)(using Context): TypeDef =
-    ta.assignType(untpd.TypeDef(sym.name, TypeTree(sym.info)), sym)
+    ta.assignType(untpd.TypeDef(sym.symName, TypeTree(sym.info)), sym)
 
   def ClassDef(cls: ClassSymbol, constr: DefDef, body: List[Tree], superArgs: List[Tree] = Nil)(using Context): TypeDef = {
     val firstParent :: otherParents = cls.info.parents
@@ -320,7 +320,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       .orElse(newLocalDummy(cls))
     val impl = untpd.Template(constr, parents, Nil, selfType, newTypeParams ++ body)
       .withType(localDummy.termRef)
-    ta.assignType(untpd.TypeDef(cls.name, impl), cls)
+    ta.assignType(untpd.TypeDef(cls.symName, impl), cls)
   }
 
   /** An anonymous class

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -67,7 +67,7 @@ object Annotations {
             // seems to be enough to ensure this (note that after erasure, `ctx.typer`
             // will be the Erasure typer, but that doesn't seem to affect the annotation
             // trees we create, so we leave it as is)
-        case sym: Symbol if sym.defRunId != parentCtx.runId =>
+        case sym: Symbol @unchecked if sym.defRunId != parentCtx.runId =>
           mySym = sym.denot.current.symbol
         case _ =>
       }

--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -18,7 +18,7 @@ object ContextOps:
     */
     def enter(sym: Symbol): Symbol = inContext(ctx) {
       ctx.owner match
-        case cls: ClassSymbol => cls.classDenot.enter(sym)
+        case cls: ClassSymbol @unchecked => cls.classDenot.enter(sym)
         case _ => ctx.scope.openForMutations.enter(sym)
       sym
     }
@@ -63,7 +63,7 @@ object ContextOps:
     def inClassContext(selfInfo: TypeOrSymbol): Context = inContext(ctx) {
       val localCtx: Context = ctx.fresh.setNewScope
       selfInfo match {
-        case sym: Symbol if sym.exists && sym.name != nme.WILDCARD => localCtx.scope.openForMutations.enter(sym)
+        case sym: Symbol @unchecked if sym.exists && sym.name != nme.WILDCARD => localCtx.scope.openForMutations.enter(sym)
         case _ =>
       }
       localCtx

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1679,7 +1679,7 @@ class Definitions {
   def isValueSubType(tref1: TypeRef, tref2: TypeRef)(using Context): Boolean =
     valueTypeEnc(tref2.name) % valueTypeEnc(tref1.name) == 0
   def isValueSubClass(sym1: Symbol, sym2: Symbol): Boolean =
-    valueTypeEnc(sym2.asClass.name) % valueTypeEnc(sym1.asClass.name) == 0
+    valueTypeEnc(sym2.name.asTypeName) % valueTypeEnc(sym1.name.asTypeName) == 0
 
   @tu lazy val specialErasure: SimpleIdentityMap[Symbol, ClassSymbol] =
     SimpleIdentityMap.empty[Symbol]

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -179,7 +179,9 @@ object Denotations {
   abstract class Denotation(_symbol: SymbolImpl, protected var myInfo: Type) extends PreDenotation with printing.Showable {
     type AsSeenFromResult <: Denotation
 
-    val symbol: Symbol = _symbol.fromSymbolImpl
+    val symbol: Symbol =
+      if _symbol == null then this.asInstanceOf[Symbol]
+      else _symbol.fromSymbolImpl
 
     /** The type info.
      *  The info is an instance of TypeType iff this is a type denotation
@@ -573,7 +575,7 @@ object Denotations {
   abstract class SingleDenotation(_symbol: SymbolImpl, initInfo: Type) extends Denotation(_symbol, initInfo) {
     protected def newLikeThis(symbol: Symbol, info: Type, pre: Type): SingleDenotation
 
-    final def name(using Context): Name = symbol.name
+    def name(using Context): Name = symbol.name
 
     /** If this is not a SymDenotation: The prefix under which the denotation was constructed.
      *  NoPrefix for SymDenotations.
@@ -773,7 +775,7 @@ object Denotations {
           assert(!d.is(Package), s"illegal transformation of package denotation by transformer $transformer")
         case _ =>
 
-      def escapeToNext = nextDefined.ensuring(_.validFor != Nowhere)
+      def escapeToNext = nextDefined.ensuring(_.validFor != Nowhere, name)
 
       def toNewRun =
         util.Stats.record("current.bringForward")

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -249,7 +249,7 @@ final class ProperGadtConstraint private(
 
   private def externalize(param: TypeParamRef)(using Context): Type =
     reverseMapping(param) match {
-      case sym: Symbol => sym.typeRef
+      case sym: Symbol @unchecked => sym.typeRef
       case null => param
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -25,7 +25,7 @@ object Names {
   /** A common superclass of Name and Symbol. After bootstrap, this should be
    *  just the type alias Name | Symbol
    */
-  abstract class Designator
+  trait Designator
 
   /** A name if either a term name or a type name. Term names can be simple
    *  or derived. A simple term name is essentially an interned string stored

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1014,7 +1014,7 @@ object SymDenotations {
           case ClassInfo(_, _, _, _, selfType) =>
             def sourceOfSelf(tp: TypeOrSymbol): Symbol = (tp: @unchecked) match {
               case tp: TermRef => tp.symbol
-              case tp: Symbol => sourceOfSelf(tp.info)
+              case tp: Symbol @unchecked => sourceOfSelf(tp.info)
               case tp: RefinedType => sourceOfSelf(tp.parent)
             }
             sourceOfSelf(selfType)
@@ -1748,7 +1748,7 @@ object SymDenotations {
      */
     def givenSelfType(using Context): Type = classInfo.selfInfo match {
       case tp: Type => tp
-      case self: Symbol => self.info
+      case self: Symbol @unchecked => self.info
     }
 
    // ------ class-specific operations -----------------------------------
@@ -1804,7 +1804,7 @@ object SymDenotations {
       def traverse(parents: List[Type]): Unit = parents match {
         case p :: parents1 =>
           p.classSymbol match {
-            case pcls: ClassSymbol => builder.addAll(pcls.baseClasses)
+            case pcls: ClassSymbol @unchecked => builder.addAll(pcls.baseClasses)
             case _ => assert(isRefinementClass || p.isError || ctx.mode.is(Mode.Interactive), s"$this has non-class parent: $p")
           }
           traverse(parents1)

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -32,7 +32,7 @@ object SymDenotations {
   /** A sym-denotation represents the contents of a definition
    *  during a period.
    */
-  class SymDenotation private[SymDenotations] (
+  class SymDenotation private[core] (
     _symbol: SymbolImpl,
     final val _maybeOwner: SymbolImpl,
     final val name: Name,
@@ -543,7 +543,7 @@ object SymDenotations {
     final def isRealClass(using Context): Boolean = isClass && !is(Trait)
 
     /** Cast to class denotation */
-    final def asClass: ClassDenotation = asInstanceOf[ClassDenotation]
+    def asClass: ClassDenotation = asInstanceOf[ClassDenotation]
 
     /** is this symbol the result of an erroneous definition? */
     def isError: Boolean = false
@@ -2209,7 +2209,7 @@ object SymDenotations {
 
   /** The contents of a class definition during a period
    */
-  class ClassDenotationImpl private[SymDenotations] (
+  class ClassDenotationImpl private[core] (
     _symbol: SymbolImpl,
     _maybeOwner: SymbolImpl,
     name: Name,
@@ -2382,7 +2382,7 @@ object SymDenotations {
     }
   end PackageClassDenotation
 
-  class PackageClassDenotationImpl private[SymDenotations] (
+  class PackageClassDenotationImpl private[core] (
     _symbol: SymbolImpl,
     _maybeOwner: SymbolImpl,
     name: Name,

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -33,14 +33,16 @@ object SymDenotations {
    *  during a period.
    */
   class SymDenotation private[SymDenotations] (
-    symbol: Symbol,
-    final val maybeOwner: Symbol,
+    _symbol: SymbolImpl,
+    final val _maybeOwner: SymbolImpl,
     final val name: Name,
     initFlags: FlagSet,
     initInfo: Type,
-    initPrivateWithin: Symbol = NoSymbol) extends SingleDenotation(symbol, initInfo) {
+    initPrivateWithin: SymbolImpl = NoSymbol.toSymbolImpl) extends SingleDenotation(_symbol, initInfo) {
 
     //assert(symbol.id != 4940, name)
+
+    final val maybeOwner: Symbol = _maybeOwner.fromSymbolImpl
 
     override def hasUniqueSym: Boolean = exists
 
@@ -54,7 +56,7 @@ object SymDenotations {
     // ------ Getting and setting fields -----------------------------
 
     private var myFlags: FlagSet = adaptFlags(initFlags)
-    private var myPrivateWithin: Symbol = initPrivateWithin
+    private var myPrivateWithin: Symbol = initPrivateWithin.fromSymbolImpl
     private var myAnnotations: List[Annotation] = Nil
     private var myParamss: List[List[Symbol]] = Nil
 
@@ -1498,7 +1500,7 @@ object SymDenotations {
     // ----- copies and transforms  ----------------------------------------
 
     protected def newLikeThis(s: Symbol, i: Type, pre: Type): SingleDenotation =
-      new UniqueRefDenotation(s, i, validFor, pre)
+      new UniqueRefDenotation(s.toSymbolImpl, i, validFor, pre)
 
     /** Copy this denotation, overriding selective fields */
     final def copySymDenotation(
@@ -2208,13 +2210,13 @@ object SymDenotations {
   /** The contents of a class definition during a period
    */
   class ClassDenotationImpl private[SymDenotations] (
-    symbol: Symbol,
-    maybeOwner: Symbol,
+    _symbol: SymbolImpl,
+    _maybeOwner: SymbolImpl,
     name: Name,
     initFlags: FlagSet,
     initInfo: Type,
-    initPrivateWithin: Symbol)
-    extends SymDenotation(symbol, maybeOwner, name, initFlags, initInfo, initPrivateWithin),
+    initPrivateWithin: SymbolImpl)
+    extends SymDenotation(_symbol, _maybeOwner, name, initFlags, initInfo, initPrivateWithin),
       ClassDenotation
 
   /** The denotation of a package class.
@@ -2381,18 +2383,18 @@ object SymDenotations {
   end PackageClassDenotation
 
   class PackageClassDenotationImpl private[SymDenotations] (
-    symbol: Symbol,
-    ownerIfExists: Symbol,
+    _symbol: SymbolImpl,
+    _maybeOwner: SymbolImpl,
     name: Name,
     initFlags: FlagSet,
     initInfo: Type,
-    initPrivateWithin: Symbol)
+    initPrivateWithin: SymbolImpl)
     extends
-      ClassDenotationImpl(symbol, ownerIfExists, name, initFlags, initInfo, initPrivateWithin),
+      ClassDenotationImpl(_symbol, _maybeOwner, name, initFlags, initInfo, initPrivateWithin),
       PackageClassDenotation
 
   @sharable object NoDenotation
-  extends SymDenotation(NoSymbol, NoSymbol, "<none>".toTermName, Permanent, NoType) {
+  extends SymDenotation(NoSymbol.toSymbolImpl, NoSymbol.toSymbolImpl, "<none>".toTermName, Permanent, NoType) {
     override def isType: Boolean = false
     override def isTerm: Boolean = false
     override def exists: Boolean = false
@@ -2434,9 +2436,9 @@ object SymDenotations {
     initPrivateWithin: Symbol = NoSymbol)(using Context): SymDenotation = {
     val result =
       if (symbol.isClass)
-        if (initFlags.is(Package)) new PackageClassDenotationImpl(symbol, owner, name, initFlags, initInfo, initPrivateWithin)
-        else new ClassDenotationImpl(symbol, owner, name, initFlags, initInfo, initPrivateWithin)
-      else new SymDenotation(symbol, owner, name, initFlags, initInfo, initPrivateWithin)
+        if (initFlags.is(Package)) new PackageClassDenotationImpl(symbol.toSymbolImpl, owner.toSymbolImpl, name, initFlags, initInfo, initPrivateWithin.toSymbolImpl)
+        else new ClassDenotationImpl(symbol.toSymbolImpl, owner.toSymbolImpl, name, initFlags, initInfo, initPrivateWithin.toSymbolImpl)
+      else new SymDenotation(symbol.toSymbolImpl, owner.toSymbolImpl, name, initFlags, initInfo, initPrivateWithin.toSymbolImpl)
     result.validFor = currentStablePeriod
     result
   }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -34,7 +34,7 @@ object SymDenotations {
    */
   class SymDenotation private[core] (
     _symbol: SymbolImpl,
-    final val _maybeOwner: SymbolImpl,
+    _maybeOwner: SymbolImpl,
     final val name: Name,
     initFlags: FlagSet,
     initInfo: Type,
@@ -42,7 +42,9 @@ object SymDenotations {
 
     //assert(symbol.id != 4940, name)
 
-    final val maybeOwner: Symbol = _maybeOwner.fromSymbolImpl
+    val maybeOwner: Symbol =
+      if _maybeOwner == null then this.asInstanceOf[Symbol]
+      else _maybeOwner.fromSymbolImpl
 
     override def hasUniqueSym: Boolean = exists
 
@@ -1471,7 +1473,8 @@ object SymDenotations {
       else if myFlags.is(Method) then "method"
       else                            "val"
 
-    override def toString: String = s"$kindString $name"
+    def denotString: String = s"$kindString $name"
+    override def toString: String = denotString
 
     // ----- Sanity checks and debugging */
 
@@ -2393,25 +2396,7 @@ object SymDenotations {
       ClassDenotationImpl(_symbol, _maybeOwner, name, initFlags, initInfo, initPrivateWithin),
       PackageClassDenotation
 
-  @sharable object NoDenotation
-  extends SymDenotation(NoSymbol.toSymbolImpl, NoSymbol.toSymbolImpl, "<none>".toTermName, Permanent, NoType) {
-    override def isType: Boolean = false
-    override def isTerm: Boolean = false
-    override def exists: Boolean = false
-    override def owner: Symbol = throw new AssertionError("NoDenotation.owner")
-    override def computeAsSeenFrom(pre: Type)(using Context): SingleDenotation = this
-    override def mapInfo(f: Type => Type)(using Context): SingleDenotation = this
-
-    override def matches(other: SingleDenotation)(using Context): Boolean = false
-    override def targetName(using Context): Name = EmptyTermName
-    override def mapInherited(ownDenots: PreDenotation, prevDenots: PreDenotation, pre: Type)(using Context): SingleDenotation = this
-    override def filterWithPredicate(p: SingleDenotation => Boolean): SingleDenotation = this
-    override def filterDisjoint(denots: PreDenotation)(using Context): SingleDenotation = this
-    override def filterWithFlags(required: FlagSet, excluded: FlagSet)(using Context): SingleDenotation = this
-
-    NoSymbol.denot = this
-    validFor = Period.allInRun(NoRunId)
-  }
+  @sharable val NoDenotation: SymDenotation = NoSymbol.toSymbolImpl
 
   /** Can a private symbol with given name and flags be inferred to be local,
    *  if all references to such symbols are via `this`?

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -568,11 +568,11 @@ object Symbols {
     override protected def prefixString: String = "ClassSymbol"
   }
 
-  @sharable object NoSymbol extends Symbol(NoCoord, 0) {
+  @sharable
+  val NoSymbol: Symbol = new Symbol(NoCoord, 0) {
     override def associatedFile(using Context): AbstractFile = NoSource.file
     override def recomputeDenot(lastd: SymDenotation)(using Context): SymDenotation = NoDenotation
   }
-
   NoDenotation // force it in order to set `denot` field of NoSymbol
 
   extension [N <: Name](sym: Symbol { type ThisName = N })(using Context) {

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -36,7 +36,7 @@ import scala.annotation.internal.sharable
 import config.Printers.typr
 import annotation.targetName
 
-object Symbols {
+object Symbols:
 
   opaque type Symbol >: Null <: SymbolDecl = SymbolImpl
   opaque type ClassSymbol >: Null <: Symbol & ClassSymbolDecl = ClassSymbolImpl
@@ -102,19 +102,14 @@ object Symbols {
     def asTerm(using Context): TermSymbol
     def asType(using Context): TypeSymbol
 
-    @targetName("Symbol_isClass")
     def isClass: Boolean
-
-    @targetName("Symbol_asClass")
     def asClass: ClassSymbol
 
     def isPrivate(using Context): Boolean
     def isPatternBound(using Context): Boolean
 
-    @targetName("Symbol_isStatic")
     def isStatic(using Context): Boolean
 
-    @targetName("Symbol_name")
     def name(using Context): ThisName
     def signature(using Context): Signature
 
@@ -305,10 +300,8 @@ object Symbols {
       asInstanceOf[TypeSymbol]
     }
 
-    @targetName("Symbol_isClass")
     final def isClass: Boolean = isInstanceOf[ClassSymbol]
 
-    @targetName("Symbol_asClass")
     final def asClass: ClassSymbol = asInstanceOf[ClassSymbol]
 
     /** Test whether symbol is private. This
@@ -333,7 +326,6 @@ object Symbols {
         Signature.NotAMethod
 
     /** Special cased here, because it may be used on naked symbols in substituters */
-    @targetName("Symbol_isStatic")
     final def isStatic(using Context): Boolean =
       lastDenot != null && lastDenot.initial.isStatic
 
@@ -390,7 +382,6 @@ object Symbols {
     def filter(p: Symbol => Boolean): Symbol = if (p(this)) this else NoSymbol
 
     /** The current name of this symbol */
-    @targetName("Symbol_name")
     final def name(using Context): ThisName = denot.name.asInstanceOf[ThisName]
 
     /** The source or class file from which this class or
@@ -1048,4 +1039,4 @@ object Symbols {
   }
 
   def requiredMethodRef(path: PreName)(using Context): TermRef = requiredMethod(path).termRef
-}
+end Symbols

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -90,17 +90,27 @@ object Symbols {
     @targetName("invalidSymbol")
     def symbol(implicit ev: DontUseSymbolOnSymbol): Nothing
 
+    @targetName("Symbol_isTerm")
     def isTerm(using Context): Boolean
+
+    @targetName("Symbol_isType")
     def isType(using Context): Boolean
     def asTerm(using Context): TermSymbol
     def asType(using Context): TypeSymbol
+
+    @targetName("Symbol_isClass")
     def isClass: Boolean
+
+    @targetName("Symbol_asClass")
     def asClass: ClassSymbol
 
     def isPrivate(using Context): Boolean
     def isPatternBound(using Context): Boolean
+
+    @targetName("Symbol_isStatic")
     def isStatic(using Context): Boolean
 
+    @targetName("Symbol_name")
     def name(using Context): ThisName
     def signature(using Context): Signature
 
@@ -274,10 +284,14 @@ object Symbols {
         // periods check out OK. But once a package member is overridden it is not longer
         // valid. If the option would be removed, the check would be no longer needed.
 
+    @targetName("Symbol_isTerm")
     final def isTerm(using Context): Boolean =
       (if (defRunId == ctx.runId) lastDenot else denot).isTerm
+
+    @targetName("Symbol_isType")
     final def isType(using Context): Boolean =
       (if (defRunId == ctx.runId) lastDenot else denot).isType
+
     final def asTerm(using Context): TermSymbol = {
       assert(isTerm, s"asTerm called on not-a-Term $this" );
       asInstanceOf[TermSymbol]
@@ -287,7 +301,10 @@ object Symbols {
       asInstanceOf[TypeSymbol]
     }
 
+    @targetName("Symbol_isClass")
     final def isClass: Boolean = isInstanceOf[ClassSymbol]
+
+    @targetName("Symbol_asClass")
     final def asClass: ClassSymbol = asInstanceOf[ClassSymbol]
 
     /** Test whether symbol is private. This
@@ -312,6 +329,7 @@ object Symbols {
         Signature.NotAMethod
 
     /** Special cased here, because it may be used on naked symbols in substituters */
+    @targetName("Symbol_isStatic")
     final def isStatic(using Context): Boolean =
       lastDenot != null && lastDenot.initial.isStatic
 
@@ -368,6 +386,7 @@ object Symbols {
     def filter(p: Symbol => Boolean): Symbol = if (p(this)) this else NoSymbol
 
     /** The current name of this symbol */
+    @targetName("Symbol_name")
     final def name(using Context): ThisName = denot.name.asInstanceOf[ThisName]
 
     /** The source or class file from which this class or

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -333,7 +333,7 @@ object Symbols {
       if ctx.phaseId != phase.next.id then
         atPhase(phase.next)(enteredAfter(phase))
       else this.owner match {
-        case owner: ClassSymbol =>
+        case owner: ClassSymbol @unchecked =>
           if (owner.is(Package)) {
             denot.validFor |= InitialPeriod
             if (this.is(Module)) this.moduleClass.validFor |= InitialPeriod
@@ -405,7 +405,7 @@ object Symbols {
             valid(denot.owner.source) match {
               case NoSource =>
                 this match {
-                  case cls: ClassSymbol      => valid(cls.sourceOfClass)
+                  case cls: ClassSymbol @unchecked => valid(cls.sourceOfClass)
                   case _ if denot.is(Module) => valid(denot.moduleClass.source)
                   case _ => NoSource
                 }
@@ -419,7 +419,7 @@ object Symbols {
      *
      *  @see enclosingSourceSymbols
      */
-    final def sourceSymbol(using Context): Symbol =
+    final def sourceSymbol(using Context): SymbolImpl =
       if (!denot.exists)
         this
       else if (denot.is(ModuleVal))
@@ -948,7 +948,7 @@ object Symbols {
    */
   object TermSymbols:
     def unapply(xs: List[Symbol])(using Context): Option[List[TermSymbol]] = xs match
-      case (x: Symbol) :: _ if x.isType => None
+      case (x: Symbol @unchecked) :: _ if x.isType => None
       case _ => Some(xs.asInstanceOf[List[TermSymbol]])
 
   /** Matches lists of type symbols, excluding the empty list.
@@ -956,7 +956,7 @@ object Symbols {
    */
   object TypeSymbols:
     def unapply(xs: List[Symbol])(using Context): Option[List[TypeSymbol]] = xs match
-      case (x: Symbol) :: _ if x.isType => Some(xs.asInstanceOf[List[TypeSymbol]])
+      case (x: Symbol @unchecked) :: _ if x.isType => Some(xs.asInstanceOf[List[TypeSymbol]])
       case _ => None
 
 // ----- Locating predefined symbols ----------------------------------------
@@ -971,7 +971,7 @@ object Symbols {
   def requiredClass(path: PreName)(using Context): ClassSymbol = {
     val name = path.toTypeName
     staticRef(name).requiredSymbol("class", name)(_.isClass) match {
-      case cls: ClassSymbol => cls
+      case cls: ClassSymbol @unchecked => cls
       case sym => defn.AnyClass
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -115,7 +115,7 @@ object Symbols:
 
     def isStatic(using Context): Boolean
 
-    def name(using Context): ThisName
+    def symName(using Context): ThisName
     def signature(using Context): Signature
 
     def span: Span
@@ -387,7 +387,7 @@ object Symbols:
     def filter(p: Symbol => Boolean): Symbol = if (p(this.fromSymbolImpl)) this.fromSymbolImpl else NoSymbol
 
     /** The current name of this symbol */
-    final def name(using Context): ThisName = denot.name.asInstanceOf[ThisName]
+    final def symName(using Context): ThisName = denot.name.asInstanceOf[ThisName]
 
     /** The source or class file from which this class or
      *  the class containing this symbol was generated, null if not applicable.
@@ -471,7 +471,7 @@ object Symbols:
 
     // ParamInfo types and methods
     def isTypeParam(using Context): Boolean = denot.is(TypeParam)
-    def paramName(using Context): ThisName = name.asInstanceOf[ThisName]
+    def paramName(using Context): ThisName = symName
     def paramInfo(using Context): Type = denot.info
     def paramInfoAsSeenFrom(pre: Type)(using Context): Type = pre.memberInfo(this.fromSymbolImpl)
     def paramInfoOrCompleter(using Context): Type = denot.infoOrCompleter
@@ -607,7 +607,7 @@ object Symbols:
      */
     def copy(
         owner: Symbol = sym.owner,
-        name: N = sym.name,
+        name: N = sym.symName,
         flags: FlagSet = sym.flags,
         info: Type = sym.info,
         privateWithin: Symbol = sym.privateWithin,

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -506,21 +506,6 @@ object Symbols {
   def MutableSymbolMap[T](): EqHashMap[Symbol, T] = EqHashMap[Symbol, T]()
   def MutableSymbolMap[T](initialCapacity: Int): EqHashMap[Symbol, T] = EqHashMap[Symbol, T](initialCapacity)
 
-// ---- Factory methods for symbol creation ----------------------
-//
-// All symbol creations should be done via the next two methods.
-
-  /** Create a symbol without a denotation.
-   *  Note this uses a cast instead of a direct type refinement because
-   *  it's debug-friendlier not to create an anonymous class here.
-   */
-  def newNakedSymbol[N <: Name](coord: Coord = NoCoord)(using Context): Symbol { type ThisName = N } =
-    new Symbol(coord, ctx.base.nextSymId).asInstanceOf[Symbol { type ThisName = N }]
-
-  /** Create a class symbol without a denotation. */
-  def newNakedClassSymbol(coord: Coord = NoCoord, assocFile: AbstractFile = null)(using Context): ClassSymbol =
-    new ClassSymbol(coord, assocFile, ctx.base.nextSymId)
-
 // ---- Symbol creation methods ----------------------------------
 
   /** Create a symbol from its fields (info may be lazy) */
@@ -531,18 +516,10 @@ object Symbols {
       info: Type,
       privateWithin: Symbol = NoSymbol,
       coord: Coord = NoCoord)(using Context): Symbol { type ThisName = N } = {
-    val sym = newNakedSymbol[N](coord)
+    val sym = new Symbol(coord, ctx.base.nextSymId).asInstanceOf[Symbol { type ThisName = N }]
     val denot = SymDenotation(sym, owner, name, flags, info, privateWithin)
     sym.denot = denot
     sym
-  }
-
-  /** Create a class symbol from a function producing its denotation */
-  def newClassSymbolDenoting(denotFn: ClassSymbol => SymDenotation,
-       coord: Coord = NoCoord, assocFile: AbstractFile = null)(using Context): ClassSymbol = {
-    val cls = newNakedClassSymbol(coord, assocFile)
-    cls.denot = denotFn(cls)
-    cls
   }
 
   /** Create a class symbol from its non-info fields and a function
@@ -557,7 +534,7 @@ object Symbols {
       coord: Coord = NoCoord,
       assocFile: AbstractFile = null)(using Context): ClassSymbol
   = {
-    val cls = newNakedClassSymbol(coord, assocFile)
+    val cls = new ClassSymbol(coord, assocFile, ctx.base.nextSymId)
     val denot = SymDenotation(cls, owner, name, flags, infoFn(cls), privateWithin)
     cls.denot = denot
     cls
@@ -620,19 +597,15 @@ object Symbols {
       assocFile: AbstractFile = null)(using Context): TermSymbol
   = {
     val base = owner.thisType
-    val module = newNakedSymbol[TermName](coord)
-    val modcls = newNakedClassSymbol(coord, assocFile)
     val modclsFlags = clsFlags | ModuleClassCreationFlags
     val modclsName = name.toTypeName.adjustIfModuleClass(modclsFlags)
-    val cdenot = SymDenotation(
-        modcls, owner, modclsName, modclsFlags,
-        infoFn(module, modcls), privateWithin)
-    val mdenot = SymDenotation(
-        module, owner, name, modFlags | ModuleValCreationFlags,
-        if (cdenot.isCompleted) TypeRef(owner.thisType, modcls)
-        else new ModuleCompleter(modcls))
-    module.denot = mdenot
-    modcls.denot = cdenot
+    val module = newSymbol(
+      owner, name, modFlags | ModuleValCreationFlags, NoCompleter, privateWithin, coord)
+    val modcls = newClassSymbol(
+      owner, modclsName, modclsFlags, infoFn(module, _), privateWithin, coord, assocFile)
+    module.info =
+      if (modcls.isCompleted) TypeRef(owner.thisType, modcls)
+      else new ModuleCompleter(modcls)
     module
   }
 
@@ -802,12 +775,13 @@ object Symbols {
       originals
     else {
       val copies: List[Symbol] = for (original <- originals) yield
-        original match {
-          case original: ClassSymbol =>
-            newNakedClassSymbol(original.coord, original.assocFile)
-          case _ =>
-            newNakedSymbol[original.ThisName](original.coord)
-        }
+        val odenot = original.denot
+        original.copy(
+          owner = ttmap.mapOwner(odenot.owner),
+          flags = odenot.flags &~ Touched,
+          info = NoCompleter,
+          privateWithin = ttmap.mapOwner(odenot.privateWithin),
+          coord = original.coord)
       val ttmap1 = ttmap.withSubstitution(originals, copies)
       originals.lazyZip(copies) foreach { (original, copy) =>
         val odenot = original.denot
@@ -844,13 +818,7 @@ object Symbols {
 
         end completer
 
-        copy.denot = odenot.copySymDenotation(
-          symbol = copy,
-          owner = ttmap1.mapOwner(odenot.owner),
-          initFlags = odenot.flags &~ Touched,
-          info = completer,
-          privateWithin = ttmap1.mapOwner(odenot.privateWithin), // since this refers to outer symbols, need not include copies (from->to) in ownermap here.
-          annotations = odenot.annotations)
+        copy.info = completer
         copy.denot match
           case cd: ClassDenotation =>
             cd.registeredCompanion = cd.unforcedRegisteredCompanion.subst(originals, copies)

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -45,6 +45,9 @@ object Symbols {
   type TermSymbol = Symbol { type ThisName = TermName }
   type TypeSymbol = Symbol { type ThisName = TypeName }
 
+  extension (sym: Symbol) def toSymbolImpl: SymbolImpl = sym
+  extension (sym: SymbolImpl) def fromSymbolImpl: Symbol = sym
+
   implicit def eqSymbol: CanEqual[Symbol, Symbol] = CanEqual.derived
 
   /** Tree attachment containing the identifiers in a tree as a sorted array */

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -211,8 +211,8 @@ class TypeApplications(val self: Type) extends AnyVal {
 
   /** If `self` is a generic class, its type parameter symbols, otherwise Nil */
   final def typeParamSymbols(using Context): List[TypeSymbol] = typeParams match {
-    case tparams @ (_: Symbol) :: _ =>
-      assert(tparams.forall(_.isInstanceOf[Symbol]))
+    case tparams @ (_: Symbol @unchecked) :: _ =>
+      assert(tparams.forall(_.isInstanceOf[Symbol @unchecked]))
       tparams.asInstanceOf[List[TypeSymbol]]
         // Note: Two successive calls to typeParams can yield different results here because
         // of different completion status. I.e. the first call might produce some symbols,

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1433,7 +1433,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
          *  paths is less intrusive than skolemization.
          */
         def compareCaptured(arg1: TypeBounds, arg2: Type) = tparam match {
-          case tparam: Symbol =>
+          case tparam: Symbol @unchecked =>
             if (leftRoot.isStable || (ctx.isAfterTyper || ctx.mode.is(Mode.TypevarsMissContext))
                 && leftRoot.member(tparam.name).exists) {
               val captured = TypeRef(leftRoot, tparam)
@@ -1458,7 +1458,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
             val arg1norm = arg1 match {
               case arg1: TypeBounds =>
                 tparam match {
-                  case tparam: Symbol => arg1 & paramBounds(tparam)
+                  case tparam: Symbol @unchecked => arg1 & paramBounds(tparam)
                   case _ => arg1 // This case can only arise when a hk-type is illegally instantiated with a wildcard
                 }
               case _ => arg1

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -757,7 +757,7 @@ object Types {
         }
         else
           val joint = pdenot.meet(
-            new JointRefDenotation(NoSymbol, rinfo, Period.allInRun(ctx.runId), pre),
+            new JointRefDenotation(NoSymbol.toSymbolImpl, rinfo, Period.allInRun(ctx.runId), pre),
             pre,
             safeIntersection = ctx.base.pendingMemberSearches.contains(name))
           joint match
@@ -814,7 +814,7 @@ object Types {
       def goSuper(tp: SuperType) = go(tp.underlying) match {
         case d: JointRefDenotation =>
           typr.println(i"redirecting super.$name from $tp to ${d.symbol.showLocated}")
-          new UniqueRefDenotation(d.symbol, tp.memberInfo(d.symbol), d.validFor, pre)
+          new UniqueRefDenotation(d.symbol.toSymbolImpl, tp.memberInfo(d.symbol), d.validFor, pre)
         case d => d
       }
 
@@ -4684,7 +4684,7 @@ object Types {
         // also other information about the named type (e.g. bounds).
         contains(
           TypeRef(tp.prefix, cls)
-            .withDenot(new UniqueRefDenotation(cls, tp, cls.validFor, tp.prefix)))
+            .withDenot(new UniqueRefDenotation(cls.toSymbolImpl, tp, cls.validFor, tp.prefix)))
       case _ =>
         lo <:< tp && tp <:< hi
     }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2029,7 +2029,7 @@ object Types {
 
     private def computeName: Name = designator match {
       case name: Name => name
-      case sym: Symbol => sym.originDenotation.name
+      case sym: Symbol @unchecked => sym.originDenotation.name
     }
 
     /** The signature computed from the last known denotation with `sigFromDenot`,
@@ -2073,7 +2073,7 @@ object Types {
 
     private def computeSymbol(using Context): Symbol =
       designator match {
-        case sym: Symbol =>
+        case sym: Symbol @unchecked =>
           if (sym.isValidInCurrentRun) sym else denot.symbol
         case name =>
           (if (denotationIsCurrent) lastDenotation else denot).symbol
@@ -2095,7 +2095,7 @@ object Types {
      *  Normally, it's better to use `symbol`, not `currentSymbol`.
      */
     final def currentSymbol(using Context): Symbol = designator match {
-      case sym: Symbol => sym
+      case sym: Symbol @unchecked => sym
       case _ => if (denotationIsCurrent) lastDenotation.symbol else NoSymbol
     }
 
@@ -2141,7 +2141,7 @@ object Types {
           val sym = lastSymbol
           val allowPrivate = sym == null || (sym == NoSymbol) || sym.lastKnownDenotation.flagsUNSAFE.is(Private)
           finish(memberDenot(name, allowPrivate))
-        case sym: Symbol =>
+        case sym: Symbol @unchecked =>
           val symd = sym.lastKnownDenotation
           if (symd.validFor.runId != ctx.runId && !stillValid(symd))
             finish(memberDenot(symd.initial.name, allowPrivate = false))
@@ -2252,7 +2252,7 @@ object Types {
       lastSymbol = denot.symbol
       checkedPeriod = if (prefix.isProvisional) Nowhere else ctx.period
       designator match {
-        case sym: Symbol if designator ne lastSymbol =>
+        case sym: Symbol @unchecked if designator ne lastSymbol =>
           designator = lastSymbol.asInstanceOf[Designator{ type ThisName = self.ThisName }]
         case _ =>
       }
@@ -2302,7 +2302,7 @@ object Types {
 
     /** Is this a reference to a class or object member? */
     def isMemberRef(using Context): Boolean = designator match {
-      case sym: Symbol => infoDependsOnPrefix(sym, prefix)
+      case sym: Symbol @unchecked => infoDependsOnPrefix(sym, prefix)
       case _ => true
     }
 
@@ -2462,7 +2462,7 @@ object Types {
         val adapted = withSym(denot.symbol)
         val result =
           if (adapted.eq(this)
-              || designator.isInstanceOf[Symbol]
+              || designator.isInstanceOf[Symbol @unchecked]
               || !adapted.denotationIsCurrent
               || adapted.info.eq(denot.info))
             adapted
@@ -2488,7 +2488,7 @@ object Types {
       if (prefix eq this.prefix) this
       else if (lastDenotation == null) NamedType(prefix, designator)
       else designator match {
-        case sym: Symbol =>
+        case sym: Symbol @unchecked =>
           if (infoDependsOnPrefix(sym, prefix) && !prefix.isArgPrefixOf(sym)) {
             val candidate = reload()
             val falseOverride = sym.isClass && candidate.symbol.exists && candidate.symbol != symbol
@@ -2615,12 +2615,12 @@ object Types {
   }
 
   final class CachedTermRef(prefix: Type, designator: Designator, hc: Int) extends TermRef(prefix, designator) {
-    assert((prefix ne NoPrefix) || designator.isInstanceOf[Symbol])
+    assert((prefix ne NoPrefix) || designator.isInstanceOf[Symbol @unchecked])
     myHash = hc
   }
 
   final class CachedTypeRef(prefix: Type, designator: Designator, hc: Int) extends TypeRef(prefix, designator) {
-    assert((prefix ne NoPrefix) || designator.isInstanceOf[Symbol])
+    assert((prefix ne NoPrefix) || designator.isInstanceOf[Symbol @unchecked])
     myHash = hc
   }
 
@@ -2647,7 +2647,7 @@ object Types {
 
   object NamedType {
     def isType(desig: Designator)(using Context): Boolean = desig match {
-      case sym: Symbol => sym.isType
+      case sym: Symbol @unchecked => sym.isType
       case name: Name => name.isTypeName
     }
     def apply(prefix: Type, designator: Designator)(using Context): NamedType =
@@ -2693,7 +2693,7 @@ object Types {
    */
   abstract case class ThisType(tref: TypeRef) extends CachedProxyType with SingletonType {
     def cls(using Context): ClassSymbol = tref.stableInRunSymbol match {
-      case cls: ClassSymbol => cls
+      case cls: ClassSymbol @unchecked => cls
       case _ if ctx.mode.is(Mode.Interactive) => defn.AnyClass // was observed to happen in IDE mode
     }
 
@@ -3843,7 +3843,7 @@ object Types {
         else
           super.fromParams(params, tp)
       def isOpaqueAlias = params match
-        case (param: Symbol) :: _ => param.owner.is(Opaque)
+        case (param: Symbol @unchecked) :: _ => param.owner.is(Opaque)
         case _ => false
       bounds match {
         case bounds: MatchAlias =>
@@ -4607,7 +4607,7 @@ object Types {
             case self: Type =>
               cinfo.derivedClassInfo(
                 selfInfo = refineSelfType(self.orElse(defn.AnyType)))
-            case self: Symbol =>
+            case self: Symbol @unchecked =>
               self.info = refineSelfType(self.info)
               cinfo
         else cinfo

--- a/compiler/src/dotty/tools/dotc/core/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/core/Variances.scala
@@ -141,7 +141,7 @@ object Variances {
    */
   def variancesConform(tparams1: List[TypeParamInfo], tparams2: List[TypeParamInfo])(using Context): Boolean =
     val needsDetailedCheck = tparams2 match
-      case (_: Symbol) :: _ => true
+      case (_: Symbol @unchecked) :: _ => true
       case LambdaParam(tl: HKTypeLambda, _) :: _ => tl.isDeclaredVarianceLambda
       case _ => false
     if needsDetailedCheck then tparams1.corresponds(tparams2)(varianceConforms)

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -1214,7 +1214,7 @@ class ClassfileParser(
       }
       else c = value match {
           case tp: Type => tp
-          case cls: Symbol => cls.typeRef
+          case cls: Symbol @unchecked => cls.typeRef
       }
       c
     }
@@ -1252,7 +1252,7 @@ class ClassfileParser(
       }
       value match {
         case ct: Constant  => ct
-        case cls: Symbol   => Constant(cls.typeRef)
+        case cls: Symbol @unchecked   => Constant(cls.typeRef)
         case arr: Type     => Constant(arr)
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -223,7 +223,7 @@ class TreePickler(pickler: TastyPickler) {
         case name: Name =>
           writeByte(if (tpe.isType) TYPEREF else TERMREF)
           pickleName(name); pickleType(tpe.prefix)
-        case sym: Symbol =>
+        case sym: Symbol @unchecked =>
           if (isLocallyDefined(sym)) {
             writeByte(if (tpe.isType) TYPEREFsymbol else TERMREFsymbol)
             pickleSymRef(sym); pickleType(tpe.prefix)
@@ -583,7 +583,7 @@ class TreePickler(pickler: TastyPickler) {
                 if (!tree.self.isEmpty) registerTreeAddr(tree.self)
                 pickleType {
                   selfInfo match {
-                    case sym: Symbol => sym.info
+                    case sym: Symbol @unchecked => sym.info
                     case tp: Type => tp
                   }
                 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -586,7 +586,7 @@ class TreeUnpickler(reader: TastyReader,
       if sym.isOpaqueAlias then sym.setFlag(Deferred)
       val isScala2MacroDefinedInScala3 = flags.is(Macro, butNot = Inline) && flags.is(Erased)
       ctx.owner match {
-        case cls: ClassSymbol if !isScala2MacroDefinedInScala3 || cls == defn.StringContextClass  =>
+        case cls: ClassSymbol @unchecked if !isScala2MacroDefinedInScala3 || cls == defn.StringContextClass  =>
           // Enter all members of classes that are not Scala 2 macros.
           //
           // For `StringContext`, enter `s`, `f` and `raw`

--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
@@ -34,7 +34,7 @@ class ReadTasty extends Phase {
       }
 
       def compilationUnit(cls: Symbol): Option[CompilationUnit] = cls match {
-        case cls: ClassSymbol =>
+        case cls: ClassSymbol @unchecked =>
           (cls.rootTreeOrProvider: @unchecked) match {
             case unpickler: tasty.DottyUnpickler =>
               if (cls.rootTree.isEmpty) None

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -183,7 +183,7 @@ object Completion {
       if (ctx.owner.isClass) {
         addAccessibleMembers(ctx.owner.thisType)
         ctx.owner.asClass.classInfo.selfInfo match {
-          case selfSym: Symbol => add(selfSym, selfSym.name)
+          case selfSym: Symbol @unchecked => add(selfSym, selfSym.name)
           case _ =>
         }
       }

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -92,7 +92,7 @@ object Formatting {
     def isSensical(arg: Any): Boolean = arg match {
       case tpe: Type =>
         tpe.exists && !tpe.isErroneous
-      case sym: Symbol if sym.isCompleted =>
+      case sym: Symbol @unchecked if sym.isCompleted =>
         sym.info match {
           case _: ErrorType | TypeAlias(_: ErrorType) | NoType => false
           case _ => true
@@ -118,7 +118,7 @@ object Formatting {
        *  and scala.collection.immutable.List as two different types
        */
       def followAlias(e1: Recorded): Recorded = e1 match {
-        case e1: Symbol if e1.isAliasType =>
+        case e1: Symbol @unchecked if e1.isAliasType =>
           val underlying = e1.typeRef.underlyingClassRef(refinementOK = false).typeSymbol
           if (underlying.name == e1.name) underlying else e1
         case _ => e1
@@ -202,7 +202,7 @@ object Formatting {
         s"is a type variable${addendum("constraint", TypeComparer.bounds(param))}"
       case param: TermParamRef =>
         s"is a reference to a value parameter"
-      case sym: Symbol =>
+      case sym: Symbol @unchecked =>
         val info =
           if (ctx.gadt.contains(sym))
             sym.info & ctx.gadt.fullBounds(sym)
@@ -224,7 +224,7 @@ object Formatting {
       case param: TypeParamRef => ctx.typerState.constraint.contains(param)
       case param: ParamRef     => false
       case skolem: SkolemType => true
-      case sym: Symbol =>
+      case sym: Symbol @unchecked =>
         ctx.gadt.contains(sym) && ctx.gadt.fullBounds(sym) != TypeBounds.empty
     }
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -388,7 +388,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
           if (tparams.isEmpty) Text() else ("[" ~ dclsText(tparams) ~ "]").close
         val selfText: Text = selfInfo match {
           case NoType => Text()
-          case sym: Symbol if !sym.isCompleted => "this: ? =>"
+          case sym: Symbol @unchecked if !sym.isCompleted => "this: ? =>"
           case _ => "this: " ~ atPrec(InfixPrec) { toText(tp.selfType) } ~ " =>"
         }
         val trueDecls = otherDecls.filterNot(treatAsTypeArg)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -736,7 +736,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 
   private def Modifiers(sym: Symbol): Modifiers = untpd.Modifiers(
     sym.flags & (if (sym.isType) ModifierFlags | VarianceFlags else ModifierFlags),
-    if (sym.privateWithin.exists) sym.privateWithin.asType.name else tpnme.EMPTY,
+    if (sym.privateWithin.exists) sym.privateWithin.name.asTypeName else tpnme.EMPTY,
     sym.annotations.filterNot(ann => dropAnnotForModText(ann.symbol)).map(_.tree))
 
   protected def dropAnnotForModText(sym: Symbol): Boolean = sym == defn.BodyAnnot

--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -106,7 +106,7 @@ abstract class AccessProxies {
       case getterRef: RefTree =>
         val getter = getterRef.symbol.asTerm
         val accessed = accessedBy(getter)
-        val setterName = getter.name.setterName
+        val setterName = getter.symName.setterName
         def toSetterInfo(getterInfo: Type): Type = getterInfo match {
           case getterInfo: LambdaType =>
             getterInfo.derivedLambdaType(resType = toSetterInfo(getterInfo.resType))
@@ -134,7 +134,7 @@ abstract class AccessProxies {
       if (accessorClass.exists) {
         if accessorClass.is(Package) then
           accessorClass = ctx.owner.topLevelClass
-        val accessorName = accessorNameKind(accessed.name)
+        val accessorName = accessorNameKind(accessed.symName)
         val accessorInfo =
           accessed.info.ensureMethodic.asSeenFrom(accessorClass.thisType, accessed.owner)
         val accessor = accessorSymbol(accessorClass, accessorName, accessorInfo, accessed)

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -225,7 +225,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
                 if sym.setter.exists then
                   sym.setter
                 else
-                  val setterName = sym.asTerm.name.setterName
+                  val setterName = sym.name.asTermName.setterName
                   sym.owner.info.decls.find(d => d.is(Accessor) && d.name == setterName)
               val setter =
                 if (symSetter.exists) symSetter

--- a/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
@@ -30,9 +30,9 @@ class ElimErasedValueType extends MiniPhase with InfoTransformer { thisPhase =>
   override def runsAfter: Set[String] = Set(Erasure.name)
 
   def transformInfo(tp: Type, sym: Symbol)(using Context): Type = sym match {
-    case sym: ClassSymbol if sym.is(ModuleClass) =>
+    case sym: ClassSymbol @unchecked if sym.is(ModuleClass) =>
       sym.companionClass match {
-        case origClass: ClassSymbol if isDerivedValueClass(origClass) =>
+        case origClass: ClassSymbol @unchecked if isDerivedValueClass(origClass) =>
           val cinfo = tp.asInstanceOf[ClassInfo]
           val decls1 = cinfo.decls.cloneScope
           // Remove synthetic cast methods introduced by ExtensionMethods,

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -112,7 +112,7 @@ class Erasure extends Phase with DenotTransformer {
       }
     case ref: JointRefDenotation =>
       new UniqueRefDenotation(
-        ref.symbol, transformInfo(ref.symbol, ref.symbol.info), ref.validFor, ref.prefix)
+        ref.symbol.toSymbolImpl, transformInfo(ref.symbol, ref.symbol.info), ref.validFor, ref.prefix)
     case _ =>
       ref.derivedSingleDenotation(ref.symbol, transformInfo(ref.symbol, ref.symbol.info))
   }

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -56,7 +56,7 @@ class ExpandSAMs extends MiniPhase:
           val tpe1 = checkRefinements(tpe, fn)
           val Seq(samDenot) = tpe1.possibleSamMethods
           cpy.Block(tree)(stats,
-              AnonClass(tpe1 :: Nil, fn.symbol.asTerm :: Nil, samDenot.symbol.asTerm.name :: Nil))
+              AnonClass(tpe1 :: Nil, fn.symbol.asTerm :: Nil, samDenot.symbol.name.asTermName :: Nil))
       }
     case _ =>
       tree

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -31,7 +31,7 @@ object ExpandSAMs:
 
   def needsWrapperClass(tpe: Type)(using Context): Boolean =
     tpe.classSymbol match
-      case cls: ClassSymbol => !isPlatformSam(cls) || cls == defn.PartialFunctionClass
+      case cls: ClassSymbol @unchecked => !isPlatformSam(cls) || cls == defn.PartialFunctionClass
       case _ => false
 
 class ExpandSAMs extends MiniPhase:

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -147,7 +147,7 @@ object ExplicitOuter {
     if (cls.is(Scala2x))
       encl.asClass.classInfo.selfInfo match {
         case tp: TypeRef => tp.classSymbol
-        case self: Symbol => self
+        case self: Symbol @unchecked => self
         case _ => encl
       }
     else encl
@@ -299,7 +299,7 @@ object ExplicitOuter {
   private def outerPrefix(tpe: Type)(using Context): Type = tpe match {
     case tpe: TypeRef =>
       tpe.symbol match {
-        case cls: ClassSymbol =>
+        case cls: ClassSymbol @unchecked =>
           if (tpe.prefix eq NoPrefix) cls.owner.enclosingClass.thisType
           else tpe.prefix
         case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -56,7 +56,7 @@ class ExtensionMethods extends MiniPhase with DenotTransformer with FullParamete
   override def transform(ref: SingleDenotation)(using Context): SingleDenotation = ref match {
     case moduleClassSym: ClassDenotation if moduleClassSym.is(ModuleClass) =>
       moduleClassSym.linkedClass match {
-        case valueClass: ClassSymbol if isDerivedValueClass(valueClass) =>
+        case valueClass: ClassSymbol @unchecked if isDerivedValueClass(valueClass) =>
           val cinfo = moduleClassSym.classInfo
           val decls1 = cinfo.decls.cloneScope
           val moduleSym = moduleClassSym.symbol.asClass
@@ -116,7 +116,7 @@ class ExtensionMethods extends MiniPhase with DenotTransformer with FullParamete
       ref.info match {
         case ClassInfo(pre, cls, _, _, _) if cls is ModuleClass =>
           cls.linkedClass match {
-            case valueClass: ClassSymbol if isDerivedValueClass(valueClass) =>
+            case valueClass: ClassSymbol @unchecked if isDerivedValueClass(valueClass) =>
               val info1 = atPhase(ctx.phase.next)(cls.denot).asClass.classInfo.derivedClassInfo(prefix = pre)
               ref.derivedSingleDenotation(ref.symbol, info1)
             case _ => ref

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -41,7 +41,7 @@ class FirstTransform extends MiniPhase with InfoTransformer { thisPhase =>
 
   /** eliminate self symbol in ClassInfo */
   override def transformInfo(tp: Type, sym: Symbol)(using Context): Type = tp match {
-    case tp @ ClassInfo(_, _, _, _, self: Symbol) =>
+    case tp @ ClassInfo(_, _, _, _, self: Symbol @unchecked) =>
       tp.derivedClassInfo(selfInfo = self.info)
     case _ =>
       tp

--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -97,7 +97,7 @@ trait FullParameterization {
       case _ => (0, info)
     }
     val ctparams = if (abstractOverClass) clazz.typeParams else Nil
-    val ctnames = ctparams.map(_.name)
+    val ctnames = ctparams.map(_.symName)
 
     /** The method result type */
     def resultType(mapClassParams: Type => Type) = {

--- a/compiler/src/dotty/tools/dotc/transform/Getters.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Getters.scala
@@ -96,7 +96,7 @@ class Getters extends MiniPhase with SymTransformer { thisPhase =>
   def ensureSetter(sym: TermSymbol)(using Context) =
     if !sym.setter.exists then
       newSetters += sym.copy(
-        name = sym.name.setterName,
+        name = sym.symName.setterName,
         info = MethodType(sym.info.widenExpr :: Nil, defn.UnitType)
       ).enteredAfter(thisPhase)
 

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -298,10 +298,10 @@ object LambdaLift {
 
     private def newName(sym: Symbol)(using Context): Name =
       if (sym.isAnonymousFunction && sym.owner.is(Method))
-        sym.name.replace {
+        sym.symName.replace {
           case name: SimpleName => ExpandPrefixName(sym.owner.name.asTermName, name)
         }.freshened
-      else sym.name.freshened
+      else sym.symName.freshened
 
     private def generateProxies()(using Context): Unit =
       for ((owner, freeValues) <- free.iterator) {

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -125,7 +125,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
     */
   def transformSyntheticModule(tree: ValOrDefDef)(using Context): Thicket = {
     val sym = tree.symbol
-    val holderSymbol = newSymbol(sym.owner, LazyLocalName.fresh(sym.asTerm.name),
+    val holderSymbol = newSymbol(sym.owner, LazyLocalName.fresh(sym.name.asTermName),
       Synthetic, sym.info.widen.resultType).enteredAfter(this)
     val field = ValDef(holderSymbol, tree.rhs.changeOwnerAfter(sym, holderSymbol, this))
     val getter = DefDef(sym.asTerm, ref(holderSymbol))

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -380,7 +380,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
     val thizClass = Literal(Constant(claz.info))
     val helperModule = requiredModule("scala.runtime.LazyVals")
     val getOffset = Select(ref(helperModule), lazyNme.RLazyVals.getOffset)
-    var offsetSymbol: TermSymbol = null
+    var offsetSymbol: Symbol = null
     var flag: Tree = EmptyTree
     var ord = 0
 
@@ -404,7 +404,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
           val flagName = LazyBitMapName.fresh(id.toString.toTermName)
           val flagSymbol = newSymbol(claz, flagName, containerFlags, defn.LongType).enteredAfter(this)
           flag = ValDef(flagSymbol, Literal(Constant(0L)))
-          val offsetTree = ValDef(offsetSymbol, getOffset.appliedTo(thizClass, Literal(Constant(flagName.toString))))
+          val offsetTree = ValDef(offsetSymbol.asTerm, getOffset.appliedTo(thizClass, Literal(Constant(flagName.toString))))
           info.defs = offsetTree :: info.defs
         }
 
@@ -414,7 +414,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
         val flagName = LazyBitMapName.fresh("0".toTermName)
         val flagSymbol = newSymbol(claz, flagName, containerFlags, defn.LongType).enteredAfter(this)
         flag = ValDef(flagSymbol, Literal(Constant(0L)))
-        val offsetTree = ValDef(offsetSymbol, getOffset.appliedTo(thizClass, Literal(Constant(flagName.toString))))
+        val offsetTree = ValDef(offsetSymbol.asTerm, getOffset.appliedTo(thizClass, Literal(Constant(flagName.toString))))
         appendOffsetDefs += (claz -> new OffsetInfo(List(offsetTree), ord))
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
@@ -21,7 +21,7 @@ class MixinOps(cls: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
   def mkForwarderSym(member: TermSymbol, extraFlags: FlagSet = EmptyFlags): TermSymbol = {
     val res = member.copy(
       owner = cls,
-      name = member.name.stripScala2LocalSuffix,
+      name = member.symName.stripScala2LocalSuffix,
       flags = member.flags &~ Deferred &~ Module | Synthetic | extraFlags,
       info = cls.thisType.memberInfo(member)).enteredAfter(thisPhase).asTerm
     res.addAnnotations(member.annotations.filter(_.symbol != defn.TailrecAnnot))

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -84,7 +84,7 @@ class NonLocalReturns extends MiniPhase {
 
   override def transformDefDef(tree: DefDef)(using Context): Tree =
     nonLocalReturnKeys.remove(tree.symbol) match
-      case key: TermSymbol => cpy.DefDef(tree)(rhs = nonLocalReturnTry(tree.rhs, key, tree.symbol))
+      case key: TermSymbol @unchecked => cpy.DefDef(tree)(rhs = nonLocalReturnTry(tree.rhs, key, tree.symbol))
       case null => tree
 
   override def transformReturn(tree: Return)(using Context): Tree =

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -285,7 +285,7 @@ object PCPCheckAndHeal {
         info = TypeAlias(splicedTree.tpe.select(tpnme.Underlying)),
         coord = span).asType
       local.addAnnotation(Annotation(defn.QuotedRuntime_SplicedTypeAnnot))
-      ctx.typeAssigner.assignType(untpd.TypeDef(local.name, alias), local)
+      ctx.typeAssigner.assignType(untpd.TypeDef(local.symName, alias), local)
     }
 
   }

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -59,7 +59,7 @@ class ParamForwarding extends MiniPhase with IdentityDenotTransformer:
       val alias = atPhase(thisPhase)(inheritedAccessor(sym))
       if alias.exists then
         sym.copySymDenotation(
-            name = ParamAccessorName(sym.name),
+            name = ParamAccessorName(sym.symName),
             initFlags = sym.flags | Method | StableRealizable,
             info = sym.info.ensureMethodic
           ).installAfter(thisPhase)

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -155,11 +155,11 @@ object SymUtils:
       self.info.decls.filter(_.is(CaseAccessor))
 
     def getter(using Context): Symbol =
-      if (self.isGetter) self else accessorNamed(self.asTerm.name.getterName)
+      if (self.isGetter) self else accessorNamed(self.name.asTermName.getterName)
 
     def setter(using Context): Symbol =
       if (self.isSetter) self
-      else accessorNamed(self.asTerm.name.setterName)
+      else accessorNamed(self.name.asTermName.setterName)
 
     def traitSetter(using Context): Symbol =
       if (self.name.is(TraitSetterName)) self

--- a/compiler/src/dotty/tools/dotc/transform/init/Env.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Env.scala
@@ -56,7 +56,7 @@ case class Env(ctx: Context) {
     }
 
   /** Cache for outer this */
-  private case class OuterKey(warm: Warm, cls: ClassSymbol)
+  private case class OuterKey(warm: Warm, cls: ClassSymbol @unchecked)
   private val outerCache: mutable.Map[OuterKey, Potentials] = mutable.Map.empty
   def resolveOuter(warm: Warm, cls: ClassSymbol)(implicit env: Env): Potentials =
     val key = OuterKey(warm, cls)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -364,7 +364,7 @@ class SpaceEngine(using Context) extends SpaceLogic {
   /** Return the space that represents the pattern `pat` */
   def project(pat: Tree): Space = pat match {
     case Literal(c) =>
-      if (c.value.isInstanceOf[Symbol])
+      if (c.value.isInstanceOf[Symbol @unchecked])
         Typ(c.value.asInstanceOf[Symbol].termRef, false)
       else
         Typ(ConstantType(c), false)

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
@@ -97,7 +97,7 @@ object JSSymUtils {
     def isJSDefaultParam(using Context): Boolean = {
       sym.name.is(DefaultGetterName) && {
         val owner = sym.owner
-        val methName = sym.name.exclude(DefaultGetterName)
+        val methName = sym.symName.exclude(DefaultGetterName)
         if (methName == nme.CONSTRUCTOR) {
           owner.linkedClass.isJSType
         } else {
@@ -125,7 +125,7 @@ object JSSymUtils {
     }
 
     def defaultJSName(using Context): String =
-      if (sym.isTerm) sym.asTerm.name.unexpandedName.getterName.toString()
+      if (sym.isTerm) sym.asTerm.symName.unexpandedName.getterName.toString()
       else sym.name.unexpandedName.stripModuleClassSuffix.toString()
   }
 }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -217,7 +217,7 @@ object Applications {
         }
       }
       val getterPrefix =
-        if (meth.is(Synthetic) && meth.name == nme.apply) nme.CONSTRUCTOR else meth.name
+        if (meth.is(Synthetic) && meth.name == nme.apply) nme.CONSTRUCTOR else meth.symName
       def getterName = DefaultGetterName(getterPrefix, n + numArgs(fn))
       if !meth.hasDefaultParams then
         EmptyTree

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -932,7 +932,7 @@ trait Checking {
 
     cls.info.decls.foreach(checkDecl)
     cls.info match {
-      case ClassInfo(_, _, _, _, selfSym: Symbol) => checkDecl(selfSym)
+      case ClassInfo(_, _, _, _, selfSym: Symbol @unchecked) => checkDecl(selfSym)
       case _ =>
     }
   }
@@ -1002,7 +1002,7 @@ trait Checking {
    */
   def checkTraitInheritance(parent: Symbol, cls: ClassSymbol, pos: SrcPos)(using Context): Unit =
     parent match {
-      case parent: ClassSymbol if parent.is(Trait) =>
+      case parent: ClassSymbol @unchecked if parent.is(Trait) =>
         val psuper = parent.superClass
         val csuper = cls.superClass
         val ok = csuper.derivesFrom(psuper) ||
@@ -1017,7 +1017,7 @@ trait Checking {
    */
   def checkCaseInheritance(parent: Symbol, caseCls: ClassSymbol, pos: SrcPos)(using Context): Unit =
     parent match {
-      case parent: ClassSymbol =>
+      case parent: ClassSymbol @unchecked =>
         if (parent.is(Case))
           report.error(ex"""case $caseCls has case ancestor $parent, but case-to-case inheritance is prohibited.
                         |To overcome this limitation, use extractors to pattern match on non-leaf nodes.""", pos)

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -196,7 +196,7 @@ object Inliner {
     val meth = mdef.symbol.asTerm
 
     val retainer = meth.copy(
-      name = BodyRetainerName(meth.name),
+      name = BodyRetainerName(meth.symName),
       flags = meth.flags &~ (Inline | Macro | Override) | Private,
       coord = mdef.rhs.span.startPos).asTerm
     retainer.deriveTargetNameAnnotation(meth, name => BodyRetainerName(name.asTermName))

--- a/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
@@ -156,7 +156,7 @@ object PrepareInlineable {
           val accessedType = refPart.tpe.widen
           val accessor = accessorSymbol(
             owner = inlineSym.owner,
-            accessorName = InlineAccessorName(UniqueInlineName.fresh(accessed.name)),
+            accessorName = InlineAccessorName(UniqueInlineName.fresh(accessed.symName)),
             accessorInfo = abstractQualType(addQualType(dealiasMap(accessedType))),
             accessed = accessed)
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1228,7 +1228,7 @@ class RefChecks extends MiniPhase { thisPhase =>
     checkUndesiredProperties(sym, tree.srcPos)
     currentLevel.enterReference(sym, tree.span)
     tpe.dealias.foreachPart {
-      case TermRef(_, s: Symbol) => currentLevel.enterReference(s, tree.span)
+      case TermRef(_, s: Symbol @unchecked) => currentLevel.enterReference(s, tree.span)
       case _ =>
     }
     tree

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -273,7 +273,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
 
       def solve(sym: Symbol): Type = sym match
-        case caseClass: ClassSymbol =>
+        case caseClass: ClassSymbol @unchecked =>
           assert(caseClass.is(Case))
           if caseClass.is(Module) then
             caseClass.sourceModule.termRef

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1788,7 +1788,7 @@ class Typer extends Namer
               (arg, WildcardType)
           if (tpt1.symbol.isClass)
             tparam match {
-              case tparam: Symbol =>
+              case tparam: Symbol @unchecked =>
                 tparam.ensureCompleted() // This is needed to get the test `compileParSetSubset` to work
               case _ =>
             }
@@ -3518,7 +3518,7 @@ class Typer extends Namer
       case tp: AnnotatedType => tp.derivedAnnotatedType(captureWildcards(tp.parent), tp.annot)
       case tp @ AppliedType(tycon, args) if tp.hasWildcardArg =>
         tycon.typeParams match {
-          case tparams @ ((_: Symbol) :: _) =>
+          case tparams @ ((_: Symbol @unchecked) :: _) =>
             val boundss = tparams.map(_.paramInfo.substApprox(tparams.asInstanceOf[List[TypeSymbol]], args))
             val args1 = args.zipWithConserve(boundss) { (arg, bounds) =>
               arg match {

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2544,7 +2544,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           }
 
         def isTypeParam: Boolean = self.isTypeParam
-        def signature: Signature = self.signature
+        def signature: Signature = self.denot.signature
         def moduleClass: Symbol = self.denot.moduleClass
         def companionClass: Symbol = self.denot.companionClass
         def companionModule: Symbol = self.denot.companionModule

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2476,7 +2476,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def exists: Boolean = self != Symbol.noSymbol
 
         def declaredField(name: String): Symbol =
-          val sym = self.unforcedDecls.find(sym => sym.name == name.toTermName)
+          val sym = self.unforcedDecls.find(sym => sym.symName == name.toTermName)
           if (isField(sym)) sym else dotc.core.Symbols.NoSymbol
 
         def declaredFields: List[Symbol] = self.unforcedDecls.filter(isField)
@@ -2522,7 +2522,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           }.toList
 
         def memberType(name: String): Symbol =
-          self.unforcedDecls.find(sym => sym.name == name.toTypeName)
+          self.unforcedDecls.find(sym => sym.symName == name.toTypeName)
 
         def memberTypes: List[Symbol] =
           self.unforcedDecls.filter(_.isType)

--- a/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
+++ b/doc-tool/src/dotty/tools/dottydoc/model/factories.scala
@@ -160,7 +160,7 @@ object factories {
     }
 
   def constructors(sym: Symbol)(using Context): List[List[ParamList]] = sym match {
-    case sym: ClassSymbol =>
+    case sym: ClassSymbol @unchecked =>
       paramLists(sym.primaryConstructor.info) :: Nil
     case _ => Nil
   }

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -359,7 +359,7 @@ class DottyLanguageServer extends LanguageServer
 
       perProjectInfo.flatMap { (remoteDriver, ctx, definitions) =>
         definitions.flatMap { definition =>
-          val name = definition.name(using ctx).sourceModuleName.toString
+          val name = definition.symName(using ctx).sourceModuleName.toString
           val trees = remoteDriver.sourceTreesContaining(name)(using ctx)
           val matches = Interactive.findTreesMatching(trees, includes, definition)(using ctx)
           matches.map(tree => location(tree.namePos(using ctx)))

--- a/staging/src/scala/quoted/staging/QuoteCompiler.scala
+++ b/staging/src/scala/quoted/staging/QuoteCompiler.scala
@@ -68,7 +68,11 @@ private class QuoteCompiler extends Compiler:
           val cls = newCompleteClassSymbol(defn.RootClass, outputClassName, EmptyFlags,
             defn.ObjectType :: Nil, newScope, coord = pos, assocFile = assocFile).entered.asClass
           cls.enter(newDefaultConstructor(cls), EmptyScope)
-          val meth = newSymbol(cls, nme.apply, Method, ExprType(defn.AnyType), coord = pos).entered
+          val meth = newSymbol(cls.asInstanceOf, nme.apply, Method, ExprType(defn.AnyType), coord = pos).entered
+            //TODO (dotty problem): we get an error for `cls` above without the `asInstanceOf`:
+            //  Found:    (cls : dotty.tools.dotc.core.Symbols.ClassSymbol)
+            //  Required: dotty.tools.dotc.core.Symbols.Symbol
+            //Figure out what'st he cause of this.
 
           val quoted =
             given Context = unitCtx.withOwner(meth)


### PR DESCRIPTION
These methods produce a partially initialized symbol, which is dangerous for any code
using them. It turns out that any delays in the symbol initialization we need can be
provided by the symbol's completer.