### PR TITLE
Fix BootstrappedOnlyCompilationTests error reporting

### DIFF
--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -13,20 +13,11 @@ import vulpix._
 import java.nio.file._
 
 @Category(Array(classOf[BootstrappedOnlyTests]))
-class BootstrappedOnlyCompilationTests extends ParallelTesting {
+class BootstrappedOnlyCompilationTests {
   import ParallelTesting._
   import TestConfiguration._
   import BootstrappedOnlyCompilationTests._
   import CompilationTest.aggregateTests
-
-  // Test suite configuration --------------------------------------------------
-
-  def maxDuration = 60.seconds
-  def numberOfSlaves = Runtime.getRuntime().availableProcessors()
-  def safeMode = Properties.testsSafeMode
-  def isInteractive = SummaryReport.isInteractive
-  def testFilter = Properties.testsFilter
-  def updateCheckFiles: Boolean = Properties.testsUpdateCheckfile
 
   // Positive tests ------------------------------------------------------------
 
@@ -211,7 +202,19 @@ class BootstrappedOnlyCompilationTests extends ParallelTesting {
   }
 }
 
-object BootstrappedOnlyCompilationTests {
+object BootstrappedOnlyCompilationTests extends ParallelTesting {
+  // Test suite configuration --------------------------------------------------
+
+  def maxDuration = 60.seconds
+  def numberOfSlaves = Runtime.getRuntime().availableProcessors()
+  def safeMode = Properties.testsSafeMode
+  def isInteractive = SummaryReport.isInteractive
+  def testFilter = Properties.testsFilter
+  def updateCheckFiles: Boolean = Properties.testsUpdateCheckfile
+
   implicit val summaryReport: SummaryReporting = new SummaryReport
-  @AfterClass def cleanup(): Unit = summaryReport.echoSummary()
+  @AfterClass def tearDown(): Unit = {
+    super.cleanup()
+    summaryReport.echoSummary()
+  }
 }


### PR DESCRIPTION
Now it lists the failed tests at the end.

Code ported from `CompilationTests.scala`. See https://github.com/lampepfl/dotty/commit/f9747071ecf432242a7ba5c4c8824737071261dd.