### PR TITLE
Rename scala.quoted.staging.{Toolbox => Compiler}

### DIFF
--- a/docs/docs/reference/metaprogramming/staging.md
+++ b/docs/docs/reference/metaprogramming/staging.md
@@ -60,8 +60,8 @@ The framework as discussed so far allows code to be staged, i.e. be prepared
 to be executed at a later stage. To run that code, there is another method
 in class `Expr` called `run`. Note that `$` and `run` both map from `Expr[T]`
 to `T` but only `$` is subject to the PCP, whereas `run` is just a normal method.
-`run` provides a `Quotes` that can be used to show the expression in its scope.
-On the other hand `withQuotes` provides a `Quotes` without evaluating the expression.
+`scala.quoted.staging.run` provides a `Quotes` that can be used to show the expression in its scope.
+On the other hand `scala.quoted.staging.withQuotes` provides a `Quotes` without evaluating the expression.
 
 ```scala
 package scala.quoted.staging
@@ -99,17 +99,17 @@ scala -with-compiler -classpath out Test
 Now take exactly the same example as in [Macros](./macros.md). Assume that we
 do not want to pass an array statically but generate code at run-time and pass
 the value, also at run-time. Note, how we make a future-stage function of type
-`Expr[Array[Int] => Int]` in line 6 below. Using `run { ... }` we can evaluate an
-expression at runtime. Within the scope of `run` we can also invoke `show` on an expression
+`Expr[Array[Int] => Int]` in line 6 below. Using `staging.run { ... }` we can evaluate an
+expression at runtime. Within the scope of `staging.run` we can also invoke `show` on an expression
 to get a source-like representation of the expression.
 
 ```scala
-import scala.quoted.staging._
+import scala.quoted._
 
 // make available the necessary compiler for runtime code generation
-given Compiler = Compiler.make(getClass.getClassLoader)
+given staging.Compiler = staging.Compiler.make(getClass.getClassLoader)
 
-val f: Array[Int] => Int = run {
+val f: Array[Int] => Int = staging.run {
    val stagedSum: Expr[Array[Int] => Int] =
       '{ (arr: Array[Int]) => ${sum('arr)}}
    println(stagedSum.show) // Prints "(arr: Array[Int]) => { var sum = 0; ... }"

--- a/docs/docs/reference/metaprogramming/staging.md
+++ b/docs/docs/reference/metaprogramming/staging.md
@@ -66,9 +66,9 @@ On the other hand `withQuotes` provides a `Quotes` without evaluating the expres
 ```scala
 package scala.quoted.staging
 
-def run[T](expr: Quotes ?=> Expr[T])(using toolbox: Toolbox): T = ...
+def run[T](expr: Quotes ?=> Expr[T])(using Compiler): T = ...
 
-def withQuotes[T](thunk: Quotes ?=> T)(using toolbox: Toolbox): T = ...
+def withQuotes[T](thunk: Quotes ?=> T)(using Compiler): T = ...
 ```
 
 ## Create a new Scala 3 project with staging enabled
@@ -106,8 +106,8 @@ to get a source-like representation of the expression.
 ```scala
 import scala.quoted.staging._
 
-// make available the necessary toolbox for runtime code generation
-given Toolbox = Toolbox.make(getClass.getClassLoader)
+// make available the necessary compiler for runtime code generation
+given Compiler = Compiler.make(getClass.getClassLoader)
 
 val f: Array[Int] => Int = run {
    val stagedSum: Expr[Array[Int] => Int] =

--- a/sbt-dotty/sbt-test/sbt-dotty/i7897/src/main/scala/hello/i7897.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/i7897/src/main/scala/hello/i7897.scala
@@ -1,6 +1,6 @@
 import scala.quoted._, staging._
 
-given Toolbox = Toolbox.make(getClass.getClassLoader)
+given Compiler = Compiler.make(getClass.getClassLoader)
 
 val f: Array[Int] => Int = run {
   val stagedSum: Expr[Array[Int] => Int] = '{ (arr: Array[Int]) => 6 }

--- a/sbt-dotty/sbt-test/sbt-dotty/quoted-example-project/src/main/scala/hello/Hello.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/quoted-example-project/src/main/scala/hello/Hello.scala
@@ -2,11 +2,11 @@ package hello
 
 // Import `Expr` and some extension methods
 import scala.quoted._
-import scala.quoted.staging.{run, Toolbox}
+import scala.quoted.staging.{run, Compiler}
 
 object Main {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
 

--- a/sbt-dotty/sbt-test/sbt-dotty/quoted-example-project/src/test/scala/hello/Tests.scala
+++ b/sbt-dotty/sbt-test/sbt-dotty/quoted-example-project/src/test/scala/hello/Tests.scala
@@ -4,10 +4,11 @@ import org.junit.Test
 
 // Import Expr and some extension methods
 import scala.quoted._
+import scala.quoted.staging._
 
 class Tests {
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   @Test def test(): Unit = {
     import hello.Main._

--- a/staging/src/scala/quoted/staging/Compiler.scala
+++ b/staging/src/scala/quoted/staging/Compiler.scala
@@ -5,26 +5,26 @@ import scala.annotation.implicitNotFound
 
 import scala.quoted.runtime.impl.ScopeException
 
-@implicitNotFound("Could not find implicit scala.quoted.staging.Toolbox.\n\nDefault toolbox can be instantiated with:\n  `given scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)`\n\n")
-trait Toolbox:
+@implicitNotFound("Could not find implicit scala.quoted.staging.Compiler.\n\nDefault compiler can be instantiated with:\n  `import scala.quoted.staging.Compiler; given Compiler = Compiler.make(getClass.getClassLoader)`\n\n")
+trait Compiler:
   def run[T](expr: Quotes => Expr[T]): T
 
-object Toolbox:
+object Compiler:
 
-  /** Create a new instance of the toolbox using the the classloader of the application.
+  /** Create a new instance of the compiler using the the classloader of the application.
    *
    * Usuage:
    * ```
    * import scala.quoted.staging._
-   * given Toolbox = Toolbox.make(getClass.getClassLoader)
+   * given Compiler = Compiler.make(getClass.getClassLoader)
    * ```
    *
    * @param appClassloader classloader of the application that generated the quotes
-   * @param settings toolbox settings
-   * @return A new instance of the toolbox
+   * @param settings compiler settings
+   * @return A new instance of the compiler
    */
-  def make(appClassloader: ClassLoader)(implicit settings: Settings): Toolbox =
-    new Toolbox:
+  def make(appClassloader: ClassLoader)(implicit settings: Settings): Compiler =
+    new Compiler:
 
       private[this] val driver: QuoteDriver = new QuoteDriver(appClassloader)
 
@@ -43,14 +43,14 @@ object Toolbox:
 
     end new
 
-  /** Setting of the Toolbox instance. */
+  /** Setting of the Compiler instance. */
   case class Settings private (outDir: Option[String], compilerArgs: List[String])
 
   object Settings:
 
     implicit def default: Settings = make()
 
-    /** Make toolbox settings
+    /** Make compiler settings
      *  @param outDir Output directory for the compiled quote. If set to None the output will be in memory
      *  @param compilerArgs Compiler arguments. Use only if you know what you are doing.
      */
@@ -62,4 +62,4 @@ object Toolbox:
 
   end Settings
 
-end Toolbox
+end Compiler

--- a/staging/src/scala/quoted/staging/QuoteDriver.scala
+++ b/staging/src/scala/quoted/staging/QuoteDriver.scala
@@ -9,7 +9,7 @@ import dotty.tools.repl.AbstractFileClassLoader
 import dotty.tools.dotc.reporting._
 import dotty.tools.dotc.util.ClasspathFromClassloader
 import scala.quoted._
-import scala.quoted.staging.Toolbox
+import scala.quoted.staging.Compiler
 import java.io.File
 import scala.annotation.tailrec
 
@@ -22,7 +22,7 @@ private class QuoteDriver(appClassloader: ClassLoader) extends Driver:
 
   private[this] val contextBase: ContextBase = new ContextBase
 
-  def run[T](exprBuilder: Quotes => Expr[T], settings: Toolbox.Settings): T =
+  def run[T](exprBuilder: Quotes => Expr[T], settings: Compiler.Settings): T =
     val outDir: AbstractFile =
       settings.outDir match
         case Some(out) =>
@@ -34,7 +34,7 @@ private class QuoteDriver(appClassloader: ClassLoader) extends Driver:
     end outDir
 
     val (_, ctx0: Context) = setup(settings.compilerArgs.toArray :+ "dummy.scala", initCtx.fresh)
-    val ctx = setToolboxSettings(ctx0.fresh.setSetting(ctx0.settings.outputDir, outDir), settings)
+    val ctx = setCompilerSettings(ctx0.fresh.setSetting(ctx0.settings.outputDir, outDir), settings)
 
     new QuoteCompiler().newRun(ctx).compileExpr(exprBuilder) match
       case Right(value) =>
@@ -59,7 +59,7 @@ private class QuoteDriver(appClassloader: ClassLoader) extends Driver:
     ictx.settings.classpath.update(ClasspathFromClassloader(appClassloader))(using ictx)
     ictx
 
-  private def setToolboxSettings(ctx: FreshContext, settings: Toolbox.Settings): ctx.type =
+  private def setCompilerSettings(ctx: FreshContext, settings: Compiler.Settings): ctx.type =
     // An error in the generated code is a bug in the compiler
     // Setting the throwing reporter however will report any exception
     ctx.setReporter(new ThrowingReporter(ctx.reporter))

--- a/staging/src/scala/quoted/staging/staging.scala
+++ b/staging/src/scala/quoted/staging/staging.scala
@@ -16,7 +16,7 @@ package object staging:
    *  This method should not be called in a context where there is already has a `Quotes`
    *  such as within a `run` or a `withQuotes`.
    */
-  def run[T](expr: Quotes ?=> Expr[T])(using toolbox: Toolbox): T = toolbox.run(expr(using _))
+  def run[T](expr: Quotes ?=> Expr[T])(using compiler: Compiler): T = compiler.run(expr(using _))
 
   /** Provide a new quote context within the scope of the argument that is only valid within the scope the argument.
    *  Return the result of the argument.
@@ -32,15 +32,15 @@ package object staging:
    *  This method should not be called in a context where there is already has a `Quotes`
    *  such as within a `run` or a `withQuotes`.
    */
-  def withQuotes[T](thunk: Quotes ?=> T)(using toolbox: Toolbox): T =
+  def withQuotes[T](thunk: Quotes ?=> T)(using compiler: Compiler): T =
     val noResult = new Object
     var result: T = noResult.asInstanceOf[T]
     def dummyRun(using Quotes): Expr[Unit] = {
       result = thunk
       '{}
     }
-    toolbox.run(dummyRun(using _))
-    assert(result != noResult) // toolbox.run should have thrown an exception
+    compiler.run(dummyRun(using _))
+    assert(result != noResult) // compiler.run should have thrown an exception
     result
   end withQuotes
 

--- a/staging/test-resources/repl-staging/i6007
+++ b/staging/test-resources/repl-staging/i6007
@@ -1,7 +1,7 @@
 scala> import scala.quoted._
-scala> import scala.quoted.staging._
-scala> implicit def toolbox: Toolbox = Toolbox.make(getClass.getClassLoader)
-def toolbox: quoted.staging.Toolbox
+scala> import quoted.staging.{Compiler => StagingCompiler, _}
+scala> implicit def compiler: StagingCompiler = StagingCompiler.make(getClass.getClassLoader)
+def compiler: quoted.staging.Compiler
 scala> def v(using Quotes) = '{ (if true then Some(1) else None).map(v => v+1) }
 def v(using x$1: quoted.Quotes): quoted.Expr[Option[Int]]
 scala> scala.quoted.staging.withQuotes(v.show)

--- a/staging/test-resources/repl-staging/i6263
+++ b/staging/test-resources/repl-staging/i6263
@@ -1,7 +1,7 @@
 scala> import quoted._
-scala> import quoted.staging._
-scala> implicit def toolbox: Toolbox = Toolbox.make(getClass.getClassLoader)
-def toolbox: quoted.staging.Toolbox
+scala> import quoted.staging.{Compiler => StagingCompiler, _}
+scala> implicit def compiler: StagingCompiler = StagingCompiler.make(getClass.getClassLoader)
+def compiler: quoted.staging.Compiler
 scala> def fn[T : Type](v : T) = println("ok")
 def fn[T](v: T)(implicit evidence$1: quoted.Type[T]): Unit
 scala> withQuotes { fn("foo") }

--- a/tests/disabled/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
+++ b/tests/disabled/neg-with-compiler/quote-run-in-macro-2/quoted_1.scala
@@ -4,7 +4,7 @@ object Macros {
 
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int])(using Quotes): Expr[Int] = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     val y: Int = run(i)
     y
   }

--- a/tests/disabled/run-staging/quote-macro-in-splice/quoted_2.scala
+++ b/tests/disabled/run-staging/quote-macro-in-splice/quoted_2.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 import Macros._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     val x = '{
       val y = 1

--- a/tests/neg-staging/i5941/macro_1.scala
+++ b/tests/neg-staging/i5941/macro_1.scala
@@ -12,7 +12,7 @@ object Lens {
   }
 
   def impl[S: Type, T: Type](getter: Expr[S => T])(using Quotes): Expr[Lens[S, T]] = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(this.getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Compiler = scala.quoted.staging.Compiler.make(this.getClass.getClassLoader)
     import quotes.reflect._
     import util._
     // obj.copy(field = value)

--- a/tests/neg-staging/i9692.scala
+++ b/tests/neg-staging/i9692.scala
@@ -3,8 +3,8 @@ import scala.quoted.staging._
 
 object Test extends App {
 
-  // make available the necessary toolbox for runtime code generation
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  // make available the necessary compiler for runtime code generation
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   run {
     val expr: Expr[Int] = '{ var x = 1; x = 2; 42 }

--- a/tests/neg-staging/i9693.scala
+++ b/tests/neg-staging/i9693.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 object Test extends App {
 
   // make available the necessary toolbox for runtime code generation
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   run {
     val expr: Expr[Int] = '{ var x = 1; x = 2; 42 }

--- a/tests/neg-staging/quote-run-in-macro-1/quoted_1.scala
+++ b/tests/neg-staging/quote-run-in-macro-1/quoted_1.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Macros {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   inline def foo(i: => Int): Int = ${ fooImpl('i) }
   def fooImpl(i: Expr[Int])(using Quotes): Expr[Int] = {
     val y: Int = run(i)

--- a/tests/pos-staging/quote-0.scala
+++ b/tests/pos-staging/quote-0.scala
@@ -27,7 +27,7 @@ object Macros {
 
 class Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   run {
     val program = '{

--- a/tests/pos-staging/quote-assert/quoted_2.scala
+++ b/tests/pos-staging/quote-assert/quoted_2.scala
@@ -17,6 +17,6 @@ object Test {
     ${ assertImpl('{x != 0}) }
   }
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   run(program)
 }

--- a/tests/run-staging/abstract-int-quote.scala
+++ b/tests/run-staging/abstract-int-quote.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test:
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit =
     def reduce[T: Type](using Quotes)(succ: Expr[T] => Expr[T], zero: Expr[T]): Expr[T] = '{

--- a/tests/run-staging/expr-matches.scala
+++ b/tests/run-staging/expr-matches.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     assert('{1} matches '{1})
     assert('{println("foo")} matches '{println("foo")})

--- a/tests/run-staging/i3823-b.scala
+++ b/tests/run-staging/i3823-b.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     def f[T](x: Expr[T])(implicit t: Type[T]) = '{
       val z: t.Underlying = $x

--- a/tests/run-staging/i3823-c.scala
+++ b/tests/run-staging/i3823-c.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     def f[T](x: Expr[T])(implicit t: Type[T]) = '{
       val z = $x

--- a/tests/run-staging/i3823.scala
+++ b/tests/run-staging/i3823.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     def f[T](x: Expr[T])(using t: Type[T]) = '{
       val z: t.Underlying = $x

--- a/tests/run-staging/i3847-b.scala
+++ b/tests/run-staging/i3847-b.scala
@@ -14,7 +14,7 @@ object Arrays {
 }
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     import Arrays._
     implicit val ct: Expr[ClassTag[Int]] = '{ClassTag.Int}

--- a/tests/run-staging/i3847.scala
+++ b/tests/run-staging/i3847.scala
@@ -14,7 +14,7 @@ object Arrays {
 }
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(this.getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Compiler = scala.quoted.staging.Compiler.make(this.getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     import Arrays._
     implicit val ct: Expr[ClassTag[Int]] = '{ClassTag.Int}

--- a/tests/run-staging/i3876-b.scala
+++ b/tests/run-staging/i3876-b.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
 
     def x(using Quotes): Expr[Int] = '{3}
 

--- a/tests/run-staging/i3876-c.scala
+++ b/tests/run-staging/i3876-c.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    implicit def toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    implicit def toolbox: scala.quoted.staging.Compiler = scala.quoted.staging.Compiler.make(getClass.getClassLoader)
 
     def x(using Quotes): Expr[Int] = '{3}
 

--- a/tests/run-staging/i3876-d.scala
+++ b/tests/run-staging/i3876-d.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
 
     def x(using Quotes): Expr[Int] = '{3}
 

--- a/tests/run-staging/i3876-e.scala
+++ b/tests/run-staging/i3876-e.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
 
     def x(using Quotes): Expr[Int] = '{ println(); 3 }
 

--- a/tests/run-staging/i3876.scala
+++ b/tests/run-staging/i3876.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
 
     def x(using Quotes): Expr[Int] = '{3}
 

--- a/tests/run-staging/i3946.scala
+++ b/tests/run-staging/i3946.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def u(using Quotes): Expr[Unit] = '{}
     println(withQuotes(u.show))
     println(run(u))

--- a/tests/run-staging/i3947.scala
+++ b/tests/run-staging/i3947.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {
       val lclazz = Expr(clazz)

--- a/tests/run-staging/i3947b.scala
+++ b/tests/run-staging/i3947b.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-staging/i3947b2.scala
+++ b/tests/run-staging/i3947b2.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: Quotes ?=> java.lang.Class[T]) = {

--- a/tests/run-staging/i3947b3.scala
+++ b/tests/run-staging/i3947b3.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-staging/i3947c.scala
+++ b/tests/run-staging/i3947c.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-staging/i3947d.scala
+++ b/tests/run-staging/i3947d.scala
@@ -2,7 +2,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-staging/i3947d2.scala
+++ b/tests/run-staging/i3947d2.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-staging/i3947e.scala
+++ b/tests/run-staging/i3947e.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
 

--- a/tests/run-staging/i3947f.scala
+++ b/tests/run-staging/i3947f.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-staging/i3947g.scala
+++ b/tests/run-staging/i3947g.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {
       val lclazz = Expr(clazz)

--- a/tests/run-staging/i3947i.scala
+++ b/tests/run-staging/i3947i.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-staging/i3947j.scala
+++ b/tests/run-staging/i3947j.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     def test[T: Type](clazz: java.lang.Class[T]) = {

--- a/tests/run-staging/i4044a.scala
+++ b/tests/run-staging/i4044a.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 class Foo {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def foo: Unit = withQuotes {
     val e: Expr[Int] = '{3}
     val q = '{ ${ '{ $e } } }

--- a/tests/run-staging/i4044b.scala
+++ b/tests/run-staging/i4044b.scala
@@ -20,7 +20,7 @@ object VarRef {
 }
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     val q = VarRef('{4})(varRef => '{ ${varRef.update('{3})}; ${varRef.expr} })
     println(q.show)

--- a/tests/run-staging/i4044c.scala
+++ b/tests/run-staging/i4044c.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 class Foo {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def foo: Unit = withQuotes {
     val q = '{ ${ '{ ${ '{ 5 } } } } }
     println(q.show)

--- a/tests/run-staging/i4044d.scala
+++ b/tests/run-staging/i4044d.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 class Foo {
   def foo: Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     run {
       val a: Expr[Int] = '{3}
       val q: Expr[Int] = '{

--- a/tests/run-staging/i4044e.scala
+++ b/tests/run-staging/i4044e.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 class Foo {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def foo: Unit = withQuotes {
     val e: Expr[Int] = '{3}
     val f: Expr[Int] = '{5}

--- a/tests/run-staging/i4044f.scala
+++ b/tests/run-staging/i4044f.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 class Foo {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def foo: Unit = withQuotes {
     val e: Expr[Int] = '{3}
     val f: Expr[Int] = '{5}

--- a/tests/run-staging/i4350.scala
+++ b/tests/run-staging/i4350.scala
@@ -7,7 +7,7 @@ class Foo[T: Type] {
 }
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     println((new Foo[Object]).q.show)
     println((new Foo[String]).q.show)

--- a/tests/run-staging/i4591.scala
+++ b/tests/run-staging/i4591.scala
@@ -9,7 +9,7 @@ object Test {
   }
 
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     run(foo('{Option(9)}))
   }
 

--- a/tests/run-staging/i4730.scala
+++ b/tests/run-staging/i4730.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def ret(using Quotes): Expr[Int => Int] = '{ (x: Int) =>
     ${
       val z = run('{x + 1}) // throws scala.quoted.runtime.impl.ScopeException =>
@@ -16,7 +16,7 @@ object Test {
 
 package scala {
   package mytest {
-    def myTest()(using Toolbox) = {
+    def myTest()(using Compiler) = {
       try {
         run(Test.ret).apply(10)
         throw new Exception

--- a/tests/run-staging/i5144.scala
+++ b/tests/run-staging/i5144.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int])(using Quotes): Expr[Int] = '{$ff(42)}
 
   def peval1()(using Quotes): Expr[Unit] = '{

--- a/tests/run-staging/i5144b.scala
+++ b/tests/run-staging/i5144b.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int])(using Quotes): Expr[Int] =
     Expr.betaReduce('{ $ff(42) })
 

--- a/tests/run-staging/i5152.scala
+++ b/tests/run-staging/i5152.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def eval1(ff: Expr[Int => Int])(using Quotes): Expr[Int => Int] = '{identity}
 
   def peval1()(using Quotes): Expr[Unit] = '{

--- a/tests/run-staging/i5161.scala
+++ b/tests/run-staging/i5161.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   enum Exp {
     case Int2(x: Int)

--- a/tests/run-staging/i5161b.scala
+++ b/tests/run-staging/i5161b.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
     def res(using Quotes) = '{

--- a/tests/run-staging/i5247.scala
+++ b/tests/run-staging/i5247.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     println(foo[Object].show)
     println(bar[Object].show)

--- a/tests/run-staging/i5376.scala
+++ b/tests/run-staging/i5376.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
     var e = '{1}

--- a/tests/run-staging/i5434.scala
+++ b/tests/run-staging/i5434.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
 

--- a/tests/run-staging/i5965.scala
+++ b/tests/run-staging/i5965.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
     withQuotes(Type.of[List])
 

--- a/tests/run-staging/i5965b.scala
+++ b/tests/run-staging/i5965b.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 object Test {
 
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
 
     withQuotes(Type.of[List])
     def list(using Quotes) = bound('{List(1, 2, 3)})

--- a/tests/run-staging/i5997.scala
+++ b/tests/run-staging/i5997.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     val v = '{ (if true then Some(1) else None).map(v => v+1) }
     println(v.show)

--- a/tests/run-staging/i6263.scala
+++ b/tests/run-staging/i6263.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
     fn("foo")

--- a/tests/run-staging/i6281.scala
+++ b/tests/run-staging/i6281.scala
@@ -37,7 +37,7 @@ object Test extends App {
 
   def m(using Quotes): STM[Int, RS] = k => k('{42})
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Compiler = scala.quoted.staging.Compiler.make(getClass.getClassLoader)
 
   withQuotes {
      println(Effects[RS].reify[Int] { m }.show)

--- a/tests/run-staging/i6754.scala
+++ b/tests/run-staging/i6754.scala
@@ -9,7 +9,7 @@ object Test {
 
 package scala {
   object MyTest {
-    implicit val tbx: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    implicit val tbx: scala.quoted.staging.Compiler = scala.quoted.staging.Compiler.make(getClass.getClassLoader)
 
     def myTest() = {
       def y(using Quotes): Expr[Unit] = '{

--- a/tests/run-staging/i6992/Macro_1.scala
+++ b/tests/run-staging/i6992/Macro_1.scala
@@ -16,7 +16,7 @@ package scala {
   object MyTest {
     import macros._
 
-   given Toolbox = Toolbox.make(getClass.getClassLoader)
+   given Compiler = Compiler.make(getClass.getClassLoader)
 
     def mcrImpl(body: Expr[Any])(using ctx: Quotes): Expr[Any] = {
       import ctx.reflect._

--- a/tests/run-staging/i7142.scala
+++ b/tests/run-staging/i7142.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 import scala.util.control.NonLocalReturns._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit =
     try run {returning('{ { (x: Int) => ${ throwReturn('x) }} apply 0 })}
     catch {

--- a/tests/run-staging/i7381.scala
+++ b/tests/run-staging/i7381.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 object Test {
 
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     withQuotes {
       val expr = Expr(List(1, 2, 3))
       println(expr.show)

--- a/tests/run-staging/i7897.scala
+++ b/tests/run-staging/i7897.scala
@@ -1,7 +1,7 @@
 import scala.quoted._, staging._
 
 object Test:
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   val f: Array[Int] => Int = run {
     val stagedSum: Expr[Array[Int] => Int] = '{ (arr: Array[Int]) => 6 }

--- a/tests/run-staging/i8178.scala
+++ b/tests/run-staging/i8178.scala
@@ -8,7 +8,7 @@ def foo(n: Int, t: Expr[Int])(using Quotes): Expr[Int] =
 object Test:
   def main(args: Array[String]) = {
     // make available the necessary toolbox for runtime code generation
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
 
     val f: Int = run { foo(2, Expr(5)) }
 

--- a/tests/run-staging/i8585.scala
+++ b/tests/run-staging/i8585.scala
@@ -1,8 +1,8 @@
 import scala.quoted._
-import scala.quoted.staging.{run, withQuotes, Toolbox}
+import scala.quoted.staging.{run, withQuotes, Compiler}
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = {
     val toTheEighth = stagedPower(8)

--- a/tests/run-staging/inline-at-level-2.scala
+++ b/tests/run-staging/inline-at-level-2.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = run {
     '{

--- a/tests/run-staging/inline-quote.scala
+++ b/tests/run-staging/inline-quote.scala
@@ -8,7 +8,7 @@ object Test {
     $x
   }
 
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
     val y = '{45}

--- a/tests/run-staging/liftables.scala
+++ b/tests/run-staging/liftables.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     println(Expr(true).show)
     println(Expr(false).show)

--- a/tests/run-staging/multi-staging.scala
+++ b/tests/run-staging/multi-staging.scala
@@ -5,11 +5,11 @@ import scala.quoted.staging._
 object Test {
   def main(args: Array[String]): Unit =
     val s1: Quotes ?=> Expr[Int] = {
-      given Toolbox = Toolbox.make(getClass.getClassLoader)
+      given Compiler = Compiler.make(getClass.getClassLoader)
       run[Quotes ?=> Expr[Int]] { stage1('{2}) }
     }
     {
-      given Toolbox = Toolbox.make(getClass.getClassLoader)
+      given Compiler = Compiler.make(getClass.getClassLoader)
       println(run(s1))
     }
   def stage1(x: Expr[Int])(using Quotes): Expr[Quotes ?=> Expr[Int]] =

--- a/tests/run-staging/quote-ackermann-1.scala
+++ b/tests/run-staging/quote-ackermann-1.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 object Test {
 
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     val ack3 = run { ackermann(3) }
     println(ack3(1))
     println(ack3(2))

--- a/tests/run-staging/quote-fun-app-1.scala
+++ b/tests/run-staging/quote-fun-app-1.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 object Test {
 
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     val f = run {
       f1
     }

--- a/tests/run-staging/quote-function-applied-to.scala
+++ b/tests/run-staging/quote-function-applied-to.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def show(expr: Quotes ?=> Expr[_]): String = withQuotes(expr.show)
     println(show(Expr.betaReduce('{ (() => x(0))() })))
     println(show(Expr.betaReduce('{ ((x1: Int) => x1)(x(1)) })))

--- a/tests/run-staging/quote-lambda.scala
+++ b/tests/run-staging/quote-lambda.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     '{ (x: Int) => ${'x} }
   }

--- a/tests/run-staging/quote-lib.scala
+++ b/tests/run-staging/quote-lib.scala
@@ -9,7 +9,7 @@ import liftable.Lists._
 import liftable.Exprs._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     val liftedUnit: Expr[Unit] = '{}
 

--- a/tests/run-staging/quote-lift-Array.scala
+++ b/tests/run-staging/quote-lift-Array.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  implicit val toolbox: scala.quoted.staging.Compiler = scala.quoted.staging.Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     '{
       def p[T](arr: Array[T]): Unit = {

--- a/tests/run-staging/quote-lift-BigDecimal.scala
+++ b/tests/run-staging/quote-lift-BigDecimal.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = println(run {
     val a = Expr(BigDecimal(2.3))
     val b = Expr(BigDecimal("1005849025843905834908593485984390583429058574925.95489543"))

--- a/tests/run-staging/quote-lift-BigInt.scala
+++ b/tests/run-staging/quote-lift-BigInt.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = println(run {
     val a = Expr(BigInt(2))
     val b = Expr(BigInt("1005849025843905834908593485984390583429058574925"))

--- a/tests/run-staging/quote-lift-IArray.scala
+++ b/tests/run-staging/quote-lift-IArray.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     '{
       def p[T](arr: IArray[T]): Unit = {

--- a/tests/run-staging/quote-nested-1.scala
+++ b/tests/run-staging/quote-nested-1.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     val q = '{ (q: Quotes) ?=> '{3} }
     println(q.show)

--- a/tests/run-staging/quote-nested-2.scala
+++ b/tests/run-staging/quote-nested-2.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
     val q = '{(q: Quotes) ?=>

--- a/tests/run-staging/quote-nested-3.scala
+++ b/tests/run-staging/quote-nested-3.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
     val q = '{

--- a/tests/run-staging/quote-nested-4.scala
+++ b/tests/run-staging/quote-nested-4.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
 
     val q = '{ (q: Quotes) ?=>

--- a/tests/run-staging/quote-nested-5.scala
+++ b/tests/run-staging/quote-nested-5.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
 
     val q = '{(q: Quotes) ?=>

--- a/tests/run-staging/quote-nested-6.scala
+++ b/tests/run-staging/quote-nested-6.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
     val q = '{

--- a/tests/run-staging/quote-owners-2.scala
+++ b/tests/run-staging/quote-owners-2.scala
@@ -3,7 +3,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     val q = f(g(Type.of[Int]))
     println(q.show)

--- a/tests/run-staging/quote-owners.scala
+++ b/tests/run-staging/quote-owners.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def q(using Quotes) = f
     println(run(q))
     println(withQuotes(q.show))

--- a/tests/run-staging/quote-run-2.scala
+++ b/tests/run-staging/quote-run-2.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     def powerCode(n: Int, x: Expr[Double]): Expr[Double] =
       if (n == 0) '{1.0}

--- a/tests/run-staging/quote-run-b.scala
+++ b/tests/run-staging/quote-run-b.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def lambdaExpr(using Quotes) = '{
       (x: Int) => println("lambda(" + x + ")")
     }

--- a/tests/run-staging/quote-run-c.scala
+++ b/tests/run-staging/quote-run-c.scala
@@ -4,7 +4,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def classExpr(using Quotes) = '{
       class A {
         override def toString: String = "Foo"

--- a/tests/run-staging/quote-run-constants.scala
+++ b/tests/run-staging/quote-run-constants.scala
@@ -5,7 +5,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def runAndPrint[T](expr: Quotes ?=> Expr[T]): Unit = println(run(expr))
 
     runAndPrint(Expr(true))

--- a/tests/run-staging/quote-run-large.scala
+++ b/tests/run-staging/quote-run-large.scala
@@ -60,7 +60,7 @@ object Test {
       new Foo(5)
     }
 
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
 
     withQuotes {
       a.show // Force unpiclking of the expression

--- a/tests/run-staging/quote-run-many.scala
+++ b/tests/run-staging/quote-run-many.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def expr(i: Int)(using Quotes) = '{
       val a = 3 + ${Expr(i)}
       2 + a

--- a/tests/run-staging/quote-run-staged-interpreter.scala
+++ b/tests/run-staging/quote-run-staged-interpreter.scala
@@ -27,7 +27,7 @@ object Test {
 
 
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     val exp = Plus(Plus(Num(2), Var("x")), Num(4))
     val letExp = Let("x", Num(3), exp)
 

--- a/tests/run-staging/quote-run-with-settings.scala
+++ b/tests/run-staging/quote-run-with-settings.scala
@@ -6,7 +6,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def expr(using Quotes) = '{
       val a = 3
       println("foo")
@@ -22,8 +22,8 @@ object Test {
     Files.deleteIfExists(classFile)
 
     {
-      implicit val settings = Toolbox.Settings.make(outDir = Some(outDir.toString))
-      implicit val toolbox2: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+      implicit val settings = Compiler.Settings.make(outDir = Some(outDir.toString))
+      implicit val toolbox2: scala.quoted.staging.Compiler = scala.quoted.staging.Compiler.make(getClass.getClassLoader)
       println(run(expr))
       assert(Files.exists(classFile))
     }

--- a/tests/run-staging/quote-run.scala
+++ b/tests/run-staging/quote-run.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     def expr(using Quotes) = '{
       val a = 3
       println("foo")

--- a/tests/run-staging/quote-show-blocks.scala
+++ b/tests/run-staging/quote-show-blocks.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def a(n: Int, x: Expr[Unit]): Expr[Unit] =
       if (n == 0) x

--- a/tests/run-staging/quote-simple-hole.scala
+++ b/tests/run-staging/quote-simple-hole.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
     val x = '{0}

--- a/tests/run-staging/quote-toExprOfTuple.scala
+++ b/tests/run-staging/quote-toExprOfTuple.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = {
     for (n <- 0 to 25) {
       prev = 0

--- a/tests/run-staging/quote-two-captured-ref.scala
+++ b/tests/run-staging/quote-two-captured-ref.scala
@@ -2,7 +2,7 @@ import quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     val q = '{
       val x = 1

--- a/tests/run-staging/quote-type-matcher.scala
+++ b/tests/run-staging/quote-type-matcher.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 import scala.reflect.ClassTag
 
 object Test {
-  given Toolbox = Toolbox.make(this.getClass.getClassLoader)
+  given Compiler = Compiler.make(this.getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     val '[List[Int]] = Type.of[List[Int]]
 

--- a/tests/run-staging/quote-type-tags.scala
+++ b/tests/run-staging/quote-type-tags.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def asof[T: Type, U](x: Expr[T], t: Type[U]): Expr[U] =
       '{$x.asInstanceOf[t.Underlying]}

--- a/tests/run-staging/quote-unrolled-foreach.scala
+++ b/tests/run-staging/quote-unrolled-foreach.scala
@@ -3,7 +3,7 @@ import scala.quoted._
 import scala.quoted.staging._
 
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = run {
     def code1(using Quotes) = '{ (arr: Array[Int], f: Int => Unit) => ${ foreach1('arr, 'f) } }
     println(code1.show)

--- a/tests/run-staging/quote-valueof-list.scala
+++ b/tests/run-staging/quote-valueof-list.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
 

--- a/tests/run-staging/quote-valueof.scala
+++ b/tests/run-staging/quote-valueof.scala
@@ -3,7 +3,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
     println(('{true}).value)

--- a/tests/run-staging/quote-var.scala
+++ b/tests/run-staging/quote-var.scala
@@ -31,7 +31,7 @@ object Test {
   }
 
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     val res = run {
       test1()
     }

--- a/tests/run-staging/shonan-hmm-simple.scala
+++ b/tests/run-staging/shonan-hmm-simple.scala
@@ -98,7 +98,7 @@ class Blas1[Idx, T](r: Ring[T], ops: VecOps[Idx, T]):
 
 object Test:
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit =
     val arr1 = Array(0, 1, 2, 4, 8)
     val arr2 = Array(1, 0, 1, 0, 1)

--- a/tests/run-staging/shonan-hmm/Test.scala
+++ b/tests/run-staging/shonan-hmm/Test.scala
@@ -5,7 +5,7 @@ import scala.quoted.staging._
 
 object Test {
 
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
 
   def main(args: Array[String]): Unit = withQuotes {
 

--- a/tests/run-staging/staged-streams_1.scala
+++ b/tests/run-staging/staged-streams_1.scala
@@ -657,7 +657,7 @@ object Test {
     .fold('{0}, ((a: Expr[Int], b : Expr[Int]) => '{ $a + $b }))
 
   def main(args: Array[String]): Unit = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     println(run(test1()))
     println
     println(run(test2()))

--- a/tests/run-staging/staged-tuples/Test.scala
+++ b/tests/run-staging/staged-tuples/Test.scala
@@ -4,7 +4,7 @@ import scala.internal.StagedTuple._
 object Test {
 
   def main(args: Array[String]): Unit = {
-    implicit val toolbox: scala.quoted.staging.Toolbox = scala.quoted.staging.Toolbox.make(getClass.getClassLoader)
+    implicit val toolbox: scala.quoted.staging.Compiler = scala.quoted.staging.Compiler.make(getClass.getClassLoader)
 
     assert(run(fromArrayStaged[EmptyTuple]('{ Array.empty[Object] }, Some(0))) == Tuple())
     assert(run(fromArrayStaged[Tuple1[String]]('{ Array[Object]("a") }, Some(1))) == Tuple1("a"))

--- a/tests/run-staging/tasty-extractors-constants-2/quoted_1.scala
+++ b/tests/run-staging/tasty-extractors-constants-2/quoted_1.scala
@@ -6,7 +6,7 @@ object Macros {
   inline def testMacro: Unit = ${impl}
 
   def impl(using Quotes): Expr[Unit] = {
-    given Toolbox = Toolbox.make(getClass.getClassLoader)
+    given Compiler = Compiler.make(getClass.getClassLoader)
     // 2 is a lifted constant
     val show1 = withQuotes(power('{2}, '{3.0}).show)
     val run1  = run(power('{2}, '{3.0}))

--- a/tests/run-staging/unliftables.scala
+++ b/tests/run-staging/unliftables.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 object Test {
-  given Toolbox = Toolbox.make(getClass.getClassLoader)
+  given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit = withQuotes {
     println('{ true }.value)
     println('{ false }.value)


### PR DESCRIPTION
The purpose is to make it clearer what this abstraction contains.
This would also help users understand that if they want to use staging within a macro they need to create a second compiler (usually not a good idea).