### PR TITLE
Add overriding check

### DIFF
--- a/tests/neg/i11130.scala
+++ b/tests/neg/i11130.scala
@@ -1,0 +1,22 @@
+@main def test: Unit = {
+  class Foo
+  class Bar extends Foo
+
+  trait S[-A] {
+    type T >: A
+  }
+  trait PFoo extends S[Foo]
+  trait PBar extends S[Bar] {
+    override type T = Bar
+  }
+  class PFooBar extends PBar with PFoo {
+    override type T >: Bar  // error
+  }
+
+  def patmat[A](s: S[A]): s.T = s match {
+    case p: (PFoo & s.type) => (new Foo): p.T
+  }
+
+  // ClassCastException: Foo cannot be cast to class Bar
+  val x: Bar = patmat(new PFooBar: PBar)
+}

--- a/tests/neg/i7359-b.check
+++ b/tests/neg/i7359-b.check
@@ -1,4 +1,0 @@
--- [E105] Syntax Error: tests/neg/i7359-b.scala:3:6 --------------------------------------------------------------------
-3 |  def notifyAll(): Unit // error
-  |      ^
-  |      Traits cannot redefine final method notifyAll from class AnyRef.

--- a/tests/neg/i7359-b.scala
+++ b/tests/neg/i7359-b.scala
@@ -1,3 +1,0 @@
-trait SAMTrait:
-  def first(): String
-  def notifyAll(): Unit // error

--- a/tests/neg/i7359-c.check
+++ b/tests/neg/i7359-c.check
@@ -1,4 +1,0 @@
--- [E105] Syntax Error: tests/neg/i7359-c.scala:3:6 --------------------------------------------------------------------
-3 |  def wait(): Unit // error
-  |      ^
-  |      Traits cannot redefine final method wait from class AnyRef.

--- a/tests/neg/i7359-c.scala
+++ b/tests/neg/i7359-c.scala
@@ -1,3 +1,0 @@
-trait SAMTrait:
-  def first(): String
-  def wait(): Unit // error

--- a/tests/neg/i7359-d.check
+++ b/tests/neg/i7359-d.check
@@ -1,4 +1,0 @@
--- [E105] Syntax Error: tests/neg/i7359-d.scala:3:6 --------------------------------------------------------------------
-3 |  def wait(a: Long): Unit // error
-  |      ^
-  |      Traits cannot redefine final method wait from class AnyRef.

--- a/tests/neg/i7359-d.scala
+++ b/tests/neg/i7359-d.scala
@@ -1,3 +1,0 @@
-trait SAMTrait:
-  def first(): String
-  def wait(a: Long): Unit // error

--- a/tests/neg/i7359-e.check
+++ b/tests/neg/i7359-e.check
@@ -1,4 +1,0 @@
--- [E105] Syntax Error: tests/neg/i7359-e.scala:3:6 --------------------------------------------------------------------
-3 |  def wait(a: Long, n: Int): Unit // error
-  |      ^
-  |      Traits cannot redefine final method wait from class AnyRef.

--- a/tests/neg/i7359-e.scala
+++ b/tests/neg/i7359-e.scala
@@ -1,3 +1,0 @@
-trait SAMTrait:
-  def first(): String
-  def wait(a: Long, n: Int): Unit // error

--- a/tests/neg/i7359.check
+++ b/tests/neg/i7359.check
@@ -1,4 +1,5 @@
--- [E105] Syntax Error: tests/neg/i7359.scala:3:6 ----------------------------------------------------------------------
+-- Error: tests/neg/i7359.scala:3:6 ------------------------------------------------------------------------------------
 3 |  def notify(): Unit // error
   |      ^
-  |      Traits cannot redefine final method notify from class AnyRef.
+  |      error overriding method notify in class Object of type (): Unit;
+  |        method notify of type (): Unit cannot override final member method notify in class Object

--- a/tests/neg/inline-override.scala
+++ b/tests/neg/inline-override.scala
@@ -25,14 +25,14 @@ object Test {
     override def f1(): Int // OK
     override def f2(): Int // OK
     override def f3(): Int // error
-    override def f4(): Int // OK not retained
+    override def f4(): Int // error
   }
 
   abstract class E extends A { // error f1
     inline override def f1(): Int
     inline override def f2(): Int
     inline override def f3(): Int
-    inline override def f4(): Int // OK not retained
+    inline override def f4(): Int // error
   }
 
 }


### PR DESCRIPTION
In a situation like
```
class A { type T = B }
class B extends A { override type T }
```

We only checked that `T` in `A` correctly overrides `T` in `B`, since `T` in `A`
is taken to be the overriding member, since it is concrete. But we also have to check
the reverse.

This replaces a more specialized treatment where we checked that final members
in `Object` could not be overridden by abstract members in traits. I removed a bunch
of tests that all tested variations of that other check, and changed the check
file for one representative.

Fixes #11130