### PR TITLE
Closes #9883 - Change ConstantType print format

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -247,7 +247,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
   }.close
 
   def toTextSingleton(tp: SingletonType): Text =
-    "(" ~ toTextRef(tp) ~ " : " ~ toTextGlobal(tp.underlying) ~ ")"
+    tp match {
+      case ConstantType(value) => toText(value)
+      case tp => "(" ~ toTextRef(tp) ~ " : " ~ toTextGlobal(tp.underlying) ~ ")"
+    }
 
   protected def paramsText(lam: LambdaType): Text = {
     def paramText(name: Name, tp: Type) =

--- a/compiler/test/dotty/tools/repl/TypeTests.scala
+++ b/compiler/test/dotty/tools/repl/TypeTests.scala
@@ -26,4 +26,12 @@ class TypeTests extends ReplTest {
     run(":type")
     assertEquals(":type <expression>", storedOutput().trim)
   }
+
+  @Test def typeOfUnion =
+    fromInitialState { implicit s => run("val bit: 0|1 = 1") }
+    .andThen { implicit s =>
+      storedOutput() // discard output
+      run(":type bit")
+      assertEquals("0 | 1", storedOutput().trim)
+    }
 }


### PR DESCRIPTION
- ConstantType(v) should now be printed as "v" instead of "(v: V)"
- A test has been added to check for this behaviour

I recently started contributing to open source projects. Any kind of feedback is welcome :)