### PR TITLE
Fix #11137: Use a system property for the Scala.js version in sbt scripted tests

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1256,6 +1256,7 @@ object Build {
       scriptedLaunchOpts ++= Seq(
         "-Dplugin.version=" + version.value,
         "-Dplugin.scalaVersion=" + dottyVersion,
+        "-Dplugin.scalaJSVersion=" + scalaJSVersion,
         "-Dsbt.boot.directory=" + ((baseDirectory in ThisBuild).value / ".sbt-scripted").getAbsolutePath // Workaround sbt/sbt#3469
       ),
       // Pass along ivy home and repositories settings to sbt instances run from the tests

--- a/sbt-dotty/sbt-test/scalajs/basic/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scalajs/basic/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.scalaJSVersion"))


### PR DESCRIPTION
Prevents the Scala.js version in the tests from getting out of sync with the rest of the build.

Fixes #11137 

[test_sbt]