### PR TITLE
CI: run `test_sbt` by default for pull requests and pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,14 +241,11 @@ jobs:
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
     if: "github.event_name == 'schedule' && github.repository == 'lampepfl/dotty'
-         || (
-           github.event_name == 'push'
-           && startsWith(github.event.ref, 'refs/tags/')
-         )
+         || github.event_name == 'push'
          || (
            github.event_name == 'pull_request'
            && !contains(github.event.pull_request.body, '[skip ci]')
-           && contains(github.event.pull_request.body, '[test_sbt]')
+           && !contains(github.event.pull_request.body, '[skip test_sbt]')
          )"
 
     steps:


### PR DESCRIPTION
Now that we're using sbt 1.4.x and batch mode for scripted tests, `test_sbt` runs quick enough to enable it by default.