### PR TITLE
creator-applications.md: Improve readability of source code comment

### DIFF
--- a/docs/docs/reference/other-new-features/creator-applications.md
+++ b/docs/docs/reference/other-new-features/creator-applications.md
@@ -12,8 +12,8 @@ Scala 3 generalizes this scheme to all concrete classes. Example:
 class StringBuilder(s: String):
    def this() = this("")
 
-StringBuilder("abc")  // same as new StringBuilder("abc")
-StringBuilder()       // same as new StringBuilder()
+StringBuilder("abc")  // old: new StringBuilder("abc")
+StringBuilder()       // old: new StringBuilder()
 ```
 
 This works since a companion object with two `apply` methods


### PR DESCRIPTION
One can not easily identify the start of the "code section" in "same as new StringBuilder()". Instead, use a colon to separate words from code.