### PR TITLE
fix #11128: skip ctor proxy in named export

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -995,7 +995,7 @@ class Namer { typer: Typer =>
         def whyNoForwarder(mbr: SingleDenotation): String = {
           val sym = mbr.symbol
           if (!sym.isAccessibleFrom(path.tpe)) "is not accessible"
-          else if (sym.isConstructor || sym.is(ModuleClass) || sym.is(Bridge)) SKIP
+          else if (sym.isConstructor || sym.is(ModuleClass) || sym.is(Bridge) || sym.is(ConstructorProxy)) SKIP
           else if (cls.derivesFrom(sym.owner) &&
                    (sym.owner == cls || !sym.is(Deferred))) i"is already a member of $cls"
           else if (sym.is(Override))

--- a/tests/pos/i11128-wildcard.scala
+++ b/tests/pos/i11128-wildcard.scala
@@ -1,0 +1,15 @@
+package foo
+
+object Outer {
+
+  object Wrap {
+    export Outer._
+  }
+
+  class Bar
+
+}
+
+import Outer._
+
+val wrapBar = new Wrap.Bar()

--- a/tests/pos/i11128.scala
+++ b/tests/pos/i11128.scala
@@ -1,0 +1,9 @@
+package foo
+
+object Wrap {
+  export foo.Bar
+}
+
+class Bar
+
+val wrapBar = new Wrap.Bar()


### PR DESCRIPTION
fixes #11128 

This does not enable creator applications to work with exported classes, a follow up change would be needed to decide the correct encoding of a constructor proxy for an exported class.