### PR TITLE
Update definition of `nn` to use extension method

### DIFF
--- a/docs/docs/reference/other-new-features/explicit-nulls.md
+++ b/docs/docs/reference/other-new-features/explicit-nulls.md
@@ -81,9 +81,10 @@ So far, we have found the following useful:
   - An extension method `.nn` to "cast away" nullability
 
     ```scala
-    def[T] (x: T|Null) nn: x.type & T =
-       if x == null then new NullPointerException("tried to cast away nullability, but value is null")
-       else x.asInstanceOf[x.type & T]
+    extension [T](x: T | Null)
+      inline def nn: T =
+        assert(x != null)
+        x.asInstanceOf[T]
     ```
 
     This means that given `x: String|Null`, `x.nn` has type `String`, so we can call all the


### PR DESCRIPTION
The definition of `nn` has [changed](https://github.com/lampepfl/dotty/blob/fad5b8d7d7563768c491846c9cdfcf5b08aa92cf/compiler/src/dotty/tools/package.scala#L31) and uses the new extension syntax, is inlined, and uses `assert`.