### PR TITLE
Allow `with` after class

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1566,33 +1566,32 @@ object Parsers {
     def infixTypeRest(t: Tree): Tree =
       infixOps(t, canStartTypeTokens, refinedType, isType = true, isOperator = !isPostfixStar)
 
-    /** RefinedType   ::=  WithType {[nl] Refinement}
+    /** RefinedType   ::=  WithType {[nl | ‘with’] Refinement}
      */
     val refinedType: () => Tree = () => refinedTypeRest(withType())
 
-    def refinedTypeRest(t: Tree): Tree = {
+    def refinedTypeRest(t: Tree): Tree =
       argumentStart()
-      if (in.isNestedStart)
+      if isTemplateBodyStart then
+        if in.token == WITH then in.nextToken()
         refinedTypeRest(atSpan(startOffset(t)) {
           RefinedTypeTree(rejectWildcardType(t), refinement(indentOK = true))
         })
       else t
-    }
 
     /** WithType ::= AnnotType {`with' AnnotType}    (deprecated)
      */
     def withType(): Tree = withTypeRest(annotType())
 
     def withTypeRest(t: Tree): Tree =
-      if in.token == WITH then
-        val withOffset = in.offset
+      def isRefinementStart =
+        val la = in.lookahead
+        la.isAfterLineEnd || la.token == LBRACE
+      if in.token == WITH && !isRefinementStart then
         in.nextToken()
-        if in.token == LBRACE || in.token == INDENT then
-          t
-        else
-          if sourceVersion.isAtLeast(`3.1`) then
-            deprecationWarning(DeprecatedWithOperator(), withOffset)
-          atSpan(startOffset(t)) { makeAndType(t, withType()) }
+        if sourceVersion.isAtLeast(`3.1`) then
+          deprecationWarning(DeprecatedWithOperator())
+        atSpan(startOffset(t)) { makeAndType(t, withType()) }
       else t
 
     /** AnnotType ::= SimpleType {Annotation}

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3549,7 +3549,7 @@ object Parsers {
         syntaxError(i"extension clause can only define methods", stat.span)
     }
 
-    /** GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | ConstrApps TemplateBody)
+    /** GivenDef          ::=  [GivenSig] (AnnotType [‘=’ Expr] | ConstrApps TemplateBody)
      *  GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClauses} ‘:’
      */
     def givenDef(start: Offset, mods: Modifiers, givenMod: Mod) = atSpan(start, nameStart) {
@@ -3567,7 +3567,9 @@ object Parsers {
         newLinesOpt()
         val noParams = tparams.isEmpty && vparamss.isEmpty
         if !(name.isEmpty && noParams) then accept(COLON)
-        val parents = if isSimpleLiteral then toplevelTyp() :: Nil else constrApps()
+        val parents =
+          if isSimpleLiteral then rejectWildcardType(annotType()) :: Nil
+          else constrApps()
         val parentsIsType = parents.length == 1 && parents.head.isType
         newLineOptWhenFollowedBy(LBRACE)
         if in.token == EQUALS && parentsIsType then

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -196,6 +196,7 @@ object Parsers {
     def isTemplateIntro = templateIntroTokens contains in.token
     def isDclIntro = dclIntroTokens contains in.token
     def isStatSeqEnd = in.isNestedEnd || in.token == EOF || in.token == RPAREN
+    def isTemplateBodyStart = in.token == WITH || in.isNestedStart
     def mustStartStat = mustStartStatTokens contains in.token
 
     /** Is current token a hard or soft modifier (in modifier position or not)? */
@@ -919,6 +920,39 @@ object Parsers {
       val next = in.lookahead.token
       next == LBRACKET || next == LPAREN
 
+    /** Does a template start after `with`? This is the case if either
+     *   - the next token is `{`
+     *   - the `with` is at the end of a line
+     *     (except for source = 3.0-migration, when a warning is issued)
+     *   - the next tokens is `<ident>` or `this` and the one after it is `:` or `=>`
+     *     (i.e. we see the start of a self type)
+     */
+    def followingIsTemplateStart() =
+      val lookahead = in.LookaheadScanner()
+      lookahead.nextToken()
+      lookahead.token == LBRACE
+      || lookahead.isAfterLineEnd
+          && {
+            if migrateTo3 then
+              warning(
+                em"""In Scala 3, `with` at the end of a line will start definitions,
+                    |so it cannot be used in front of a parent constructor anymore.
+                    |Place the `with` at the beginning of the next line instead.""")
+              false
+            else
+              true
+          }
+      || (lookahead.isIdent || lookahead.token == THIS)
+          && {
+            lookahead.nextToken()
+            lookahead.token == COLON
+            && {  // needed only as long as we support significant colon at eol
+              lookahead.nextToken()
+              !lookahead.isAfterLineEnd
+            }
+            || lookahead.token == ARROW
+          }
+
 /* --------- OPERAND/OPERATOR STACK --------------------------------------- */
 
     var opStack: List[OpInfo] = Nil
@@ -1281,14 +1315,14 @@ object Parsers {
             in.sourcePos())
           patch(source, Span(in.offset), "  ")
 
-    def possibleTemplateStart(isNew: Boolean = false): Unit =
+    def possibleTemplateStart(): Unit =
       in.observeColonEOL()
-      if in.token == COLONEOL || in.token == WITH then
+      if in.token == COLONEOL then
         if in.lookahead.isIdent(nme.end) then in.token = NEWLINE
         else
           in.nextToken()
           if in.token != INDENT && in.token != LBRACE then
-            syntaxErrorOrIncomplete(i"indented definitions expected, ${in} found")
+            syntaxErrorOrIncomplete(ExpectedTokenButFound(INDENT, in.token))
       else
         newLineOptWhenFollowedBy(LBRACE)
 
@@ -2313,13 +2347,11 @@ object Parsers {
       val start = in.skipToken()
       def reposition(t: Tree) = t.withSpan(Span(start, in.lastOffset))
       possibleTemplateStart()
-      val parents =
-        if in.isNestedStart then Nil
-        else constrApp() :: withConstrApps()
+      val parents = if isTemplateBodyStart then Nil else constrApp() :: withConstrApps()
       colonAtEOLOpt()
-      possibleTemplateStart(isNew = true)
+      possibleTemplateStart()
       parents match {
-        case parent :: Nil if !in.isNestedStart =>
+        case parent :: Nil if !isTemplateBodyStart =>
           reposition(if (parent.isType) ensureApplied(wrapNew(parent)) else parent)
         case _ =>
           New(reposition(templateBodyOpt(emptyConstructor, parents, Nil)))
@@ -3643,21 +3675,7 @@ object Parsers {
     /** `{`with` ConstrApp} but no EOL allowed after `with`.
      */
     def withConstrApps(): List[Tree] =
-      def isTemplateStart =
-        val la = in.lookahead
-        la.token == LBRACE
-        || la.isAfterLineEnd
-           && {
-             if migrateTo3 then
-                warning(
-                  em"""In Scala 3, `with` at the end of a line will start definitions,
-                      |so it cannot be used in front of a parent constructor anymore.
-                      |Place the `with` at the beginning of the next line instead.""")
-                false
-              else
-                true
-           }
-      if in.token == WITH && !isTemplateStart then
+      if in.token == WITH && !followingIsTemplateStart() then
         in.nextToken()
         constrApp() :: withConstrApps()
       else Nil
@@ -3701,18 +3719,20 @@ object Parsers {
         template(constr)
       else
         possibleTemplateStart()
-        if in.isNestedStart then
+        if isTemplateBodyStart then
           template(constr)
         else
           checkNextNotIndented()
           Template(constr, Nil, Nil, EmptyValDef, Nil)
 
-    /** TemplateBody ::=  [nl] `{' TemplateStatSeq `}'
-     *  EnumBody     ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
+    /** TemplateBody ::=  [nl | ‘with’] `{' TemplateStatSeq `}'
+     *                 |  ‘with’ [SelfType] indent TemplateStats outdent
+     *  EnumBody     ::=  [nl | ‘with’] ‘{’ [SelfType] EnumStats ‘}’
+     *                 |  ‘with’ [SelfType] indent EnumStats outdent
      */
     def templateBodyOpt(constr: DefDef, parents: List[Tree], derived: List[Tree]): Template =
       val (self, stats) =
-        if in.isNestedStart then
+        if isTemplateBodyStart then
           templateBody()
         else
           checkNextNotIndented()
@@ -3720,12 +3740,44 @@ object Parsers {
       Template(constr, parents, derived, self, stats)
 
     def templateBody(): (ValDef, List[Tree]) =
-      val r = inDefScopeBraces(templateStatSeq(), rewriteWithColon = true)
+      val givenSelf =
+        if in.token == WITH then
+          in.nextToken()
+          selfDefOpt()
+        else EmptyValDef
+      val r = inDefScopeBraces(templateStatSeq(givenSelf), rewriteWithColon = true)
       if in.token == WITH then
         syntaxError(EarlyDefinitionsNotSupported())
         in.nextToken()
         template(emptyConstructor)
       r
+
+    /** SelfType ::=  id [‘:’ InfixType] ‘=>’
+     *             |  ‘this’ ‘:’ InfixType ‘=>’
+     *  Only called immediately after a `with`, in which case it must in turn
+     *  be followed by `INDENT`.
+     */
+    def selfDefOpt(): ValDef = atSpan(in.offset) {
+      val vd =
+        if in.isIdent then
+          val selfName = ident()
+          if in.token == COLON then
+            in.nextToken()
+            makeSelfDef(selfName, infixType())
+          else
+            makeSelfDef(selfName, TypeTree())
+        else if in.token == THIS then
+          in.nextToken()
+          accept(COLON)
+          makeSelfDef(nme.WILDCARD, infixType())
+        else
+          EmptyValDef
+      if !vd.isEmpty then
+        accept(ARROW)
+        if in.token != INDENT then
+          syntaxErrorOrIncomplete(ExpectedTokenButFound(INDENT, in.token))
+      vd
+    }
 
     /** with Template, with EOL <indent> interpreted */
     def withTemplate(constr: DefDef, parents: List[Tree]): Template =
@@ -3800,10 +3852,10 @@ object Parsers {
      *  EnumStat         ::= TemplateStat
      *                     | Annotations Modifiers EnumCase
      */
-    def templateStatSeq(): (ValDef, List[Tree]) = checkNoEscapingPlaceholders {
-      var self: ValDef = EmptyValDef
+    def templateStatSeq(givenSelf: ValDef = EmptyValDef): (ValDef, List[Tree]) = checkNoEscapingPlaceholders {
+      var self = givenSelf
       val stats = new ListBuffer[Tree]
-      if (isExprIntro && !isDefIntro(modifierTokens)) {
+      if (self.isEmpty && isExprIntro && !isDefIntro(modifierTokens)) {
         val first = expr1()
         if (in.token == ARROW) {
           first match {
@@ -3956,7 +4008,7 @@ object Parsers {
             possibleTemplateStart()
             if in.token == EOF then
               ts += makePackaging(start, pkg, List())
-            else if in.isNestedStart then
+            else if isTemplateBodyStart then
               ts += inDefScopeBraces(makePackaging(start, pkg, topStatSeq()), rewriteWithColon = true)
               continue = true
             else
@@ -3994,6 +4046,7 @@ object Parsers {
     }
 
     override def templateBody(): (ValDef, List[Thicket]) = {
+      if in.token == WITH then in.nextToken()
       skipBraces()
       (EmptyValDef, List(EmptyTree))
     }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -920,6 +920,16 @@ object Parsers {
       val next = in.lookahead.token
       next == LBRACKET || next == LPAREN
 
+    private def withEndMigrationWarning(): Boolean =
+      migrateTo3
+      && {
+        warning(
+          em"""In Scala 3, `with` at the end of a line will start definitions,
+              |so it cannot be used in front of a parent constructor anymore.
+              |Place the `with` at the beginning of the next line instead.""")
+        true
+      }
+
     /** Does a template start after `with`? This is the case if either
      *   - the next token is `{`
      *   - the `with` is at the end of a line
@@ -931,17 +941,7 @@ object Parsers {
       val lookahead = in.LookaheadScanner()
       lookahead.nextToken()
       lookahead.token == LBRACE
-      || lookahead.isAfterLineEnd
-          && {
-            if migrateTo3 then
-              warning(
-                em"""In Scala 3, `with` at the end of a line will start definitions,
-                    |so it cannot be used in front of a parent constructor anymore.
-                    |Place the `with` at the beginning of the next line instead.""")
-              false
-            else
-              true
-          }
+      || lookahead.isAfterLineEnd && !withEndMigrationWarning()
       || (lookahead.isIdent || lookahead.token == THIS)
           && {
             lookahead.nextToken()
@@ -952,6 +952,20 @@ object Parsers {
             }
             || lookahead.token == ARROW
           }
+
+    /** Does a refinement start after `with`? This is the case if either
+     *   - the next token is `{`
+     *   - the `with` is at the end of a line and is followed by a token that starts a declaration
+     */
+    def followingIsRefinementStart() =
+      val lookahead = in.LookaheadScanner()
+      lookahead.nextToken()
+      lookahead.token == LBRACE
+      || lookahead.isAfterLineEnd
+         && {
+           if lookahead.token == INDENT then lookahead.nextToken()
+           dclIntroTokens.contains(lookahead.token)
+         }
 
 /* --------- OPERAND/OPERATOR STACK --------------------------------------- */
 
@@ -1584,11 +1598,8 @@ object Parsers {
     def withType(): Tree = withTypeRest(annotType())
 
     def withTypeRest(t: Tree): Tree =
-      def isRefinementStart =
-        val la = in.lookahead
-        la.isAfterLineEnd || la.token == LBRACE
-      if in.token == WITH && !isRefinementStart then
-        in.nextToken()
+      if in.token == WITH && !followingIsRefinementStart() then
+        in.nextTokenNoIndent()
         if sourceVersion.isAtLeast(`3.1`) then
           deprecationWarning(DeprecatedWithOperator())
         atSpan(startOffset(t)) { makeAndType(t, withType()) }
@@ -3858,8 +3869,7 @@ object Parsers {
               if (name != nme.ERROR)
                 self = makeSelfDef(name, tpt).withSpan(first.span)
           }
-          in.token = SELFARROW // suppresses INDENT insertion after `=>`
-          in.nextToken()
+          in.nextTokenNoIndent()
         }
         else {
           stats += first

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3619,8 +3619,11 @@ object Parsers {
         isUsingClause(extParams)
       do ()
       leadParamss ++= paramClauses(givenOnly = true, numLeadParams = nparams)
-      if in.token == COLON then
-        syntaxError("no `:` expected here")
+      if in.token == WITH then
+        syntaxError(
+          i"""No `with` expected here.
+             |
+             |An extension clause is simply followed by one or more method definitions.""")
         in.nextToken()
       val methods =
         if isDefIntro(modifierTokens) then

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3549,7 +3549,7 @@ object Parsers {
         syntaxError(i"extension clause can only define methods", stat.span)
     }
 
-    /** GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | StructuralInstance)
+    /** GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | ConstrApps TemplateBody)
      *  GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClauses} ‘:’
      */
     def givenDef(start: Offset, mods: Modifiers, givenMod: Mod) = atSpan(start, nameStart) {
@@ -3567,10 +3567,9 @@ object Parsers {
         newLinesOpt()
         val noParams = tparams.isEmpty && vparamss.isEmpty
         if !(name.isEmpty && noParams) then accept(COLON)
-        val parents =
-          if isSimpleLiteral then toplevelTyp() :: Nil
-          else constrApp() :: withConstrApps()
+        val parents = if isSimpleLiteral then toplevelTyp() :: Nil else constrApps()
         val parentsIsType = parents.length == 1 && parents.head.isType
+        newLineOptWhenFollowedBy(LBRACE)
         if in.token == EQUALS && parentsIsType then
           accept(EQUALS)
           mods1 |= Final
@@ -3579,17 +3578,17 @@ object Parsers {
             ValDef(name, parents.head, subExpr())
           else
             DefDef(name, joinParams(tparams, vparamss), parents.head, subExpr())
-        else if in.token != WITH && parentsIsType then
-          if name.isEmpty then
-            syntaxError(em"anonymous given cannot be abstract")
-          DefDef(name, joinParams(tparams, vparamss), parents.head, EmptyTree)
-        else
+        else if isTemplateBodyStart then
           val tparams1 = tparams.map(tparam => tparam.withMods(tparam.mods | PrivateLocal))
           val vparamss1 = vparamss.map(_.map(vparam =>
             vparam.withMods(vparam.mods &~ Param | ParamAccessor | Protected)))
-          val templ = withTemplate(makeConstructor(tparams1, vparamss1), parents)
+          val templ = templateBodyOpt(makeConstructor(tparams1, vparamss1), parents, Nil)
           if noParams then ModuleDef(name, templ)
           else TypeDef(name.toTypeName, templ)
+        else
+          if name.isEmpty then
+            syntaxError(em"anonymous given cannot be abstract")
+          DefDef(name, joinParams(tparams, vparamss), parents.head, EmptyTree)
       end gdef
       finalizeDef(gdef, mods1, start)
     }
@@ -3778,14 +3777,6 @@ object Parsers {
           syntaxErrorOrIncomplete(ExpectedTokenButFound(INDENT, in.token))
       vd
     }
-
-    /** with Template, with EOL <indent> interpreted */
-    def withTemplate(constr: DefDef, parents: List[Tree]): Template =
-      if in.token != WITH then syntaxError(em"`with` expected")
-      possibleTemplateStart() // consumes a WITH token
-      val (self, stats) = templateBody()
-      Template(constr, parents, Nil, self, stats)
-        .withSpan(Span(constr.span.orElse(parents.head.span).start, in.lastOffset))
 
 /* -------- STATSEQS ------------------------------------------- */
 

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1338,7 +1338,7 @@ object Scanners {
    *   InBraces    a pair of braces { ... }
    *   Indented    a pair of <indent> ... <outdent> tokens
    */
-  abstract class Region:
+  abstract class Region(val code: String):
     /** The region enclosing this one, or `null` for the outermost region */
     def outer: Region | Null
 
@@ -1367,17 +1367,17 @@ object Scanners {
       knownWidth = enclosing.knownWidth
   end Region
 
-  case class InString(multiLine: Boolean, outer: Region) extends Region
-  case class InParens(prefix: Token, outer: Region) extends Region
-  case class InBraces(outer: Region) extends Region
-  case class InCase(outer: Region) extends Region
+  case class InString(multiLine: Boolean, outer: Region) extends Region("IS")
+  case class InParens(prefix: Token, outer: Region) extends Region("IP")
+  case class InBraces(outer: Region) extends Region("IB")
+  case class InCase(outer: Region) extends Region("IC")
 
   /** A class describing an indentation region.
    *  @param width   The principal indendation width
    *  @param others  Other indendation widths > width of lines in the same region
    *  @param prefix  The token before the initial <indent> of the region
    */
-  case class Indented(width: IndentWidth, others: Set[IndentWidth], prefix: Token, outer: Region | Null) extends Region:
+  case class Indented(width: IndentWidth, others: Set[IndentWidth], prefix: Token, outer: Region | Null) extends Region("II"):
     knownWidth = width
 
   def topLevelRegion(width: IndentWidth) = Indented(width, Set(), EMPTY, null)

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -323,6 +323,11 @@ object Scanners {
       printState()
     }
 
+    /** Like nextToken, but don't insert indent characters afterwards */
+    def nextTokenNoIndent(): Unit =
+      token = EMPTY // this will suppress newline and indent insertion
+      nextToken()
+
     final def printState() =
       if debugTokenStream && (showLookAheadOnDebug || !isInstanceOf[LookaheadScanner]) then
         print(s"[$show${if isInstanceOf[LookaheadScanner] then "(LA)" else ""}]")
@@ -493,8 +498,6 @@ object Scanners {
           if canStartIndentTokens.contains(lastToken) then
             currentRegion = Indented(nextWidth, Set(), lastToken, currentRegion)
             insert(INDENT, offset)
-          else if lastToken == SELFARROW then
-            currentRegion.knownWidth = nextWidth
         else if (lastWidth != nextWidth)
           errorButContinue(spaceTabMismatchMsg(lastWidth, nextWidth))
       currentRegion match {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1338,7 +1338,7 @@ object Scanners {
    *   InBraces    a pair of braces { ... }
    *   Indented    a pair of <indent> ... <outdent> tokens
    */
-  abstract class Region(val code: String):
+  abstract class Region:
     /** The region enclosing this one, or `null` for the outermost region */
     def outer: Region | Null
 
@@ -1367,17 +1367,17 @@ object Scanners {
       knownWidth = enclosing.knownWidth
   end Region
 
-  case class InString(multiLine: Boolean, outer: Region) extends Region("IS")
-  case class InParens(prefix: Token, outer: Region) extends Region("IP")
-  case class InBraces(outer: Region) extends Region("IB")
-  case class InCase(outer: Region) extends Region("IC")
+  case class InString(multiLine: Boolean, outer: Region) extends Region
+  case class InParens(prefix: Token, outer: Region) extends Region
+  case class InBraces(outer: Region) extends Region
+  case class InCase(outer: Region) extends Region
 
   /** A class describing an indentation region.
    *  @param width   The principal indendation width
    *  @param others  Other indendation widths > width of lines in the same region
    *  @param prefix  The token before the initial <indent> of the region
    */
-  case class Indented(width: IndentWidth, others: Set[IndentWidth], prefix: Token, outer: Region | Null) extends Region("II"):
+  case class Indented(width: IndentWidth, others: Set[IndentWidth], prefix: Token, outer: Region | Null) extends Region:
     knownWidth = width
 
   def topLevelRegion(width: IndentWidth) = Indented(width, Set(), EMPTY, null)

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -204,7 +204,6 @@ object Tokens extends TokensCommon {
   final val QUOTE = 87;            enter(QUOTE, "'")
 
   final val COLONEOL = 88;         enter(COLONEOL, ":", ": at eol")
-  final val SELFARROW = 89;        enter(SELFARROW, "=>") // reclassified ARROW following self-type
 
   /** XML mode */
   final val XMLSTART = 99;         enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1126,6 +1126,7 @@ import transform.SymUtils._
     def msg =
       val expectedText =
         if (Tokens.isIdentifier(expected)) "an identifier"
+        else if expected == Tokens.INDENT then "indented definitions"
         else Tokens.showToken(expected)
       em"""${expectedText} expected, but ${foundText} found"""
 

--- a/docs/docs/internals/explicit-nulls.md
+++ b/docs/docs/internals/explicit-nulls.md
@@ -111,7 +111,7 @@ The reason for casting to `x.type & T`, as opposed to just `T`, is that it allow
 support flow typing for paths of length greater than one.
 
 ```scala
-abstract class Node:
+abstract class Node with
    val x: String
    val next: Node | Null
 

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -385,9 +385,8 @@ ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses        
 ConstrMods        ::=  {Annotation} [AccessModifier]
 ObjectDef         ::=  id [Template]                                            ModuleDef(mods, name, template)  // no constructor
 EnumDef           ::=  id ClassConstr InheritClauses EnumBody
-GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | StructuralInstance)
+GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | ConstrApps TemplateBody)
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’         -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
-StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} TemplateBody
 Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’
                        {UsingParamClause}] ExtMethods
 ExtMethods        ::=  ExtMethod | [nl] ‘{’ ExtMethod {semi ExtMethod ‘}’

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -148,7 +148,7 @@ FunParamClause    ::=  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’
 TypedFunParam     ::=  id ‘:’ Type
 MatchType         ::=  InfixType `match` ‘{’ TypeCaseClauses ‘}’
 InfixType         ::=  RefinedType {id [nl] RefinedType}                        InfixOp(t1, op, t2)
-RefinedType       ::=  WithType {[nl] Refinement}                               RefinedTypeTree(t, ds)
+RefinedType       ::=  WithType {[nl | ‘with’] Refinement}                      RefinedTypeTree(t, ds)
 WithType          ::=  AnnotType {‘with’ AnnotType}                             (deprecated)
 AnnotType         ::=  SimpleType {Annotation}                                  Annotated(t, annot)
 
@@ -401,6 +401,7 @@ ConstrExpr        ::=  SelfInvocation
 SelfInvocation    ::=  ‘this’ ArgumentExprs {ArgumentExprs}
 
 TemplateBody      ::=  [nl | ‘with’] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
+                    |  ‘with’ [SelfType] indent TemplateStats outdent
 TemplateStat      ::=  Import
                     |  Export
                     |  {Annotation [nl]} {Modifier} Def
@@ -412,7 +413,9 @@ TemplateStat      ::=  Import
 SelfType          ::=  id [‘:’ InfixType] ‘=>’                                  ValDef(_, name, tpt, _)
                     |  ‘this’ ‘:’ InfixType ‘=>’
 
-EnumBody          ::=  [nl | ‘with’] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
+EnumBody          ::=  [nl | ‘with’] ‘{’ [SelfType] EnumStats ‘}’
+                    |  ‘with’ [SelfType] indent EnumStats outdent
+EnumStats         ::=  EnumStat {semi EnumStat}
 EnumStat          ::=  TemplateStat
                     |  {Annotation [nl]} {Modifier} EnumCase
 EnumCase          ::=  ‘case’ (id ClassConstr [‘extends’ ConstrApps]] | ids)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -83,7 +83,6 @@ comment          ::=  ‘/*’ “any sequence of characters; nested comments ar
 
 nl               ::=  “new line character”
 semi             ::=  ‘;’ |  nl {nl}
-colonEol         ::=  ": at end of line that can start a template body"
 ```
 
 ## Keywords
@@ -218,9 +217,8 @@ SimpleExpr        ::=  SimpleRef
                     |  ‘$’ ‘{’ Block ‘}’
                     |  Quoted
                     |  quoteId                                                  -- only inside splices
-                    |  ‘new’ ConstrApp {‘with’ ConstrApp}                       New(constr | templ)
-                       [[colonEol] TemplateBody
-                    |  ‘new’ [colonEol] TemplateBody
+                    |  ‘new’ ConstrApp {‘with’ ConstrApp} [TemplateBody]        New(constr | templ)
+                    |  ‘new’ TemplateBody
                     |  ‘(’ ExprsInParens ‘)’                                    Parens(exprs)
                     |  SimpleExpr ‘.’ id                                        Select(expr, id)
                     |  SimpleExpr ‘.’ MatchClause
@@ -386,15 +384,15 @@ ClassDef          ::=  id ClassConstr [Template]                                
 ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses        with DefDef(_, <init>, Nil, vparamss, EmptyTree, EmptyTree) as first stat
 ConstrMods        ::=  {Annotation} [AccessModifier]
 ObjectDef         ::=  id [Template]                                            ModuleDef(mods, name, template)  // no constructor
-EnumDef           ::=  id ClassConstr InheritClauses [colonEol] EnumBody
+EnumDef           ::=  id ClassConstr InheritClauses EnumBody
 GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | StructuralInstance)
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’         -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
-StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody
+StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} TemplateBody
 Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’
                        {UsingParamClause}] ExtMethods
 ExtMethods        ::=  ExtMethod | [nl] ‘{’ ExtMethod {semi ExtMethod ‘}’
 ExtMethod         ::=  {Annotation [nl]} {Modifier} ‘def’ DefDef
-Template          ::=  InheritClauses [colonEol] [TemplateBody]                 Template(constr, parents, self, stats)
+Template          ::=  InheritClauses [TemplateBody]                           Template(constr, parents, self, stats)
 InheritClauses    ::=  [‘extends’ ConstrApps] [‘derives’ QualId {‘,’ QualId}]
 ConstrApps        ::=  ConstrApp ({‘,’ ConstrApp} | {‘with’ ConstrApp})
 ConstrApp         ::=  SimpleType1 {Annotation} {ParArgumentExprs}              Apply(tp, args)
@@ -402,7 +400,7 @@ ConstrExpr        ::=  SelfInvocation
                     |  ‘{’ SelfInvocation {semi BlockStat} ‘}’
 SelfInvocation    ::=  ‘this’ ArgumentExprs {ArgumentExprs}
 
-TemplateBody      ::=  [nl] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
+TemplateBody      ::=  [nl | ‘with’] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
 TemplateStat      ::=  Import
                     |  Export
                     |  {Annotation [nl]} {Modifier} Def
@@ -414,7 +412,7 @@ TemplateStat      ::=  Import
 SelfType          ::=  id [‘:’ InfixType] ‘=>’                                  ValDef(_, name, tpt, _)
                     |  ‘this’ ‘:’ InfixType ‘=>’
 
-EnumBody          ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
+EnumBody          ::=  [nl | ‘with’] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
 EnumStat          ::=  TemplateStat
                     |  {Annotation [nl]} {Modifier} EnumCase
 EnumCase          ::=  ‘case’ (id ClassConstr [‘extends’ ConstrApps]] | ids)
@@ -428,7 +426,7 @@ TopStat           ::=  Import
                     |  PackageObject
                     |  EndMarker
                     |
-Packaging         ::=  ‘package’ QualId [nl | colonEol] ‘{’ TopStatSeq ‘}’      Package(qid, stats)
+Packaging         ::=  ‘package’ QualId [nl| ‘with’] ‘{’ TopStatSeq ‘}’      Package(qid, stats)
 PackageObject     ::=  ‘package’ ‘object’ ObjectDef                             object with package in mods.
 
 CompilationUnit   ::=  {‘package’ QualId semi} TopStatSeq                       Package(qid, stats)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -385,7 +385,7 @@ ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses        
 ConstrMods        ::=  {Annotation} [AccessModifier]
 ObjectDef         ::=  id [Template]                                            ModuleDef(mods, name, template)  // no constructor
 EnumDef           ::=  id ClassConstr InheritClauses EnumBody
-GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | ConstrApps TemplateBody)
+GivenDef          ::=  [GivenSig] (AnnotType [‘=’ Expr] | ConstrApps TemplateBody)
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’         -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
 Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’
                        {UsingParamClause}] ExtMethods

--- a/docs/docs/reference/changed-features/compiler-plugins.md
+++ b/docs/docs/reference/changed-features/compiler-plugins.md
@@ -62,14 +62,14 @@ import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
 import dotty.tools.dotc.transform.{Pickler, Staging}
 
-class DivideZero extends StandardPlugin:
+class DivideZero extends StandardPlugin with
    val name: String = "divideZero"
    override val description: String = "divide zero check"
 
    def init(options: List[String]): List[PluginPhase] =
       (new DivideZeroPhase) :: Nil
 
-class DivideZeroPhase extends PluginPhase:
+class DivideZeroPhase extends PluginPhase with
    import tpd._
 
    val phaseName = "divideZero"
@@ -108,7 +108,7 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.plugins.ResearchPlugin
 
-class DummyResearchPlugin extends ResearchPlugin:
+class DummyResearchPlugin extends ResearchPlugin with
    val name: String = "dummy"
    override val description: String = "dummy research plugin"
 

--- a/docs/docs/reference/changed-features/implicit-conversions-spec.md
+++ b/docs/docs/reference/changed-features/implicit-conversions-spec.md
@@ -16,7 +16,7 @@ The standard library defines an abstract class `Conversion`:
 ```scala
 package scala
 @java.lang.FunctionalInterface
-abstract class Conversion[-T, +U] extends Function1[T, U]:
+abstract class Conversion[-T, +U] extends Function1[T, U] with
    def apply(x: T): U
 ```
 

--- a/docs/docs/reference/changed-features/implicit-resolution.md
+++ b/docs/docs/reference/changed-features/implicit-resolution.md
@@ -44,7 +44,7 @@ no longer applies.
 
   given a: A = A()
 
-  object o:
+  object o with
      given b: B = B()
      type C
 ```

--- a/docs/docs/reference/changed-features/main-functions.md
+++ b/docs/docs/reference/changed-features/main-functions.md
@@ -61,7 +61,7 @@ The Scala compiler generates a program from a `@main` method `f` as follows:
 For instance, the `happyBirthDay` method above would generate additional code equivalent to the following class:
 
 ```scala
-final class happyBirthday:
+final class happyBirthday with
    import scala.util.{CommandLineParser => CLP}
    <static> def main(args: Array[String]): Unit =
       try

--- a/docs/docs/reference/changed-features/numeric-literals.md
+++ b/docs/docs/reference/changed-features/numeric-literals.md
@@ -130,7 +130,7 @@ class MalformedNumber(msg: String = "malformed number literal") extends FromDigi
 As a fully worked out example, here is an implementation of a new numeric class, `BigFloat`, that accepts numeric literals. `BigFloat` is defined in terms of a `BigInt` mantissa and an `Int` exponent:
 
 ```scala
-case class BigFloat(mantissa: BigInt, exponent: Int):
+case class BigFloat(mantissa: BigInt, exponent: Int) with
    override def toString = s"${mantissa}e${exponent}"
 ```
 
@@ -145,7 +145,7 @@ The companion object of `BigFloat` defines an `apply` constructor method to cons
 from a `digits` string. Here is a possible implementation:
 
 ```scala
-object BigFloat:
+object BigFloat with
    import scala.util.FromDigits
 
    def apply(digits: String): BigFloat =
@@ -206,7 +206,7 @@ To do this, replace the `FromDigits` instance in the `BigFloat` object by the fo
 object BigFloat:
    ...
 
-   class FromDigits extends FromDigits.Floating[BigFloat]:
+   class FromDigits extends FromDigits.Floating[BigFloat] with
       def fromDigits(digits: String) = apply(digits)
 
    given FromDigits with

--- a/docs/docs/reference/changed-features/numeric-literals.md
+++ b/docs/docs/reference/changed-features/numeric-literals.md
@@ -86,7 +86,7 @@ whole numbers with a given radix, for numbers with a decimal point, and for
 numbers that can have both a decimal point and an exponent:
 
 ```scala
-object FromDigits:
+object FromDigits with
 
    /** A subclass of `FromDigits` that also allows to convert whole
     *  number literals with a radix other than 10
@@ -203,7 +203,7 @@ into a macro, i.e. make it an inline method with a splice as right-hand side.
 To do this, replace the `FromDigits` instance in the `BigFloat` object by the following two definitions:
 
 ```scala
-object BigFloat:
+object BigFloat with
    ...
 
    class FromDigits extends FromDigits.Floating[BigFloat] with

--- a/docs/docs/reference/changed-features/pattern-matching.md
+++ b/docs/docs/reference/changed-features/pattern-matching.md
@@ -121,7 +121,7 @@ For example:
 <!-- To be kept in sync with tests/new/patmat-spec.scala -->
 
 ```scala
-class FirstChars(s: String) extends Product:
+class FirstChars(s: String) extends Product with
    def _1 = s.charAt(0)
    def _2 = s.charAt(1)
 
@@ -147,7 +147,7 @@ object FirstChars:
 <!-- To be kept in sync with tests/new/patmat-spec.scala -->
 
 ```scala
-class Nat(val x: Int):
+class Nat(val x: Int) with
    def get: Int = x
    def isEmpty = x < 0
 

--- a/docs/docs/reference/changed-features/pattern-matching.md
+++ b/docs/docs/reference/changed-features/pattern-matching.md
@@ -100,7 +100,7 @@ For example:
 <!-- To be kept in sync with tests/new/patmat-spec.scala -->
 
 ```scala
-object Even:
+object Even with
    def unapply(s: String): Boolean = s.size % 2 == 0
 
 "even" match
@@ -130,7 +130,7 @@ class FirstChars(s: String) extends Product with
    def productArity: Int = ???
    def productElement(n: Int): Any = ???
 
-object FirstChars:
+object FirstChars with
    def unapply(s: String): FirstChars = new FirstChars(s)
 
 "Hi!" match
@@ -151,7 +151,7 @@ class Nat(val x: Int) with
    def get: Int = x
    def isEmpty = x < 0
 
-object Nat:
+object Nat with
    def unapply(x: Int): Nat = new Nat(x)
 
 5 match
@@ -167,7 +167,7 @@ object Nat:
 - Pattern-matching on exactly `N` patterns with types `P1, P2, ..., PN`
 
 ```Scala
-object ProdEmpty:
+object ProdEmpty with
    def _1: Int = ???
    def _2: String = ???
    def isEmpty = true
@@ -199,7 +199,7 @@ type X = {
 <!-- To be kept in sync with tests/new/patmat-spec.scala -->
 
 ```scala
-object CharList:
+object CharList with
    def unapplySeq(s: String): Option[Seq[Char]] = Some(s.toList)
 
 "example" match
@@ -221,7 +221,7 @@ object CharList:
 
 ```Scala
 class Foo(val name: String, val children: Int *)
-object Foo:
+object Foo with
    def unapplySeq(f: Foo): Option[(String, Seq[Int])] =
       Some((f.name, f.children))
 

--- a/docs/docs/reference/changed-features/structural-types.md
+++ b/docs/docs/reference/changed-features/structural-types.md
@@ -152,7 +152,7 @@ defines the necessary `selectDynamic` member.
 `Vehicle` could also extend some other subclass of `scala.Selectable` that implements `selectDynamic` and `applyDynamic` differently. But if it does not extend a `Selectable` at all, the code would no longer typecheck:
 
 ```scala
-trait Vehicle:
+trait Vehicle with
    val wheels: Int
 
 val i3 = new Vehicle: // i3: Vehicle

--- a/docs/docs/reference/changed-features/structural-types.md
+++ b/docs/docs/reference/changed-features/structural-types.md
@@ -34,13 +34,13 @@ configure how fields and methods should be resolved.
 Here's an example of a structural type `Person`:
 
 ```scala
-  class Record(elems: (String, Any)*) extends Selectable:
+  class Record(elems: (String, Any)*) extends Selectable with
      private val fields = elems.toMap
      def selectDynamic(name: String): Any = fields(name)
 
   type Person = Record { val name: String; val age: Int }
  ```
- 
+
 The type `Person` adds a _refinement_ to its parent type `Record` that defines the two fields `name` and `age`. We say the refinement is _structural_ since  `name` and `age` are not defined in the parent type. But they exist nevertheless as members of class `Person`. For instance, the following
 program would print  "Emma is 42 years old.":
 
@@ -82,10 +82,10 @@ Structural types can also be accessed using [Java reflection](https://www.oracle
 ```scala
   type Closeable = { def close(): Unit }
 
-  class FileInputStream:
+  class FileInputStream with
     def close(): Unit
 
-  class Channel:
+  class Channel with
     def close(): Unit
 ```
 

--- a/docs/docs/reference/contextual/context-functions.md
+++ b/docs/docs/reference/contextual/context-functions.md
@@ -116,7 +116,7 @@ With that setup, the table construction code above compiles and expands to:
 As a larger example, here is a way to define constructs for checking arbitrary postconditions using an extension method `ensuring` so that the checked result can be referred to simply by `result`. The example combines opaque type aliases, context function types, and extension methods to provide a zero-overhead abstraction.
 
 ```scala
-object PostConditions:
+object PostConditions with
    opaque type WrappedResult[T] = T
 
    def result[T](using r: WrappedResult[T]): T = r

--- a/docs/docs/reference/contextual/context-functions.md
+++ b/docs/docs/reference/contextual/context-functions.md
@@ -67,12 +67,12 @@ the aim is to construct tables like this:
 The idea is to define classes for `Table` and `Row` that allow the
 addition of elements via `add`:
 ```scala
-  class Table:
+  class Table with
      val rows = new ArrayBuffer[Row]
      def add(r: Row): Unit = rows += r
      override def toString = rows.mkString("Table(", ", ", ")")
 
-  class Row:
+  class Row with
      val cells = new ArrayBuffer[Cell]
      def add(c: Cell): Unit = cells += c
      override def toString = cells.mkString("Row(", ", ", ")")

--- a/docs/docs/reference/contextual/conversions.md
+++ b/docs/docs/reference/contextual/conversions.md
@@ -6,7 +6,7 @@ title: "Implicit Conversions"
 Implicit conversions are defined by given instances of the `scala.Conversion` class.
 This class is defined in package `scala` as follows:
 ```scala
-abstract class Conversion[-T, +U] extends (T => U):
+abstract class Conversion[-T, +U] extends (T => U) with
    def apply (x: T): U
 ```
 For example, here is an implicit conversion from `String` to `Token`:
@@ -43,15 +43,15 @@ conversion from `Int` to `java.lang.Integer` can be defined as follows:
 
 2. The "magnet" pattern is sometimes used to express many variants of a method. Instead of defining overloaded versions of the method, one can also let the method take one or more arguments of specially defined "magnet" types, into which various argument types can be converted. Example:
    ```scala
-   object Completions:
+   object Completions with
 
       // The argument "magnet" type
-      enum CompletionArg:
+      enum CompletionArg with
          case Error(s: String)
          case Response(f: Future[HttpResponse])
          case Status(code: Future[StatusCode])
 
-      object CompletionArg:
+      object CompletionArg with
 
        // conversions defining the possible arguments to pass to `complete`
        // these always come with CompletionArg

--- a/docs/docs/reference/contextual/derivation-macro.md
+++ b/docs/docs/reference/contextual/derivation-macro.md
@@ -142,7 +142,7 @@ import scala.quoted._
 trait Eq[T]:
    def eqv(x: T, y: T): Boolean
 
-object Eq:
+object Eq with
    given Eq[String] with
       def eqv(x: String, y: String) = x == y
 
@@ -195,7 +195,7 @@ object Eq:
    end derived
 end Eq
 
-object Macro3:
+object Macro3 with
    extension [T](inline x: T)
       inline def === (inline y: T)(using eq: Eq[T]): Boolean = eq.eqv(x, y)
 

--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -40,7 +40,7 @@ They also provide minimal term level infrastructure to allow higher level librar
 derivation support.
 
 ```scala
-sealed trait Mirror:
+sealed trait Mirror with
 
    /** the type being mirrored */
    type MirroredType
@@ -57,7 +57,7 @@ sealed trait Mirror:
    /** The names of the elements of the type */
    type MirroredElemLabels <: Tuple
 
-object Mirror:
+object Mirror with
 
    /** The Mirror for a product type */
    trait Product extends Mirror:
@@ -242,7 +242,7 @@ inline def summonAll[T <: Tuple]: List[Eq[_]] =
 trait Eq[T]:
    def eqv(x: T, y: T): Boolean
 
-object Eq:
+object Eq with
    given Eq[Int] with
       def eqv(x: Int, y: Int) = x == y
 

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -174,7 +174,7 @@ There are four possible ways for an extension method to be applicable:
 Here is an example for the first rule:
 
 ```scala
-trait IntOps:
+trait IntOps with
    extension (i: Int) def isZero: Boolean = i == 0
 
    extension (i: Int) def safeMod(x: Int): Option[Int] =
@@ -182,13 +182,13 @@ trait IntOps:
       if x.isZero then None
       else Some(i % x)
 
-object IntOpsEx extends IntOps:
+object IntOpsEx extends IntOps with
    extension (i: Int) def safeDiv(x: Int): Option[Int] =
       // extension method brought into scope via inheritance from IntOps
       if x.isZero then None
       else Some(i / x)
 
-trait SafeDiv:
+trait SafeDiv with
    import IntOpsEx._ // brings safeDiv and safeMod into scope
 
    extension (i: Int) def divide(d: Int): Option[(Int, Int)] =
@@ -209,9 +209,9 @@ given ops1: IntOps with {}  // brings safeMod into scope
 By the third and fourth rule, an extension method is available if it is in the implicit scope of the receiver type or in a given instance in that scope. Example:
 
 ```scala
-class List[T]:
+class List[T] with
    ...
-object List:
+object List with
    ...
    extension [T](xs: List[List[T]])
       def flatten: List[T] = xs.foldLeft(Nil: List[T])(_ ++ _)

--- a/docs/docs/reference/contextual/given-imports.md
+++ b/docs/docs/reference/contextual/given-imports.md
@@ -6,12 +6,12 @@ title: "Importing Givens"
 A special form of import wildcard selector is used to import given instances. Example:
 
 ```scala
-object A:
+object A with
    class TC
    given tc: TC = ???
    def f(using TC) = ???
 
-object B:
+object B with
    import A._
    import A.given
    ...
@@ -22,7 +22,7 @@ of `A` _except_ the given instance `tc`. Conversely, the second import `import A
 The two import clauses can also be merged into one:
 
 ```scala
-object B:
+object B with
    import A.{given, _}
    ...
 ```
@@ -58,7 +58,7 @@ Importing all given instances of a parameterized type is expressed by wildcard a
 For instance, assuming the object
 
 ```scala
-object Instances:
+object Instances with
    given intOrd: Ordering[Int] = ...
    given listOrd[T: Ordering]: Ordering[List[T]] = ...
    given ec: ExecutionContext = ...

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -153,11 +153,10 @@ Here is the syntax for given instances:
 ```
 TmplDef             ::=  ...
                      |   ‘given’ GivenDef
-GivenDef            ::=  [GivenSig] StructuralInstance
+GivenDef            ::=  [GivenSig] ConstrApps TemplateBody
                      |   [GivenSig] Type ‘=’ Expr
                      |   [GivenSig] Type
 GivenSig            ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’
-StructuralInstance  ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody
 ```
 
 A given instance starts with the reserved word `given` and an optional _signature_. The signature

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -7,7 +7,7 @@ Given instances (or, simply, "givens") define "canonical" values of certain type
 that serve for synthesizing arguments to [context parameters](./using-clauses.md). Example:
 
 ```scala
-trait Ord[T]:
+trait Ord[T] with
    def compare(x: T, y: T): Int
    extension (x: T) def < (y: T) = compare(x, y) < 0
    extension (x: T) def > (y: T) = compare(x, y) > 0
@@ -130,7 +130,7 @@ import scala.util.NotGiven
 trait Tagged[A]
 
 case class Foo[A](value: Boolean)
-object Foo:
+object Foo with
    given fooTagged[A](using Tagged[A]): Foo[A] = Foo(true)
    given fooNotTagged[A](using NotGiven[Tagged[A]]): Foo[A] = Foo(false)
 

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -154,8 +154,8 @@ Here is the syntax for given instances:
 TmplDef             ::=  ...
                      |   ‘given’ GivenDef
 GivenDef            ::=  [GivenSig] ConstrApps TemplateBody
-                     |   [GivenSig] Type ‘=’ Expr
-                     |   [GivenSig] Type
+                     |   [GivenSig] AnnotType ‘=’ Expr
+                     |   [GivenSig] AnnotType
 GivenSig            ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’
 ```
 

--- a/docs/docs/reference/contextual/multiversal-equality.md
+++ b/docs/docs/reference/contextual/multiversal-equality.md
@@ -54,7 +54,7 @@ import annotation.implicitNotFound
 @implicitNotFound("Values of types ${L} and ${R} cannot be compared with == or !=")
 sealed trait CanEqual[-L, -R]
 
-object CanEqual:
+object CanEqual with
    object derived extends CanEqual[Any, Any]
 ```
 

--- a/docs/docs/reference/contextual/multiversal-equality.md
+++ b/docs/docs/reference/contextual/multiversal-equality.md
@@ -172,7 +172,7 @@ we are dealing with a refinement of pre-existing, universal equality. It is best
 
 Say you want to come up with a safe version of the `contains` method on `List[T]`. The original definition of `contains` in the standard library was:
 ```scala
-class List[+T]:
+class List[+T] with
    ...
    def contains(x: Any): Boolean
 ```

--- a/docs/docs/reference/contextual/type-classes.md
+++ b/docs/docs/reference/contextual/type-classes.md
@@ -16,10 +16,10 @@ Here are some examples of common type classes:
 Here's the `Monoid` type class definition:
 
 ```scala
-trait SemiGroup[T]:
+trait SemiGroup[T] with
    extension (x: T) def combine (y: T): T
 
-trait Monoid[T] extends SemiGroup[T]:
+trait Monoid[T] extends SemiGroup[T] with
    def unit: T
 ```
 
@@ -49,7 +49,7 @@ def combineAll[T: Monoid](xs: List[T]): T =
 To get rid of the `summon[...]` we can define a `Monoid` object as follows:
 
 ```scala
-object Monoid:
+object Monoid with
    def apply[T](using m: Monoid[T]) = m
 ```
 
@@ -68,7 +68,7 @@ Therefore we write it `F[_]`, hinting that the type `F` takes another type as ar
 The definition of a generic `Functor` would thus be written as:
 
 ```scala
-trait Functor[F[_]]:
+trait Functor[F[_]] with
    def map[A, B](x: F[A], f: A => B): F[B]
 ```
 
@@ -100,7 +100,7 @@ That's a first step, but in practice we probably would like the `map` function t
 As in the previous example of Monoids, [`extension` methods](extension-methods.md) help achieving that. Let's re-define the `Functor` type class with extension methods.
 
 ```scala
-trait Functor[F[_]]:
+trait Functor[F[_]] with
    extension [A](x: F[A])
       def map[B](f: A => B): F[B]
 ```
@@ -138,7 +138,7 @@ That's where `Monad` comes in. A `Monad` for type `F[_]` is a `Functor[F]` with 
 Here is the translation of this definition in Scala 3:
 
 ```scala
-trait Monad[F[_]] extends Functor[F]:
+trait Monad[F[_]] extends Functor[F] with
 
    /** The unit value for a monad */
    def pure[A](x: A): F[A]

--- a/docs/docs/reference/dropped-features/auto-apply.md
+++ b/docs/docs/reference/dropped-features/auto-apply.md
@@ -73,10 +73,10 @@ by a nullary method or _vice versa_. Instead, both methods must agree
 exactly in their parameter lists.
 
 ```scala
-class A:
+class A with
    def next(): Int
 
-class B extends A:
+class B extends A with
    def next: Int // overriding error: incompatible type
 ```
 

--- a/docs/docs/reference/dropped-features/delayed-init.md
+++ b/docs/docs/reference/dropped-features/delayed-init.md
@@ -20,7 +20,7 @@ for benchmarking! Also, if you want to access the command line arguments,
 you need to use an explicit `main` method for that.
 
 ```scala
-object Hello:
+object Hello with
    def main(args: Array[String]) =
       println(s"Hello, ${args(0)}")
 ```

--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -67,7 +67,7 @@ enum Option[+T] with
       case None => false
       case some => true
 
-object Option:
+object Option with
 
    def apply[T >: Null](x: T): Option[T] =
       if x == null then None else Some(x)

--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -8,7 +8,7 @@ types (ADTs) and their generalized version (GADTs). Here is an example
 how an `Option` type can be represented as an ADT:
 
 ```scala
-enum Option[+T]:
+enum Option[+T] with
    case Some(x: T)
    case None
 ```
@@ -23,7 +23,7 @@ The `extends` clauses that were omitted in the example above can also
 be given explicitly:
 
 ```scala
-enum Option[+T]:
+enum Option[+T] with
    case Some(x: T) extends Option[T]
    case None       extends Option[Nothing]
 ```
@@ -59,7 +59,7 @@ As all other enums, ADTs can define methods. For instance, here is `Option` agai
 `isDefined` method and an `Option(...)` constructor in its companion object.
 
 ```scala
-enum Option[+T]:
+enum Option[+T] with
    case Some(x: T)
    case None
 

--- a/docs/docs/reference/enums/enums.md
+++ b/docs/docs/reference/enums/enums.md
@@ -153,7 +153,7 @@ For a more in-depth example of using Scala 3 enums from Java, see [this test](ht
 ### Implementation
 
 Enums are represented as `sealed` classes that extend the `scala.reflect.Enum` trait.
-This trait defines a single public method, `ordinal`:
+This trait defines a single public method, `ordinal` with
 
 ```scala
 package scala.reflect

--- a/docs/docs/reference/enums/enums.md
+++ b/docs/docs/reference/enums/enums.md
@@ -6,7 +6,7 @@ title: "Enumerations"
 An enumeration is used to define a type consisting of a set of named values.
 
 ```scala
-enum Color:
+enum Color with
    case Red, Green, Blue
 ```
 
@@ -79,7 +79,7 @@ end Planet
 It is also possible to define an explicit companion object for an enum:
 
 ```scala
-object Planet:
+object Planet with
    def main(args: Array[String]) =
       val earthWeight = args(0).toDouble
       val mass = earthWeight / Earth.surfaceGravity

--- a/docs/docs/reference/metaprogramming/erased-terms.md
+++ b/docs/docs/reference/metaprogramming/erased-terms.md
@@ -20,7 +20,7 @@ final class Off extends State
 
 @implicitNotFound("State must be Off")
 class IsOff[S <: State]
-object IsOff:
+object IsOff with
    given isOff: IsOff[Off] = new IsOff[Off]
 
 class Machine[S <: State] with
@@ -118,14 +118,14 @@ final class Off extends State
 
 @implicitNotFound("State must be Off")
 class IsOff[S <: State]
-object IsOff:
+object IsOff with
    // will not be called at runtime for turnedOn, the
    // compiler will only require that this evidence exists
    given IsOff[Off] = new IsOff[Off]
 
 @implicitNotFound("State must be On")
 class IsOn[S <: State]
-object IsOn:
+object IsOn with
    // will not exist at runtime, the compiler will only
    // require that this evidence exists at compile time
    erased given IsOn[On] = new IsOn[On]
@@ -135,7 +135,7 @@ class Machine[S <: State] private () with
    def turnedOn(using erased ev: IsOff[S]): Machine[On] = new Machine[On]
    def turnedOff(using erased ev: IsOn[S]): Machine[Off] = new Machine[Off]
 
-object Machine:
+object Machine with
    def newMachine(): Machine[Off] = new Machine[Off]
 
 @main def test =
@@ -174,7 +174,7 @@ class Machine[S <: State] with
          case _: On  => new Machine[Off]
          case _: Off => error("Turning off an already turned off machine")
 
-object Machine:
+object Machine with
    def newMachine(): Machine[Off] =
       println("newMachine")
       new Machine[Off]

--- a/docs/docs/reference/metaprogramming/erased-terms.md
+++ b/docs/docs/reference/metaprogramming/erased-terms.md
@@ -23,7 +23,7 @@ class IsOff[S <: State]
 object IsOff:
    given isOff: IsOff[Off] = new IsOff[Off]
 
-class Machine[S <: State]:
+class Machine[S <: State] with
    def turnedOn(using IsOff[S]): Machine[On] = new Machine[On]
 
 val m = new Machine[Off]
@@ -130,7 +130,7 @@ object IsOn:
    // require that this evidence exists at compile time
    erased given IsOn[On] = new IsOn[On]
 
-class Machine[S <: State] private ():
+class Machine[S <: State] private () with
    // ev will disappear from both functions
    def turnedOn(using erased ev: IsOff[S]): Machine[On] = new Machine[On]
    def turnedOff(using erased ev: IsOn[S]): Machine[Off] = new Machine[Off]
@@ -163,7 +163,7 @@ sealed trait State
 final class On extends State
 final class Off extends State
 
-class Machine[S <: State]:
+class Machine[S <: State] with
    transparent inline def turnOn(): Machine[On] =
       inline erasedValue[S] match
          case _: Off => new Machine[On]

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -9,10 +9,10 @@ title: Inline
 definition will be inlined at the point of use. Example:
 
 ```scala
-object Config:
+object Config with
    inline val logging = false
 
-object Logger:
+object Logger with
 
    private var indent = 0
 
@@ -235,7 +235,7 @@ inline val four: 4 = 4
 It is also possible to have inline vals of types that do not have a syntax, such as `Short(4)`.
 
 ```scala
-trait InlineConstants:
+trait InlineConstants with
    inline val myShort: Short
 
 object Constants extends InlineConstants:

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -143,11 +143,11 @@ Inline methods can override other non-inline methods. The rules are as follows:
 1. If an inline method `f` implements or overrides another, non-inline method, the inline method can also be invoked at runtime. For instance, consider the scenario:
 
     ```scala
-    abstract class A:
+    abstract class A with
        def f: Int
        def g: Int = f
 
-    class B extends A:
+    class B extends A with
        inline def f = 22
        override inline def g = f + 11
 
@@ -168,7 +168,7 @@ Inline methods can override other non-inline methods. The rules are as follows:
 3. Inline methods can also be abstract. An abstract inline method can be implemented only by other inline methods. It cannot be invoked directly:
 
     ```scala
-    abstract class A:
+    abstract class A with
        inline def f: Int
 
     object B extends A:
@@ -250,7 +250,7 @@ specialized to a more precise type upon expansion. Example:
 
 ```scala
 class A
-class B extends A:
+class B extends A with
    def m = true
 
 transparent inline def choose(b: Boolean): A =
@@ -535,7 +535,7 @@ not. We can create a set of implicit definitions like this:
 ```scala
 trait SetFor[T, S <: Set[T]]
 
-class LowPriority:
+class LowPriority with
    implicit def hashSetFor[T]: SetFor[T, HashSet[T]] = ...
 
 object SetsFor extends LowPriority:

--- a/docs/docs/reference/metaprogramming/macros-spec.md
+++ b/docs/docs/reference/metaprogramming/macros-spec.md
@@ -211,7 +211,7 @@ given AsFunction1[T, U]: Conversion[Expr[T => U], Expr[T] => Expr[U]] with
 ```
 This assumes an extractor
 ```scala
-object Lambda:
+object Lambda with
    def unapply[T, U](x: Expr[T => U]): Option[Expr[T] => Expr[U]]
 ```
 Once we allow inspection of code via extractors, it’s tempting to also

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -168,7 +168,7 @@ In some cases we want to remove the lambda from the code, for this we provide th
 describing a function into a function mapping trees to trees.
 
 ```scala
-object Expr:
+object Expr with
    ...
    def betaReduce[...](...)(...): ... = ...
 ```
@@ -231,7 +231,7 @@ a compiler through staging.
 ```scala
 import scala.quoted._
 
-enum Exp:
+enum Exp with
    case Num(n: Int)
    case Plus(e1: Exp, e2: Exp)
    case Var(x: String)
@@ -284,7 +284,7 @@ The `Expr.apply` method is defined in package `quoted`:
 ```scala
 package quoted
 
-object Expr:
+object Expr with
    ...
    def apply[T: ToExpr](x: T)(using Quotes): Expr[T] =
       summon[ToExpr[T]].toExpr(x)
@@ -391,7 +391,7 @@ a macro library and a quoted program. For instance, here’s the `assert` macro
 again together with a program that calls `assert`.
 
 ```scala
-object Macros:
+object Macros with
 
    inline def assert(inline expr: Boolean): Unit =
       ${ assertImpl('expr) }
@@ -525,7 +525,7 @@ Assume we have two methods, one `map` that takes an `Expr[Array[T]]` and a
 function `f` and one `sum` that performs a sum by delegating to `map`.
 
 ```scala
-object Macros:
+object Macros with
 
    def map[T](arr: Expr[Array[T]], f: Expr[T] => Expr[Unit])
              (using Type[T], Quotes): Expr[Unit] = '{

--- a/docs/docs/reference/metaprogramming/tasty-inspect.md
+++ b/docs/docs/reference/metaprogramming/tasty-inspect.md
@@ -21,7 +21,7 @@ To inspect the trees of a TASTy file a consumer can be defined in the following 
 import scala.quoted._
 import scala.tasty.inspector._
 
-class MyInspector extends TastyInspector:
+class MyInspector extends TastyInspector with
    protected def processCompilationUnit(using Quotes)(tree: quotes.reflect.Tree): Unit =
       import quotes.reflect._
       // Do something with the tree
@@ -30,7 +30,7 @@ class MyInspector extends TastyInspector:
 Then the consumer can be instantiated with the following code to get the tree of the `foo/Bar.tasty` file.
 
 ```scala
-object Test:
+object Test with
    def main(args: Array[String]): Unit =
       new MyInspector().inspectTastyFiles("foo/Bar.tasty")
 ```

--- a/docs/docs/reference/new-types/dependent-function-types-spec.md
+++ b/docs/docs/reference/new-types/dependent-function-types-spec.md
@@ -75,7 +75,7 @@ In the following example the depend type `f.Eff` refers to the effect type `CanT
 trait Effect
 
 // Type X => Y
-abstract class Fun[-X, +Y]:
+abstract class Fun[-X, +Y] with
    type Eff <: Effect
    def apply(x: X): Eff ?=> Y
 
@@ -85,11 +85,11 @@ class CanIO extends Effect
 given ct: CanThrow = new CanThrow
 given ci: CanIO = new CanIO
 
-class I2S extends Fun[Int, String]:
+class I2S extends Fun[Int, String] with
    type Eff = CanThrow
    def apply(x: Int) = x.toString
 
-class S2I extends Fun[String, Int]:
+class S2I extends Fun[String, Int] with
    type Eff = CanIO
    def apply(x: String) = x.length
 

--- a/docs/docs/reference/new-types/intersection-types.md
+++ b/docs/docs/reference/new-types/intersection-types.md
@@ -59,7 +59,7 @@ So if one defines a class `C` that inherits `A` and `B`, one needs
 to give at that point a definition of a `children` method with the required type.
 
 ```scala
-class C extends A, B:
+class C extends A, B with
    def children: List[A & B] = ???
 ```
 

--- a/docs/docs/reference/new-types/intersection-types.md
+++ b/docs/docs/reference/new-types/intersection-types.md
@@ -10,7 +10,7 @@ Used on types, the `&` operator creates an intersection type.
 The type `S & T` represents values that are of the type `S` and `T` at the same time.
 
 ```scala
-trait Resettable:
+trait Resettable with
    def reset(): Unit
 
 trait Growable[T]:
@@ -34,10 +34,10 @@ If a member appears in both `A` and `B`, its type in `A & B` is the intersection
 of its type in `A` and its type in `B`. For instance, assume the definitions:
 
 ```scala
-trait A:
+trait A with
    def children: List[A]
 
-trait B:
+trait B with
    def children: List[B]
 
 val x: A & B = new C

--- a/docs/docs/reference/other-new-features/creator-applications.md
+++ b/docs/docs/reference/other-new-features/creator-applications.md
@@ -9,7 +9,7 @@ function application, without needing to write `new`.
 Scala 3 generalizes this scheme to all concrete classes. Example:
 
 ```scala
-class StringBuilder(s: String):
+class StringBuilder(s: String) with
    def this() = this("")
 
 StringBuilder("abc")  // same as new StringBuilder("abc")

--- a/docs/docs/reference/other-new-features/creator-applications.md
+++ b/docs/docs/reference/other-new-features/creator-applications.md
@@ -20,7 +20,7 @@ This works since a companion object with two `apply` methods
 is generated together with the class. The object looks like this:
 
 ```scala
-object StringBuilder:
+object StringBuilder with
    inline def apply(s: String): StringBuilder = new StringBuilder(s)
    inline def apply(): StringBuilder = new StringBuilder()
 ```

--- a/docs/docs/reference/other-new-features/explicit-nulls.md
+++ b/docs/docs/reference/other-new-features/explicit-nulls.md
@@ -39,7 +39,7 @@ The new type system is unsound with respect to `null`. This means there are stil
 The unsoundness happens because uninitialized fields in a class start out as `null`:
 
 ```scala
-class C:
+class C with
    val f: String = foo(f)
    def foo(f2: String): String = f2
 
@@ -114,7 +114,7 @@ Specifically, we patch
     ```
     ==>
     ```scala
-    class C:
+    class C with
        val s: String|UncheckedNull
        val x: Int
     ```
@@ -132,7 +132,7 @@ Specifically, we patch
     Notice this is rule is sometimes too conservative, as witnessed by
 
     ```scala
-    class InScala:
+    class InScala with
        val c: C[Bool] = ???  // C as above
        val b: Bool = c.foo() // no longer typechecks, since foo now returns Bool|Null
     ```
@@ -169,7 +169,7 @@ Specifically, we patch
     ```
     ==>
     ```scala
-    class BoxFactory[T]:
+    class BoxFactory[T] with
        def makeBox(): Box[T | UncheckedNull] | UncheckedNull
        def makeCrazyBoxes(): List[Box[List[T] | UncheckedNull]] | UncheckedNull
     ```
@@ -195,7 +195,7 @@ Specifically, we patch
     ```
     ==>
     ```scala
-    class Constants:
+    class Constants with
        val NAME: String("name") = "name"
        val AGE: Int(0) = 0
        val CHAR: Char('a') = 'a'
@@ -215,7 +215,7 @@ Specifically, we patch
     ```
     ==>
     ```scala
-    class C:
+    class C with
        val name: String
        def getNames(prefix: String | UncheckedNull): List[String] // we still need to nullify the paramter types
        def getBoxedName(): Box[String | UncheckedNull] // we don't append `UncheckedNull` to the outmost level, but we still need to nullify inside

--- a/docs/docs/reference/other-new-features/export.md
+++ b/docs/docs/reference/other-new-features/export.md
@@ -9,16 +9,16 @@ An export clause defines aliases for selected members of an object. Example:
 class BitMap
 class InkJet
 
-class Printer:
+class Printer with
    type PrinterType
    def print(bits: BitMap): Unit = ???
    def status: List[String] = ???
 
-class Scanner:
+class Scanner with
    def scan(): BitMap = ???
    def status: List[String] = ???
 
-class Copier:
+class Copier with
    private val printUnit = new Printer { type PrinterType = InkJet }
    private val scanUnit = new Scanner
 

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -120,7 +120,7 @@ With these new rules, the following constructs are all valid:
 trait A:
    def f: Int
 
-class C(x: Int) extends A:
+class C(x: Int) extends A with
    def f = x
 
 object O:
@@ -256,7 +256,7 @@ For instance, the following end markers are all legal:
 ```scala
 package p1.p2:
 
-   abstract class C():
+   abstract class C() with
 
       def this(x: Int) =
          this()

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -117,16 +117,16 @@ Analogous rules apply for enum bodies and local packages containing nested defin
 With these new rules, the following constructs are all valid:
 
 ```scala
-trait A:
+trait A with
    def f: Int
 
 class C(x: Int) extends A with
    def f = x
 
-object O:
+object O with
    def f = 3
 
-enum Color:
+enum Color with
    case Red, Green, Blue
 
 new A:
@@ -285,7 +285,7 @@ package p1.p2:
       def f: String
    end C
 
-   object C:
+   object C with
       given C =
          new C:
             def f = "!"
@@ -327,7 +327,7 @@ TopStat           ::=  ... | EndMarker
 Here is a (somewhat meta-circular) example of code using indentation. It provides a concrete representation of indentation widths as defined above together with efficient operations for constructing and comparing indentation widths.
 
 ```scala
-enum IndentWidth:
+enum IndentWidth with
    case Run(ch: Char, n: Int)
    case Conc(l: IndentWidth, r: Run)
 
@@ -356,7 +356,7 @@ enum IndentWidth:
       case Conc(l, r) =>
          s"$l, $r"
 
-object IndentWidth:
+object IndentWidth with
    private inline val MaxCached = 40
 
    private val spaces = IArray.tabulate(MaxCached + 1)(new Run(' ', _))

--- a/docs/docs/reference/other-new-features/matchable.md
+++ b/docs/docs/reference/other-new-features/matchable.md
@@ -75,7 +75,7 @@ extended by both `AnyVal` and `AnyRef`. Since `Matchable` is a supertype of ever
 Here is the hierarchy of top-level classes and traits with their defined methods:
 
 ```scala
-abstract class Any:
+abstract class Any with
    def getClass
    def isInstanceOf
    def asInstanceOf
@@ -102,7 +102,7 @@ Matchable warning is turned on. The most common such method is the universal
 `equals` method. It will have to be written as in the following example:
 
 ```scala
-class C(val x: String):
+class C(val x: String) with
 
    override def equals(that: Any): Boolean =
       that.asInstanceOf[Matchable] match

--- a/docs/docs/reference/other-new-features/opaques-details.md
+++ b/docs/docs/reference/other-new-features/opaques-details.md
@@ -33,7 +33,7 @@ type T >: L <: U
 A special case arises if the opaque type alias is defined in an object. Example:
 
 ```scala
-object o:
+object o with
    opaque type T = R
 ```
 
@@ -44,7 +44,7 @@ that `o.this.T` equals `R`. The two equalities compose. That is, inside `o`, it 
 also known that `o.T` is equal to `R`. This means the following code type-checks:
 
 ```scala
-object o:
+object o with
    opaque type T = Int
    val x: Int = id(2)
 def id(x: o.T): o.T = x
@@ -88,7 +88,7 @@ objects and classes and in all other source files. Example:
 opaque type A = String
 val x: A = "abc"
 
-object obj:
+object obj with
    val y: A = "abc"  // error: found: "abc", required: A
 
 // in test2.scala
@@ -100,7 +100,7 @@ object test1$package:
    opaque type A = String
    val x: A = "abc"
 
-object obj:
+object obj with
    val y: A = "abc"  // error: cannot assign "abc" to opaque type alias A
 ```
 The opaque type alias `A` is transparent in its scope, which includes the definition of `x`, but not the definitions of `obj` and `y`.

--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -6,11 +6,11 @@ title: "Opaque Type Aliases"
 Opaque types aliases provide type abstraction without any overhead. Example:
 
 ```scala
-object Logarithms:
+object Logarithms with
 
    opaque type Logarithm = Double
 
-   object Logarithm:
+   object Logarithm with
 
       // These are the two ways to lift to the Logarithm type
 
@@ -63,7 +63,7 @@ l / l2                  // error: `/` is not a member of Logarithm
 Opaque type aliases can also come with bounds. Example:
 
 ```scala
-object Access:
+object Access with
 
    opaque type Permissions = Int
    opaque type PermissionChoice = Int
@@ -110,7 +110,7 @@ it known outside the `Access` object that `Permission` is a subtype of the other
 two types.  Hence, the following usage scenario type-checks.
 
 ```scala
-object User:
+object User with
    import Access._
 
    case class Item(rights: Permissions)

--- a/docs/docs/reference/other-new-features/open-classes.md
+++ b/docs/docs/reference/other-new-features/open-classes.md
@@ -8,7 +8,7 @@ An `open` modifier on a class signals that the class is planned for extensions. 
 // File Writer.scala
 package p
 
-open class Writer[T]:
+open class Writer[T] with
 
    /** Sends to stdout, can be overridden */
    def send(x: T) = println(x)
@@ -20,7 +20,7 @@ end Writer
 // File EncryptedWriter.scala
 package p
 
-class EncryptedWriter[T: Encryptable] extends Writer[T]:
+class EncryptedWriter[T: Encryptable] extends Writer[T] with
    override def send(x: T) = super.send(encrypt(x))
 ```
 An open class typically comes with some documentation that describes

--- a/docs/docs/reference/other-new-features/safe-initialization.md
+++ b/docs/docs/reference/other-new-features/safe-initialization.md
@@ -39,7 +39,7 @@ The checker will report:
 Given the code below:
 
 ``` scala
-object Trees:
+object Trees with
    class ValDef { counter += 1 }
    class EmptyValDef extends ValDef
    val theEmptyValDef = new EmptyValDef

--- a/docs/docs/reference/other-new-features/safe-initialization.md
+++ b/docs/docs/reference/other-new-features/safe-initialization.md
@@ -14,11 +14,11 @@ To get a feel of how it works, we first show several examples below.
 Given the following code snippet:
 
 ``` scala
-abstract class AbstractFile:
+abstract class AbstractFile with
    def name: String
    val extension: String = name.substring(4)
 
-class RemoteFile(url: String) extends AbstractFile:
+class RemoteFile(url: String) extends AbstractFile with
    val localFile: String = s"${url.##}.tmp"  // error: usage of `localFile` before it's initialized
    def name: String = localFile
 ```
@@ -63,11 +63,11 @@ The checker will report:
 Given the code below:
 
 ``` scala
-abstract class Parent:
+abstract class Parent with
    val f: () => String = () => this.message
    def message: String
 
-class Child extends Parent:
+class Child extends Parent with
    val a = f()
    val b = "hello"           // error
    def message: String = b
@@ -122,11 +122,11 @@ following example shows:
 
 ``` scala
 class MyException(val b: B) extends Exception("")
-class A:
+class A with
    val b = try { new B } catch { case myEx: MyException => myEx.b }
    println(b.a)
 
-class B:
+class B with
    throw new MyException(this)
    val a: Int = 1
 ```
@@ -141,10 +141,10 @@ field points to an initialized object may not later point to an
 object under initialization. As an example, the following code will be rejected:
 
 ``` scala
-trait Reporter:
+trait Reporter with
    def report(msg: String): Unit
 
-class FileReporter(ctx: Context) extends Reporter:
+class FileReporter(ctx: Context) extends Reporter with
    ctx.typer.reporter = this                // ctx now reaches an uninitialized object
    val file: File = new File("report.txt")
    def report(msg: String) = file.write(msg)
@@ -214,11 +214,11 @@ project boundaries. For example, the following code passes the check when the
 two classes are defined in the same project:
 
 ```Scala
-class Base:
+class Base with
    private val map: mutable.Map[Int, String] = mutable.Map.empty
    def enter(k: Int, v: String) = map(k) = v
 
-class Child extends Base:
+class Child extends Base with
    enter(1, "one")
    enter(2, "two")
 ```

--- a/docs/docs/reference/other-new-features/targetName.md
+++ b/docs/docs/reference/other-new-features/targetName.md
@@ -70,9 +70,9 @@ between two definitions that have otherwise the same names and types. So the fol
 
 ```scala
 import annotation.targetName
-class A:
+class A with
    def f(): Int = 1
-class B extends A:
+class B extends A with
    @targetName("g") def f(): Int = 2
 ```
 
@@ -98,9 +98,9 @@ be present in the original code. So the following example would also be in error
 
 ```scala
 import annotation.targetName
-class A:
+class A with
    def f(): Int = 1
-class B extends A:
+class B extends A with
    @targetName("f") def g(): Int = 2
 ```
 
@@ -109,7 +109,7 @@ different names. But once we switch to target names, there is a clash that is re
 
 ```
 -- [E120] Naming Error: test.scala:4:6 -----------------------------------------
-4 |class B extends A:
+4 |class B extends A with
   |      ^
   |      Name clash between defined and inherited member:
   |      def f(): Int in class A at line 3 and

--- a/docs/docs/reference/other-new-features/targetName.md
+++ b/docs/docs/reference/other-new-features/targetName.md
@@ -8,7 +8,7 @@ A `@targetName` annotation on a definition defines an alternate name for the imp
 ```scala
 import scala.annotation.targetName
 
-object VecOps:
+object VecOps with
    extension [T](xs: Vec[T])
       @targetName("append")
       def ++= [T] (ys: Vec[T]): Vec[T] = ...

--- a/docs/docs/reference/other-new-features/threadUnsafe-annotation.md
+++ b/docs/docs/reference/other-new-features/threadUnsafe-annotation.md
@@ -12,6 +12,6 @@ a `lazy val`. When this annotation is used, the initialization of the
 ```scala
 import scala.annotation.threadUnsafe
 
-class Hello:
+class Hello with
    @threadUnsafe lazy val x: Int = 1
 ```

--- a/docs/docs/reference/other-new-features/trait-parameters.md
+++ b/docs/docs/reference/other-new-features/trait-parameters.md
@@ -9,7 +9,7 @@ Scala 3 allows traits to have parameters, just like classes have parameters.
 trait Greeting(val name: String):
    def msg = s"How are you, $name"
 
-class C extends Greeting("Bob"):
+class C extends Greeting("Bob") with
    println(msg)
 ```
 

--- a/docs/docs/reference/other-new-features/type-test.md
+++ b/docs/docs/reference/other-new-features/type-test.md
@@ -19,7 +19,7 @@ The second case is when an extractor takes an argument that is not a subtype of 
 (x: X) match
    case y @ Y(n) =>
 
-object Y:
+object Y with
    def unapply(x: Y): Some[Int] = ...
 ```
 
@@ -115,7 +115,7 @@ Given the following abstract definition of Peano numbers that provides two given
 ```scala
 import scala.reflect._
 
-trait Peano:
+trait Peano with
    type Nat
    type Zero <: Nat
    type Succ <: Nat
@@ -125,11 +125,11 @@ trait Peano:
    val Zero: Zero
 
    val Succ: SuccExtractor
-   trait SuccExtractor:
+   trait SuccExtractor with
       def apply(nat: Nat): Succ
       def unapply(nat: Succ): Option[Nat]
 
-   given typeTestOfZero: TypeTest[Nat, Zero] 
+   given typeTestOfZero: TypeTest[Nat, Zero]
    given typeTestOfSucc: TypeTest[Nat, Succ]
 ```
 

--- a/docs/docs/release-notes/syntax-changes-0.22.md
+++ b/docs/docs/release-notes/syntax-changes-0.22.md
@@ -94,7 +94,7 @@ class Str(str: String) extends Text:
 class Append(txt1: Text, txt2: Text) extends Text:
   def toString = txt1 ++ txt2
 
-object Empty extends Text:
+object Empty extends Text with
   def toString = ""
 
 extension on (t: Text):

--- a/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
+++ b/stdlib-bootstrapped-tasty-tests/test/BootstrappedStdLibTASYyTest.scala
@@ -12,7 +12,7 @@ import scala.quoted._
 import java.io.File.pathSeparator
 import java.io.File.separator
 
-class BootstrappedStdLibTASYyTest:
+class BootstrappedStdLibTASYyTest with
 
   import BootstrappedStdLibTASYyTest._
 
@@ -88,7 +88,7 @@ class BootstrappedStdLibTASYyTest:
 
 end BootstrappedStdLibTASYyTest
 
-object BootstrappedStdLibTASYyTest:
+object BootstrappedStdLibTASYyTest with
 
   def scalaLibJarPath = System.getProperty("dotty.scala.library")
   def scalaLibClassesPath =

--- a/stdlib-bootstrapped/test/Main.scala
+++ b/stdlib-bootstrapped/test/Main.scala
@@ -3,7 +3,7 @@ package hello
 enum Color:
   case Red, Green, Blue
 
-object HelloWorld:
+object HelloWorld with
   def main(args: Array[String]): Unit = {
     println("hello dotty.superbootstrapped!")
     println(Color.Red)

--- a/tests/bench/string-interpolation-macro/Test.scala
+++ b/tests/bench/string-interpolation-macro/Test.scala
@@ -1,4 +1,4 @@
 import Macro._
 
-class Test:
+class Test with
   def test: String = x"a${1}b${2}c${3}d${4}e${5}f"

--- a/tests/disabled/pos/i8311.scala
+++ b/tests/disabled/pos/i8311.scala
@@ -1,12 +1,12 @@
 
-trait Show[O]:
+trait Show[O] with
   extension (o: O)
     def show: String
 
 class Box[A]
 class Foo
 
-object test:
+object test with
 
   given box[A](using Show[A]): Show[Box[A]] = _.toString
   given foo: Show[Foo] = _.toString

--- a/tests/neg-custom-args/explicit-nulls/byname-nullables.scala
+++ b/tests/neg-custom-args/explicit-nulls/byname-nullables.scala
@@ -1,4 +1,4 @@
-object Test1:
+object Test1 with
 
   def f(x: String) =
     x ++ x
@@ -9,7 +9,7 @@ object Test1:
     else x
 
 
-object Test2:
+object Test2 with
 
   def f(x: => String) =
     x ++ x
@@ -19,7 +19,7 @@ object Test2:
     if x != null then f(x)   // error: f is call-by-name
     else x
 
-object Test3:
+object Test3 with
 
   def f(x: String, y: String) = x
 
@@ -31,7 +31,7 @@ object Test3:
     if x != null then f(x, 1)   // OK: not-null check successfully dropped
     else x
 
-object Test4:
+object Test4 with
 
   def f(x: String, y: String) = x
 
@@ -43,7 +43,7 @@ object Test4:
     if x != null then f(identity(x), 1)   // error: dropping not null check fails typing
     else x
 
-object Test5:
+object Test5 with
   import compiletime.byName
 
   def f(x: String, y: String) = x
@@ -56,7 +56,7 @@ object Test5:
     if x != null then f(byName(identity(x)), 1)   // OK, byName avoids the flow typing
     else x
 
-object Test6:
+object Test6 with
 
   def f(x: String, y: String) = x
 
@@ -68,7 +68,7 @@ object Test6:
     if x != null then f(x, 1)   // error: dropping not null check typechecks OK, but gives incompatible result type
     else x
 
-object Test7:
+object Test7 with
   import compiletime.byName
 
   def f(x: String, y: String) = x

--- a/tests/neg-custom-args/explicit-nulls/byname-nullables1.scala
+++ b/tests/neg-custom-args/explicit-nulls/byname-nullables1.scala
@@ -1,7 +1,7 @@
 def f(op: => Boolean): Unit = ()
 def f(op: Int): Unit = ()
 
-class C:
+class C with
   var fld: String | Null = null
 
 def test() =

--- a/tests/neg-custom-args/fatal-warnings/enum-variance.scala
+++ b/tests/neg-custom-args/fatal-warnings/enum-variance.scala
@@ -1,10 +1,10 @@
-enum View[-T]:
+enum View[-T] with
   case Refl(f: T => T) // error: enum case Refl requires explicit declaration of type T
 
 enum ExplicitView[-T]: // desugared version of View
   case Refl[-T](f: T => T) extends ExplicitView[T] // error: contravariant type T occurs in covariant position
 
-enum InvariantView[-T, +U] extends (T => U):
+enum InvariantView[-T, +U] extends (T => U) with
   case Refl[T](f: T => T) extends InvariantView[T, T]
 
   final def apply(t: T): U = this match

--- a/tests/neg-custom-args/fatal-warnings/i8781b.scala
+++ b/tests/neg-custom-args/fatal-warnings/i8781b.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
 
   println((3: Boolean | Int).isInstanceOf[Boolean])
 

--- a/tests/neg-custom-args/fatal-warnings/opaque-match.scala
+++ b/tests/neg-custom-args/fatal-warnings/opaque-match.scala
@@ -1,6 +1,6 @@
 case class C()
 
-object O:
+object O with
   opaque type T <: C = C
   val x: T = C()
   (??? : Any) match
@@ -17,7 +17,7 @@ def Test[T] =
   (??? : Any) match
     case _: List[O.T] => ???  // error
   (??? : Any) match
-    case _: List[O.T @unchecked] => ???  // OK 
+    case _: List[O.T @unchecked] => ???  // OK
   (??? : Any) match
     case _: List[T] => ???  // error
 

--- a/tests/neg-custom-args/fatal-warnings/supertraits.scala
+++ b/tests/neg-custom-args/fatal-warnings/supertraits.scala
@@ -4,7 +4,7 @@ trait S
 case object a extends S, TA, TB
 case object b extends S, TA, TB
 
-object Test:
+object Test with
 
   def choose0[X](x: X, y: X): X = x
   def choose1[X <: TA](x: X, y: X): X = x

--- a/tests/neg-custom-args/infix.scala
+++ b/tests/neg-custom-args/infix.scala
@@ -1,11 +1,11 @@
 // Compile with -strict -Xfatal-warnings -deprecation
-class C:
+class C with
   infix def op(x: Int): Int = ???
   def meth(x: Int): Int = ???
   def matching(x: Int => Int) = ???
   def +(x: Int): Int = ???
 
-object C:
+object C with
   given AnyRef with
     extension (x: C)
       infix def iop (y: Int) = ???

--- a/tests/neg-macros/BigFloat/BigFloatFromDigitsImpl_1.scala
+++ b/tests/neg-macros/BigFloat/BigFloatFromDigitsImpl_1.scala
@@ -3,7 +3,7 @@ import language.experimental.genericNumberLiterals
 import scala.util.FromDigits
 import scala.quoted._
 
-object BigFloatFromDigitsImpl:
+object BigFloatFromDigitsImpl with
   def apply(digits: Expr[String])(using Quotes): Expr[BigFloat] =
     digits.value match
       case Some(ds) =>

--- a/tests/neg-macros/GenericNumLits/EvenFromDigitsImpl_1.scala
+++ b/tests/neg-macros/GenericNumLits/EvenFromDigitsImpl_1.scala
@@ -3,7 +3,7 @@ import scala.util.FromDigits
 import scala.quoted._
 import Even._
 
-object EvenFromDigitsImpl:
+object EvenFromDigitsImpl with
   def apply(digits: Expr[String])(using Quotes): Expr[Even] = digits.value match {
     case Some(ds) =>
       val ev =

--- a/tests/neg-macros/i9972b/Test_2.scala
+++ b/tests/neg-macros/i9972b/Test_2.scala
@@ -1,5 +1,5 @@
 
 class T[A]
 
-object T:
+object T with
   implicit inline def derived[A]: T[A] = new T[A]

--- a/tests/neg-with-compiler/GenericNumLits/EvenFromDigitsImpl_1.scala
+++ b/tests/neg-with-compiler/GenericNumLits/EvenFromDigitsImpl_1.scala
@@ -3,7 +3,7 @@ import scala.util.FromDigits
 import scala.quoted._
 import Even._
 
-object EvenFromDigitsImpl:
+object EvenFromDigitsImpl with
   def apply(digits: Expr[String])(using Quotes): Expr[Even] = digits.value match {
     case Some(ds) =>
       val ev =

--- a/tests/neg/abstract-givens.scala
+++ b/tests/neg/abstract-givens.scala
@@ -1,9 +1,9 @@
-trait T:
+trait T with
   given x: Int
   given y(using Int): String = summon[Int].toString
   given z[T](using T): List[T]
 
-object Test extends T:
+object Test extends T with
   given x: Int = 22
   given y(using Int): String = summon[Int].toString * 22 // error
   given z[T](using T): Seq[T] = List(summon[T]) // error

--- a/tests/neg/abstract-inline-val.scala
+++ b/tests/neg/abstract-inline-val.scala
@@ -1,4 +1,4 @@
-trait C:
+trait C with
   inline def x: Int
   inline val y: Int
 

--- a/tests/neg/ambiref.scala
+++ b/tests/neg/ambiref.scala
@@ -1,43 +1,43 @@
-object test1:
+object test1 with
 
-  class C:
+  class C with
     val x = 0
-  object Test:
+  object Test with
     val x = 1
-    class D extends C:
+    class D extends C with
       println(x)  // error
-    new C:
+    new C with
       println(x)  // error
 
-object test2:
+object test2 with
   def c(y: Float) =
-    class D:
+    class D with
       val y = 2
-    new D:
+    new D with
       println(y)  // error
 
-object test3:
+object test3 with
   def c(y: Float) =
-    class D:
+    class D with
       val y = 2
-    class E extends D:
-      class F:
+    class E extends D with
+      class F with
         println(y)  // error
 
-object test4:
+object test4 with
 
-  class C:
+  class C with
     val x = 0
-  object Test:
+  object Test with
     val x = 1
-    class D extends C:
+    class D extends C with
       def x(y: Int) = 3
       val y: Int = this.x // OK
       val z: Int = x      // OK
 end test4
 
 val global = 0
-class C:
+class C with
   val global = 1
-object D extends C:
+object D extends C with
   println(global)    // OK, since global is defined in package

--- a/tests/neg/bad-unapplies.scala
+++ b/tests/neg/bad-unapplies.scala
@@ -1,19 +1,19 @@
 trait A
 trait B
 class C extends A, B
-object A:
+object A with
   def unapply(x: A): Option[String] = Some(x.toString)
   def unapply(x: B): Option[String] = Some(x.toString)
 
 object B
 
-object D:
+object D with
   def unapply(x: A, y: B): Option[String] = Some(x.toString)
 
-object E:
+object E with
   val unapply: Option[String] = Some("")
 
-object F:
+object F with
   def unapply(x: Int): Boolean = true
 
 

--- a/tests/neg/case-semi.scala
+++ b/tests/neg/case-semi.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
   type X = Int
   val x: X = 1
 

--- a/tests/neg/creator-ambiguous.scala
+++ b/tests/neg/creator-ambiguous.scala
@@ -2,11 +2,11 @@
 // This used to succeed with old creator methods scheme
 // What happened was: the overloading resolution gave an ambiguous
 // overload, but then the falblback picked the constructor
-object Test:
+object Test with
 
   case class Record(elems: (String, Any)*)
 
-  object Record:
+  object Record with
 
     inline def apply[R <: Record](elems: (String, Any)*) : R = new Record(elems: _*).asInstanceOf[R]
 

--- a/tests/neg/curried-dependent-ift.scala
+++ b/tests/neg/curried-dependent-ift.scala
@@ -1,9 +1,9 @@
-trait Ctx1:
+trait Ctx1 with
   type T
   val x: T
   val y: T
 
-trait Ctx2:
+trait Ctx2 with
   type T
   val x: T
   val y: T

--- a/tests/neg/endmarkers.scala
+++ b/tests/neg/endmarkers.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
 
   locally {
     var x = 0
@@ -43,11 +43,11 @@ object Test:
     x < 10
   do ()
 
-class Test2:
+class Test2 with
   self =>
   def foo = 1
 
-  object x:
+  object x with
     new Test2 {
       override def foo = 2
       end new               // error: misaligned end marker
@@ -56,16 +56,16 @@ class Test2:
   end Test2                 // error: misaligned end marker
 end Test2
 
-class Test3:
+class Test3 with
  self =>
   def foo = 1
  end Test3  // error: misaligned end marker
 
 import collection.mutable.HashMap
 
-class Coder(words: List[String]):
+class Coder(words: List[String]) with
 
-  class Foo:
+  class Foo with
     println()
     end Foo  // error: misaligned end marker
 

--- a/tests/neg/endmarkers1.scala
+++ b/tests/neg/endmarkers1.scala
@@ -4,7 +4,7 @@ def f7[T](x: Option[T]) = x match
   case None =>
 end if  // error: misaligned end marker
 
-object Test4:
+object Test4 with
   def f[T](x: Option[T]) = x match
     case Some(y) =>
     case None =>

--- a/tests/neg/enum-values.scala
+++ b/tests/neg/enum-values.scala
@@ -1,26 +1,26 @@
 package example
 
-enum Tag[T]:
+enum Tag[T] with
   case Int extends Tag[Int]
   case String extends Tag[String]
   case OfClass[T]()(using val tag: reflect.ClassTag[T]) extends Tag[T]
 
-enum ListLike[+T]:
+enum ListLike[+T] with
   case Cons[T](head: T, tail: ListLike[T]) extends ListLike[T]
   case EmptyListLike
-object ListLike:
+object ListLike with
   def valuef(s: String): ListLike[?] = ??? // this will usually trigger a "- did you mean ListLike.valuef" addendum
 
-object Extensions:
+object Extensions with
   extension (foo: Nothing) // this will usually trigger an attempted extension method addendum
     def values: Array[Tag[?]] = ???
 
-enum TypeCtorsK[F[_]]:
+enum TypeCtorsK[F[_]] with
   case List       extends TypeCtorsK[List]
   case Option     extends TypeCtorsK[Option]
   case Const[T]() extends TypeCtorsK[[U] =>> T]
 
-object UnimportedExtensions:
+object UnimportedExtensions with
   extension (TypeCtorsKModule: TypeCtorsK.type) // this will usually trigger an import suggestions addendum
     def valueOf(name: String): TypeCtorsK[?] = ???
 

--- a/tests/neg/enums.scala
+++ b/tests/neg/enums.scala
@@ -42,10 +42,10 @@ enum Option[+T] derives CanEqual {
 
 object DollarNew {
 
-  enum MyEnum:
+  enum MyEnum with
     case A
 
-  object MyEnum:
+  object MyEnum with
 
     def $new: MyEnum = new MyEnum with runtime.EnumValue { // error: anonymous class in method $new extends enum MyEnum, but extending enums is prohibited.
       override def $ordinal = 1

--- a/tests/neg/enumvalues.scala
+++ b/tests/neg/enumvalues.scala
@@ -1,7 +1,7 @@
-enum Color:
+enum Color with
   case Red, Green, Blue
 
-enum Option[+T]:
+enum Option[+T] with
   case None extends Option[Nothing]
 
 import scala.runtime.EnumValue

--- a/tests/neg/eql.scala
+++ b/tests/neg/eql.scala
@@ -1,6 +1,6 @@
-object lst:
+object lst with
   opaque type Lst[+T] = Any
-  object Lst:
+  object Lst with
     given lstCanEqual[T, U]: CanEqual[Lst[T], Lst[U]] = CanEqual.derived
     val Empty: Lst[Nothing] = ???
 end lst

--- a/tests/neg/exports1.scala
+++ b/tests/neg/exports1.scala
@@ -1,20 +1,20 @@
-object A:
+object A with
   def f: String = ""
 
-trait B:
+trait B with
   def f: String = "abc"
 
-trait B2 extends B:
+trait B2 extends B with
   override def f: String = "abc"
 
-object D extends B:
+object D extends B with
   object b extends B
   export b._             // ok
 
-object D1 extends B:
+object D1 extends B with
   object b extends B
   export b.f             // error
 
-object D2 extends B:
+object D2 extends B with
   object b2 extends B2
   export b2.f            // error

--- a/tests/neg/exports2.scala
+++ b/tests/neg/exports2.scala
@@ -1,9 +1,9 @@
-object A:
+object A with
   def f: String = ""
 
-trait B:
+trait B with
   def f: String = "abc"
 
-object C extends B:
+object C extends B with
   export A._            // error
 

--- a/tests/neg/extend-java-enum-nonstatic.scala
+++ b/tests/neg/extend-java-enum-nonstatic.scala
@@ -1,22 +1,22 @@
 import java.{lang => jl}
 
-object TestSuite:
+object TestSuite with
   def test(op: => Unit): Unit = op
   test {
     enum E extends jl.Enum[E] { case A } // error: enum extending java.lang.Enum must be declared in a static scope
   }
 
-class Container:
+class Container with
   enum E extends jl.Enum[E] { case A } // error: enum extending java.lang.Enum must be declared in a static scope
 
-object Wrap:
+object Wrap with
   def force =
     enum E extends jl.Enum[E] { case A } // error: enum extending java.lang.Enum must be declared in a static scope
 
-trait Universe:
+trait Universe with
   enum E extends jl.Enum[E] { case A } // error: enum extending java.lang.Enum must be declared in a static scope
 
 enum E extends jl.Enum[E] { case A } // ok, a declaration at package level is static.
 
-object Static:
+object Static with
   enum E extends jl.Enum[E] { case A } // ok, a declaration within a static object is static.

--- a/tests/neg/extension-colon.check
+++ b/tests/neg/extension-colon.check
@@ -1,4 +1,0 @@
--- Error: tests/neg/extension-colon.scala:1:18 -------------------------------------------------------------------------
-1 |extension (x: Int): // error
-  |                  ^
-  |                  no `:` expected here

--- a/tests/neg/extension-colon.scala
+++ b/tests/neg/extension-colon.scala
@@ -1,2 +1,0 @@
-extension (x: Int): // error
-  def foo = x

--- a/tests/neg/extension-with.check
+++ b/tests/neg/extension-with.check
@@ -1,0 +1,6 @@
+-- Error: tests/neg/extension-with.scala:1:19 --------------------------------------------------------------------------
+1 |extension (x: Int) with // error
+  |                   ^^^^
+  |                   No `with` expected here.
+  |
+  |                   An extension clause is simply followed by one or more method definitions.

--- a/tests/neg/extension-with.scala
+++ b/tests/neg/extension-with.scala
@@ -1,0 +1,2 @@
+extension (x: Int) with // error
+  def foo = x

--- a/tests/neg/gadt-approximation-interaction.scala
+++ b/tests/neg/gadt-approximation-interaction.scala
@@ -1,5 +1,5 @@
 object MemberHealing {
-  enum SUB[-A, +B]:
+  enum SUB[-A, +B] with
     case Refl[S]() extends SUB[S, S]
 
   def foo[T](t: T, ev: T SUB Int) =
@@ -9,7 +9,7 @@ object MemberHealing {
 }
 
 object ImplicitLookup {
-  enum SUB[-A, +B]:
+  enum SUB[-A, +B] with
     case Refl[S]() extends SUB[S, S]
 
   class Tag[T]
@@ -23,7 +23,7 @@ object ImplicitLookup {
 }
 
 object GivenLookup {
-  enum SUB[-A, +B]:
+  enum SUB[-A, +B] with
     case Refl[S]() extends SUB[S, S]
 
   class Tag[T]
@@ -37,10 +37,10 @@ object GivenLookup {
 }
 
 object ImplicitConversion {
-  enum SUB[-A, +B]:
+  enum SUB[-A, +B] with
     case Refl[S]() extends SUB[S, S]
 
-  class Pow(self: Int):
+  class Pow(self: Int) with
     def **(other: Int): Int = math.pow(self, other).toInt
 
   implicit def pow(i: Int): Pow = Pow(i)
@@ -57,10 +57,10 @@ object ImplicitConversion {
 }
 
 object GivenConversion {
-  enum SUB[-A, +B]:
+  enum SUB[-A, +B] with
     case Refl[S]() extends SUB[S, S]
 
-  class Pow(self: Int):
+  class Pow(self: Int) with
     def **(other: Int): Int = math.pow(self, other).toInt
 
   given Conversion[Int, Pow] = (i: Int) => Pow(i)
@@ -77,7 +77,7 @@ object GivenConversion {
 }
 
 object ExtensionMethod {
-  enum SUB[-A, +B]:
+  enum SUB[-A, +B] with
     case Refl[S]() extends SUB[S, S]
 
   extension (x: Int)
@@ -90,10 +90,10 @@ object ExtensionMethod {
 }
 
 object HKFun {
-  enum SUB[-A, +B]:
+  enum SUB[-A, +B] with
     case Refl[S]() extends SUB[S, S]
 
-  enum HKSUB[-F[_], +G[_]]:
+  enum HKSUB[-F[_], +G[_]] with
     case Refl[H[_]]() extends HKSUB[H, H]
 
   def foo[F[_], T](ft: F[T], hkev: F HKSUB Option, ev: T SUB Int) =
@@ -107,7 +107,7 @@ object HKFun {
       }
     }
 
-  enum COVHKSUB[-F[+_], +G[+_]]:
+  enum COVHKSUB[-F[+_], +G[+_]] with
     case Refl[H[_]]() extends COVHKSUB[H, H]
 
   def bar[F[+_], T](ft: F[T], hkev: F COVHKSUB Option, ev: T SUB Int) =
@@ -123,7 +123,7 @@ object HKFun {
 }
 
 object NestedConstrained {
-  enum SUB[-A, +B]:
+  enum SUB[-A, +B] with
     case Refl[S]() extends SUB[S, S]
 
   def foo[A, B](a: A, ev1: A SUB Option[B], ev2: B SUB Int) =

--- a/tests/neg/given-eta.scala
+++ b/tests/neg/given-eta.scala
@@ -1,5 +1,5 @@
 
-trait D:
+trait D with
    type T
    def trans(other: T): T
 

--- a/tests/neg/i10546.scala
+++ b/tests/neg/i10546.scala
@@ -1,4 +1,4 @@
-object test:
+object test with
   def times(num : Int)(block : => Unit) : Unit = ()
     times(10): println("ah") // error: end of statement expected but '(' found // error
 

--- a/tests/neg/i10817.scala
+++ b/tests/neg/i10817.scala
@@ -1,6 +1,6 @@
 import annotation.static
 
-class T:
+class T with
   @static val foo = 10 // error
 
 val x = (new T).foo

--- a/tests/neg/i10857.scala
+++ b/tests/neg/i10857.scala
@@ -1,25 +1,25 @@
-object Module:
+object Module with
 
   class Bar
   class Baz
   class Qux
 
-  object Givens:
+  object Givens with
     given GivenBar: Bar = new Bar()
     def GivenBar(ignored: Int): Bar = new Bar()
     class GivenBar
 
-  object Members:
+  object Members with
     given Member: Baz = new Baz()
     private def Member(ignored1: String)(ignored2: Int): Bar = new Bar()
     def Member(ignored: Int): Baz = new Baz()
     class Member
 
-  object Combined:
+  object Combined with
     given GivenQux: Qux = new Qux()
     def GivenQux(ignored: Int): Qux = new Qux()
 
-  enum Color:
+  enum Color with
     case Red, Green, Blue
 
   export Color._ // will only export synthetic defs with same name as standard definition

--- a/tests/neg/i10870.scala
+++ b/tests/neg/i10870.scala
@@ -1,7 +1,7 @@
 final case class A()
 final case class B(a:A)
 
-object Test:
+object Test with
 
   extension(a:A)
     def x = 5

--- a/tests/neg/i10901.scala
+++ b/tests/neg/i10901.scala
@@ -52,10 +52,10 @@ object BugExp4Point2D {
 
 class C
 
-object Container:
+object Container with
   given C with {}
 
-object Test:
+object Test with
   extension (x: String)(using C)
     def foo: String = x
 

--- a/tests/neg/i11066.scala
+++ b/tests/neg/i11066.scala
@@ -1,12 +1,12 @@
 class PreferredPrompt(val preference: String)
-object Greeter:
+object Greeter with
   def greet(name: String)(using prompt: PreferredPrompt) =
     println(s"Welcome, $name. The system is ready.")
     println(prompt.preference)
-object JillsPrefs:
+object JillsPrefs with
   given jillsPrompt: PreferredPrompt =
     PreferredPrompt("Your wish> ")
-object JoesPrefs:
+object JoesPrefs with
   given joesPrompt: PreferredPrompt =
     PreferredPrompt("relax> ")
 

--- a/tests/neg/i11081.scala
+++ b/tests/neg/i11081.scala
@@ -1,6 +1,6 @@
-enum Outer:
+enum Outer with
   case Foo(u: Unavailable) // error
   case Bar(u: DefinitelyNotAvailable) // error
-object Outer:
+object Outer with
   class Unavailable(i: Int)
   case class DefinitelyNotAvailable()

--- a/tests/neg/i1501.scala
+++ b/tests/neg/i1501.scala
@@ -24,5 +24,5 @@ object Test2 {
   trait TSubA extends SubA(2) // error: trait TSubA may not call constructor of class SubA
 
 
-  class Foo extends TA with TSubA // error: missing argument for parameter x of constructor SubA:
+  class Foo extends TA with TSubA // error: missing argument for parameter x of constructor SubA with
 }

--- a/tests/neg/i3253.scala
+++ b/tests/neg/i3253.scala
@@ -1,5 +1,5 @@
 import Test.test
 
-class A:
+class A with
   def test = "  " * 10 // error
 object Test extends A

--- a/tests/neg/i6183.scala
+++ b/tests/neg/i6183.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
   extension [A](a: A) def render: String = "Hi"
   extension [B](b: B) def render(using DummyImplicit): Char = 'x'
 

--- a/tests/neg/i6205.scala
+++ b/tests/neg/i6205.scala
@@ -1,6 +1,6 @@
 class Contra[-T >: Null]
 
-object Test:
+object Test with
   def foo =   // error
     class A
     new Contra[A]

--- a/tests/neg/i6779.scala
+++ b/tests/neg/i6779.scala
@@ -3,7 +3,7 @@ type G[T]
 type Stuff
 given Stuff = ???
 
-object Test:
+object Test with
   extension [T](x: T) def f(using Stuff): F[T] = ???
 
 

--- a/tests/neg/i7359-g.scala
+++ b/tests/neg/i7359-g.scala
@@ -1,4 +1,4 @@
-trait SAMTrait:
+trait SAMTrait with
   def first(): String
   def equals(obj: Int): Boolean
 

--- a/tests/neg/i7359.scala
+++ b/tests/neg/i7359.scala
@@ -1,3 +1,3 @@
-trait SAMTrait:
+trait SAMTrait with
   def first(): String
   def notify(): Unit // error

--- a/tests/neg/i7526.scala
+++ b/tests/neg/i7526.scala
@@ -1,9 +1,9 @@
 type Tr[-I, +O, +A] = I => (O, A)
 
-trait NetApi:
+trait NetApi with
   type Comp
 
-trait NetDB extends NetApi:
+trait NetDB extends NetApi with
   class Comp
 
 trait NetHelper extends NetApi

--- a/tests/neg/i7709.scala
+++ b/tests/neg/i7709.scala
@@ -1,31 +1,31 @@
 
-object X:
+object X with
   protected class Y
-object A:
+object A with
   class B extends X.Y // error
   class B2 extends X.Y: // error
     def this(n: Int) = this()
   class B3(x: Any)
   class B4 extends B3(new X.Y) // error
-  class B5(x: String):
+  class B5(x: String) with
     def this(n: Int) = this(new X.Y().toString) // error
-trait T:
+trait T with
   class B extends X.Y // error
-class XX:
+class XX with
   protected class Y
-class C:
+class C with
   def xx = new XX
   def y  = new xx.Y  // error
-class D:
+class D with
   def this(n: Int) = {
     this()
     def xx = new XX
     def y  = new xx.Y  // error
   }
-class YY extends XX:
+class YY extends XX with
   def y = new Y
 
 package p:
-  object X:
+  object X with
     protected class Y
   class Q extends X.Y // error

--- a/tests/neg/i7980.scala
+++ b/tests/neg/i7980.scala
@@ -1,6 +1,6 @@
 trait Evidence[X]
 
-trait Trait[X : Evidence]:
+trait Trait[X : Evidence] with
   def method(x : X) : X
 
 given ev: Evidence[Int] = new Evidence[Int]{}

--- a/tests/neg/i8050.scala
+++ b/tests/neg/i8050.scala
@@ -1,4 +1,4 @@
-object stuff:
+object stuff with
   def exec(dir: Int) = ???
 
 extension (a: Int)

--- a/tests/neg/i8069.scala
+++ b/tests/neg/i8069.scala
@@ -1,7 +1,7 @@
-trait A:
+trait A with
   type B
 
-enum Test:
+enum Test with
   case Test(a: A, b: a.B)   // error: Implementation restriction: case classes cannot have dependencies between parameters
 
 case class Test2(a: A, b: a.B) // error: Implementation restriction: case classes cannot have dependencies between parameters

--- a/tests/neg/i8333.scala
+++ b/tests/neg/i8333.scala
@@ -1,12 +1,12 @@
-class A:
+class A with
   type T = Int // can also be class T
-class B(x: A, y: A):
+class B(x: A, y: A) with
   export x._
   export y._  // error: duplicate
-class C(x: A):
+class C(x: A) with
   type T = String
   export x._  // error: duplicate
-class D(x: A):
+class D(x: A) with
   export x._  // error: duplicate
   type T = String
 

--- a/tests/neg/i8407.scala
+++ b/tests/neg/i8407.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
   val xs = List(1, 2, 3, 4, 5)
   xs match {
     case List(1, 2, xs1 @ xs2: _*) => println(xs2) // error // error

--- a/tests/neg/i8623.scala
+++ b/tests/neg/i8623.scala
@@ -1,6 +1,6 @@
 
-trait QC:
-  object tasty:
+trait QC with
+  object tasty with
     type Tree
     extension (tree: Tree)
       def pos: Tree = ???

--- a/tests/neg/i8731.scala
+++ b/tests/neg/i8731.scala
@@ -1,4 +1,4 @@
-object test:
+object test with
 
   3 match
   case 3 => ???

--- a/tests/neg/i9014.scala
+++ b/tests/neg/i9014.scala
@@ -1,4 +1,4 @@
 trait Bar
-object Bar:
+object Bar with
   inline given Bar = compiletime.error("Failed to expand!")
   val tests = summon[Bar] // error

--- a/tests/neg/i9051.scala
+++ b/tests/neg/i9051.scala
@@ -1,11 +1,11 @@
 package zio:
 
   class ZRef
-  object ZRef:
+  object ZRef with
 
-    private[zio] implicit class ZRefSyntax(private val self: ZRef):
+    private[zio] implicit class ZRefSyntax(private val self: ZRef) with
       def unsafeUpdate: Boolean = true
 
-object Main:
+object Main with
   val ref = new zio.ZRef
   println(ref.unsafeUpdate)  // error

--- a/tests/neg/i9437.scala
+++ b/tests/neg/i9437.scala
@@ -1,7 +1,7 @@
 class Bag extends reflect.Selectable
 
 @main def Test =
-  val x = new Bag:
+  val x = new Bag with
     val f1 = 23
 
   println(x.f1())  // error

--- a/tests/neg/i9562.scala
+++ b/tests/neg/i9562.scala
@@ -1,7 +1,7 @@
-class Foo:
+class Foo with
   def foo = 23
 
-object Unrelated:
+object Unrelated with
   extension (f: Foo)
     def g = f.foo // OK
 

--- a/tests/neg/i9790.scala
+++ b/tests/neg/i9790.scala
@@ -1,4 +1,4 @@
-object A:
+object A with
    def fn: Unit =
     if true then
   println(1)

--- a/tests/neg/i9928.scala
+++ b/tests/neg/i9928.scala
@@ -1,14 +1,14 @@
-trait Magic[F]:
+trait Magic[F] with
   extension (x: Int) def read: F
 
-object Magic:
+object Magic with
   given Magic[String] with
     extension(x: Int) def read: String =
       println("In string")
       s"$x"
 
 opaque type Foo = String
-object Foo:
+object Foo with
   import Magic.given
   def apply(s: String): Foo = s
 

--- a/tests/neg/import-given.scala
+++ b/tests/neg/import-given.scala
@@ -25,6 +25,6 @@ object E {
   foo            // ok
   foo(using tc)  // ok
 }
-object F:
+object F with
   import A.{given ?}  // error: unbound wildcard type
 

--- a/tests/neg/inline-abstract.scala
+++ b/tests/neg/inline-abstract.scala
@@ -1,7 +1,7 @@
-class A:
+class A with
   inline def f(): Int
 
-class B extends A:
+class B extends A with
   inline def f() = 1
 
 def Test =

--- a/tests/neg/missing-implicit1.scala
+++ b/tests/neg/missing-implicit1.scala
@@ -1,4 +1,4 @@
-object testObjectInstance:
+object testObjectInstance with
   trait Zip[F[_]]
   trait Traverse[F[_]] {
     extension [A, B, G[_] : Zip](fa: F[A]) def traverse(f: A => G[B]): G[F[B]]

--- a/tests/neg/missing-implicit2.scala
+++ b/tests/neg/missing-implicit2.scala
@@ -1,6 +1,6 @@
 trait X
 trait Y
-object test:
+object test with
   def f(using x: X) = ???
   object instances {
     given y: Y = ???

--- a/tests/neg/missing-implicit5.scala
+++ b/tests/neg/missing-implicit5.scala
@@ -1,4 +1,4 @@
-object testObjectInstance:
+object testObjectInstance with
   trait Zip[F[_]]
   trait Traverse[F[_]] {
     extension [A, B, G[_] : Zip](fa: F[A]) def traverse(f: A => G[B]): G[F[B]]

--- a/tests/neg/name-hints.scala
+++ b/tests/neg/name-hints.scala
@@ -1,8 +1,8 @@
-object O:
+object O with
   val abcde: Int = 0
   val xy: Int = 1
 
-object Test:
+object Test with
   val x1 = Int.maxvalue  // error
   val x2 = Int.MxValue   // error
   val x3 = Int.MaxxValue // error

--- a/tests/neg/namedTypeParams.scala
+++ b/tests/neg/namedTypeParams.scala
@@ -1,7 +1,7 @@
 class C[T]
 class D[type T] // error: identifier expected, but `type` found
 
-object Test0:
+object Test0 with
   def f[X, Y](x: X, y: Y): Int = ???
   f[X = Int, Y = Int](1, 2) // error: experimental // error: experimental
 

--- a/tests/neg/null-anyval.scala
+++ b/tests/neg/null-anyval.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
   val x: Int = 0
   val y: Int | Null = x // during erasure, x is boxed here, and Int | Null becomes Object
   val z0: Int = identity(y) // error
@@ -8,5 +8,5 @@ object Test:
   class StrWrapper(x: String) extends AnyVal
   val z3: StrWrapper = null  // error
   val z4: O.T = null // error
-object O:
+object O with
   opaque type T = String

--- a/tests/neg/override-erasure-clash.scala
+++ b/tests/neg/override-erasure-clash.scala
@@ -1,5 +1,5 @@
 import annotation.targetName
-class A:
+class A with
   def f(): Int = 1
 class B extends A:   // error
   @targetName("f") def g(): Int = 2

--- a/tests/neg/override-inner-class.scala
+++ b/tests/neg/override-inner-class.scala
@@ -1,5 +1,5 @@
-class C:
+class C with
   type T >: String <: Any
 
-class D extends C:
+class D extends C with
   class T  // error

--- a/tests/neg/source-import.scala
+++ b/tests/neg/source-import.scala
@@ -1,6 +1,6 @@
 import language.`3.0`
 import language.`3.0` // error
 
-class C:
+class C with
   import language.`3.0-migration` // error
 

--- a/tests/neg/spaces-vs-tabs.scala
+++ b/tests/neg/spaces-vs-tabs.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
 
 	if true then
 		println(1)   // ok
@@ -7,7 +7,7 @@ object Test:
 	  println(4)   // error
  else ()         // error
 
-	object Test2:
+	object Test2 with
 
 	    if true then
 	      1

--- a/tests/neg/targetName-override-2.scala
+++ b/tests/neg/targetName-override-2.scala
@@ -1,6 +1,6 @@
 import annotation.targetName
 
-class Alpha[T]:
+class Alpha[T] with
 
   def foo() = 1
 

--- a/tests/neg/transparent-inline.scala
+++ b/tests/neg/transparent-inline.scala
@@ -1,6 +1,6 @@
 transparent def bar: Any = 2  // error: transparent can be used only with inline
 
-object test1:
+object test1 with
 
   def x: Int = baz(true) // error: type mismatch
   inline def baz(x: Boolean): Any =
@@ -9,7 +9,7 @@ object test1:
     if x then 1 else ""
   def y: Int = bam(true) // error: type mismatch
 
-object test2:
+object test2 with
 
   def x: 1 = baz(true) // OK
   transparent inline def baz(x: Boolean) =
@@ -18,7 +18,7 @@ object test2:
     if x then 1 else ""
   def y: 1 = bam(true) // OK
 
-object test3:
+object test3 with
 
   def x: Int = baz(true) // error: type mismatch
   inline def baz(x: Boolean) =
@@ -27,7 +27,7 @@ object test3:
     if x then 1 else ""
   def y: Int = bam(true) // error: type mismatch
 
-object test4:
+object test4 with
 
   def x: 1 = baz(true) // OK
   transparent inline def baz(x: Boolean): Any =

--- a/tests/neg/with-template.check
+++ b/tests/neg/with-template.check
@@ -1,0 +1,22 @@
+-- Error: tests/neg/with-template.scala:6:5 ----------------------------------------------------------------------------
+6 |  B  with  // error // error this one allows an informative hint
+  |     ^^^^
+  |     end of statement expected but 'with' found
+  |
+  |     Maybe you meant to write a mixin in an extends clause?
+  |     Note that this requires the `with` to come first now.
+  |     I.e.
+  |
+  |         with B
+-- [E006] Not Found Error: tests/neg/with-template.scala:6:2 -----------------------------------------------------------
+6 |  B  with  // error // error this one allows an informative hint
+  |  ^
+  |  Not found: B
+
+longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/with-template.scala:10:2 ----------------------------------------------------------
+10 |  B { // error  this one is harder since it is syntactically correct
+   |  ^
+   |  Not found: B
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/with-template.scala
+++ b/tests/neg/with-template.scala
@@ -1,0 +1,14 @@
+class A
+trait B
+trait C
+
+object Test extends A with
+  B  with  // error // error this one allows an informative hint
+  C
+
+object Test2 extends A with
+  B { // error  this one is harder since it is syntactically correct
+    println("foo")
+  }
+
+

--- a/tests/neg/with-template.scala
+++ b/tests/neg/with-template.scala
@@ -11,4 +11,10 @@ object Test2 extends A with
     println("foo")
   }
 
+def foo: A with
+  B with
+  C = ???
+
+
+
 

--- a/tests/new/test.scala
+++ b/tests/new/test.scala
@@ -1,3 +1,2 @@
-object Test:
-
-  def test = ???
+object Test with
+  val x = 1

--- a/tests/patmat/i10085.scala
+++ b/tests/patmat/i10085.scala
@@ -1,10 +1,10 @@
-enum Bool:
+enum Bool with
   case True
   case False
 
 import Bool._
 
-enum SBool[B <: Bool]:
+enum SBool[B <: Bool] with
   case STrue extends SBool[True.type]
   case SFalse extends SBool[False.type]
 

--- a/tests/patmat/i8922.scala
+++ b/tests/patmat/i8922.scala
@@ -1,6 +1,6 @@
 case class Token(tokenType: TokenType, lexeme: String, line: Int)
 
-enum TokenType:
+enum TokenType with
   // Single-character tokens.
   case MINUS, PLUS, SLASH, STAR,
 
@@ -14,7 +14,7 @@ enum Expr {
     case Binary(left: Expr, operator: Token, right: Expr)
 }
 
-object Interpreter:
+object Interpreter with
     import Expr._
     import TokenType._
 

--- a/tests/patmat/i8922c.scala
+++ b/tests/patmat/i8922c.scala
@@ -1,6 +1,6 @@
 case class Token(tokenType: TokenType, lexeme: String, line: Int)
 
-enum TokenType:
+enum TokenType with
   // Single-character tokens.
   case MINUS, PLUS, SLASH, STAR,
 
@@ -14,7 +14,7 @@ enum Expr {
     case Binary(left: Expr, operator: Token, right: Expr)
 }
 
-object Interpreter:
+object Interpreter with
     import Expr._
     import TokenType._
 

--- a/tests/pending/pos/cps-async-failure.scala
+++ b/tests/pending/pos/cps-async-failure.scala
@@ -1,7 +1,7 @@
 
 import scala.quoted._
 
-trait App[F[_],CT]:
+trait App[F[_],CT] with
   this: Base[F,CT] =>
 
   import quotes.reflect._
@@ -39,10 +39,10 @@ trait Base[F[_]:Type,CT:Type]  // Both :Type context bounds are necessary for fa
 extends Cps with Root[F, CT] with App[F, CT]:
   implicit val qctx: Quotes
 
-trait Root[F[_], CT]:
+trait Root[F[_], CT] with
   this: Base[F, CT] =>
   def runRoot(): CpsTree = ???
 
-trait Cps:
+trait Cps with
   sealed abstract class CpsTree
 

--- a/tests/pending/pos/inlinetuple.scala
+++ b/tests/pending/pos/inlinetuple.scala
@@ -1,6 +1,6 @@
 // TODO: Ensure that this inlines properly. So far only
 // x._1 inlines, but not x._2.
-object Test:
+object Test with
 
   def g(x: Int, y: Int) = x + y
   inline def f(inline x: (Int, Int)) = g(x._1, x._2)

--- a/tests/pos-custom-args/erased/i10848b.scala
+++ b/tests/pos-custom-args/erased/i10848b.scala
@@ -1,4 +1,4 @@
-class Foo:
+class Foo with
   erased given Int = 1
   def foo(using erased x: Int): Unit = ()
   foo

--- a/tests/pos-custom-args/erased/i7868.scala
+++ b/tests/pos-custom-args/erased/i7868.scala
@@ -12,13 +12,14 @@ object Coproduct {
 
   object At {
 
-    given atHead[Head, Tail]: At[Head +: Tail, Head, 0] with {
+    given atHead[Head, Tail]: At[Head +: Tail, Head, 0] {
       def cast: Head <:< Head +: Tail = summon[Head <:< Head +: Tail]
     }
 
     given atTail[Head, Tail, Value, NextIndex <: Int]
           (using atNext: At[Tail, Value, NextIndex])
-      : At[Head +: Tail, Value, S[NextIndex]] with
+      : At[Head +: Tail, Value, S[NextIndex]]
+    with
       val cast: Value <:< Head +: Tail = atNext.cast
 
     given [A](using A): (() => A) = { () => summon[A]}

--- a/tests/pos-custom-args/semanticdb/inline-unapply/Macro_1.scala
+++ b/tests/pos-custom-args/semanticdb/inline-unapply/Macro_1.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-object Succ:
+object Succ with
 
   inline def unapply(n: Int): Option[Int] = ${ impl('n) }
 

--- a/tests/pos-macros/i10151/Macro_1.scala
+++ b/tests/pos-macros/i10151/Macro_1.scala
@@ -2,20 +2,20 @@ package x
 
 import scala.quoted._
 
-trait CB[T]:
+trait CB[T] with
  def map[S](f: T=>S): CB[S] = ???
  def flatMap[S](f: T=>CB[S]): CB[S] = ???
 
-class MyArr[AK,AV]:
+class MyArr[AK,AV] with
  def map1[BK,BV](f: ((AK,AV)) => (BK, BV)):MyArr[BK,BV] = ???
  def map1Out[BK, BV](f: ((AK,AV)) => CB[(BK,BV)]): CB[MyArr[BK,BV]] = ???
 
 def await[T](x:CB[T]):T = ???
 
-object CBM:
+object CBM with
   def pure[T](t:T):CB[T] = ???
 
-object X:
+object X with
 
  inline def process[T](inline f:T) = ${
    processImpl[T]('f)

--- a/tests/pos-macros/i10211/Macro_1.scala
+++ b/tests/pos-macros/i10211/Macro_1.scala
@@ -2,11 +2,11 @@ package x
 
 import scala.quoted._
 
-trait CB[T]:
+trait CB[T] with
  def map[S](f: T=>S): CB[S] = ???
 
 
-class MyArr[A]:
+class MyArr[A] with
  def map[B](f: A=>B):MyArr[B] = ???
  def mapOut[B](f: A=> CB[B]): CB[MyArr[B]] = ???
  def flatMap[B](f: A=>MyArr[B]):MyArr[B] = ???
@@ -15,7 +15,7 @@ class MyArr[A]:
  def withFilterOut(p: A=>CB[Boolean]): DelayedWithFilter[A] = ???
  def map2[B](f: A=>B):MyArr[B] = ???
 
-class DelayedWithFilter[A]:
+class DelayedWithFilter[A] with
  def map[B](f: A=>B):MyArr[B] = ???
  def mapOut[B](f: A=> CB[B]): CB[MyArr[B]] = ???
  def flatMap[B](f: A=>MyArr[B]):MyArr[B] = ???
@@ -25,11 +25,11 @@ class DelayedWithFilter[A]:
 
 def await[T](x:CB[T]):T = ???
 
-object CBM:
+object CBM with
   def pure[T](t:T):CB[T] = ???
   def map[T,S](a:CB[T])(f:T=>S):CB[S] = ???
 
-object X:
+object X with
 
  inline def process[T](inline f:T) = ${
    processImpl[T]('f)

--- a/tests/pos-macros/i10771/MacroA_1.scala
+++ b/tests/pos-macros/i10771/MacroA_1.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 case class MyQuoted(val ast: String, runtimeQuotes: List[String])
 
-object MyQuoteMacro:
+object MyQuoteMacro with
   inline def myquote: MyQuoted = ${ MyQuoteMacro.apply }
   def apply(using Quotes): Expr[MyQuoted] =
     '{ MyQuoted("p", ${Expr.ofList(List( '{ "foo" } ))}) }

--- a/tests/pos-macros/i10771/MacroB_1.scala
+++ b/tests/pos-macros/i10771/MacroB_1.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-object PullAst:
+object PullAst with
   def applyImpl(quoted: Expr[MyQuoted])(using qctx: Quotes): Expr[String] =
     '{ $quoted.ast.toString }
   inline def apply(inline quoted: MyQuoted): String =

--- a/tests/pos-macros/i10771/Test_2.scala
+++ b/tests/pos-macros/i10771/Test_2.scala
@@ -1,3 +1,3 @@
-object Test:
+object Test with
   def main(args: Array[String]): Unit =
     println( PullAst.apply( MyQuoteMacro.myquote ) )

--- a/tests/pos-macros/i10910/Macro_1.scala
+++ b/tests/pos-macros/i10910/Macro_1.scala
@@ -2,15 +2,15 @@ package x
 
 import scala.quoted._
 
-trait CB[T]:
+trait CB[T] with
  def map[S](f: T=>S): CB[S] = ???
 
 def await[T](x:CB[T]):T = ???
 
-object CBM:
+object CBM with
   def pure[T](t:T):CB[T] = ???
 
-object X:
+object X with
 
  inline def process[T](inline f:T) = ${
    processImpl[T]('f)

--- a/tests/pos-macros/i8325/Macro_1.scala
+++ b/tests/pos-macros/i8325/Macro_1.scala
@@ -3,7 +3,7 @@ package a
 import scala.quoted._
 
 
-object A:
+object A with
 
   inline def transform[A](inline expr: A): A = ${
     transformImplExpr('expr)

--- a/tests/pos-macros/i8325b/Macro_1.scala
+++ b/tests/pos-macros/i8325b/Macro_1.scala
@@ -3,7 +3,7 @@ package a
 import scala.quoted._
 
 
-object A:
+object A with
 
   inline def transform[A](inline expr: A): A = ${
     transformImplExpr('expr)

--- a/tests/pos-macros/i9812.scala
+++ b/tests/pos-macros/i9812.scala
@@ -2,7 +2,7 @@
 import quoted._
 
 sealed abstract class SomeEnum
-object SomeEnum:
+object SomeEnum with
   final val Foo = new SomeEnum {}
 
 def quoteFoo: Quotes ?=> Expr[SomeEnum.Foo.type] = '{SomeEnum.Foo}

--- a/tests/pos-macros/i9894/Macro_1.scala
+++ b/tests/pos-macros/i9894/Macro_1.scala
@@ -2,19 +2,19 @@ package x
 
 import scala.quoted._
 
-trait CB[T]:
+trait CB[T] with
  def map[S](f: T=>S): CB[S] = ???
 
-class MyArr[A]:
+class MyArr[A] with
  def map1[B](f: A=>B):MyArr[B] = ???
  def map1Out[B](f: A=> CB[B]): CB[MyArr[B]] = ???
 
 def await[T](x:CB[T]):T = ???
 
-object CBM:
+object CBM with
   def pure[T](t:T):CB[T] = ???
 
-object X:
+object X with
 
  inline def process[T](inline f:T) = ${
    processImpl[T]('f)

--- a/tests/pos-macros/nil-liftable.scala
+++ b/tests/pos-macros/nil-liftable.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-class Test:
+class Test with
   given NilToExpr: ToExpr[Nil.type] with {
     def apply(xs: Nil.type)(using Quotes): Expr[Nil.type] =
       '{ Nil }

--- a/tests/pos-macros/quote-aliases.scala
+++ b/tests/pos-macros/quote-aliases.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-object Test:
+object Test with
 
   def f1(using Quotes)(t: quotes.reflect.Tree): Unit = ()
 

--- a/tests/pos-special/fatal-warnings/i10259.scala
+++ b/tests/pos-special/fatal-warnings/i10259.scala
@@ -1,4 +1,4 @@
-trait S[T] extends (T => T):
+trait S[T] extends (T => T) with
   def apply(x: T) = ???
   extension (x: T) def show: String
 

--- a/tests/pos-special/fatal-warnings/i9260.scala
+++ b/tests/pos-special/fatal-warnings/i9260.scala
@@ -1,14 +1,14 @@
 package asts
 
-enum Ast[-T >: Null]:
+enum Ast[-T >: Null] with
   case DefDef()
 
-trait AstImpl[T >: Null]:
+trait AstImpl[T >: Null] with
   type Ast = asts.Ast[T]
   type DefDef = Ast.DefDef[T]
 end AstImpl
 
-object untpd extends AstImpl[Null]:
+object untpd extends AstImpl[Null] with
 
   def DefDef(ast: Ast): DefDef = ast match
     case ast: DefDef => ast

--- a/tests/pos-special/fatal-warnings/patmat-exhaustive.scala
+++ b/tests/pos-special/fatal-warnings/patmat-exhaustive.scala
@@ -1,5 +1,5 @@
 def foo: Unit =
-  object O:
+  object O with
     sealed abstract class A
   class B extends O.A
   class C extends O.A

--- a/tests/pos-special/fatal-warnings/type-test-matchable.scala
+++ b/tests/pos-special/fatal-warnings/type-test-matchable.scala
@@ -1,13 +1,13 @@
 import scala.language.`3.1-migration`
 import scala.reflect.TypeTest
 
-trait Foo:
+trait Foo with
   type X
   type Y <: X
   def x: X
   given TypeTest[X, Y] = ???
 
-object Test:
+object Test with
   def test(foo: Foo): Unit =
     foo.x match
       case x: foo.Y =>

--- a/tests/pos-special/i7296.scala
+++ b/tests/pos-special/i7296.scala
@@ -1,2 +1,2 @@
-class Foo:
+class Foo with
   private var blah: Double = 0L

--- a/tests/pos-special/indent-colons.scala
+++ b/tests/pos-special/indent-colons.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
 
   locally:
     var x = 0
@@ -56,26 +56,26 @@ object Test:
     x < 10
   do ()
 
-class Test2:
+class Test2 with
   self =>
   def foo = 1
 
   val x =
-    new Test2:
+    new Test2 with
       override def foo = 2
     end new
   end x
 end Test2
 
-class Test3:
+class Test3 with
  self =>
   def foo = 1
 
 import collection.mutable.HashMap
 
-class Coder(words: List[String]):
+class Coder(words: List[String]) with
 
-  class Foo:
+  class Foo with
     println()
   end Foo
 
@@ -114,5 +114,5 @@ class Coder(words: List[String]):
         case (digit, str) => str map (ltr => ltr -> digit)
 end Coder
 
-object Test22:
+object Test22 with
   def foo: Int = 22

--- a/tests/pos-special/notNull.scala
+++ b/tests/pos-special/notNull.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
   def notNull[A](x: A | Null): x.type & A =
     assert(x != null)
     x.asInstanceOf  // TODO: drop the .asInstanceOf when explicit nulls are implemented

--- a/tests/pos-special/sourcepath/outer/nested/indent1.scala
+++ b/tests/pos-special/sourcepath/outer/nested/indent1.scala
@@ -1,8 +1,8 @@
 package outer
 package nested
 
-object indent1:
-  object inner:
+object indent1 with
+  object inner with
     def x: Int = 1
   end inner
   val y: Int = 2

--- a/tests/pos/abstract-givens.scala
+++ b/tests/pos/abstract-givens.scala
@@ -1,0 +1,9 @@
+class C { type T }
+trait A with
+  given C with {}   // concrete
+  given c0: C {}    // concrete
+  given c1: C {}    // concrete
+  given c2: (C {type T <: Int})  // abstract with refinement
+
+object B extends A with
+  override given c2: C with { type T = Int }

--- a/tests/pos/abstract-inline-val.scala
+++ b/tests/pos/abstract-inline-val.scala
@@ -1,11 +1,11 @@
-trait C:
+trait C with
   inline def x: Int
   inline val y: Int
 
-class C1 extends C:
+class C1 extends C with
   inline val x = 1
   inline val y = 2
 
-class C2 extends C:
+class C2 extends C with
   inline def x = 3
   inline val y = 4

--- a/tests/pos/consume.scala
+++ b/tests/pos/consume.scala
@@ -1,4 +1,4 @@
-object Test1:
+object Test1 with
   def consume(xs: List[Int], limit: Int): List[Int] = xs match
     case x :: xs1 if limit > 0 => consume(xs1, limit - x)
     case _ => xs
@@ -16,18 +16,18 @@ object Test2 {
     }
 }
 
-object math3:
-  trait Ord[T]:
+object math3 with
+  trait Ord[T] with
     extension (x: T) def > (t: T): Boolean = ???
     extension (x: T) def <= (t: T): Boolean = ???
 
-  trait Numeric[T] extends Ord[T]:
+  trait Numeric[T] extends Ord[T] with
     extension (x: T) def + (y: T): T = ???
     extension (x: T) def - (y: T): T = ???
     extension (x: Int) def numeric: T = ???
 end math3
 
-object Test3:
+object Test3 with
   import math3.Numeric
   import collection.immutable.Seq
 

--- a/tests/pos/end-nested.scala
+++ b/tests/pos/end-nested.scala
@@ -3,7 +3,7 @@ def f[T](x: Option[T]) = x match
   case None =>
 end f
 
-object Test:
+object Test with
   try List(1, 2, 3) match
   case x :: xs => println(x)
   case Nil => println("Nil")

--- a/tests/pos/endmarkers.scala
+++ b/tests/pos/endmarkers.scala
@@ -1,5 +1,5 @@
-trait T:
-  object O:
+trait T with
+  object O with
     def foo =
       1
     end foo
@@ -13,7 +13,7 @@ end T
 
 package p1.p2:
 
-  abstract class C():
+  abstract class C() with
 
     def this(x: Int) =
       this()
@@ -42,9 +42,9 @@ package p1.p2:
     def f: String
   end C
 
-  object C:
+  object C with
     given C =
-      new C:
+      new C with
         def f = "!"
         end f
       end new

--- a/tests/pos/enum-companion-first.scala
+++ b/tests/pos/enum-companion-first.scala
@@ -1,7 +1,7 @@
-object Planet:
+object Planet with
   final val G = 6.67300E-11
 
-enum Planet(mass: Double, radius: Double) extends Enum[Planet]:
+enum Planet(mass: Double, radius: Double) extends Enum[Planet] with
   def surfaceGravity = Planet.G * mass / (radius * radius)
   def surfaceWeight(otherMass: Double) =  otherMass * surfaceGravity
 

--- a/tests/pos/enum-variance.scala
+++ b/tests/pos/enum-variance.scala
@@ -1,14 +1,14 @@
 class Animal
 class Dog extends Animal
 
-enum Opt[+T]:
+enum Opt[+T] with
   case Sm(t: T)
   case None
 
 val smDog: Opt.Sm[Dog] = new Opt.Sm(Dog())
 val smAnimal: Opt.Sm[Animal] = smDog
 
-enum Show[-T]:
+enum Show[-T] with
   case Refl(op: T => String)
 
   def show(t: T): String = this match

--- a/tests/pos/enum-widen.scala
+++ b/tests/pos/enum-widen.scala
@@ -1,6 +1,6 @@
-object test:
+object test with
 
-  enum Option[+T]:
+  enum Option[+T] with
     case Some[T](x: T) extends Option[T]
     case None
 
@@ -13,7 +13,7 @@ object test:
   x = None
   xc = None
 
-  enum Nat:
+  enum Nat with
     case Z
     case S[N <: Z.type | S[_]](pred: N)
   import Nat._

--- a/tests/pos/extmethods.scala
+++ b/tests/pos/extmethods.scala
@@ -32,7 +32,7 @@ val y1: List[Int] = y
 val z = (1 :: Nil).concat(Nil)
 val z1: List[Int] = z
 
-trait TT:
+trait TT with
   type A
   val m: A
   def f[B <: A](x: B): A = if ??? then m else x
@@ -40,7 +40,7 @@ trait TT:
 extension (x: TT)
   def foo[B <: x.A](y: B) = x.f(y)
 
-object CC extends TT:
+object CC extends TT with
   type A = Seq[Int]
   val m = Nil
 

--- a/tests/pos/i10080.scala
+++ b/tests/pos/i10080.scala
@@ -1,4 +1,4 @@
-trait Foo:
+trait Foo with
 end Foo
 
 trait Bar

--- a/tests/pos/i10080.scala
+++ b/tests/pos/i10080.scala
@@ -1,5 +1,2 @@
-trait Foo with
-end Foo
-
 trait Bar
 end Bar

--- a/tests/pos/i10082.scala
+++ b/tests/pos/i10082.scala
@@ -1,4 +1,4 @@
-object Kotlin:
+object Kotlin with
   def it[T](using t: T) = t
   def fun[T, U](fn: T ?=> U)(x: T): U = fn(using x)
 

--- a/tests/pos/i10253.scala
+++ b/tests/pos/i10253.scala
@@ -1,9 +1,9 @@
-object test:
+object test with
   def foo(qc: QC): Unit =
     object treeMap extends qc.reflect.TreeMap
 
-trait QC:
+trait QC with
   val reflect: Reflection
-  trait Reflection:
-    trait TreeMap:
+  trait Reflection with
+    trait TreeMap with
       def transformTree: Unit = ???

--- a/tests/pos/i10295.scala
+++ b/tests/pos/i10295.scala
@@ -1,6 +1,6 @@
-trait M:
+trait M with
   type X
-  object X:
+  object X with
     def foo(): X = ???
 
 inline def m(using m: M): m.type = m

--- a/tests/pos/i10311.scala
+++ b/tests/pos/i10311.scala
@@ -7,7 +7,7 @@ object Module {
     extension (self: MyInt) def y: Int = self.y
   }
 }
-object test:
+object test with
   import Module._
 
   val a = new MyInt(42, 43)

--- a/tests/pos/i10495.scala
+++ b/tests/pos/i10495.scala
@@ -1,7 +1,7 @@
-class Foo:
+class Foo with
   extension(x: String) def run: Unit  = ???
 
-object Bar extends Foo:
+object Bar extends Foo with
   def run(v: Int): Unit = ???
 
   "ABC".run  // Failed before:  Reference to run is ambiguous...

--- a/tests/pos/i10634/BasicSupport.scala
+++ b/tests/pos/i10634/BasicSupport.scala
@@ -1,5 +1,5 @@
 // BasicSupport.scala
-trait BasicSupport:
+trait BasicSupport with
   self: Parser =>
 
   object SymOps extends SymOps[ctx.type](ctx)

--- a/tests/pos/i10634/Context.scala
+++ b/tests/pos/i10634/Context.scala
@@ -1,8 +1,8 @@
 // Context.scala
-trait Context:
+trait Context with
   type Symbol
 
-trait SymOps[C <: Context](val c: C):
+trait SymOps[C <: Context](val c: C) with
   extension (sym: c.Symbol)
     def getVisibility(): Int = 0
 

--- a/tests/pos/i10951.scala
+++ b/tests/pos/i10951.scala
@@ -1,6 +1,6 @@
 import scala.language.dynamics
 
-object Dyn extends Dynamic:
+object Dyn extends Dynamic with
   def selectDynamic[T](name: String): Option[T] = None
 
 val a: Option[(Int, Int)] = Dyn.asdf[Tuple2[Int, Int]]

--- a/tests/pos/i11081.scala
+++ b/tests/pos/i11081.scala
@@ -1,6 +1,6 @@
-enum Outer:
+enum Outer with
   case Foo
-object Outer:
+object Outer with
   trait Bar
   case class Baz(bar: Bar)
   case class Bam(bar: Bar = new Bar() {})

--- a/tests/pos/i4561.scala
+++ b/tests/pos/i4561.scala
@@ -1,6 +1,6 @@
-object abc:
+object abc with
   trait Test0
-  trait Test1[T]:
+  trait Test1[T] with
     def apply(f: T => T): Unit
     def apply(s: String): Unit
 

--- a/tests/pos/i6375.scala
+++ b/tests/pos/i6375.scala
@@ -28,7 +28,7 @@
         }
       }
  */
-class Test:
+class Test with
   given Int = 0
 
   def f(): Int ?=> Boolean = true : (Int ?=> Boolean)

--- a/tests/pos/i6734.scala
+++ b/tests/pos/i6734.scala
@@ -1,4 +1,4 @@
-object Bug:
+object Bug with
 
   extension [A, B, Z](ab: (A, B))
     def pipe2(f: (A, B) => Z): Z = f(ab._1, ab._2)

--- a/tests/pos/i6900.scala
+++ b/tests/pos/i6900.scala
@@ -1,15 +1,15 @@
 object Test1 {
-  trait Foo[A]:
+  trait Foo[A] with
     def foo[C]: C => A
 
   // Works with old-style conversion
-  implicit def i2f[A](a: A): Foo[A] = new Foo[A]:
+  implicit def i2f[A](a: A): Foo[A] = new Foo[A] with
     def foo[C]: C => A = _ => a
 
   // But not with newstyle
   /*
   given [A]: Conversion[A, Foo[A]] with
-    def apply(a: A) = new Foo[A]:
+    def apply(a: A) = new Foo[A] with
       def foo[C]: C => A = _ => a
   */
 

--- a/tests/pos/i6938.scala
+++ b/tests/pos/i6938.scala
@@ -1,5 +1,5 @@
 trait Foo[T]
-object Foo:
+object Foo with
   given [T]: Foo[Tuple1[T]] with {}
   given [T, U]: Foo[(T, U)] with {}
   given [T, U, V]: Foo[(T, U, V)] with {}

--- a/tests/pos/i7217.scala
+++ b/tests/pos/i7217.scala
@@ -1,4 +1,4 @@
-class Foo(p1: String, p2: String):
+class Foo(p1: String, p2: String) with
   def this(p1: String) = this(p1, "blah")
 
 val x = { Foo("blah", "hah") }

--- a/tests/pos/i7359.scala
+++ b/tests/pos/i7359.scala
@@ -1,95 +1,95 @@
 package test
 
-trait ObjectInterface:
+trait ObjectInterface with
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMPlain:
+trait SAMPlain with
   def first(): String
 
-trait SAMPlainWithOverriddenObjectMethods:
+trait SAMPlainWithOverriddenObjectMethods with
   def first(): String
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMPlainWithExtends extends ObjectInterface:
+trait SAMPlainWithExtends extends ObjectInterface with
   def first(): String
 
-trait SAMPlainWithExtendsAndOverride extends ObjectInterface:
+trait SAMPlainWithExtendsAndOverride extends ObjectInterface with
   def first(): String
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString(): String
 
-trait SAMPlainCovariantOut[+O]:
+trait SAMPlainCovariantOut[+O] with
   def first(): O
 
-trait SAMCovariantOut[+O]:
+trait SAMCovariantOut[+O] with
   def first(): O
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMCovariantOutExtends[+O] extends ObjectInterface:
+trait SAMCovariantOutExtends[+O] extends ObjectInterface with
   def first(): O
 
-trait SAMCovariantOutExtendsAndOverride[+O] extends ObjectInterface:
+trait SAMCovariantOutExtendsAndOverride[+O] extends ObjectInterface with
   def first(): O
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString(): String
 
-trait SAMPlainContravariantIn[-I]:
+trait SAMPlainContravariantIn[-I] with
   def first(in: I): Unit
 
-trait SAMContravariantIn[-I]:
+trait SAMContravariantIn[-I] with
   def first(in: I): Unit
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMContravariantInExtends[-I] extends ObjectInterface:
+trait SAMContravariantInExtends[-I] extends ObjectInterface with
   def first(in: I): Unit
 
-trait SAMContravariantInExtendsAndOverride[-I] extends ObjectInterface:
+trait SAMContravariantInExtendsAndOverride[-I] extends ObjectInterface with
   def first(in: I): Unit
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString(): String
 
-trait SAMPlainInvariant[T]:
+trait SAMPlainInvariant[T] with
   def first(in: T): T
 
-trait SAMInvariant[T]:
+trait SAMInvariant[T] with
   def first(in: T): T
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMInvariantExtends[T] extends ObjectInterface:
+trait SAMInvariantExtends[T] extends ObjectInterface with
   def first(in: T): T
 
-trait SAMInvariantExtendsAndOverride[T] extends ObjectInterface:
+trait SAMInvariantExtendsAndOverride[T] extends ObjectInterface with
   def first(in: T): T
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString(): String
 
-trait SAMPlainInOut[-I, +O]:
+trait SAMPlainInOut[-I, +O] with
   def first(in: I): O
 
-trait SAMInOut[-I, +O]:
+trait SAMInOut[-I, +O] with
   def first(in: I): O
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMInOutExtends[-I, +O] extends ObjectInterface:
+trait SAMInOutExtends[-I, +O] extends ObjectInterface with
   def first(in: I): O
 
-trait SAMInOutExtendsAndOverride[-I, +O] extends ObjectInterface:
+trait SAMInOutExtendsAndOverride[-I, +O] extends ObjectInterface with
   def first(in: I): O
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
@@ -99,13 +99,13 @@ type CustomString = String
 type CustomBoolean = Boolean
 type CustomInt = Int
 
-trait SAMWithCustomAliases:
+trait SAMWithCustomAliases with
   def first(): String
   def equals(obj: Any): CustomBoolean
   def hashCode(): CustomInt
   def toString(): CustomString
 
-object Main:
+object Main with
   def main(args: Array[String]) =
     val samPlain : SAMPlain = () => "Hello, World!"
     val samPlainWithOverriddenObjectMethods: SAMPlainWithOverriddenObjectMethods = () => "Hello, World!"

--- a/tests/pos/i7375.scala
+++ b/tests/pos/i7375.scala
@@ -1,10 +1,10 @@
-trait Entity[M, T, P]:
+trait Entity[M, T, P] with
   extension (me: M) def receive(sender: T)(msg: P)(using Entity[T, M, P]): Unit
   extension (me: M) def name(): String
 
 class GreetingPerson(private val name: String)
 
-object GreetingPerson:
+object GreetingPerson with
   given GreetingPersonEntity: Entity[GreetingPerson, GreetedPerson, String] with
     extension (me: GreetingPerson) def receive(sender: GreetedPerson)(msg: String)(using Entity[GreetedPerson, GreetingPerson, String]): Unit =
        println(f"Thanks for saying $msg, ${sender.name()}")
@@ -14,7 +14,7 @@ object GreetingPerson:
 
 class GreetedPerson(private val name: String)
 
-object GreetedPerson:
+object GreetedPerson with
   given GreetedPersonEntity: Entity[GreetedPerson, GreetingPerson, String] with
     extension (me: GreetedPerson) def receive(sender: GreetingPerson)(msg: String)(using Entity[GreetingPerson, GreetedPerson, String]): Unit =
       println(f"Thanks for saying $msg, ${sender.name()}")

--- a/tests/pos/i7413.scala
+++ b/tests/pos/i7413.scala
@@ -2,20 +2,20 @@ import scala.language.implicitConversions
 
 trait Fixture[A] extends Conversion[0, A]
 
-trait TestFramework[A]:
+trait TestFramework[A] with
   extension (testName: String) def in(test: Fixture[A] ?=> Unit): Unit = ???
 
-trait Greeter:
+trait Greeter with
   def greet(name: String): String = s"Hello $name"
 
 case class MyFixture(name: String, greeter: Greeter)
 
-object Test1:
+object Test1 with
   given conv: Conversion[0, Greeter] with
     def apply(x: 0): Greeter = ???
   val g: Greeter = 0
 
-class MyTest extends TestFramework[MyFixture]:
+class MyTest extends TestFramework[MyFixture] with
   "say hello" in {
     assert(0.greeter.greet(0.name) == s"Hello ${0.name}")
   }

--- a/tests/pos/i7428.scala
+++ b/tests/pos/i7428.scala
@@ -1,5 +1,5 @@
-class ABug:
-  enum Tag:
+class ABug with
+  enum Tag with
     case first
   import Tag.first
   val xx = first

--- a/tests/pos/i7648.scala
+++ b/tests/pos/i7648.scala
@@ -11,7 +11,7 @@ class Stream[+F[_], +A] {
   }
 }
 
-object Test:
+object Test with
 
   implicit val ioMonad: Monad[IO] = null
 

--- a/tests/pos/i7700.scala
+++ b/tests/pos/i7700.scala
@@ -1,12 +1,12 @@
 package test
 
-trait Show[-A]:
+trait Show[-A] with
   def show(a: A): String
 
-object Macros:
+object Macros with
   extension (sc: StringContext) inline def show(args: =>Any*): String = ???
 
-object Show:
+object Show with
   extension [A] (a: A) def show(using S: Show[A]): String = S.show(a)
 
   export Macros.show

--- a/tests/pos/i7757.scala
+++ b/tests/pos/i7757.scala
@@ -1,7 +1,7 @@
 val m: Map[Int, String] = ???
 val _ = m.map((a, b) => a + b.length)
 
-trait Foo:
+trait Foo with
   def g(f: ((Int, Int)) => Int): Int = 1
   def g(f: ((Int, Int)) => (Int, Int)): String = "2"
 

--- a/tests/pos/i7793.scala
+++ b/tests/pos/i7793.scala
@@ -1,4 +1,4 @@
-trait Foo:
+trait Foo with
   def g(f: Int => Int): Int = 1
   def g(using String)(f: Int => String): String = "2"
 

--- a/tests/pos/i7807.scala
+++ b/tests/pos/i7807.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
 
   def flip: (x: 0 | 1) => x.type match { case 0 => 1 case 1 => 0 } = ???
 

--- a/tests/pos/i8181.scala
+++ b/tests/pos/i8181.scala
@@ -1,4 +1,4 @@
-object Main:
+object Main with
   def main(args: Array[String]): Unit =
     extension (a: AnyRef)
       def putout(): Unit = println(a)

--- a/tests/pos/i8182.scala
+++ b/tests/pos/i8182.scala
@@ -1,6 +1,6 @@
 package example
 
-trait Show[-A]:
+trait Show[-A] with
   extension (a: A) def show: String
 
 given (using rec: Show[String]): Show[String] = ??? // must be Show[String] as the argument

--- a/tests/pos/i8319.scala
+++ b/tests/pos/i8319.scala
@@ -5,7 +5,7 @@ case class Lam[T,U]() extends Tree[Any]
 case class App[T,U]() extends Tree[Any]
 case class Var()      extends Tree[Any]
 
-object Branch:
+object Branch with
   def unapply(branch: Lam[?,?] | App[?,?]): true = true
 
 private def foo(s: Option[Tree[?]]) = s match // seems to only occur in a nested pattern

--- a/tests/pos/i8397.scala
+++ b/tests/pos/i8397.scala
@@ -3,13 +3,13 @@ given foo(using x: Int): AnyRef with
 
 // #7859
 
-trait Lub2[A, B]:
+trait Lub2[A, B] with
   type Output
 
 given [A <: C, B <: C, C]: Lub2[A, B] with
   type Output = C
 
-trait Lub[Union]:
+trait Lub[Union] with
   type Output
 
 given [A]: Lub[A] with

--- a/tests/pos/i8530.scala
+++ b/tests/pos/i8530.scala
@@ -1,19 +1,19 @@
-object MyBoooleanUnapply:
+object MyBoooleanUnapply with
   inline def unapply(x: Int): Boolean = true
 
-object MyOptionUnapply:
+object MyOptionUnapply with
   inline def unapply(x: Int): Option[Long] = Some(x)
 
-object MyUnapplyImplicits:
+object MyUnapplyImplicits with
   inline def unapply(x: Int)(using DummyImplicit): Option[Long] = Some(x)
 
-object MyPolyUnapply:
+object MyPolyUnapply with
   inline def unapply[T](x: T): Option[T] = Some(x)
 
-object MySeqUnapply:
+object MySeqUnapply with
   inline def unapplySeq(x: Int): Seq[Int] = Seq(x, x)
 
-object MyWhiteboxUnapply:
+object MyWhiteboxUnapply with
   transparent inline def unapply(x: Int): Option[Any] = Some(x)
 
 def test: Unit =

--- a/tests/pos/i8623.scala
+++ b/tests/pos/i8623.scala
@@ -1,6 +1,6 @@
 
-trait QC:
-  object tasty:
+trait QC with
+  object tasty with
     type Tree
     extension (tree: Tree)
       def pos: Tree = ???

--- a/tests/pos/i8750.scala
+++ b/tests/pos/i8750.scala
@@ -1,4 +1,4 @@
-class Abc:
+class Abc with
   opaque type Log = Double
 
 val v : Abc = new Abc

--- a/tests/pos/i8801.scala
+++ b/tests/pos/i8801.scala
@@ -1,4 +1,4 @@
-object Foo:
+object Foo with
  locally {
     case class Baz()
   }

--- a/tests/pos/i8843.scala
+++ b/tests/pos/i8843.scala
@@ -1,4 +1,4 @@
-class C:
+class C with
   type X <: Tuple
 
 inline def f(c: C): Unit = {

--- a/tests/pos/i8845.scala
+++ b/tests/pos/i8845.scala
@@ -1,4 +1,4 @@
-trait IntToLong:
+trait IntToLong with
   def apply(v: Int) : Long
 
 inline def convert1(       f: IntToLong) = ???

--- a/tests/pos/i8874.scala
+++ b/tests/pos/i8874.scala
@@ -1,4 +1,4 @@
-trait Abc:
+trait Abc with
   opaque type Log = Double
 
 class AbcClass extends Abc

--- a/tests/pos/i8892.scala
+++ b/tests/pos/i8892.scala
@@ -1,7 +1,7 @@
-trait Reporter:
+trait Reporter with
   def report(m: String): Unit
 
-class Dummy extends Reporter:
+class Dummy extends Reporter with
   def report(m: String) = ()
 
   object ABug {

--- a/tests/pos/i8920/Qu_1.scala
+++ b/tests/pos/i8920/Qu_1.scala
@@ -1,9 +1,9 @@
 package scala.collection.mutable
 
-class Qu[A] protected (array: Array[AnyRef], start: Int, end: Int):
+class Qu[A] protected (array: Array[AnyRef], start: Int, end: Int) with
   def this(initialSize: Int = ArrayDeque.DefaultInitialSize) =
     this(ArrayDeque.alloc(initialSize), start = 0, end = 0)
 
-object Qu:
+object Qu with
   def f[A](array: Array[AnyRef], start: Int, end: Int) = 1
   def f[A](initialSize: Int = 1) = 2

--- a/tests/pos/i8927.scala
+++ b/tests/pos/i8927.scala
@@ -1,14 +1,14 @@
 import scala.language.implicitConversions
 
-trait Eq[k <: AnyKind, K[_ <: k]]:
+trait Eq[k <: AnyKind, K[_ <: k]] with
   extension [A <: k, B <: k](k: K[A]) def isEq (k2: K[B]): Eq.GEQ[k, K, A, B]
 
-object Eq:
-  enum GEQ[k <: AnyKind, K[_ <: k], A <: k, B <: k]:
+object Eq with
+  enum GEQ[k <: AnyKind, K[_ <: k], A <: k, B <: k] with
     case Y[k <: AnyKind, K[_ <: k], A <: k](res: K[A]) extends GEQ[k, K, A, A]
     case N()
 
-sealed trait DPair[k <: AnyKind, K[_ <: k], +V[_ <: k]]:
+sealed trait DPair[k <: AnyKind, K[_ <: k], +V[_ <: k]] with
   type A <: k
   val key: K[A]
   val value: V[A]
@@ -16,8 +16,8 @@ sealed trait DPair[k <: AnyKind, K[_ <: k], +V[_ <: k]]:
     case y: Eq.GEQ.Y[k, K, A] => Some(value)
     case _    => None
 
-object DPair:
+object DPair with
   given pair [k, K[_ <: k], V[_ <: k], C <: k]: Conversion[(K[C], V[C]), DPair[k, K, V]] = tup =>
-    case class dpair(key: K[C], value: V[C]) extends DPair[k, K, V]:
+    case class dpair(key: K[C], value: V[C]) extends DPair[k, K, V] with
       type A = C
     dpair(tup._1, tup._2)

--- a/tests/pos/i8968.scala
+++ b/tests/pos/i8968.scala
@@ -1,7 +1,7 @@
-object Foo:
+object Foo with
   inline def get = 0
 
-object Bar:
+object Bar with
   export Foo._
 
 val v = Bar.get

--- a/tests/pos/i8972.scala
+++ b/tests/pos/i8972.scala
@@ -1,7 +1,7 @@
-trait Num:
+trait Num with
   type Nat
 
-object IsInt:
+object IsInt with
   def unapply(using num: Num)(sc: num.Nat): Option[Int] = ???
 
 def test(using num: Num)(x: num.Nat) =

--- a/tests/pos/i8997.scala
+++ b/tests/pos/i8997.scala
@@ -1,4 +1,4 @@
-object Foo:
+object Foo with
   def unapply(n: Int)(using x: DummyImplicit)(using y: Int): Option[Int] = ???
 
 def test =

--- a/tests/pos/i9052/A.scala
+++ b/tests/pos/i9052/A.scala
@@ -1,4 +1,4 @@
-object impl:
+object impl with
   case object UNone
 
 import impl._

--- a/tests/pos/i9069/Wrapper.scala
+++ b/tests/pos/i9069/Wrapper.scala
@@ -1,4 +1,4 @@
 sealed trait Foo
-object Foo:
+object Foo with
   case object Baz extends Foo
 case class Bar(x: Int) extends Foo

--- a/tests/pos/i9103.scala
+++ b/tests/pos/i9103.scala
@@ -1,4 +1,4 @@
-object a:
+object a with
   trait Foo[T]
   given Foo[Unit] = ???
 

--- a/tests/pos/i9213.scala
+++ b/tests/pos/i9213.scala
@@ -1,5 +1,5 @@
 trait A(a: Any, b: Int)
-trait B(a: Any, b: Int):
+trait B(a: Any, b: Int) with
   var x = 0
 class C(a: String, b: Int)
 

--- a/tests/pos/i9307.scala
+++ b/tests/pos/i9307.scala
@@ -1,4 +1,4 @@
-class Foo:
+class Foo with
   private var foo1: Int = _
   private var foo2: Array[Int] = _
   private[this] var foo3: Array[Int] = _

--- a/tests/pos/i9342b.scala
+++ b/tests/pos/i9342b.scala
@@ -1,4 +1,4 @@
-trait Label[A]:
+trait Label[A] with
   def apply(v: A): String
 
 given [A]: Label[A] = _.toString

--- a/tests/pos/i9342c.scala
+++ b/tests/pos/i9342c.scala
@@ -1,4 +1,4 @@
-trait Label[A]:
+trait Label[A] with
   def apply(v: A): String
 
 def g[A]: Label[A] = _.toString

--- a/tests/pos/i9352.scala
+++ b/tests/pos/i9352.scala
@@ -1,6 +1,6 @@
 abstract class Foo[B] extends Bar[B]
 
-trait Bar[A]:
+trait Bar[A] with
   self: Foo[A] =>
 
   def foo       : Unit   = bar(???)

--- a/tests/pos/i9457.scala
+++ b/tests/pos/i9457.scala
@@ -1,4 +1,4 @@
-object inlinetuple:
+object inlinetuple with
   def test: Int =
     f((1, 2))
   inline def f(inline p: (Int, Int)): Int =

--- a/tests/pos/i9464.scala
+++ b/tests/pos/i9464.scala
@@ -1,4 +1,4 @@
-trait T:
+trait T with
   type X
   def x: X
 

--- a/tests/pos/i9530.scala
+++ b/tests/pos/i9530.scala
@@ -1,12 +1,12 @@
 trait Food
 case class Banana(color: String) extends Food
 
-trait Diet[A <: Animal]:
+trait Diet[A <: Animal] with
   type F <: Food
   def food: Seq[F]
 
 trait Animal
-object Animal:
+object Animal with
   extension [A <: Animal](using diet: Diet[A])(animal: A) def food1 = diet.food
   extension [A <: Animal](animal: A)(using diet: Diet[A]) def food2 = diet.food
 

--- a/tests/pos/i9562.scala
+++ b/tests/pos/i9562.scala
@@ -1,7 +1,7 @@
-class Foo:
+class Foo with
   def foo = 23
 
-object Unrelated:
+object Unrelated with
   extension (f: Foo)
     def g = f.foo // OK
 

--- a/tests/pos/i9844.scala
+++ b/tests/pos/i9844.scala
@@ -1,4 +1,4 @@
-object test1:
+object test1 with
   trait Foo[A]
 
   trait Baz[A]  {
@@ -8,13 +8,13 @@ object test1:
     }
   }
 
-object test2:
+object test2 with
 
-  trait Foo:
+  trait Foo with
     private var f = "abc"
 
   trait Baz  {
-    trait Bam:
+    trait Bam with
       val f = 0
     trait Bar extends Bam {
       this: Foo =>
@@ -23,7 +23,7 @@ object test2:
     }
   }
 
-object test3:
+object test3 with
   object DetSkipOctree {
     sealed trait Leaf  [PL]
     sealed trait Branch[PL]

--- a/tests/pos/i9967.scala
+++ b/tests/pos/i9967.scala
@@ -1,6 +1,6 @@
 import collection.mutable
 
-class MaxSizeMap[K, V](maxSize: Int)(using o: Ordering[K]):
+class MaxSizeMap[K, V](maxSize: Int)(using o: Ordering[K]) with
   val sortedMap: mutable.TreeMap[K, V] = mutable.TreeMap.empty[K, V](o)
 
   export sortedMap._

--- a/tests/pos/i9994.scala
+++ b/tests/pos/i9994.scala
@@ -1,7 +1,7 @@
 package pkg
 
-trait Foo:
+trait Foo with
   def foo: this.type
 
-final class Bar extends Foo:
+final class Bar extends Foo with
   def foo: this.type = this

--- a/tests/pos/indent.scala
+++ b/tests/pos/indent.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
 
   locally {
     var x = 0
@@ -82,7 +82,7 @@ object Test:
     x < 10
   do ()
 
-class Test2:
+class Test2 with
   self =>
   def foo(x: Int) =
     if x < 0 then throw
@@ -97,15 +97,15 @@ class Test2:
   end x
 end Test2
 
-class Test3:
+class Test3 with
  self =>
   def foo = 1
 
 import collection.mutable.HashMap
 
-class Coder(words: List[String]):
+class Coder(words: List[String]) with
 
-  class Foo:
+  class Foo with
     println()
   end Foo
 
@@ -146,5 +146,5 @@ class Coder(words: List[String]):
       }
 end Coder
 
-object Test22:
+object Test22 with
   def foo: Int = 22

--- a/tests/pos/indent.scala
+++ b/tests/pos/indent.scala
@@ -82,8 +82,7 @@ object Test with
     x < 10
   do ()
 
-class Test2 with
-  self =>
+class Test2 with self: Test2 =>
   def foo(x: Int) =
     if x < 0 then throw
       val ex = new AssertionError()
@@ -98,8 +97,10 @@ class Test2 with
 end Test2
 
 class Test3 with
- self =>
+  self =>
   def foo = 1
+
+class Test4 with { val x = 5 }
 
 import collection.mutable.HashMap
 

--- a/tests/pos/indent2.scala
+++ b/tests/pos/indent2.scala
@@ -1,6 +1,6 @@
-object testindent:
+object testindent with
 
-  class C:
+  class C with
     val x = 0
 
   val c = new C

--- a/tests/pos/indent4.scala
+++ b/tests/pos/indent4.scala
@@ -1,4 +1,4 @@
-object testindent:
+object testindent with
 
   if (true)
     val x = 1

--- a/tests/pos/inline-val-constValue-1.scala
+++ b/tests/pos/inline-val-constValue-1.scala
@@ -1,6 +1,6 @@
 import compiletime._
 
-class C:
+class C with
   type X <: Tuple
 
 def test: Unit =

--- a/tests/pos/inline-val-constValue-2.scala
+++ b/tests/pos/inline-val-constValue-2.scala
@@ -1,6 +1,6 @@
 import compiletime._
 
-class C:
+class C with
   type N <: Int
 
 def test: Unit =

--- a/tests/pos/main-method-scheme-class-based.scala
+++ b/tests/pos/main-method-scheme-class-based.scala
@@ -11,7 +11,7 @@ import collection.mutable
  *      or `command.argsGetter` if is a final varargs parameter,
  *    - a call to `command.run` with the closure of user-main applied to all arguments.
  */
-trait MainAnnotation extends StaticAnnotation:
+trait MainAnnotation extends StaticAnnotation with
 
   /** The class used for argument string parsing. E.g. `scala.util.CommandLineParser.FromString`,
    *  but could be something else
@@ -25,7 +25,7 @@ trait MainAnnotation extends StaticAnnotation:
   def command(args: Array[String]): Command
 
   /** A class representing a command to run */
-  abstract class Command:
+  abstract class Command with
 
     /** The getter for the next argument of type `T` */
     def argGetter[T](argName: String, fromString: ArgumentParser[T], defaultValue: Option[T] = None): () => T
@@ -42,12 +42,12 @@ end MainAnnotation
 
 //Sample main class, can be freely implemented:
 
-class main extends MainAnnotation:
+class main extends MainAnnotation with
 
   type ArgumentParser[T] = util.CommandLineParser.FromString[T]
   type MainResultType = Any
 
-  def command(args: Array[String]): Command = new Command:
+  def command(args: Array[String]): Command = new Command with
 
     /** A buffer of demanded argument names, plus
      *   "?"  if it has a default
@@ -135,7 +135,7 @@ end main
 
 // Sample main method
 
-object myProgram:
+object myProgram with
 
   /** Adds two numbers */
   @main def add(num: Int, inc: Int = 1): Unit =
@@ -145,7 +145,7 @@ end myProgram
 
 //  Compiler generated code:
 
-object add extends main:
+object add extends main with
   def main(args: Array[String]) =
     val cmd = command(args)
     val arg1 = cmd.argGetter[Int]("num", summon[ArgumentParser[Int]])

--- a/tests/pos/main-method-scheme.scala
+++ b/tests/pos/main-method-scheme.scala
@@ -1,7 +1,7 @@
 import annotation.StaticAnnotation
 import collection.mutable
 
-trait MainAnnotation extends StaticAnnotation:
+trait MainAnnotation extends StaticAnnotation with
 
   type ArgumentParser[T]
 
@@ -18,7 +18,7 @@ end MainAnnotation
 
 //Sample main class, can be freely implemented:
 
-class main(progName: String, args: Array[String], docComment: String) extends MainAnnotation:
+class main(progName: String, args: Array[String], docComment: String) extends MainAnnotation with
 
   def this() = this("", Array(), "")
 
@@ -106,7 +106,7 @@ end main
 
 // Sample main method
 
-object myProgram:
+object myProgram with
 
   /** Adds two numbers */
   @main def add(num: Int, inc: Int = 1) =
@@ -116,7 +116,7 @@ end myProgram
 
 //  Compiler generated code:
 
-object add:
+object add with
   def main(args: Array[String]) =
     val cmd = new main("add", args, "Adds two numbers")
     val arg1 = cmd.getArg[Int]("num", summon[cmd.ArgumentParser[Int]])

--- a/tests/pos/matches.scala
+++ b/tests/pos/matches.scala
@@ -1,5 +1,5 @@
 package matches
-object Test:
+object Test with
   2 min 3 match
     case 2 => "OK"
     case 3 => "?"

--- a/tests/pos/matrixOps.scala
+++ b/tests/pos/matrixOps.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
 
   type Matrix = Array[Array[Double]]
   type Vector = Array[Double]

--- a/tests/pos/opaques-queue.scala
+++ b/tests/pos/opaques-queue.scala
@@ -1,11 +1,11 @@
 class Elem
-trait QueueSignature:
+trait QueueSignature with
   type Queue
   def empty: Queue
   def append(q: Queue, e: Elem): Queue
   def pop(q: Queue): Option[(Elem, Queue)]
 val QueueModule: QueueSignature =
-  object QueueImpl extends QueueSignature:
+  object QueueImpl extends QueueSignature with
     type Queue = (List[Elem], List[Elem])
     def empty = (Nil, Nil)
     def append(q: Queue, e: Elem): Queue = (q._1, e :: q._2)
@@ -15,7 +15,7 @@ val QueueModule: QueueSignature =
       case (Nil, ys) => pop((ys.reverse, Nil))
   QueueImpl
 
-object queues:
+object queues with
   opaque type Queue = (List[Elem], List[Elem])
   def empty = (Nil, Nil)
   def append(q: Queue, e: Elem): Queue = (q._1, e :: q._2)

--- a/tests/pos/packagings.scala
+++ b/tests/pos/packagings.scala
@@ -1,10 +1,10 @@
 package foo:
   package bar:
-    object A:
+    object A with
       def foo = 1
   end bar
 end foo
 package baz:
-  object B:
+  object B with
     def f = foo.bar.A.foo
 end baz

--- a/tests/pos/postconditions.scala
+++ b/tests/pos/postconditions.scala
@@ -1,4 +1,4 @@
-object PostConditions:
+object PostConditions with
   opaque type WrappedResult[T] = T
 
   def result[T](using r: WrappedResult[T]): T = r
@@ -8,6 +8,6 @@ object PostConditions:
     assert(condition)
     x
 
-object Test:
+object Test with
   import PostConditions.{ensuring, result}
   val s = List(1, 2, 3).sum.ensuring(result == 6)

--- a/tests/pos/reference/adts.scala
+++ b/tests/pos/reference/adts.scala
@@ -1,25 +1,25 @@
 package adts
-object t1:
+object t1 with
 
-  enum Option[+T]:
+  enum Option[+T] with
     case Some[T](x: T) extends Option[T]
     case None
 
-object t2:
+object t2 with
 
-  enum Option[+T]:
+  enum Option[+T] with
     case Some[T](x: T) extends Option[T]
     case None          extends Option[Nothing]
 
-enum Color(val rgb: Int):
+enum Color(val rgb: Int) with
   case Red   extends Color(0xFF0000)
   case Green extends Color(0x00FF00)
   case Blue  extends Color(0x0000FF)
   case Mix(mix: Int) extends Color(mix)
 
-object t3:
+object t3 with
 
-  enum Option[+T]:
+  enum Option[+T] with
     case Some[T](x: T) extends Option[T]
     case None
 
@@ -27,6 +27,6 @@ object t3:
       case None => false
       case some => true
 
-  object Option:
+  object Option with
     def apply[T >: Null](x: T): Option[T] =
       if (x == null) None else Some(x)

--- a/tests/pos/reference/auto-param-tupling.scala
+++ b/tests/pos/reference/auto-param-tupling.scala
@@ -1,6 +1,6 @@
 package autoParamTupling
 
-object t1:
+object t1 with
   val xs: List[(Int, Int)] = ???
 
   xs.map {

--- a/tests/pos/reference/compile-time.scala
+++ b/tests/pos/reference/compile-time.scala
@@ -1,6 +1,6 @@
 package compiletime
 
-class Test:
+class Test with
   import scala.compiletime.{constValue, erasedValue, S}
 
   trait Nat

--- a/tests/pos/reference/delegate-match.scala
+++ b/tests/pos/reference/delegate-match.scala
@@ -1,6 +1,6 @@
 package implicitmatch
 
-class Test extends App:
+class Test extends App with
   import scala.collection.immutable.{TreeSet, HashSet}
   import scala.compiletime.summonFrom
 

--- a/tests/pos/reference/delegates.scala
+++ b/tests/pos/reference/delegates.scala
@@ -1,30 +1,30 @@
-class Common:
+class Common with
 
-  trait Ord[T]:
+  trait Ord[T] with
     extension (x: T) def compareTo(y: T): Int
     extension (x: T) def < (y: T) = x.compareTo(y) < 0
     extension (x: T) def > (y: T) = x.compareTo(y) > 0
 
-  trait Convertible[From, To]:
+  trait Convertible[From, To] with
     extension (x: From) def convert: To
 
-  trait SemiGroup[T]:
+  trait SemiGroup[T] with
     extension (x: T) def combine(y: T): T
 
-  trait Monoid[T] extends SemiGroup[T]:
+  trait Monoid[T] extends SemiGroup[T] with
     def unit: T
 
-  trait Functor[F[_]]:
+  trait Functor[F[_]] with
     extension [A](x: F[A]) def map[B](f: A => B): F[B]
 
-  trait Monad[F[_]] extends Functor[F]:
+  trait Monad[F[_]] extends Functor[F] with
     extension [A](x: F[A]) def flatMap[B](f: A => F[B]): F[B]
     extension [A](x: F[A]) def map[B](f: A => B) = x.flatMap(f `andThen` pure)
 
     def pure[A](x: A): F[A]
 end Common
 
-object Instances extends Common:
+object Instances extends Common with
 
   given intOrd: Ord[Int] with
     extension (x: Int) def compareTo(y: Int) =
@@ -64,7 +64,7 @@ object Instances extends Common:
   def maximum[T](xs: List[T])(using Ord[T]): T =
     xs.reduceLeft((x, y) => if (x < y) y else x)
 
-  def descending[T](using asc: Ord[T]): Ord[T] = new Ord[T]:
+  def descending[T](using asc: Ord[T]): Ord[T] = new Ord[T] with
     extension (x: T) def compareTo(y: T) = asc.compareTo(y)(x)
 
   def minimum[T](xs: List[T])(using Ord[T]) =
@@ -85,20 +85,20 @@ object Instances extends Common:
   class B
   val ab: (x: A, y: B) ?=> Int = (a: A, b: B) ?=> 22
 
-  trait TastyAPI:
+  trait TastyAPI with
     type Symbol
-    trait SymDeco:
+    trait SymDeco with
       extension (sym: Symbol) def name: String
     given symDeco: SymDeco
 
-  object TastyImpl extends TastyAPI:
+  object TastyImpl extends TastyAPI with
     type Symbol = String
     given symDeco: SymDeco with
       extension (sym: Symbol) def name = sym
 
   class D[T]
 
-  class C(using ctx: Context):
+  class C(using ctx: Context) with
     def f() =
       locally {
         given Context = this.ctx
@@ -121,14 +121,14 @@ object Instances extends Common:
 
   class Token(str: String)
 
-  object Token:
+  object Token with
     given StringToToken: Conversion[String, Token] with
       def apply(str: String): Token = new Token(str)
 
   val x: Token = "if"
 end Instances
 
-object PostConditions:
+object PostConditions with
   opaque type WrappedResult[T] = T
 
   def result[T](using x: WrappedResult[T]): T = x
@@ -139,7 +139,7 @@ object PostConditions:
       x
 end PostConditions
 
-object AnonymousInstances extends Common:
+object AnonymousInstances extends Common with
   given Ord[Int] with
     extension (x: Int) def compareTo(y: Int) =
       if (x < y) -1 else if (x > y) +1 else 0
@@ -173,12 +173,12 @@ object AnonymousInstances extends Common:
       xs.foldLeft(summon[Monoid[T]].unit)(_.combine(_))
 end AnonymousInstances
 
-object Implicits extends Common:
-  implicit object IntOrd extends Ord[Int]:
+object Implicits extends Common with
+  implicit object IntOrd extends Ord[Int] with
     extension (x: Int) def compareTo(y: Int) =
       if (x < y) -1 else if (x > y) +1 else 0
 
-  class ListOrd[T: Ord] extends Ord[List[T]]:
+  class ListOrd[T: Ord] extends Ord[List[T]] with
     extension (xs: List[T]) def compareTo(ys: List[T]): Int = (xs, ys).match
       case (Nil, Nil) => 0
       case (Nil, _) => -1
@@ -199,31 +199,31 @@ object Implicits extends Common:
                 (implicit cmp: Ord[T]): T =
     xs.reduceLeft((x, y) => if (x < y) y else x)
 
-  def descending[T](implicit asc: Ord[T]): Ord[T] = new Ord[T]:
+  def descending[T](implicit asc: Ord[T]): Ord[T] = new Ord[T] with
     extension (x: T) def compareTo(y: T) = asc.compareTo(y)(x)
 
   def minimum[T](xs: List[T])(implicit cmp: Ord[T]) =
     maximum(xs)(descending)
 
-object Test extends App:
+object Test extends App with
   Instances.test()
   import PostConditions.{result, ensuring}
   val s = List(1, 2, 3).sum
   s.ensuring(result == 6)
 end Test
 
-object Completions:
+object Completions with
 
   class Future[T]
   class HttpResponse
   class StatusCode
 
   // The argument "magnet" type
-  enum CompletionArg:
+  enum CompletionArg with
     case Error(s: String)
     case Response(f: Future[HttpResponse])
     case Status(code: Future[StatusCode])
-  object CompletionArg:
+  object CompletionArg with
 
     // conversions defining the possible arguments to pass to `complete`
     // these always come with CompletionArg

--- a/tests/pos/reference/extension-methods.scala
+++ b/tests/pos/reference/extension-methods.scala
@@ -1,4 +1,4 @@
-object ExtMethods:
+object ExtMethods with
 
   case class Circle(x: Double, y: Double, radius: Double)
 
@@ -44,7 +44,7 @@ object ExtMethods:
       val limit = smallest(n).max
       xs.zipWithIndex.collect { case (x, i) if x <= limit => i }
 
-  trait IntOps:
+  trait IntOps with
     extension (i: Int) def isZero: Boolean = i == 0
 
     extension (i: Int) def safeMod(x: Int): Option[Int] =
@@ -53,13 +53,13 @@ object ExtMethods:
       else Some(i % x)
   end IntOps
 
-  object IntOpsEx extends IntOps:
+  object IntOpsEx extends IntOps with
     extension (i: Int) def safeDiv(x: Int): Option[Int] =
       // extension method brought into scope via inheritance from IntOps
       if x.isZero then None
       else Some(i / x)
 
-  trait SafeDiv:
+  trait SafeDiv with
     import IntOpsEx._ // brings safeDiv and safeMod into scope
 
     extension (i: Int) def divide(d: Int) : Option[(Int, Int)] =
@@ -73,19 +73,19 @@ object ExtMethods:
     given ops1: IntOps with {} // brings safeMod into scope
     1.safeMod(2)
 
-  class Lst[T](xs: T*):
+  class Lst[T](xs: T*) with
     private val elems = xs.toList
     def foldLeft[U](x: U)(op: (U, T) => U): U = elems.foldLeft(x)(op)
     def ++ (other: Lst[T]): Lst[T] = Lst(elems ++ other.elems: _*)
 
-  trait Ord[T]:
+  trait Ord[T] with
     extension (x: T) def less (y: T): Boolean
-  object Ord:
+  object Ord with
     given Ord[Int] with
       extension (x: Int) def less (y: Int): Boolean = x < y
   end Ord
 
-  object Lst:
+  object Lst with
 
     extension [T](xs: Lst[Lst[T]])
       def flatten: Lst[T] = xs.foldLeft(Lst())(_ ++ _)
@@ -110,7 +110,7 @@ object ExtMethods:
       if n < s.length && s(n) != ch then position(ch, n + 1)
       else n
 
-  object DoubleOps:
+  object DoubleOps with
     extension (x: Double) def ** (exponent: Int): Double =
       require(exponent > 0)
       if exponent == 0 then 1 else x * (x ** (exponent - 1))

--- a/tests/pos/reference/structural-closeable.scala
+++ b/tests/pos/reference/structural-closeable.scala
@@ -2,10 +2,10 @@ type Closeable = {
   def close(): Unit
 }
 
-class FileInputStream:
+class FileInputStream with
   def close(): Unit = ()
 
-class Channel:
+class Channel with
   def close(): Unit = ()
 
 import scala.reflect.Selectable.reflectiveSelectable

--- a/tests/pos/refinements.scala
+++ b/tests/pos/refinements.scala
@@ -10,6 +10,10 @@ trait UU {
   type UX
   val u: UX
   val x: this.type & { type UX = Int }
+  val x1: this.type { type UX = Int }
+  val x2: this.type with { type UX = Int }
+  val x3: this.type with
+    type UX = Int
   val y: Int = x.u
   val z: x.UX = y
 }

--- a/tests/pos/single-case.scala
+++ b/tests/pos/single-case.scala
@@ -1,4 +1,4 @@
-object test:
+object test with
 
   try
     println("hi")

--- a/tests/pos/targetName-infer-result.scala
+++ b/tests/pos/targetName-infer-result.scala
@@ -1,23 +1,23 @@
 import annotation.targetName
-enum Tree:
+enum Tree with
   case Bind(sym: Symbol, body: Tree)
 
 class Symbol
 
-object Test1:
-  abstract class TreeAccumulator[X]:
+object Test1 with
+  abstract class TreeAccumulator[X] with
     def app(x: X, tree: Tree): X
     def app(x: X, trees: List[Tree]): X = ???
 
-  val acc = new TreeAccumulator[List[Symbol]]:
+  val acc = new TreeAccumulator[List[Symbol]] with
     def app(syms: List[Symbol], tree: Tree) = tree match
       case Tree.Bind(sym, body) => app(sym :: syms, body)
 
-object Test2:
-  abstract class TreeAccumulator[X]:
+object Test2 with
+  abstract class TreeAccumulator[X] with
     @targetName("apply") def app(x: X, tree: Tree): X
     def app(x: X, trees: List[Tree]): X = ???
 
-  val acc = new TreeAccumulator[List[Symbol]]:
+  val acc = new TreeAccumulator[List[Symbol]] with
     @targetName("apply") def app(syms: List[Symbol], tree: Tree) = tree match
       case Tree.Bind(sym, body) => app(sym :: syms, body)

--- a/tests/pos/targetName-override.scala
+++ b/tests/pos/targetName-override.scala
@@ -1,11 +1,11 @@
 import scala.annotation.targetName
 
-class A:
+class A with
   @targetName("ff") def f(x: => Int): Int = x
   def f(x: => String): Int = x.length
 
 
-class B extends A:
+class B extends A with
   @targetName("ff") override def f(x: => Int): Int = x // OK
   override def f(x: => String): Int = x.length // OK
 

--- a/tests/pos/targetName-refine.scala
+++ b/tests/pos/targetName-refine.scala
@@ -1,7 +1,7 @@
 import annotation.targetName
-trait T:
+trait T with
   @targetName("f2") def f: Any
-class C extends T:
+class C extends T with
   @targetName("f2") def f: Int = 1
 
 val x: T { def f: Int } = C()

--- a/tests/pos/tasty-tags-obscure.scala
+++ b/tests/pos/tasty-tags-obscure.scala
@@ -1,15 +1,15 @@
-object ObscureTasty:
+object ObscureTasty with
 
   def foo(f: [t] => List[t] ?=> Unit) = ???
   def test1 = foo([t] => (a: List[t]) ?=> ()) // POLYtype => GIVENMETHODType
   def bar(f: [t] => List[t] => Unit) = ???
   def test2 = bar([t] => (a: List[t]) => ()) // POLYtype => METHODType
 
-  class Bar:
+  class Bar with
     final val bar = "Bar.bar"
 
-  class Foo extends Bar:
-    object A:
+  class Foo extends Bar with
+    object A with
       def unapply(a: Any): Some[Foo.super.bar.type] = ???
 
     def foo =

--- a/tests/pos/typeclass-encoding3.scala
+++ b/tests/pos/typeclass-encoding3.scala
@@ -45,7 +45,7 @@ object Test {
 
   class Str(val s: String) extends Monoid
     def combine(that: Str): Str = new Str(this.s + that.s)
-  object Str:
+  object Str with
     def unit = ""
 
   extension for String : Monoid

--- a/tests/pos/widen-union.scala
+++ b/tests/pos/widen-union.scala
@@ -1,10 +1,10 @@
 
-object Test1:
+object Test1 with
   val x: Int | String = 1
   val y = x
   val z: Int | String = y
 
-object Test2:
+object Test2 with
   type Sig = Int | String
   def consistent(x: Sig, y: Sig): Boolean = ???// x == y
 
@@ -12,7 +12,7 @@ object Test2:
        xs.corresponds(ys)(consistent)        // OK
     || xs.corresponds(ys)(consistent(_, _))  // error, found: Any, required: Int | String
 
-object Test3:
+object Test3 with
 
   def g[X](x: X | String): Int = ???
   def y: Boolean | String = ???

--- a/tests/run-custom-args/tasty-inspector/i10359.scala
+++ b/tests/run-custom-args/tasty-inspector/i10359.scala
@@ -33,7 +33,7 @@ object Test {
   }
 }
 
-class TestInspector() extends TastyInspector:
+class TestInspector() extends TastyInspector with
 
   protected def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit =
     import quotes.reflect._

--- a/tests/run-custom-args/tasty-inspector/i8163.scala
+++ b/tests/run-custom-args/tasty-inspector/i8163.scala
@@ -20,7 +20,7 @@ object Test {
   }
 }
 
-class TestInspector() extends TastyInspector:
+class TestInspector() extends TastyInspector with
 
   protected def processCompilationUnit(using Quotes)(root: quotes.reflect.Tree): Unit =
     inspectClass(root)

--- a/tests/run-custom-args/tasty-inspector/i8460.scala
+++ b/tests/run-custom-args/tasty-inspector/i8460.scala
@@ -33,7 +33,7 @@ object Test {
   }
 }
 
-class TestInspector_Children() extends TastyInspector:
+class TestInspector_Children() extends TastyInspector with
 
   var kids: List[String] = Nil
 

--- a/tests/run-custom-args/tasty-inspector/i9970.scala
+++ b/tests/run-custom-args/tasty-inspector/i9970.scala
@@ -46,7 +46,7 @@ object Test {
 
 // Inspector that performs the actual tests
 
-class TestInspector() extends TastyInspector:
+class TestInspector() extends TastyInspector with
 
   private var foundIOApp: Boolean = false
   private var foundSimple: Boolean = false

--- a/tests/run-macros/BigFloat/BigFloatFromDigitsImpl_1.scala
+++ b/tests/run-macros/BigFloat/BigFloatFromDigitsImpl_1.scala
@@ -3,7 +3,7 @@ import language.experimental.genericNumberLiterals
 import scala.util.FromDigits
 import scala.quoted._
 
-object BigFloatFromDigitsImpl:
+object BigFloatFromDigitsImpl with
   def apply(digits: Expr[String])(using Quotes): Expr[BigFloat] =
     digits.value match
       case Some(ds) =>

--- a/tests/run-macros/enum-nat-macro/Macros_2.scala
+++ b/tests/run-macros/enum-nat-macro/Macros_2.scala
@@ -4,7 +4,7 @@ import Nat._
  inline def ZeroMacro: Zero.type = ${ Macros.natZero }
  transparent inline def toNatMacro(inline int: Int): Nat = ${ Macros.toNatImpl('int) }
 
- object Macros:
+ object Macros with
    import quoted._
 
    def toIntImpl(nat: Expr[Nat])(using Quotes): Expr[Int] =

--- a/tests/run-macros/enum-nat-macro/Nat_1.scala
+++ b/tests/run-macros/enum-nat-macro/Nat_1.scala
@@ -1,3 +1,3 @@
-enum Nat:
+enum Nat with
   case Zero
   case Succ[N <: Nat](n: N)

--- a/tests/run-macros/i10464/Person_1.scala
+++ b/tests/run-macros/i10464/Person_1.scala
@@ -1,4 +1,4 @@
-trait Person:
+trait Person with
   def name: String
 
 case class PersonA(name: String) extends Person

--- a/tests/run-macros/i7716/Macro_1.scala
+++ b/tests/run-macros/i7716/Macro_1.scala
@@ -1,14 +1,14 @@
 import scala.quoted._
 
-trait Foo:
+trait Foo with
   def mcrImpl1(e: Expr[Any])(using ctx: Quotes): Expr[Any] =
     '{println(s"Hello ${$e}")}
 
-object Foo extends Foo:
+object Foo extends Foo with
   def mcrImpl2(e: Expr[Any])(using ctx: Quotes): Expr[Any] =
     '{println(s"Hello ${$e}")}
 
-object Bar:
+object Bar with
   import Foo._
   inline def mcr1(e: => Any) = ${mcrImpl1('e)}
 

--- a/tests/run-macros/i8530/Macro_1.scala
+++ b/tests/run-macros/i8530/Macro_1.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-object Succ:
+object Succ with
 
   inline def unapply(n: Int): Option[Int] = ${ impl('n) }
 

--- a/tests/run-macros/i9812b/Macro_1.scala
+++ b/tests/run-macros/i9812b/Macro_1.scala
@@ -6,14 +6,14 @@ trait Liftable[T] {
   def toExpr(x: T): Quotes ?=> Expr[T]
 }
 
-object Lift:
+object Lift with
   def apply[T: Liftable](t: T)(using q: Quotes, ev: Liftable[T]): Expr[T] = ev.toExpr(t)
 
 sealed abstract class SomeEnum
-object SomeEnum:
+object SomeEnum with
   final val Foo = new SomeEnum {}
   final case class Bar[S <: SomeEnum](s: S) extends SomeEnum
-  object Bar:
+  object Bar with
     def apply[S <: SomeEnum](s: S): SomeEnum = new Bar(s)
 
 given LiftFoo: Liftable[Foo.type] with

--- a/tests/run-macros/paramSymss/Test_2.scala
+++ b/tests/run-macros/paramSymss/Test_2.scala
@@ -16,5 +16,5 @@ object Test {
     println(showParamSyms(new Test(1, 2)))
 }
 
-class Test[T](a: T):
+class Test[T](a: T) with
     def this(a: Int, b: T) = this(b)

--- a/tests/run-macros/refined-selectable-macro/Macro_1.scala
+++ b/tests/run-macros/refined-selectable-macro/Macro_1.scala
@@ -2,7 +2,7 @@ import scala.quoted._
 
 object Macro {
 
-  trait Selectable extends scala.Selectable:
+  trait Selectable extends scala.Selectable with
     def selectDynamic(name: String): Any
 
   trait SelectableRecord extends Selectable {

--- a/tests/run-macros/tasty-overload-secondargs/Macro_1.scala
+++ b/tests/run-macros/tasty-overload-secondargs/Macro_1.scala
@@ -1,6 +1,6 @@
 import scala.quoted._
 
-object X:
+object X with
 
   def andThen[A,B](a:A)(f: A => B): B =
      println("totalFunction")
@@ -11,7 +11,7 @@ object X:
      f.lift.apply(a)
 
 
-object Macro:
+object Macro with
 
     inline def mThen[A,B](inline x:A=>B):B = ${
        mThenImpl[A,B,A=>B,B]('x)

--- a/tests/run-macros/tasty-overload-secondargs/Test_2.scala
+++ b/tests/run-macros/tasty-overload-secondargs/Test_2.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
 
  def main(args:Array[String]):Unit =
     val x1 = X.andThen(1){case x if (x%2 == 0) => x}

--- a/tests/run-macros/tasty-tree-map/quoted_1.scala
+++ b/tests/run-macros/tasty-tree-map/quoted_1.scala
@@ -1,9 +1,9 @@
 import scala.quoted._
 
-object Macros:
+object Macros with
   implicit inline def identityMaped[T](x: => T): T = ${ MacrosImpl.impl('x) }
 
-object MacrosImpl:
+object MacrosImpl with
   def impl[T: Type](x: Expr[T])(using Quotes) : Expr[T] = {
     import quotes.reflect._
     val identityMap = new TreeMap { }

--- a/tests/run-staging/abstract-int-quote.scala
+++ b/tests/run-staging/abstract-int-quote.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 
-object Test:
+object Test with
 
   given Compiler = Compiler.make(getClass.getClassLoader)
 

--- a/tests/run-staging/i7897.scala
+++ b/tests/run-staging/i7897.scala
@@ -1,6 +1,6 @@
 import scala.quoted._, staging._
 
-object Test:
+object Test with
   given Compiler = Compiler.make(getClass.getClassLoader)
 
   val f: Array[Int] => Int = run {

--- a/tests/run-staging/i8178.scala
+++ b/tests/run-staging/i8178.scala
@@ -5,7 +5,7 @@ def foo(n: Int, t: Expr[Int])(using Quotes): Expr[Int] =
   if (n == 0) t
   else '{ val a = ${Expr(n)}; ${foo(n - 1, 'a)} + $t  }
 
-object Test:
+object Test with
   def main(args: Array[String]) = {
     // make available the necessary toolbox for runtime code generation
     given Compiler = Compiler.make(getClass.getClassLoader)

--- a/tests/run-staging/shonan-hmm-simple.scala
+++ b/tests/run-staging/shonan-hmm-simple.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.quoted.staging._
 
-trait Ring[T]:
+trait Ring[T] with
   val zero: T
   val one: T
   val add: (x: T, y: T) => T
@@ -9,7 +9,7 @@ trait Ring[T]:
   val mul: (x: T, y: T) => T
 end Ring
 
-class RingInt extends Ring[Int]:
+class RingInt extends Ring[Int] with
   val zero = 0
   val one  = 1
   val add  = (x, y) => x + y
@@ -17,30 +17,30 @@ class RingInt extends Ring[Int]:
   val mul  = (x, y) => x * y
 
 
-class RingIntExpr(using Quotes) extends Ring[Expr[Int]]:
+class RingIntExpr(using Quotes) extends Ring[Expr[Int]] with
   val zero = '{0}
   val one  = '{1}
   val add  = (x, y) => '{$x + $y}
   val sub  = (x, y) => '{$x - $y}
   val mul  = (x, y) => '{$x * $y}
 
-class RingComplex[U](u: Ring[U]) extends Ring[Complex[U]]:
+class RingComplex[U](u: Ring[U]) extends Ring[Complex[U]] with
   val zero = Complex(u.zero, u.zero)
   val one  = Complex(u.one, u.zero)
   val add  = (x, y) => Complex(u.add(x.re, y.re), u.add(x.im, y.im))
   val sub  = (x, y) => Complex(u.sub(x.re, y.re), u.sub(x.im, y.im))
   val mul  = (x, y) => Complex(u.sub(u.mul(x.re, y.re), u.mul(x.im, y.im)), u.add(u.mul(x.re, y.im), u.mul(x.im, y.re)))
 
-sealed trait PV[T]:
+sealed trait PV[T] with
   def expr(using ToExpr[T], Quotes): Expr[T]
 
-case class Sta[T](x: T) extends PV[T]:
+case class Sta[T](x: T) extends PV[T] with
   def expr(using ToExpr[T], Quotes): Expr[T] = Expr(x)
 
-case class Dyn[T](x: Expr[T]) extends PV[T]:
+case class Dyn[T](x: Expr[T]) extends PV[T] with
   def expr(using ToExpr[T], Quotes): Expr[T] = x
 
-class RingPV[U: ToExpr](u: Ring[U], eu: Ring[Expr[U]])(using Quotes) extends Ring[PV[U]]:
+class RingPV[U: ToExpr](u: Ring[U], eu: Ring[Expr[U]])(using Quotes) extends Ring[PV[U]] with
   val zero: PV[U] = Sta(u.zero)
   val one: PV[U] = Sta(u.one)
   val add = (x: PV[U], y: PV[U]) => (x, y) match
@@ -62,28 +62,28 @@ class RingPV[U: ToExpr](u: Ring[U], eu: Ring[Expr[U]])(using Quotes) extends Rin
 
 case class Complex[T](re: T, im: T)
 
-object Complex:
-  implicit def isToExpr[T: Type: ToExpr]: ToExpr[Complex[T]] = new ToExpr[Complex[T]]:
+object Complex with
+  implicit def isToExpr[T: Type: ToExpr]: ToExpr[Complex[T]] = new ToExpr[Complex[T]] with
     def apply(comp: Complex[T])(using Quotes) = '{Complex(${Expr(comp.re)}, ${Expr(comp.im)})}
 
-case class Vec[Idx, T](size: Idx, get: Idx => T):
+case class Vec[Idx, T](size: Idx, get: Idx => T) with
   def map[U](f: T => U): Vec[Idx, U] = Vec(size, i => f(get(i)))
   def zipWith[U, V](other: Vec[Idx, U], f: (T, U) => V): Vec[Idx, V] = Vec(size, i => f(get(i), other.get(i)))
 
-object Vec:
+object Vec with
   def from[T](elems: T*): Vec[Int, T] = new Vec(elems.size, i => elems(i))
 
-trait VecOps[Idx, T]:
+trait VecOps[Idx, T] with
   val reduce: ((T, T) => T, T, Vec[Idx, T]) => T
 
-class StaticVecOps[T] extends VecOps[Int, T]:
+class StaticVecOps[T] extends VecOps[Int, T] with
   val reduce: ((T, T) => T, T, Vec[Int, T]) => T = (plus, zero, vec) =>
     var sum = zero
     for (i <- 0 until vec.size)
       sum = plus(sum, vec.get(i))
     sum
 
-class ExprVecOps[T: Type](using Quotes) extends VecOps[Expr[Int], Expr[T]]:
+class ExprVecOps[T: Type](using Quotes) extends VecOps[Expr[Int], Expr[T]] with
   val reduce: ((Expr[T], Expr[T]) => Expr[T], Expr[T], Vec[Expr[Int], Expr[T]]) => Expr[T] = (plus, zero, vec) => '{
     var sum = $zero
     var i = 0
@@ -93,10 +93,10 @@ class ExprVecOps[T: Type](using Quotes) extends VecOps[Expr[Int], Expr[T]]:
     sum
   }
 
-class Blas1[Idx, T](r: Ring[T], ops: VecOps[Idx, T]):
+class Blas1[Idx, T](r: Ring[T], ops: VecOps[Idx, T]) with
   def dot(v1: Vec[Idx, T], v2: Vec[Idx, T]): T = ops.reduce(r.add, r.zero, v1.zipWith(v2, r.mul))
 
-object Test:
+object Test with
 
   given Compiler = Compiler.make(getClass.getClassLoader)
   def main(args: Array[String]): Unit =

--- a/tests/run-staging/shonan-hmm/PV.scala
+++ b/tests/run-staging/shonan-hmm/PV.scala
@@ -7,7 +7,7 @@ case class Sta[T](x: T) extends PV[T]
 
 case class Dyn[T](x: Expr[T]) extends PV[T]
 
-object Dyn:
+object Dyn with
   def apply[T: ToExpr](x: T)(using Quotes): Dyn[T] = Dyn(Expr(x))
 
 object Dyns {

--- a/tests/run-with-compiler/intmaptest.scala
+++ b/tests/run-with-compiler/intmaptest.scala
@@ -1,12 +1,12 @@
-trait Generator[+T]:
+trait Generator[+T] with
   self =>
   def generate: T
-  def map[S](f: T => S) = new Generator[S]:
+  def map[S](f: T => S) = new Generator[S] with
     def generate: S = f(self.generate)
-  def flatMap[S](f: T => Generator[S]) = new Generator[S]:
+  def flatMap[S](f: T => Generator[S]) = new Generator[S] with
     def generate: S = f(self.generate).generate
 
-object Generator:
+object Generator with
   val NumLimit = 300
   val Iterations = 10000
 
@@ -20,7 +20,7 @@ object Generator:
   def range(end: Int): Generator[Int] =
     integers.map(x => (x % end).abs)
 
-  enum Op:
+  enum Op with
     case Lookup, Update, Remove
   export Op._
 

--- a/tests/run-with-compiler/maptest.scala
+++ b/tests/run-with-compiler/maptest.scala
@@ -1,12 +1,12 @@
-trait Generator[+T]:
+trait Generator[+T] with
   self =>
   def generate: T
-  def map[S](f: T => S) = new Generator[S]:
+  def map[S](f: T => S) = new Generator[S] with
     def generate: S = f(self.generate)
-  def flatMap[S](f: T => Generator[S]) = new Generator[S]:
+  def flatMap[S](f: T => Generator[S]) = new Generator[S] with
     def generate: S = f(self.generate).generate
 
-object Generator:
+object Generator with
   val NumLimit = 300
   val Iterations = 10000
 
@@ -20,7 +20,7 @@ object Generator:
   def range(end: Int): Generator[Int] =
     integers.map(x => (x % end).abs)
 
-  enum Op:
+  enum Op with
     case Lookup, Update, Remove
   export Op._
 

--- a/tests/run-with-compiler/settest.scala
+++ b/tests/run-with-compiler/settest.scala
@@ -1,12 +1,12 @@
-trait Generator[+T]:
+trait Generator[+T] with
   self =>
   def generate: T
-  def map[S](f: T => S) = new Generator[S]:
+  def map[S](f: T => S) = new Generator[S] with
     def generate: S = f(self.generate)
-  def flatMap[S](f: T => Generator[S]) = new Generator[S]:
+  def flatMap[S](f: T => Generator[S]) = new Generator[S] with
     def generate: S = f(self.generate).generate
 
-object Generator:
+object Generator with
   val NumLimit = 300
   val Iterations = 10000
 
@@ -20,7 +20,7 @@ object Generator:
   def range(end: Int): Generator[Int] =
     integers.map(x => (x % end).abs)
 
-  enum Op:
+  enum Op with
     case Lookup, Update, Remove
   export Op._
 

--- a/tests/run/ConfManagement.scala
+++ b/tests/run/ConfManagement.scala
@@ -1,12 +1,12 @@
 case class Person(name: String)
 case class Paper(title: String, authors: List[Person], body: String)
 
-object ConfManagement:
+object ConfManagement with
   opaque type Viewers = Set[Person]
   def viewers(using vs: Viewers) = vs
   type Viewed[T] = Viewers ?=> T
 
-  class Conference(ratings: (Paper, Int)*):
+  class Conference(ratings: (Paper, Int)*) with
     private val realScore = ratings.toMap
 
     def papers: List[Paper] = ratings.map(_._1).toList

--- a/tests/run/LazyLists.scala
+++ b/tests/run/LazyLists.scala
@@ -1,7 +1,7 @@
 package xcollections:
   import annotation.unchecked.uncheckedVariance
 
-  abstract class LazyList[+T]:
+  abstract class LazyList[+T] with
 
     private var myHead: T = _
     private var myTail: LazyList[T] = _
@@ -40,12 +40,12 @@ package xcollections:
       case xs: LazyList[T] @unchecked => xs
       case _ => LazyList.fromIterator(xs.iterator)
 
-  object LazyList:
+  object LazyList with
 
     val empty: LazyList[Nothing] = new:
       protected def force(): LazyList[Nothing] = this
 
-    object #:: :
+    object #::  with
       def unapply[T](xs: LazyList[T]): Option[(T, LazyList[T])] =
         if xs.isEmpty then None
         else Some((xs.head, xs.tail))

--- a/tests/run/Pouring.scala
+++ b/tests/run/Pouring.scala
@@ -1,8 +1,8 @@
-class Pouring(capacity: Vector[Int]):
+class Pouring(capacity: Vector[Int]) with
   type Glass = Int
   type Content = Vector[Int]
 
-  enum Move:
+  enum Move with
     def apply(content: Content): Content = this match
       case Empty(g) => content.updated(g, 0)
       case Fill(g) => content.updated(g, capacity(g))
@@ -23,7 +23,7 @@ class Pouring(capacity: Vector[Int]):
     ++ (for g <- glasses yield Move.Fill(g))
     ++ (for g1 <- glasses; g2 <- glasses if g1 != g2 yield Move.Pour(g1, g2))
 
-  class Path(history: List[Move], val endContent: Content):
+  class Path(history: List[Move], val endContent: Content) with
     def extend(move: Move) = Path(move :: history, move(endContent))
     override def toString = s"${history.reverse.mkString(" ")} --> $endContent"
   end Path

--- a/tests/run/Signals.scala
+++ b/tests/run/Signals.scala
@@ -2,7 +2,7 @@
 import annotation.unchecked._
 package frp:
 
-  sealed class Signal[+T](expr: Signal.Caller ?=> T):
+  sealed class Signal[+T](expr: Signal.Caller ?=> T) with
     private var myExpr: Signal.Caller => T = _
     private var myValue: T = _
     private var observers: Set[Signal.Caller] = Set()
@@ -26,19 +26,19 @@ package frp:
         observers = Set()
         obs.foreach(_.computeValue())
 
-  object Signal:
+  object Signal with
     type Caller = Signal[?]
     given noCaller: Caller(???) with
       override def computeValue() = ()
   end Signal
 
-  class Var[T](expr: Signal.Caller ?=> T) extends Signal[T](expr):
+  class Var[T](expr: Signal.Caller ?=> T) extends Signal[T](expr) with
     def update(expr: Signal.Caller ?=> T): Unit = changeTo(expr)
   end Var
 end frp
 
 import frp._
-class BankAccount:
+class BankAccount with
   def balance: Signal[Int] = myBalance
 
   private var myBalance: Var[Int] = Var(0)

--- a/tests/run/Signals1.scala
+++ b/tests/run/Signals1.scala
@@ -2,12 +2,12 @@
 import annotation.unchecked._
 package frp:
 
-  trait Signal[+T]:
+  trait Signal[+T] with
     def apply()(using caller: Signal.Caller): T
 
-  object Signal:
+  object Signal with
 
-    abstract class AbstractSignal[+T] extends Signal[T]:
+    abstract class AbstractSignal[+T] extends Signal[T] with
       private var currentValue: T = _
       private var observers: Set[Caller] = Set()
 
@@ -29,11 +29,11 @@ package frp:
     end AbstractSignal
 
     def apply[T](expr: Caller ?=> T): Signal[T] =
-      new AbstractSignal[T]:
+      new AbstractSignal[T] with
         protected val eval = expr(using _)
         computeValue()
 
-    class Var[T](expr: Caller ?=> T) extends AbstractSignal[T]:
+    class Var[T](expr: Caller ?=> T) extends AbstractSignal[T] with
       protected var eval: Caller => T = expr(using _)
       computeValue()
 
@@ -43,7 +43,7 @@ package frp:
     end Var
 
     opaque type Caller = AbstractSignal[?]
-    given noCaller: Caller = new AbstractSignal[Nothing]:
+    given noCaller: Caller = new AbstractSignal[Nothing] with
       override def eval = ???
       override def computeValue() = ()
 
@@ -51,7 +51,7 @@ package frp:
 end frp
 
 import frp._
-class BankAccount:
+class BankAccount with
   def balance: Signal[Int] = myBalance
 
   private val myBalance: Signal.Var[Int] = Signal.Var(0)

--- a/tests/run/Typeable.scala
+++ b/tests/run/Typeable.scala
@@ -16,15 +16,15 @@
  *  it's unclear whether this should expand to `C[T].unapply(x)`, (as it does now)
  *  or to `C.unapply[T](x)` (which is what TypeLevel Scala 4 did, I believe)
  */
-trait Typeable[T]:
+trait Typeable[T] with
   def cast(x: Any): Option[T]
   def describe: String
   override def toString = s"Typeable[$describe]"
 
-object Typeable:
+object Typeable with
   def apply[T: Typeable]: Typeable[T] = summon
 
-  class instanceOf[T: Typeable]:
+  class instanceOf[T: Typeable] with
     def unapply(x: Any): Option[T] = Typeable[T].cast(x)
 
   given int: Typeable[Int] with

--- a/tests/run/abstract-givens.scala
+++ b/tests/run/abstract-givens.scala
@@ -1,9 +1,9 @@
-trait T:
+trait T with
   given x: Int
   given y(using Int): String
   given z[T](using T): Seq[T]
 
-object Test extends T, App:
+object Test extends T, App with
   given x: Int = 22
   override given y(using Int): String = summon[Int].toString
   given z[T](using T): Seq[T] with

--- a/tests/run/context-functions.scala
+++ b/tests/run/context-functions.scala
@@ -1,4 +1,4 @@
-trait A:
+trait A with
 
   type Ctx[T]
   type Mega[T]
@@ -14,7 +14,7 @@ trait A:
   def trans(x: Ctx[Int]): Ctx[Int] = x
 end A
 
-object m extends A:
+object m extends A with
 
   type Ctx[T] = String ?=> T
   type Mega[T] = (Int, Int, Int, Int, Int,
@@ -36,7 +36,7 @@ object m extends A:
   def mega: Mega[Int] = summon[String].length
 end m
 
-trait B:
+trait B with
 
   type Ctx[T]
 
@@ -45,7 +45,7 @@ trait B:
   def id[T](x: T): T = drop(wrap(x))
 
 end B
-object n extends B:
+object n extends B with
   type Ctx[T] = String ?=> Int ?=> T
 
   def wrap[T](x: T): Ctx[T] = x

--- a/tests/run/decorators/DocComment.scala
+++ b/tests/run/decorators/DocComment.scala
@@ -5,7 +5,7 @@
  *  `body` what comes before the first tagged line
  */
 case class DocComment(body: String, tags: Map[String, List[String]])
-object DocComment:
+object DocComment with
   def fromString(str: String): DocComment =
     val lines = str.linesIterator.toList
     def tagged(line: String): Option[(String, String)] =

--- a/tests/run/decorators/EntryPoint.scala
+++ b/tests/run/decorators/EntryPoint.scala
@@ -1,7 +1,7 @@
 import collection.mutable
 
 /** A framework for defining stackable entry point wrappers */
-object EntryPoint:
+object EntryPoint with
 
   /** A base trait for wrappers of entry points.
   *  Sub-traits: Annotation#Wrapper
@@ -26,14 +26,14 @@ object EntryPoint:
   *
   *  The wrapper class has this outline:
   *
-  *     object <wrapperClass>:
+  *     object <wrapperClass> with
   *       @WrapperAnnotation def <wrapperMethod>(args: <Argument>) =
   *         ...
   *
   *  Here `<wrapperClass>` and `<wrapperMethod>` are obtained from an
   *  inline call to the `wrapperName` method.
   */
-  trait Annotation extends annotation.StaticAnnotation:
+  trait Annotation extends annotation.StaticAnnotation with
 
     /** The class used for argument parsing. E.g. `scala.util.FromString`, if
     *  arguments are strings, but it could be something else.
@@ -56,7 +56,7 @@ object EntryPoint:
     def wrapper(entryPointName: String, docComment: String): Wrapper
 
     /** Base class for descriptions of an entry point wrappers */
-    abstract class Wrapper extends EntryPoint.Wrapper:
+    abstract class Wrapper extends EntryPoint.Wrapper with
 
       /** The type of the wrapper argument. E.g., for Java main methods: `Array[String]` */
       type Argument
@@ -80,7 +80,7 @@ object EntryPoint:
       def call(arg: Argument): Call
 
       /** A class representing a wrapper call */
-      abstract class Call:
+      abstract class Call with
 
         /** The getter for the next argument of type `T` */
         def nextArgGetter[T](argName: String, fromString: ArgumentParser[T], defaultValue: Option[T] = None): () => T
@@ -124,7 +124,7 @@ object EntryPoint:
   *      created from @logged, @transactional, and @main, respectively.
   *    - `x` is the argument of the outer $logged$wrapper.
   */
-  trait Adapter extends annotation.StaticAnnotation:
+  trait Adapter extends annotation.StaticAnnotation with
 
     /** Creates a new wrapper around `wrapped` */
     def wrapper(wrapped: EntryPoint.Wrapper): Wrapper
@@ -169,7 +169,7 @@ object EntryPoint:
     *  keep the `adapt` type contract implicit (types are still checked when adapts
     *  are generated, of course).
     */
-    abstract class Wrapper extends EntryPoint.Wrapper:
+    abstract class Wrapper extends EntryPoint.Wrapper with
       /** The wrapper that this wrapped in turn by this wrapper */
       val wrapped: EntryPoint.Wrapper
 

--- a/tests/run/decorators/Test.scala
+++ b/tests/run/decorators/Test.scala
@@ -1,4 +1,4 @@
-object Test:
+object Test with
   def main(args: Array[String]) =
     def testAdd(args: String) =
       println(s"> java add $args")

--- a/tests/run/decorators/main.scala
+++ b/tests/run/decorators/main.scala
@@ -3,7 +3,7 @@ import collection.mutable
 /** A sample @main entry point annotation.
  *  Generates a main function.
  */
-class main extends EntryPoint.Annotation:
+class main extends EntryPoint.Annotation with
 
   type ArgumentParser[T] = util.CommandLineParser.FromString[T]
   type EntryPointResult  = Unit
@@ -13,11 +13,11 @@ class main extends EntryPoint.Annotation:
 
   def wrapper(name: String, doc: String): MainWrapper = new MainWrapper(name, doc)
 
-  class MainWrapper(val entryPointName: String, val docComment: String) extends Wrapper:
+  class MainWrapper(val entryPointName: String, val docComment: String) extends Wrapper with
     type Argument = Array[String]
     type Result = Unit
 
-    def call(args: Array[String]) = new Call:
+    def call(args: Array[String]) = new Call with
 
       /** A buffer of demanded argument names, plus
       *   "?"  if it has a default

--- a/tests/run/decorators/sample-adapters.scala
+++ b/tests/run/decorators/sample-adapters.scala
@@ -1,10 +1,10 @@
 // Sample adapters:
 
-class logged extends EntryPoint.Adapter:
+class logged extends EntryPoint.Adapter with
 
   def wrapper(wrapped: EntryPoint.Wrapper): LoggedWrapper = LoggedWrapper(wrapped)
 
-  class LoggedWrapper(val wrapped: EntryPoint.Wrapper) extends Wrapper:
+  class LoggedWrapper(val wrapped: EntryPoint.Wrapper) extends Wrapper with
     def adapt[A, R](op: A => R)(args: A): R =
       val argsString: String = args match
         case args: Array[_] => args.mkString(", ")
@@ -17,18 +17,18 @@ class logged extends EntryPoint.Adapter:
   end LoggedWrapper
 end logged
 
-class split extends EntryPoint.Adapter:
+class split extends EntryPoint.Adapter with
 
   def wrapper(wrapped: EntryPoint.Wrapper): SplitWrapper = SplitWrapper(wrapped)
 
-  class SplitWrapper(val wrapped: EntryPoint.Wrapper) extends Wrapper:
+  class SplitWrapper(val wrapped: EntryPoint.Wrapper) extends Wrapper with
     def adapt[R](op: Array[String] => R)(args: String): R = op(args.split(" "))
 end split
 
-class join extends EntryPoint.Adapter:
+class join extends EntryPoint.Adapter with
 
   def wrapper(wrapped: EntryPoint.Wrapper): JoinWrapper = JoinWrapper(wrapped)
 
-  class JoinWrapper(val wrapped: EntryPoint.Wrapper) extends Wrapper:
+  class JoinWrapper(val wrapped: EntryPoint.Wrapper) extends Wrapper with
     def adapt[R](op: String => R)(args: Array[String]): R = op(args.mkString(" "))
 end join

--- a/tests/run/decorators/sample-program.scala
+++ b/tests/run/decorators/sample-program.scala
@@ -1,4 +1,4 @@
-object myProgram:
+object myProgram with
 
   /** Adds two numbers
    *  @param  num   the first number
@@ -15,7 +15,7 @@ end myProgram
 
 //  Compiler generated code:
 
-object add:
+object add with
   private val $main = new main()
   private val $main$wrapper = $main.wrapper(
     "MyProgram.add",
@@ -29,7 +29,7 @@ object add:
     cll.run(myProgram.add(arg1(), arg2()))
 end add
 
-object addAll:
+object addAll with
   private val $main = new main()
   private val $split = new split()
   private val $logged = new logged()

--- a/tests/run/defunctionalized.scala
+++ b/tests/run/defunctionalized.scala
@@ -1,4 +1,4 @@
-enum Filter:
+enum Filter with
   case IsOdd
   case IsPrime
   case LessThan(bound: Int)

--- a/tests/run/enum-custom-toString.scala
+++ b/tests/run/enum-custom-toString.scala
@@ -1,23 +1,23 @@
-enum ES:
+enum ES with
   case A
   override def toString: String = "overridden"
 
-enum EJ extends java.lang.Enum[EJ]:
+enum EJ extends java.lang.Enum[EJ] with
   case B
   override def toString: String = "overridden"
 
-trait Mixin extends reflect.Enum:
+trait Mixin extends reflect.Enum with
   override def productPrefix: String = "noprefix"
   override def toString: String = "overridden"
 
-enum EM extends Mixin:
+enum EM extends Mixin with
   case C
 
-enum ET[T] extends java.lang.Enum[ET[_]]:
+enum ET[T] extends java.lang.Enum[ET[_]] with
   case D extends ET[Unit]
   override def toString: String = "overridden"
 
-enum EZ:
+enum EZ with
   case E(arg: Int)
   override def toString: String = "overridden"
 
@@ -25,20 +25,20 @@ enum EC: // control case
   case F
   case G(arg: Int)
 
-enum EO:
+enum EO with
   case H
   case I(arg: Int)
   override def productPrefix: String = "noprefix"
   override def toString: String = "overridden"
 end EO
 
-enum EQ:
+enum EQ with
   case J           extends EQ with Mixin
   case K(arg: Int) extends EQ with Mixin
 
 abstract class Tag[T] extends reflect.Enum
-object Tag:
-  private final class IntTagImpl extends Tag[Int] with runtime.EnumValue:
+object Tag with
+  private final class IntTagImpl extends Tag[Int] with runtime.EnumValue with
     def ordinal = 0
     override def hashCode = 123
   final val IntTag: Tag[Int] = IntTagImpl()

--- a/tests/run/enum-nat.scala
+++ b/tests/run/enum-nat.scala
@@ -1,11 +1,11 @@
 import Nat._
 import compiletime._
 
-enum Nat:
+enum Nat with
   case Zero
   case Succ[N <: Nat.Refract](n: N)
 
-object Nat:
+object Nat with
   type Refract = Zero.type | Succ[_]
 
 inline def toIntTypeLevel[N <: Nat]: Int = inline erasedValue[N] match

--- a/tests/run/enum-ordinal-java/Lib.scala
+++ b/tests/run/enum-ordinal-java/Lib.scala
@@ -1,5 +1,5 @@
-object Lib1:
+object Lib1 with
   trait MyJavaEnum[E <: java.lang.Enum[E]] extends java.lang.Enum[E]
 
-object Lib2:
+object Lib2 with
   type JavaEnumAlias[E <: java.lang.Enum[E]] = java.lang.Enum[E]

--- a/tests/run/enum-ordinal-java/Test.scala
+++ b/tests/run/enum-ordinal-java/Test.scala
@@ -1,7 +1,7 @@
-enum Color1 extends Lib1.MyJavaEnum[Color1]:
+enum Color1 extends Lib1.MyJavaEnum[Color1] with
   case Red, Green, Blue
 
-enum Color2 extends Lib2.JavaEnumAlias[Color2]:
+enum Color2 extends Lib2.JavaEnumAlias[Color2] with
     case Red, Green, Blue
 
 @main def Test =

--- a/tests/run/enum-values-order.scala
+++ b/tests/run/enum-values-order.scala
@@ -5,9 +5,9 @@ enum LatinAlphabet2 extends java.lang.Enum[LatinAlphabet2] { case A, B, C, D, E,
 
 enum LatinAlphabet3[+T] extends java.lang.Enum[LatinAlphabet3[_]] { case A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z }
 
-object Color:
+object Color with
   trait Pretty
-enum Color extends java.lang.Enum[Color]:
+enum Color extends java.lang.Enum[Color] with
   case Red, Green, Blue
   case Aqua extends Color with Color.Pretty
   case Grey, Black, White

--- a/tests/run/enum-values.scala
+++ b/tests/run/enum-values.scala
@@ -1,31 +1,31 @@
 import reflect.Selectable.reflectiveSelectable
 import deriving.Mirror
 
-enum Color:
+enum Color with
   case Red, Green, Blue
 
-enum Suits extends java.lang.Enum[Suits]:
+enum Suits extends java.lang.Enum[Suits] with
   case Clubs, Spades, Diamonds, Hearts
 
-enum Tag[T]:
+enum Tag[T] with
   case Int extends Tag[Int]
   case OfClass[T]()(using val tag: reflect.ClassTag[T]) extends Tag[T] // mix order of class and value
   case String extends Tag[String]
 
-enum Expr[-T >: Null]:
+enum Expr[-T >: Null] with
   case EmptyTree extends Expr[Null]
   case AnyTree
 
-enum ListLike[+T]:
+enum ListLike[+T] with
   case Cons[T](head: T, tail: ListLike[T]) extends ListLike[T]
   case EmptyListLike
 
-enum TypeCtorsK[F[_]]:
+enum TypeCtorsK[F[_]] with
   case List       extends TypeCtorsK[List]
   case Const[T]() extends TypeCtorsK[[U] =>> T] // mix order of class and value
   case Option     extends TypeCtorsK[Option]
 
-enum MixedParams[F[_], G[X,Y] <: collection.Map[X,Y], T]:
+enum MixedParams[F[_], G[X,Y] <: collection.Map[X,Y], T] with
   case Foo extends MixedParams[List, collection.mutable.LinkedHashMap, Unit]
 
 enum ClassOnly: // this should still generate the `ordinal` and `fromOrdinal` companion methods

--- a/tests/run/enums-precise.scala
+++ b/tests/run/enums-precise.scala
@@ -1,8 +1,8 @@
-enum NonEmptyList[+T]:
+enum NonEmptyList[+T] with
   case Many[+U](head: U, tail: NonEmptyList[U]) extends NonEmptyList[U]
   case One [+U](value: U)                       extends NonEmptyList[U]
 
-enum Ast:
+enum Ast with
   case Binding(name: String, tpe: String)
   case Lambda(args: NonEmptyList[Binding], rhs: Ast) // reference to another case of the enum
   case Ident(name: String)

--- a/tests/run/enums-serialization-compat.scala
+++ b/tests/run/enums-serialization-compat.scala
@@ -1,22 +1,22 @@
 import java.io._
 import scala.util.Using
 
-enum JColor extends java.lang.Enum[JColor]:
+enum JColor extends java.lang.Enum[JColor] with
   case Red // java enum has magic JVM support
 
-enum SColor:
+enum SColor with
   case Green // simple case last
 
-enum SColorTagged[T]:
+enum SColorTagged[T] with
   case Blue                                     extends SColorTagged[Unit]
   case Rgb(r: Byte, g: Byte, b: Byte)           extends SColorTagged[(Byte, Byte, Byte)] // mixing pattern kinds
   case Indigo                                   extends SColorTagged[Unit]
   case Cmyk(c: Byte, m: Byte, y: Byte, k: Byte) extends SColorTagged[(Byte, Byte, Byte, Byte)] // class case last
 
-enum Nucleobase:
+enum Nucleobase with
   case A,C,G,T // patdef last
 
-enum MyClassTag[T](wrapped: Class[?]):
+enum MyClassTag[T](wrapped: Class[?]) with
   case IntTag  extends MyClassTag[Int](classOf[Int])
   case UnitTag extends MyClassTag[Unit](classOf[Unit]) // value case last
 

--- a/tests/run/erased-inline-vals.scala
+++ b/tests/run/erased-inline-vals.scala
@@ -1,17 +1,17 @@
 
-abstract class A:
+abstract class A with
   def x: Int
   val y: Int
 
-class B extends A:
+class B extends A with
   inline def x: Int = 1
   inline val y = 2
 
-class C extends A:
+class C extends A with
   final val x: Int = 3
   final val y = 4
 
-class D:
+class D with
   inline def x: Int = 5
   inline val y = 6
 

--- a/tests/run/exports.scala
+++ b/tests/run/exports.scala
@@ -48,8 +48,8 @@ final class Foo {
   export foo._ // nothing is exported
 }
 
-class A:
+class A with
   val x: Int = 1
-class B(a: A):
+class B(a: A) with
   export a.x
 object B extends B(A())

--- a/tests/run/extension-override.scala
+++ b/tests/run/extension-override.scala
@@ -1,8 +1,8 @@
-class A:
+class A with
   extension (s: String)
     def len: Int = s.length
 
-object B extends A:
+object B extends A with
   extension (s: String)
     override def len: Int = s.length + 1
 

--- a/tests/run/fragables-extension.scala
+++ b/tests/run/fragables-extension.scala
@@ -3,7 +3,7 @@ trait Frag
 case class IntFrag(x: Int) extends Frag
 case class StringFrag(x: String) extends Frag
 
-trait Fragable[T]:
+trait Fragable[T] with
   extension (x: T)
     def toFrags: List[Frag]
 

--- a/tests/run/given-eta.scala
+++ b/tests/run/given-eta.scala
@@ -1,6 +1,6 @@
 class C(val x: Int)
 
-trait D:
+trait D with
    type T
    def trans(other: T): T
 

--- a/tests/run/given-var.scala
+++ b/tests/run/given-var.scala
@@ -1,5 +1,5 @@
 // Demonstrates that monomorphic givens are cached
-object a:
+object a with
   private var x = 1
   given Int = x
   def init(x: Int) = this.x = x

--- a/tests/run/i10082.scala
+++ b/tests/run/i10082.scala
@@ -1,4 +1,4 @@
-object Kotlin:
+object Kotlin with
   class Ctx[T](val x: T) extends AnyVal
 
   def fun[T, U](fn: Ctx[T] ?=> U): T => U = (x: T) => fn(using Ctx(x))

--- a/tests/run/i10857.scala
+++ b/tests/run/i10857.scala
@@ -1,6 +1,6 @@
-object Module:
+object Module with
 
-  enum Foo:
+  enum Foo with
     case Value
     case Parameterised(i: Int)
 

--- a/tests/run/i10884/Test_2.scala
+++ b/tests/run/i10884/Test_2.scala
@@ -1,4 +1,4 @@
-object Exporter:
+object Exporter with
   export JavaExporter_1._
 
 import Exporter._

--- a/tests/run/i10905.scala
+++ b/tests/run/i10905.scala
@@ -1,5 +1,5 @@
 class C(val x: Int) extends TypeHelpers
-abstract class TypeHelpers:
+abstract class TypeHelpers with
   self: C =>
   def f = x
 @main def Test =

--- a/tests/run/i7359.scala
+++ b/tests/run/i7359.scala
@@ -1,34 +1,34 @@
-trait ObjectInterface:
+trait ObjectInterface with
   def equals(obj: Any): Boolean
   def hashCode(): Int
   def toString(): String
 
-trait SAMPlainWithExtends extends ObjectInterface:
+trait SAMPlainWithExtends extends ObjectInterface with
   def first(): String
 
-trait SAMCovariantOutExtends[+O] extends ObjectInterface:
+trait SAMCovariantOutExtends[+O] extends ObjectInterface with
   def first(): O
 
-trait SAMContravariantInExtends[-I] extends ObjectInterface:
+trait SAMContravariantInExtends[-I] extends ObjectInterface with
   def first(in: I): Unit
 
-trait SAMInvariantExtends[T] extends ObjectInterface:
+trait SAMInvariantExtends[T] extends ObjectInterface with
   def first(in: T): T
 
-trait SAMInOutExtends[-I, +O] extends ObjectInterface:
+trait SAMInOutExtends[-I, +O] extends ObjectInterface with
   def first(in: I): O
 
 type CustomString = String
 type CustomBoolean = Boolean
 type CustomInt = Int
 
-trait SAMWithCustomAliases:
+trait SAMWithCustomAliases with
   def first(): String
   def equals(obj: Any): CustomBoolean
   def hashCode(): CustomInt
   def toString(): CustomString
 
-object Test:
+object Test with
 
   def main(args: Array[String]): Unit =
     val samPlainWithExtends : SAMPlainWithExtends = () => "o"

--- a/tests/run/i7788.scala
+++ b/tests/run/i7788.scala
@@ -1,4 +1,4 @@
-trait Show[-A]:
+trait Show[-A] with
   def show(a:A): String
 
 given Show[String] = x => x

--- a/tests/run/i8396.scala
+++ b/tests/run/i8396.scala
@@ -1,7 +1,7 @@
-trait Show[A]:
+trait Show[A] with
   def show(a: A): String = a.toString
 
-object Prefix:
+object Prefix with
   type AbstractType
   type UpperBoundedType <: String
   type FullyBoundedType >: String <: String

--- a/tests/run/i8530-b.scala
+++ b/tests/run/i8530-b.scala
@@ -1,6 +1,6 @@
 import scala.compiletime.erasedValue
 
-class MyRegex[Pattern <: String & Singleton/*Literal constant*/]:
+class MyRegex[Pattern <: String & Singleton/*Literal constant*/] with
   inline def unapplySeq(s: CharSequence): Option[List[String]] =
     inline erasedValue[Pattern] match
       case "foo" => if s == "foo" then Some(Nil) else None

--- a/tests/run/i8530.scala
+++ b/tests/run/i8530.scala
@@ -1,16 +1,16 @@
-object MyBoooleanUnapply:
+object MyBoooleanUnapply with
   inline def unapply(x: Int): Boolean = true
 
-object MyOptionUnapply:
+object MyOptionUnapply with
   inline def unapply(x: Int): Option[Long] = Some(x)
 
-object MyPolyUnapply:
+object MyPolyUnapply with
   inline def unapply[T](x: T): Option[T] = Some(x)
 
-object MySeqUnapply:
+object MySeqUnapply with
   inline def unapplySeq(x: Int): Seq[Int] = Seq(x, x + 1)
 
-object MyWhiteboxUnapply:
+object MyWhiteboxUnapply with
   transparent inline def unapply(x: Int): Option[Any] = Some(x)
 
 

--- a/tests/run/i8931.scala
+++ b/tests/run/i8931.scala
@@ -1,4 +1,4 @@
-object test1:
+object test1 with
 
   trait Trait
 
@@ -18,7 +18,7 @@ object test1:
     }
   }
 
-object test2:
+object test2 with
 
   trait Trait
 
@@ -38,16 +38,16 @@ object test2:
     }
   }
 
-object test3:
+object test3 with
 
   trait Trait
 
-  trait Managed[T]:
+  trait Managed[T] with
 
     def flatMap[U](f: T => Managed[U]) =
-      class C:
+      class C with
         def make() =
-          class D:
+          class D with
             def bar(): T = ???
             val t: T = ???
             val u =

--- a/tests/run/i9011.scala
+++ b/tests/run/i9011.scala
@@ -1,4 +1,4 @@
-enum Opt[+T] derives Eq:
+enum Opt[+T] derives Eq with
   case Sm[T](t: T) extends Opt[T]
   case Nn
 

--- a/tests/run/i9068.scala
+++ b/tests/run/i9068.scala
@@ -1,4 +1,4 @@
-case class MyClass(v1: Int, v2: Int, v3: Int, v4: Int) extends Product3[Int, Int, Int]:
+case class MyClass(v1: Int, v2: Int, v3: Int, v4: Int) extends Product3[Int, Int, Int] with
   val _1: Int = v2
   def _2: Int = v3
   var _3: Int = v4

--- a/tests/run/i9155.scala
+++ b/tests/run/i9155.scala
@@ -1,7 +1,7 @@
-object Foo:
+object Foo with
   @scala.annotation.targetName("w") def \/\/ = "W"
 
-object Bar:
+object Bar with
   export Foo._
 
 @main def Test =

--- a/tests/run/i9530.scala
+++ b/tests/run/i9530.scala
@@ -1,4 +1,4 @@
-trait Scope:
+trait Scope with
    type Expr
    type Value
    def expr(x: String): Expr

--- a/tests/run/i9928.scala
+++ b/tests/run/i9928.scala
@@ -1,17 +1,17 @@
-trait Magic[F]:
+trait Magic[F] with
   extension (x: Int) def read: F
 
-trait LowPrio:
+trait LowPrio with
   given Magic[String] with
     extension(x: Int) def read: String =
       println("In string")
       s"$x"
 
-object test1:
+object test1 with
   object Magic extends LowPrio
 
   opaque type Foo = String
-  object Foo extends LowPrio:
+  object Foo extends LowPrio with
     import Magic.given
     def apply(s: String): Foo = s
 
@@ -23,15 +23,15 @@ object test1:
     def test: Unit =
       (3.read: Foo)
 
-object test2:
-  object Magic extends LowPrio:
+object test2 with
+  object Magic extends LowPrio with
     given Magic[Foo] with
       extension (x: Int) def read: Foo =
         println("In foo")
         Foo(s"$x")
 
   opaque type Foo = String
-  object Foo extends LowPrio:
+  object Foo extends LowPrio with
     import Magic.given
     def apply(s: String): Foo = s
 

--- a/tests/run/ift-return.scala
+++ b/tests/run/ift-return.scala
@@ -1,7 +1,7 @@
-trait A:
+trait A with
   val x: Int
 
-trait Ctx:
+trait Ctx with
   type T
   val x: T
   val y: T

--- a/tests/run/inline-override.scala
+++ b/tests/run/inline-override.scala
@@ -1,12 +1,12 @@
 import annotation.targetName
 
-abstract class A:
+abstract class A with
   def f(x: Int) = s"dynamic $x"
   def h(x: Int): String
   @targetName("h2") def h1(x: Int): String
   inline def i(x: Int): String
 
-class B extends A:
+class B extends A with
   inline override def f(x: Int) = g(x)
   inline def g(x: Int) = s"inline $x"
   inline def h(x: Int) = g(x)

--- a/tests/run/instances.scala
+++ b/tests/run/instances.scala
@@ -40,10 +40,10 @@ object Test extends App {
   assert(List(names, List("!")).flattened == names :+ "!")
   assert(Nil.flattened == Nil)
 
-  trait SemiGroup[T]:
+  trait SemiGroup[T] with
     extension (x: T) def combine(y: T): T
 
-  trait Monoid[T] extends SemiGroup[T]:
+  trait Monoid[T] extends SemiGroup[T] with
     def unit: T
 
   given StringMonoid: Monoid[String] with
@@ -56,7 +56,7 @@ object Test extends App {
 
   println(sum(names))
 
-  trait Ord[T]:
+  trait Ord[T] with
     extension (x: T) def compareTo(y: T): Int
     extension (x: T) def < (y: T) = x.compareTo(y) < 0
     extension (x: T) def > (y: T) = x.compareTo(y) > 0
@@ -88,11 +88,11 @@ object Test extends App {
 
   println(max(List(1, 2, 3), List(2)))
 
-  trait Functor[F[_]]:
+  trait Functor[F[_]] with
     extension [A](x: F[A]) def map[B](f: A => B): F[B]
   end Functor
 
-  trait Monad[F[_]] extends Functor[F]:
+  trait Monad[F[_]] extends Functor[F] with
     extension [A](x: F[A]) def flatMap[B](f: A => F[B]): F[B]
     extension [A](x: F[A]) def map[B](f: A => B) = x.flatMap(f `andThen` pure)
 

--- a/tests/run/lazy-impl.scala
+++ b/tests/run/lazy-impl.scala
@@ -46,7 +46,7 @@
 
  *  The code makes use of the following runtime class:
 
-    class Waiting:
+    class Waiting with
         private var done = false
         def release(): Unit = synchronized:
             done = true

--- a/tests/run/option-extract.scala
+++ b/tests/run/option-extract.scala
@@ -1,5 +1,5 @@
 
-enum Option[+A]:
+enum Option[+A] with
   case Some(x: A)
   case None
 

--- a/tests/run/outer-accessors.scala
+++ b/tests/run/outer-accessors.scala
@@ -1,15 +1,15 @@
-class A:
+class A with
   val a = 2
 
-  class B:
+  class B with
     val b = 3
 
-    trait T:
+    trait T with
       def t = a + b
 
   val bb = B()
 
-  class C extends bb.T:
+  class C extends bb.T with
     def result = a + t
 
 @main def Test =

--- a/tests/run/quoted-sematics-1.scala
+++ b/tests/run/quoted-sematics-1.scala
@@ -25,7 +25,7 @@ object Name {
 }
 
 
-enum Term:
+enum Term with
   case Nat(n: Int)
   case Ref(name: Name)
   case Lambda(name: Name, tpe: Type, body: Term)
@@ -37,7 +37,7 @@ enum Term:
   case Fix(term: Term)
 
 
-enum Pattern:
+enum Pattern with
   case PNat(n: Int)
   case PRef(name: Name)
   case PApp(fun: Pattern, arg: Pattern)
@@ -46,7 +46,7 @@ enum Pattern:
   case PFun(name: Name)
 
 
-enum Type:
+enum Type with
   case NatType
   case LambdaType(arg: Type, res: Type)
   case BoxType(inner: Type)

--- a/tests/run/selectable-new.scala
+++ b/tests/run/selectable-new.scala
@@ -1,10 +1,10 @@
 @main def Test =
   val x =
-    class C extends reflect.Selectable:
+    class C extends reflect.Selectable with
       def name: String = "hello"
     new C
 
-  val y = new reflect.Selectable:
+  val y = new reflect.Selectable with
     def name: String = "hello"
 
   assert(x.name == "hello")

--- a/tests/run/singleton-ops-flags.scala
+++ b/tests/run/singleton-ops-flags.scala
@@ -3,7 +3,7 @@ package example {
   import compiletime.S
   import compiletime.ops.int.<<
 
-  object TastyFlags:
+  object TastyFlags with
 
     final val EmptyFlags  = baseFlags
     final val Erased      = EmptyFlags.next
@@ -40,7 +40,7 @@ package example {
         case Open        => "Open"
       }) mkString(" | ")
 
-    object opaques:
+    object opaques with
 
       opaque type FlagSet = Int
       opaque type EmptyFlagSet <: FlagSet = 0

--- a/tests/run/structural-contextual.scala
+++ b/tests/run/structural-contextual.scala
@@ -1,7 +1,7 @@
-trait Resolver:
+trait Resolver with
   def resolve(label: String): Any
 
-class ResolvingSelectable extends Selectable:
+class ResolvingSelectable extends Selectable with
   def selectDynamic(label: String)(using r: Resolver): Any =
     r.resolve(label)
   def applyDynamic(label: String)(args: Any*)(using r: Resolver): Any =

--- a/tests/run/targetName.scala
+++ b/tests/run/targetName.scala
@@ -1,23 +1,23 @@
 import annotation.targetName
 
-object A:
+object A with
   def f(x: => String): Int = x.length
   @targetName("f2") def f(x: => Int): Int = x
 
 import A._
 
-trait T:
+trait T with
   def f(x: => String): Int
   @targetName("f2") def f(x: => Int): Int
 
-class C:
+class C with
   def f(x: => String): Int = x.length
   @targetName("f2") def f(x: => Int): Int = x
 
-object B1 extends C, T:
+object B1 extends C, T with
   @targetName("f2") override def f(x: => Int): Int = x + 1
 
-object B2 extends C, T:
+object B2 extends C, T with
   override def f(x: => String): Int = x.length + 1
 
 @targetName("fooString") def foo(ps: String*) : Unit = println(s"strings: $ps")

--- a/tests/run/typable.scala
+++ b/tests/run/typable.scala
@@ -1,6 +1,6 @@
 import scala.reflect._
 
-object Test:
+object Test with
   def main(args: Array[String]): Unit =
     assert(f[String])
     assert(!f[Int])

--- a/tests/run/unambiref.scala
+++ b/tests/run/unambiref.scala
@@ -1,5 +1,5 @@
-class A(val x: Int):
-  class B extends A(2):
+class A(val x: Int) with
+  class B extends A(2) with
     println(x)
 
 @main def Test =

--- a/tests/semanticdb/expect/Enums.expect.scala
+++ b/tests/semanticdb/expect/Enums.expect.scala
@@ -1,17 +1,17 @@
-object Enums/*<-_empty_::Enums.*/:
+object Enums/*<-_empty_::Enums.*/ with
   import <:</*->_empty_::Enums.`<:<`.*/._
 
-  enum Colour/*<-_empty_::Enums.Colour#*/:
+  enum Colour/*<-_empty_::Enums.Colour#*/ with
     import Colour/*->_empty_::Enums.Colour.*/.Red/*->_empty_::Enums.Colour.Red.*/
     case Red/*<-_empty_::Enums.Colour.Red.*/, Green/*<-_empty_::Enums.Colour.Green.*/, Blue/*<-_empty_::Enums.Colour.Blue.*/
 
-  enum Directions/*<-_empty_::Enums.Directions#*/:
+  enum Directions/*<-_empty_::Enums.Directions#*/ with
     case North/*<-_empty_::Enums.Directions.North.*/, East/*<-_empty_::Enums.Directions.East.*/, South/*<-_empty_::Enums.Directions.South.*/, West/*<-_empty_::Enums.Directions.West.*/
 
-  enum Suits/*<-_empty_::Enums.Suits#*/ derives /*->scala::CanEqual.derived.*/CanEqual:
+  enum Suits/*<-_empty_::Enums.Suits#*/ derives /*->scala::CanEqual.derived.*/CanEqual with
     case Hearts/*<-_empty_::Enums.Suits.Hearts.*/, Spades/*<-_empty_::Enums.Suits.Spades.*/, Clubs/*<-_empty_::Enums.Suits.Clubs.*/, Diamonds/*<-_empty_::Enums.Suits.Diamonds.*/
 
-  object Suits/*<-_empty_::Enums.Suits.*/:
+  object Suits/*<-_empty_::Enums.Suits.*/ with
     extension (suit/*<-_empty_::Enums.Suits.isRed().(suit)*/: Suits/*->_empty_::Enums.Suits#*/) def isRed/*<-_empty_::Enums.Suits.isRed().*/: Boolean/*->scala::Boolean#*/ =
       suit/*->_empty_::Enums.Suits.isRed().(suit)*/ ==/*->scala::Any#`==`().*/ Hearts/*->_empty_::Enums.Suits.Hearts.*/ ||/*->scala::Boolean#`||`().*/ suit/*->_empty_::Enums.Suits.isRed().(suit)*/ ==/*->scala::Any#`==`().*/ Diamonds/*->_empty_::Enums.Suits.Diamonds.*/
 
@@ -19,7 +19,7 @@ object Enums/*<-_empty_::Enums.*/:
       case Spades/*->_empty_::Enums.Suits.Spades.*/ | Clubs/*->_empty_::Enums.Suits.Clubs.*/ => true
       case _              => false
 
-  enum WeekDays/*<-_empty_::Enums.WeekDays#*/:
+  enum WeekDays/*<-_empty_::Enums.WeekDays#*/ with
     case Monday/*<-_empty_::Enums.WeekDays.Monday.*/
     case Tuesday/*<-_empty_::Enums.WeekDays.Tuesday.*/
     case Wednesday/*<-_empty_::Enums.WeekDays.Wednesday.*/
@@ -28,25 +28,25 @@ object Enums/*<-_empty_::Enums.*/:
     case Saturday/*<-_empty_::Enums.WeekDays.Saturday.*/
     case Sunday/*<-_empty_::Enums.WeekDays.Sunday.*/
 
-  enum Coin/*<-_empty_::Enums.Coin#*/(value/*<-_empty_::Enums.Coin#value.*/: Int/*->scala::Int#*/):
+  enum Coin/*<-_empty_::Enums.Coin#*/(value/*<-_empty_::Enums.Coin#value.*/: Int/*->scala::Int#*/) with
     case Penny/*<-_empty_::Enums.Coin.Penny.*/    extends Coin/*->_empty_::Enums.Coin#*/(1)/*->scala::runtime::EnumValue#*/
     case Nickel/*<-_empty_::Enums.Coin.Nickel.*/   extends Coin/*->_empty_::Enums.Coin#*/(5)/*->scala::runtime::EnumValue#*/
     case Dime/*<-_empty_::Enums.Coin.Dime.*/     extends Coin/*->_empty_::Enums.Coin#*/(10)/*->scala::runtime::EnumValue#*/
     case Quarter/*<-_empty_::Enums.Coin.Quarter.*/  extends Coin/*->_empty_::Enums.Coin#*/(25)/*->scala::runtime::EnumValue#*/
     case Dollar/*<-_empty_::Enums.Coin.Dollar.*/   extends Coin/*->_empty_::Enums.Coin#*/(100)/*->scala::runtime::EnumValue#*/
 
-  enum Maybe/*<-_empty_::Enums.Maybe#*/[+A/*<-_empty_::Enums.Maybe#[A]*/]:
+  enum Maybe/*<-_empty_::Enums.Maybe#*/[+A/*<-_empty_::Enums.Maybe#[A]*/] with
     case Just/*<-_empty_::Enums.Maybe.Just#*/(value/*<-_empty_::Enums.Maybe.Just#value.*/: A/*->_empty_::Enums.Maybe.Just#[A]*/)
     case None/*<-_empty_::Enums.Maybe.None.*//*->scala::runtime::EnumValue#*/
 
-  enum Tag/*<-_empty_::Enums.Tag#*/[A/*<-_empty_::Enums.Tag#[A]*/]:
+  enum Tag/*<-_empty_::Enums.Tag#*/[A/*<-_empty_::Enums.Tag#[A]*/] with
     case IntTag/*<-_empty_::Enums.Tag.IntTag.*/ extends Tag/*->_empty_::Enums.Tag#*/[Int/*->scala::Int#*/]/*->scala::runtime::EnumValue#*/
     case BooleanTag/*<-_empty_::Enums.Tag.BooleanTag.*/ extends Tag/*->_empty_::Enums.Tag#*/[Boolean/*->scala::Boolean#*/]/*->scala::runtime::EnumValue#*/
 
-  enum <:</*<-_empty_::Enums.`<:<`#*/[-A/*<-_empty_::Enums.`<:<`#[A]*/, B/*<-_empty_::Enums.`<:<`#[B]*/]:
+  enum <:</*<-_empty_::Enums.`<:<`#*/[-A/*<-_empty_::Enums.`<:<`#[A]*/, B/*<-_empty_::Enums.`<:<`#[B]*/] with
     case Refl/*<-_empty_::Enums.`<:<`.Refl#*/[C/*<-_empty_::Enums.`<:<`.Refl#[C]*/]() extends (C/*->_empty_::Enums.`<:<`.Refl#[C]*/ <:</*->_empty_::Enums.`<:<`#*/ C/*->_empty_::Enums.`<:<`.Refl#[C]*/)
 
-  object <:</*<-_empty_::Enums.`<:<`.*/ :
+  object <:</*<-_empty_::Enums.`<:<`.*/  with
     given [T]: (T/*<-_empty_::Enums.`<:<`.given_T().*//*<-_empty_::Enums.`<:<`.given_T().[T]*//*->_empty_::Enums.`<:<`.given_T().[T]*/ <:</*->_empty_::Enums.`<:<`#*/ T/*->_empty_::Enums.`<:<`.given_T().[T]*/) = Refl/*->_empty_::Enums.`<:<`.Refl.*//*->_empty_::Enums.`<:<`.Refl.apply().*/()
 
   extension [A/*<-_empty_::Enums.unwrap().[A]*/, B/*<-_empty_::Enums.unwrap().[B]*/](opt/*<-_empty_::Enums.unwrap().(opt)*/: Option/*->scala::Option#*/[A/*->_empty_::Enums.unwrap().[A]*/]) def unwrap/*<-_empty_::Enums.unwrap().*/(using ev/*<-_empty_::Enums.unwrap().(ev)*/: A/*->_empty_::Enums.unwrap().[A]*/ <:</*->_empty_::Enums.`<:<`#*/ Option/*->scala::Option#*/[B/*->_empty_::Enums.unwrap().[B]*/]): Option/*->scala::Option#*/[B/*->_empty_::Enums.unwrap().[B]*/] = ev/*->_empty_::Enums.unwrap().(ev)*/ match
@@ -54,7 +54,7 @@ object Enums/*<-_empty_::Enums.*/:
 
   val some1/*<-_empty_::Enums.some1.*/ = /*->_empty_::Enums.unwrap().*/Some/*->scala::Some.*//*->scala::Some.apply().*/(Some/*->scala::Some.*//*->scala::Some.apply().*/(1)).unwrap/*->_empty_::Enums.`<:<`.given_T().*/
 
-  enum Planet/*<-_empty_::Enums.Planet#*/(mass/*<-_empty_::Enums.Planet#mass.*/: Double/*->scala::Double#*/, radius/*<-_empty_::Enums.Planet#radius.*/: Double/*->scala::Double#*/) extends Enum/*->java::lang::Enum#*/[Planet/*->_empty_::Enums.Planet#*/]/*->java::lang::Enum#`<init>`().*/:
+  enum Planet/*<-_empty_::Enums.Planet#*/(mass/*<-_empty_::Enums.Planet#mass.*/: Double/*->scala::Double#*/, radius/*<-_empty_::Enums.Planet#radius.*/: Double/*->scala::Double#*/) extends Enum/*->java::lang::Enum#*/[Planet/*->_empty_::Enums.Planet#*/]/*->java::lang::Enum#`<init>`().*/ with
     private final val G/*<-_empty_::Enums.Planet#G.*/ = 6.67300E-11
     def surfaceGravity/*<-_empty_::Enums.Planet#surfaceGravity().*/ = G/*->_empty_::Enums.Planet#G.*/ */*->scala::Double#`*`(+6).*/ mass/*->_empty_::Enums.Planet#mass.*/ //*->scala::Double#`::`(+6).*/ (radius/*->_empty_::Enums.Planet#radius.*/ */*->scala::Double#`*`(+6).*/ radius/*->_empty_::Enums.Planet#radius.*/)
     def surfaceWeight/*<-_empty_::Enums.Planet#surfaceWeight().*/(otherMass/*<-_empty_::Enums.Planet#surfaceWeight().(otherMass)*/: Double/*->scala::Double#*/) = otherMass/*->_empty_::Enums.Planet#surfaceWeight().(otherMass)*/ */*->scala::Double#`*`(+6).*/ surfaceGravity/*->_empty_::Enums.Planet#surfaceGravity().*/

--- a/tests/semanticdb/expect/Enums.scala
+++ b/tests/semanticdb/expect/Enums.scala
@@ -1,17 +1,17 @@
-object Enums:
+object Enums with
   import <:<._
 
-  enum Colour:
+  enum Colour with
     import Colour.Red
     case Red, Green, Blue
 
-  enum Directions:
+  enum Directions with
     case North, East, South, West
 
-  enum Suits derives CanEqual:
+  enum Suits derives CanEqual with
     case Hearts, Spades, Clubs, Diamonds
 
-  object Suits:
+  object Suits with
     extension (suit: Suits) def isRed: Boolean =
       suit == Hearts || suit == Diamonds
 
@@ -19,7 +19,7 @@ object Enums:
       case Spades | Clubs => true
       case _              => false
 
-  enum WeekDays:
+  enum WeekDays with
     case Monday
     case Tuesday
     case Wednesday
@@ -28,25 +28,25 @@ object Enums:
     case Saturday
     case Sunday
 
-  enum Coin(value: Int):
+  enum Coin(value: Int) with
     case Penny    extends Coin(1)
     case Nickel   extends Coin(5)
     case Dime     extends Coin(10)
     case Quarter  extends Coin(25)
     case Dollar   extends Coin(100)
 
-  enum Maybe[+A]:
+  enum Maybe[+A] with
     case Just(value: A)
     case None
 
-  enum Tag[A]:
+  enum Tag[A] with
     case IntTag extends Tag[Int]
     case BooleanTag extends Tag[Boolean]
 
-  enum <:<[-A, B]:
+  enum <:<[-A, B] with
     case Refl[C]() extends (C <:< C)
 
-  object <:< :
+  object <:<  with
     given [T]: (T <:< T) = Refl()
 
   extension [A, B](opt: Option[A]) def unwrap(using ev: A <:< Option[B]): Option[B] = ev match
@@ -54,7 +54,7 @@ object Enums:
 
   val some1 = Some(Some(1)).unwrap
 
-  enum Planet(mass: Double, radius: Double) extends Enum[Planet]:
+  enum Planet(mass: Double, radius: Double) extends Enum[Planet] with
     private final val G = 6.67300E-11
     def surfaceGravity = G * mass / (radius * radius)
     def surfaceWeight(otherMass: Double) = otherMass * surfaceGravity

--- a/tests/semanticdb/expect/Givens.expect.scala
+++ b/tests/semanticdb/expect/Givens.expect.scala
@@ -1,7 +1,7 @@
 package a
 package b
 
-object Givens/*<-a::b::Givens.*/:
+object Givens/*<-a::b::Givens.*/ with
 
   extension [A/*<-a::b::Givens.sayHello().[A]*/](any/*<-a::b::Givens.sayHello().(any)*/: A/*->a::b::Givens.sayHello().[A]*/)
     def sayHello/*<-a::b::Givens.sayHello().*/ = s"/*->scala::StringContext.apply().*/Hello, I am $any/*->a::b::Givens.sayHello().(any)*/"/*->scala::StringContext#s().*/
@@ -14,7 +14,7 @@ object Givens/*<-a::b::Givens.*/:
   val goodbye1/*<-a::b::Givens.goodbye1.*/ = /*->a::b::Givens.sayGoodbye().*/1.sayGoodbye
   val soLong1/*<-a::b::Givens.soLong1.*/ = /*->a::b::Givens.saySoLong().*/1.saySoLong
 
-  trait Monoid/*<-a::b::Givens.Monoid#*/[A/*<-a::b::Givens.Monoid#[A]*/]:
+  trait Monoid/*<-a::b::Givens.Monoid#*/[A/*<-a::b::Givens.Monoid#[A]*/] with
     def empty/*<-a::b::Givens.Monoid#empty().*/: A/*->a::b::Givens.Monoid#[A]*/
     extension (x/*<-a::b::Givens.Monoid#combine().(x)*/: A/*->a::b::Givens.Monoid#[A]*/) def combine/*<-a::b::Givens.Monoid#combine().*/(y/*<-a::b::Givens.Monoid#combine().(y)*/: A/*->a::b::Givens.Monoid#[A]*/): A/*->a::b::Givens.Monoid#[A]*/
 

--- a/tests/semanticdb/expect/Givens.scala
+++ b/tests/semanticdb/expect/Givens.scala
@@ -1,7 +1,7 @@
 package a
 package b
 
-object Givens:
+object Givens with
 
   extension [A](any: A)
     def sayHello = s"Hello, I am $any"
@@ -14,7 +14,7 @@ object Givens:
   val goodbye1 = 1.sayGoodbye
   val soLong1 = 1.saySoLong
 
-  trait Monoid[A]:
+  trait Monoid[A] with
     def empty: A
     extension (x: A) def combine(y: A): A
 

--- a/tests/semanticdb/expect/inlineconsume.expect.scala
+++ b/tests/semanticdb/expect/inlineconsume.expect.scala
@@ -2,5 +2,5 @@ package inlineconsume
 
 import inlinedefs.FakePredef/*->inlinedefs::FakePredef.*/.assert/*->inlinedefs::FakePredef.assert().*/
 
-class Foo/*<-inlineconsume::Foo#*/:
+class Foo/*<-inlineconsume::Foo#*/ with
   def test/*<-inlineconsume::Foo#test().*/ = assert/*->inlinedefs::FakePredef.assert().*/(3 >/*->scala::Int#`>`(+3).*/ 2)

--- a/tests/semanticdb/expect/inlineconsume.scala
+++ b/tests/semanticdb/expect/inlineconsume.scala
@@ -2,5 +2,5 @@ package inlineconsume
 
 import inlinedefs.FakePredef.assert
 
-class Foo:
+class Foo with
   def test = assert(3 > 2)

--- a/tests/semanticdb/expect/inlinedefs.expect.scala
+++ b/tests/semanticdb/expect/inlinedefs.expect.scala
@@ -1,6 +1,6 @@
 package inlinedefs
 
-object FakePredef/*<-inlinedefs::FakePredef.*/:
+object FakePredef/*<-inlinedefs::FakePredef.*/ with
 
   /** Super long padded documentation
    *  Lorem ipsum dolor sit amet, consectetur adipiscing elit,

--- a/tests/semanticdb/expect/inlinedefs.scala
+++ b/tests/semanticdb/expect/inlinedefs.scala
@@ -1,6 +1,6 @@
 package inlinedefs
 
-object FakePredef:
+object FakePredef with
 
   /** Super long padded documentation
    *  Lorem ipsum dolor sit amet, consectetur adipiscing elit,

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/EnumTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/EnumTestScala3.scala
@@ -3,7 +3,7 @@ package org.scalajs.testsuite.compiler
 import org.junit.Assert._
 import org.junit.Test
 
-class EnumTestScala3:
+class EnumTestScala3 with
   import EnumTestScala3._
 
   @Test def testColor1(): Unit =
@@ -141,26 +141,26 @@ class EnumTestScala3:
 
   end testOpt
 
-object EnumTestScala3:
+object EnumTestScala3 with
 
-  enum Color1 derives CanEqual:
+  enum Color1 derives CanEqual with
     case Red, Green, Blue
 
-  enum Color2 extends java.lang.Enum[Color2] derives CanEqual:
+  enum Color2 extends java.lang.Enum[Color2] derives CanEqual with
     case Red, Green, Blue
 
   // test "non-simple" cases with anonymous subclasses
-  enum Currency1(val dollarValue: Double) derives CanEqual:
+  enum Currency1(val dollarValue: Double) derives CanEqual with
     case Dollar    extends Currency1(1.0)
     case SwissFanc extends Currency1(1.09)
     case Euro      extends Currency1(1.18)
 
-  enum Currency2(val dollarValue: Double) extends java.lang.Enum[Currency2] derives CanEqual:
+  enum Currency2(val dollarValue: Double) extends java.lang.Enum[Currency2] derives CanEqual with
     case Dollar    extends Currency2(1.0)
     case SwissFanc extends Currency2(1.09)
     case Euro      extends Currency2(1.18)
 
-  enum Opt[+T]:
+  enum Opt[+T] with
     case Sm[+T1](value: T1) extends Opt[T1]
     case Nn                 extends Opt[Nothing]
 


### PR DESCRIPTION
Allow `with` after `class`, `object`, `trait`, `enum`. This is a trial to test the proposed syntax changes.
