### PR TITLE
more fixes in Markdown files

### DIFF
--- a/docs/docs/reference/changed-features/compiler-plugins.md
+++ b/docs/docs/reference/changed-features/compiler-plugins.md
@@ -42,7 +42,7 @@ pluginClass=dividezero.DivideZero
 This is different from `scalac` plugins that required a `scalac-plugin.xml` file.
 
 Starting from 1.1.5, `sbt` also supports Scala 3 compiler plugins. Please refer to the
-`sbt` [documentation][2] for more information.
+[`sbt` documentation][2] for more information.
 
 ## Writing a Standard Compiler Plugin
 

--- a/docs/docs/reference/changed-features/interpolation-escapes.md
+++ b/docs/docs/reference/changed-features/interpolation-escapes.md
@@ -1,11 +1,11 @@
 ---
 layout: doc-page
-title: Escapes in interpolations
+title: "Escapes in interpolations"
 ---
 
-In Scala 2 there was no straightforward way to represent a single quote character `"` in a single quoted interpolation. A `\` character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether the `"` should be escaped or used as a terminator.
+In Scala 2 there is no straightforward way to represent a single quote character `"` in a single quoted interpolation. A `\` character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether the `"` should be escaped or used as a terminator.
 
-In Scala 3, you can use the `$` meta character of interpolations to escape a `"` character.
+In Scala 3, we can use the `$` meta character of interpolations to escape a `"` character. Example:
 
 ```scala
   val inventor = "Thomas Edison"

--- a/docs/docs/reference/changed-features/main-functions.md
+++ b/docs/docs/reference/changed-features/main-functions.md
@@ -56,7 +56,7 @@ The Scala compiler generates a program from a `@main` method `f` as follows:
  - The class has a static method `main` with the usual signature. It takes an `Array[String]`
    as argument and returns `Unit`.
  - The generated `main` method calls method `f` with arguments converted using
-   methods in the [`scala.util.CommandLineParser` object](https://dotty.epfl.ch/api/scala/util/CommandLineParser$.html).
+   methods in the [`scala.util.CommandLineParser`](https://dotty.epfl.ch/api/scala/util/CommandLineParser$.html) object.
 
 For instance, the `happyBirthDay` method above would generate additional code equivalent to the following class:
 
@@ -84,5 +84,5 @@ object happyBirthday extends App:
    ...
 ```
 
-The previous functionality of `App`, which relied on the "magic" [`DelayedInit`](../dropped-features/delayed-init.md) trait, is no longer available. `App` still exists in limited form for now, but it does not support command line arguments and will be deprecated in the future. If programs need to cross-build
+The previous functionality of `App`, which relied on the "magic" [`DelayedInit`](../dropped-features/delayed-init.md) trait, is no longer available. [`App`](https://dotty.epfl.ch/api/scala/App.html) still exists in limited form for now, but it does not support command line arguments and will be deprecated in the future. If programs need to cross-build
 between Scala 2 and Scala 3, it is recommended to use an explicit `main` method with an `Array[String]` argument instead.

--- a/docs/docs/reference/contextual/derivation-macro.md
+++ b/docs/docs/reference/contextual/derivation-macro.md
@@ -1,6 +1,6 @@
 ---
 layout: doc-page
-title: How to write a type class `derived` method using macros
+title: "How to write a type class `derived` method using macros"
 ---
 
 In the main [derivation](./derivation.md) documentation page, we explained the
@@ -97,8 +97,8 @@ One additional difference with the body of `derived` here as opposed to the one
 with `inline` is that with macros we need to synthesize the body of the code during the
 macro-expansion time. That is the rationale behind the `eqProductBody` function.
 Assuming that we calculate the equality of two `Person`s defined with a case
-class that holds a name of type `String` and an age of type `Int`, the equality
-check we want to generate is the following:
+class that holds a name of type [`String`](https://dotty.epfl.ch/api/scala/Predef$.html#String)
+and an age of type `Int`, the equality check we want to generate is the following:
 
 ```scala
    true

--- a/docs/docs/reference/dropped-features/early-initializers.md
+++ b/docs/docs/reference/dropped-features/early-initializers.md
@@ -4,8 +4,12 @@ title: "Dropped: Early Initializers"
 ---
 
 Early initializers of the form
+
 ```scala
 class C extends { ... } with SuperClass ...
 ```
+
 have been dropped. They were rarely used, and mostly to compensate for the lack of
 [trait parameters](../other-new-features/trait-parameters.md), which are now directly supported in Scala 3.
+
+For more information, see [SLS §5.1.6](https://www.scala-lang.org/files/archive/spec/2.13/05-classes-and-objects.html#early-definitions).

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -16,10 +16,7 @@ schemes with the familiar string interpolation syntax.
 println(s"Hello, $name, here is the result of 1 + 1 = ${1 + 1}")
 ```
 
-In string interpolation we _quoted_ a string and then we _spliced_ into it, two
-others. The first, `name`, is a reference to a value of type `string`, and the
-second is an arithmetic expression that will be _evaluated_ followed by the
-splicing of its string representation.
+In string interpolation we _quoted_ a string and then we _spliced_ into it, two others. The first, `name`, is a reference to a value of type [`String`](https://dotty.epfl.ch/api/scala/Predef$.html#String), and the second is an arithmetic expression that will be _evaluated_ followed by the splicing of its string representation.
 
 Quotes and splices in this section allow us to treat code in a similar way,
 effectively supporting macros. The entry point for macros is an inline method
@@ -86,7 +83,7 @@ and it takes types `T` to expressions of type `Type[T]`. Splicing
 takes expressions of type `Expr[T]` to expressions of type `T` and it
 takes expressions of type `Type[T]` to types `T`.
 
-The two types can be defined in package `scala.quoted` as follows:
+The two types can be defined in package [`scala.quoted`](https://dotty.epfl.ch/api/scala/quoted.html) as follows:
 
 ```scala
 package scala.quoted

--- a/docs/docs/reference/metaprogramming/tasty-inspect.md
+++ b/docs/docs/reference/metaprogramming/tasty-inspect.md
@@ -22,17 +22,17 @@ import scala.quoted._
 import scala.tasty.inspector._
 
 class MyInspector extends TastyInspector:
-  protected def processCompilationUnit(using Quotes)(tree: quotes.reflect.Tree): Unit =
-    import quotes.reflect._
-    // Do something with the tree
+   protected def processCompilationUnit(using Quotes)(tree: quotes.reflect.Tree): Unit =
+      import quotes.reflect._
+      // Do something with the tree
 ```
 
 Then the consumer can be instantiated with the following code to get the tree of the `foo/Bar.tasty` file.
 
 ```scala
 object Test:
-  def main(args: Array[String]): Unit =
-    new MyInspector().inspectTastyFiles("foo/Bar.tasty")
+   def main(args: Array[String]): Unit =
+      new MyInspector().inspectTastyFiles("foo/Bar.tasty")
 ```
 
 Note that if we need to run the main (in the example below defined in an object called `Test`) after compilation we need to make the compiler available to the runtime:

--- a/docs/docs/reference/other-new-features/safe-initialization.md
+++ b/docs/docs/reference/other-new-features/safe-initialization.md
@@ -141,7 +141,9 @@ field points to an initialized object may not later point to an
 object under initialization. As an example, the following code will be rejected:
 
 ``` scala
-trait Reporter { def report(msg: String): Unit }
+trait Reporter:
+   def report(msg: String): Unit
+
 class FileReporter(ctx: Context) extends Reporter:
    ctx.typer.reporter = this                // ctx now reaches an uninitialized object
    val file: File = new File("report.txt")

--- a/docs/docs/reference/overview.md
+++ b/docs/docs/reference/overview.md
@@ -48,7 +48,7 @@ These constructs replace existing constructs with the aim of making the language
  instead of `new` expressions. `new` expressions stay around as a fallback for
  the cases where creator applications cannot be used.
 
-With the exception of early initializers and old-style vararg patterns, all superseded constructs continue to be available in Scala 3.0. The plan is to deprecate and phase them out later.
+With the exception of [early initializers](dropped-features/early-initializers.md) and old-style vararg patterns, all superseded constructs continue to be available in Scala 3.0. The plan is to deprecate and phase them out later.
 
 Value classes (superseded by opaque type aliases) are a special case. There are currently no deprecation plans for value classes, since we might bring them back in a more general form if they are supported natively by the JVM as is planned by [project Valhalla](https://openjdk.java.net/projects/valhalla/).
 


### PR DESCRIPTION
Follow up of PR #10767, #10826, #10860, #10875, #10953, #11016 and #11062.

Fixes more issues found in Markdown files in [`docs/reference/`](https://github.com/lampepfl/dotty/tree/master/docs/docs/reference), e.g.
- corrected typos (eg. `string` -> `String`)
- add a few external links (e.g. Scala 3 API)
- improved example in section "Type Test" (§6.17.3 in generated PDF file)

**PS.** The above changes can also be viewed in the PDF document [`scala3_reference.pdf`](https://github.com/michelou/dotty-examples/blob/master/docs/scala3_reference.pdf) (955 Kb) generated with [Pandoc 2.11](https://pandoc.org/releases.html) in ~1:10 minute.
