### PR TITLE
Make summon parameter an inline parameter

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -219,7 +219,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
           toTextGlobal(tp.resultType)
         }
       case AnnotatedType(tpe, annot) =>
-        toTextLocal(tpe) ~ " " ~ toText(annot)
+        if annot.symbol == defn.InlineParamAnnot then toText(tpe)
+        else toTextLocal(tpe) ~ " " ~ toText(annot)
       case tp: TypeVar =>
         if (tp.isInstantiated)
           toTextLocal(tp.instanceOpt) ~ (Str("^") provided printDebug)

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -31,7 +31,7 @@ object Predef:
    *  @tparam T the type of the value to be summoned
    *  @return the given value typed: the provided type parameter
    */
-  inline def summon[T](using x: T): x.type = x
+  transparent inline def summon[T](using inline x: T): x.type = x
 
   // Extension methods for working with explicit nulls
 


### PR DESCRIPTION
This reduces the size of the tree that is generated when inlining by avoiding extra bindings and type ascriptions.

It needs to be transparent to workaround #11163. It also removes the need for the type ascription. In this particular case transparent or non-transparent have the same sematic. We may also need to make it transparent in #9984.