### PR TITLE
Disallow case classes defined in inline methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -169,7 +169,8 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     InvalidReferenceInImplicitNotFoundAnnotationID,
     TraitMayNotDefineNativeMethodID,
     JavaEnumParentArgsID,
-    AlreadyDefinedID
+    AlreadyDefinedID,
+    CaseClassInInlinedCodeID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2500,3 +2500,14 @@ import transform.SymUtils._
                    |""".stripMargin
     def explain = ""
   }
+
+  class CaseClassInInlinedCode(tree: tpd.Tree)(using Context)
+    extends SyntaxMsg(CaseClassInInlinedCodeID) {
+
+    def defKind = if tree.symbol.is(Module) then "object" else "class"
+    def msg = s"Case $defKind definitions are not allowed in inline methods or quoted code. Use a normal $defKind instead."
+    def explain =
+      em"""Case class/object definitions generate a considerable fooprint in code size.
+          |Inlining such definition would multiply this footprint for each call site.
+          |""".stripMargin
+  }

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -93,7 +93,9 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
         checkAnnotations(tree)
         healInfo(tree, tree.srcPos)
         super.transform(tree)
-
+      case tree: TypeDef if tree.symbol.is(Case) && level > 0 =>
+        report.error(reporting.CaseClassInInlinedCode(tree), tree)
+        super.transform(tree)
       case _ =>
         super.transform(tree)
     }

--- a/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PrepareInlineable.scala
@@ -177,7 +177,11 @@ object PrepareInlineable {
             //  myAccessors += TypeDef(accessor).withPos(tree.pos.focus)
             //  ref(accessor).withSpan(tree.span)
             //
-        case _ => tree
+        case _: TypeDef if tree.symbol.is(Case) =>
+          report.error(reporting.CaseClassInInlinedCode(tree), tree)
+          tree
+        case _ =>
+          tree
       }
     }
 
@@ -251,7 +255,7 @@ object PrepareInlineable {
         }
     }
 
-  def checkInlineMethod(inlined: Symbol, body: Tree)(using Context): body.type = {
+  private def checkInlineMethod(inlined: Symbol, body: Tree)(using Context): body.type = {
     if (inlined.owner.isClass && inlined.owner.seesOpaques)
       report.error(em"Implementation restriction: No inline methods allowed where opaque type aliases are in scope", inlined.srcPos)
     if Inliner.inInlineMethod(using ctx.outer) then

--- a/tests/neg-macros/i4396b.scala
+++ b/tests/neg-macros/i4396b.scala
@@ -1,4 +1,4 @@
 import scala.quoted._
 def test(using Quotes) = {
-  '{ case class Foo() }
+  '{ case class Foo() } // error
 }

--- a/tests/neg-macros/i7068-c.scala
+++ b/tests/neg-macros/i7068-c.scala
@@ -1,0 +1,9 @@
+def species(using quoted.Quotes) = '{
+  case object Bar // error
+  case class FooT() // error
+  ${
+    case object Baz // ok
+    ???
+  }
+  FooT()
+}

--- a/tests/neg/i7068-a.scala
+++ b/tests/neg/i7068-a.scala
@@ -3,7 +3,7 @@ sealed trait Foo[T] {
 }
 
 inline def species[T](t: T) = {
-  case class FooT(x: T) extends Foo[T] {
+  case class FooT(x: T) extends Foo[T] { // error
     def foo(s: Foo[T]) = s match {
       case FooT(x) => ???
     }

--- a/tests/neg/i7068-b.scala
+++ b/tests/neg/i7068-b.scala
@@ -1,5 +1,5 @@
 inline def species() = {
-  case class FooT()
+  case class FooT() // error
   FooT()
 }
 val foo = species()


### PR DESCRIPTION
The motivations are

* Disallow code that looks inoffensive small but has a large code size impact when inlined. We can still implement the same but must be explicit. Or implement those case classes outside of the method and avoid duplication.
* Simplify implementation of #9984
