### PR TITLE
fix #11175: consider terms in inventTypeName

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -992,7 +992,9 @@ object desugar {
       if (x.isEmpty)
         tree match {
           case Select(pre, nme.CONSTRUCTOR) => foldOver(x, pre)
-          case tree: RefTree if tree.name.isTypeName => tree.name.toString
+          case tree: RefTree =>
+            if tree.name.isTypeName then tree.name.toString
+            else s"${tree.name}_type"
           case tree: TypeDef => tree.name.toString
           case tree: AppliedTypeTree if followArgs && tree.args.nonEmpty =>
             s"${apply(x, tree.tpt)}_${extractArgs(tree.args)}"

--- a/tests/pos/i11175.scala
+++ b/tests/pos/i11175.scala
@@ -1,0 +1,25 @@
+package x
+
+trait Printer[T]:
+  def print(t:T):String
+
+extension[T](t:T)(using Printer[T])
+  def print():String = summon[Printer[T]].print(t)
+
+object A
+
+object B
+
+given Printer[A.type] with
+   def print(a:A.type):String = "a"
+
+given Printer[B.type] with
+   def print(b:B.type):String = "b"
+
+
+object Main {
+
+  def main(args:Array[String]):Unit =
+    System.out.println(B.print())
+
+}


### PR DESCRIPTION
A reference to `Foo.type` will appear in an anonymous given's name as `Foo_type`

e.g.

```scala
object Foo

given Show[Foo.type] with { ... } // has name `given_Show_Foo_type`
```

fixes #11175