### PR TITLE
Implement @covers annotation for partial irrefutable specification

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -936,6 +936,7 @@ class Definitions {
   @tu lazy val FunctionalInterfaceAnnot: ClassSymbol = requiredClass("java.lang.FunctionalInterface")
   @tu lazy val TargetNameAnnot: ClassSymbol = requiredClass("scala.annotation.targetName")
   @tu lazy val VarargsAnnot: ClassSymbol = requiredClass("scala.annotation.varargs")
+  @tu lazy val CoversAnnot: ClassSymbol = requiredClass("scala.annotation.covers")
 
   // A list of meta-annotations that are relevant for fields and accessors
   @tu lazy val FieldAccessorMetaAnnots: Set[Symbol] =

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -32,7 +32,7 @@ import NameKinds.DefaultGetterName
 import NameOps._
 import SymDenotations.{NoCompleter, NoDenotation}
 import Applications.unapplyArgs
-import transform.patmat.SpaceEngine.isIrrefutableUnapply
+import transform.patmat.SpaceEngine.isIrrefutable
 import config.Feature._
 import config.SourceVersion._
 
@@ -723,7 +723,7 @@ trait Checking {
             recur(pat1, pt)
           case UnApply(fn, _, pats) =>
             check(pat, pt) &&
-            (isIrrefutableUnapply(fn, pats.length) || fail(pat, pt)) && {
+            (isIrrefutable(fn) || fail(pat, pt)) && {
               val argPts = unapplyArgs(fn.tpe.widen.finalResultType, fn, pats, pat.srcPos)
               pats.corresponds(argPts)(recur)
             }

--- a/library/src/scala/annotation/covers.scala
+++ b/library/src/scala/annotation/covers.scala
@@ -1,0 +1,19 @@
+package scala.annotation
+
+/** An annotation specifying that an extractor is irrefutable
+ *  if the scrutinee is a subtype of `T`.
+ *
+ *  For example, the extractor `:+` covers non-empty list (`::[T]`):
+ *
+ *      object :+ {
+ *        def unapply[T](l: List[T]): Option[(List[T], T)] @covers[::[T]] = ...
+ *      }
+ *
+ *      def f(xs: List[Int]) =
+ *        xs match
+ *        case init :+ last => ()
+ *        case Nil => ()
+ *
+ *  Therefore, the pattern match above is exhaustive.
+ */
+final class covers[T] extends StaticAnnotation

--- a/library/src/scala/reflect/TypeTest.scala
+++ b/library/src/scala/reflect/TypeTest.scala
@@ -20,7 +20,7 @@ trait TypeTest[-S, T] extends Serializable:
    * `SomeExtractor(...)` is turned into `tt(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
    * is uncheckable, but we have an instance of `TypeTest[S, T]`.
    */
-  def unapply(x: S): Option[x.type & T]
+  def unapply(x: S): Option[x.type & T] @scala.annotation.covers[T]
 
 object TypeTest:
 

--- a/tests/patmat/i10961.scala
+++ b/tests/patmat/i10961.scala
@@ -34,12 +34,12 @@ object test2lib {
 
   type ParamClause = ValDefs | TypeDefs
 
-  object ValDefs with
+  object ValDefs:
     def unapply(pc: ParamClause): Option[ValDefs] @covers[ValDefs] = ??? // matches empty list and all lists of ValDefs
 
     def apply(vals: List[ValDef]): ValDefs = vals
 
-  object TypeDefs with
+  object TypeDefs:
     def unapply(pc: ParamClause): Option[TypeDefs] @covers[TypeDefs] = ??? // matches non-empty lists of TypeDefs
 
     def apply(tdefs: List[TypeDef]): TypeDefs =
@@ -64,7 +64,7 @@ object test3lib {
 
   type Num = Nat | Neg
 
-  object Nat with
+  object Nat:
     def unapply(x: Num): Option[Nat] @covers[Nat] =
       if x >= 0 then Some(x) else None
 
@@ -72,7 +72,7 @@ object test3lib {
       assert(x >= 0)
       x
 
-  object Neg with
+  object Neg:
     def unapply(x: Num): Option[Neg] @covers[Neg] =
       if x < 0 then Some(x) else None
 
@@ -88,4 +88,13 @@ object test3 {
     x match
     case Nat(x) =>
     case Neg(x) =>
+}
+
+object test4 {
+  import scala.reflect.TypeTest
+
+  def test[A](a: A | String)(using TypeTest[A | String, A]) =
+    a match
+    case a: A =>
+    case s: String =>
 }

--- a/tests/patmat/i10961.scala
+++ b/tests/patmat/i10961.scala
@@ -1,0 +1,91 @@
+object test0 {
+  object :+ {
+    def unapply[T](l: ::[T]): (List[T], T) = (l.tail, l.head)
+  }
+
+  def f(xs: List[Int]) =
+    xs match
+    case init :+ last => ()
+    case Nil => ()
+}
+
+object test1 {
+  import scala.annotation.covers
+
+  type /[T, U] = T @covers[U]
+
+  object :+ {
+    def unapply[T](l: List[T]): Option[(List[T], T)] / ::[T] = ???
+  }
+
+  def f(xs: List[Int]) =
+    xs match
+    case init :+ last => ()
+    case Nil => ()
+}
+
+object test2lib {
+  import scala.annotation.covers
+
+  class ValDef
+  class TypeDef
+  opaque type ValDefs  <: List[ValDef]  = List[ValDef]
+  opaque type TypeDefs <: List[TypeDef] = List[TypeDef]
+
+  type ParamClause = ValDefs | TypeDefs
+
+  object ValDefs with
+    def unapply(pc: ParamClause): Option[ValDefs] @covers[ValDefs] = ??? // matches empty list and all lists of ValDefs
+
+    def apply(vals: List[ValDef]): ValDefs = vals
+
+  object TypeDefs with
+    def unapply(pc: ParamClause): Option[TypeDefs] @covers[TypeDefs] = ??? // matches non-empty lists of TypeDefs
+
+    def apply(tdefs: List[TypeDef]): TypeDefs =
+      assert(tdefs.nonEmpty)
+      tdefs
+}
+
+object test2 {
+  import test2lib._
+
+  def f(pc: ParamClause) =
+    pc match
+    case ValDefs(vs) => ()
+    case TypeDefs(ts) => ()
+}
+
+object test3lib {
+  import scala.annotation.covers
+
+  opaque type Nat <: Int = Int
+  opaque type Neg <: Int = Int
+
+  type Num = Nat | Neg
+
+  object Nat with
+    def unapply(x: Num): Option[Nat] @covers[Nat] =
+      if x >= 0 then Some(x) else None
+
+    def apply(x: Int): Nat =
+      assert(x >= 0)
+      x
+
+  object Neg with
+    def unapply(x: Num): Option[Neg] @covers[Neg] =
+      if x < 0 then Some(x) else None
+
+    def apply(x: Int): Nat =
+      assert(x < 0)
+      x
+}
+
+object test3 {
+  import test3lib._
+
+  def foo(x: Num) =
+    x match
+    case Nat(x) =>
+    case Neg(x) =>
+}

--- a/tests/patmat/i2363.check
+++ b/tests/patmat/i2363.check
@@ -1,2 +1,2 @@
 15: Pattern Match Exhaustivity: List(_, _*)
-21: Pattern Match Exhaustivity: _: Expr
+21: Pattern Match Exhaustivity: _: IntExpr, _: BooleanExpr

--- a/tests/patmat/irrefutable.check
+++ b/tests/patmat/irrefutable.check
@@ -1,2 +1,2 @@
-22: Pattern Match Exhaustivity: _: Base
-65: Pattern Match Exhaustivity: _: M
+22: Pattern Match Exhaustivity: _: A, _: B, C(_, _)
+65: Pattern Match Exhaustivity: ExM(_, _)

--- a/tests/patmat/optionless.check
+++ b/tests/patmat/optionless.check
@@ -1,1 +1,1 @@
-28: Pattern Match Exhaustivity: _: Tree
+28: Pattern Match Exhaustivity: Ident(_)

--- a/tests/patmat/patmat-extractor.check
+++ b/tests/patmat/patmat-extractor.check
@@ -1,2 +1,2 @@
-13: Pattern Match Exhaustivity: _: Node
+13: Pattern Match Exhaustivity: NodeA(_), NodeB(_), NodeC(_)
 15: Match case Unreachable


### PR DESCRIPTION
We propose two orthogonal annotations to enhance _exhaustivity check_ for custom extractors and virtual ADT data types.

- `@covers[T]`: specifying that an `unapply` is partially Irrefutable (**implemented in this PR**)
- `@branch[T]`: defining a branch for a virtual ADT data type `T` (**to be implemented**)

## 1. Partially Irrefutable Extractor

Currently, Scala only supports specifying that an `unapply` is irrefutable if its result type is of the form `Some[T]`, or it is a subtype of `ProductN[T1, .., TN]`, or it has a member `isEmpty` whose result type `true`. In all such cases, the extractor is either irrefutable or refutable.

The annotation `@covers[T]` provides a way to support specifying partial irrefutability. If the result type of `unapply` has the form `U @covers[T]`, then the extractor is _irrefutable_ when the scrutinee is a subtype of `T`.

### Example 1

```Scala
  import scala.annotation.covers

  type /[T, U] = T @covers[U]

  object :+ {
    def unapply[T](l: List[T]): Option[(List[T], T)] / ::[T] = ???
  }

  def f(xs: List[Int]) =
    xs match
    case init :+ last => ()
    case Nil => ()
```

### Example 2

```Scala
  import scala.annotation.covers

  class ValDef
  class TypeDef
  opaque type ValDefs  <: List[ValDef]  = List[ValDef]
  opaque type TypeDefs <: List[TypeDef] = List[TypeDef]

  type ParamClause = ValDefs | TypeDefs

  object ValDefs with
    def unapply(pc: ParamClause): Option[ValDefs] @covers[ValDefs] = ??? // matches empty list and all lists of ValDefs

    def apply(vals: List[ValDef]): ValDefs = vals

  object TypeDefs with
    def unapply(pc: ParamClause): Option[TypeDefs] @covers[TypeDefs] = ??? // matches non-empty lists of TypeDefs

    def apply(tdefs: List[TypeDef]): TypeDefs =
      assert(tdefs.nonEmpty)
      tdefs

  def f(pc: ParamClause) =
    pc match
    case ValDefs(vs) => ()
    case TypeDefs(ts) => ()
```

## 2. Virtual ADT

Sometimes, we might want to define a virtual ADT:

- for a set of abstract types (e.g. in final tagless encoding)
- for existing non-ADT types, such as `Int`

The annotation `@branch` enables a library author to define a virtual ADT. 

### Example 3

The following is an example that makes `Int` a virtual ADT.

``` Scala
  import scala.annotation.covers

  @branch[Num]
  opaque type Nat <: Int = Int

  @branch[Num]
  opaque type Neg <: Int = Int

  type Num = Int

  object Nat with
    def unapply(x: Num): Option[Nat] @covers[Nat] =
      if x >= 0 then Some(x) else None

    def apply(x: Int): Nat =
      assert(x >= 0)
      x

  object Neg with
    def unapply(x: Num): Option[Neg] @covers[Neg] =
      if x < 0 then Some(x) else None

    def apply(x: Int): Nat =
      assert(x < 0)
      x

  def foo(x: Option[Int]) =
    x match
    case Some(Nat(x)) =>
    case Some(Neg(x)) =>
    case None =>
```

### Example 4

This example is a tentative solution to the problem discussed in the [contributor forum](https://contributors.scala-lang.org/t/trouble-with-2-13-4-exhaustivity-checking-being-too-strict/4817):

``` Scala
object Opt {
  @branch[Opt]
  type NonEmptyOpt[+T] <: Opt[T]

  @branch[Opt]
  val Empty: Opt[Nothing] = ???

  def unapply[T](x: Opt[T]): Opt[T] @covers[NonEmptyOpt[T]] = x
}

final class Opt[+T](v: T) { ... }
```

## Links

- Related issue: #10961 
- [Contributor discussion](https://contributors.scala-lang.org/t/trouble-with-2-13-4-exhaustivity-checking-being-too-strict/4817)