### PR TITLE
Make code completions and import suggestions work correctly for extensions with leading using clauses

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -38,6 +38,8 @@ import Constants.{Constant, IntTag, LongTag}
 import Denotations.SingleDenotation
 import annotation.{constructorOnly, threadUnsafe}
 
+import scala.util.control.NonFatal
+
 object Applications {
   import tpd._
 
@@ -2140,11 +2142,11 @@ trait Applications extends Compatibility {
    *
    *  return the tree representing methodRef partially applied to the receiver and all the implicit parameters preceding it (A, B, C)
    *  with the type parameters of the extension (T1, T2) inferred.
-   *  A failure is returned if the implicit search fails for any of the leading implicit parameters or if the receiver has a wrong type
+   *  None is returned if the implicit search fails for any of the leading implicit parameters or if the receiver has a wrong type
    *  (note that in general the type of the receiver might depend on the exact types of the found instances of the proceding implicits).
    *  No implicit search is tried for implicits following the receiver or for parameters of the def (D, E).
    */
-  private def applyWithoutPostreceiverImplicits(methodRef: TermRef, receiver: Tree)(using Context): scala.util.Try[Tree] =
+  def tryApplyingExtensionMethod(methodRef: TermRef, receiver: Tree)(using Context): Option[Tree] =
       // Drop all parameters sections of an extension method following the receiver; the return type after truncation is not important
     def truncateExtension(tp: Type)(using Context): Type = tp match
       case poly: PolyType =>
@@ -2154,27 +2156,28 @@ trait Applications extends Compatibility {
       case meth: MethodType =>
         meth.newLikeThis(meth.paramNames, meth.paramInfos, defn.AnyType)
 
-    val truncatedSym = methodRef.symbol.asTerm.copy(owner = defn.RootPackage, name = Names.termName(""), info = truncateExtension(methodRef.info))
-    val truncatedRef = ref(truncatedSym).withSpan(receiver.span)
-    val newCtx = ctx.fresh.setNewScope.setReporter(new reporting.ThrowingReporter(ctx.reporter))
-    scala.util.Try {
-      inContext(newCtx) {
-        ctx.enter(truncatedSym)
-        ctx.typer.extMethodApply(truncatedRef, receiver, WildcardType)
-      }
-    }.filter(tree => tree.tpe.exists && !tree.tpe.isError)
-
-  def tryApplyingReceiver(methodRef: TermRef, receiver: Tree)(using Context): Option[Tree] =
     def replaceCallee(inTree: Tree, replacement: Tree)(using Context): Tree = inTree match
       case Apply(fun, args) => Apply(replaceCallee(fun, replacement), args)
       case TypeApply(fun, args) => TypeApply(replaceCallee(fun, replacement), args)
       case _: Ident => replacement
 
-    applyWithoutPostreceiverImplicits(methodRef, receiver)
-      .toOption
-      .map(tree => replaceCallee(tree, ref(methodRef)))
+    val truncatedSym = methodRef.symbol.asTerm.copy(owner = defn.RootPackage, name = Names.termName(""), info = truncateExtension(methodRef.info))
+    val truncatedRef = ref(truncatedSym).withSpan(receiver.span)
+    val newCtx = ctx.fresh.setNewScope.setReporter(new reporting.ThrowingReporter(ctx.reporter))
+
+    try
+      val appliedTree = inContext(newCtx) {
+        ctx.enter(truncatedSym)
+        ctx.typer.extMethodApply(truncatedRef, receiver, WildcardType)
+      }
+      if appliedTree.tpe.exists && !appliedTree.tpe.isError then
+        Some(replaceCallee(appliedTree, ref(methodRef)))
+      else
+        None
+    catch
+      case NonFatal(_) => None
 
   def isApplicableExtensionMethod(methodRef: TermRef, receiverType: Type)(using Context): Boolean =
     methodRef.symbol.is(ExtensionMethod) && !receiverType.isBottomType &&
-      applyWithoutPostreceiverImplicits(methodRef, Typed(EmptyTree, TypeTree(receiverType))).isSuccess
+      tryApplyingExtensionMethod(methodRef, Typed(EmptyTree, TypeTree(receiverType))).nonEmpty
 }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2133,15 +2133,29 @@ trait Applications extends Compatibility {
     }
   }
 
-  private def tryApplyingReceiverToTruncatedExtMethod(methodSym: TermSymbol, receiver: Tree)(using Context): scala.util.Try[Tree] =
-    // Drop all parameters sections of an extension method following the receiver to prevent them from being inferred by the typer
-    def truncateExtension(tp: Type): Type = tp match
-      case poly: PolyType => poly.newLikeThis(poly.paramNames, poly.paramInfos, truncateExtension(poly.resType))
-      case meth: MethodType if meth.isContextualMethod => meth.newLikeThis(meth.paramNames, meth.paramInfos, truncateExtension(meth.resType))
-      case meth: MethodType => meth.newLikeThis(meth.paramNames, meth.paramInfos, defn.AnyType)
+  /** Assuming methodRef is a reference to an extension method defined e.g. as
+   *
+   *  extension [T1, T2](using A)(using B, C)(receiver: R)(using D)
+   *    def foo[T3](using E)(f: F): G = ???
+   *
+   *  return the tree representing methodRef partially applied to the receiver and all the implicit parameters preceding it (A, B, C)
+   *  with the type parameters of the extension (T1, T2) inferred.
+   *  A failure is returned if the implicit search fails for any of the leading implicit parameters or if the receiver has a wrong type
+   *  (note that in general the type of the receiver might depend on the exact types of the found instances of the proceding implicits).
+   *  No implicit search is tried for implicits following the receiver or for parameters of the def (D, E).
+   */
+  private def applyWithoutPostreceiverImplicits(methodRef: TermRef, receiver: Tree)(using Context): scala.util.Try[Tree] =
+      // Drop all parameters sections of an extension method following the receiver; the return type after truncation is not important
+    def truncateExtension(tp: Type)(using Context): Type = tp match
+      case poly: PolyType =>
+        poly.newLikeThis(poly.paramNames, poly.paramInfos, truncateExtension(poly.resType))
+      case meth: MethodType if meth.isContextualMethod =>
+        meth.newLikeThis(meth.paramNames, meth.paramInfos, truncateExtension(meth.resType))
+      case meth: MethodType =>
+        meth.newLikeThis(meth.paramNames, meth.paramInfos, defn.AnyType)
 
-    val truncatedSym = methodSym.copy(owner = defn.RootPackage, name = Names.termName(""), info = truncateExtension(methodSym.info))
-    val truncatedRef = ref(truncatedSym).withSpan(Span(0, 0)) // Fake span needed to make this work in REPL
+    val truncatedSym = methodRef.symbol.asTerm.copy(owner = defn.RootPackage, name = Names.termName(""), info = truncateExtension(methodRef.info))
+    val truncatedRef = ref(truncatedSym).withSpan(receiver.span)
     val newCtx = ctx.fresh.setNewScope.setReporter(new reporting.ThrowingReporter(ctx.reporter))
     scala.util.Try {
       inContext(newCtx) {
@@ -2150,17 +2164,17 @@ trait Applications extends Compatibility {
       }
     }.filter(tree => tree.tpe.exists && !tree.tpe.isError)
 
-  def tryApplyingReceiver(methodSym: TermSymbol, receiver: Tree)(using Context): Option[Tree] =
-    def replaceAppliedRef(inTree: Tree, replacement: Tree)(using Context): Tree = inTree match
-      case Apply(fun, args) => Apply(replaceAppliedRef(fun, replacement), args)
-      case TypeApply(fun, args) => TypeApply(replaceAppliedRef(fun, replacement), args)
+  def tryApplyingReceiver(methodRef: TermRef, receiver: Tree)(using Context): Option[Tree] =
+    def replaceCallee(inTree: Tree, replacement: Tree)(using Context): Tree = inTree match
+      case Apply(fun, args) => Apply(replaceCallee(fun, replacement), args)
+      case TypeApply(fun, args) => TypeApply(replaceCallee(fun, replacement), args)
       case _: Ident => replacement
 
-    tryApplyingReceiverToTruncatedExtMethod(methodSym, receiver)
+    applyWithoutPostreceiverImplicits(methodRef, receiver)
       .toOption
-      .map(tree => replaceAppliedRef(tree, ref(methodSym)))
+      .map(tree => replaceCallee(tree, ref(methodRef)))
 
-  def isApplicableExtensionMethod(ref: TermRef, receiverType: Type)(using Context) =
-    ref.symbol.is(ExtensionMethod) && !receiverType.isBottomType &&
-      tryApplyingReceiverToTruncatedExtMethod(ref.symbol.asTerm, Typed(EmptyTree, TypeTree(receiverType))).isSuccess
+  def isApplicableExtensionMethod(methodRef: TermRef, receiverType: Type)(using Context): Boolean =
+    methodRef.symbol.is(ExtensionMethod) && !receiverType.isBottomType &&
+      applyWithoutPostreceiverImplicits(methodRef, Typed(EmptyTree, TypeTree(receiverType))).isSuccess
 }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -107,7 +107,7 @@ class TabcompleteTests extends ReplTest {
   @Test def `null` = fromInitialState { implicit s =>
     val comp = tabComplete("null.")
     assertEquals(
-      List("!=", "##", "==", "asInstanceOf", "clone", "eq", "equals", "finalize", "getClass", "hashCode",
+      List("!=", "##", "==", "asInstanceOf", "eq", "equals", "getClass", "hashCode",
           "isInstanceOf", "ne", "notify", "notifyAll", "synchronized", "toString", "wait"),
       comp.distinct.sorted)
   }
@@ -115,7 +115,7 @@ class TabcompleteTests extends ReplTest {
   @Test def anyRef = fromInitialState { implicit s =>
     val comp = tabComplete("(null: AnyRef).")
     assertEquals(
-      List("!=", "##", "->", "==", "asInstanceOf", "clone", "ensuring", "eq", "equals", "finalize", "formatted",
+      List("!=", "##", "->", "==", "asInstanceOf", "ensuring", "eq", "equals", "formatted",
           "getClass", "hashCode", "isInstanceOf", "ne", "nn", "notify", "notifyAll", "synchronized", "toString", "wait", "→"),
       comp.distinct.sorted)
   }

--- a/tests/neg/missing-implicit6.check
+++ b/tests/neg/missing-implicit6.check
@@ -1,0 +1,39 @@
+-- [E008] Not Found Error: tests/neg/missing-implicit6.scala:34:8 ------------------------------------------------------
+34 |    "a".xxx // error, no suggested import
+   |    ^^^^^^^
+   |    value xxx is not a member of String
+-- [E008] Not Found Error: tests/neg/missing-implicit6.scala:35:8 ------------------------------------------------------
+35 |    123.xxx // error, suggested import
+   |    ^^^^^^^
+   |    value xxx is not a member of Int, but could be made available as an extension method.
+   |
+   |    The following import might fix the problem:
+   |
+   |      import Test.Ops.xxx
+   |
+-- [E008] Not Found Error: tests/neg/missing-implicit6.scala:36:8 ------------------------------------------------------
+36 |    123.yyy // error, suggested import
+   |    ^^^^^^^
+   |    value yyy is not a member of Int, but could be made available as an extension method.
+   |
+   |    The following import might fix the problem:
+   |
+   |      import Test.Ops.yyy
+   |
+-- [E008] Not Found Error: tests/neg/missing-implicit6.scala:41:8 ------------------------------------------------------
+41 |    123.xxx // error, no suggested import
+   |    ^^^^^^^
+   |    value xxx is not a member of Int
+-- [E008] Not Found Error: tests/neg/missing-implicit6.scala:42:8 ------------------------------------------------------
+42 |    123.yyy // error, no suggested import
+   |    ^^^^^^^
+   |    value yyy is not a member of Int
+-- [E008] Not Found Error: tests/neg/missing-implicit6.scala:43:8 ------------------------------------------------------
+43 |    123.zzz // error, suggested import even though there's no instance of Bar in scope
+   |    ^^^^^^^
+   |    value zzz is not a member of Int, but could be made available as an extension method.
+   |
+   |    The following import might fix the problem:
+   |
+   |      import Test.Ops.zzz
+   |

--- a/tests/neg/missing-implicit6.scala
+++ b/tests/neg/missing-implicit6.scala
@@ -1,0 +1,45 @@
+trait Foo {
+  type Out <: { type Out }
+}
+
+trait Bar {
+  type Out
+}
+
+object instances {
+  given foo: Foo with {
+    type Out = Bar
+  }
+
+  given bar: Bar with {
+    type Out = Int
+  }
+}
+
+object Test {
+  object Ops {
+    extension (using foo: Foo, bar: foo.Out)(i: Int)
+      def xxx = ???
+
+    extension (using foo: Foo, fooOut: foo.Out)(x: fooOut.Out)
+      def yyy = ???
+
+    extension (using foo: Foo)(i: Int)(using fooOut: foo.Out)
+      def zzz = ???
+  }
+
+  locally {
+    import instances.given
+
+    "a".xxx // error, no suggested import
+    123.xxx // error, suggested import
+    123.yyy // error, suggested import
+  }
+
+  locally {
+    import instances.foo
+    123.xxx // error, no suggested import
+    123.yyy // error, no suggested import
+    123.zzz // error, suggested import even though there's no instance of Bar in scope
+  }
+}


### PR DESCRIPTION
This is needed after https://github.com/lampepfl/dotty/pull/10940 got merged.

One disputable aspect might be whether an extension method should be suggested in code completion if it requires a given which is not available in scope.
Before the syntax change only trailing using clauses were allowed in extensions, e.g.
```scala
extension (i: Int)(using Foo)
  def xxx = ???
```
and the current behaviour was that for `123.x` `123.xxx` would be suggested even if there's no given `Foo`.
On the one hand not suggesting `xxx` would de-pollute the namespace and cause less confusion if there are multiple extension methods available which are applicable to anything that implements a type class, e.g.
```scala
extension [A](a: A)(using Show[A]) def show: String = ???
```
On the other hand it is still possible to call such methods if you provide the implicit explicitly.
So it seems to keep the current behaviour (to suggest `xxx` instead of hide it) as it is consistent with how code completion currently works with normal methods and methods introduced by implicit classes.

With leading using clauses, e.g.
```scala
extension (using Foo)(i: Int)
  def xxx = ???
```
the situation is slightly different. If a given instance of `Foo` is not in scope it cannot be passed to the method explicitly when one calls it like `123.xxx` so the argument against not suggesting `xxx` doesn't apply anymore.
What's more the type of the receiver parameter might sometimes depend on the leading implicits.
So it makes sense not to suggest `xxx` when there's no given `Foo`. This also seems to be how completion works with implicit classes.

In case of import suggestions this currently seems to work analogically to code completions so I decided to keep this analogy (which also allowed some code reuse) even though sometimes the suggested import might not be enough to make an extension method work
