### PR TITLE
Revert #10591: use sbt-jmh 0.3.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.13")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
Revert #10591: use sbt-jmh 0.3.2

- sbt-jmh 0.3.2 uses jmh 1.19
- sbt-jmh 0.4.0 uses jmh 1.25

Run the same command:

```
scala3-bench-bootstrapped/jmh:run tests/bench/FindRef.scala
```

sbt-jmh 0.3.2 takes <1 min, while 0.4.0 takes ~8min.

Not much information found in the archive and internet:
https://mail.openjdk.java.net/pipermail/jmh-dev/

Will eventually update when we have a better fix.