### PR TITLE
Make sure language imports are detectable syntactically

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -188,7 +188,7 @@ class ImportInfo(symf: Context ?=> Symbol,
 
   private var featureCache: SimpleIdentityMap[TermName, java.lang.Boolean] = SimpleIdentityMap.empty
 
-  /** Does this import clause or a preceding import clause enable or disable `feature`?
+  /** Does this import clause enable or disable `feature`?
    *  @param  feature   See featureImported for a description
    *  @return Some(true)  if `feature` is imported
    *          Some(false) if `feature` is excluded


### PR DESCRIPTION
Make sure that something is a language import if and only if it
looks like one. i.e. is of one of the forms

    import language.xyz
    import scala.language.xyz
    import _root_.scala.language.xyz

This is a pre-requisite for using language imports also during parsing, where we cannot resolve imports.

Using language imports during parsing can make the parser more robust by never considering possibilities that are not enabled bu a language import. For instance, we do not need to get confused with postfix operators.
