### PR TITLE
Add mode bit to track whether we are in safe nulls mode

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -24,6 +24,8 @@ import printing.XprintMode
 import parsing.Parsers.Parser
 import parsing.JavaParsers.JavaParser
 import typer.ImplicitRunInfo
+import config.Feature
+import StdNames.nme
 
 import java.io.{BufferedWriter, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
@@ -76,7 +78,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
       .setTyper(new Typer)
       .addMode(Mode.ImplicitsEnabled)
       .setTyperState(ctx.typerState.fresh(ctx.reporter))
-    if ctx.settings.YexplicitNulls.value then
+    if ctx.settings.YexplicitNulls.value && !Feature.enabledBySetting(nme.unsafeNulls) then
       start = start.addMode(Mode.SafeNulls)
     ctx.initialize()(using start) // re-initialize the base context with start
     start.setRun(this)

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -71,11 +71,13 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
       .setPeriod(Period(comp.nextRunId, FirstPhaseId))
       .setScope(rootScope)
     rootScope.enter(ctx.definitions.RootPackage)(using bootstrap)
-    val start = bootstrap.fresh
+    var start = bootstrap.fresh
       .setOwner(defn.RootClass)
       .setTyper(new Typer)
       .addMode(Mode.ImplicitsEnabled)
       .setTyperState(ctx.typerState.fresh(ctx.reporter))
+    if ctx.settings.YexplicitNulls.value then
+      start = start.addMode(Mode.SafeNulls)
     ctx.initialize()(using start) // re-initialize the base context with start
     start.setRun(this)
   }

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -251,21 +251,27 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case TypeDefs(_) => true
     case _ => isUsingClause(params)
 
-  private val languageImportParts = List(nme.language, nme.scala, nme.ROOTPKG)
-  private val languageImportNested = Set[Name](nme.experimental)
+  /** If `path` looks like a language import, `Some(name)` where name
+   *  is `experimental` if that sub-module is imported, and the empty
+   *  term name otherwise.
+   */
+  def languageImport(path: Tree): Option[TermName] = path match
+    case Select(p1, nme.experimental) =>
+      languageImport(p1) match
+        case Some(EmptyTermName) => Some(nme.experimental)
+        case _ => None
+    case p1: RefTree if p1.name == nme.language =>
+      p1.qualifier match
+        case EmptyTree => Some(EmptyTermName)
+        case p2: RefTree if p2.name == nme.scala =>
+          p2.qualifier match
+            case EmptyTree => Some(EmptyTermName)
+            case Ident(nme.ROOTPKG) => Some(EmptyTermName)
+            case _ => None
+        case _ => None
+    case _ => None
 
-  /** Strip the name of any local object in `scala.language` from `path` */
-  def stripLanguageNested(path: Tree): Tree = path match
-    case Select(qual, name) if languageImportNested.contains(name) => qual
-    case _ => path
-
-  /** Does this `path` look like a language import? */
-  def isLanguageImport(path: Tree): Boolean =
-    def parts(tree: Tree): List[Name] = tree match
-      case tree: RefTree => tree.name :: parts(tree.qualifier)
-      case EmptyTree => Nil
-      case _ => EmptyTermName :: Nil
-    !path.isEmpty && languageImportParts.startsWith(parts(stripLanguageNested(path)))
+  def isLanguageImport(path: Tree): Boolean = languageImport(path).isDefined
 
   /** The underlying pattern ignoring any bindings */
   def unbind(x: Tree): Tree = unsplice(x) match {

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -9,12 +9,17 @@ import Decorators.{_, given}
 import util.SrcPos
 import SourceVersion._
 import reporting.Message
+import NameKinds.QualifiedName
 
 object Feature:
 
-  private val dependent = "dependent".toTermName
-  private val namedTypeArguments = "namedTypeArguments".toTermName
-  private val genericNumberLiterals = "genericNumberLiterals".toTermName
+  private def experimental(str: String): TermName =
+    QualifiedName(nme.experimental, str.toTermName)
+
+  private val Xdependent = experimental("dependent")
+  private val XnamedTypeArguments = experimental("namedTypeArguments")
+  private val XgenericNumberLiterals = experimental("genericNumberLiterals")
+  private val Xmacros = experimental("macros")
 
 /** Is `feature` enabled by by a command-line setting? The enabling setting is
    *
@@ -23,12 +28,8 @@ object Feature:
    *  where <prefix> is the fully qualified name of `owner`, followed by a ".",
    *  but subtracting the prefix `scala.language.` at the front.
    */
-  def enabledBySetting(feature: TermName, owner: Symbol = NoSymbol)(using Context): Boolean =
-    def toPrefix(sym: Symbol): String =
-      if !sym.exists || sym == defn.LanguageModule.moduleClass then ""
-      else toPrefix(sym.owner) + sym.name.stripModuleClassSuffix + "."
-    val prefix = if owner ne NoSymbol then toPrefix(owner) else ""
-    ctx.base.settings.language.value.contains(prefix + feature)
+  def enabledBySetting(feature: TermName)(using Context): Boolean =
+    ctx.base.settings.language.value.contains(feature.toString)
 
   /** Is `feature` enabled by by an import? This is the case if the feature
    *  is imported by a named import
@@ -39,39 +40,31 @@ object Feature:
    *
    *       import owner.{ feature => _ }
    */
-  def enabledByImport(feature: TermName, owner: Symbol = NoSymbol)(using Context): Boolean =
-    atPhase(typerPhase) {
-      ctx.importInfo != null
-      && ctx.importInfo.featureImported(feature,
-          if owner.exists then owner else defn.LanguageModule.moduleClass)
-    }
+  def enabledByImport(feature: TermName)(using Context): Boolean =
+    //atPhase(typerPhase) {
+      ctx.importInfo != null && ctx.importInfo.featureImported(feature)
+    //}
 
   /** Is `feature` enabled by either a command line setting or an import?
    *  @param  feature   The name of the feature
    *  @param  owner     The prefix symbol (nested in `scala.language`) where the
    *                    feature is defined.
    */
-  def enabled(feature: TermName, owner: Symbol = NoSymbol)(using Context): Boolean =
-    enabledBySetting(feature, owner) || enabledByImport(feature, owner)
+  def enabled(feature: TermName)(using Context): Boolean =
+    enabledBySetting(feature) || enabledByImport(feature)
 
   /** Is auto-tupling enabled? */
-  def autoTuplingEnabled(using Context): Boolean =
-    !enabled(nme.noAutoTupling)
+  def autoTuplingEnabled(using Context): Boolean = !enabled(nme.noAutoTupling)
 
-  def dynamicsEnabled(using Context): Boolean =
-    enabled(nme.dynamics)
+  def dynamicsEnabled(using Context): Boolean = enabled(nme.dynamics)
 
-  def dependentEnabled(using Context) =
-    enabled(dependent, defn.LanguageExperimentalModule.moduleClass)
+  def dependentEnabled(using Context) = enabled(Xdependent)
 
-  def namedTypeArgsEnabled(using Context) =
-    enabled(namedTypeArguments, defn.LanguageExperimentalModule.moduleClass)
+  def namedTypeArgsEnabled(using Context) = enabled(XnamedTypeArguments)
 
-  def genericNumberLiteralsEnabled(using Context) =
-    enabled(genericNumberLiterals, defn.LanguageExperimentalModule.moduleClass)
+  def genericNumberLiteralsEnabled(using Context) = enabled(XgenericNumberLiterals)
 
-  def scala2ExperimentalMacroEnabled(using Context) =
-    enabled("macros".toTermName, defn.LanguageExperimentalModule.moduleClass)
+  def scala2ExperimentalMacroEnabled(using Context) = enabled(Xmacros)
 
   def sourceVersionSetting(using Context): SourceVersion =
     SourceVersion.valueOf(ctx.settings.source.value)

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -474,13 +474,8 @@ object Contexts {
       else fresh.setOwner(exprOwner)
 
     /** A new context that summarizes an import statement */
-    def importContext(imp: Import[?], sym: Symbol): FreshContext = {
-      val impNameOpt = imp.expr match {
-        case ref: RefTree[?] => Some(ref.name.asTermName)
-        case _               => None
-      }
-      fresh.setImportInfo(ImportInfo(sym, imp.selectors, impNameOpt))
-    }
+    def importContext(imp: Import[?], sym: Symbol): FreshContext =
+       fresh.setImportInfo(ImportInfo(sym, imp.selectors, imp.expr))
 
     /** Is the debug option set? */
     def debug: Boolean = base.settings.Ydebug.value

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -119,4 +119,7 @@ object Mode {
 
   /** Are we resolving a TypeTest node? */
   val InTypeTest: Mode = newMode(27, "InTypeTest")
+
+  /** Are we enforcing null safety */
+  val SafeNulls = newMode(28, "SafeNulls")
 }

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -613,6 +613,7 @@ object StdNames {
     val unapplySeq: N           = "unapplySeq"
     val unbox: N                = "unbox"
     val universe: N             = "universe"
+    val unsafeNulls: N          = "unsafeNulls"
     val update: N               = "update"
     val updateDynamic: N        = "updateDynamic"
     val using: N                = "using"

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3068,11 +3068,7 @@ object Parsers {
 
     /** Create an import node and handle source version imports */
     def mkImport(outermost: Boolean = false): ImportConstr = (tree, selectors) =>
-      val isLanguageImport = tree match
-        case Ident(nme.language) => true
-        case Select(Ident(nme.scala), nme.language) => true
-        case _ => false
-      if isLanguageImport then
+      if isLanguageImport(tree) then
         for
           case ImportSelector(id @ Ident(imported), EmptyTree, _) <- selectors
           if allSourceVersionNames.contains(imported)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -736,13 +736,19 @@ trait Checking {
   /** Check that `path` is a legal prefix for an import clause */
   def checkLegalImportPath(path: Tree)(using Context): Unit =
     checkLegalImportOrExportPath(path, "import prefix")
-    val normPath = stripLanguageNested(path)
-    if isLanguageImport(normPath) then
-      if normPath.symbol != defn.LanguageModule then
-        report.error(em"import looks like a language import, but refers to something else: ${normPath.symbol.showLocated}", path.srcPos)
-    else
-      if normPath.tpe.classSymbols.contains(defn.LanguageModule.moduleClass) then
-        report.error(em"no aliases can be used to refer to a language import", path.srcPos)
+    languageImport(path) match
+      case Some(prefix) =>
+        val required =
+          if prefix == nme.experimental then defn.LanguageExperimentalModule
+          else defn.LanguageModule
+        if path.symbol != required then
+          report.error(em"import looks like a language import, but refers to something else: ${path.symbol.showLocated}", path.srcPos)
+      case None =>
+        val foundClasses = path.tpe.classSymbols
+        if foundClasses.contains(defn.LanguageModule.moduleClass)
+           || foundClasses.contains(defn.LanguageExperimentalModule.moduleClass)
+        then
+          report.error(em"no aliases can be used to refer to a language import", path.srcPos)
 
   /** Check that `path` is a legal prefix for an export clause */
   def checkLegalExportPath(path: Tree, selectors: List[untpd.ImportSelector])(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -734,9 +734,15 @@ trait Checking {
   }
 
   /** Check that `path` is a legal prefix for an import clause */
-  def checkLegalImportPath(path: Tree)(using Context): Unit = {
+  def checkLegalImportPath(path: Tree)(using Context): Unit =
     checkLegalImportOrExportPath(path, "import prefix")
-  }
+    val normPath = stripLanguageNested(path)
+    if isLanguageImport(normPath) then
+      if normPath.symbol != defn.LanguageModule then
+        report.error(em"import looks like a language import, but refers to something else: ${normPath.symbol.showLocated}", path.srcPos)
+    else
+      if normPath.tpe.classSymbols.contains(defn.LanguageModule.moduleClass) then
+        report.error(em"no aliases can be used to refer to a language import", path.srcPos)
 
   /** Check that `path` is a legal prefix for an export clause */
   def checkLegalExportPath(path: Tree, selectors: List[untpd.ImportSelector])(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -33,7 +33,7 @@ object ImportInfo {
       val expr = tpd.Ident(ref.refFn()) // refFn must be called in the context of ImportInfo.sym
       tpd.Import(expr, selectors).symbol
 
-    ImportInfo(sym, selectors, None, isRootImport = true)
+    ImportInfo(sym, selectors, untpd.EmptyTree, isRootImport = true)
 
   extension (c: Context)
     def withRootImports(rootRefs: List[RootRef])(using Context): Context =
@@ -42,21 +42,25 @@ object ImportInfo {
     def withRootImports: Context =
       given Context = c
       c.withRootImports(defn.rootImportFns)
-
 }
 
 /** Info relating to an import clause
  *  @param   sym           The import symbol defined by the clause
  *  @param   selectors     The selector clauses
- *  @param   symNameOpt    Optionally, the name of the import symbol. None for root imports.
+ *  @param   qualifier     The import qualifier, or EmptyTree for root imports.
  *                         Defined for all explicit imports from ident or select nodes.
  *  @param   isRootImport  true if this is one of the implicit imports of scala, java.lang,
  *                         scala.Predef in the start context, false otherwise.
  */
 class ImportInfo(symf: Context ?=> Symbol,
                  val selectors: List[untpd.ImportSelector],
-                 symNameOpt: Option[TermName],
+                 val qualifier: untpd.Tree,
                  val isRootImport: Boolean = false) extends Showable {
+
+  private def symNameOpt = qualifier match {
+    case ref: untpd.RefTree => Some(ref.name.asTermName)
+    case _                  => None
+  }
 
   def sym(using Context): Symbol = {
     if (mySym == null) {
@@ -177,6 +181,8 @@ class ImportInfo(symf: Context ?=> Symbol,
       assert(myUnimported != null)
     myUnimported
 
+  private val isLanguageImport: Boolean = untpd.isLanguageImport(qualifier)
+
   private var myUnimported: Symbol = _
 
   private var myOwner: Symbol = null
@@ -185,14 +191,15 @@ class ImportInfo(symf: Context ?=> Symbol,
   /** Does this import clause or a preceding import clause import `owner.feature`? */
   def featureImported(feature: TermName, owner: Symbol)(using Context): Boolean =
 
-    def compute =
-      val isImportOwner = site.typeSymbol.eq(owner)
-      if isImportOwner && forwardMapping.contains(feature) then true
-      else if isImportOwner && excluded.contains(feature) then false
-      else
-        var c = ctx.outer
-        while c.importInfo eq ctx.importInfo do c = c.outer
-        (c.importInfo != null) && c.importInfo.featureImported(feature, owner)(using c)
+    def compute: Boolean =
+      if isLanguageImport then
+        val isImportOwner = site.typeSymbol.eq(owner)
+        if isImportOwner then
+          if forwardMapping.contains(feature) then return true
+          if excluded.contains(feature) then return false
+      var c = ctx.outer
+      while c.importInfo eq ctx.importInfo do c = c.outer
+      (c.importInfo != null) && c.importInfo.featureImported(feature, owner)(using c)
 
     if myOwner.ne(owner) || !myResults.contains(feature) then
       myOwner = owner

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -122,7 +122,7 @@ trait ImportSuggestions:
               .flatMap(sym => rootsIn(sym.termRef))
         val imported =
           if ctx.importInfo eq ctx.outer.importInfo then Nil
-          else ctx.importInfo.sym.info match
+          else ctx.importInfo.importSym.info match
             case ImportType(expr) => rootsOnPath(expr.tpe)
             case _ => Nil
         defined ++ imported ++ recur(using ctx.outer)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -206,7 +206,7 @@ class Typer extends Namer
         else found
 
       def selection(imp: ImportInfo, name: Name, checkBounds: Boolean): Type =
-        imp.sym.info match
+        imp.importSym.info match
           case ImportType(expr) =>
             val pre = expr.tpe
             var denot = pre.memberBasedOnFlags(name, required, excluded)
@@ -222,8 +222,8 @@ class Typer extends Namer
                 if unimported.isEmpty || !unimported.contains(pre.termSymbol) then
                   return pre.select(name, denot)
           case _ =>
-            if imp.sym.isCompleting then
-              report.warning(i"cyclic ${imp.sym}, ignored", pos)
+            if imp.importSym.isCompleting then
+              report.warning(i"cyclic ${imp.importSym}, ignored", pos)
         NoType
 
       /** The type representing a named import with enclosing name when imported
@@ -393,7 +393,7 @@ class Typer extends Namer
               val namedImp = namedImportRef(curImport)
               if (namedImp.exists)
                 recurAndCheckNewOrShadowed(namedImp, NamedImport, ctx)(using outer)
-              else if (isPossibleImport(WildImport) && !curImport.sym.isCompleting) {
+              else if (isPossibleImport(WildImport) && !curImport.importSym.isCompleting) {
                 val wildImp = wildImportRef(curImport)
                 if (wildImp.exists)
                   recurAndCheckNewOrShadowed(wildImp, WildImport, ctx)(using outer)

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -77,6 +77,8 @@ object language:
    */
   object adhocExtensions
 
+  object unsafeNulls
+
   /** Set source version to 3.0-migration.
     *
     * @see [[https://scalacenter.github.io/scala-3-migration-guide/docs/scala-3-migration-mode]]

--- a/tests/neg/language-import.scala
+++ b/tests/neg/language-import.scala
@@ -1,0 +1,23 @@
+object a with
+  val l = _root_.scala.language
+  import l.noAutoTupling     // error
+  import l.experimental.genericNumberLiterals  // error
+  val scala = c
+  import scala.language.noAutoTupling  // error
+  val language = b
+  import language.experimental.genericNumberLiterals // error
+
+object b with
+  val strictEquality = 22
+  object experimental with
+    val genericNumberLiterals = 22
+
+object c with
+  val language = b
+  import b.strictEquality
+
+object d with
+  import language.experimental.genericNumberLiterals // ok
+  import scala.language.noAutoTupling  // ok
+  import _root_.scala.language.strictEquality // ok
+


### PR DESCRIPTION

The bit is set if

 - -Yexplicit-nulls is set
 - we are not in an `import.unsafeNulls` scope