### PR TITLE
Change colon to with in dotty codebase

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -7,7 +7,7 @@ import org.junit.{Ignore, Test}
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.experimental.categories.Category
 
-abstract class CommunityBuildTest:
+abstract class CommunityBuildTest with
   given CommunityBuildTest = this
 
   /** Depending on the mode of operation, either
@@ -81,7 +81,7 @@ abstract class CommunityBuildTest:
 end CommunityBuildTest
 
 @Category(Array(classOf[TestCategory]))
-class CommunityBuildTestA extends CommunityBuildTest:
+class CommunityBuildTestA extends CommunityBuildTest with
   @Test def endpoints4s = projects.endpoints4s.run()
   @Test def fansi = projects.fansi.run()
   @Test def fastparse = projects.fastparse.run()
@@ -119,7 +119,7 @@ class CommunityBuildTestA extends CommunityBuildTest:
 end CommunityBuildTestA
 
 @Category(Array(classOf[TestCategory]))
-class CommunityBuildTestB extends CommunityBuildTest:
+class CommunityBuildTestB extends CommunityBuildTest with
   @Test def algebra = projects.algebra.run()
   @Test def betterfiles = projects.betterfiles.run()
   @Test def cats = projects.cats.run()

--- a/compiler/src/dotty/tools/dotc/Bench.scala
+++ b/compiler/src/dotty/tools/dotc/Bench.scala
@@ -11,7 +11,7 @@ import scala.annotation.internal.sharable
  *  number of compilers and run each (sequentially) a given number of times
  *  on the same sources.
  */
-object Bench extends Driver:
+object Bench extends Driver with
 
   @sharable private var numRuns = 1
 

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -20,7 +20,7 @@ object DesugarEnums {
     val Simple, Object, Class: Value = Value
   }
 
-  final case class EnumConstraints(minKind: CaseKind.Value, maxKind: CaseKind.Value, enumCases: List[(Int, RefTree)]):
+  final case class EnumConstraints(minKind: CaseKind.Value, maxKind: CaseKind.Value, enumCases: List[(Int, RefTree)]) with
     require(minKind <= maxKind && !(cached && enumCases.isEmpty))
     def requiresCreator = minKind == CaseKind.Simple
     def isEnumeration   = maxKind < CaseKind.Class

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -943,7 +943,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   /** Extractor for not-null assertions.
    *  A not-null assertion for reference `x` has the form `x.$asInstanceOf$[x.type & T]`.
    */
-  object AssertNotNull :
+  object AssertNotNull  with
     def apply(tree: tpd.Tree, tpnn: Type)(using Context): tpd.Tree =
       tree.select(defn.Any_typeCast).appliedToType(AndType(tree.tpe, tpnn))
 

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -382,7 +382,7 @@ object Trees {
     def rhs(using Context): Tree[T] = forceIfLazy
   }
 
-  trait ValOrTypeDef[-T >: Untyped] extends MemberDef[T]:
+  trait ValOrTypeDef[-T >: Untyped] extends MemberDef[T] with
     type ThisTree[-T >: Untyped] <: ValOrTypeDef[T]
 
   type ParamClause[T >: Untyped] = List[ValDef[T]] | List[TypeDef[T]]
@@ -444,7 +444,7 @@ object Trees {
   }
 
   /** The kind of application */
-  enum ApplyKind:
+  enum ApplyKind with
     case Regular      // r.f(x)
     case Using        // r.f(using x)
     case InfixTuple   // r f (x1, ..., xN) where N != 1;  needs to be treated specially for an error message in typedApply
@@ -1591,12 +1591,12 @@ object Trees {
       }
     }.asInstanceOf[tree.ThisTree[T]]
 
-    object TypeDefs:
+    object TypeDefs with
       def unapply(xs: List[Tree]): Option[List[TypeDef]] = xs match
         case (x: TypeDef) :: _ => Some(xs.asInstanceOf[List[TypeDef]])
         case _ => None
 
-    object ValDefs:
+    object ValDefs with
       def unapply(xs: List[Tree]): Option[List[ValDef]] = xs match
         case Nil => Some(Nil)
         case (x: ValDef) :: _ => Some(xs.asInstanceOf[List[ValDef]])

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1230,12 +1230,12 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     Ident(defn.ScalaRuntimeModule.requiredMethod(name).termRef).appliedToTermArgs(args)
 
   /** An extractor that pulls out type arguments */
-  object MaybePoly:
+  object MaybePoly with
     def unapply(tree: Tree): Option[(Tree, List[Tree])] = tree match
       case TypeApply(tree, targs) => Some(tree, targs)
       case _ => Some(tree, Nil)
 
-  object TypeArgs:
+  object TypeArgs with
     def unapply(ts: List[Tree]): Option[List[Tree]] =
       if ts.nonEmpty && ts.head.isType then Some(ts) else None
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -155,7 +155,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   }
 
   def WildcardTypeBoundsTree()(using src: SourceFile): TypeBoundsTree = TypeBoundsTree(EmptyTree, EmptyTree, EmptyTree)
-  object WildcardTypeBoundsTree:
+  object WildcardTypeBoundsTree with
     def unapply(tree: untpd.Tree): Boolean = tree match
       case TypeBoundsTree(EmptyTree, EmptyTree, _) => true
       case _ => false

--- a/compiler/src/dotty/tools/dotc/config/CommandLineParser.scala
+++ b/compiler/src/dotty/tools/dotc/config/CommandLineParser.scala
@@ -6,7 +6,7 @@ import java.lang.Character.isWhitespace
 
 /** A simple enough command line parser.
  */
-object CommandLineParser:
+object CommandLineParser with
   inline private val DQ  = '"'
   inline private val SQ  = '\''
   inline private val EOF = -1

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -10,7 +10,7 @@ import util.SrcPos
 import SourceVersion._
 import reporting.Message
 
-object Feature:
+object Feature with
 
   private val dependent = "dependent".toTermName
   private val namedTypeArguments = "namedTypeArguments".toTermName

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -8,7 +8,7 @@ import core.StdNames.nme
 import core.Decorators.{_, given}
 import util.Property
 
-enum SourceVersion:
+enum SourceVersion with
   case `3.0-migration`, `3.0`, `3.1-migration`, `3.1`
 
   val isMigrating: Boolean = toString.endsWith("-migration")
@@ -18,7 +18,7 @@ enum SourceVersion:
 
   def isAtLeast(v: SourceVersion) = stable.ordinal >= v.ordinal
 
-object SourceVersion extends Property.Key[SourceVersion]:
+object SourceVersion extends Property.Key[SourceVersion] with
   def defaultSourceVersion = `3.0`
 
   val allSourceVersionNames = values.toList.map(_.toString.toTermName)

--- a/compiler/src/dotty/tools/dotc/core/Atoms.scala
+++ b/compiler/src/dotty/tools/dotc/core/Atoms.scala
@@ -12,7 +12,7 @@ import Types._
  *  If the underlying type of a singleton type is another singleton type,
  *  only the latter type ends up in the sets.
  */
-enum Atoms:
+enum Atoms with
   case Range(lo: Set[Type], hi: Set[Type])
   case Unknown
 

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -249,7 +249,7 @@ trait ConstraintHandling {
     /** Substitute wildcards with fresh TypeParamRefs, to be compared with
      *  other bound, so that they can be instantiated.
      */
-    object substWildcards extends TypeMap:
+    object substWildcards extends TypeMap with
       override def stopAtStatic = true
 
       var trackedPolis: List[PolyType] = Nil

--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -7,7 +7,7 @@ import SymDenotations.LazyType, Names.Name, StdNames.nme
 import ast.untpd
 
 /** Extension methods for contexts where we want to keep the ctx.<methodName> syntax */
-object ContextOps:
+object ContextOps with
 
   extension (ctx: Context)
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1172,7 +1172,7 @@ class Definitions {
 
   @tu lazy val TupleType: Array[TypeRef] = mkArityArray("scala.Tuple", MaxTupleArity, 1)
 
-  private class FunType(prefix: String):
+  private class FunType(prefix: String) with
     private var classRefs: Array[TypeRef] = new Array(22)
     def apply(n: Int): TypeRef =
       while n >= classRefs.length do
@@ -1526,7 +1526,7 @@ class Definitions {
    *  dependent refinements. Optionally returns a triple consisting of the argument
    *  types `As`, the result type `B` and a whether the type is an erased context function.
    */
-  object ContextFunctionType:
+  object ContextFunctionType with
     def unapply(tp: Type)(using Context): Option[(List[Type], Type, Boolean)] =
       if ctx.erasedTypes then
         atPhase(erasurePhase)(unapply(tp))

--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -9,7 +9,7 @@ import config.Config
 import ast.untpd
 
 /** Operations that are shared between Namer and TreeUnpickler */
-object NamerOps:
+object NamerOps with
 
   /** The given type, unless `sym` is a constructor, in which case the
    *  type of the constructed instance is returned
@@ -83,7 +83,7 @@ object NamerOps:
     && !cls.isAnonymousClass
 
   /** The completer of a constructor proxy apply method */
-  class ApplyProxyCompleter(constr: Symbol)(using Context) extends LazyType:
+  class ApplyProxyCompleter(constr: Symbol)(using Context) extends LazyType with
     def complete(denot: SymDenotation)(using Context): Unit =
       denot.info = constr.info
 

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -535,7 +535,7 @@ object Names {
       chrs.copyToArray(newchrs)
       chrs = newchrs
 
-  private class NameTable extends HashSet[SimpleName](initialCapacity = 0x10000, capacityMultiple = 2):
+  private class NameTable extends HashSet[SimpleName](initialCapacity = 0x10000, capacityMultiple = 2) with
     import util.Stats
 
     override def hash(x: SimpleName) = hashValue(chrs, x.start, x.length) // needed for resize

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -5,7 +5,7 @@ import Types._, Symbols._, Contexts._, Decorators._
 /** Substitution operations on types. See the corresponding `subst` and
  *  `substThis` methods on class Type for an explanation.
  */
-object Substituters:
+object Substituters with
 
   final def subst(tp: Type, from: BindingType, to: BindingType, theMap: SubstBindingMap)(using Context): Type =
     tp match {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2556,7 +2556,7 @@ object SymDenotations {
     def needsCompletion(symd: SymDenotation)(using Context): Boolean = true
   }
 
-  object LazyType:
+  object LazyType with
     private val NoSymbolFn = (_: Context) ?=> NoSymbol
 
   /** A subtrait of LazyTypes where completerTypeParams yields a List[TypeSymbol], which

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -864,7 +864,7 @@ object Symbols {
   /** Matches lists of term symbols, including the empty list.
    *  All symbols in the list are assumed to be of the same kind.
    */
-  object TermSymbols:
+  object TermSymbols with
     def unapply(xs: List[Symbol])(using Context): Option[List[TermSymbol]] = xs match
       case (x: Symbol) :: _ if x.isType => None
       case _ => Some(xs.asInstanceOf[List[TermSymbol]])
@@ -872,7 +872,7 @@ object Symbols {
   /** Matches lists of type symbols, excluding the empty list.
    *  All symbols in the list are assumed to be of the same kind.
    */
-  object TypeSymbols:
+  object TypeSymbols with
     def unapply(xs: List[Symbol])(using Context): Option[List[TypeSymbol]] = xs match
       case (x: Symbol) :: _ if x.isType => Some(xs.asInstanceOf[List[TypeSymbol]])
       case _ => None

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -32,7 +32,7 @@ object TypeApplications {
    *
    *  @param tycon     C
    */
-  object EtaExpansion:
+  object EtaExpansion with
 
     def apply(tycon: Type)(using Context): Type =
       assert(tycon.typeParams.nonEmpty, tycon)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2558,7 +2558,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
 
 object TypeComparer {
 
-  enum CompareResult:
+  enum CompareResult with
     case OK, Fail, OKwithGADTUsed
 
   /** Class for unification variables used in `natValue`. */
@@ -2577,7 +2577,7 @@ object TypeComparer {
    *   - `LoApprox`: The left type is approximated (i.e widened)"
    *   - `HiApprox`: The right type is approximated (i.e narrowed)"
    */
-  object ApproxState:
+  object ApproxState with
     opaque type Repr = Int
 
     val None: Repr = 0

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -24,7 +24,7 @@ import reporting.TestingReporter
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
 
-object TypeOps:
+object TypeOps with
 
   @sharable var track: Boolean = false // for debugging
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -112,7 +112,7 @@ object Types {
     def isProvisional(using Context): Boolean = mightBeProvisional && testProvisional
 
     private def testProvisional(using Context): Boolean =
-      class ProAcc extends TypeAccumulator[Boolean]:
+      class ProAcc extends TypeAccumulator[Boolean] with
         override def apply(x: Boolean, t: Type) = x || test(t, this)
       def test(t: Type, theAcc: TypeAccumulator[Boolean]): Boolean =
         if t.mightBeProvisional then
@@ -3413,7 +3413,7 @@ object Types {
     private var myParamDependencyStatus: DependencyStatus = Unknown
 
     private def depStatus(initial: DependencyStatus, tp: Type)(using Context): DependencyStatus =
-      class DepAcc extends TypeAccumulator[DependencyStatus]:
+      class DepAcc extends TypeAccumulator[DependencyStatus] with
         def apply(status: DependencyStatus, tp: Type) = compute(status, tp, this)
       def combine(x: DependencyStatus, y: DependencyStatus) =
         val status = (x & StatusMask) max (y & StatusMask)
@@ -4419,7 +4419,7 @@ object Types {
       s"TypeVar($origin$instStr)"
     }
   }
-  object TypeVar:
+  object TypeVar with
     def apply(initOrigin: TypeParamRef, creatorState: TyperState)(using Context) =
       new TypeVar(initOrigin, creatorState, ctx.owner.nestingLevel)
 
@@ -4841,7 +4841,7 @@ object Types {
 
   class CachedAnnotatedType(parent: Type, annot: Annotation) extends AnnotatedType(parent, annot)
 
-  object AnnotatedType:
+  object AnnotatedType with
     def make(underlying: Type, annots: List[Annotation])(using Context): Type =
       annots.foldLeft(underlying)(apply(_, _))
     def apply(parent: Type, annot: Annotation)(using Context): AnnotatedType =
@@ -4889,14 +4889,14 @@ object Types {
     def msg(using Context): Message
   }
 
-  object ErrorType:
+  object ErrorType with
     def apply(m: Message)(using Context): ErrorType =
       val et = new PreviousErrorType
       ctx.base.errorTypeMsg(et) = m
       et
   end ErrorType
 
-  class PreviousErrorType extends ErrorType:
+  class PreviousErrorType extends ErrorType with
     def msg(using Context): Message =
       ctx.base.errorTypeMsg.get(this) match
         case Some(m) => m
@@ -5053,7 +5053,7 @@ object Types {
   // ----- TypeMaps --------------------------------------------------------------------
 
   /** Common base class of TypeMap and TypeAccumulator */
-  abstract class VariantTraversal:
+  abstract class VariantTraversal with
     protected[core] var variance: Int = 1
 
     inline protected def atVariance[T](v: Int)(op: => T): T = {

--- a/compiler/src/dotty/tools/dotc/core/Uniques.scala
+++ b/compiler/src/dotty/tools/dotc/core/Uniques.scala
@@ -6,7 +6,7 @@ import config.Config
 import Decorators._
 import util.{HashSet, Stats}
 
-class Uniques extends HashSet[Type](Config.initialUniquesCapacity):
+class Uniques extends HashSet[Type](Config.initialUniquesCapacity) with
   override def hash(x: Type): Int = x.hash
   override def isEqual(x: Type, y: Type) = x.eql(y)
 
@@ -15,7 +15,7 @@ class Uniques extends HashSet[Type](Config.initialUniquesCapacity):
  *  All sets offer a `enterIfNew` method which checks whether a type
  *  with the given parts exists already and creates a new one if not.
  */
-object Uniques:
+object Uniques with
 
   private inline def recordCaching(tp: Type): Unit = recordCaching(tp.hash, tp.getClass)
   private inline def recordCaching(h: Int, clazz: Class[?]): Unit =
@@ -32,7 +32,7 @@ object Uniques:
     if tp.hash == NotCached then tp
     else ctx.uniques.put(tp).asInstanceOf[T]
 
-  final class NamedTypeUniques extends HashSet[NamedType](Config.initialUniquesCapacity * 4) with Hashable:
+  final class NamedTypeUniques extends HashSet[NamedType](Config.initialUniquesCapacity * 4) with Hashable with
     override def hash(x: NamedType): Int = x.hash
 
     def enterIfNew(prefix: Type, designator: Designator, isTerm: Boolean)(using Context): NamedType =
@@ -53,7 +53,7 @@ object Uniques:
         addEntryAt(idx, newType)
   end NamedTypeUniques
 
-  final class AppliedUniques extends HashSet[AppliedType](Config.initialUniquesCapacity * 2) with Hashable:
+  final class AppliedUniques extends HashSet[AppliedType](Config.initialUniquesCapacity * 2) with Hashable with
     override def hash(x: AppliedType): Int = x.hash
 
     def enterIfNew(tycon: Type, args: List[Type]): AppliedType =

--- a/compiler/src/dotty/tools/dotc/core/tasty/CommentPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/CommentPickler.scala
@@ -10,7 +10,7 @@ import dotty.tools.tasty.TastyFormat.CommentsSection
 
 import java.nio.charset.StandardCharsets
 
-class CommentPickler(pickler: TastyPickler, addrOfTree: tpd.Tree => Addr, docString: untpd.MemberDef => Option[Comment]):
+class CommentPickler(pickler: TastyPickler, addrOfTree: tpd.Tree => Addr, docString: untpd.MemberDef => Option[Comment]) with
   private val buf = new TastyBuffer(5000)
   pickler.newSection(CommentsSection, buf)
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -130,8 +130,8 @@ class PositionPickler(
       traverse(root, NoSource)
   }
 }
-object PositionPickler:
+object PositionPickler with
   // Note: This could be just TreeToAddr => Addr if functions are specialized to value classes.
   // We use a SAM type to avoid boxing of Addr
-  @FunctionalInterface trait TreeToAddr:
+  @FunctionalInterface trait TreeToAddr with
     def apply(x: untpd.Tree): Addr

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -12,7 +12,7 @@ import util.Spans.offsetToInt
 import printing.Highlighting._
 import dotty.tools.tasty.TastyFormat.{ASTsSection, PositionsSection, CommentsSection}
 
-object TastyPrinter:
+object TastyPrinter with
   def show(bytes: Array[Byte])(using Context): String =
     val printer =
       if ctx.settings.color.value == "never" then new TastyPrinter(bytes)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -45,7 +45,7 @@ object Parsers {
     def nonePositive: Boolean = parCounts forall (_ <= 0)
   }
 
-  enum Location(val inParens: Boolean, val inPattern: Boolean, val inArgs: Boolean):
+  enum Location(val inParens: Boolean, val inPattern: Boolean, val inArgs: Boolean) with
     case InParens      extends Location(true, false, false)
     case InArgs        extends Location(true, false, true)
     case InPattern     extends Location(false, true, false)

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1341,7 +1341,7 @@ object Scanners {
    *   InBraces    a pair of braces { ... }
    *   Indented    a pair of <indent> ... <outdent> tokens
    */
-  abstract class Region:
+  abstract class Region with
     /** The region enclosing this one, or `null` for the outermost region */
     def outer: Region | Null
 
@@ -1380,7 +1380,7 @@ object Scanners {
    *  @param others  Other indendation widths > width of lines in the same region
    *  @param prefix  The token before the initial <indent> of the region
    */
-  case class Indented(width: IndentWidth, others: Set[IndentWidth], prefix: Token, outer: Region | Null) extends Region:
+  case class Indented(width: IndentWidth, others: Set[IndentWidth], prefix: Token, outer: Region | Null) extends Region with
     knownWidth = width
 
   def topLevelRegion(width: IndentWidth) = Indented(width, Set(), EMPTY, null)

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -71,7 +71,7 @@ object Formatting {
    *  like concatenation, stripMargin etc on the values returned by em"...", and in the current error
    *  message composition methods, this is crucial.
    */
-  class ErrorMessageFormatter(sc: StringContext) extends StringFormatter(sc):
+  class ErrorMessageFormatter(sc: StringContext) extends StringFormatter(sc) with
     override protected def showArg(arg: Any)(using Context): String =
       wrapNonSensical(arg, super.showArg(arg)(using errorMessageCtx))
 

--- a/compiler/src/dotty/tools/dotc/printing/MessageLimiter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/MessageLimiter.scala
@@ -7,7 +7,7 @@ import Contexts._
 import util.Property
 import Texts.Text
 
-abstract class MessageLimiter:
+abstract class MessageLimiter with
 
   protected def recurseLimit = 100
   protected var recurseCount: Int = 0
@@ -29,17 +29,17 @@ abstract class MessageLimiter:
 
 object MessageLimiter extends Property.Key[MessageLimiter]
 
-class DefaultMessageLimiter extends MessageLimiter:
+class DefaultMessageLimiter extends MessageLimiter with
   override def recursionLimitExceeded()(using Context): Unit =
     if ctx.debug then
       report.warning("Exceeded recursion depth attempting to print.")
       Thread.dumpStack()
 
-class SummarizeMessageLimiter(depth: Int) extends MessageLimiter:
+class SummarizeMessageLimiter(depth: Int) extends MessageLimiter with
   override val recurseLimit = recurseCount + depth
   override def recursionLimitExceeded()(using Context): Unit = ()
 
-class ErrorMessageLimiter extends MessageLimiter:
+class ErrorMessageLimiter extends MessageLimiter with
   private val initialRecurseLimit = 50
   private val sizeLimit = 10000
 

--- a/compiler/src/dotty/tools/dotc/quoted/QuoteUtils.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuoteUtils.scala
@@ -6,7 +6,7 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Decorators._
 import dotty.tools.dotc.core.Symbols._
 
-object QuoteUtils:
+object QuoteUtils with
   import tpd._
 
   /** Get the owner of a tree if it has one */

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -11,7 +11,7 @@ import config.Feature.sourceVersion
 import java.lang.System.currentTimeMillis
 
 
-object report:
+object report with
 
   /** For sending messages that are printed only if -verbose is set */
   def inform(msg: => String, pos: SrcPos = NoSourcePosition)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
@@ -9,7 +9,7 @@ import interfaces.Diagnostic.{ERROR, INFO, WARNING}
 
 import java.util.Optional
 
-object Diagnostic:
+object Diagnostic with
 
   def shouldExplain(dia: Diagnostic)(using Context): Boolean =
     dia.msg.explanation.nonEmpty && ctx.settings.explain.value

--- a/compiler/src/dotty/tools/dotc/reporting/ExploringReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ExploringReporter.scala
@@ -7,7 +7,7 @@ import core.Contexts.Context
 import Diagnostic._
 
 /** A re-usable Reporter used in Contexts#test */
-class ExploringReporter extends StoreReporter(null):
+class ExploringReporter extends StoreReporter(null) with
   infos = new mutable.ListBuffer[Diagnostic]
 
   override def hasUnreportedErrors: Boolean =

--- a/compiler/src/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/TestReporter.scala
@@ -6,7 +6,7 @@ import collection.mutable
 import Diagnostic._
 
 /** A re-usable Reporter used in Contexts#test */
-class TestingReporter extends StoreReporter(null):
+class TestingReporter extends StoreReporter(null) with
   infos = new mutable.ListBuffer[Diagnostic]
   override def hasUnreportedErrors: Boolean = infos.exists(_.isInstanceOf[Error])
   def reset(): Unit = infos.clear()

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -38,36 +38,36 @@ import transform.SymUtils._
   *  ```
   */
 
-  abstract class SyntaxMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class SyntaxMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Syntax"
 
-  abstract class TypeMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class TypeMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Type"
 
-  abstract class TypeMismatchMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class TypeMismatchMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Type Mismatch"
 
-  abstract class NamingMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class NamingMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Naming"
 
-  abstract class DeclarationMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class DeclarationMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Declaration"
 
   /** A simple not found message (either for idents, or member selection.
    *  Messages of this class are sometimes dropped in favor of other, more
    *  specific messages.
    */
-  abstract class NotFoundMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class NotFoundMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Not Found"
     def name: Name
 
-  abstract class PatternMatchMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class PatternMatchMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Pattern Match"
 
-  abstract class CyclicMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class CyclicMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Cyclic"
 
-  abstract class ReferenceMsg(errorId: ErrorMessageID) extends Message(errorId):
+  abstract class ReferenceMsg(errorId: ErrorMessageID) extends Message(errorId) with
     def kind = "Reference"
 
   abstract class EmptyCatchOrFinallyBlock(tryBody: untpd.Tree, errNo: ErrorMessageID)(using Context)
@@ -242,7 +242,7 @@ import transform.SymUtils._
     // the idea is that if the bounds are also not-subtypes of each other to report
     // the type mismatch on the bounds instead of the original TypeParamRefs, since
     // these are usually easier to analyze.
-    object reported extends TypeMap:
+    object reported extends TypeMap with
       def setVariance(v: Int) = variance = v
       val constraint = mapCtx.typerState.constraint
       def apply(tp: Type): Type = tp match
@@ -1190,7 +1190,7 @@ import transform.SymUtils._
            |""".stripMargin
   }
 
-  class UnreducibleApplication(tycon: Type)(using Context) extends TypeMsg(UnreducibleApplicationID):
+  class UnreducibleApplication(tycon: Type)(using Context) extends TypeMsg(UnreducibleApplicationID) with
     def msg = em"unreducible application of higher-kinded type $tycon to wildcard arguments"
     def explain =
       em"""|An abstract type constructor cannot be applied to wildcard arguments.
@@ -1662,7 +1662,7 @@ import transform.SymUtils._
     def explain = "Method inlining prohibits calling superclass methods, as it may lead to confusion about which super is being called."
   }
 
-  class NotAPath(tp: Type, usage: String)(using Context) extends TypeMsg(NotAPathID):
+  class NotAPath(tp: Type, usage: String)(using Context) extends TypeMsg(NotAPathID) with
     def msg = em"$tp is not a valid $usage, since it is not an immutable path"
     def explain =
       i"""An immutable path is
@@ -1852,7 +1852,7 @@ import transform.SymUtils._
     def explain = ""
   }
 
-  class AlreadyDefined(name: Name, owner: Symbol, conflicting: Symbol)(using Context) extends NamingMsg(AlreadyDefinedID):
+  class AlreadyDefined(name: Name, owner: Symbol, conflicting: Symbol)(using Context) extends NamingMsg(AlreadyDefinedID) with
     private def where: String =
       if conflicting.effectiveOwner.is(Package) && conflicting.associatedFile != null then
         i" in ${conflicting.associatedFile}"

--- a/compiler/src/dotty/tools/dotc/reporting/trace.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/trace.scala
@@ -7,11 +7,11 @@ import config.Config
 import config.Printers
 import core.Mode
 
-object trace extends TraceSyntax:
+object trace extends TraceSyntax with
   inline def isEnabled = Config.tracingEnabled
   protected val isForced = false
 
-  object force extends TraceSyntax:
+  object force extends TraceSyntax with
     inline def isEnabled: true = true
     protected val isForced = true
 end trace
@@ -20,7 +20,7 @@ end trace
  *  is false. The `trace` operation is called in various hotspots, so every tiny bit
  *  of overhead is unacceptable: boxing, closures, additional method calls are all out.
  */
-trait TraceSyntax:
+trait TraceSyntax with
 
   inline def isEnabled: Boolean
   protected val isForced: Boolean

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -28,7 +28,7 @@ import scala.PartialFunction.condOpt
  *  for a description of the format.
  *  TODO: Also extract type information
  */
-class ExtractSemanticDB extends Phase:
+class ExtractSemanticDB extends Phase with
   import Scala3.{_, given}
   import Symbols.given
 
@@ -47,7 +47,7 @@ class ExtractSemanticDB extends Phase:
     ExtractSemanticDB.write(unit.source, extract.occurrences.toList, extract.symbolInfos.toList)
 
   /** Extractor of symbol occurrences from trees */
-  class Extractor extends TreeTraverser:
+  class Extractor extends TreeTraverser with
 
     private var nextLocalIdx: Int = 0
 
@@ -249,7 +249,7 @@ class ExtractSemanticDB extends Phase:
         name => locals.keys.find(local => local.isTerm && local.owner == funSym && local.name == name)
                       .fold("<?>")(Symbols.LocalPrefix + _)
 
-    private object PatternValDef:
+    private object PatternValDef with
 
       def unapply(tree: ValDef)(using Context): Option[(Tree, Tree)] = tree.rhs match
 
@@ -583,7 +583,7 @@ class ExtractSemanticDB extends Phase:
           registerSymbol(vparam.symbol, symbolName(vparam.symbol), symkinds)
         traverse(vparam.tpt)
 
-object ExtractSemanticDB:
+object ExtractSemanticDB with
   import java.nio.file.Path
   import scala.collection.JavaConverters._
   import java.nio.file.Files

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -15,7 +15,7 @@ import java.lang.Character.{isJavaIdentifierPart, isJavaIdentifierStart}
 import scala.annotation.internal.sharable
 import scala.annotation.switch
 
-object Scala3:
+object Scala3 with
   import Symbols._
   import core.NameOps._
 
@@ -25,7 +25,7 @@ object Scala3:
 
   private val WILDCARDTypeName = nme.WILDCARD.toTypeName
 
-  enum SymbolKind derives CanEqual:
+  enum SymbolKind derives CanEqual with
     kind =>
 
     case Val, Var, Setter, Abstract
@@ -38,13 +38,13 @@ object Scala3:
 
   end SymbolKind
 
-  object SymbolKind:
+  object SymbolKind with
     val ValSet   = Set(Val)
     val VarSet   = Set(Var)
     val emptySet = Set.empty[SymbolKind]
   end SymbolKind
 
-  object Symbols:
+  object Symbols with
 
     val RootPackage: String = "_root_/"
     val EmptyPackage: String = "_empty_/"
@@ -126,7 +126,7 @@ object Scala3:
 
   end SymbolOps
 
-  object LocalSymbol:
+  object LocalSymbol with
 
     def unapply(symbolInfo: SymbolInformation): Option[Int] = symbolInfo.symbol match
       case locals(ints) =>
@@ -234,7 +234,7 @@ object Scala3:
     *
     * taken from https://github.com/scalameta/scalameta/blob/master/semanticdb/metap/src/main/scala/scala/meta/internal/metap/IdentifierOrdering.scala
     */
-  private class IdentifierOrdering[T <: CharSequence] extends Ordering[T]:
+  private class IdentifierOrdering[T <: CharSequence] extends Ordering[T] with
 
     override def compare(o1: T, o2: T): Int =
       val len = math.min(o1.length(), o2.length())

--- a/compiler/src/dotty/tools/dotc/semanticdb/Tools.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Tools.scala
@@ -6,7 +6,7 @@ import scala.collection.JavaConverters._
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.semanticdb.Scala3.{_, given}
 
-object Tools:
+object Tools with
 
   /** Converts a Path to a String that is URI encoded, without forcing absolute paths. */
   def mkURIstring(path: Path): String =

--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -30,7 +30,7 @@ import ast.TreeTypeMap
  *  A typical use case is eliminating redundant closures for blackbox macros that
  *  return context functions. See i6375.scala.
  */
-class BetaReduce extends MiniPhase:
+class BetaReduce extends MiniPhase with
   import ast.tpd._
 
   def phaseName: String = "betaReduce"
@@ -44,7 +44,7 @@ class BetaReduce extends MiniPhase:
       app
 
 
-object BetaReduce:
+object BetaReduce with
   import ast.tpd._
 
   /** Beta-reduces a call to `fn` with arguments `argSyms` or returns `tree` */

--- a/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ContextFunctionResults.scala
@@ -9,7 +9,7 @@ import ast.untpd
 import ast.tpd._
 import config.Config
 
-object ContextFunctionResults:
+object ContextFunctionResults with
 
   /** Annotate methods that have context function result types directly matched by context
    *  closures on their right-hand side. Parameters to such closures will be integrated

--- a/compiler/src/dotty/tools/dotc/transform/CountOuterAccesses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CountOuterAccesses.scala
@@ -13,7 +13,7 @@ import ExplicitOuter.isOuterParamAccessor
 
 import collection.mutable
 
-object CountOuterAccesses:
+object CountOuterAccesses with
   val name: String = "countOuterAccesses"
 
   /** Characterizes outer accessors and outer fields that can be dropped
@@ -32,7 +32,7 @@ object CountOuterAccesses:
  *  is collected in `outerAccessCount` and used in the subsequent
  *  DropOuterAccessors phase
  */
-class CountOuterAccesses extends MiniPhase:
+class CountOuterAccesses extends MiniPhase with
   thisPhase =>
   import tpd._
 

--- a/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
@@ -16,14 +16,14 @@ import CountOuterAccesses.mightBeDropped
 import collection.mutable
 import annotation.threadUnsafe
 
-object DropOuterAccessors:
+object DropOuterAccessors with
   val name: String = "dropOuterAccessors"
 
 /** Drops unused outer accessors of inner classes that are visible only in one
  *  toplevel class. For other classes, we can't tell whether an outer accessor
  *  is used or not. It could for instance be used in a type test in some other source.
  */
-class DropOuterAccessors extends MiniPhase with IdentityDenotTransformer:
+class DropOuterAccessors extends MiniPhase with IdentityDenotTransformer with
   thisPhase =>
   import tpd._
 

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -208,7 +208,7 @@ object Erasure {
         else mt
       case _ => mt
 
-  object Boxing:
+  object Boxing with
 
     def isUnbox(sym: Symbol)(using Context): Boolean =
       sym.name == nme.unbox && sym.owner.linkedClass.isPrimitiveValueClass

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -22,7 +22,7 @@ import dotty.tools.dotc.util.Spans.Span
  *
  *  However, implicit function types do not count as SAM types.
  */
-object ExpandSAMs:
+object ExpandSAMs with
   val name: String = "expandSAMs"
 
   /** Is the SAMType `cls` also a SAM under the rules of the platform? */
@@ -34,7 +34,7 @@ object ExpandSAMs:
       case cls: ClassSymbol => !isPlatformSam(cls) || cls == defn.PartialFunctionClass
       case _ => false
 
-class ExpandSAMs extends MiniPhase:
+class ExpandSAMs extends MiniPhase with
   import ast.tpd._
 
   override def phaseName: String = ExpandSAMs.name

--- a/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
@@ -26,7 +26,7 @@ import ast.TreeTypeMap
  *
  *  This removes placeholders added by inline `unapply`/`unapplySeq` patterns.
  */
-class InlinePatterns extends MiniPhase:
+class InlinePatterns extends MiniPhase with
   import ast.tpd._
 
   def phaseName: String = "inlinePatterns"
@@ -46,7 +46,7 @@ class InlinePatterns extends MiniPhase:
           app
     else app
 
-  private object App:
+  private object App with
     def unapply(app: Tree): (Tree, List[List[Tree]]) =
       app match
         case Apply(App(fn, argss), args) => (fn, argss :+ args)

--- a/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
@@ -12,7 +12,7 @@ import ast.Trees._
  *  but leave closures alone. This is necessary to be able to
  *  collapse applies of IFTs (this is done in Erasure).
  */
-class LetOverApply extends MiniPhase:
+class LetOverApply extends MiniPhase with
   import ast.tpd._
 
   override def phaseName: String = "letOverApply"

--- a/compiler/src/dotty/tools/dotc/transform/LiftTry.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LiftTry.scala
@@ -78,5 +78,5 @@ class LiftTry extends MiniPhase with IdentityDenotTransformer { thisPhase =>
     }
     else tree
 }
-object LiftTry:
+object LiftTry with
   val name = "liftTry"

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -31,7 +31,7 @@ import config.Printers.typr
  *
  *  The aim of this transformation is to avoid redundant parameter accessor fields.
  */
-class ParamForwarding extends MiniPhase with IdentityDenotTransformer:
+class ParamForwarding extends MiniPhase with IdentityDenotTransformer with
   import ast.tpd._
 
   private def thisPhase: ParamForwarding = this

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -22,7 +22,7 @@ import ast.tpd.Literal
 import language.implicitConversions
 import scala.annotation.tailrec
 
-object SymUtils:
+object SymUtils with
 
   extension (self: Symbol)
 

--- a/compiler/src/dotty/tools/dotc/transform/UncacheGivenAliases.scala
+++ b/compiler/src/dotty/tools/dotc/transform/UncacheGivenAliases.scala
@@ -13,7 +13,7 @@ import core.Decorators._
 import core.TypeErasure.erasure
 import ast.tpd
 
-object UncacheGivenAliases:
+object UncacheGivenAliases with
   val name: String = "uncacheGivenAliases"
 
 /** This phase optimizes alias givens represented as lazy vals to be uncached
@@ -24,7 +24,7 @@ object UncacheGivenAliases:
  *    this.y
  *    y
  */
-class UncacheGivenAliases extends MiniPhase with IdentityDenotTransformer:
+class UncacheGivenAliases extends MiniPhase with IdentityDenotTransformer with
   thisPhase =>
   import tpd._
 

--- a/compiler/src/dotty/tools/dotc/typer/ConstFold.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ConstFold.scala
@@ -14,7 +14,7 @@ import StdNames._
 import Contexts._
 import transform.TypeUtils._
 
-object ConstFold:
+object ConstFold with
 
   import tpd._
 

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -155,7 +155,7 @@ class LiftComplex extends Lifter {
 }
 object LiftComplex extends LiftComplex
 
-object LiftErased extends LiftComplex:
+object LiftErased extends LiftComplex with
   override def isErased = true
 
 /** Lift all impure or complex arguments to `def`s */

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -40,7 +40,7 @@ import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
 
 /** Implicit resolution */
-object Implicits:
+object Implicits with
   import tpd._
 
   /** An implicit definition `implicitRef` that is visible under a different name, `alias`.
@@ -517,14 +517,14 @@ object Implicits:
   }
 
   /** A search failure type for attempted ill-typed extension method calls */
-  class FailedExtension(extApp: Tree, val expectedType: Type, val whyFailed: Message) extends SearchFailureType:
+  class FailedExtension(extApp: Tree, val expectedType: Type, val whyFailed: Message) extends SearchFailureType with
     def argument = EmptyTree
     def explanation(using Context) = em"$extApp does not $qualify"
 
    /** A search failure type for aborted searches of extension methods, typically
     *  because of a cyclic reference or similar.
     */
-  class NestedFailure(_msg: Message, val expectedType: Type) extends SearchFailureType:
+  class NestedFailure(_msg: Message, val expectedType: Type) extends SearchFailureType with
     def argument = EmptyTree
     override def msg(using Context) = _msg
     def explanation(using Context) = msg.toString
@@ -534,8 +534,7 @@ end Implicits
 import Implicits._
 
 /** Info relating to implicits that is kept for one run */
-trait ImplicitRunInfo:
-  self: Run =>
+trait ImplicitRunInfo with self: Run =>
 
   private val implicitScopeCache = util.EqHashMap[Type, OfTypeImplicits]()
 
@@ -554,7 +553,7 @@ trait ImplicitRunInfo:
 
   private def computeIScope(rootTp: Type): OfTypeImplicits =
 
-    object collectParts extends TypeTraverser:
+    object collectParts extends TypeTraverser with
 
       private var provisional: Boolean = _
       private var parts: mutable.LinkedHashSet[Type] = _
@@ -757,7 +756,7 @@ trait ImplicitRunInfo:
 end ImplicitRunInfo
 
 /** The implicit resolution part of type checking */
-trait Implicits:
+trait Implicits with
   self: Typer =>
 
   import tpd._
@@ -931,7 +930,7 @@ trait Implicits:
       implicits.println(i"CanEqual witness found for $ltp / $rtp: $res: ${res.tpe}")
     }
 
-  object hasSkolem extends TreeAccumulator[Boolean]:
+  object hasSkolem extends TreeAccumulator[Boolean] with
     def apply(x: Boolean, tree: Tree)(using Context): Boolean =
       x || {
         tree match
@@ -1076,7 +1075,7 @@ trait Implicits:
     }
 
   /** An implicit search; parameters as in `inferImplicit` */
-  class ImplicitSearch(protected val pt: Type, protected val argument: Tree, span: Span)(using Context):
+  class ImplicitSearch(protected val pt: Type, protected val argument: Tree, span: Span)(using Context) with
     assert(argument.isEmpty || argument.tpe.isValueType || argument.tpe.isInstanceOf[ExprType],
         em"found: $argument: ${argument.tpe}, expected: $pt")
 
@@ -1443,7 +1442,7 @@ end Implicits
  * recursive references and emit a complete implicit dictionary when the outermost search
  * is complete.
  */
-abstract class SearchHistory:
+abstract class SearchHistory with
   val root: SearchRoot
   /** Does this search history contain any by name implicit arguments. */
   val byname: Boolean
@@ -1471,7 +1470,7 @@ abstract class SearchHistory:
   override def toString: String = s"SearchHistory(open = $openSearchPairs, byname = $byname)"
 end SearchHistory
 
-case class OpenSearch(cand: Candidate, pt: Type, outer: SearchHistory)(using Context) extends SearchHistory:
+case class OpenSearch(cand: Candidate, pt: Type, outer: SearchHistory)(using Context) extends SearchHistory with
   val root = outer.root
   val byname = outer.byname || pt.isByName
   def openSearchPairs = (cand, pt) :: outer.openSearchPairs
@@ -1489,7 +1488,7 @@ end OpenSearch
 /**
  * The the state corresponding to the outermost context of an implicit searcch.
  */
-final class SearchRoot extends SearchHistory:
+final class SearchRoot extends SearchHistory with
   val root = this
   val byname = false
   def openSearchPairs = Nil
@@ -1657,7 +1656,7 @@ final class SearchRoot extends SearchHistory:
 end SearchRoot
 
 /** A set of term references where equality is =:= */
-sealed class TermRefSet(using Context):
+sealed class TermRefSet(using Context) with
   private val elems = new java.util.LinkedHashMap[TermSymbol, Type | List[Type]]
 
   def isEmpty = elems.size == 0
@@ -1692,7 +1691,7 @@ sealed class TermRefSet(using Context):
 
   override def toString = showAsList.toString
 
-object TermRefSet:
+object TermRefSet with
 
   @sharable val empty = new TermRefSet(using NoContext):
     override def += (ref: TermRef): Unit = throw UnsupportedOperationException("+=")

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -18,8 +18,7 @@ import scala.util.control.NonFatal
 /** This trait defines the method `importSuggestionAddendum` that adds an addendum
  *  to error messages suggesting additional imports.
  */
-trait ImportSuggestions:
-  this: Typer =>
+trait ImportSuggestions with this: Typer =>
 
   /** The maximal number of suggested imports to make */
   inline val MaxSuggestions = 10

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -619,6 +619,6 @@ trait Inferencing { this: Typer =>
   val flipBottom: Value = new Value(_ => true, IfBottom.flip)
 }
 
-enum IfBottom:
+enum IfBottom with
   case ok, fail, flip
 

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -276,7 +276,7 @@ object Inliner {
 
   object Intrinsics {
     import dotty.tools.dotc.reporting.Diagnostic.Error
-    private enum ErrorKind:
+    private enum ErrorKind with
       case Parser, Typer
 
     private def compileForErrors(tree: Tree, stopAfterParser: Boolean)(using Context): List[(ErrorKind, Error)] =

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -120,7 +120,7 @@ object ProtoTypes {
   }
 
   /** A class marking ignored prototypes that can be revealed by `deepenProto` */
-  abstract case class IgnoredProto(ignored: Type) extends CachedGroundType with MatchAlways:
+  abstract case class IgnoredProto(ignored: Type) extends CachedGroundType with MatchAlways with
     override def revealIgnored = ignored
     override def deepenProto(using Context): Type = ignored
 
@@ -135,7 +135,7 @@ object ProtoTypes {
 
   final class CachedIgnoredProto(ignored: Type) extends IgnoredProto(ignored)
 
-  object IgnoredProto:
+  object IgnoredProto with
     def apply(ignored: Type)(using Context): IgnoredProto = ignored match
       case ignored: IgnoredProto => ignored
       case _ => unique(CachedIgnoredProto(ignored))

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1023,7 +1023,7 @@ object RefChecks {
   /** Verify that references in the user-defined `@implicitNotFound` message are valid.
    *  (i.e. they refer to a type variable that really occurs in the signature of the annotated symbol.)
    */
-  private object checkImplicitNotFoundAnnotation:
+  private object checkImplicitNotFoundAnnotation with
     /** Warns if the class or trait has an @implicitNotFound annotation
      *  with invalid type variable references.
      */
@@ -1040,7 +1040,7 @@ object RefChecks {
         if param.isTerm
       do checkReferences(param.denot)
 
-    private object PositionedStringLiteralArgument:
+    private object PositionedStringLiteralArgument with
       def unapply(tree: Tree): Option[(String, Span)] = tree match {
         case l@Literal(Constant(s: String)) => Some((s, l.span))
         case NamedArg(_, l@Literal(Constant(s: String))) => Some((s, l.span))

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -18,7 +18,7 @@ import util.Property
 import annotation.{tailrec, constructorOnly}
 
 /** Synthesize terms for special classes */
-class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
+class Synthesizer(typer: Typer)(using @constructorOnly c: Context) with
   import ast.tpd._
 
   /** Handlers to synthesize implicits for special types */

--- a/compiler/src/dotty/tools/dotc/util/CharBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/util/CharBuffer.scala
@@ -5,7 +5,7 @@ package util
 /** A character buffer that exposes the internal array for reading.
  *  That way we can avoid copying when converting to names.
  */
-class CharBuffer(initialSize: Int = 1024):
+class CharBuffer(initialSize: Int = 1024) with
   private var cs: Array[Char] = new Array[Char](initialSize)
   private var len: Int = 0
 

--- a/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashMap.scala
@@ -1,7 +1,7 @@
 package dotty.tools
 package dotc.util
 
-object GenericHashMap:
+object GenericHashMap with
 
   /** The number of elements up to which dense packing is used.
    *  If the number of elements reaches `DenseLimit` a hash table is used instead
@@ -163,7 +163,7 @@ abstract class GenericHashMap[Key, Value]
     allocate(newLength)
     copyFrom(oldTable)
 
-  private abstract class EntryIterator[T] extends Iterator[T]:
+  private abstract class EntryIterator[T] extends Iterator[T] with
     def entry(idx: Int): T
     private var idx = 0
     def hasNext =

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -1,6 +1,6 @@
 package dotty.tools.dotc.util
 
-object HashSet:
+object HashSet with
 
   /** The number of elements up to which dense packing is used.
    *  If the number of elements reaches `DenseLimit` a hash table is used instead
@@ -159,7 +159,7 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Mu
     allocate(newLength)
     copyFrom(oldTable)
 
-  abstract class EntryIterator extends Iterator[T]:
+  abstract class EntryIterator extends Iterator[T] with
     def entry(idx: Int): T
     private var idx = 0
     def hasNext =

--- a/compiler/src/dotty/tools/dotc/util/LinearMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearMap.scala
@@ -10,7 +10,7 @@ import collection.immutable
 opaque type LinearMap[K <: AnyRef, V >: Null <: AnyRef] =
   immutable.Map[K, V] | HashMap[K, V]
 
-object LinearMap:
+object LinearMap with
 
   def empty[K <: AnyRef, V >: Null <: AnyRef]: LinearMap[K, V] =
     immutable.Map.empty[K, V]

--- a/compiler/src/dotty/tools/dotc/util/LinearSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/LinearSet.scala
@@ -8,7 +8,7 @@ import collection.immutable
 opaque type LinearSet[Elem >: Null <: AnyRef] =
   immutable.Set[Elem] | HashSet[Elem]
 
-object LinearSet:
+object LinearSet with
 
   def empty[Elem >: Null <: AnyRef]: LinearSet[Elem] = immutable.Set.empty[Elem]
 

--- a/compiler/src/dotty/tools/dotc/util/MutableMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableMap.scala
@@ -3,7 +3,7 @@ package dotc.util
 
 /** A common class for lightweight mutable maps.
  */
-abstract class MutableMap[Key, Value] extends ReadOnlyMap[Key, Value]:
+abstract class MutableMap[Key, Value] extends ReadOnlyMap[Key, Value] with
 
   def update(k: Key, v: Value): Unit
 

--- a/compiler/src/dotty/tools/dotc/util/MutableSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableSet.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc.util
 
 /** A common class for lightweight mutable sets.
  */
-abstract class MutableSet[T] extends ReadOnlySet[T]:
+abstract class MutableSet[T] extends ReadOnlySet[T] with
 
   /** Add element `x` to the set */
   def +=(x: T): Unit

--- a/compiler/src/dotty/tools/dotc/util/PerfectHashing.scala
+++ b/compiler/src/dotty/tools/dotc/util/PerfectHashing.scala
@@ -1,6 +1,6 @@
 package dotty.tools.dotc.util
 
-object PerfectHashing:
+object PerfectHashing with
 
   /** The number of elements up to which dense packing is used.
    *  If the number of elements reaches `DenseLimit` a hash table is used instead
@@ -19,7 +19,7 @@ object PerfectHashing:
  *                           However, a table of size up to DenseLimit will be re-sized only
  *                           once the number of elements reaches the table's size.
  */
-class PerfectHashing[Key](initialCapacity: Int = 8, capacityMultiple: Int = 2):
+class PerfectHashing[Key](initialCapacity: Int = 8, capacityMultiple: Int = 2) with
   import PerfectHashing.DenseLimit
 
   private var used: Int = _

--- a/compiler/src/dotty/tools/dotc/util/ReadOnlyMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/ReadOnlyMap.scala
@@ -3,7 +3,7 @@ package dotc.util
 
 /** A class for the reading part of mutable or immutable maps.
  */
-abstract class ReadOnlyMap[Key, Value]:
+abstract class ReadOnlyMap[Key, Value] with
 
   def lookup(x: Key): Value | Null
 

--- a/compiler/src/dotty/tools/dotc/util/ReadOnlySet.scala
+++ b/compiler/src/dotty/tools/dotc/util/ReadOnlySet.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc.util
 
 /** A class for the readonly part of mutable sets.
  */
-abstract class ReadOnlySet[T]:
+abstract class ReadOnlySet[T] with
 
   /** The entry in the set such that `isEqual(x, entry)`, or else `null`. */
   def lookup(x: T): T | Null
@@ -19,6 +19,6 @@ abstract class ReadOnlySet[T]:
 
   def isEmpty = size == 0
 
-object ReadOnlySet:
+object ReadOnlySet with
   def empty[T]: ReadOnlySet[T] = HashSet[T](4)
 

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -91,7 +91,7 @@ extends SrcPos, interfaces.SourcePosition, Showable {
 }
 
 /** Things that can produce a source position and a span */
-trait SrcPos:
+trait SrcPos with
   def sourcePos(using ctx: Context): SourcePosition
   def span: Span
   def startPos(using ctx: Context): SourcePosition = sourcePos.startPos

--- a/compiler/src/dotty/tools/dotc/util/StackTraceOps.scala
+++ b/compiler/src/dotty/tools/dotc/util/StackTraceOps.scala
@@ -16,7 +16,7 @@ import collection.mutable, mutable.ListBuffer
 import scala.util.chaining.given
 import java.lang.System.lineSeparator
 
-object StackTraceOps:
+object StackTraceOps with
 
   extension (t: Throwable)
 

--- a/compiler/src/dotty/tools/repl/ReplCompillationUnit.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompillationUnit.scala
@@ -4,5 +4,5 @@ import dotty.tools.dotc.CompilationUnit
 import dotty.tools.dotc.util.SourceFile
 
 
-class ReplCompilationUnit(source: SourceFile) extends CompilationUnit(source):
+class ReplCompilationUnit(source: SourceFile) extends CompilationUnit(source) with
   override def isSuspendable: Boolean = false

--- a/compiler/src/dotty/tools/scripting/Main.scala
+++ b/compiler/src/dotty/tools/scripting/Main.scala
@@ -3,7 +3,7 @@ package dotty.tools.scripting
 import java.io.File
 
 /** Main entry point to the Scripting execution engine */
-object Main:
+object Main with
   /** All arguments before -script <target_script> are compiler arguments.
       All arguments afterwards are script arguments.*/
   def distinguishArgs(args: Array[String]): (Array[String], File, Array[String]) =

--- a/compiler/src/dotty/tools/scripting/ScriptingDriver.scala
+++ b/compiler/src/dotty/tools/scripting/ScriptingDriver.scala
@@ -16,7 +16,7 @@ import dotty.tools.dotc.config.Settings.Setting._
 
 import sys.process._
 
-class ScriptingDriver(compilerArgs: Array[String], scriptFile: File, scriptArgs: Array[String]) extends Driver:
+class ScriptingDriver(compilerArgs: Array[String], scriptFile: File, scriptArgs: Array[String]) extends Driver with
   def compileAndRun(): Unit =
     val outDir = Files.createTempDirectory("scala3-scripting")
     val (toCompile, rootCtx) = setup(compilerArgs :+ scriptFile.getAbsolutePath, initCtx.fresh)

--- a/compiler/test/dotty/tools/AnnotationsTests.scala
+++ b/compiler/test/dotty/tools/AnnotationsTests.scala
@@ -14,7 +14,7 @@ import dotc.core.Symbols._
 import java.io.File
 import java.nio.file._
 
-class AnnotationsTest:
+class AnnotationsTest with
 
   @Test def annotTreeNotErased: Unit =
     withJavaCompiled(

--- a/compiler/test/dotty/tools/SignatureTest.scala
+++ b/compiler/test/dotty/tools/SignatureTest.scala
@@ -14,7 +14,7 @@ import dotc.core.Symbols._
 import java.io.File
 import java.nio.file._
 
-class SignatureTest:
+class SignatureTest with
   @Test def signatureCaching: Unit =
     inCompilerContext(TestConfiguration.basicClasspath, separateRun = true, "case class Foo(value: Unit)") {
       val (ref, refSig) = atPhase(erasurePhase.next) {

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -411,7 +411,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
   }
 
   @Test def i6375 = {
-    val source = """class Test:
+    val source = """class Test with
                    |  given Int = 0
                    |  def f(): Int ?=> Boolean = true : (Int ?=> Boolean)
                    |  transparent inline def g(): Int ?=> Boolean = true
@@ -440,7 +440,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
   }
 
   @Test def i6800a = {
-    val source = """class Foo:
+    val source = """class Foo with
                    |  inline def inlined(f: => Unit): Unit = f
                    |  def test: Unit = inlined { println("") }
                  """.stripMargin
@@ -459,7 +459,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
   }
 
   @Test def i6800b = {
-    val source = """class Foo:
+    val source = """class Foo with
                    |  inline def printIfZero(x: Int): Unit = inline x match
                    |    case 0 => println("zero")
                    |    case _ => ()
@@ -485,7 +485,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
 
   @Test def i9246 = {
-    val source = """class Foo:
+    val source = """class Foo with
                    |  inline def check(v:Double): Unit = if(v==0) throw new Exception()
                    |  inline def divide(v: Double, d: Double): Double = { check(d); v / d }
                    |  def test =  divide(10,2)
@@ -504,7 +504,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
   }
 
   @Test def finalVals = {
-    val source = """class Test:
+    val source = """class Test with
                    |  final val a = 1 // should be inlined but not erased
                    |  inline val b = 2 // should be inlined and erased
                    |  def test: Int = a + b
@@ -527,7 +527,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
 
 
   @Test def i9466 = {
-    val source = """class Test:
+    val source = """class Test with
                    |  inline def i(inline f: Int => Boolean): String =
                    |   if f(34) then "a"
                    |   else "b"
@@ -553,7 +553,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
   }
 
   @Test def beta_reduce_under_block = {
-    val source = """class Test:
+    val source = """class Test with
                    |  def test =
                    |    {
                    |      val a = 3

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -41,7 +41,7 @@ class SettingsTests {
     assertEquals(1, reporter.errorCount)
 
   @Test def acceptUnconstrained: Unit =
-    object Settings extends SettingGroup:
+    object Settings extends SettingGroup with
       val foo = StringSetting("-foo", "foo", "Foo", "a")
       val bar = IntSetting("-bar", "Bar", 0)
 
@@ -54,7 +54,7 @@ class SettingsTests {
     }
 
   @Test def validateChoices: Unit =
-    object Settings extends SettingGroup:
+    object Settings extends SettingGroup with
       val foo = ChoiceSetting("-foo", "foo", "Foo", List("a", "b"), "a")
       val bar = IntChoiceSetting("-bar", "Bar", List(0, 1, 2), 0)
       val baz = IntChoiceSetting("-baz", "Baz", 0 to 10, 10)

--- a/compiler/test/dotty/tools/dotc/config/CommandLineParserTest.scala
+++ b/compiler/test/dotty/tools/dotc/config/CommandLineParserTest.scala
@@ -4,7 +4,7 @@ package dotty.tools.dotc.config
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
-class CommandLineParserTest:
+class CommandLineParserTest with
   import CommandLineParser.{tokenize, ParseException}
 
   private def check(tokens: String*)(input: String): Unit = assertEquals(tokens, tokenize(input))

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -7,10 +7,10 @@ import Settings._
 import org.junit.Test
 import org.junit.Assert._
 
-class ScalaSettingsTests:
+class ScalaSettingsTests with
 
   @Test def `A setting with aliases is accepted`: Unit =
-    class MySettings extends SettingGroup:
+    class MySettings extends SettingGroup with
       val classpath: Setting[String] = PathSetting("-classpath", "Specify where to find user class files.", ".", aliases = List("--class-path", "-cp"))
     val settings = MySettings()
     val args = tokenize("-cp path/to/classes1:other/path/to/classes2")
@@ -23,7 +23,7 @@ class ScalaSettingsTests:
     assertTrue("wrong classpath", classpath == "path/to/classes1:other/path/to/classes2")
 
   @Test def `A multistring setting is multivalued`: Unit =
-    class SUT extends SettingGroup:
+    class SUT extends SettingGroup with
       val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.")
     val sut  = SUT()
     val args = tokenize("-language:implicitConversions,dynamics")
@@ -37,7 +37,7 @@ class ScalaSettingsTests:
     assertTrue("Has the feature", set.contains("dynamics"))
 
   @Test def `t9719 Apply -language more than once`: Unit =
-    class SUT extends SettingGroup:
+    class SUT extends SettingGroup with
       val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.")
     val sut  = SUT()
     val args = tokenize("-language:implicitConversions -language:dynamics")
@@ -51,7 +51,7 @@ class ScalaSettingsTests:
     assertTrue("Has the feature", set.contains("dynamics"))
 
   @Test def `Warn if multistring element is supplied multiply`: Unit =
-    class SUT extends SettingGroup:
+    class SUT extends SettingGroup with
       val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.")
     val sut  = SUT()
     val args = tokenize("-language:dynamics -language:implicitConversions -language:dynamics")

--- a/compiler/test/dotty/tools/dotc/semanticdb/SemanticdbTests.scala
+++ b/compiler/test/dotty/tools/dotc/semanticdb/SemanticdbTests.scala
@@ -26,7 +26,7 @@ import dotty.tools.dotc.util.SourceFile
   SemanticdbTests().runExpectTest(updateExpectFiles = true)
 
 @Category(Array(classOf[BootstrappedOnlyTests]))
-class SemanticdbTests:
+class SemanticdbTests with
   val javaFile = FileSystems.getDefault.getPathMatcher("glob:**.java")
   val scalaFile = FileSystems.getDefault.getPathMatcher("glob:**.scala")
   val expectFile = FileSystems.getDefault.getPathMatcher("glob:**.expect.scala")
@@ -124,7 +124,7 @@ class SemanticdbTests:
 
 end SemanticdbTests
 
-object SemanticdbTests:
+object SemanticdbTests with
   /** Prettyprint a text document with symbol occurrences next to each resolved identifier.
    *
    * Useful for testing purposes to ensure that SymbolOccurrence values make sense and are correct.

--- a/compiler/test/dotty/tools/dotc/util/StackTraceTest.scala
+++ b/compiler/test/dotty/tools/dotc/util/StackTraceTest.scala
@@ -7,7 +7,7 @@ import scala.util.chaining.given
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
-class StackTraceTest:
+class StackTraceTest with
   val CausedBy   = "Caused by: "
   val Suppressed = "Suppressed: "
 

--- a/compiler/test/dotty/tools/scripting/ScriptingTests.scala
+++ b/compiler/test/dotty/tools/scripting/ScriptingTests.scala
@@ -10,7 +10,7 @@ import vulpix.TestConfiguration
 
 
 /** Runs all tests contained in `compiler/test-resources/repl/` */
-class ScriptingTests:
+class ScriptingTests with
   extension (str: String) def dropExtension =
     str.reverse.dropWhile(_ != '.').drop(1).reverse
 

--- a/library/src/scala/Conversion.scala
+++ b/library/src/scala/Conversion.scala
@@ -19,5 +19,5 @@ package scala
 *  from two to one.
 */
 @java.lang.FunctionalInterface
-abstract class Conversion[-T, +U] extends Function1[T, U]:
+abstract class Conversion[-T, +U] extends Function1[T, U] with
   def apply(x: T): U

--- a/library/src/scala/Selectable.scala
+++ b/library/src/scala/Selectable.scala
@@ -23,7 +23,7 @@ package scala
  */
 trait Selectable extends Any
 
-object Selectable:
+object Selectable with
   /* Scala 2 compat + allowing for cross-compilation:
    * enable scala.reflect.Selectable.reflectiveSelectable when there is an
    * import scala.language.reflectiveCalls in scope.

--- a/library/src/scala/compiletime/ops/any.scala
+++ b/library/src/scala/compiletime/ops/any.scala
@@ -1,7 +1,7 @@
 package scala.compiletime
 package ops
 
-object any:
+object any with
   /** Equality comparison of two singleton types.
    * ```scala
    * val eq1: 1 == 1 = true

--- a/library/src/scala/compiletime/ops/boolean.scala
+++ b/library/src/scala/compiletime/ops/boolean.scala
@@ -1,7 +1,7 @@
 package scala.compiletime
 package ops
 
-object boolean:
+object boolean with
 
   /** Negation of a `Boolean` singleton type.
    *  ```scala

--- a/library/src/scala/compiletime/ops/int.scala
+++ b/library/src/scala/compiletime/ops/int.scala
@@ -1,7 +1,7 @@
 package scala.compiletime
 package ops
 
-object int:
+object int with
   /** Addition of two `Int` singleton types.
    *  ```scala
    *  val sum: 2 + 2 = 4

--- a/library/src/scala/compiletime/ops/string.scala
+++ b/library/src/scala/compiletime/ops/string.scala
@@ -1,7 +1,7 @@
 package scala.compiletime
 package ops
 
-object string:
+object string with
   /** Concatenation of two `String` singleton types.
    *  ```scala
    *  val hello: "hello " + "world" = "hello world"

--- a/library/src/scala/compiletime/testing/ErrorKind.scala
+++ b/library/src/scala/compiletime/testing/ErrorKind.scala
@@ -3,6 +3,6 @@ package scala.compiletime.testing
 /** An error can be either a parse-time or a typecheck-time */
 sealed trait ErrorKind // This should be an enum but currently, Dotty lib fails to
                        // compile with an obscure error.
-object ErrorKind:
+object ErrorKind with
   case object Parser extends ErrorKind
   case object Typer extends ErrorKind

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -1,6 +1,6 @@
 package scala.quoted
 
-trait ExprMap:
+trait ExprMap with
 
   /** Map an expression `e` with a type `T` */
   def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T]

--- a/library/src/scala/quoted/Exprs.scala
+++ b/library/src/scala/quoted/Exprs.scala
@@ -1,6 +1,6 @@
 package scala.quoted
 
-object Exprs:
+object Exprs with
 
   /** Matches literal sequence of literal constant value expressions and return a sequence of values.
    *

--- a/library/src/scala/quoted/Type.scala
+++ b/library/src/scala/quoted/Type.scala
@@ -3,13 +3,13 @@ package scala.quoted
 import scala.annotation.compileTimeOnly
 
 /** Type (or type constructor) `T` needed contextually when using `T` in a quoted expression `'{... T ...}` */
-abstract class Type[T <: AnyKind] private[scala]:
+abstract class Type[T <: AnyKind] private[scala] with
   /** The type represented `Type` */
   type Underlying = T
 end Type
 
 /** Methods to interact with the current `Type[T]` in scope */
-object Type:
+object Type with
 
   /** Show a source code like representation of this type without syntax highlight */
   def show[T <: AnyKind](using Type[T])(using Quotes): String =

--- a/library/src/scala/quoted/runtime/Expr.scala
+++ b/library/src/scala/quoted/runtime/Expr.scala
@@ -4,7 +4,7 @@ package runtime
 import scala.annotation.{Annotation, compileTimeOnly}
 
 @compileTimeOnly("Illegal reference to `scala.quoted.runtime.Expr`")
-object Expr:
+object Expr with
 
   /** A term quote is desugared by the compiler into a call to this method
    *

--- a/library/src/scala/quoted/runtime/QuoteMatching.scala
+++ b/library/src/scala/quoted/runtime/QuoteMatching.scala
@@ -3,7 +3,7 @@ package scala.quoted.runtime
 import scala.quoted.{Expr, Type}
 
 /** Part of the Quotes interface that needs to be implemented by the compiler but is not visible to users */
-trait QuoteMatching:
+trait QuoteMatching with
 
   val ExprMatch: ExprMatchModule
 

--- a/library/src/scala/quoted/runtime/QuoteUnpickler.scala
+++ b/library/src/scala/quoted/runtime/QuoteUnpickler.scala
@@ -3,7 +3,7 @@ package scala.quoted.runtime
 import scala.quoted.{Quotes, Expr, Type}
 
 /** Part of the Quotes interface that needs to be implemented by the compiler but is not visible to users */
-trait QuoteUnpickler:
+trait QuoteUnpickler with
 
   /** Unpickle `repr` which represents a pickled `Expr` tree,
    *  replacing splice nodes with `holes`

--- a/library/src/scala/reflect/Enum.scala
+++ b/library/src/scala/reflect/Enum.scala
@@ -1,7 +1,7 @@
 package scala.reflect
 
 /** A base trait of all Scala enum definitions */
-@annotation.transparentTrait trait Enum extends Any, Product, Serializable:
+@annotation.transparentTrait trait Enum extends Any, Product, Serializable with
 
   /** A number uniquely identifying a case of an enum */
   def ordinal: Int

--- a/library/src/scala/reflect/Selectable.scala
+++ b/library/src/scala/reflect/Selectable.scala
@@ -8,7 +8,7 @@ package scala.reflect
  *  In Scala.js, it is implemented using a separate Scala.js-specific
  *  mechanism, since Java reflection is not available.
  */
-trait Selectable extends scala.Selectable:
+trait Selectable extends scala.Selectable with
 
   /** The value from which structural members are selected.
    *  By default this is the Selectable instance itself, but it can
@@ -39,7 +39,7 @@ trait Selectable extends scala.Selectable:
     ensureAccessible(mth)
     mth.invoke(selectedValue, args.asInstanceOf[Seq[AnyRef]]: _*)
 
-object Selectable:
+object Selectable with
 
   /** An implicit conversion that turns a value into a Selectable
    *  such that structural selections are performed on that value.

--- a/library/src/scala/reflect/TypeTest.scala
+++ b/library/src/scala/reflect/TypeTest.scala
@@ -10,7 +10,7 @@ package scala.reflect
  *  then a given instance of `TypeTest[S, T]` is summoned and used to perform the test.
  */
 @scala.annotation.implicitNotFound(msg = "No TypeTest available for [${S}, ${T}]")
-trait TypeTest[-S, T] extends Serializable:
+trait TypeTest[-S, T] extends Serializable with
 
   /** A TypeTest[S, T] can serve as an extractor that matches only S of type T.
    *
@@ -22,7 +22,7 @@ trait TypeTest[-S, T] extends Serializable:
    */
   def unapply(x: S): Option[x.type & T]
 
-object TypeTest:
+object TypeTest with
 
   /** Trivial type test that always succeeds */
   def identity[T]: TypeTest[T, T] = Some(_)

--- a/library/src/scala/runtime/EnumValue.scala
+++ b/library/src/scala/runtime/EnumValue.scala
@@ -1,6 +1,6 @@
 package scala.runtime
 
-@annotation.transparentTrait trait EnumValue extends Product, Serializable:
+@annotation.transparentTrait trait EnumValue extends Product, Serializable with
   override def canEqual(that: Any) = this eq that.asInstanceOf[AnyRef]
   override def productArity: Int = 0
   override def productElement(n: Int): Any =

--- a/library/src/scala/runtime/Scala3RunTime.scala
+++ b/library/src/scala/runtime/Scala3RunTime.scala
@@ -1,6 +1,6 @@
 package scala.runtime
 
-object Scala3RunTime:
+object Scala3RunTime with
 
   // Called by inline def assert's. Extracted to minimize the bytecode size at call site.
 

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -1,6 +1,6 @@
 package scala.runtime.stdLibPatches
 
-object Predef:
+object Predef with
   import compiletime.summonFrom
 
   inline def assert(inline assertion: Boolean, inline message: => Any): Unit =

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -2,7 +2,7 @@ package scala.runtime.stdLibPatches
 
 /** Scala 3 additions and replacements to the `scala.language` object.
  */
-object language:
+object language with
 
   /** The experimental object contains features that have been recently added but have not
    *  been thoroughly tested in production yet.
@@ -16,7 +16,7 @@ object language:
    *
    *  @group experimental
    */
-  object experimental:
+  object experimental with
 
     /* Experimental support for richer dependent types (disabled for now)
      * One can still run the compiler with support for parsing singleton applications

--- a/stdlib-bootstrapped/test/Main.scala
+++ b/stdlib-bootstrapped/test/Main.scala
@@ -1,6 +1,6 @@
 package hello
 
-enum Color:
+enum Color with
   case Red, Green, Blue
 
 object HelloWorld with

--- a/tests/pos/i11015.scala
+++ b/tests/pos/i11015.scala
@@ -1,5 +1,5 @@
 import annotation.targetName
-object Foo:
+object Foo with
    def apply[A <: Int]: Int = 0
    @targetName("applyS") def apply[B <: String]: String = "0"
 

--- a/tests/pos/i11141.scala
+++ b/tests/pos/i11141.scala
@@ -1,5 +1,5 @@
 package p
 export X._
 
-object X:
+object X with
   val A = 42

--- a/tests/pos/i11175.scala
+++ b/tests/pos/i11175.scala
@@ -1,6 +1,6 @@
 package x
 
-trait Printer[T]:
+trait Printer[T] with
   def print(t:T):String
 
 extension[T](t:T)(using Printer[T])

--- a/tests/pos/t5856b.scala
+++ b/tests/pos/t5856b.scala
@@ -1,3 +1,3 @@
-class Test:
+class Test with
   def test = f("a" == s"a")
   inline def f(inline b: Boolean): Boolean = !b


### PR DESCRIPTION
Change to `with` after class, object, enum, trait. That way we get to use the new syntax for a bit before settling on it for good.
