### PR TITLE
Fix trace command for `effect.asSeenFrom`

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Effects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Effects.scala
@@ -61,7 +61,7 @@ object Effects {
   extension (eff: Effect) def toEffs: Effects = Effects.empty + eff
 
   def asSeenFrom(eff: Effect, thisValue: Potential)(implicit env: Env): Effect =
-    trace(eff.show + " asSeenFrom " + thisValue.show + ", current = " + currentClass.show, init, effs => show(effs.asInstanceOf[Effects])) { eff match {
+    trace(eff.show + " asSeenFrom " + thisValue.show + ", current = " + currentClass.show, init, eff => show(Effects.empty + eff.asInstanceOf[Effect])) { eff match {
       case Promote(pot) =>
         val pot1 = Potentials.asSeenFrom(pot, thisValue)
         Promote(pot1)(eff.source)


### PR DESCRIPTION
<!-- 
  TODO first sign the CLA 
  https://www.lightbend.com/contribute/cla/scala
-->

Fix the `trace` callback in `Effect.asSeenFrom`. Previously the callback was called as if it is expecting an `Effects` object (not `Effect`), causing it to crash from the downcast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lampepfl/dotty/11200)
<!-- Reviewable:end -->
