### PR TITLE
Handle adaptation of a method with implicit followed by type parameter

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3697,7 +3697,7 @@ class Typer extends Namer
             case pt: FunProto =>
               if tree.symbol.isAllOf(ApplyProxyFlags) then newExpr
               else adaptToArgs(wtp, pt)
-            case pt: PolyProto =>
+            case pt: PolyProto if !wtp.isImplicitMethod =>
               tryInsertApplyOrImplicit(tree, pt, locked)(tree) // error will be reported in typedTypeApply
             case _ =>
               if (ctx.mode is Mode.Type) adaptType(tree.tpe)

--- a/tests/pos/i11168.scala
+++ b/tests/pos/i11168.scala
@@ -1,0 +1,29 @@
+trait Foo
+given foo: Foo with {}
+
+extension (using Foo)(x: Any)
+  def foo1[A] = ???
+
+extension (x: Any)(using Foo)
+  def foo2[A] = ???
+
+implicit class LeadingFooOps(using Foo)(x: Any) {
+  def foo3[A] = ???
+}
+
+implicit class TrailingFooOps(x: Any)(using Foo) {
+  def foo4[A] = ???
+}
+
+def a1 = "".foo1[Any]
+def a2: Any = "".foo2[Any]
+def a3 = "".foo3[Any]
+def a4 = "".foo4[Any]
+
+def b2 = "".foo2(using foo)[Any]
+
+def c1 = foo1("")[Any]
+def c2 = foo2("")[Any]
+
+def d1 = foo1(using foo)("")[Any]
+def d2 = foo2("")(using foo)[Any]


### PR DESCRIPTION
Handle adaptation of a method that takes a using clause and then a type parameter.
When passing a type argument, we have to first insert an implicit argument for
the using clause.

Fixes #11168