### PR TITLE
issue templates: better version prompt

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -9,10 +9,8 @@ assignees: ''
 
 ## Compiler version
 
-``` bash
-# get compiler version via command line
-scalac -version
-```
+If you're not sure what version you're using, run `print scalaVersion` from sbt
+(if you're running scalac manually, use `scalac -version` instead).
 
 ## Minimized code
 

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -9,10 +9,8 @@ assignees: ''
 
 ## Compiler version
 
-``` bash
-# get compiler version via command line
-scalac -version
-```
+If you're not sure what version you're using, run `print scalaVersion` from sbt
+(if you're running scalac manually, use `scalac -version` instead).
 
 ## Minimized code
 

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -8,10 +8,8 @@ assignees: ''
 
 ## Compiler version
 
-``` bash
-# get compiler version via command line
-scalac -version
-```
+If you're not sure what version you're using, run `print scalaVersion` from sbt
+(if you're running scalac manually, use `scalac -version` instead).
 
 ## Minimized example
 


### PR DESCRIPTION
Almost no one uses `scalac` by hand, so it's not a good way to get the
current compiler version (example:
https://github.com/lampepfl/dotty/issues/11211), give the sbt command
instead.