### PR TITLE
Change error message when enumeration type param is invariant

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -74,7 +74,7 @@ object DesugarEnums {
         tparam.info.bounds.hi
       else {
         def problem =
-          if (!tparam.isOneOf(VarianceFlags)) "is non variant"
+          if (!tparam.isOneOf(VarianceFlags)) "is invariant"
           else "has bounds that depend on a type parameter in the same parameter list"
         errorType(i"""cannot determine type argument for enum parent $enumClass,
                      |type parameter $tparam $problem""", ctx.source.atSpan(span))


### PR DESCRIPTION
Minor thing I noticed when working with enumerations:

```scala
scala> enum Lst[A]:
     |   case Nil
     |   case Cons(head: A, tail: Lst[A])
     |
2 |  case Nil
  |  ^^^^^^^^
  |  cannot determine type argument for enum parent class Lst,
  |  type parameter type A is non variant
```

This is the only occurrence of "non variant" in any compiler error messages. PR changes this to "invariant".