### PR TITLE
Fix #11234: Avoid cycles in unifying F-bounded type parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -393,7 +393,9 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     order(this, param1, param2).checkNonCyclic()
 
   def unify(p1: TypeParamRef, p2: TypeParamRef)(using Context): This =
-    val p1Bounds = (nonParamBounds(p1) & nonParamBounds(p2)).substParam(p2, p1)
+    val bound1 = nonParamBounds(p1).substParam(p2, p1)
+    val bound2 = nonParamBounds(p2).substParam(p2, p1)
+    val p1Bounds = bound1 & bound2
     updateEntry(p1, p1Bounds).replace(p2, p1)
 
 // ---------- Replacements and Removals -------------------------------------

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -3,7 +3,7 @@ package dotc
 package core
 
 import Contexts._, Types._, Symbols._, Names._, Flags._
-import Denotations._, SymDenotations._
+import SymDenotations._
 import util.Spans._
 import util.Stats
 import NameKinds.DepParamName

--- a/tests/pos/i11234.scala
+++ b/tests/pos/i11234.scala
@@ -1,0 +1,19 @@
+trait Foo[A <: Foo[A]]
+trait FooCreator[A <: Foo[A]] {
+  def createFoo(): A
+}
+
+trait FooWrapper {
+  type A <: Foo[A]
+  def foo: A
+}
+
+object FooWrapper {
+  def apply[A0 <: Foo[A0]](toWrap: A0): FooWrapper { type A = A0 } = new FooWrapper {
+    type A = A0
+    def foo: A0 = toWrap
+  }
+}
+
+def error(fooWrapper: FooWrapper, processor: [A <: Foo[A]] => A => A): FooWrapper =
+  FooWrapper(processor(fooWrapper.foo))


### PR DESCRIPTION
Fix #11234 

In tests/pos/11234.scala, we have the following F-bounded constraints:

    bounds =
	A0 <: Foo[LazyRef(A0)]
	A <: Foo[LazyRef(A)]
    ordering =
	A <: A0

As `Foo[T]` is non-variant, at some point we will add `A0 <: A`, it
will trigger unification of `A0` and `A`. The unification will call
`Foo[A0].&(Foo[A])`, which in turn calls `TypeComparer.glb(Foo[A0],
Foo[A])`.  The call `glb(Foo[A0], Foo[A])` in a fresh TypeComparer
will in turn add `A0 <: A` thus trigger the unification again.

We need to perform substitution before merging the bounds.