### PR TITLE
Improve variable instantiation when member is missing

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -32,6 +32,7 @@ i7868.scala
 i7872.scala
 6709.scala
 6687.scala
+i11236.scala
 
 # Opaque type
 i5720.scala

--- a/tests/pos/i11236.scala
+++ b/tests/pos/i11236.scala
@@ -1,0 +1,22 @@
+class Test {
+  val tup: Char #: Int #: String #: TupleK = ???
+  val x: String #: TupleK = (tup.tail: Int #: String #: TupleK).tail
+  val a = tup.tail
+  val b = a.tail
+  val y: String #: TupleK = tup.tail.tail
+  val z: Unit = tup.tail.tail
+}
+
+trait TupleK
+
+object TupleK {
+  type Tail[X <: NonEmptyTupleK] <: TupleK = X match {
+    case _ #: xs => xs
+  }
+}
+
+trait NonEmptyTupleK extends TupleK {
+  /*inline*/ def tail[This >: this.type <: NonEmptyTupleK]: TupleK.Tail[This] = ???
+}
+
+abstract class #:[+H, +T <: TupleK] extends NonEmptyTupleK

--- a/tests/pos/i9567.scala
+++ b/tests/pos/i9567.scala
@@ -2,8 +2,11 @@
 //   val x: Int => Int = identity
 // }
 
-trait Foo[F[_]] {
+trait Foo[F[_], I[X] <: X] {
+  type Id[X] <: X
   def foo[G[x] >: F[x]]: G[Unit]
+  def foo2[X >: F[String]]: Id[X]
+  def foo3[X >: F[String]]: I[X]
 }
 
 trait M[A] {
@@ -12,11 +15,10 @@ trait M[A] {
 }
 
 object Test {
-  def bar(x: Foo[M]): Unit = {
-    // error: value bla is not a member of G[Unit], where:    G is a type variable with constraint >: M and <: [x] =>> Any
+  def bar(x: Foo[M, [X] =>> X]): Unit = {
     x.foo.bla
-
-    // error: value bla is not a member of G[Unit], where:    G is a type variable with constraint >: M and <: [x] =>> Any
     x.foo.baz(x => x)
+    x.foo2.bla
+    x.foo3.bla
   }
 }


### PR DESCRIPTION
The `couldInstantiateTypeVar` method instantiated only type variables
that were the constructor of an applied type. But sometimes we
might also need to instantiate the argument(s), since doing so can
influence the members of the applied type. This happens in two cases

 1. The applied type's rhs is a match type
 2. The applied type's result is one of its type parameters

i11236.scala tests the first case, the additions to i9567.scala the second.

Fixes #11236