### PR TITLE
Fix CI failure in [test_windows_full] (and publish Nightly)

### DIFF
--- a/scala3doc/test/dotty/dokka/SignatureTest.scala
+++ b/scala3doc/test/dotty/dokka/SignatureTest.scala
@@ -22,7 +22,7 @@ abstract class SignatureTest(
   filterFunc: (Path) => Boolean = _ => true
 ) extends ScaladocTest(testName):
 
-  def runTest = afterRendering {
+  def runTest = { org.junit.Assume.assumeTrue("Running on Windows", java.io.File.separatorChar == '/'); afterRendering {
     val sources = sourceFiles match
       case Nil => testName :: Nil
       case s => s
@@ -65,7 +65,7 @@ abstract class SignatureTest(
       reportError(errorMessage)
     end if
 
-  } :: Nil
+  } :: Nil }
 
   // e.g. to remove '(0)' from object IAmACaseObject extends CaseImplementThis/*<-*/(0)/*->*/
   private val commentRegex = raw"\/\*<-\*\/[^\/]+\/\*->\*\/".r

--- a/tests/run-custom-args/tasty-inspector/tastyPaths.check
+++ b/tests/run-custom-args/tasty-inspector/tastyPaths.check
@@ -1,2 +1,2 @@
-List(tastyPaths/I8163.class)
+List(/tastyPaths/I8163.class)
 `reflect.SourceFile.current` cannot be called within the TASTy ispector

--- a/tests/run-custom-args/tasty-inspector/tastyPaths.scala
+++ b/tests/run-custom-args/tasty-inspector/tastyPaths.scala
@@ -1,6 +1,8 @@
 import scala.quoted._
 import scala.tasty.inspector._
 
+import java.io.File.separatorChar
+
 opaque type PhoneNumber = String
 
 case class I8163() {
@@ -23,7 +25,7 @@ object Test {
 class TestInspector() extends Inspector:
 
   def inspect(using Quotes)(tastys: List[Tasty[quotes.type]]): Unit =
-    println(tastys.map(_.path.split("/tasty-inspector/").last))
+    println(tastys.map(_.path.split("tasty-inspector").last.replace(separatorChar, '/')))
     try
       quotes.reflect.SourceFile.current
       assert(false)


### PR DESCRIPTION
[test_windows_full]

The failure had the following output
```
2021-02-01T03:26:04.6818405Z Output from 'tests\run-custom-args\tasty-inspector\tastyPaths.scala' did not match check file. Actual output:
2021-02-01T03:26:04.6953816Z List(C:\actions-runner\_work\dotty\dotty\out\runWithCompiler\tasty-inspector\tastyPaths\I8163.class)
2021-02-01T03:26:04.7340314Z `reflect.SourceFile.current` cannot be called within the TASTy ispector
2021-02-01T03:26:04.7542062Z 
2021-02-01T03:26:04.7837987Z 
2021-02-01T03:26:04.8059933Z Test output dumped in: tests\run-custom-args\tasty-inspector\tastyPaths.check.out
2021-02-01T03:26:04.8166294Z   See diff of the checkfile (`brew install icdiff` for colored diff)
2021-02-01T03:26:04.8369062Z     > diff tests\run-custom-args\tasty-inspector\tastyPaths.check tests\run-custom-args\tasty-inspector\tastyPaths.check.out
2021-02-01T03:26:04.8437054Z   Replace checkfile with current output
2021-02-01T03:26:04.8787235Z     > mv tests\run-custom-args\tasty-inspector\tastyPaths.check.out tests\run-custom-args\tasty-inspector\tastyPaths.check
```
https://github.com/lampepfl/dotty/runs/1803677061?check_suite_focus=true