### PR TITLE
Use all available context info for healing ambiguous implicits

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1652,6 +1652,11 @@ object Types {
      */
     def deepenProto(using Context): Type = this
 
+    /** If this is a prototype with some ignored component, reveal it, and
+     *  deepen the result transitively. Otherwise the type itself.
+     */
+    def deepenProtoTrans(using Context): Type = this
+
     /** If this is an ignored proto type, its underlying type, otherwise the type itself */
     def revealIgnored: Type = this
 
@@ -3436,7 +3441,7 @@ object Types {
           case tp: TermRef => applyPrefix(tp)
           case tp: AppliedType => tp.fold(status, compute(_, _, theAcc))
           case tp: TypeVar if !tp.isInstantiated => combine(status, Provisional)
-          case TermParamRef(`thisLambdaType`, _) => TrueDeps
+          case tp: TermParamRef if tp.binder eq thisLambdaType => TrueDeps
           case _: ThisType | _: BoundType | NoPrefix => status
           case _ =>
             (if theAcc != null then theAcc else DepAcc()).foldOver(status, tp)

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -12,7 +12,6 @@ import Implicits.RenamedImplicitRef
 import config.SourceVersion
 import StdNames.nme
 import printing.Texts.Text
-import ProtoTypes.NoViewsAllowed.normalizedCompatible
 import NameKinds.QualifiedName
 import Decorators._
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3183,10 +3183,7 @@ class Typer extends Namer
             arg.tpe match
               case failed: AmbiguousImplicits =>
                 val pt1 = pt.deepenProtoTrans
-                if (pt1 `ne` pt) && (pt1 ne sharpenedPt)
-                   && withMode(Mode.ConstrainResultDeep)(
-                        constrainResult(tree.symbol, wtp, pt1)
-                      )
+                if (pt1 `ne` pt) && (pt1 ne sharpenedPt) && constrainResult(tree.symbol, wtp, pt1)
                 then implicitArgs(formals, argIndex, pt1)
                 else arg :: implicitArgs(formals1, argIndex + 1, pt1)
               case failed: SearchFailureType =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3182,9 +3182,11 @@ class Typer extends Namer
             val arg = inferImplicitArg(formal, tree.span.endPos)
             arg.tpe match
               case failed: AmbiguousImplicits =>
-                val pt1 = pt.deepenProto
+                val pt1 = pt.deepenProtoTrans
                 if (pt1 `ne` pt) && (pt1 ne sharpenedPt)
-                   && constrainResult(tree.symbol, wtp, pt1)
+                   && withMode(Mode.ConstrainResultDeep)(
+                        constrainResult(tree.symbol, wtp, pt1)
+                      )
                 then implicitArgs(formals, argIndex, pt1)
                 else arg :: implicitArgs(formals1, argIndex + 1, pt1)
               case failed: SearchFailureType =>

--- a/tests/neg/i6391.scala
+++ b/tests/neg/i6391.scala
@@ -1,4 +1,4 @@
 object Test {
   def foo(x: String, y: x.type): Any = ???
-  val f = foo  // error // error: cannot convert to closure
+  val f = foo  // error
 }

--- a/tests/pos/i11243.scala
+++ b/tests/pos/i11243.scala
@@ -1,0 +1,127 @@
+object WriterTest extends App {
+
+  object Functor:
+    def apply[F[_]](using f: Functor[F]) = f
+
+  trait Functor[F[_]]:
+    extension [A, B](x: F[A])
+      def map(f: A => B): F[B]
+
+  object Applicative:
+    def apply[F[_]](using a: Applicative[F]) = a
+
+  trait Applicative[F[_]] extends Functor[F]:
+    def pure[A](x:A):F[A]
+
+    extension [A,B](x: F[A])
+      def ap(f: F[A => B]): F[B]
+
+      def map(f: A => B): F[B] = {
+        x.ap(pure(f))
+      }
+
+    extension [A,B,C](fa: F[A]) def map2(fb: F[B])(f: (A,B) => C): F[C] = {
+      val fab: F[B => C] = fa.map((a: A) => (b: B) => f(a,b))
+      fb.ap(fab)
+    }
+
+  end Applicative
+
+
+  object Monad:
+    def apply[F[_]](using m: Monad[F]) = m
+
+  trait Monad[F[_]] extends Applicative[F]:
+
+    // The unit value for a monad
+    def pure[A](x:A):F[A]
+
+    extension[A,B](fa :F[A])
+      // The fundamental composition operation
+        def flatMap(f :A=>F[B]):F[B]
+
+        // Monad can also implement `ap` in terms of `map` and `flatMap`
+        def ap(fab: F[A => B]): F[B] = {
+          fab.flatMap {
+            f =>
+              fa.flatMap {
+                a =>
+                  pure(f(a))
+              }
+          }
+
+        }
+
+  end Monad
+
+  given eitherMonad[Err]: Monad[[X] =>> Either[Err,X]] with
+    def pure[A](a: A): Either[Err, A] = Right(a)
+    extension [A,B](x: Either[Err,A]) def flatMap(f: A => Either[Err, B]) = {
+      x match {
+        case Right(a) => f(a)
+        case Left(err) => Left(err)
+      }
+    }
+
+  given optionMonad: Monad[Option] with
+    def pure[A](a: A) = Some(a)
+    extension[A,B](fa: Option[A])
+      def flatMap(f: A => Option[B]) = {
+        fa match {
+          case Some(a) =>
+            f(a)
+          case None =>
+            None
+        }
+      }
+
+  given listMonad: Monad[List] with
+    def pure[A](a: A): List[A] = List(a)
+
+    extension[A,B](x: List[A])
+      def flatMap(f: A => List[B]): List[B] = {
+        x match {
+          case hd :: tl => f(hd) ++ tl.flatMap(f)
+          case Nil => Nil
+        }
+      }
+
+  case class Transformer[F[_]: Monad,A](val wrapped: F[A])
+
+  given transformerMonad[F[_]: Monad]: Monad[[X] =>> Transformer[F,X]] with {
+
+    def pure[A](a: A): Transformer[F,A] = Transformer(summon[Monad[F]].pure(a))
+
+    extension [A,B](fa: Transformer[F,A])
+      def flatMap(f: A => Transformer[F,B]) = {
+        val ffa: F[B] = Monad[F].flatMap(fa.wrapped) {
+          case a => {
+            f(a).wrapped.map {
+              case b =>
+                b
+            }
+          }
+        }
+        Transformer(ffa)
+      }
+  }
+
+  type EString[A] = Either[String,A]
+
+  def incrementEven(a: Int): Transformer[EString,Int] = {
+    if(a % 2 == 1) Transformer(Left("Odd number provided"))
+    else Transformer(Right(a + 1))
+  }
+
+  def doubleOdd(a: Int): Transformer[EString, Int] = {
+    if(a % 2 == 0) Transformer(Left("Even number provided"))
+    else Transformer(Right(a * 2))
+  }
+
+  val writerExample = incrementEven(8)
+  val example =
+    WriterTest.transformerMonad.flatMap(writerExample)(doubleOdd)
+    //writerExample.flatMap(doubleOdd) // Error ambiguous F
+
+
+}

--- a/tests/pos/i5773b.scala
+++ b/tests/pos/i5773b.scala
@@ -10,7 +10,7 @@ object Semigroup {
 
   implicit def sumSemigroup[N](implicit N: Numeric[N]): Semigroup[N] = new {
     extension (lhs: N) override def append(rhs: N): N = N.plus(lhs, rhs)
-    extension (lhs: Int) def appendS(rhs: N): N = ??? // N.plus(lhs, rhs)
+    extension (lhs: Int) override def appendS(rhs: N): N = ??? // N.plus(lhs, rhs)
   }
 }
 
@@ -18,7 +18,7 @@ object Semigroup {
 object Main {
   import Semigroup.sumSemigroup // this is not sufficient
   def f1 = {
-    println(1 appendS 2) // error This should give the following error message:
+    println(1 appendS 2) // This used to give the following error message:
 /*
 21 |    println(1 appendS 2)
    |            ^^^^^^^^^


### PR DESCRIPTION
When retrying after an ambiguous implicit, we now make use of all the
information in the prototype, including ignored parts. We also try
to match formal parameters with actually given arguments.

Fixes #11243
Fixes #5773, which previously was closed with a more detailed error message.