### PR TITLE
Init: Promote `this` after all its fields have been initialized

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -52,6 +52,7 @@ class Checker extends MiniPhase {
         thisClass = cls,
         fieldsInited = mutable.Set.empty,
         parentsInited = mutable.Set.empty,
+        safePromoted = mutable.Set.empty,
         env = baseEnv.withCtx(ctx.withOwner(cls))
       )
 

--- a/tests/init/neg/inner11.scala
+++ b/tests/init/neg/inner11.scala
@@ -13,6 +13,7 @@ object NameKinds {
     type ThisInfo = Info
     val info: Info = new Info
     println(info.kind)                     // error
+    val n = 10
   }
 }
 

--- a/tests/init/pos/early-promote-simple.scala
+++ b/tests/init/pos/early-promote-simple.scala
@@ -2,3 +2,13 @@ class P() {
     val a = 1
     List(this)
 }
+
+class Outer {
+    class Inner {
+        val b = a
+    }
+    val a = 5
+    val b = new Inner()
+    List(new Inner())
+    List(b)
+}

--- a/tests/init/pos/early-promote-simple.scala
+++ b/tests/init/pos/early-promote-simple.scala
@@ -1,0 +1,4 @@
+class P() {
+    val a = 1
+    List(this)
+}


### PR DESCRIPTION
## Description

The initialization checker will now accept uses of `this` and  `this`-referencing objects as fully-initialized objects ("hot") after all `val` declarations have been evaluated.

Simple example:

```scala
class Obj() {
    val a = 1
    List(this) // Previously fails, now succeeds
}
    
```

A simple test is included.


<!-- 
  TODO first sign the CLA 
  https://www.lightbend.com/contribute/cla/scala
-->


<!-- TODO description of the change --> 


<!-- Ideally should have a single commit -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lampepfl/dotty/11278)
<!-- Reviewable:end -->
