### PR TITLE
Fix Java 8 CI

### DIFF
--- a/scala3doc-testcases/src/tests/deprecated.scala
+++ b/scala3doc-testcases/src/tests/deprecated.scala
@@ -19,5 +19,5 @@ class B extends A:
   val y: Int = 1
 
 
-@java.lang.Deprecated(since = "1.1")
+@java.lang.Deprecated
 class JavaDeprecated


### PR DESCRIPTION
`java.lang.Deprecated` did not have arguments in Java 8. They were added in Java 9.
* https://docs.oracle.com/javase/8/docs/api/java/lang/Deprecated.html
* https://docs.oracle.com/javase/9/docs/api/java/lang/Deprecated.html

[test_java8]
[test_windows_full]