### PR TITLE
Let the info of opaque types always depend on the prefix

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2299,6 +2299,7 @@ object Types {
      */
     private def infoDependsOnPrefix(symd: SymDenotation, prefix: Type)(using Context): Boolean =
       symd.maybeOwner.membersNeedAsSeenFrom(prefix) && !symd.is(NonMember)
+      || prefix.isInstanceOf[Types.ThisType] && symd.is(Opaque) // see pos/i11277.scala for a test where this matters
 
     /** Is this a reference to a class or object member? */
     def isMemberRef(using Context): Boolean = designator match {

--- a/tests/pos/i11277.scala
+++ b/tests/pos/i11277.scala
@@ -1,0 +1,8 @@
+class Foo {
+  opaque type Num = Int
+
+  val z = Test.id(this)(1)
+}
+object Test {
+  def id(f: Foo)(x: f.Num): f.Num = x
+}


### PR DESCRIPTION
Fixes #11277