### PR TITLE
LambdaLift: reload non-sym denotations when needed

### DIFF
--- a/tests/pos/t6231c.scala
+++ b/tests/pos/t6231c.scala
@@ -1,0 +1,9 @@
+object Bug {
+  def bar(ev: Any) = {
+    trait X(val x: Int) {
+      def qux: () => x.type = { () => println(ev); x }
+    }
+    (new X(1) {}).qux()
+  }
+}
+


### PR DESCRIPTION
When we manually insert a SymDenotation with `installAfter`, we need to reload any non-sym SingleDenotation for the same symbol, since they won't automatically become stale. It would be nicer if this was done automatically (in NonSymSingleDenotation#current perhaps?), but that seems complicated.