### PR TITLE
Load .tasty files from in-memory file systems too

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -917,8 +917,13 @@ class ClassfileParser(
               }
             case _ =>
               if (classfile.jpath == null) {
-                report.error("Could not load TASTY from .tasty for virtual file " + classfile)
-                Array.empty
+                val tastyFileOrNull = classfile.container
+                  .lookupName(classfile.name.stripSuffix(".class") + ".tasty", false)
+                if (tastyFileOrNull == null) {
+                  report.error("Could not load TASTY from .tasty for virtual file " + classfile)
+                  Array.empty
+                } else
+                  tastyFileOrNull.toByteArray
               } else {
                 val plainFile = new PlainFile(io.File(classfile.jpath).changeExtension("tasty"))
                 if (plainFile.exists) plainFile.toByteArray

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -916,22 +916,14 @@ class ClassfileParser(
                 Array.empty
               }
             case _ =>
-              if (classfile.jpath == null) {
-                val tastyFileOrNull = classfile.container
-                  .lookupName(classfile.name.stripSuffix(".class") + ".tasty", false)
-                if (tastyFileOrNull == null) {
-                  report.error("Could not load TASTY from .tasty for virtual file " + classfile)
-                  Array.empty
-                } else
-                  tastyFileOrNull.toByteArray
-              } else {
-                val plainFile = new PlainFile(io.File(classfile.jpath).changeExtension("tasty"))
-                if (plainFile.exists) plainFile.toByteArray
-                else {
-                  report.error("Could not find " + plainFile)
-                  Array.empty
-                }
-              }
+              val dir = classfile.container
+              val name = classfile.name.stripSuffix(".class") + ".tasty"
+              val tastyFileOrNull = dir.lookupName(name, false)
+              if (tastyFileOrNull == null) {
+                report.error(s"Could not find TASTY file $name under $dir")
+                Array.empty
+              } else
+                tastyFileOrNull.toByteArray
           }
           if (tastyBytes.nonEmpty) {
             val reader = new TastyReader(bytes, 0, 16)


### PR DESCRIPTION
Related to https://github.com/lihaoyi/Ammonite/pull/1150.

This PR allows to load `*.tasty` files from in-memory file systems (like `dotty.tools.io.VirtualDirectory`-based things) during compilation, rather than requiring them to exist on disk. This would be useful from Ammonite for example, that keeps the compiler output of previous compilation steps in memory.

Not sure if or where I should add tests for that.