### PR TITLE
Fix typo 'Deprectated' -> 'Deprecated'

### DIFF
--- a/scala3doc/src/dotty/renderers/MemberRenderer.scala
+++ b/scala3doc/src/dotty/renderers/MemberRenderer.scala
@@ -197,9 +197,9 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
       val (depInherited, inherited) = allInherited.partition(isDeprecated)
       (
         actualGroup(name, defined),
-        actualGroup(s"Deprectated ${name.toLowerCase}", depDefined),
+        actualGroup(s"Deprecated ${name.toLowerCase}", depDefined),
         actualGroup(s"Inherited ${name.toLowerCase}", inherited),
-        actualGroup(s"Deprectated and Inherited ${name.toLowerCase}", depInherited)
+        actualGroup(s"Deprecated and Inherited ${name.toLowerCase}", depInherited)
       )
     }
 


### PR DESCRIPTION
Mentioned here: https://github.com/scala/docs.scala-lang/issues/1919.