### PR TITLE
Fix #11299: Disallow implicit search on TermRef of Null

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -779,14 +779,15 @@ trait Implicits:
    */
   def inferView(from: Tree, to: Type)(using Context): SearchResult = {
     record("inferView")
+    val wfromtp = from.tpe.widen
     if    to.isAny
        || to.isAnyRef
        || to.isRef(defn.UnitClass)
-       || from.tpe.isRef(defn.NothingClass)
-       || from.tpe.isRef(defn.NullClass)
+       || wfromtp.isRef(defn.NothingClass)
+       || wfromtp.isRef(defn.NullClass)
        || !ctx.mode.is(Mode.ImplicitsEnabled)
        || from.isInstanceOf[Super]
-       || (from.tpe eq NoPrefix)
+       || (wfromtp eq NoPrefix)
     then NoMatchingImplicitsFailure
     else {
       def adjust(to: Type) = to.stripTypeVar.widenExpr match {

--- a/tests/neg/i11299.scala
+++ b/tests/neg/i11299.scala
@@ -1,0 +1,10 @@
+val myNull: Null = null
+
+val n1: Int = null // error
+val n2: Int = myNull // error
+
+val b1: Boolean = null // error
+val b2: Boolean = myNull // error
+
+val v1: AnyVal = null // error
+val v2: AnyVal = myNull // error


### PR DESCRIPTION
Fix #11299 

If `from.tpe` is a TermRef to a Null value, `from.tpe.isRef(defn.NullClass)` is false, which causes implicit search on the tree.