### PR TITLE
Don't use suffix `_` in eta expansion

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -241,9 +241,8 @@ object EtaExpansion extends LiftImpure {
     var ids: List[Tree] = mt.paramNames map (name => Ident(name).withSpan(tree.span.startPos))
     if (mt.paramInfos.nonEmpty && mt.paramInfos.last.isRepeatedParam)
       ids = ids.init :+ repeated(ids.last)
-    val app = Apply(lifted, ids)
-    if (mt.isContextualMethod) app.setApplyKind(ApplyKind.Using)
-    val body = if (isLastApplication) app else PostfixOp(app, Ident(nme.WILDCARD))
+    val body = Apply(lifted, ids)
+    if (mt.isContextualMethod) body.setApplyKind(ApplyKind.Using)
     val fn =
       if (mt.isContextualMethod) new untpd.FunctionWithMods(params, body, Modifiers(Given))
       else if (mt.isImplicitMethod) new untpd.FunctionWithMods(params, body, Modifiers(Implicit))

--- a/tests/pos/i11311.scala
+++ b/tests/pos/i11311.scala
@@ -1,0 +1,4 @@
+object Test:
+
+  def cat1(s1: String)(s2: String) = s1 + s2
+  val fcat1 = cat1

--- a/tests/pos/i11311.scala
+++ b/tests/pos/i11311.scala
@@ -1,3 +1,4 @@
+import language.`3.1`
 object Test:
 
   def cat1(s1: String)(s2: String) = s1 + s2


### PR DESCRIPTION
There was a superfluous `_` added in eta expansion. That was needed in Scala 2,
but is no longer needed in Scala 3.

Fixes #11311