### PR TITLE
Fix #9740: harden type checking for pattern match on objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3780,11 +3780,20 @@ class Typer extends Namer
         withMode(Mode.GadtConstraintInference) {
           TypeComparer.constrainPatternType(tree.tpe, pt)
         }
-        val cmp =
-          untpd.Apply(
-            untpd.Select(untpd.TypedSplice(tree), nme.EQ),
-            untpd.TypedSplice(dummyTreeOfType(pt)))
-        typedExpr(cmp, defn.BooleanType)
+
+        if tree.symbol.is(Module) && !(tree.tpe <:< pt) then
+          // We could check whether `equals` is overriden.
+          // Reasons for not doing so:
+          // - it complicates the protocol
+          // - such code patterns usually implies hidden errors in the code
+          // - it's safe/sound to reject the code
+          report.error(TypeMismatch(tree.tpe, pt, "\npattern type is incompatible with expected type"), tree.srcPos)
+        else
+          val cmp =
+            untpd.Apply(
+              untpd.Select(untpd.TypedSplice(tree), nme.EQ),
+              untpd.TypedSplice(dummyTreeOfType(pt)))
+          typedExpr(cmp, defn.BooleanType)
       case _ =>
 
   private def checkStatementPurity(tree: tpd.Tree)(original: untpd.Tree, exprOwner: Symbol)(using Context): Unit =

--- a/tests/neg/i5077.scala
+++ b/tests/neg/i5077.scala
@@ -9,12 +9,12 @@ def Test = {
   val c_any: C[_] = c_string
   val any: Any = c_string
 
-  // Case 1: error, tested in tests/neg/i5077.scala
-  // c_string match {
-  //   case C(IsInt, _) => println(s"An Int") // Can't possibly happen!
-  //   case C(IsString, s) => println(s"A String with length ${s.length}")
-  //   case _ => println("No match")
-  // }
+  // Case 1: error
+  c_string match {
+    case C(IsInt, _) => println(s"An Int") // error
+    case C(IsString, s) => println(s"A String with length ${s.length}")
+    case _ => println("No match")
+  }
 
   // Case 2: Should match the second case and print the length of the string
   c_any match {

--- a/tests/neg/i9740.scala
+++ b/tests/neg/i9740.scala
@@ -1,0 +1,16 @@
+abstract class RecoveryCompleted
+object RecoveryCompleted extends RecoveryCompleted
+
+abstract class TypedRecoveryCompleted
+object TypedRecoveryCompleted extends TypedRecoveryCompleted
+
+class Test {
+  TypedRecoveryCompleted match {
+    case RecoveryCompleted => println("Recovery completed")            // error
+    case TypedRecoveryCompleted => println("Typed recovery completed")
+  }
+
+  def foo(x: TypedRecoveryCompleted) = x match
+    case RecoveryCompleted =>             // error
+    case TypedRecoveryCompleted =>
+}

--- a/tests/pos/autoTuplingTest.scala
+++ b/tests/pos/autoTuplingTest.scala
@@ -1,6 +1,6 @@
 object autoTupling {
 
-  val x = Some(1, 2)
+  val x: Option[(Int, Int)] = Some(1, 2)
 
   x match {
     case Some(a, b) => a + b

--- a/tests/pos/i7516.scala
+++ b/tests/pos/i7516.scala
@@ -1,3 +1,3 @@
-val foo: Int => Int = Some(7) match
+val foo: Int => Int = Option(7) match
   case Some(y) => x => y
   case None => identity[Int]

--- a/tests/pos/i9740b.scala
+++ b/tests/pos/i9740b.scala
@@ -1,0 +1,11 @@
+sealed trait Exp[T]
+case class IntExp(x: Int) extends Exp[Int]
+case class StrExp(x: String) extends Exp[String]
+object UnitExp extends Exp[Unit]
+
+class Foo[U <: Int, T <: U] {
+  def bar[A <: T](x: Exp[A]): Unit = x match
+    case IntExp(x) =>
+    case StrExp(x) =>
+    case UnitExp =>
+}

--- a/tests/pos/i9740c.scala
+++ b/tests/pos/i9740c.scala
@@ -1,0 +1,16 @@
+sealed trait Exp[T]
+case class IntExp(x: Int) extends Exp[Int]
+case class StrExp(x: String) extends Exp[String]
+object UnitExp extends Exp[Unit]
+
+trait Txn[T <: Txn[T]]
+case class Obj(o: AnyRef) extends Txn[Obj] with Exp[AnyRef]
+
+
+class Foo {
+  def bar[A <: Txn[A]](x: Exp[A]): Unit = x match
+    case IntExp(x) =>
+    case StrExp(x) =>
+    case UnitExp =>
+    case Obj(o) =>
+}

--- a/tests/run/i5077.check
+++ b/tests/run/i5077.check
@@ -1,3 +1,2 @@
 A String with length 4
 A String with length 4
-A String with length 4


### PR DESCRIPTION
Fix #9740: harden type checking for pattern match on objects

We enforce that when pattern match on an object, the object should be
a subtype of the scrutinee type. It aligns with Scala 2 behavior.

Reasons for doing so:

- such code patterns usually implies hidden errors in the code
- it's always safe/sound to reject the code

We could check whether `equals` is overridden in the object, but

- it complicates the protocol
- overriding `equals` of object is also a bad practice
- there is no sign that the slightly improved completeness is useful