### PR TITLE
Make it possible to always set the prefix of denotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -205,4 +205,13 @@ object Config {
 
   /** When in IDE, turn StaleSymbol errors into warnings instead of crashing */
   inline val ignoreStaleInIDE = true
+
+  /** If true, `Denotation#asSeenFrom` is allowed to return an existing
+   *  `SymDenotation` instead of allocating a new `SingleDenotation` if
+   *  the two would only differ in their `prefix` (SymDenotation always
+   *  have `NoPrefix` as their prefix).
+   *  This is done for performance reasons: when compiling Dotty itself this
+   *  reduces the number of allocated denotations by ~50%.
+   */
+  inline val reuseSymDenotations = true
 }

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -21,7 +21,7 @@ class JavaPlatform extends Platform {
   }
 
   // The given symbol is a method with the right name and signature to be a runnable java program.
-  def isMainMethod(sym: SymDenotation)(using Context): Boolean =
+  def isMainMethod(sym: Symbol)(using Context): Boolean =
     (sym.name == nme.main) && (sym.info match {
       case MethodTpe(_, defn.ArrayOf(el) :: Nil, restpe) => el =:= defn.StringType && (restpe isRef defn.UnitClass)
       case _ => false

--- a/compiler/src/dotty/tools/dotc/config/Platform.scala
+++ b/compiler/src/dotty/tools/dotc/config/Platform.scala
@@ -38,12 +38,10 @@ abstract class Platform {
   def newClassLoader(bin: AbstractFile)(using Context): SymbolLoader
 
   /** The given symbol is a method with the right name and signature to be a runnable program. */
-  def isMainMethod(sym: SymDenotation)(using Context): Boolean
+  def isMainMethod(sym: Symbol)(using Context): Boolean
 
   /** The given class has a main method. */
   final def hasMainMethod(sym: Symbol)(using Context): Boolean =
-    sym.info.member(nme.main).hasAltWith {
-      case x: SymDenotation => isMainMethod(x) && (sym.is(Module) || x.isStatic)
-      case _ => false
-    }
+    sym.info.member(nme.main).hasAltWith(d =>
+      isMainMethod(d.symbol) && (sym.is(Module) || d.symbol.isStatic))
 }

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -556,6 +556,8 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisPhase =>
     // The Lifter updates the type of symbols using `installAfter` to give them a
     // new `SymDenotation`, but that doesn't affect non-sym denotations, so we
     // reload them manually here.
+    // Note: If you tweak this code, make sure to test your changes with
+    // `Config.reuseSymDenotations` set to false to exercise this path more.
     if denot.isInstanceOf[NonSymSingleDenotation] && lifter.free.contains(sym) then
       tree.qualifier.select(sym).withSpan(tree.span)
     else tree

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -66,7 +66,7 @@ object Signatures {
           case _ =>
             val funSymbol = fun.symbol
             val alternatives = funSymbol.owner.info.member(funSymbol.name).alternatives
-            val alternativeIndex = alternatives.indexOf(funSymbol.denot) max 0
+            val alternativeIndex = alternatives.map(_.symbol).indexOf(funSymbol) max 0
             (alternativeIndex, alternatives)
         }
 


### PR DESCRIPTION
The comment above `derived` used to say "Currently this fails
bootstrap", this was fixed by #11303, and this commit takes care of
updating the few places where we were assuming that something had to be
a SymDenotation when it didn't. Nevertheless, we still keep essentially
the same behavior of reusing denotations that existed before this commit
for performance reason, but this is now toggleable using
`Config.reuseSymDenotations`.

There's one difference with what we did before: if we need to create a
new denotation anyway because the info changed, then we always update
the prefix at the same time, this doesn't cost us anything and means
that we can rely on `prefix` being correctly set on non-sym denotations.