### PR TITLE
Fix unpickling of match type aliases

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -858,10 +858,7 @@ class TreeUnpickler(reader: TastyReader,
                 rhs.tpe.typeParams
             }
             sym.info = sym.opaqueToBounds(
-              rhs.tpe match {
-                case _: TypeBounds | _: ClassInfo => checkNonCyclic(sym, rhs.tpe, reportErrors = false)
-                case _ => rhs.tpe.toBounds
-              },
+              checkNonCyclic(sym, rhs.tpe.toBounds, reportErrors = false),
               rhs, rhs.tpe.typeParams)
             if sym.isOpaqueAlias then sym.typeRef.recomputeDenot() // make sure we see the new bounds from now on
             sym.resetFlag(Provisional)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -463,7 +463,9 @@ trait TypeAssigner {
   def assignType(tree: untpd.TypeBoundsTree, lo: Tree, hi: Tree, alias: Tree)(using Context): TypeBoundsTree =
     tree.withType(
       if !alias.isEmpty then alias.tpe
-      else if lo eq hi then TypeAlias(lo.tpe)
+      else if lo eq hi then
+        if lo.tpe.isMatch then MatchAlias(lo.tpe)
+        else TypeAlias(lo.tpe)
       else TypeBounds(lo.tpe, hi.tpe))
 
   def assignType(tree: untpd.Bind, sym: Symbol)(using Context): Bind =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -865,9 +865,9 @@ class Typer extends Namer
      */
     val arg1 = pt match {
       case AppliedType(a, typ :: Nil) if ctx.isJava && a.isRef(defn.ArrayClass) =>
-        tryAlternatively { typed(tree.arg, pt) } { 
+        tryAlternatively { typed(tree.arg, pt) } {
             val elemTp = untpd.TypedSplice(TypeTree(typ))
-            typed(untpd.JavaSeqLiteral(tree.arg :: Nil, elemTp), pt) 
+            typed(untpd.JavaSeqLiteral(tree.arg :: Nil, elemTp), pt)
         }
       case _ => typed(tree.arg, pt)
     }

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -34,6 +34,7 @@ i7872.scala
 6687.scala
 i11236.scala
 i11247.scala
+i11250
 
 # Opaque type
 i5720.scala

--- a/tests/pos/i11250/1.scala
+++ b/tests/pos/i11250/1.scala
@@ -1,0 +1,29 @@
+package shapeless3.data
+
+import scala.compiletime._
+
+trait Monoidal {
+  type to[_] <: Tuple
+  type length[m] = Monoidal.length[to[m]]
+}
+
+object Monoidal {
+  import Tuple._
+
+  type length[m <: Tuple] = Size[m]
+}
+
+trait UnboundedMonoidal[T0[_, _], U0] extends Monoidal {
+  type to[t] <: Tuple = t match {
+    case T0[hd, tl] => hd *: to[tl]
+    case U0 => EmptyTuple
+  }
+}
+
+object pairs extends UnboundedMonoidal[Tuple2, Unit]
+
+object MonoidalTest { // Compiles fine here
+  type p = (Int, (String, (Boolean, Unit)))
+  summon[pairs.length[p] =:= 3]
+}
+

--- a/tests/pos/i11250/2.scala
+++ b/tests/pos/i11250/2.scala
@@ -1,0 +1,7 @@
+package shapeless3.data
+
+object MonoidalTest2 { // But not here
+  type p = (Int, (String, (Boolean, Unit)))
+  summon[pairs.length[p] =:= 3]
+}
+


### PR DESCRIPTION
We missed a cyclic check for them, which meant that no LazyRefs
were inserted that would prevent stackoverflows in subsequent operations.

Fixes #11250 

The fix was simple but it took a while to figure out what was wrong.
