### PR TITLE
Change 3.1 to future

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -226,7 +226,7 @@ object desugar {
 
     def desugarContextBounds(rhs: Tree): Tree = rhs match
       case ContextBounds(tbounds, cxbounds) =>
-        val iflag = if sourceVersion.isAtLeast(`3.1`) then Given else Implicit
+        val iflag = if sourceVersion.isAtLeast(`future`) then Given else Implicit
         evidenceParamBuf ++= makeImplicitParameters(
           cxbounds, iflag, forPrimaryConstructor = isPrimaryConstructor)
         tbounds

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -169,7 +169,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   enum GenCheckMode {
     case Ignore       // neither filter nor check since filtering was done before
     case Check        // check that pattern is irrefutable
-    case FilterNow    // filter out non-matching elements since we are not yet in 3.1
+    case FilterNow    // filter out non-matching elements since we are not yet in 3.x
     case FilterAlways // filter out non-matching elements since pattern is prefixed by `case`
   }
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -95,7 +95,7 @@ class ScalaSettings extends Settings.SettingGroup with CommonScalaSettings {
   val feature: Setting[Boolean] = BooleanSetting("-feature", "Emit warning and location for usages of features that should be imported explicitly.", aliases = List("--feature"))
   val help: Setting[Boolean] = BooleanSetting("-help", "Print a synopsis of standard options.", aliases = List("--help"))
   val release: Setting[String] = ChoiceSetting("-release", "release", "Compile code with classes specific to the given version of the Java platform available on the classpath and emit bytecode for this version.", supportedReleaseVersions, "", aliases = List("--release"))
-  val source: Setting[String] = ChoiceSetting("-source", "source version", "source version", List("3.0", "3.1", "3.0-migration", "3.1-migration"), "3.0", aliases = List("--source"))
+  val source: Setting[String] = ChoiceSetting("-source", "source version", "source version", List("3.0", "future", "3.0-migration", "future-migration"), "3.0", aliases = List("--source"))
   val scalajs: Setting[Boolean] = BooleanSetting("-scalajs", "Compile in Scala.js mode (requires scalajs-library.jar on the classpath).", aliases = List("--scalajs"))
   val unchecked: Setting[Boolean] = BooleanSetting("-unchecked", "Enable additional warnings where generated code depends on assumptions.", aliases = List("--unchecked"))
   val uniqid: Setting[Boolean] = BooleanSetting("-uniqid", "Uniquely tag all identifiers in debugging output.", aliases = List("--unique-id"))

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -9,7 +9,7 @@ import core.Decorators.{_, given}
 import util.Property
 
 enum SourceVersion:
-  case `3.0-migration`, `3.0`, `3.1-migration`, `3.1`
+  case `3.0-migration`, `3.0`, `future-migration`, `future`
 
   val isMigrating: Boolean = toString.endsWith("-migration")
 

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -6,7 +6,7 @@ import Contexts._, Types._, Symbols._, Names._, Flags._
 import Denotations.SingleDenotation
 import Decorators._
 import collection.mutable
-import config.SourceVersion.`3.1`
+import config.SourceVersion.future
 import config.Feature.sourceVersion
 
 /** Realizability status */
@@ -202,8 +202,8 @@ class CheckRealizable(using Context) {
           realizability(fld.info).mapError(r => new HasProblemField(fld, r))
         }
       }
-    if sourceVersion.isAtLeast(`3.1`) then
-      // check fields only from version 3.1.
+    if sourceVersion.isAtLeast(future) then
+      // check fields only from version 3.x.
       // Reason: An embedded field could well be nullable, which means it
       // should not be part of a path and need not be checked; but we cannot recognize
       // this situation until we have a typesystem that tracks nullability.

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -946,7 +946,7 @@ object SymDenotations {
       is(Macro, butNot = Inline) && is(Erased)
       // Consider the macros of StringContext as plain Scala 2 macros when
       // compiling the standard library with Dotty.
-      // This should be removed on Scala 3.1
+      // This should be removed on Scala 3.x
       && owner.ne(defn.StringContextClass)
 
     /** An erased value or an erased inline method or field */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3111,7 +3111,7 @@ object Parsers {
 
       /** ‘*' | ‘_' */
       def wildcardSelector() =
-        if in.token == USCORE && sourceVersion.isAtLeast(`3.1`) then
+        if in.token == USCORE && sourceVersion.isAtLeast(future) then
           report.errorOrMigrationWarning(
             em"`_` is no longer supported for a wildcard import; use `*` instead${rewriteNotice("3.1")}",
             in.sourcePos())
@@ -3129,7 +3129,7 @@ object Parsers {
       /** id [‘as’ (id | ‘_’) */
       def namedSelector(from: Ident) =
         if in.token == ARROW || isIdent(nme.as) then
-          if in.token == ARROW && sourceVersion.isAtLeast(`3.1`) then
+          if in.token == ARROW && sourceVersion.isAtLeast(future) then
             report.errorOrMigrationWarning(
               em"The import renaming `a => b` is no longer supported ; use `a as b` instead${rewriteNotice("3.1")}",
               in.sourcePos())

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1563,7 +1563,7 @@ object Parsers {
         if in.token == LBRACE || in.token == INDENT then
           t
         else
-          if sourceVersion.isAtLeast(`3.1`) then
+          if sourceVersion.isAtLeast(future) then
             deprecationWarning(DeprecatedWithOperator(), withOffset)
           atSpan(startOffset(t)) { makeAndType(t, withType()) }
       else t
@@ -1613,7 +1613,7 @@ object Parsers {
       if isSimpleLiteral then
         SingletonTypeTree(simpleLiteral())
       else if in.token == USCORE then
-        if sourceVersion.isAtLeast(`3.1`) then
+        if sourceVersion.isAtLeast(future) then
           deprecationWarning(em"`_` is deprecated for wildcard arguments of types: use `?` instead")
           patch(source, Span(in.offset, in.offset + 1), "?")
         val start = in.skipToken()
@@ -2080,11 +2080,11 @@ object Parsers {
           val isVarargSplice = location.inArgs && followingIsVararg()
           in.nextToken()
           if isVarargSplice then
-            if sourceVersion.isAtLeast(`3.1`) then
+            if sourceVersion.isAtLeast(future) then
               report.errorOrMigrationWarning(
-                em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead${rewriteNotice("3.1")}",
+                em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead${rewriteNotice("future")}",
                 in.sourcePos(uscoreStart))
-            if sourceVersion == `3.1-migration` then
+            if sourceVersion == `future-migration` then
               patch(source, Span(t.span.end, in.lastOffset), " *")
           else if opStack.nonEmpty then
             report.errorOrMigrationWarning(
@@ -2158,15 +2158,15 @@ object Parsers {
         val name = bindingName()
         val t =
           if (in.token == COLON && location == Location.InBlock) {
-            if sourceVersion.isAtLeast(`3.1`) then
+            if sourceVersion.isAtLeast(future) then
                 // Don't error in non-strict mode, as the alternative syntax "implicit (x: T) => ... "
                 // is not supported by Scala2.x
               report.errorOrMigrationWarning(
-                s"This syntax is no longer supported; parameter needs to be enclosed in (...)${rewriteNotice("3.1")}",
+                s"This syntax is no longer supported; parameter needs to be enclosed in (...)${rewriteNotice("future")}",
                 source.atSpan(Span(start, in.lastOffset)))
             in.nextToken()
             val t = infixType()
-            if (sourceVersion == `3.1-migration`) {
+            if (sourceVersion == `future-migration`) {
               patch(source, Span(start), "(")
               patch(source, Span(in.lastOffset), ")")
             }
@@ -2482,7 +2482,7 @@ object Parsers {
       atSpan(startOffset(pat), accept(LARROW)) {
         val checkMode =
           if (casePat) GenCheckMode.FilterAlways
-          else if sourceVersion.isAtLeast(`3.1`) then GenCheckMode.Check
+          else if sourceVersion.isAtLeast(future) then GenCheckMode.Check
           else GenCheckMode.FilterNow  // filter for now, to keep backwards compat
         GenFrom(pat, subExpr(), checkMode)
       }
@@ -2655,7 +2655,7 @@ object Parsers {
         p
 
     private def warnStarMigration(p: Tree) =
-      if sourceVersion.isAtLeast(`3.1`) then
+      if sourceVersion.isAtLeast(future) then
         report.errorOrMigrationWarning(
           em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead",
           in.sourcePos(startOffset(p)))
@@ -2790,8 +2790,8 @@ object Parsers {
           syntaxError(DuplicatePrivateProtectedQualifier())
         inBrackets {
           if in.token == THIS then
-            if sourceVersion.isAtLeast(`3.1`) then
-              deprecationWarning("The [this] qualifier is deprecated in Scala 3.1; it should be dropped.")
+            if sourceVersion.isAtLeast(future) then
+              deprecationWarning("The [this] qualifier will be deprecated in the future; it should be dropped.")
             in.nextToken()
             mods | Local
           else mods.withPrivateWithin(ident().toTypeName)
@@ -3226,7 +3226,7 @@ object Parsers {
     /** PatDef  ::=  ids [‘:’ Type] ‘=’ Expr
      *            |  Pattern2 [‘:’ Type] ‘=’ Expr
      *  VarDef  ::=  PatDef
-     *            | id {`,' id} `:' Type `=' `_' (deprecated in 3.1)
+     *            | id {`,' id} `:' Type `=' `_' (deprecated in 3.x)
      *  ValDcl  ::=  id {`,' id} `:' Type
      *  VarDcl  ::=  id {`,' id} `:' Type
      */
@@ -3253,7 +3253,7 @@ object Parsers {
           subExpr() match
             case rhs0 @ Ident(name) if placeholderParams.nonEmpty && name == placeholderParams.head.name
                 && !tpt.isEmpty && mods.is(Mutable) && lhs.forall(_.isInstanceOf[Ident]) =>
-              if sourceVersion.isAtLeast(`3.1`) then
+              if sourceVersion.isAtLeast(future) then
                 deprecationWarning(
                   em"""`= _` has been deprecated; use `= uninitialized` instead.
                       |`uninitialized` can be imported with `scala.compiletime.uninitialized`.""", rhsOffset)

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -89,7 +89,7 @@ class NonLocalReturns extends MiniPhase {
 
   override def transformReturn(tree: Return)(using Context): Tree =
     if isNonLocalReturn(tree) then
-      if sourceVersion.isAtLeast(`3.1`) then
+      if sourceVersion.isAtLeast(future) then
         report.errorOrMigrationWarning("Non local returns are no longer supported; use scala.util.control.NonLocalReturns instead", tree.srcPos)
       nonLocalReturnThrow(tree.expr, tree.from.symbol).withSpan(tree.span)
     else tree

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -159,7 +159,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
           if sym.isScala2Macro && !ctx.settings.XignoreScala2Macros.value then
             if !sym.owner.unforcedDecls.exists(p => !p.isScala2Macro && p.name == sym.name && p.signature == sym.signature)
                // Allow scala.reflect.materializeClassTag to be able to compile scala/reflect/package.scala
-               // This should be removed on Scala 3.1
+               // This should be removed on Scala 3.x
                && sym.owner != defn.ReflectPackageClass
             then
               report.error("No Scala 3 implementation found for this Scala 2 macro.", tree.srcPos)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -700,7 +700,7 @@ trait Checking {
     def check(pat: Tree, pt: Type): Boolean = (pt <:< pat.tpe) || fail(pat, pt)
 
     def recur(pat: Tree, pt: Type): Boolean =
-      !sourceVersion.isAtLeast(`3.1`) || // only for 3.1 for now since mitigations work only after this PR
+      !sourceVersion.isAtLeast(future) || // only for 3.x for now since mitigations work only after this PR
       pt.hasAnnotation(defn.UncheckedAnnot) || {
         patmatch.println(i"check irrefutable $pat: ${pat.tpe} against $pt")
         pat match {
@@ -844,7 +844,7 @@ trait Checking {
              !meth.isDeclaredInfix &&
              !meth.maybeOwner.is(Scala2x) &&
              !infixOKSinceFollowedBy(tree.right) &&
-             sourceVersion.isAtLeast(`3.1`) =>
+             sourceVersion.isAtLeast(future) =>
             val (kind, alternative) =
               if (ctx.mode.is(Mode.Type))
                 ("type", (n: Name) => s"prefix syntax $n[...]")
@@ -1265,7 +1265,7 @@ trait Checking {
         if stat.isDef then seen += tname
 
   def checkMatchable(tp: Type, pos: SrcPos, pattern: Boolean)(using Context): Unit =
-    if !tp.derivesFrom(defn.MatchableClass) && sourceVersion.isAtLeast(`3.1-migration`) then
+    if !tp.derivesFrom(defn.MatchableClass) && sourceVersion.isAtLeast(`future-migration`) then
       val kind = if pattern then "pattern selector" else "value"
       report.warning(
         em"""${kind} should be an instance of Matchable,

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1227,7 +1227,7 @@ class Namer { typer: Typer =>
             else if pclazz.isEffectivelySealed && pclazz.associatedFile != cls.associatedFile then
               if pclazz.is(Sealed) then
                 report.error(UnableToExtendSealedClass(pclazz), cls.srcPos)
-              else if sourceVersion.isAtLeast(`3.1`) then
+              else if sourceVersion.isAtLeast(future) then
                 checkFeature(nme.adhocExtensions,
                   i"Unless $pclazz is declared 'open', its extension in a separate file",
                   cls.topLevelClass,

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -61,7 +61,7 @@ trait QuotesAndSplices {
         typedQuotePattern(tree, pt, qctx)
       else if tree.quoted.isType then
         val msg = em"Consider using canonical type constructor scala.quoted.Type.of[${tree.quoted}] instead"
-        if sourceVersion.isAtLeast(`3.1-migration`) then report.error(msg, tree.srcPos)
+        if sourceVersion.isAtLeast(`future-migration`) then report.error(msg, tree.srcPos)
         else report.warning(msg, tree.srcPos)
         typedTypeApply(untpd.TypeApply(untpd.ref(defn.QuotedTypeModule_of.termRef), tree.quoted :: Nil), pt)(using quoteContext).select(nme.apply).appliedTo(qctx)
       else
@@ -166,7 +166,7 @@ trait QuotesAndSplices {
     else
       val tree1 = typedSelect(untpd.Select(tree.expr, tpnme.Underlying), pt)(using spliceContext).withSpan(tree.span)
       val msg = em"Consider using canonical type reference ${tree1.tpe} instead"
-      if sourceVersion.isAtLeast(`3.1-migration`) then report.error(msg, tree.srcPos)
+      if sourceVersion.isAtLeast(`future-migration`) then report.error(msg, tree.srcPos)
       else report.warning(msg, tree.srcPos)
       tree1
   }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -49,9 +49,9 @@ class CompilationTests {
       ),
       compileFile("tests/pos-special/typeclass-scaling.scala", defaultOptions.and("-Xmax-inlines", "40")),
       compileFile("tests/pos-special/indent-colons.scala", defaultOptions.and("-Yindent-colons")),
-      compileFile("tests/pos-special/i7296.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/pos-special/i7296.scala", defaultOptions.and("-source", "future", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/pos-special/notNull.scala", defaultOptions.and("-Yexplicit-nulls")),
-      compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-source", "3.1", "-feature", "-Xfatal-warnings")),
+      compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-source", "future", "-feature", "-Xfatal-warnings")),
       compileFile("tests/pos-special/i7575.scala", defaultOptions.andLanguageFeature("dynamics")),
       compileFile("tests/pos-special/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/run/i5606.scala", defaultOptions.and("-Yretain-trees")),
@@ -120,7 +120,7 @@ class CompilationTests {
     aggregateTests(
       compileFilesInDir("tests/neg", defaultOptions),
       compileFilesInDir("tests/neg-tailcall", defaultOptions),
-      compileFilesInDir("tests/neg-strict", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
+      compileFilesInDir("tests/neg-strict", defaultOptions.and("-source", "future", "-deprecation", "-Xfatal-warnings")),
       compileFilesInDir("tests/neg-no-kind-polymorphism", defaultOptions and "-Yno-kind-polymorphism"),
       compileFilesInDir("tests/neg-custom-args/deprecation", defaultOptions.and("-Xfatal-warnings", "-deprecation")),
       compileFilesInDir("tests/neg-custom-args/fatal-warnings", defaultOptions.and("-Xfatal-warnings")),
@@ -155,18 +155,18 @@ class CompilationTests {
         "tests/neg-custom-args/toplevel-samesource/nested/S.scala"),
         defaultOptions),
       compileFile("tests/neg-custom-args/i6300.scala", allowDeepSubtypes),
-      compileFile("tests/neg-custom-args/infix.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/infix.scala", defaultOptions.and("-source", "future", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/missing-alpha.scala", defaultOptions.and("-Yrequire-targetName", "-Xfatal-warnings")),
-      compileFile("tests/neg-custom-args/wildcards.scala", defaultOptions.and("-source", "3.1", "-deprecation", "-Xfatal-warnings")),
+      compileFile("tests/neg-custom-args/wildcards.scala", defaultOptions.and("-source", "future", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/neg-custom-args/indentRight.scala", defaultOptions.and("-no-indent", "-Xfatal-warnings")),
-      compileDir("tests/neg-custom-args/adhoc-extension", defaultOptions.and("-source", "3.1", "-feature", "-Xfatal-warnings")),
+      compileDir("tests/neg-custom-args/adhoc-extension", defaultOptions.and("-source", "future", "-feature", "-Xfatal-warnings")),
       compileFile("tests/neg/i7575.scala", defaultOptions.withoutLanguageFeatures.and("-language:_")),
       compileFile("tests/neg-custom-args/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/neg-custom-args/typeclass-derivation2.scala", defaultOptions.and("-Yerased-terms")),
       compileFile("tests/neg-custom-args/i5498-postfixOps.scala", defaultOptions withoutLanguageFeature "postfixOps"),
       compileFile("tests/neg-custom-args/deptypes.scala", defaultOptions.and("-language:experimental.dependent")),
-      compileFile("tests/neg-custom-args/matchable.scala", defaultOptions.and("-Xfatal-warnings", "-source", "3.1")),
-      compileFile("tests/neg-custom-args/i7314.scala", defaultOptions.and("-Xfatal-warnings", "-source", "3.1"))
+      compileFile("tests/neg-custom-args/matchable.scala", defaultOptions.and("-Xfatal-warnings", "-source", "future")),
+      compileFile("tests/neg-custom-args/i7314.scala", defaultOptions.and("-Xfatal-warnings", "-source", "future"))
     ).checkExpectedErrors()
   }
 
@@ -182,7 +182,7 @@ class CompilationTests {
     aggregateTests(
       compileFile("tests/run-custom-args/tuple-cons.scala", allowDeepSubtypes),
       compileFile("tests/run-custom-args/i5256.scala", allowDeepSubtypes),
-      compileFile("tests/run-custom-args/fors.scala", defaultOptions.and("-source", "3.1")),
+      compileFile("tests/run-custom-args/fors.scala", defaultOptions.and("-source", "future")),
       compileFile("tests/run-custom-args/no-useless-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
       compileFile("tests/run-custom-args/defaults-serizaliable-no-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
       compileFilesInDir("tests/run-custom-args/erased", defaultOptions.and("-Yerased-terms")),
@@ -245,7 +245,7 @@ class CompilationTests {
       compileList("lib", librarySources,
         defaultOptions.and("-Ycheck-reentrant",
           "-Yerased-terms", // support declaration of scala.compiletime.erasedValue
-          //  "-source", "3.1",  // TODO: re-enable once we allow : @unchecked in pattern definitions. Right now, lots of narrowing pattern definitions fail.
+          //  "-source", "future",  // TODO: re-enable once we allow : @unchecked in pattern definitions. Right now, lots of narrowing pattern definitions fail.
           ))(libGroup)
 
     val tastyCoreSources = sources(Paths.get("tasty/src")) ++ sources(Paths.get("tasty/src-bootstrapped"))

--- a/compiler/test/dotty/tools/dotc/reporting/TestMessageLaziness.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestMessageLaziness.scala
@@ -26,5 +26,5 @@ class TestMessageLaziness extends DottyTest {
     report.error(LazyError())
 
   @Test def assureLazyExtendMessage =
-    report.errorOrMigrationWarning(LazyError(), from = config.SourceVersion.`3.1`)
+    report.errorOrMigrationWarning(LazyError(), from = config.SourceVersion.future)
 }

--- a/docs/docs/reference/changed-features/operators.md
+++ b/docs/docs/reference/changed-features/operators.md
@@ -92,7 +92,7 @@ The purpose of the `infix` modifier is to achieve consistency across a code base
     can be applied using infix syntax, i.e. `A op B`.
 
  5. To smooth migration to Scala 3.0, alphanumeric operators will only be deprecated from Scala 3.1 onwards,
-or if the `-source 3.1` option is given in Dotty/Scala 3.
+or if the `-source future` option is given in Dotty/Scala 3.
 
 ## The `@targetName` Annotation
 

--- a/docs/docs/reference/changed-features/pattern-bindings.md
+++ b/docs/docs/reference/changed-features/pattern-bindings.md
@@ -15,7 +15,7 @@ val xs: List[Any] = List(1, 2, 3)
 val (x: String) :: _ = xs   // error: pattern's type String is more specialized
                             // than the right-hand side expression's type Any
 ```
-This code gives a compile-time warning in Scala 3.1 (and also in Scala 3.0 under the `-source 3.1` setting) whereas it will fail at runtime with a `ClassCastException` in Scala 2. In Scala 3.1, a pattern binding is only allowed if the pattern is _irrefutable_, that is, if the right-hand side's type conforms to the pattern's type. For instance, the following is OK:
+This code gives a compile-time warning in Scala 3.1 (and also in Scala 3.0 under the `-source future` setting) whereas it will fail at runtime with a `ClassCastException` in Scala 2. In Scala 3.1, a pattern binding is only allowed if the pattern is _irrefutable_, that is, if the right-hand side's type conforms to the pattern's type. For instance, the following is OK:
 ```scala
 val pair = (1, true)
 val (x, y) = pair
@@ -56,4 +56,4 @@ Generator      ::=  [‘case’] Pattern1 ‘<-’ Expr
 
 ## Migration
 
-The new syntax is supported in Scala 3.0. However, to enable smooth cross compilation between Scala 2 and Scala 3, the changed behavior and additional type checks are only enabled under the `-source 3.1` setting. They will be enabled by default in version 3.1 of the language.
+The new syntax is supported in Scala 3.0. However, to enable smooth cross compilation between Scala 2 and Scala 3, the changed behavior and additional type checks are only enabled under the `-source future` setting. They will be enabled by default in version 3.1 of the language.

--- a/docs/docs/reference/changed-features/vararg-splices.md
+++ b/docs/docs/reference/changed-features/vararg-splices.md
@@ -34,9 +34,9 @@ ParArgumentExprs  ::=  ‘(’ [‘using’] ExprsInParens ‘)’
 ## Compatibility considerations
 
 To enable cross compilation between Scala 2 and Scala 3, the compiler will
-accept both the old and the new syntax. Under the `-source 3.1` setting, an error
+accept both the old and the new syntax. Under the `-source future` setting, an error
 will be emitted when the old syntax is encountered. An automatic rewrite from old
-to new syntax is offered under `-source 3.1-migration`.
+to new syntax is offered under `-source future-migration`.
 
 
 

--- a/docs/docs/reference/changed-features/wildcards.md
+++ b/docs/docs/reference/changed-features/wildcards.md
@@ -31,7 +31,7 @@ A step-by-step migration is made possible with the following measures:
  2. In Scala 3.1, `_` is deprecated in favor of `?` as a name for a wildcard. A `-rewrite` option is
     available to rewrite one to the other.
  3. In Scala 3.2, the meaning of `_` changes from wildcard to placeholder for type parameter.
- 4. The Scala 3.1 behavior is already available today under the `-source 3.1` setting.
+ 4. The Scala 3.1 behavior is already available today under the `-source future` setting.
 
 To smooth the transition for codebases that use kind-projector, we adopt the following measures under the command line
 option `-Ykind-projector`:

--- a/docs/docs/reference/contextual/context-bounds.md
+++ b/docs/docs/reference/contextual/context-bounds.md
@@ -32,7 +32,7 @@ def g[T <: B : C](x: T): R = ...
 To ease migration, context bounds in Dotty map in Scala 3.0 to old-style implicit parameters
 for which arguments can be passed either with a `(using ...)` clause or with a normal application. From Scala 3.1 on, they will map to context parameters instead, as is described above.
 
-If the source version is `3.1` and the `-migration` command-line option is set, any pairing of an evidence
+If the source version is `future` and the `-migration` command-line option is set, any pairing of an evidence
 context parameter stemming from a context bound with a normal argument will give a migration
 warning. The warning indicates that a `(using ...)` clause is needed instead. The rewrite can be
 done automatically under `-rewrite`.

--- a/docs/docs/reference/contextual/context-bounds.md
+++ b/docs/docs/reference/contextual/context-bounds.md
@@ -32,7 +32,7 @@ def g[T <: B : C](x: T): R = ...
 To ease migration, context bounds in Dotty map in Scala 3.0 to old-style implicit parameters
 for which arguments can be passed either with a `(using ...)` clause or with a normal application. From Scala 3.1 on, they will map to context parameters instead, as is described above.
 
-If the source version is `future` and the `-migration` command-line option is set, any pairing of an evidence
+If the source version is `future-migration`, any pairing of an evidence
 context parameter stemming from a context bound with a normal argument will give a migration
 warning. The warning indicates that a `(using ...)` clause is needed instead. The rewrite can be
 done automatically under `-rewrite`.

--- a/docs/docs/reference/other-new-features/matchable.md
+++ b/docs/docs/reference/other-new-features/matchable.md
@@ -53,7 +53,7 @@ a type pattern `_: C` it is required that the selector type conforms
 to `Matchable`. If that's not the case a warning is issued. For instance when compiling the example at the start of this section we get:
 
 ```
-> sc ../new/test.scala -source 3.1
+> sc ../new/test.scala -source future
 -- Warning: ../new/test.scala:4:12 ---------------------------------------------
 4 |    case a: Array[Int] => a(0) = 0
   |            ^^^^^^^^^^
@@ -62,7 +62,7 @@ to `Matchable`. If that's not the case a warning is issued. For instance when co
 ```
 
 To allow migration from Scala 2 and cross-compiling
-between Scala 2 and 3 the warning is turned on only for `-source 3.1-migration` or higher.
+between Scala 2 and 3 the warning is turned on only for `-source future-migration` or higher.
 
 `Matchable` is a universal trait with `Any` as its parent class. It is
 extended by both `AnyVal` and `AnyRef`. Since `Matchable` is a supertype of every concrete value or reference class it means that instances of such classes can be matched as before. However, match selectors of the following types will produce a warning:

--- a/docs/docs/reference/other-new-features/open-classes.md
+++ b/docs/docs/reference/other-new-features/open-classes.md
@@ -76,4 +76,4 @@ A class that is neither `abstract` nor `open` is similar to a `sealed` class: it
 
 ### Migration
 
-`open` is a new modifier in Scala 3. To allow cross compilation between Scala 2.13 and Scala 3.0 without warnings, the feature warning for ad-hoc extensions is produced only under `-source 3.1`. It will be produced by default from Scala 3.1 on.
+`open` is a new modifier in Scala 3. To allow cross compilation between Scala 2.13 and Scala 3.0 without warnings, the feature warning for ad-hoc extensions is produced only under `-source future`. It will be produced by default from Scala 3.1 on.

--- a/docs/docs/usage/language-versions.md
+++ b/docs/docs/usage/language-versions.md
@@ -5,8 +5,6 @@ title: "Language Versions"
 
 The default Scala language version currently supported by the Dotty compiler is `3.0`. There are also other language versions that can be specified instead:
 
- - `3.1`: A preview of changes introduced in the next version after 3.0. Some Scala-2 specific idioms will be dropped in this version. The feature set supported by this version will be refined over time  as we approach its release.
-
  - `3.0-migration`: Same as `3.0` but with a Scala 2 compatibility mode that helps moving Scala 2.13 sources over to Scala 3. In particular, it
 
     - flags some Scala 2 constructs that are disallowed in Scala 3 as migration warnings instead of hard errors,
@@ -14,7 +12,11 @@ The default Scala language version currently supported by the Dotty compiler is 
     - gives some additional warnings where the semantics has changed between Scala 2.13 and 3.0
     - in conjunction with `-rewrite`, offer code rewrites from Scala 2.13 to 3.0.
 
- - `3.1-migration`: Same as `3.1` but with additional helpers to migrate from `3.0`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
+ - `future`: A preview of changes introduced in the next versions after 3.0. In the doc pages here we refer to the language version with these changes as `3.1`, but it might be that some of these changes will be rolled out in later `3.x` versions.
+
+ Some Scala-2 specific idioms will be dropped in this version. The feature set supported by this version will be refined over time  as we approach its release.
+
+ - `future-migration`: Same as `future` but with additional helpers to migrate from `3.0`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
 
 There are two ways to specify a language version.
 
@@ -23,9 +25,10 @@ There are two ways to specify a language version.
 
 ```scala
 package p
-import scala.language.`3.1`
+import scala.language.`future-migration`
 
 class C { ... }
 ```
 
-Language imports supersede command-line settings in the compilation units where they are specified. Only one language import is allowed in a compilation unit, and it must come before any definitions in that unit.
+Language imports supersede command-line settings in the compilation units where they are specified. Only one language import specifying a source version is allowed in a compilation unit, and it must come before any definitions in that unit.
+

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -79,6 +79,10 @@ object language:
 
   object unsafeNulls
 
+  object future
+
+  object `future-migration`
+
   /** Set source version to 3.0-migration.
     *
     * @see [[https://scalacenter.github.io/scala-3-migration-guide/docs/scala-3-migration-mode]]
@@ -91,6 +95,7 @@ object language:
     */
   object `3.0`
 
+/* This can be added when we go to 3.1
   /** Set source version to 3.1-migration.
     *
     * @see [[https://scalacenter.github.io/scala-3-migration-guide/docs/scala-3-migration-mode]]
@@ -102,4 +107,5 @@ object language:
     * @see [[https://scalacenter.github.io/scala-3-migration-guide/docs/scala-3-migration-mode]]
     */
   object `3.1`
+*/
 end language

--- a/tests/neg-custom-args/fatal-warnings/classtag-typetest/3_1-migration.scala
+++ b/tests/neg-custom-args/fatal-warnings/classtag-typetest/3_1-migration.scala
@@ -1,4 +1,4 @@
-import scala.language.`3.1-migration`
+import scala.language.`future-migration`
 import scala.reflect.ClassTag
 
 def f3_1m[T: ClassTag](x: Any): Unit =

--- a/tests/neg-custom-args/fatal-warnings/classtag-typetest/3_1.scala
+++ b/tests/neg-custom-args/fatal-warnings/classtag-typetest/3_1.scala
@@ -1,4 +1,4 @@
-import scala.language.`3.1`
+import scala.language.future
 import scala.reflect.ClassTag
 
 def f3_1[T: ClassTag](x: Any): Unit =

--- a/tests/neg-custom-args/fatal-warnings/i9266.check
+++ b/tests/neg-custom-args/fatal-warnings/i9266.check
@@ -2,4 +2,4 @@
 3 |def test = { implicit x: Int => x + x } // error
   |                      ^
   |                      This syntax is no longer supported; parameter needs to be enclosed in (...)
-  |                      This construct can be rewritten automatically under -rewrite -source 3.1-migration.
+  |                      This construct can be rewritten automatically under -rewrite -source future-migration.

--- a/tests/neg-custom-args/fatal-warnings/i9266.scala
+++ b/tests/neg-custom-args/fatal-warnings/i9266.scala
@@ -1,3 +1,3 @@
-import language.`3.1-migration`
+import language.`future-migration`
 
 def test = { implicit x: Int => x + x } // error

--- a/tests/neg/i8896-b.scala
+++ b/tests/neg/i8896-b.scala
@@ -1,4 +1,4 @@
-import scala.language.`3.1`
+import scala.language.future
 
 trait Foo[A]
 

--- a/tests/pos-special/fatal-warnings/matchable-same-type.scala
+++ b/tests/pos-special/fatal-warnings/matchable-same-type.scala
@@ -1,4 +1,4 @@
-import scala.language.`3.1-migration`
+import scala.language.`future-migration`
 
 type X
 def x: X = ???

--- a/tests/pos-special/fatal-warnings/type-test-matchable.scala
+++ b/tests/pos-special/fatal-warnings/type-test-matchable.scala
@@ -1,4 +1,4 @@
-import scala.language.`3.1-migration`
+import scala.language.`future-migration`
 import scala.reflect.TypeTest
 
 trait Foo:

--- a/tests/pos/classtag-typetest/3_1-migration.scala
+++ b/tests/pos/classtag-typetest/3_1-migration.scala
@@ -1,4 +1,4 @@
-import scala.language.`3.1-migration`
+import scala.language.`future-migration`
 import scala.reflect.ClassTag
 
 def f3_1m[T: ClassTag](x: Any): Unit =

--- a/tests/pos/classtag-typetest/3_1.scala
+++ b/tests/pos/classtag-typetest/3_1.scala
@@ -1,4 +1,4 @@
-import scala.language.`3.1`
+import scala.language.future
 import scala.reflect.ClassTag
 
 def f3_1[T: ClassTag](x: Any): Unit =

--- a/tests/pos/i11311.scala
+++ b/tests/pos/i11311.scala
@@ -1,4 +1,4 @@
-import language.`3.1`
+import language.future
 object Test:
 
   def cat1(s1: String)(s2: String) = s1 + s2

--- a/tests/pos/i9266.scala
+++ b/tests/pos/i9266.scala
@@ -1,3 +1,3 @@
-import language.`3.1-migration`
+import language.`future-migration`
 
 def test = { implicit x: Int => x + x }


### PR DESCRIPTION
It's now

    -source future
    -source future-migration

    import language.future
    import language.`future-migration`

instead of

    -source 3.1
    -source 3.1-migration

    import language.`3.1`
    import language.`3.1-migration`