### PR TITLE
Don't generate JavaArrayTypes in class constants

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -39,7 +39,10 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
               if defn.SpecialClassTagClasses.contains(sym) then
                 classTag.select(sym.name.toTermName)
               else
-                classTag.select(nme.apply).appliedToType(tp).appliedTo(clsOf(erasure(tp)))
+                val clsOfType = erasure(tp) match
+                  case JavaArrayType(elemType) => defn.ArrayOf(elemType)
+                  case etp => etp
+                classTag.select(nme.apply).appliedToType(tp).appliedTo(clsOf(clsOfType))
             tag.withSpan(span)
           case tp => EmptyTree
       case _ => EmptyTree

--- a/tests/pos/i11353.scala
+++ b/tests/pos/i11353.scala
@@ -1,0 +1,10 @@
+def iarr = IArray(
+  IArray(1, 2, 3),
+  IArray(4, 5, 6),
+  IArray(7, 8, 9)
+)
+def arr = Array( // same issue
+  IArray(1, 2, 3),
+  Array(4, 5, 6),
+  Array(7, 8, 9)
+)


### PR DESCRIPTION
E.g. generate Array[Int] instead of []Int.

Fixes #11353