### PR TITLE
Fix #10883: Override `line` and `column` in NoSourcePosition

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -86,6 +86,8 @@ extends SrcPos, interfaces.SourcePosition, Showable {
 
 /** A sentinel for a non-existing source position */
 @sharable object NoSourcePosition extends SourcePosition(NoSource, NoSpan, null) {
+  override def line: Int = -1
+  override def column: Int = -1
   override def toString: String = "?"
   override def withOuter(outer: SourcePosition): SourcePosition = outer
 }

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -233,3 +233,31 @@ object ReplCompilerTests {
   }
 
 }
+
+class ReplXPrintTyperTests extends ReplTest(ReplTest.defaultOptions :+ "-Xprint:typer") {
+  @Test def i9111 = fromInitialState { implicit state =>
+    run("""|enum E {
+           |  case A
+           |}""".stripMargin)
+    assert(storedOutput().trim().endsWith("// defined class E"))
+  }
+
+  @Test def i10883 = fromInitialState { implicit state =>
+    run("val a = 42")
+    assert(storedOutput().trim().endsWith("val a: Int = 42"))
+  }
+}
+
+class ReplVerboseTests extends ReplTest(ReplTest.defaultOptions :+ "-verbose") {
+  @Test def i9111 = fromInitialState { implicit state =>
+    run("""|enum E {
+           |  case A
+           |}""".stripMargin)
+    assert(storedOutput().trim().endsWith("// defined class E"))
+  }
+
+  @Test def i10883 = fromInitialState { implicit state =>
+    run("val a = 42")
+    assert(storedOutput().trim().endsWith("val a: Int = 42"))
+  }
+}

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -16,19 +16,8 @@ import dotty.tools.dotc.reporting.MessageRendering
 import org.junit.{After, Before}
 import org.junit.Assert._
 
-
-class ReplTest(withStaging: Boolean = false, out: ByteArrayOutputStream = new ByteArrayOutputStream) extends ReplDriver(
-  Array(
-    "-classpath",
-    if (withStaging)
-      TestConfiguration.withStagingClasspath
-    else
-      TestConfiguration.basicClasspath,
-    "-color:never",
-    "-Yerased-terms",
-  ),
-  new PrintStream(out, true, StandardCharsets.UTF_8.name)
-) with MessageRendering {
+class ReplTest(options: Array[String] = ReplTest.defaultOptions, out: ByteArrayOutputStream = new ByteArrayOutputStream)
+extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.name)) with MessageRendering {
   /** Get the stored output from `out`, resetting the buffer */
   def storedOutput(): String = {
     val output = stripColor(out.toString(StandardCharsets.UTF_8.name))
@@ -103,3 +92,8 @@ class ReplTest(withStaging: Boolean = false, out: ByteArrayOutputStream = new By
     end if
   }
 }
+
+object ReplTest:
+  val commonOptions = Array("-color:never", "-Yerased-terms")
+  val defaultOptions = commonOptions ++ Array("-classpath", TestConfiguration.basicClasspath)
+  lazy val withStagingOptions = commonOptions ++ Array("-classpath", TestConfiguration.withStagingClasspath)

--- a/staging/test/scala/quoted/staging/repl/StagingScriptedReplTests.scala
+++ b/staging/test/scala/quoted/staging/repl/StagingScriptedReplTests.scala
@@ -8,7 +8,7 @@ import org.junit.Test
 import org.junit.experimental.categories.Category
 
 /** Runs all tests contained in `staging/test-resources/repl-staging` */
-class StagingScriptedReplTests extends ReplTest(withStaging = true) {
+class StagingScriptedReplTests extends ReplTest(ReplTest.withStagingOptions) {
 
   @Category(Array(classOf[BootstrappedOnlyTests]))
   @Test def replStagingTests = scripts("/repl-staging").foreach(testFile)


### PR DESCRIPTION
The REPL driver uses the `line` and `column` methods of `SourcePosition` for ordering its output, however there are several diagnostics that are reported using `NoSourcePosition`, for example:

https://github.com/lampepfl/dotty/blob/a63b1d114179d79be32a1ee6552fc160c1bb2410/compiler/src/dotty/tools/dotc/Run.scala#L256
https://github.com/lampepfl/dotty/blob/a63b1d114179d79be32a1ee6552fc160c1bb2410/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala#L345

This was working until the `SourcePosition` implementation was changed in #10363, after which calls to `line` or `column` on `NoSourcePosition` resulted in an assertion error rather than returning -1 in accordance with:

https://github.com/lampepfl/dotty/blob/a63b1d114179d79be32a1ee6552fc160c1bb2410/interfaces/src/dotty/tools/dotc/interfaces/SourcePosition.java#L20-L23

Fixes #10883 
Fixes #9111 (previously fixed by #9351, broken again by #10363)