### PR TITLE
Accept -cp alias in bin/scala

### DIFF
--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -62,7 +62,7 @@ while [[ $# -gt 0 ]]; do
       execute_run=true
       shift
       ;;
-    -classpath)
+    -cp | -classpath)
       CLASS_PATH="$2"
       class_path_count+=1
       shift


### PR DESCRIPTION
Not doing so passes it through to `java`, which does accept it as
an alias for -classpath, overwriting the classpath containing
the standard library.

Fixes #8095
