### PR TITLE
Merge multiple parameter lists in resolveOverloaded

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1903,7 +1903,7 @@ trait Applications extends Compatibility {
       def skip(tp: Type): Type = tp match {
         case tp: PolyType =>
           val rt = skip(tp.resultType)
-          if (rt.exists) tp.derivedLambdaType(resType = rt) else rt
+          if rt.exists then tp.derivedLambdaType(resType = rt).asInstanceOf[PolyType].flatten else rt
         case tp: MethodType =>
           tp.instantiate(argTypes)
         case _ =>
@@ -1974,7 +1974,7 @@ trait Applications extends Compatibility {
         None
     }
     val mapped = reverseMapping.map(_._1)
-    overload.println(i"resolve mapped: $mapped")
+    overload.println(i"resolve mapped: ${mapped.map(_.widen)}%, % with $pt")
     resolveOverloaded(mapped, pt).map(reverseMapping.toMap)
 
   /** Try to typecheck any arguments in `pt` that are function values missing a

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1897,7 +1897,8 @@ trait Applications extends Compatibility {
     }
 
     /** The type of alternative `alt` after instantiating its first parameter
-     *  clause with `argTypes`.
+     *  clause with `argTypes`. In addition, if the resulting type is a PolyType
+     *  and `typeArgs` matches its parameter list, instantiate the result with `typeArgs`.
      */
     def skipParamClause(argTypes: List[Type], typeArgs: List[Type])(alt: TermRef): Type =
       def skip(tp: Type): Type = tp match {

--- a/tests/pos/i11358.scala
+++ b/tests/pos/i11358.scala
@@ -1,0 +1,8 @@
+object Test:
+
+  def test1: IArray[Int] = IArray(1, 2) +++ IArray(2, 3)
+  def test2: IArray[Int] = IArray(1, 2) +++ List(2, 3)
+
+  extension [A: reflect.ClassTag](arr: IArray[A])
+    def +++[B >: A: reflect.ClassTag](suffix: IArray[B]): IArray[B] = ???
+    def +++[B >: A: reflect.ClassTag](suffix: IterableOnce[B]): IArray[B] = ???

--- a/tests/pos/i11358.scala
+++ b/tests/pos/i11358.scala
@@ -2,6 +2,12 @@ object Test:
 
   def test1: IArray[Int] = IArray(1, 2) +++ IArray(2, 3)
   def test2: IArray[Int] = IArray(1, 2) +++ List(2, 3)
+  def test3 = +++[Int](IArray(1, 2))(IArray(2, 3))
+  def test4 = +++[Int](IArray(1, 2))(List(2, 3))
+  def test5: IArray[Int] = IArray(1, 2).+++[Int](IArray(2, 3))
+  def test6: IArray[Int] = IArray(1, 2).+++[Int](List(2, 3))
+  def test7 = +++(IArray(1, 2))[Int](IArray(2, 3))
+  def test8 = +++(IArray(1, 2))[Int](List(2, 3))
 
   extension [A: reflect.ClassTag](arr: IArray[A])
     def +++[B >: A: reflect.ClassTag](suffix: IArray[B]): IArray[B] = ???


### PR DESCRIPTION
Resolve overloaded does an applicability test which can make use of only a single
type parameter list. When going deeper into several alternatives that contain a common
prefex we might uncover other type parameter lists. These need to be merged.