### PR TITLE
Recover the denotation of constant-folded selections

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ConstFold.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ConstFold.scala
@@ -23,7 +23,7 @@ object ConstFold:
     nme.LT, nme.GT, nme.LE, nme.GE, nme.LSL, nme.LSR, nme.ASR,
     nme.ADD, nme.SUB, nme.MUL, nme.DIV, nme.MOD)
 
-  private val foldedUnops = Set[Name](
+  val foldedUnops = Set[Name](
     nme.UNARY_!, nme.UNARY_~, nme.UNARY_+, nme.UNARY_-)
 
   def Apply[T <: Apply](tree: T)(using Context): T =


### PR DESCRIPTION
With this change, the only term selections without a symbol after Typer and before Pickler
come from polymorphic function calls or outer selects. This should be good enough to let
us use SELECTin in all situations where overloads can appear as #11210
is attempting.