### PR TITLE
Better disambiguation of leading operators

### DIFF
--- a/tests/pos/i11371.scala
+++ b/tests/pos/i11371.scala
@@ -1,0 +1,19 @@
+object HelloWorld {
+  def whileLoop: Int = {
+    var i = 0
+    var acc = 0
+    while (i < 3) {
+      var `i'` = 0
+      while (`i'` < 4) {
+        acc += (i * `i'`)
+        `i'` += 1
+      }
+      i += 1
+    }
+    acc
+  }
+
+  def main(args: Array[String]): Unit = {
+    println(s"hello world: ${whileLoop}")
+  }
+}

--- a/tests/run/i7031.scala
+++ b/tests/run/i7031.scala
@@ -2,8 +2,7 @@
   val a = 5
   val x = 1
 
-    + //
-    `a` * 6
+    + `a` * 6
 
   assert(x == 1, x)
 }


### PR DESCRIPTION
Classify something as a leading operator only if it is not followed in turn
by an operator. This means that

```scala
acc += (i * `i'`)
`i'` += 1
```
the `i'` is no longer classified as a leading operator.