### PR TITLE
Fix #11276: Scala.js: Take JUnit tests from superclasses/traits into account.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
@@ -304,7 +304,11 @@ class JUnitBootstrappers extends MiniPhase {
     ref(param).cast(clazz.typeRef)
 
   private def annotatedMethods(owner: ClassSymbol, annot: Symbol)(using Context): List[Symbol] =
-    owner.info.decls.filter(m => m.is(Method) && m.hasAnnotation(annot))
+    owner.info
+      .membersBasedOnFlags(Method, EmptyFlags)
+      .filter(_.symbol.hasAnnotation(annot))
+      .map(_.symbol)
+      .toList
 }
 
 object JUnitBootstrappers {


### PR DESCRIPTION
The Scala 2 code uses

    owner.info.members.filter(m => m.isMethod && m.hasAnnotation(annot))

for the equivalent operation.

The code in Scala 3 used `decls` instead of `members`, which is
clearly incorrect. This commit fixes the discrepancy.

This was tested manually by making sure that

    > sjsJUnitTests/testOnly org.scalajs.testsuite.javalib.util.ArrayListTest

runs 40 tests, and not just 1. It is not clear how to write
automated tests for this fix.