### PR TITLE
Fix typo in FromExpr

### DIFF
--- a/library/src/scala/quoted/FromExpr.scala
+++ b/library/src/scala/quoted/FromExpr.scala
@@ -25,7 +25,7 @@ trait FromExpr[T] {
 object FromExpr {
 
   /** Default implementation of `FromExpr[Boolean]`
-   *  - Unlifts `'{true}` into `Some(ture)`
+   *  - Unlifts `'{true}` into `Some(true)`
    *  - Unlifts `'{false}` into `Some(false)`
    *  - Otherwise unlifts to `None`
    */


### PR DESCRIPTION
#11337 re-created as suggested in the precedent PR.

> @Iltotore maybe it is simpler to just create a new branch/PR from dotty/master and fix the typo again.

