### PR TITLE
 fix #11331

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2207,7 +2207,9 @@ object SymDenotations {
       if !myCompanion.exists then
         ensureCompleted()
       myCompanion
-    override def registeredCompanion_=(c: Symbol) = { myCompanion = c }
+
+    override def registeredCompanion_=(c: Symbol) = 
+      myCompanion = c 
 
     private var myNestingLevel = -1
 
@@ -2458,6 +2460,7 @@ object SymDenotations {
       || owner.isRefinementClass
       || owner.is(Scala2x)
       || owner.unforcedDecls.contains(denot.name, denot.symbol)
+      || (denot.is(Synthetic) && denot.is(ModuleClass) && stillValidInOwner(denot.companionClass))
       || denot.isSelfSym
       || denot.isLocalDummy)
   catch case ex: StaleSymbol => false

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -28,6 +28,7 @@ class BootstrappedOnlyCompilationTests {
       compileFilesInDir("tests/pos-macros", defaultOptions),
       compileFilesInDir("tests/pos-custom-args/semanticdb", defaultOptions.and("-Xsemanticdb")),
       compileDir("tests/pos-special/i7592", defaultOptions.and("-Yretain-trees")),
+      compileDir("tests/pos-special/i11331.1", defaultOptions),
     ).checkCompile()
   }
 

--- a/tests/pos-special/i11331.1/Macro_1.scala
+++ b/tests/pos-special/i11331.1/Macro_1.scala
@@ -1,0 +1,16 @@
+package i11331
+
+import scala.quoted._
+
+class I11331Class
+
+  
+object X:
+
+ inline def process[T](inline f:T) = ${
+   processImpl[T]('f)
+ }
+
+ def processImpl[T:Type](t:Expr[T])(using Quotes):Expr[T] =
+   import quotes.reflect._
+   t

--- a/tests/pos-special/i11331.1/Test_2.scala
+++ b/tests/pos-special/i11331.1/Test_2.scala
@@ -1,0 +1,10 @@
+package i11331
+
+
+object Main:
+
+ def main(args:Array[String]):Unit =
+   X.process{
+    val a = new I11331Class
+    a
+   }


### PR DESCRIPTION
 (the previous version of this with discussion was part of  #11335)
Now tracked to separated.

Note, that when testDir situated in posMacro and running with all macro tests - the test passed with an unmodified compiler (i.e. bug is not triggered).  I guess this is because with 2 files in dir something keep states in memory instead of rereading.