### PR TITLE
Tighten restriction for varargs splices

### DIFF
--- a/docs/docs/reference/changed-features/vararg-splices.md
+++ b/docs/docs/reference/changed-features/vararg-splices.md
@@ -6,8 +6,8 @@ title: "Vararg Splices"
 The syntax of vararg splices in patterns and function arguments has changed. The new syntax uses a postfix `*`,  analogously to how a vararg parameter is declared.
 
 ```scala
-val arr = Array(1, 2, 3)
-val lst = List(0, arr*)                  // vararg splice argument
+val arr = Array(0, 1, 2, 3)
+val lst = List(arr*)                  // vararg splice argument
 lst match
    case List(0, 1, xs*) => println(xs)   // binds xs to Seq(2, 3)
    case List(1, _*) =>                   // wildcard pattern
@@ -16,7 +16,7 @@ lst match
 The old syntax for splice arguments will be phased out.
 
 ```scala
-/*!*/ val lst = List(0, arr: _*)         // syntax error
+/*!*/ val lst = List(arr: _*)         // syntax error
       lst match
          case List(1, 2, xs @ _*)        // ok, equivalent to `xs*`
 ```

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
@@ -83,10 +83,11 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
     val message = named.find(_.name.get == "message")
     val since = named.find(_.name.get == "since")
 
-    val content = Seq(
-      since.map(s => code("[Since version ", parameter(s), "] ")),
-      message.map(m => parameter(m)),
-      m.docs.map(_.deprecated.toSeq.map(renderDocPart)):_*
+    val content = (
+      Seq(
+        since.map(s => code("[Since version ", parameter(s), "] ")),
+        message.map(m => parameter(m)))
+      ++ m.docs.map(_.deprecated.toSeq.map(renderDocPart))
     ).flatten
     Seq(dt("Deprecated"), dd(content:_*))
   }

--- a/tests/neg/i11419.scala
+++ b/tests/neg/i11419.scala
@@ -1,0 +1,7 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val arr: Array[String] = Array("foo")
+    val lst = List("x", arr: _*) // error
+    println(lst)
+  }
+}

--- a/tests/pos/i5039.scala
+++ b/tests/pos/i5039.scala
@@ -2,7 +2,4 @@ class I0 {
   List(null:_*)
   List[Null](null:_*)
   List[Nothing](null:_*)
-  List(1, 2, null:_*)
-  List(null, null:_*)
-  List(???, null:_*)
 }

--- a/tests/pos/reference/vararg-patterns.scala
+++ b/tests/pos/reference/vararg-patterns.scala
@@ -4,3 +4,9 @@ object t1 extends App {
   println(xs)
   val List(1, 2, _ *) = List(1, 2, 3)
 }
+@main def Test =
+  val arr = Array(0, 1, 2, 3)
+  val lst = List(arr*)                  // vararg splice argument
+  lst match
+    case List(0, 1, xs*) => println(xs)   // binds xs to Seq(2, 3)
+    case List(1, _*) =>                   // wildcard pattern


### PR DESCRIPTION
A vararg splice must be the only argument for a repeated parameter.

Fixes #11419 
