### PR TITLE
Skip overloaded methods when looking for an extractor

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -158,7 +158,8 @@ class Typer extends Namer
      */
     def qualifies(denot: Denotation): Boolean =
       reallyExists(denot)
-      && !(pt.isInstanceOf[UnapplySelectionProto] && denot.symbol.is(Method, butNot = Accessor))
+      && (!pt.isInstanceOf[UnapplySelectionProto]
+          || denot.hasAltWith(sd => !sd.symbol.is(Method, butNot = Accessor)))
       && !denot.symbol.is(PackageClass)
 
     /** Find the denotation of enclosing `name` in given context `ctx`.

--- a/tests/pos/i11421.scala
+++ b/tests/pos/i11421.scala
@@ -1,0 +1,9 @@
+class Foo {
+  def ::(hd: String): Foo = ???
+  def ::(hd: Boolean): Foo  = ???
+
+  List(1, 2) match {
+    case x :: tail => ()
+    case _ => ()
+  }
+}


### PR DESCRIPTION
The previous logic only skipped non-overloaded methods.

Fixes #11421