### PR TITLE
Move checkValue to Typer

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -653,6 +653,21 @@ object Checking {
        || to.isRef(defn.ObjectClass, skipRefined = false)
     then
       report.error(em"the result of an implicit conversion must be more specific than $to", pos)
+
+  def checkValue(tree: Tree)(using Context): Unit =
+    val sym = tree.tpe.termSymbol
+    if sym.is(Flags.Package) || sym.isAllOf(Flags.JavaModule) && !ctx.isJava then
+      report.error(JavaSymbolIsNotAValue(sym), tree.srcPos)
+
+  def checkValue(tree: Tree, proto: Type)(using Context): tree.type =
+    tree match
+      case tree: RefTree
+      if tree.name.isTermName
+         && !proto.isInstanceOf[SelectionProto]
+         && !proto.isInstanceOf[FunOrPolyProto] =>
+        checkValue(tree)
+      case _ =>
+    tree
 }
 
 trait Checking {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -499,7 +499,7 @@ class Typer extends Namer
         case _ =>
           tree.withType(ownType)
       val tree2 = toNotNullTermRef(tree1, pt)
-      checkStableIdentPattern(tree2, pt)
+      checkLegalValue(tree2, pt)
       tree2
 
     def isLocalExtensionMethodRef: Boolean = rawType match
@@ -537,9 +537,12 @@ class Typer extends Namer
       errorTree(tree, MissingIdent(tree, kind, name))
   end typedIdent
 
-  /** Check that a stable identifier pattern is indeed stable (SLS 8.1.5)
+  /** (1) If this reference is neither applied nor selected, check that it does
+   *      not refer to a package or Java companion object.
+   *  (2) Check that a stable identifier pattern is indeed stable (SLS 8.1.5)
    */
-  private def checkStableIdentPattern(tree: Tree, pt: Type)(using Context): Unit =
+  private def checkLegalValue(tree: Tree, pt: Type)(using Context): Unit =
+    checkValue(tree, pt)
     if ctx.mode.is(Mode.Pattern)
        && !tree.isType
        && !pt.isInstanceOf[ApplyingProto]
@@ -557,7 +560,7 @@ class Typer extends Namer
     if checkedType.exists then
       val select = toNotNullTermRef(assignType(tree, checkedType), pt)
       if selName.isTypeName then checkStable(qual.tpe, qual.srcPos, "type prefix")
-      checkStableIdentPattern(select, pt)
+      checkLegalValue(select, pt)
       ConstFold(select)
     else if couldInstantiateTypeVar(qual.tpe.widen) then
       // try again with more defined qualifier type
@@ -2343,7 +2346,7 @@ class Typer extends Namer
       assert(imp.selectors.length == 1, imp)
       val from = imp.selectors.head.imported
       val sel = tryAlternatively
-          (typedIdent(from, WildcardType))
+          (typedIdent(from, AnySelectionProto))
           (typedIdent(cpy.Ident(from)(from.name.toTypeName), WildcardType))
 
       sel.tpe match

--- a/tests/neg/i11430.scala
+++ b/tests/neg/i11430.scala
@@ -1,0 +1,4 @@
+def a(o: String) = Seq(o, org)               // error: package org is not a value
+def a2(o: String) = Seq[String](o, org)      // error: package org is not a value
+def a3(o: String): Seq[String] = Seq(o, org) // error: package org is not a value
+def a4(o: String): Seq[String] = Seq(o, org) // error: package org is not a value


### PR DESCRIPTION
Move the check to Typer so that we get better error messages, and don't fail
subsequent assertions.

Fixes #11430