### PR TITLE
Optimization: don't run override checks between Java definitions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -474,14 +474,14 @@ object RefChecks {
        *    - matching names and types, but different target names
        */
       override def matches(sym1: Symbol, sym2: Symbol): Boolean =
-        sym1.isType
-        || {
+        !(sym1.owner.is(JavaDefined, butNot = Trait) && sym2.owner.is(JavaDefined, butNot = Trait)) && // javac already handles these checks
+        (sym1.isType || {
           val sd1 = sym1.asSeenFrom(clazz.thisType)
           val sd2 = sym2.asSeenFrom(clazz.thisType)
           sd1.matchesLoosely(sd2)
           && (sym1.hasTargetName(sym2.targetName)
              || compatibleTypes(sym1, sd1.info, sym2, sd2.info))
-        }
+        })
     end opc
 
     while opc.hasNext do


### PR DESCRIPTION
Optimization: don't run override checks between Java definitions

This is the same optimization I implemented in Scala 2 a while ago:
https://github.com/scala/scala/pull/8643/commits/ba535451795c9b3a1a40f70cd26eb7c9dea490e3

We never run RefChecks on a Java class, but we can run it on a Scala
class which inherits from a Java class B which itself inherits from
another Java class A. In that case we don't need to check that members
of B correctly override members of A.