### PR TITLE
Fix code in indentation code

### DIFF
--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -209,11 +209,11 @@ The rules allow to write `match` expressions where cases are not indented themse
 
 ```scala
 x match
-   case 1 => print("I")
-   case 2 => print("II")
-   case 3 => print("III")
-   case 4 => print("IV")
-   case 5 => print("V")
+case 1 => print("I")
+case 2 => print("II")
+case 3 => print("III")
+case 4 => print("IV")
+case 5 => print("V")
 
 println(".")
 ```


### PR DESCRIPTION
Fix code in indentation code

The code there is intended to show that indentation can be avoided for cases in a patttern match.