### PR TITLE
Fix #11464: avoid expanding local paramRef in HKTypeLambda

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2924,7 +2924,7 @@ object Types {
           tp match {
             case tp: TypeRef => apply(x, tp.prefix)
             case tp: RecThis => RecType.this eq tp.binder
-            case tp: LazyRef => true // To be safe, assume a reference exists
+            case tp: LazyRef => this(x, tp.ref)
             case _ => foldOver(x, tp)
           }
         }

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -60,4 +60,3 @@ i9793.scala
 
 # lazy_implicit symbol has different position after pickling
 i8182.scala
-

--- a/tests/pos/i11464.scala
+++ b/tests/pos/i11464.scala
@@ -1,0 +1,16 @@
+trait Txn[T <: Txn[T]]
+
+trait Adjunct
+
+trait Type0
+trait Type[A1, Repr[~ <: Txn[~]] <: Expr[~, A1]] extends Type0
+
+object Expr {
+  def test(peer: Type0): Adjunct = {
+    new AdjunctImpl(peer.asInstanceOf[Type[Any, ({ type R[~ <: Txn[~]] <: Expr[~, Any] }) # R]])
+  }
+}
+
+trait Expr[T <: Txn[T], +A]
+
+class AdjunctImpl[A, E[~ <: Txn[~]] <: Expr[~, A]](tpe: Type[A, E]) extends Adjunct


### PR DESCRIPTION
Fix #11464: avoid expanding local paramRef in HKTypeLambda
