### PR TITLE
Fix #10567: avoid forcing symbols in classfile parser 

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -385,7 +385,7 @@ class ClassfileParser(
                   if (argsBuf != null) argsBuf += arg
                 }
                 accept('>')
-                if (skiptvs) tp else tp.appliedTo(argsBuf.toList)
+                if (skiptvs) tp else AppliedType(tp, argsBuf.toList)
               }
               else tp
             case tp =>

--- a/tests/pos/i10567/Main_2.scala
+++ b/tests/pos/i10567/Main_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val bldr = SchemaBuilder_1.builder()
+  val oops = bldr.fixed("foo")
+}

--- a/tests/pos/i10567/SchemaBuilder_1.java
+++ b/tests/pos/i10567/SchemaBuilder_1.java
@@ -1,0 +1,17 @@
+public class SchemaBuilder_1 {
+  public static class Schema {}
+
+  public static TypeBuilder<Schema> builder() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static class NamespacedBuilder<R, S extends NamespacedBuilder<R, S>> {}
+
+  public static class FixedBuilder<R> extends NamespacedBuilder<R, FixedBuilder<R>> {}
+
+  public static class TypeBuilder<R> {
+    public FixedBuilder<R> fixed(String name) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/tests/pos/i10945/Built_1.java
+++ b/tests/pos/i10945/Built_1.java
@@ -1,0 +1,5 @@
+public interface Built_1 {
+    interface Builder<A> extends GeneralBuilder<Built_1, Builder<A>> {}
+}
+
+interface GeneralBuilder<R, B extends GeneralBuilder<R, B>> {}

--- a/tests/pos/i10945/Test_2.scala
+++ b/tests/pos/i10945/Test_2.scala
@@ -1,0 +1,1 @@
+def useBuilder[A](builder: Built_1.Builder[A]): Unit = ???


### PR DESCRIPTION
Fix #10567: avoid forcing symbols in classfile parser 
Fix #10945: add test

Co-authored-by: Guillaume Martres <smarter@ubuntu.com>
