### PR TITLE
Refactor class parents handling

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4528,20 +4528,21 @@ object Types {
   type TypeOrSymbol = Type | Symbol
 
   /** Roughly: the info of a class during a period.
-   *  @param prefix       The prefix on which parents, decls, and selfType need to be rebased.
-   *  @param cls          The class symbol.
-   *  @param classParents The parent types of this class.
-   *                      These are all normalized to be TypeRefs by moving any refinements
-   *                      to be member definitions of the class itself.
-   *  @param decls        The symbols defined directly in this class.
-   *  @param selfInfo     The type of `this` in this class, if explicitly given,
-   *                      NoType otherwise. If class is compiled from source, can also
-   *                      be a reference to the self symbol containing the type.
+   *  @param prefix           The prefix on which parents, decls, and selfType need to be rebased.
+   *  @param cls              The class symbol.
+   *  @param declaredParents  The parent types of this class.
+   *                          These are all normalized to be TypeRefs by moving any refinements
+   *                          to be member definitions of the class itself.
+   *                          Unlike `parents`, the types are not seen as seen from `prefix`.
+   *  @param decls            The symbols defined directly in this class.
+   *  @param selfInfo         The type of `this` in this class, if explicitly given,
+   *                          NoType otherwise. If class is compiled from source, can also
+   *                          be a reference to the self symbol containing the type.
    */
   abstract case class ClassInfo(
       prefix: Type,
       cls: ClassSymbol,
-      classParents: List[Type],
+      declaredParents: List[Type],
       decls: Scope,
       selfInfo: TypeOrSymbol) extends CachedGroundType with TypeType {
 
@@ -4577,20 +4578,20 @@ object Types {
 
     override def parents(using Context): List[Type] = {
       if (parentsCache == null)
-        parentsCache = classParents.mapConserve(_.asSeenFrom(prefix, cls.owner))
+        parentsCache = declaredParents.mapConserve(_.asSeenFrom(prefix, cls.owner))
       parentsCache
     }
 
-    protected def newLikeThis(prefix: Type, classParents: List[Type], decls: Scope, selfInfo: TypeOrSymbol)(using Context): ClassInfo =
-      ClassInfo(prefix, cls, classParents, decls, selfInfo)
+    protected def newLikeThis(prefix: Type, declaredParents: List[Type], decls: Scope, selfInfo: TypeOrSymbol)(using Context): ClassInfo =
+      ClassInfo(prefix, cls, declaredParents, decls, selfInfo)
 
     def derivedClassInfo(prefix: Type)(using Context): ClassInfo =
       if (prefix eq this.prefix) this
-      else newLikeThis(prefix, classParents, decls, selfInfo)
+      else newLikeThis(prefix, declaredParents, decls, selfInfo)
 
-    def derivedClassInfo(prefix: Type = this.prefix, classParents: List[Type] = this.classParents, decls: Scope = this.decls, selfInfo: TypeOrSymbol = this.selfInfo)(using Context): ClassInfo =
-      if ((prefix eq this.prefix) && (classParents eq this.classParents) && (decls eq this.decls) && (selfInfo eq this.selfInfo)) this
-      else newLikeThis(prefix, classParents, decls, selfInfo)
+    def derivedClassInfo(prefix: Type = this.prefix, declaredParents: List[Type] = this.declaredParents, decls: Scope = this.decls, selfInfo: TypeOrSymbol = this.selfInfo)(using Context): ClassInfo =
+      if ((prefix eq this.prefix) && (declaredParents eq this.declaredParents) && (decls eq this.decls) && (selfInfo eq this.selfInfo)) this
+      else newLikeThis(prefix, declaredParents, decls, selfInfo)
 
     /** If this class has opaque type alias members, a new class info
      *  with their aliases added as refinements to the self type of the class.
@@ -4626,13 +4627,13 @@ object Types {
       }
 
     override def computeHash(bs: Binders): Int = doHash(bs, cls, prefix)
-    override def hashIsStable: Boolean = prefix.hashIsStable && classParents.hashIsStable
+    override def hashIsStable: Boolean = prefix.hashIsStable && declaredParents.hashIsStable
 
     override def eql(that: Type): Boolean = that match {
       case that: ClassInfo =>
         prefix.eq(that.prefix) &&
         cls.eq(that.cls) &&
-        classParents.eqElements(that.classParents) &&
+        declaredParents.eqElements(that.declaredParents) &&
         decls.eq(that.decls) &&
         selfInfo.eq(that.selfInfo)
       case _ => false
@@ -4644,17 +4645,17 @@ object Types {
       case that: ClassInfo =>
         prefix.equals(that.prefix, bs) &&
         cls.eq(that.cls) &&
-        classParents.equalElements(that.classParents, bs) &&
+        declaredParents.equalElements(that.declaredParents, bs) &&
         decls.eq(that.decls) &&
         selfInfo.eq(that.selfInfo)
       case _ => false
     }
 
-    override def toString: String = s"ClassInfo($prefix, $cls, $classParents)"
+    override def toString: String = s"ClassInfo($prefix, $cls, $declaredParents)"
   }
 
-  class CachedClassInfo(prefix: Type, cls: ClassSymbol, classParents: List[Type], decls: Scope, selfInfo: TypeOrSymbol)
-    extends ClassInfo(prefix, cls, classParents, decls, selfInfo)
+  class CachedClassInfo(prefix: Type, cls: ClassSymbol, declaredParents: List[Type], decls: Scope, selfInfo: TypeOrSymbol)
+    extends ClassInfo(prefix, cls, declaredParents, decls, selfInfo)
 
   /** A class for temporary class infos where `parents` are not yet known */
   final class TempClassInfo(prefix: Type, cls: ClassSymbol, decls: Scope, selfInfo: TypeOrSymbol)
@@ -4664,15 +4665,15 @@ object Types {
     def finalized(parents: List[Type])(using Context): ClassInfo =
       ClassInfo(prefix, cls, parents, decls, selfInfo)
 
-    override def newLikeThis(prefix: Type, classParents: List[Type], decls: Scope, selfInfo: TypeOrSymbol)(using Context): ClassInfo =
+    override def newLikeThis(prefix: Type, declaredParents: List[Type], decls: Scope, selfInfo: TypeOrSymbol)(using Context): ClassInfo =
       TempClassInfo(prefix, cls, decls, selfInfo)
 
     override def toString: String = s"TempClassInfo($prefix, $cls)"
   }
 
   object ClassInfo {
-    def apply(prefix: Type, cls: ClassSymbol, classParents: List[Type], decls: Scope, selfInfo: TypeOrSymbol = NoType)(using Context): ClassInfo =
-      unique(new CachedClassInfo(prefix, cls, classParents, decls, selfInfo))
+    def apply(prefix: Type, cls: ClassSymbol, declaredParents: List[Type], decls: Scope, selfInfo: TypeOrSymbol = NoType)(using Context): ClassInfo =
+      unique(new CachedClassInfo(prefix, cls, declaredParents, decls, selfInfo))
   }
 
   /** Type bounds >: lo <: hi */
@@ -5276,7 +5277,7 @@ object Types {
     protected def mapFullClassInfo(tp: ClassInfo): ClassInfo =
       tp.derivedClassInfo(
         prefix = this(tp.prefix),
-        classParents = tp.classParents.mapConserve(this),
+        declaredParents = tp.declaredParents.mapConserve(this),
         selfInfo = tp.selfInfo match {
           case tp: Type => this(tp)
           case sym => sym

--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -140,7 +140,7 @@ object PickledQuotes {
         class ReplaceSplicedTyped extends TypeMap() {
           override def apply(tp: Type): Type = tp match {
             case tp: ClassInfo =>
-              tp.derivedClassInfo(classParents = tp.classParents.map(apply))
+              tp.derivedClassInfo(declaredParents = tp.declaredParents.map(apply))
             case tp: TypeRef =>
               typeSpliceMap.get(tp.symbol) match
                 case Some(t) if tp.typeSymbol.hasAnnotation(defn.QuotedRuntime_SplicedTypeAnnot) => mapOver(t)

--- a/compiler/src/dotty/tools/dotc/quoted/reflect/FromSymbol.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/reflect/FromSymbol.scala
@@ -31,7 +31,7 @@ object FromSymbol {
         newSymbol(cls, nme.CONSTRUCTOR, EmptyFlags, NoType)
       )
       val constr = tpd.DefDef(constrSym.asTerm)
-      val parents = cls.classParents.map(tpd.TypeTree(_))
+      val parents = cls.info.parents.map(tpd.TypeTree(_))
       val body = cls.unforcedDecls.filter(!_.isPrimaryConstructor).map(s => definitionFromSym(s))
       tpd.ClassDefWithParents(cls, constr, parents, body)
   }

--- a/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
@@ -73,8 +73,8 @@ class CheckReentrant extends MiniPhase {
               scanning(sym) {
                 sym.info.widenExpr.classSymbols.foreach(addVars)
               }
-        for (parent <- cls.classInfo.classParents)
-          addVars(parent.classSymbol.asClass)
+        for (parent <- cls.parentSyms)
+          addVars(parent.asClass)
       }
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
@@ -32,13 +32,13 @@ class ElimPolyFunction extends MiniPhase with DenotTransformer {
     case ref: ClassDenotation if ref.symbol != defn.PolyFunctionClass && ref.derivesFrom(defn.PolyFunctionClass) =>
       val cinfo = ref.classInfo
       val newParent = functionTypeOfPoly(cinfo)
-      val newParents = cinfo.classParents.map(parent =>
+      val newParents = cinfo.declaredParents.map(parent =>
         if (parent.typeSymbol == defn.PolyFunctionClass)
           newParent
         else
           parent
       )
-      ref.copySymDenotation(info = cinfo.derivedClassInfo(classParents = newParents))
+      ref.copySymDenotation(info = cinfo.derivedClassInfo(declaredParents = newParents))
     case _ =>
       ref
   }

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -455,7 +455,7 @@ class PickleQuotes extends MacroTransform {
             apply(tp.dealias)
           case tp @ TypeRef(pre, _) if pre == NoPrefix || pre.termSymbol.isLocal =>
             val hiBound = tp.typeSymbol.info match
-              case info @ ClassInfo(_, _, classParents, _, _) => classParents.reduce(_ & _)
+              case info: ClassInfo => info.parents.reduce(_ & _)
               case info => info.hiBound
             apply(hiBound)
           case tp =>

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -92,7 +92,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     lazy val accessors =
       if (isDerivedValueClass(clazz)) clazz.paramAccessors.take(1) // Tail parameters can only be `erased`
       else clazz.caseAccessors
-    val isEnumValue = clazz.isAnonymousClass && clazz.classParents.head.classSymbol.is(Enum)
+    val isEnumValue = clazz.isAnonymousClass && clazz.info.parents.head.classSymbol.is(Enum)
     val isSimpleEnumValue = isEnumValue && !clazz.owner.isAllOf(EnumCase)
     val isJavaEnumValue = isEnumValue && clazz.derivesFrom(defn.JavaEnumClass)
     val isNonJavaEnumValue = isEnumValue && !isJavaEnumValue
@@ -428,7 +428,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
 
   /** Is this an anonymous class deriving from an enum definition? */
   extension (cls: ClassSymbol) private def isEnumValueImplementation(using Context): Boolean =
-    cls.isAnonymousClass && cls.classParents.head.typeSymbol.is(Enum) // asserted in Typer
+    cls.isAnonymousClass && cls.info.parents.head.typeSymbol.is(Enum) // asserted in Typer
 
   /** If this is the class backing a serializable singleton enum value with base class `MyEnum`,
    *  and not deriving from `java.lang.Enum` add the method:
@@ -546,7 +546,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       newParents = newParents :+ TypeTree(parent)
       val oldClassInfo = clazz.classInfo
       val newClassInfo = oldClassInfo.derivedClassInfo(
-        classParents = oldClassInfo.classParents :+ parent)
+        declaredParents = oldClassInfo.declaredParents :+ parent)
       clazz.copySymDenotation(info = newClassInfo).installAfter(thisPhase)
     }
     def addMethod(name: TermName, info: Type, cls: Symbol, body: (Symbol, Tree) => Context ?=> Tree): Unit = {

--- a/compiler/src/dotty/tools/dotc/transform/init/Summarization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Summarization.scala
@@ -335,16 +335,13 @@ object Summarization {
     }
 
     if (cls.defTree.isEmpty)
-      cls.info match {
-        case cinfo: ClassInfo =>
-          val source = {
-            implicit val ctx2: Context = theCtx.withSource(cls.source(using theCtx))
-            TypeTree(cls.typeRef).withSpan(cls.span)
-          }
+        val source = {
+          implicit val ctx2: Context = theCtx.withSource(cls.source(using theCtx))
+          TypeTree(cls.typeRef).withSpan(cls.span)
+        }
 
-          val parentOuter =  cinfo.classParents.map { extractParentOuters(_, source) }.toMap
-          ClassSummary(cls, parentOuter)
-      }
+        val parentOuter = cls.info.parents.map { extractParentOuters(_, source) }.toMap
+        ClassSummary(cls, parentOuter)
     else {
       val tpl = cls.defTree.asInstanceOf[TypeDef]
       val parents = tpl.rhs.asInstanceOf[Template].parents

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
@@ -291,7 +291,7 @@ class PrepJSInterop extends MacroTransform with IdentityDenotTransformer { thisP
 
     /** Performs checks and rewrites specific to classes / objects extending `js.Any`. */
     private def transformJSClassDef(classDef: TypeDef)(using Context): Tree = {
-      val sym = classDef.symbol
+      val sym = classDef.symbol.asClass
       val isJSNative = sym.hasAnnotation(jsdefn.JSNativeAnnot)
 
       sym.addAnnotation(jsdefn.JSTypeAnnot)
@@ -315,8 +315,8 @@ class PrepJSInterop extends MacroTransform with IdentityDenotTransformer { thisP
       }
 
       // Check the parents
-      for (parent <- sym.info.parents) {
-        parent.typeSymbol match {
+      for (parentSym <- sym.parentSyms) {
+        parentSym match {
           case parentSym if parentSym == defn.ObjectClass =>
             // AnyRef is valid, except for non-native JS classes and objects
             if (!isJSNative && !sym.is(Trait)) {

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -576,8 +576,8 @@ object Checking {
           }
           tp.derivedClassInfo(
             prefix = apply(tp.prefix),
-            classParents =
-              tp.parents.map(p => transformedParent(apply(p)))
+            declaredParents =
+              tp.declaredParents.map(p => transformedParent(apply(p)))
             )
         case _ =>
           mapOver(tp)
@@ -1180,7 +1180,7 @@ trait Checking {
         report.error(i"enum case does not extend its enum $enumCls", enumCase.srcPos)
         cls.info match
           case info: ClassInfo =>
-            cls.info = info.derivedClassInfo(classParents = enumCls.typeRefApplied :: info.classParents)
+            cls.info = info.derivedClassInfo(declaredParents = enumCls.typeRefApplied :: info.declaredParents)
           case _ =>
 
     val enumCase =

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -774,7 +774,7 @@ class Namer { typer: Typer =>
           alt != denot.symbol && alt.info.matchesLoosely(denot.info))
 
       def inheritsConcreteMember =
-        denot.owner.asClass.classParents.exists(parent =>
+        denot.owner.asClass.info.parents.exists(parent =>
           parent.member(denot.name).hasAltWith(sd =>
             !sd.symbol.is(Deferred) && sd.matches(denot)))
 
@@ -809,7 +809,7 @@ class Namer { typer: Typer =>
 
       if denot.isClass && !sym.isEnumAnonymClass && !sym.isRefinementClass then
         val child = if (denot.is(Module)) denot.sourceModule else denot.symbol
-        denot.asClass.classParents.foreach { parent => register(child, parent.classSymbol.asClass) }
+        denot.info.parents.foreach { parent => register(child, parent.classSymbol.asClass) }
       else if denot.is(CaseVal, butNot = Method | Module) then
         assert(denot.is(Enum), denot)
         denot.info.classSymbols.foreach { parent => register(denot.symbol, parent) }

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -104,14 +104,14 @@ object RefChecks {
           report.error(DoesNotConformToSelfType(category, cinfo.selfType, cls, otherSelf, relation, other),
             cls.srcPos)
       }
-      val parents = cinfo.classParents
-      for (parent <- parents)
-        checkSelfConforms(parent.classSymbol.asClass, "illegal inheritance", "parent")
+      val psyms = cls.asClass.parentSyms
+      for (psym <- psyms)
+        checkSelfConforms(psym.asClass, "illegal inheritance", "parent")
       for (reqd <- cinfo.cls.givenSelfType.classSymbols)
         checkSelfConforms(reqd, "missing requirement", "required")
 
       def isClassExtendingJavaEnum =
-        !cls.isOneOf(Enum | Trait) && parents.exists(_.classSymbol == defn.JavaEnumClass)
+        !cls.isOneOf(Enum | Trait) && psyms.contains(defn.JavaEnumClass)
 
       // Prevent wrong `extends` of java.lang.Enum
       if isClassExtendingJavaEnum then

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2248,7 +2248,7 @@ class Typer extends Namer
         report.featureWarning(nme.dynamics.toString, "extension of type scala.Dynamic", cls, isRequired, cdef.srcPos)
       }
 
-      checkNonCyclicInherited(cls.thisType, cls.classParents, cls.info.decls, cdef.srcPos)
+      checkNonCyclicInherited(cls.thisType, cls.info.parents, cls.info.decls, cdef.srcPos)
 
       // check value class constraints
       checkDerivedValueClass(cls, body1)
@@ -2297,7 +2297,7 @@ class Typer extends Namer
     def realClassParent(cls: Symbol): ClassSymbol =
       if (!cls.isClass) defn.ObjectClass
       else if (!cls.is(Trait)) cls.asClass
-      else cls.asClass.classParents match {
+      else cls.info.parents match {
         case parentRef :: _ => realClassParent(parentRef.typeSymbol)
         case nil => defn.ObjectClass
       }

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -147,7 +147,7 @@ class VarianceChecker(using Context) {
           case AnnotatedType(_, annot) if annot.symbol == defn.UncheckedVarianceAnnot =>
             status
           case tp: ClassInfo =>
-            foldOver(status, tp.classParents)
+            foldOver(status, tp.parents)
           case _ =>
             foldOver(status, tp)
         }

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/CommentExpander.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/CommentExpander.scala
@@ -382,7 +382,7 @@ object CommentExpander {
       case Some(cmt) if !cmt.isExpanded =>
         expandComment(sym.owner)
         if sym.isClass then
-          for ptype <- sym.info.asInstanceOf[Types.ClassInfo].classParents do
+          for ptype <- sym.info.parents do
             expandComment(ptype.classSymbol)
         Some(expandComment(sym, sym.owner, cmt))
       case _ =>


### PR DESCRIPTION
Before this commit we had:
- Type#parents: for a ClassInfo, this is the parents of the class as seen from
  the ClassInfo prefix
- ClassInfo#classParents: this is also the parents of the class but
  _not_ as seen from the ClassInfo prefix
- ClassDenotation#classParents: this delegates to ClassInfo#parents and
  not to ClassInfo#classParents as one might think.

To clear things up this commit:
- Renames ClassInfo#classParents to initParents, to avoid accidentally
  using it instead of parents.
- Remove ClassDenotation#classParents, one can always do `info.parents`
  instead.

Additionally, this commit introduces ClassDenotation#parentSyms, to be
used when one only care about the symbols of the parents. This method
relies on `înitParents` instead of `parents` which avoids any
unnecessary call to `asSeenFrom`. It is used in `computeBaseData`
instead of the old `classParents` to avoid a cyclic reference issue I
ran into while working on an unrelated PR.