### PR TITLE
Fix #11466: disallow implicit conversion for <init>

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2994,7 +2994,7 @@ class Typer extends Namer
         SearchFailure(qual.withType(NestedFailure(ex.toMessage, selectionProto))))
 
     // try an implicit conversion or given extension
-    if ctx.mode.is(Mode.ImplicitsEnabled) && tree.name != nme.CONSTRUCTOR && qual.tpe.isValueType then
+    if ctx.mode.is(Mode.ImplicitsEnabled) && !tree.name.isConstructorName && qual.tpe.isValueType then
       trace(i"try insert impl on qualifier $tree $pt") {
         val selProto = selectionProto
         inferView(qual, selProto) match

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2994,7 +2994,7 @@ class Typer extends Namer
         SearchFailure(qual.withType(NestedFailure(ex.toMessage, selectionProto))))
 
     // try an implicit conversion or given extension
-    if ctx.mode.is(Mode.ImplicitsEnabled) && qual.tpe.isValueType then
+    if ctx.mode.is(Mode.ImplicitsEnabled) && tree.name != nme.CONSTRUCTOR && qual.tpe.isValueType then
       trace(i"try insert impl on qualifier $tree $pt") {
         val selProto = selectionProto
         inferView(qual, selProto) match

--- a/tests/neg/i11466.scala
+++ b/tests/neg/i11466.scala
@@ -1,0 +1,16 @@
+import scala.language.implicitConversions
+
+trait TripleEqualsSupport:
+  class Equalizer[L](val leftSide: L)
+  def convertToEqualizer[T](left: T): Equalizer[T]
+
+trait TripleEquals extends TripleEqualsSupport:
+  implicit override def convertToEqualizer[T](left: T): Equalizer[T] = new Equalizer(left)
+
+class GraphDB[Id]:
+  class Node private[GraphDB](val id: Id)
+
+object GraphDBSpec extends TripleEquals:
+  object graph extends GraphDB[String]
+  import graph.Node
+  val m = new Node("Alice") // error


### PR DESCRIPTION
Fix #11466: disallow implicit conversion for `<init>`
