### PR TITLE
Community build: automatic dependency overrides

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,7 +283,7 @@ jobs:
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
       - name: Test
-        run: ./project/scripts/sbt sbt-dotty/scripted
+        run: ./project/scripts/sbt "sbt-dotty/scripted; sbt-community-build/scripted"
 
   test_java8:
     runs-on: [self-hosted, Linux]

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ vscode-dotty/.vscode-test
 community-build/scala3-bootstrapped.version
 community-build/sbt-dotty-sbt
 community-build/sbt-scalajs-sbt
+community-build/dotty-community-build-deps
 
 # Vulpix output files
 *.check.out

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ val `scaladoc-js` = Build.`scaladoc-js`
 val `scala3-bench-run` = Build.`scala3-bench-run`
 val dist = Build.dist
 val `community-build` = Build.`community-build`
+val `sbt-community-build` = Build.`sbt-community-build`
 
 val sjsSandbox = Build.sjsSandbox
 val sjsJUnitTests = Build.sjsJUnitTests

--- a/sbt-community-build/sbt-test/sbt-community-build/inter-project-transitive-dep/build.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/inter-project-transitive-dep/build.sbt
@@ -1,0 +1,23 @@
+ThisBuild / scalaVersion := sys.props("plugin.scalaVersion")
+ThisBuild / organization := "org.example"
+
+lazy val a = project
+  .settings(
+    name := "a",
+    version := "0.4.1-SNAPSHOT",
+    libraryDependencies := Seq(),  // don't depend on scala-library
+  )
+
+lazy val b = project
+  .settings(onlyThisTestResolverSettings)
+  .settings(
+    name := "b",
+    libraryDependencies := Seq(organization.value %% "a" % "0.4.0-SNAPSHOT"),
+  )
+
+lazy val c = project
+  .settings(onlyThisTestResolverSettings)
+  .settings(
+    name := "c",
+    libraryDependencies := Seq(),  // don't depend on scala-library
+  ).dependsOn(b)

--- a/sbt-community-build/sbt-test/sbt-community-build/inter-project-transitive-dep/project/ThisTestPlugin.scala
+++ b/sbt-community-build/sbt-test/sbt-community-build/inter-project-transitive-dep/project/ThisTestPlugin.scala
@@ -1,0 +1,33 @@
+import sbt._
+import Keys._
+
+object ThisTestPlugin extends AutoPlugin {
+  override def requires = plugins.IvyPlugin
+  override def trigger = allRequirements
+
+  val thisTestIvyHome = settingKey[File]("Ivy home directory for artifacts published by this test")
+  val thisTestResolver = settingKey[Resolver]("Resolver for artifacts published by this test")
+  val deleteDepsFile = taskKey[Unit]("Deletes the dotty-community-build-deps dependency tracking file")
+
+  override val projectSettings = Seq(
+    publishLocalConfiguration := publishLocalConfiguration.value.withResolverName("this-test")
+  )
+
+  override val buildSettings = defaultThisTestSettings ++ Seq(
+    resolvers += thisTestResolver.value
+  )
+
+  def defaultThisTestSettings: Seq[Setting[_]] = {
+    Seq(
+      thisTestIvyHome := (LocalRootProject / target).value / "ivy-cache",
+      thisTestResolver := Resolver.file("this-test", thisTestIvyHome.value / "local")(Resolver.ivyStylePatterns),
+      deleteDepsFile := IO.delete(file(sys.props("dotty.communitybuild.dir")) / "dotty-community-build-deps"),
+    )
+  }
+
+  object autoImport {
+    def onlyThisTestResolverSettings: Seq[Setting[_]] = Seq(
+      externalResolvers := thisTestResolver.value :: Nil
+    )
+  }
+}

--- a/sbt-community-build/sbt-test/sbt-community-build/inter-project-transitive-dep/project/plugins.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/inter-project-transitive-dep/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-community-build" % sys.props("plugin.version"))
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.sbtDottyVersion"))

--- a/sbt-community-build/sbt-test/sbt-community-build/inter-project-transitive-dep/test
+++ b/sbt-community-build/sbt-test/sbt-community-build/inter-project-transitive-dep/test
@@ -1,0 +1,10 @@
+> deleteDepsFile
+> reload
+
+> a/publishLocal
+
+-> c/update
+
+> reload
+
+> c/update

--- a/sbt-community-build/sbt-test/sbt-community-build/multiple-deps/build.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/multiple-deps/build.sbt
@@ -1,0 +1,26 @@
+ThisBuild / scalaVersion := sys.props("plugin.scalaVersion")
+ThisBuild / organization := "org.example"
+
+lazy val a = project
+  .settings(
+    name := "a",
+    version := "0.2.1-SNAPSHOT",
+    libraryDependencies := Seq(),  // don't depend on scala-library
+  )
+
+lazy val b = project
+  .settings(
+    name := "b",
+    version := "1.2.1-SNAPSHOT",
+    libraryDependencies := Seq(),  // don't depend on scala-library
+  )
+
+lazy val c = project
+  .settings(onlyThisTestResolverSettings)
+  .settings(
+    name := "c",
+    libraryDependencies := Seq(
+      organization.value %% "a" % "0.2.0-SNAPSHOT",
+      organization.value %% "b" % "1.2.0-SNAPSHOT",
+    ),
+  )

--- a/sbt-community-build/sbt-test/sbt-community-build/multiple-deps/project/ThisTestPlugin.scala
+++ b/sbt-community-build/sbt-test/sbt-community-build/multiple-deps/project/ThisTestPlugin.scala
@@ -1,0 +1,33 @@
+import sbt._
+import Keys._
+
+object ThisTestPlugin extends AutoPlugin {
+  override def requires = plugins.IvyPlugin
+  override def trigger = allRequirements
+
+  val thisTestIvyHome = settingKey[File]("Ivy home directory for artifacts published by this test")
+  val thisTestResolver = settingKey[Resolver]("Resolver for artifacts published by this test")
+  val deleteDepsFile = taskKey[Unit]("Deletes the dotty-community-build-deps dependency tracking file")
+
+  override val projectSettings = Seq(
+    publishLocalConfiguration := publishLocalConfiguration.value.withResolverName("this-test")
+  )
+
+  override val buildSettings = defaultThisTestSettings ++ Seq(
+    resolvers += thisTestResolver.value
+  )
+
+  def defaultThisTestSettings: Seq[Setting[_]] = {
+    Seq(
+      thisTestIvyHome := (LocalRootProject / target).value / "ivy-cache",
+      thisTestResolver := Resolver.file("this-test", thisTestIvyHome.value / "local")(Resolver.ivyStylePatterns),
+      deleteDepsFile := IO.delete(file(sys.props("dotty.communitybuild.dir")) / "dotty-community-build-deps"),
+    )
+  }
+
+  object autoImport {
+    def onlyThisTestResolverSettings: Seq[Setting[_]] = Seq(
+      externalResolvers := thisTestResolver.value :: Nil
+    )
+  }
+}

--- a/sbt-community-build/sbt-test/sbt-community-build/multiple-deps/project/plugins.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/multiple-deps/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-community-build" % sys.props("plugin.version"))
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.sbtDottyVersion"))

--- a/sbt-community-build/sbt-test/sbt-community-build/multiple-deps/test
+++ b/sbt-community-build/sbt-test/sbt-community-build/multiple-deps/test
@@ -1,0 +1,11 @@
+> deleteDepsFile
+> reload
+
+> a/publishLocal
+> b/publishLocal
+
+-> c/update
+
+> reload
+
+> c/update

--- a/sbt-community-build/sbt-test/sbt-community-build/scalajs/build.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/scalajs/build.sbt
@@ -1,0 +1,32 @@
+ThisBuild / scalaVersion := sys.props("plugin.scalaVersion")
+ThisBuild / organization := "org.example"
+
+lazy val aJVM = project
+  .settings(
+    name := "a",
+    version := "0.5.1-SNAPSHOT",
+    libraryDependencies := Seq(),  // don't depend on scala-library
+  )
+
+lazy val aJS = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    name := "a",
+    version := "0.5.1-SNAPSHOT",
+    libraryDependencies := Seq(),  // don't depend on scala-library
+  )
+
+lazy val bJVM = project
+  .settings(onlyThisTestResolverSettings)
+  .settings(
+    name := "b",
+    libraryDependencies := Seq(organization.value %%% "a" % "0.5.0-SNAPSHOT"),
+  )
+
+lazy val bJS = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(onlyThisTestResolverSettings)
+  .settings(
+    name := "b",
+    libraryDependencies := Seq(organization.value %%% "a" % "0.5.0-SNAPSHOT"),
+  )

--- a/sbt-community-build/sbt-test/sbt-community-build/scalajs/project/ThisTestPlugin.scala
+++ b/sbt-community-build/sbt-test/sbt-community-build/scalajs/project/ThisTestPlugin.scala
@@ -1,0 +1,33 @@
+import sbt._
+import Keys._
+
+object ThisTestPlugin extends AutoPlugin {
+  override def requires = plugins.IvyPlugin
+  override def trigger = allRequirements
+
+  val thisTestIvyHome = settingKey[File]("Ivy home directory for artifacts published by this test")
+  val thisTestResolver = settingKey[Resolver]("Resolver for artifacts published by this test")
+  val deleteDepsFile = taskKey[Unit]("Deletes the dotty-community-build-deps dependency tracking file")
+
+  override val projectSettings = Seq(
+    publishLocalConfiguration := publishLocalConfiguration.value.withResolverName("this-test")
+  )
+
+  override val buildSettings = defaultThisTestSettings ++ Seq(
+    resolvers += thisTestResolver.value
+  )
+
+  def defaultThisTestSettings: Seq[Setting[_]] = {
+    Seq(
+      thisTestIvyHome := (LocalRootProject / target).value / "ivy-cache",
+      thisTestResolver := Resolver.file("this-test", thisTestIvyHome.value / "local")(Resolver.ivyStylePatterns),
+      deleteDepsFile := IO.delete(file(sys.props("dotty.communitybuild.dir")) / "dotty-community-build-deps"),
+    )
+  }
+
+  object autoImport {
+    def onlyThisTestResolverSettings: Seq[Setting[_]] = Seq(
+      externalResolvers := thisTestResolver.value :: Nil
+    )
+  }
+}

--- a/sbt-community-build/sbt-test/sbt-community-build/scalajs/project/plugins.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/scalajs/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-community-build" % sys.props("plugin.version"))
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.sbtDottyVersion"))
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.scalaJSVersion"))

--- a/sbt-community-build/sbt-test/sbt-community-build/scalajs/test
+++ b/sbt-community-build/sbt-test/sbt-community-build/scalajs/test
@@ -1,0 +1,13 @@
+> deleteDepsFile
+> reload
+
+> aJVM/publishLocal
+> aJS/publishLocal
+
+-> bJVM/update
+-> bJS/update
+
+> reload
+
+> bJVM/update
+> bJS/update

--- a/sbt-community-build/sbt-test/sbt-community-build/single-dep/build.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/single-dep/build.sbt
@@ -1,0 +1,16 @@
+ThisBuild / scalaVersion := sys.props("plugin.scalaVersion")
+ThisBuild / organization := "org.example"
+
+lazy val a = project
+  .settings(
+    name := "a",
+    version := "0.1.1-SNAPSHOT",
+    libraryDependencies := Seq(),  // don't depend on scala-library
+  )
+
+lazy val b = project
+  .settings(onlyThisTestResolverSettings)
+  .settings(
+    name := "b",
+    libraryDependencies := Seq(organization.value %% "a" % "0.1.0-SNAPSHOT"),
+  )

--- a/sbt-community-build/sbt-test/sbt-community-build/single-dep/project/ThisTestPlugin.scala
+++ b/sbt-community-build/sbt-test/sbt-community-build/single-dep/project/ThisTestPlugin.scala
@@ -1,0 +1,33 @@
+import sbt._
+import Keys._
+
+object ThisTestPlugin extends AutoPlugin {
+  override def requires = plugins.IvyPlugin
+  override def trigger = allRequirements
+
+  val thisTestIvyHome = settingKey[File]("Ivy home directory for artifacts published by this test")
+  val thisTestResolver = settingKey[Resolver]("Resolver for artifacts published by this test")
+  val deleteDepsFile = taskKey[Unit]("Deletes the dotty-community-build-deps dependency tracking file")
+
+  override val projectSettings = Seq(
+    publishLocalConfiguration := publishLocalConfiguration.value.withResolverName("this-test")
+  )
+
+  override val buildSettings = defaultThisTestSettings ++ Seq(
+    resolvers += thisTestResolver.value
+  )
+
+  def defaultThisTestSettings: Seq[Setting[_]] = {
+    Seq(
+      thisTestIvyHome := (LocalRootProject / target).value / "ivy-cache",
+      thisTestResolver := Resolver.file("this-test", thisTestIvyHome.value / "local")(Resolver.ivyStylePatterns),
+      deleteDepsFile := IO.delete(file(sys.props("dotty.communitybuild.dir")) / "dotty-community-build-deps"),
+    )
+  }
+
+  object autoImport {
+    def onlyThisTestResolverSettings: Seq[Setting[_]] = Seq(
+      externalResolvers := thisTestResolver.value :: Nil
+    )
+  }
+}

--- a/sbt-community-build/sbt-test/sbt-community-build/single-dep/project/plugins.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/single-dep/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-community-build" % sys.props("plugin.version"))
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.sbtDottyVersion"))

--- a/sbt-community-build/sbt-test/sbt-community-build/single-dep/test
+++ b/sbt-community-build/sbt-test/sbt-community-build/single-dep/test
@@ -1,0 +1,10 @@
+> deleteDepsFile
+> reload
+
+> a/publishLocal
+
+-> b/update
+
+> reload
+
+> b/update

--- a/sbt-community-build/sbt-test/sbt-community-build/transitive-dep/build.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/transitive-dep/build.sbt
@@ -1,0 +1,23 @@
+ThisBuild / scalaVersion := sys.props("plugin.scalaVersion")
+ThisBuild / organization := "org.example"
+
+lazy val a = project
+  .settings(
+    name := "a",
+    version := "0.3.1-SNAPSHOT",
+    libraryDependencies := Seq(),  // don't depend on scala-library
+  )
+
+lazy val b = project
+  .settings(
+    name := "b",
+    version := "1.3.1-SNAPSHOT",
+    libraryDependencies := Seq(organization.value %% "a" % "0.3.0-SNAPSHOT"),
+  )
+
+lazy val c = project
+  .settings(onlyThisTestResolverSettings)
+  .settings(
+    name := "c",
+    libraryDependencies := Seq(organization.value %% "b" % "1.3.0-SNAPSHOT"),
+  )

--- a/sbt-community-build/sbt-test/sbt-community-build/transitive-dep/project/ThisTestPlugin.scala
+++ b/sbt-community-build/sbt-test/sbt-community-build/transitive-dep/project/ThisTestPlugin.scala
@@ -1,0 +1,33 @@
+import sbt._
+import Keys._
+
+object ThisTestPlugin extends AutoPlugin {
+  override def requires = plugins.IvyPlugin
+  override def trigger = allRequirements
+
+  val thisTestIvyHome = settingKey[File]("Ivy home directory for artifacts published by this test")
+  val thisTestResolver = settingKey[Resolver]("Resolver for artifacts published by this test")
+  val deleteDepsFile = taskKey[Unit]("Deletes the dotty-community-build-deps dependency tracking file")
+
+  override val projectSettings = Seq(
+    publishLocalConfiguration := publishLocalConfiguration.value.withResolverName("this-test")
+  )
+
+  override val buildSettings = defaultThisTestSettings ++ Seq(
+    resolvers += thisTestResolver.value
+  )
+
+  def defaultThisTestSettings: Seq[Setting[_]] = {
+    Seq(
+      thisTestIvyHome := (LocalRootProject / target).value / "ivy-cache",
+      thisTestResolver := Resolver.file("this-test", thisTestIvyHome.value / "local")(Resolver.ivyStylePatterns),
+      deleteDepsFile := IO.delete(file(sys.props("dotty.communitybuild.dir")) / "dotty-community-build-deps"),
+    )
+  }
+
+  object autoImport {
+    def onlyThisTestResolverSettings: Seq[Setting[_]] = Seq(
+      externalResolvers := thisTestResolver.value :: Nil
+    )
+  }
+}

--- a/sbt-community-build/sbt-test/sbt-community-build/transitive-dep/project/plugins.sbt
+++ b/sbt-community-build/sbt-test/sbt-community-build/transitive-dep/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-community-build" % sys.props("plugin.version"))
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.sbtDottyVersion"))

--- a/sbt-community-build/sbt-test/sbt-community-build/transitive-dep/test
+++ b/sbt-community-build/sbt-test/sbt-community-build/transitive-dep/test
@@ -1,0 +1,13 @@
+> deleteDepsFile
+> reload
+
+> a/publishLocal
+> reload
+
+> b/publishLocal
+
+-> c/update
+
+> reload
+
+> c/update

--- a/sbt-community-build/src/dotty/communitybuild/sbtplugin/CommunityBuildPlugin.scala
+++ b/sbt-community-build/src/dotty/communitybuild/sbtplugin/CommunityBuildPlugin.scala
@@ -1,0 +1,86 @@
+package dotty.communitybuild.sbtplugin
+
+import sbt._
+import sbt.Keys._
+import sbt.librarymanagement.LibraryManagementCodec._
+import sjsonnew.support.scalajson.unsafe.{ Converter, CompactPrinter, Parser }
+import scala.util.{ Try, Failure }
+
+/** This plugin provides automatic dependency overrides for projects in the
+ *  community build. In doing so, we permit the projects in the build to
+ *  depend on arbitrary versions of other projects in the build, and the
+ *  version alignment is handled here.
+ */
+object CommunityBuildPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings: Seq[Setting[_]] = Seq(
+    publishLocal := Def.taskDyn {
+      val pubLocalResult = publishLocal.value
+      Def.task {
+        if (artifacts.value.nonEmpty && !(publish / skip).value)
+          CommunityBuildDependencies.publish(projectID.value)
+        pubLocalResult
+      }
+    }.value
+  )
+
+  override val buildSettings: Seq[Setting[_]] = Seq(
+    dependencyOverrides ++= {
+      if (scalaVersion.value.startsWith("3."))
+        CommunityBuildDependencies.allOverrides(sLog.value)
+      else Nil
+    }
+  )
+}
+
+object CommunityBuildDependencies {
+  private val communityBuildDir = Path(sys.props("dotty.communitybuild.dir"))
+  private val depsFile = communityBuildDir / "dotty-community-build-deps"
+
+  /** Publish dependency override data for a module in the community build.
+   *  This appends a single entry to the tracking file.
+   */
+  def publish(moduleID: ModuleID): Unit = {
+    val line = encode(sanitized(moduleID)) + "\n"
+    synchronized { IO.append(depsFile, line) }
+  }
+
+  /** Returns all currently tracked dependency overrides. */
+  def allOverrides(log: Logger): List[ModuleID] = load(log)
+
+  /** Load all entries from the dependency tracking file. */
+  private def load(log: Logger): List[ModuleID] = {
+    def logError(line: String): PartialFunction[Throwable, Try[ModuleID]] = {
+      case ex: Throwable =>
+        log.error(ex.toString())
+        log.error(s"while parsing input: $line")
+        Failure(ex)
+    }
+
+    log.info(s"Loading dependency tracking file $depsFile")
+    try {
+      val lines = synchronized { IO.readLines(depsFile) }
+      lines.map { s => decode(s).recoverWith(logError(s)).toOption }.flatten
+    } catch {
+      case _: java.io.FileNotFoundException =>
+        log.info(s"Dependency tracking file $depsFile does not exist")
+        Nil
+    }
+  }
+
+  private def encode(m: ModuleID): String =
+    CompactPrinter(Converter.toJsonUnsafe(m))
+
+  // It seems that badly formatted JSON will throw, e.g.
+  // sjsonnew.shaded.org.typelevel.jawn.IncompleteParseException: exhausted input
+  // But missing/misnamed fields will not and the malformed entry will be loaded
+  private def decode(s: String): Try[ModuleID] =
+    Parser.parseFromString(s)
+      .flatMap(Converter.fromJson[ModuleID])
+
+  // preserve only organization, name, revision, and crossVersion
+  private def sanitized(m: ModuleID): ModuleID =
+    ModuleID(m.organization, m.name, m.revision).withCrossVersion(m.crossVersion)
+}


### PR DESCRIPTION
A follow up to #10503.

This PR adds automatic dependency override handling to the community build using an sbt plugin.

The implementation is deliberately simple, and works thusly:

  - The `sbt-community-build` plugin is injected into each community build project.

  - The plugin hooks into the `publishLocal` task and for every published module, appends a ModuleID serialization to a tracking file.

  - The entries in the tracking file are injected as `dependencyOverrides` in build scope in subsequent community build projects.

#### Notes:

  - A fresh dependency tracking file is created for each run of the community build.

  - It was considered to apply the dependency overrides selectively at project scope.
    This was not done in this PR for two reasons:

      1. It adds considerable complexity.

      2. I ran into difficulty writing an implementation that would pass the `inter-project-transitive-dep` test, and have not had time to explore further.

#### Limitations:

Since the dependency overrides are applied en masse in build scope rather than selectively in project scope, a difficulty arises for any dependency which is published with the same organization and name but differing version, as is the case for cats-effect-2 and cats-effect-3.

This means that if some projects in the community build depend on cats-effect-2, and others depend on cats-effect-3 (causing both to be published), the automatic dependency overrides would fail for one set or the other; `sbt` seems to treat duplicate-keyed dependency overrides as last one wins.

Some projects may in fact depend on both, e.g. `munit-cats-effect` (not currently in the community build) is a multi-project build where one of its sub-projects depends on cats-effect-2 and another depends on cats-effect-3. Such a project can be handled by layering manual overrides atop the automatic dependency overrides.

Currently, no projects in the community build depend on cats-effect.

This limitation could be overcome by an implementation injecting project-scoped dependency overrides coupled with a heuristic to determine which version should be selected in the case of duplicate artifact ids.

Nevertheless I think this PR is useful in its current state.
