### PR TITLE
"sbt compile" uses non-boostrapped scaladoc

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1165,6 +1165,11 @@ object Build {
     sources.in(Test) := Nil
   )
 
+  def scalaDoc(implicit mode: Mode): Project = mode match {
+    case NonBootstrapped => `scaladoc-nonBootstrapped`
+    case Bootstrapped => scaladoc
+  }
+
   lazy val `scaladoc-testcases` = project.in(file("scaladoc-testcases")).asScaladocTestcases
 
   lazy val `scaladoc-js` = project.in(file("scaladoc-js")).asScaladocJs
@@ -1415,7 +1420,7 @@ object Build {
 
     // FIXME: we do not aggregate `bin` because its tests delete jars, thus breaking other tests
     def asDottyRoot(implicit mode: Mode): Project = project.withCommonSettings.
-      aggregate(`scala3-interfaces`, dottyLibrary, dottyCompiler, tastyCore, scaladoc, `scala3-sbt-bridge`).
+      aggregate(`scala3-interfaces`, dottyLibrary, dottyCompiler, tastyCore, `scaladoc-nonBootstrapped`, `scala3-sbt-bridge`).
       bootstrappedAggregate(`scala3-language-server`, `scala3-staging`, `scala3-tasty-inspector`,
         `scala3-library-bootstrappedJS`, scaladoc).
       dependsOn(tastyCore).
@@ -1637,7 +1642,7 @@ object Build {
     def asDist(implicit mode: Mode): Project = project.
       enablePlugins(PackPlugin).
       withCommonSettings.
-      dependsOn(`scala3-interfaces`, dottyCompiler, dottyLibrary, tastyCore, `scala3-staging`, `scala3-tasty-inspector`, scaladoc).
+      dependsOn(`scala3-interfaces`, dottyCompiler, dottyLibrary, tastyCore, `scala3-staging`, `scala3-tasty-inspector`, scalaDoc).
       settings(commonDistSettings).
       bootstrappedSettings(
         target := baseDirectory.value / "target" // override setting in commonBootstrappedSettings


### PR DESCRIPTION
"sbt compile" is supposed to only compile non-bootstrapped projects (so
we can rely on it working even if bootstrapping is broken while working
on the compiler for example), but scaladoc is a bootstrapped project and
it was part of the aggregate of the default project. Fixed by replacing
it with `scaladoc-nonBootstrapped`. To compile all bootstrapped projects
use `scala3-bootstrapped/compile` instead.

Also make sure the `dist` project uses the correct scaladoc depending on
whether it's bootstrapped or not.