### PR TITLE
Output names of function parameters

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -338,6 +338,14 @@ trait BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
     /*
      * must-single-thread
      */
+    def emitParamNames(jmethod: asm.MethodVisitor, params: List[Symbol]) =
+      for param <- params do
+        var access = asm.Opcodes.ACC_FINAL
+        jmethod.visitParameter(param.name.mangledString, access)
+
+    /*
+     * must-single-thread
+     */
     def emitParamAnnotations(jmethod: asm.MethodVisitor, pannotss: List[List[Annotation]]): Unit =
       val annotationss = pannotss map (_ filter shouldEmitAnnotation)
       if (annotationss forall (_.isEmpty)) return

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -615,7 +615,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     /*
      * must-single-thread
      */
-    def initJMethod(flags: Int, paramAnnotations: List[List[Annotation]]): Unit = {
+    def initJMethod(flags: Int, params: List[Symbol]): Unit = {
 
       val jgensig = getGenericSignature(methSymbol, claszSymbol)
       val (excs, others) = methSymbol.annotations.partition(_.symbol eq defn.ThrowsAnnot)
@@ -637,7 +637,8 @@ trait BCodeSkelBuilder extends BCodeHelpers {
       // TODO param names: (m.params map (p => javaName(p.sym)))
 
       emitAnnotations(mnode, others)
-      emitParamAnnotations(mnode, paramAnnotations)
+      emitParamNames(mnode, params)
+      emitParamAnnotations(mnode, params.map(_.annotations))
 
     } // end of method initJMethod
 
@@ -749,7 +750,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
           .addFlagIf(isNative, asm.Opcodes.ACC_NATIVE) // native methods of objects are generated in mirror classes
 
       // TODO needed? for(ann <- m.symbol.annotations) { ann.symbol.initialize }
-      initJMethod(flags, params.map(p => p.symbol.annotations))
+      initJMethod(flags, params.map(_.symbol))
 
 
       if (!isAbstractMethod && !isNative) {

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -257,6 +257,7 @@ object StdNames {
     final val DeprecatedATTR: N                   = "Deprecated"
     final val ExceptionsATTR: N                   = "Exceptions"
     final val InnerClassesATTR: N                 = "InnerClasses"
+    final val MethodParametersATTR: N             = "MethodParameters"
     final val LineNumberTableATTR: N              = "LineNumberTable"
     final val LocalVariableTableATTR: N           = "LocalVariableTable"
     final val RuntimeVisibleAnnotationATTR: N     = "RuntimeVisibleAnnotations"   // RetentionPolicy.RUNTIME

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -42,6 +42,7 @@ class CompilationTests {
       compileFilesInDir("tests/pos-custom-args/erased", defaultOptions.and("-Yerased-terms")),
       compileFilesInDir("tests/pos", defaultOptions),
       compileFilesInDir("tests/pos-deep-subtype", allowDeepSubtypes),
+      compileDir("tests/pos-special/java-param-names", defaultOptions.withJavacOnlyOptions("-parameters")),
       compileFile(
         // succeeds despite -Xfatal-warnings because of -nowarn
         "tests/neg-custom-args/fatal-warnings/xfatalWarnings.scala",

--- a/compiler/test/dotty/tools/vulpix/TestFlags.scala
+++ b/compiler/test/dotty/tools/vulpix/TestFlags.scala
@@ -5,19 +5,23 @@ import java.io.{File => JFile}
 final case class TestFlags(
   defaultClassPath: String,
   runClassPath: String, // class path that is used when running `run` tests (not compiling)
-  options: Array[String]) {
+  options: Array[String],
+  javacOptions: Array[String]) {
 
   def and(flags: String*): TestFlags =
-    TestFlags(defaultClassPath, runClassPath, options ++ flags)
+    TestFlags(defaultClassPath, runClassPath, options ++ flags, javacOptions)
 
   def without(flags: String*): TestFlags =
-    TestFlags(defaultClassPath, runClassPath, options diff flags)
+    TestFlags(defaultClassPath, runClassPath, options diff flags, javacOptions)
 
   def withClasspath(classPath: String): TestFlags =
-    TestFlags(s"$defaultClassPath${JFile.pathSeparator}$classPath", runClassPath, options)
+    TestFlags(s"$defaultClassPath${JFile.pathSeparator}$classPath", runClassPath, options, javacOptions)
 
   def withRunClasspath(classPath: String): TestFlags =
-    TestFlags(defaultClassPath, s"$runClassPath${JFile.pathSeparator}$classPath", options)
+    TestFlags(defaultClassPath, s"$runClassPath${JFile.pathSeparator}$classPath", options, javacOptions)
+
+  def withJavacOnlyOptions(flags: String*): TestFlags =
+    TestFlags(defaultClassPath, runClassPath, options, javacOptions ++ flags)
 
   def all: Array[String] = Array("-classpath", defaultClassPath) ++ options
 
@@ -43,10 +47,10 @@ final case class TestFlags(
     val flags = all
     val cp = flags.dropWhile(_ != "-classpath").take(2)
     val output = flags.dropWhile(_ != "-d").take(2)
-    cp ++ output
+    cp ++ output ++ javacOptions
   }
 }
 
 object TestFlags {
-  def apply(classPath: String, flags: Array[String]): TestFlags = TestFlags(classPath, classPath, flags)
+  def apply(classPath: String, flags: Array[String]): TestFlags = TestFlags(classPath, classPath, flags, Array.empty)
 }

--- a/tests/pos-special/java-param-names/Foo_1.java
+++ b/tests/pos-special/java-param-names/Foo_1.java
@@ -1,0 +1,4 @@
+public class Foo_1 {
+  public Foo_1(int number, String text) {}
+  public void bar(String barText, int barNumber) {}
+}

--- a/tests/pos-special/java-param-names/Test_2.scala
+++ b/tests/pos-special/java-param-names/Test_2.scala
@@ -1,0 +1,2 @@
+@main def Test =
+  new Foo_1(number = 6, text = "param-name").bar(barNumber = 8, barText = "some-method")

--- a/tests/run/i11486/Old_1.scala
+++ b/tests/run/i11486/Old_1.scala
@@ -1,0 +1,3 @@
+case class TestedOld(foo: Int, bar: String, baz: Double):
+  def target(abc: TestedOld, efg: TestedOld) = ()
+  def symbolic(`def`: Int, *** : Int, `unary_!`: Int) = ()

--- a/tests/run/i11486/Test_2.scala
+++ b/tests/run/i11486/Test_2.scala
@@ -1,0 +1,21 @@
+import java.lang.reflect.Executable
+
+case class Tested(foo: Int, bar: String, baz: Double):
+  def target(abc: Tested, efg: Tested) = ()
+  def symbolic(`def`: Int, *** : Int, `unary_!`: Int) = ()
+
+def run(cls: Class[_]) =
+  extension(m: Executable) def parameters: List[String] = m.getParameters.toList.map(_.getName)
+
+  val ctorParams = cls.getConstructors.head.parameters
+    assert(ctorParams == List("foo", "bar", "baz"))
+
+    val targetParams = cls.getMethods.toList.find(_.getName == "target").get.parameters
+    assert(targetParams == List("abc", "efg"))
+
+    val symbolicParams = cls.getMethods.toList.find(_.getName == "symbolic").get.parameters
+    assert(symbolicParams == List("def", "$times$times$times", "unary_$bang"))
+
+@main def Test =
+  run(classOf[TestedOld])
+  run(classOf[Tested])


### PR DESCRIPTION
Port of https://github.com/scala/scala/pull/4735
Fixes #11486 

The last commit is doing small changes in the test framework, as before them it was not possible to define a test that is passing flags that are only applicable to `javac`.