### PR TITLE
Handle another case in newExpr

### DIFF
--- a/tests/pos/i11230.scala
+++ b/tests/pos/i11230.scala
@@ -1,0 +1,6 @@
+trait TyperCrasher {
+  class CrashTyper(i: Int) {}
+  object CrashTyper {
+    def init: CrashTyper = CrashTyper(0)
+  }
+}


### PR DESCRIPTION
The typed prefix of an `apply` may also be this ThisType of a module class.

Fixes #11230