### PR TITLE
Avoid printing while compiling test

### DIFF
--- a/tests/neg-macros/i11386/Macro_1.scala
+++ b/tests/neg-macros/i11386/Macro_1.scala
@@ -11,7 +11,7 @@ object test {
   inline def notNull(inline i: Int): Unit = ${notNullImpl('i)}
 
   def notNullImpl(expr: Expr[Int])(using quotes: Quotes): Expr[Unit] = {
-    println(expr.show)
+    expr.show
     expr.value.foreach(i => if(i == 0) quotes.reflect.report.error("test"))
     '{()}
   }


### PR DESCRIPTION
Avoid the 
```
0
1
0
1
```
in
<img width="506" alt="Screenshot 2021-02-24 at 14 10 30" src="https://user-images.githubusercontent.com/3648029/109005275-0f692900-76aa-11eb-9a78-86700048a433.png">
