### PR TITLE
Fix #11490: Support Java type annotation parsing

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -278,6 +278,7 @@ object JavaParsers {
       }
 
     def typ(): Tree =
+      annotations()
       optArrayBrackets {
         if (in.token == FINAL) in.nextToken()
         if (in.token == IDENTIFIER) {
@@ -516,6 +517,7 @@ object JavaParsers {
 
     def typeParam(flags: FlagSet): TypeDef =
       atSpan(in.offset) {
+        annotations()
         val name = identForType()
         val hi = if (in.token == EXTENDS) { in.nextToken() ; bound() } else javaLangObject()
         TypeDef(name, TypeBoundsTree(EmptyTree, hi)).withMods(Modifiers(flags))

--- a/tests/pos/i11490/First.java
+++ b/tests/pos/i11490/First.java
@@ -1,0 +1,7 @@
+package i11490;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
+public @interface First {}

--- a/tests/pos/i11490/Second.java
+++ b/tests/pos/i11490/Second.java
@@ -1,0 +1,7 @@
+package i11490;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
+public @interface Second {}

--- a/tests/pos/i11490/Use.java
+++ b/tests/pos/i11490/Use.java
@@ -1,0 +1,7 @@
+package i11490;
+
+import java.util.List;
+
+public class Use<@First T extends @Second List<@First @Second String>> {
+    public <@First S> @Second @First String method(@Second int a, @First @Second S b) { return ""; }
+}


### PR DESCRIPTION
Direct port of https://github.com/scala/scala/commit/7e57bcc1818a402ad6ec32416af2b4522671f9ab included in https://github.com/scala/scala/pull/5068

Fixes #11490