### PR TITLE
Harden type checking for enum values

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3803,7 +3803,7 @@ class Typer extends Namer
               mapOver(tp)
         }
 
-        if tree.symbol.is(Module)
+        if tree.symbol.isOneOf(Module | Enum)
            && !(tree.tpe frozen_<:< pt) // fast track
            && !(tree.tpe frozen_<:< approx(pt))
         then

--- a/scaladoc/src/dotty/tools/scaladoc/translators/ScalaSignatureProvider.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/translators/ScalaSignatureProvider.scala
@@ -22,8 +22,6 @@ object ScalaSignatureProvider:
         givenClassSignature(documentable, cls, builder)
       case Kind.Given(d: Kind.Def, _, _) =>
         givenMethodSignature(documentable, d, builder)
-      case Kind.Given(Kind.Val, _, _) =>
-        givenPropertySignature(documentable, builder)
       case cls: Kind.Class =>
         classSignature(documentable, cls, builder)
       case enm: Kind.Enum =>

--- a/tests/neg/i9740b.scala
+++ b/tests/neg/i9740b.scala
@@ -1,0 +1,19 @@
+enum Recovery:
+  case RecoveryCompleted
+
+enum TypedRecovery:
+  case TypedRecoveryCompleted
+
+import Recovery.*
+import TypedRecovery.*
+
+class Test {
+  TypedRecoveryCompleted match {
+    case RecoveryCompleted => println("Recovery completed")            // error
+    case TypedRecoveryCompleted => println("Typed recovery completed")
+  }
+
+  def foo(x: TypedRecovery) = x match
+    case RecoveryCompleted =>             // error
+    case TypedRecoveryCompleted =>
+}

--- a/tests/run/option-extract.scala
+++ b/tests/run/option-extract.scala
@@ -6,7 +6,7 @@ enum Option[+A]:
   opaque type ExtractResult[B] = (=> B) => B
 
   def extract[B](f: A => B): ExtractResult[B] =
-    def result(default: => B): B = this match
+    def result(default: => B): B = (this: Option[A]) match
       case None => default
       case Some(elem) => f(elem)
     result


### PR DESCRIPTION
This is a follow-up of #11327.

We cannot generalize further without complications:

```Scala
val b = 'b'

56 match
case 'a' =>
case `b` =>
```
