### PR TITLE
Init check: Early Promotion of fields

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -270,7 +270,7 @@ object Checking {
   /// A potential can be (currently) directly promoted if and only if:
   /// - `pot == this` and all fields of this are initialized, or
   /// - `pot == Warm(C, outer)` where `outer` can be directly promoted.
-  private def canDirectlyPromote(pot: Potential)(using state: State): Boolean =
+  private def canDirectlyPromote(pot: Potential)(using state: State): Boolean = trace("checking direct promotion of " + pot.show, init) {
     if (state.safePromoted.contains(pot)) true
     else pot match {
       case pot: ThisRef =>
@@ -282,8 +282,13 @@ object Checking {
         }
       case Warm(cls, outer) =>
         canDirectlyPromote(outer)
-      case _ => false
+      case _ =>
+        val summary = expand(pot)
+        if (!summary.effs.isEmpty)
+          false // max depth of expansion reached
+        else summary.pots.forall(canDirectlyPromote)
     }
+  }
 
   /// Check the Promotion of a Warm object, according to "Rule 2":
   //

--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -285,6 +285,40 @@ object Checking {
       case _ => false
     }
 
+  /// Check the Promotion of a Warm object, according to "Rule 2":
+  //
+  // Rule 2: Promote(pot)
+  //
+  // for all concrete methods `m` of D
+  //    pot.m!, Promote(pot.m)
+  //
+  // for all concrete fields `f` of D
+  //    Promote(pot.f)
+  //
+  // for all inner classes `F` of D
+  //    Warm[F, pot].init!, Promote(Warm[F, pot])
+  private def checkPromoteWarm(warm: Warm, eff: Effect)(using state: State): Errors =
+    val Warm(cls, outer) = warm
+    // Errors.empty
+    val classRef = cls.info.asInstanceOf[ClassInfo].appliedRef
+    // All members of class must be promotable.
+    val memberErrs = classRef.allMembers.flatMap { denot =>
+      val sym = denot.symbol
+      val summary = warm.toPots.select(sym, warm.source, true)
+      (summary.effs ++ summary.pots.map(Promote(_)(warm.source)).toList)
+    }.flatMap(check(_))
+
+    // All inner classes of classRef must be promotable.
+    // TODO: Implement this
+    val innerClassesErrs = Errors.empty
+
+    val errs = memberErrs ++ innerClassesErrs
+    if errs.isEmpty then {
+      Errors.empty
+    } else {
+      UnsafePromotion(warm, eff.source, state.path, errs.toList).toErrors
+    }
+
   private def checkPromote(eff: Promote)(using state: State): Errors =
     if (state.safePromoted.contains(eff.potential)) Errors.empty
     else {
@@ -300,8 +334,7 @@ object Checking {
           PromoteCold(eff.source, state.path).toErrors
 
         case pot @ Warm(cls, outer) =>
-          // TODO: Implement Rule 2
-          PromoteWarm(pot, eff.source, state.path).toErrors
+          checkPromoteWarm(pot, eff)
 
         case Fun(pots, effs) =>
           val errs1 = state.test {

--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -340,11 +340,10 @@ object Checking {
     }
 
     val errs = buffer.toList.flatMap(eff => check(eff))
-    if errs.isEmpty then {
+    if errs.isEmpty then
       Errors.empty
-    } else {
+    else
       UnsafePromotion(warm, eff.source, state.path, errs.toList).toErrors
-    }
 
   private def checkPromote(eff: Promote)(using state: State): Errors =
     if (state.safePromoted.contains(eff.potential)) Errors.empty

--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -267,11 +267,11 @@ object Checking {
     }
 
   /**
-  * Check if we can just directly promote a potential.
-  * A potential can be (currently) directly promoted if and only if:
-  * - `pot == this` and all fields of this are initialized, or
-  * - `pot == Warm(C, outer)` where `outer` can be directly promoted.
-  */
+   * Check if we can just directly promote a potential.
+   * A potential can be (currently) directly promoted if and only if:
+   * - `pot == this` and all fields of this are initialized, or
+   * - `pot == Warm(C, outer)` where `outer` can be directly promoted.
+   */
   private def canDirectlyPromote(pot: Potential, visited: Set[Potential] = Set.empty)(using state: State): Boolean = trace("checking direct promotion of " + pot.show, init) {
     if (state.safePromoted.contains(pot)) true
     // If this potential's promotion depends on itself, we cannot directly promote it.
@@ -295,19 +295,19 @@ object Checking {
   }
 
   /**
-  * Check the Promotion of a Warm object, according to "Rule 2":
-  *
-  * Rule 2: Promote(pot)
-  *
-  * for all concrete methods `m` of D
-  *    pot.m!, Promote(pot.m)
-  *
-  * for all concrete fields `f` of D
-  *    Promote(pot.f)
-  *
-  * for all inner classes `F` of D
-  *    Warm[F, pot].init!, Promote(Warm[F, pot])
-  */
+   * Check the Promotion of a Warm object, according to "Rule 2":
+   *
+   * Rule 2: Promote(pot)
+   *
+   * for all concrete methods `m` of D
+   *    pot.m!, Promote(pot.m)
+   *
+   * for all concrete fields `f` of D
+   *    Promote(pot.f)
+   *
+   * for all inner classes `F` of D
+   *    Warm[F, pot].init!, Promote(Warm[F, pot])
+   */
   private def checkPromoteWarm(warm: Warm, eff: Effect)(using state: State): Errors =
     val Warm(cls, outer) = warm
     val source = eff.source

--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -299,20 +299,36 @@ object Checking {
   //    Warm[F, pot].init!, Promote(Warm[F, pot])
   private def checkPromoteWarm(warm: Warm, eff: Effect)(using state: State): Errors =
     val Warm(cls, outer) = warm
+    val source = eff.source
     // Errors.empty
     val classRef = cls.info.asInstanceOf[ClassInfo].appliedRef
     // All members of class must be promotable.
-    val memberErrs = classRef.allMembers.flatMap { denot =>
-      val sym = denot.symbol
-      val summary = warm.toPots.select(sym, warm.source, true)
-      (summary.effs ++ summary.pots.map(Promote(_)(warm.source)).toList)
-    }.flatMap(check(_))
+    val buffer = new mutable.ArrayBuffer[Effect]
+    val excludedFlags = Flags.Deferred | Flags.Private | Flags.Protected
 
-    // All inner classes of classRef must be promotable.
-    // TODO: Implement this
-    val innerClassesErrs = Errors.empty
+    classRef.fields.foreach { denot =>
+      val f = denot.symbol
+      if !f.isOneOf(excludedFlags) && f.hasSource then
+        buffer += Promote(FieldReturn(warm, f)(source))(source)
+        buffer += FieldAccess(warm, f)(source)
+    }
 
-    val errs = memberErrs ++ innerClassesErrs
+    classRef.membersBasedOnFlags(Flags.Method, Flags.Deferred).foreach { denot =>
+      val m = denot.symbol
+      if !m.isConstructor && m.hasSource && !theEnv.canIgnoreMethod(m) then
+        buffer += MethodCall(warm, m)(source)
+        buffer += Promote(MethodReturn(warm, m)(source))(source)
+    }
+
+    classRef.memberClasses.foreach { denot =>
+      val cls = denot.symbol.asClass
+      if cls.hasSource then
+        val potInner = Potentials.asSeenFrom(Warm(cls, ThisRef()(source))(source), warm)
+        buffer += MethodCall(potInner, cls.primaryConstructor)(source)
+        buffer += Promote(potInner)(source)
+    }
+
+    val errs = buffer.toList.flatMap(eff => check(eff))
     if errs.isEmpty then {
       Errors.empty
     } else {

--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -339,11 +339,12 @@ object Checking {
         buffer += Promote(potInner)(source)
     }
 
-    val errs = buffer.toList.flatMap(eff => check(eff))
-    if errs.isEmpty then
-      Errors.empty
-    else
-      UnsafePromotion(warm, eff.source, state.path, errs.toList).toErrors
+    for (eff <- buffer.toList) {
+      val err = check(eff)
+      if !errs.isEmpty then
+        return UnsafePromotion(warm, eff.source, state.path, errs.toList).toErrors
+    }
+    Errors.empty
 
   private def checkPromote(eff: Promote)(using state: State): Errors =
     if (state.safePromoted.contains(eff.potential)) Errors.empty

--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -266,10 +266,12 @@ object Checking {
         (effs2 ++ effs).toList.flatMap(check(_))
     }
 
-  /// Check if we can just directly promote a potential.
-  /// A potential can be (currently) directly promoted if and only if:
-  /// - `pot == this` and all fields of this are initialized, or
-  /// - `pot == Warm(C, outer)` where `outer` can be directly promoted.
+  /**
+  * Check if we can just directly promote a potential.
+  * A potential can be (currently) directly promoted if and only if:
+  * - `pot == this` and all fields of this are initialized, or
+  * - `pot == Warm(C, outer)` where `outer` can be directly promoted.
+  */
   private def canDirectlyPromote(pot: Potential, visited: Set[Potential] = Set.empty)(using state: State): Boolean = trace("checking direct promotion of " + pot.show, init) {
     if (state.safePromoted.contains(pot)) true
     // If this potential's promotion depends on itself, we cannot directly promote it.
@@ -292,18 +294,20 @@ object Checking {
     }
   }
 
-  /// Check the Promotion of a Warm object, according to "Rule 2":
-  //
-  // Rule 2: Promote(pot)
-  //
-  // for all concrete methods `m` of D
-  //    pot.m!, Promote(pot.m)
-  //
-  // for all concrete fields `f` of D
-  //    Promote(pot.f)
-  //
-  // for all inner classes `F` of D
-  //    Warm[F, pot].init!, Promote(Warm[F, pot])
+  /**
+  * Check the Promotion of a Warm object, according to "Rule 2":
+  *
+  * Rule 2: Promote(pot)
+  *
+  * for all concrete methods `m` of D
+  *    pot.m!, Promote(pot.m)
+  *
+  * for all concrete fields `f` of D
+  *    Promote(pot.f)
+  *
+  * for all inner classes `F` of D
+  *    Warm[F, pot].init!, Promote(Warm[F, pot])
+  */
   private def checkPromoteWarm(warm: Warm, eff: Effect)(using state: State): Errors =
     val Warm(cls, outer) = warm
     val source = eff.source

--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -340,7 +340,7 @@ object Checking {
     }
 
     for (eff <- buffer.toList) {
-      val err = check(eff)
+      val errs = check(eff)
       if !errs.isEmpty then
         return UnsafePromotion(warm, eff.source, state.path, errs.toList).toErrors
     }

--- a/tests/init/neg/inner1.scala
+++ b/tests/init/neg/inner1.scala
@@ -4,7 +4,7 @@ class Foo {
   val list = List(1, 2, 3) // error, as Inner access `this.list`
 
   val inner: Inner = new this.Inner // ok, `list` is instantiated
-  lib.escape(inner) // error
+  lib.escape(inner) // ok, can promote inner early
 
   val name = "good"
 

--- a/tests/init/neg/inner17.scala
+++ b/tests/init/neg/inner17.scala
@@ -5,7 +5,7 @@ class A {
     val a = f
   }
 
-  println(new B)              // error
+  println(new B)              // OK, can promote B early
 }
 
 class C extends A {

--- a/tests/init/neg/inner19.scala
+++ b/tests/init/neg/inner19.scala
@@ -14,6 +14,6 @@ class A {
 
 class B extends A {
   println((new O.B).f)
-  O.C(4)                // error
-  override val n = 50   // error
+  O.C(4)
+  override val n = 50   // error because line 16
 }

--- a/tests/init/pos/early-promote.scala
+++ b/tests/init/pos/early-promote.scala
@@ -27,3 +27,12 @@ class A { // checking A
   List(b) // Direct promotion works here
   val af = 42
 }
+
+class RecursiveF {
+  val a = f
+  def f: RecursiveF = f
+  class B(x: Int)
+
+  println(new a.B(5))
+  val n = 10
+}

--- a/tests/init/pos/early-promote.scala
+++ b/tests/init/pos/early-promote.scala
@@ -1,0 +1,29 @@
+class Y {
+ class X {
+   class B {
+     def g = f
+     def g2 = n
+   }
+   val f = 42
+   val b = new B  // warm(B, X.this)
+ }
+
+ val n = 10
+ val x = new X
+ List(x.b)      // unsafe promotion
+
+}
+
+class A { // checking A
+  class B {
+    def bf = 42
+    class C {
+      def x = bf // uses outer[C], but never outer[B]
+    }
+    List((new C).x)
+    def c = new C
+  }
+  val b = new B()
+  List(b) // Direct promotion works here
+  val af = 42
+}


### PR DESCRIPTION
- New checks for `Promote(pot, outer)` effect.
- The old checking rule (`Promote(pot, outer) <= Promote(outer)`) is now used as a quick check (`canDirectlyPromote`), before the newer, more costly check is run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lampepfl/dotty/11533)
<!-- Reviewable:end -->
