### PR TITLE
Correct the Macros+inline example expansion

### DIFF
--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -560,7 +560,7 @@ then it will splice `sum`:
 val arr: Array[Int] = Array.apply(1, [2,3 : Int]:Int*)
 
 var sum = 0
-${ map(arr, x => '{sum += $x}) }
+${ map('arr, x => '{sum += $x}) }
 sum
 ```
 
@@ -571,7 +571,7 @@ val arr: Array[Int] = Array.apply(1, [2,3 : Int]:Int*)
 
 var sum = 0
 val f = x => '{sum += $x}
-${ _root_.Macros.map(arr, 'f)('[Int])}
+${ _root_.Macros.map('arr, 'f)('[Int])}
 sum
 ```
 


### PR DESCRIPTION
In the whole macro+inline example, I have a feeling that the `arr` reference inside the spliced `sum` step during expansion, should be quoted.
`sum` accepts an Expr in the definition, but at call site `arr` is an Array.


Honestly I didn't check the generated docs locally. I didn't go thru the process of cloning and rebuilding everything.