### PR TITLE
Improve error message in overloading resolution

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1779,7 +1779,6 @@ class Typer extends Namer
         tpt1.tpe.typeSymbol == defn.PolyFunctionClass && rsym.name == nme.apply
       if (!polymorphicRefinementAllowed && rsym.info.isInstanceOf[PolyType] && rsym.allOverriddenSymbols.isEmpty)
         report.error(PolymorphicMethodMissingTypeInParent(rsym, tpt1.symbol), refinement.srcPos)
-
       val member = refineCls.info.member(rsym.name)
       if (member.isOverloaded)
         report.error(OverloadInRefinement(rsym), refinement.srcPos)
@@ -3124,20 +3123,16 @@ class Typer extends Namer
               }
           }
         case ambiAlts =>
-          if (tree.tpe.isErroneous || pt.isErroneous) tree.withType(UnspecifiedErrorType)
-          else {
+          if tree.tpe.isErroneous || pt.isErroneous then tree.withType(UnspecifiedErrorType)
+          else
             val remainingDenots = altDenots.filter(denot => ambiAlts.contains(altRef(denot)))
             val addendum =
-              if ambiAlts.toSet.size != ambiAlts.size then
-                // Several variants have the same signature. This can happen for structural
-                // type selections. See i8736.scala
-                """|
-                   |
-                   |Note: this happens because two or more alternatives have the same erasure,
-                   |      so they cannot be distinguished by overloading resolution""".stripMargin
+              if ambiAlts.exists(!_.symbol.exists) then
+                i"""|
+                    |
+                    |Note: Overloaded definitions introduced by refinements cannot be resolved"""
               else ""
             errorTree(tree, AmbiguousOverload(tree, remainingDenots, pt, addendum))
-          }
       }
     }
 

--- a/tests/neg/i11544.check
+++ b/tests/neg/i11544.check
@@ -1,0 +1,11 @@
+-- [E051] Reference Error: tests/neg/i11544.scala:6:13 -----------------------------------------------------------------
+6 |  val n = m1.foo(23)  // error
+  |          ^^^^^^
+  |          Ambiguous overload. The overloaded alternatives of method (str: String, int: Int): Int with types
+  |           (str: String, int: Int): Int
+  |           (arg: Int): Int
+  |          both match arguments ((23 : Int))
+  |
+  |          Note: Overloaded definitions introduced by refinements cannot be resolved
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i11544.scala
+++ b/tests/neg/i11544.scala
@@ -1,0 +1,7 @@
+import language.reflectiveCalls
+
+object Foo {
+  val m: ({ def foo(str: String, int: Int): Int }){ def foo(arg: Int): Int } = ???
+  val m1 = m
+  val n = m1.foo(23)  // error
+}

--- a/tests/neg/i8736.check
+++ b/tests/neg/i8736.check
@@ -17,7 +17,6 @@
    |                 (k: ("z" : String)): Boolean
    |                all match arguments (("z" : String))
    |
-   |                Note: this happens because two or more alternatives have the same erasure,
-   |                      so they cannot be distinguished by overloading resolution
+   |                Note: Overloaded definitions introduced by refinements cannot be resolved
 
 longer explanation available when compiling with `-explain`


### PR DESCRIPTION
Improve error message when trying to do overloading resolution of alternatives introduced by refinements.
As i8736 shows, it's not so simple to identify overloaded members introduced by refinements, since this can
arise through intersection and de-aliasing. So our best bet is to make the error message clearer at the
point of overloading resolution.

Fixes #11544 
