### PR TITLE
Reintroduce view bounds for non-implicit conversions

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1819,9 +1819,6 @@ object Parsers {
           AppliedTypeTree(toplevelTyp(), Ident(pname))
         } :: contextBounds(pname)
       case VIEWBOUND =>
-        report.errorOrMigrationWarning(
-          "view bounds `<%' are deprecated, use a context bound `:' instead",
-          in.sourcePos())
         atSpan(in.skipToken()) {
           Function(Ident(pname) :: Nil, toplevelTyp())
         } :: contextBounds(pname)

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -115,7 +115,7 @@ class TabcompleteTests extends ReplTest {
   @Test def anyRef = fromInitialState { implicit s =>
     val comp = tabComplete("(null: AnyRef).")
     assertEquals(
-      List("!=", "##", "->", "==", "asInstanceOf", "ensuring", "eq", "equals", "formatted",
+      List("!=", "##", "->", "==", "as", "asInstanceOf", "ensuring", "eq", "equals", "formatted",
           "getClass", "hashCode", "isInstanceOf", "ne", "nn", "notify", "notifyAll", "synchronized", "toString", "wait", "→"),
       comp.distinct.sorted)
   }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -115,7 +115,7 @@ class TabcompleteTests extends ReplTest {
   @Test def anyRef = fromInitialState { implicit s =>
     val comp = tabComplete("(null: AnyRef).")
     assertEquals(
-      List("!=", "##", "->", "==", "as", "asInstanceOf", "ensuring", "eq", "equals", "formatted",
+      List("!=", "##", "->", "==", "asInstanceOf", "convertTo", "ensuring", "eq", "equals", "formatted",
           "getClass", "hashCode", "isInstanceOf", "ne", "nn", "notify", "notifyAll", "synchronized", "toString", "wait", "→"),
       comp.distinct.sorted)
   }

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -194,7 +194,7 @@ ParamValueType    ::=  Type [‘*’]                                           
 TypeArgs          ::=  ‘[’ Types ‘]’                                            ts
 Refinement        ::=  ‘{’ [RefineDcl] {semi [RefineDcl]} ‘}’                   ds
 TypeBounds        ::=  [‘>:’ Type] [‘<:’ Type]                                  TypeBoundsTree(lo, hi)
-TypeParamBounds   ::=  TypeBounds {‘:’ Type}                                    ContextBounds(typeBounds, tps)
+TypeParamBounds   ::=  TypeBounds {‘<%’ Type} {‘:’ Type}                        ContextBounds(typeBounds, tps)
 Types             ::=  Type {‘,’ Type}
 ```
 

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -40,7 +40,7 @@ object Predef:
    */
 
   extension [T](x: T)
-    inline def as[A](using c: T => A) = c(x)
+    inline def convertTo[A](using c: T => A) = c(x)
 
   // Extension methods for working with explicit nulls
 

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -33,6 +33,15 @@ object Predef:
    */
   transparent inline def summon[T](using inline x: T): x.type = x
 
+  /** Apply a non-implicit conversion automatically.
+   *
+   *  @tparam T the type of the value to be converted
+   *  @return the converted value
+   */
+
+  extension [T](x: T)
+    inline def as[A](using c: T => A) = c(x)
+
   // Extension methods for working with explicit nulls
 
   /** Strips away the nullability from a value.

--- a/tests/neg/t3688.scala
+++ b/tests/neg/t3688.scala
@@ -1,0 +1,12 @@
+import collection.mutable
+import collection.convert.ImplicitConversions._
+import java.{util => ju}
+
+object Test {
+ implicitly[mutable.Map[Int, String] => ju.Dictionary[Int, String]]
+}
+
+object Test2 {
+  def m[P <% ju.List[Int]](l: P) = { val a: ju.List[Int] = l ; 1 } // error: found P required ju.List[Int]
+  m(List(1))
+}

--- a/tests/pos/t3688.scala
+++ b/tests/pos/t3688.scala
@@ -1,0 +1,12 @@
+import collection.mutable
+import collection.convert.ImplicitConversions._
+import java.{util => ju}
+
+object Test {
+ implicitly[mutable.Map[Int, String] => ju.Dictionary[Int, String]]
+}
+
+object Test2 {
+  def m[P <% ju.List[Int]](l: P) = { val a = l.as[ju.List[Int]] ; 1 }
+  m(List(1))
+}

--- a/tests/pos/t3688.scala
+++ b/tests/pos/t3688.scala
@@ -7,6 +7,6 @@ object Test {
 }
 
 object Test2 {
-  def m[P <% ju.List[Int]](l: P) = { val a = l.as[ju.List[Int]] ; 1 }
+  def m[P <% ju.List[Int]](l: P) = { val a = l.convertTo[ju.List[Int]] ; 1 }
   m(List(1))
 }


### PR DESCRIPTION
This reverts commit 7e26ac39e331eced36ea55989f198edb5dfdb82c.