### PR TITLE
fix #11583: skip typarams of right assoc ext meth

### DIFF
--- a/tests/pos/i11583.scala
+++ b/tests/pos/i11583.scala
@@ -1,0 +1,2 @@
+extension (s: String)
+  def :*:[T <: Tuple](that: T) : String *: T = ???


### PR DESCRIPTION
skip the first type parameter list of a right associative extension method before checking for a single non given parameter
fixes #11583 