### PR TITLE
Add language.deprecated.symbolLiterals import

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -251,14 +251,16 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case TypeDefs(_) => true
     case _ => isUsingClause(params)
 
+  private val languageSubCategories = Set(nme.experimental, nme.deprecated)
+
   /** If `path` looks like a language import, `Some(name)` where name
    *  is `experimental` if that sub-module is imported, and the empty
    *  term name otherwise.
    */
   def languageImport(path: Tree): Option[TermName] = path match
-    case Select(p1, nme.experimental) =>
+    case Select(p1, name: TermName) if languageSubCategories.contains(name) =>
       languageImport(p1) match
-        case Some(EmptyTermName) => Some(nme.experimental)
+        case Some(EmptyTermName) => Some(name)
         case _ => None
     case p1: RefTree if p1.name == nme.language =>
       p1.qualifier match

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -16,10 +16,14 @@ object Feature:
   private def experimental(str: String): TermName =
     QualifiedName(nme.experimental, str.toTermName)
 
+  private def deprecated(str: String): TermName =
+    QualifiedName(nme.deprecated, str.toTermName)
+
   private val Xdependent = experimental("dependent")
   private val XnamedTypeArguments = experimental("namedTypeArguments")
   private val XgenericNumberLiterals = experimental("genericNumberLiterals")
   private val Xmacros = experimental("macros")
+  private val symbolLiterals: TermName = deprecated("symbolLiterals")
 
 /** Is `feature` enabled by by a command-line setting? The enabling setting is
    *
@@ -63,6 +67,8 @@ object Feature:
   def namedTypeArgsEnabled(using Context) = enabled(XnamedTypeArguments)
 
   def genericNumberLiteralsEnabled(using Context) = enabled(XgenericNumberLiterals)
+
+  def symbolLiteralsEnabled(using Context) = enabled(symbolLiterals)
 
   def scala2ExperimentalMacroEnabled(using Context) = enabled(Xmacros)
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -773,6 +773,7 @@ class Definitions {
   @tu lazy val LanguageModule: Symbol = requiredModule("scala.language")
   @tu lazy val LanguageModuleClass: Symbol = LanguageModule.moduleClass.asClass
   @tu lazy val LanguageExperimentalModule: Symbol = requiredModule("scala.language.experimental")
+  @tu lazy val LanguageDeprecatedModule: Symbol = requiredModule("scala.language.deprecated")
   @tu lazy val NonLocalReturnControlClass: ClassSymbol = requiredClass("scala.runtime.NonLocalReturnControl")
   @tu lazy val SelectableClass: ClassSymbol = requiredClass("scala.Selectable")
 

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -449,6 +449,7 @@ object StdNames {
     val definitions: N          = "definitions"
     val delayedInit: N          = "delayedInit"
     val delayedInitArg: N       = "delayedInit$body"
+    val deprecated: N           = "deprecated"
     val derived: N              = "derived"
     val derives: N              = "derives"
     val doubleHash: N           = "doubleHash"

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1198,7 +1198,9 @@ object Parsers {
               report.errorOrMigrationWarning(
                 em"""symbol literal '${in.name} is no longer supported,
                     |use a string literal "${in.name}" or an application Symbol("${in.name}") instead,
-                    |or enclose in braces '{${in.name}} if you want a quoted expression.""",
+                    |or enclose in braces '{${in.name}} if you want a quoted expression.
+                    |For now, you can also `import language.deprecated.symbolLiterals` to accept
+                    |the idiom, but this possibility might no longer be available in the future.""",
                 in.sourcePos())
               if migrateTo3 then
                 patch(source, Span(in.offset, in.offset + 1), "Symbol(\"")

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -755,6 +755,7 @@ trait Checking {
       case Some(prefix) =>
         val required =
           if prefix == nme.experimental then defn.LanguageExperimentalModule
+          else if prefix == nme.deprecated then defn.LanguageDeprecatedModule
           else defn.LanguageModule
         if path.symbol != required then
           report.error(em"import looks like a language import, but refers to something else: ${path.symbol.showLocated}", path.srcPos)

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -38,6 +38,22 @@ object language:
     object genericNumberLiterals
   end experimental
 
+  /** The deprecated object contains features that are no longer officially suypported in Scala.
+   *  Features in this object are slated for removal. New code should not use them and
+   *  old code should migrate away from them.
+   */
+  object deprecated:
+
+    /** Symbol literals have been deprecated since 2.13. Since Scala 3.0 they
+     *  are no longer an official part of Scala. For compatibility with legacy software,
+     *  symbol literals are still supported with a language import, but new software
+     *  should not use them.
+     */
+    object symbolLiterals
+  end deprecated
+
+  object symbolLiterals
+
   /** Where imported, auto-tupling is disabled.
     *
     * '''Why control the feature?''' Auto-tupling can lead to confusing and

--- a/tests/neg/symlits.scala
+++ b/tests/neg/symlits.scala
@@ -1,0 +1,5 @@
+def f =
+  import language.deprecated.symbolLiterals
+  val x = 'Hello
+
+val y = 'no  // error


### PR DESCRIPTION
Allow symbol literals if a language import

    import language.deprecated.symbolLiterals

is given. This is useful for legacy software that uses
symbol literals. A typical case are Spark notebooks, where
column names are expressed with symbol literals.
