### PR TITLE
Add transparent as suggested at #11540

### DIFF
--- a/tests/neg-macros/GenericNumLits/Even_1.scala
+++ b/tests/neg-macros/GenericNumLits/Even_1.scala
@@ -17,7 +17,7 @@ object Even {
   }
 
   given EvenFromDigits with {
-    override inline def fromDigits(digits: String) = ${
+    override transparent inline def fromDigits(digits: String) = ${
       EvenFromDigitsImpl('digits)
     }
   }


### PR DESCRIPTION
In issue #11540, @odersky suggested that the dotty test should include transparent so that `typeChecks` would work as expected on generic num literals.