### PR TITLE
Fix memory leak through NoDenotation.cachePrefix

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -129,8 +129,8 @@ object Denotations {
     type AsSeenFromResult <: PreDenotation
 
     /** The denotation with info(s) as seen from prefix type */
-    final def asSeenFrom(pre: Type)(using Context): AsSeenFromResult =
-      if (Config.cacheAsSeenFrom && exists) {
+    def asSeenFrom(pre: Type)(using Context): AsSeenFromResult =
+      if (Config.cacheAsSeenFrom) {
         if ((cachedPrefix ne pre) || ctx.period != validAsSeenFrom) {
           cachedAsSeenFrom = computeAsSeenFrom(pre)
           cachedPrefix = pre

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -130,7 +130,7 @@ object Denotations {
 
     /** The denotation with info(s) as seen from prefix type */
     final def asSeenFrom(pre: Type)(using Context): AsSeenFromResult =
-      if (Config.cacheAsSeenFrom) {
+      if (Config.cacheAsSeenFrom && exists) {
         if ((cachedPrefix ne pre) || ctx.period != validAsSeenFrom) {
           cachedAsSeenFrom = computeAsSeenFrom(pre)
           cachedPrefix = pre

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2209,8 +2209,8 @@ object SymDenotations {
         ensureCompleted()
       myCompanion
 
-    override def registeredCompanion_=(c: Symbol) = 
-      myCompanion = c 
+    override def registeredCompanion_=(c: Symbol) =
+      myCompanion = c
 
     private var myNestingLevel = -1
 
@@ -2397,6 +2397,7 @@ object SymDenotations {
     override def owner: Symbol = throw new AssertionError("NoDenotation.owner")
     override def computeAsSeenFrom(pre: Type)(using Context): SingleDenotation = this
     override def mapInfo(f: Type => Type)(using Context): SingleDenotation = this
+    override def asSeenFrom(pre: Type)(using Context): AsSeenFromResult = this
 
     override def matches(other: SingleDenotation)(using Context): Boolean = false
     override def targetName(using Context): Name = EmptyTermName


### PR DESCRIPTION
Fix memory leak through NoDenotation.cachePrefix

We may set `NoDenotation.cachePrefix` in `Denotation.asSeenFrom`, thus
leak memory.

This memory leak is discovered by @mlachkar.

Co-authored-by: Meriam Lachkar <meriam.lachkar@gmail.com>