### PR TITLE
Skip empty statements around end markers

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -364,11 +364,15 @@ object Parsers {
       if in.isNewLine then in.nextToken() else accept(SEMI)
 
     def acceptStatSepUnlessAtEnd[T <: Tree](stats: ListBuffer[T], altEnd: Token = EOF): Unit =
+      def skipEmptyStats(): Unit =
+        while (in.token == SEMI || in.token == NEWLINE || in.token == NEWLINES) do in.nextToken()
+
       in.observeOutdented()
       in.token match
         case SEMI | NEWLINE | NEWLINES =>
-          in.nextToken()
+          skipEmptyStats()
           checkEndMarker(stats)
+          skipEmptyStats()
         case `altEnd` =>
         case _ =>
           if !isStatSeqEnd then

--- a/tests/neg/i11581.scala
+++ b/tests/neg/i11581.scala
@@ -1,0 +1,33 @@
+class Abc:
+  def a = {
+    println(10)
+    10
+  }
+
+  ;  ;
+
+  end a
+  end a // error
+;  ;
+end Abc
+end Abc // error
+
+class D:
+end D
+end D // error
+
+class Xyz {
+  def a =
+    println(10)
+    10
+
+}
+
+
+;
+end Xyz
+;
+;
+
+end Xyz // error
+

--- a/tests/pos/i11581.scala
+++ b/tests/pos/i11581.scala
@@ -1,0 +1,27 @@
+class Abc:
+  def a = {
+    println(10)
+    10
+  }
+
+  ;  ;
+
+  end a
+
+
+;  ;
+
+end Abc
+
+class Xyz {
+  def a =
+    println(10)
+    10
+
+}
+
+
+; ;
+;
+
+end Xyz


### PR DESCRIPTION
Fixes #11581

When we encounter two end markers one after another we parse it as an end marker, then one or more empty statements then another end marker. Since empty statements are not added to the list of opened statements, the last not empty statement still can be closed with an end marker, regardless if it was closed before. This PR adds skipping empty statements around end markers. That way, every end marker after the first one is treated as a new statement, which will in all sane cases result in compilation error.

This PR is not touching the question if an end marker should be allowed after the right brace,[ as it seems to be controversial.](https://github.com/lampepfl/dotty/issues/11581#issuecomment-789612605)