### PR TITLE
Change signature of quoted.Type encoding

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -936,10 +936,15 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
      *  The result can be the contents of a term or type quote, which
      *  will return a term or type tree respectively.
      */
-    def unapply(tree: tpd.Tree)(using Context): Option[tpd.Tree] = tree match {
-      case tree: GenericApply if tree.symbol.isQuote => Some(tree.args.head)
-      case _ => None
-    }
+    def unapply(tree: tpd.Apply)(using Context): Option[tpd.Tree] =
+      if tree.symbol == defn.QuotedRuntime_exprQuote then
+        // quoted.runtime.Expr.quote[T](<body>)
+        Some(tree.args.head)
+      else if tree.symbol == defn.QuotedTypeModule_of then
+        // quoted.Type.of[<body>](quotes)
+        val TypeApply(_, body :: _) = tree.fun
+        Some(body)
+      else None
   }
 
   /** Extractors for splices */

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -149,7 +149,7 @@ object Splicer {
         case Apply(Select(Apply(fn, quoted :: Nil), nme.apply), _) if fn.symbol == defn.QuotedRuntime_exprQuote =>
           // OK
 
-        case Apply(Select(TypeApply(fn, List(quoted)), nme.apply), _)if fn.symbol == defn.QuotedTypeModule_of =>
+        case Apply(TypeApply(fn, List(quoted)), _)if fn.symbol == defn.QuotedTypeModule_of =>
           // OK
 
         case Literal(Constant(value)) =>
@@ -233,7 +233,7 @@ object Splicer {
         }
         interpretQuote(quoted1)
 
-      case Apply(Select(TypeApply(fn, quoted :: Nil), _), _) if fn.symbol == defn.QuotedTypeModule_of =>
+      case Apply(TypeApply(fn, quoted :: Nil), _) if fn.symbol == defn.QuotedTypeModule_of =>
         interpretTypeQuote(quoted)
 
       case Literal(Constant(value)) =>

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -461,7 +461,7 @@ trait QuotesAndSplices {
     val quoteClass = if (tree.quoted.isTerm) defn.QuotedExprClass else defn.QuotedTypeClass
     val quotedPattern =
       if (tree.quoted.isTerm) ref(defn.QuotedRuntime_exprQuote.termRef).appliedToType(defn.AnyType).appliedTo(shape).select(nme.apply).appliedTo(qctx)
-      else ref(defn.QuotedTypeModule_of.termRef).appliedToTypeTree(shape).select(nme.apply).appliedTo(qctx)
+      else ref(defn.QuotedTypeModule_of.termRef).appliedToTypeTree(shape).appliedTo(qctx)
 
     val matchModule = if tree.quoted.isTerm then defn.QuoteMatching_ExprMatch else defn.QuoteMatching_TypeMatch
     val unapplyFun = qctx.asInstance(defn.QuoteMatchingClass.typeRef).select(matchModule).select(nme.unapply)

--- a/library/src-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-bootstrapped/scala/quoted/Type.scala
@@ -18,6 +18,6 @@ object Type:
 
   /** Return a quoted.Type with the given type */
   @compileTimeOnly("Reference to `scala.quoted.Type.of` was not handled by PickleQuotes")
-  given of[T <: AnyKind]: (Quotes ?=> Type[T]) = ???
+  given of[T <: AnyKind](using Quotes): Type[T] = ???
 
 end Type

--- a/library/src-non-bootstrapped/scala/quoted/Type.scala
+++ b/library/src-non-bootstrapped/scala/quoted/Type.scala
@@ -1,0 +1,22 @@
+package scala.quoted
+
+import scala.annotation.compileTimeOnly
+
+/** Type (or type constructor) `T` needed contextually when using `T` in a quoted expression `'{... T ...}` */
+abstract class Type[T <: AnyKind] private[scala]:
+  /** The type represented `Type` */
+  type Underlying = T
+  throw Exception("non-bootstrapped-lib")
+end Type
+
+/** Methods to interact with the current `Type[T]` in scope */
+object Type:
+
+  /** Show a source code like representation of this type without syntax highlight */
+  def show[T <: AnyKind](using Type[T])(using Quotes): String = throw Exception("non-bootstrapped-lib")
+
+  /** Return a quoted.Type with the given type */
+  @compileTimeOnly("Reference to `scala.quoted.Type.of` was not handled by PickleQuotes")
+  given of[T <: AnyKind]: (Quotes ?=> Type[T]) = throw Exception("non-bootstrapped-lib")
+
+end Type

--- a/tests/run-staging/quote-nested-4.check
+++ b/tests/run-staging/quote-nested-4.check
@@ -1,5 +1,5 @@
 ((q: scala.quoted.Quotes) ?=> {
-  val t: scala.quoted.Type[scala.Predef.String] = scala.quoted.Type.of[scala.Predef.String].apply(using q)
+  val t: scala.quoted.Type[scala.Predef.String] = scala.quoted.Type.of[scala.Predef.String](q)
 
   (t: scala.quoted.Type[scala.Predef.String])
 })


### PR DESCRIPTION
This avoids unnecessary closures in the generated code.

It will also help with meta-metaprogramming such as writing typeclass derivation for `ToExpr`.

Also updated internal documentation.