### PR TITLE
Fix markdown syntax for scala3 library docstrings

### DIFF
--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -126,13 +126,14 @@ object Tuple {
 
   /** Filters out those members of the tuple for which the predicate `P` returns `false`.
    *  A predicate `P[X]` is a type that can be either `true` or `false`. For example:
-   *  ```
+   *  ```scala
    *  type IsString[x] = x match {
    *    case String => true
    *    case _ => false
    *  }
    *  Filter[(1, "foo", 2, "bar"), IsString] =:= ("foo", "bar")
-   * ```
+   *  ```
+   *  @syntax markdown
    */
   type Filter[Tup <: Tuple, P[_] <: Boolean] <: Tuple = Tup match {
     case EmptyTuple => EmptyTuple

--- a/library/src/scala/compiletime/ops/any.scala
+++ b/library/src/scala/compiletime/ops/any.scala
@@ -8,6 +8,7 @@ object any:
    * val eq2: 1 == "1" = false
    * val eq3: "1" == "1" = true
    * ```
+   * @syntax markdown
    */
   type ==[X, Y] <: Boolean
 
@@ -17,5 +18,6 @@ object any:
    * val eq2: 1 != "1" = true
    * val eq3: "1" != "1" = false
    * ```
+   * @syntax markdown
    */
   type !=[X, Y] <: Boolean

--- a/library/src/scala/compiletime/ops/boolean.scala
+++ b/library/src/scala/compiletime/ops/boolean.scala
@@ -8,14 +8,16 @@ object boolean:
    *  val notFalse: ![false] = true
    *  val notTrue: ![true] = false
    *  ```
+   *  @syntax markdown
    */
   type ![X <: Boolean] <: Boolean
 
   /** Exclusive disjunction of two `Boolean` singleton types.
-   * ```scala
-   * val a: true ^ true = false
-   * val b: false ^ true = true
-   * ```
+   *  ```scala
+   *  val a: true ^ true = false
+   *  val b: false ^ true = true
+   *  ```
+   *  @syntax markdown
    */
   type ^[X <: Boolean, Y <: Boolean] <: Boolean
 
@@ -24,13 +26,15 @@ object boolean:
    *  val a: true && true = true
    *  val b: false && true = false
    *  ```
+   *  @syntax markdown
    */
   type &&[X <: Boolean, Y <: Boolean] <: Boolean
 
   /** Disjunction of two `Boolean` singleton types.
-   * ```scala
-   * val a: true || false = true
-   * val b: false || false = false
-   * ```
+   *  ```scala
+   *  val a: true || false = true
+   *  val b: false || false = false
+   *  ```
+   *  @syntax markdown
    */
   type ||[X <: Boolean, Y <: Boolean] <: Boolean

--- a/library/src/scala/compiletime/ops/int.scala
+++ b/library/src/scala/compiletime/ops/int.scala
@@ -6,6 +6,7 @@ object int:
    *  ```scala
    *  val sum: 2 + 2 = 4
    *  ```
+   *  @syntax markdown
    */
   type +[X <: Int, Y <: Int] <: Int
 
@@ -13,6 +14,7 @@ object int:
    *  ```scala
    *  val sub: 4 - 2 = 2
    *  ```
+   *  @syntax markdown
    */
   type -[X <: Int, Y <: Int] <: Int
 
@@ -20,6 +22,7 @@ object int:
    *  ```scala
    *  val mul: 4 * 2 = 8
    *  ```
+   *  @syntax markdown
    */
   type *[X <: Int, Y <: Int] <: Int
 
@@ -27,6 +30,7 @@ object int:
    *  ```scala
    *  val div: 5 / 2 = 2
    *  ```
+   *  @syntax markdown
    */
   type /[X <: Int, Y <: Int] <: Int
 
@@ -34,6 +38,7 @@ object int:
    *  ```scala
    *  val mod: 5 % 2 = 1
    *  ```
+   *  @syntax markdown
    */
   type %[X <: Int, Y <: Int] <: Int
 
@@ -41,6 +46,7 @@ object int:
    *  ```scala
    *  val lshift: 1 << 2 = 4
    *  ```
+   *  @syntax markdown
    */
   type <<[X <: Int, Y <: Int] <: Int
 
@@ -48,6 +54,7 @@ object int:
    *  ```scala
    *  val rshift: 10 >> 1 = 5
    *  ```
+   *  @syntax markdown
    */
   type >>[X <: Int, Y <: Int] <: Int
 
@@ -55,6 +62,7 @@ object int:
    *  ```scala
    *  val rshiftzero: 10 >>> 1 = 5
    *  ```
+   *  @syntax markdown
    */
   type >>>[X <: Int, Y <: Int] <: Int
 
@@ -62,6 +70,7 @@ object int:
    *  ```scala
    *  val xor: 10 ^ 30 = 20
    *  ```
+   *  @syntax markdown
    */
   type ^[X <: Int, Y <: Int] <: Int
 
@@ -70,6 +79,7 @@ object int:
    *  val lt1: 4 < 2 = false
    *  val lt2: 2 < 4 = true
    *  ```
+   *  @syntax markdown
    */
   type <[X <: Int, Y <: Int] <: Boolean
 
@@ -78,6 +88,7 @@ object int:
    *  val gt1: 4 > 2 = true
    *  val gt2: 2 > 2 = false
    *  ```
+   *  @syntax markdown
    */
   type >[X <: Int, Y <: Int] <: Boolean
 
@@ -86,6 +97,7 @@ object int:
    *  val ge1: 4 >= 2 = true
    *  val ge2: 2 >= 3 = false
    *  ```
+   *  @syntax markdown
    */
   type >=[X <: Int, Y <: Int] <: Boolean
 
@@ -94,6 +106,7 @@ object int:
    *  val lt1: 4 <= 2 = false
    *  val lt2: 2 <= 2 = true
    *  ```
+   *  @syntax markdown
    */
   type <=[X <: Int, Y <: Int] <: Boolean
 
@@ -102,6 +115,7 @@ object int:
    *  val and1: BitwiseAnd[4, 4] = 4
    *  val and2: BitwiseAnd[10, 5] = 0
    *  ```
+   *  @syntax markdown
    */
   type BitwiseAnd[X <: Int, Y <: Int] <: Int
 
@@ -109,6 +123,7 @@ object int:
    *  ```scala
    *  val or: BitwiseOr[10, 11] = 11
    *  ```
+   *  @syntax markdown
    */
   type BitwiseOr[X <: Int, Y <: Int] <: Int
 
@@ -116,6 +131,7 @@ object int:
    *  ```scala
    *  val abs: Abs[-1] = 1
    *  ```
+   *  @syntax markdown
    */
   type Abs[X <: Int] <: Int
 
@@ -124,6 +140,7 @@ object int:
    *  val neg1: Neg[-1] = 1
    *  val neg2: Neg[1] = -1
    *  ```
+   *  @syntax markdown
    */
   type Negate[X <: Int] <: Int
 
@@ -131,6 +148,7 @@ object int:
    *  ```scala
    *  val min: Min[-1, 1] = -1
    *  ```
+   *  @syntax markdown
    */
   type Min[X <: Int, Y <: Int] <: Int
 
@@ -138,6 +156,7 @@ object int:
    *  ```scala
    *  val max: Max[-1, 1] = 1
    *  ```
+   *  @syntax markdown
    */
   type Max[X <: Int, Y <: Int] <: Int
 
@@ -145,5 +164,6 @@ object int:
    *  ```scala
    *  val abs: ToString[1] = "1"
    *  ```
+   *  @syntax markdown
    */
   type ToString[X <: Int] <: String

--- a/library/src/scala/compiletime/ops/string.scala
+++ b/library/src/scala/compiletime/ops/string.scala
@@ -6,5 +6,6 @@ object string:
    *  ```scala
    *  val hello: "hello " + "world" = "hello world"
    *  ```
+   *  @syntax markdown
    */
   type +[X <: String, Y <: String] <: String

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -6,7 +6,7 @@ package object compiletime {
   /** Use this method when you have a type, do not have a value for it but want to
    *  pattern match on it. For example, given a type `Tup <: Tuple`, one can
    *  pattern-match on it as follows:
-   *  ```
+   *  ```scala
    *  inline erasedValue[Tup] match {
    *    case _: EmptyTuple => ...
    *    case _: h *: t => ...
@@ -14,6 +14,7 @@ package object compiletime {
    *  ```
    *  This value can only be used in an inline match and the value cannot be used in
    *  the branches.
+   *  @syntax markdown
    */
   erased def erasedValue[T]: T = ???
 
@@ -39,6 +40,7 @@ package object compiletime {
    *  inline def errorOnThisCode(inline x: Any) =
    *    error("My error of this code: " + codeOf(x))
    *  ```
+   *  @syntax markdown
    */
   inline def error(inline msg: String): Nothing = ???
 
@@ -55,8 +57,10 @@ package object compiletime {
    *
    *  The formatting of the code is not stable across version of the compiler.
    *
-   * @note only `inline` arguments will be displayed as "code".
-   *       Other values may display unintutively.
+   *  @note only `inline` arguments will be displayed as "code".
+   *        Other values may display unintutively.
+   *
+   *  @syntax markdown
    */
   transparent inline def codeOf(arg: Any): String =
     // implemented in dotty.tools.dotc.typer.Inliner.Intrinsics
@@ -75,6 +79,7 @@ package object compiletime {
    *  val m: Int = ...
    *  twice(m) // error: expected a constant value but found: m
    *  ```
+   *  @syntax markdown
    */
   inline def requireConst(inline x: Boolean | Byte | Short | Int | Long | Float | Double | Char | String): Unit =
     // implemented in dotty.tools.dotc.typer.Inliner
@@ -97,10 +102,11 @@ package object compiletime {
 
   /**
    * Use this type to widen a self-type to a tuple. E.g.
-   * ```
+   * ```scala
    * val x: (1, 3) = (1, 3)
    * val y: Widen[x.type] = x
    * ```
+   * @syntax markdown
    */
   type Widen[Tup <: Tuple] <: Tuple = Tup match {
     case EmptyTuple => EmptyTuple
@@ -121,16 +127,18 @@ package object compiletime {
 
   /** Summons first given matching one of the listed cases. E.g. in
    *
-   *      given B { ... }
+   *  ```scala
+   *  given B { ... }
    *
-   *      summonFrom {
-   *        case given A => 1
-   *        case given B => 2
-   *        case given C => 3
-   *        case _ => 4
-   *      }
-   *
+   *  summonFrom {
+   *    case given A => 1
+   *    case given B => 2
+   *    case given C => 3
+   *    case _ => 4
+   *  }
+   *  ```
    *  the returned value would be `2`.
+   *  @syntax markdown
    */
   transparent inline def summonFrom[T](f: Nothing => T): T =
     error("Compiler bug: `summonFrom` was not evaluated by the compiler")
@@ -162,13 +170,16 @@ package object compiletime {
 
   /** Succesor of a natural number where zero is the type 0 and successors are reduced as if the definition was
    *
-   *      type S[N <: Int] <: Int = N match {
-   *        case 0 => 1
-   *        case 1 => 2
-   *        case 2 => 3
-   *        ...
-   *        case 2147483646 => 2147483647
-   *      }
+   *  ```scala
+   *  type S[N <: Int] <: Int = N match {
+   *    case 0 => 1
+   *    case 1 => 2
+   *    case 2 => 3
+   *    ...
+   *    case 2147483646 => 2147483647
+   *  }
+   *  ```
+   *  @syntax markdown
    */
   type S[N <: Int] <: Int
 

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -40,13 +40,14 @@ object Expr {
    *  Otherwise returns `None`.
    *
    *  Usage:
-   *  ```
+   *  ```scala
    *  case '{ ... ${expr @ Expr(value)}: T ...} =>
    *    // expr: Expr[T]
    *    // value: T
    *  ```
    *
    *  To directly get the value of an expression `expr: Expr[T]` consider using `expr.value`/`expr.valueOrError` insead.
+   *  @syntax markdown
    */
   def unapply[T](x: Expr[T])(using FromExpr[T])(using Quotes): Option[T] =
     scala.Predef.summon[FromExpr[T]].unapply(x)
@@ -57,7 +58,6 @@ object Expr {
    *    `Seq(e1, e2, ...)` where `ei: Expr[T]`
    *  to an expression equivalent to
    *    `'{ Seq($e1, $e2, ...) }` typed as an `Expr[Seq[T]]`
-   *  ```
    */
   def ofSeq[T](xs: Seq[Expr[T]])(using Type[T])(using Quotes): Expr[Seq[T]] =
     Varargs(xs)

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -11,6 +11,7 @@ import scala.reflect.TypeTest
  *     ...
  *  }
  *  ```
+ *  @syntax markdown
  */
 transparent inline def quotes(using inline q: Quotes): q.type = q
 
@@ -29,11 +30,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Pattern matches `this` against `that`. Effectively performing a deep equality check.
     *  It does the equivalent of
-    *  ```
+    *  ```scala
     *  this match
     *    case '{...} => true // where the contents of the pattern are the contents of `that`
     *    case _ => false
     *  ```
+    *  @syntax markdown
     */
     def matches(that: Expr[Any]): Boolean
 
@@ -295,6 +297,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      *  package foo.bar
      *  // package stats
      *  ```
+     *  @syntax markdown
      */
     type PackageClause <: Tree
 
@@ -468,6 +471,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *     ...
          *  }
          *  ```
+         *  @syntax markdown
          */
         def self: Option[ValDef]
         /** Statements within the class
@@ -477,6 +481,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *     ... // statemets
          *  }
          *  ```
+         *  @syntax markdown
          */
         def body: List[Statement]
       end extension
@@ -515,6 +520,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *  ```scala
          *  extension (a: A) def f[T]() = ...
          *  ```
+         *  @syntax markdown
          */
         def leadingTypeParams: List[TypeDef]
 
@@ -525,6 +531,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *  ```scala
          *  extension (a: A) def f[T]() = ...
          *  ```
+         *  @syntax markdown
          */
         def trailingParamss: List[ParamClause]
 
@@ -971,6 +978,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *  ```
          *  - `fun` is `f(1)` in the `Apply` of `f(1)(2)`
          *  - `fun` is `f` in the `Apply` of `f(1)`
+         *  @syntax markdown
          */
         def fun: Term
         /** The arguments (implicitly) passed to the method
@@ -982,6 +990,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *  ```
          *  - `args` is `(2)` in the `Apply` of `f(1)(2)`
          *  - `args` is `(1)` in the `Apply` of `f(1)`
+         *  @syntax markdown
          */
         def args: List[Term]
       end extension
@@ -1027,6 +1036,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *  // f(1)[Int](2)
          *  ```
          *  - `fun` is `f(1)` in the `TypeApply` of `f(1)[Int]`
+         *  @syntax markdown
          */
         def fun: Term
         /** The (inferred) type arguments passed to the method
@@ -1042,6 +1052,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *  // f(1)[Int](2)
          *  ```
          *  - `fun` is `[Int]` in the `TypeApply` of `f(1)[Int]`
+         *  @syntax markdown
          */
         def args: List[TypeTree]
       end extension
@@ -1217,35 +1228,38 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** A lambda `(...) => ...` in the source code is represented as
      *  a local method and a closure:
      *
+     *  ```scala
      *  {
      *    def m(...) = ...
      *    closure(m)
      *  }
-     *
+     *  ```
      *  @note Due to the encoding, in pattern matches the case for `Lambda`
      *        should come before the case for `Block` to avoid mishandling
      *        of `Lambda`.
+     *  @syntax markdown
      */
     val Lambda: LambdaModule
 
     /** Methods of the module object `val Lambda` */
     trait LambdaModule { this: Lambda.type =>
       /** Matches a lambda definition of the form
-       *  ```
+       *  ```scala
        *  Block((DefDef(_, _, params :: Nil, _, Some(body))) :: Nil, Closure(meth, _))
        *  ```
        *  Extracts the parameter definitions and body.
-       *
+       *  @syntax markdown
        */
       def unapply(tree: Block): Option[(List[ValDef], Term)]
 
       /** Generates a lambda with the given method type.
-       *  ```
+       *  ```scala
        *  Block((DefDef(_, _, params :: Nil, _, Some(rhsFn(meth, paramRefs)))) :: Nil, Closure(meth, _))
        *  ```
-       * @param owner: owner of the generated `meth` symbol
-       * @param tpe: Type of the definition
-       * @param rhsFn: Funtion that recieves the `meth` symbol and the a list of references to the `params`
+       *  @param owner: owner of the generated `meth` symbol
+       *  @param tpe: Type of the definition
+       *  @param rhsFn: Funtion that recieves the `meth` symbol and the a list of references to the `params`
+       *  @syntax markdown
        */
       def apply(owner: Symbol, tpe: MethodType, rhsFn: (Symbol, List[Tree]) => Tree): Block
     }
@@ -2103,6 +2117,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      *    case TypeParamClause(params: List[TypeDef])
      *    case TermParamClause(params: List[ValDef])
      *  ```
+     *  @syntax markdown
      */
     type ParamClause <: AnyRef
 
@@ -2328,11 +2343,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** Convert this `TypeRepr` to an `Type[?]`
         *
         *  Usage:
-        *  ```
+        *  ```scala
         *  typeRepr.asType match
         *    case '[$t] =>
         *      '{ val x: t = ... }
         *  ```
+        *  @syntax markdown
         */
         def asType: Type[?]
 
@@ -2706,6 +2722,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      *  ```scala
      *    def foo: Int = ...
      *  ```
+     *  @syntax markdown
      */
     type ByNameType <: TypeRepr
 
@@ -3340,11 +3357,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       /** Symbol of the definition that encloses the current splicing context.
        *
        *  For example, the following call to `spliceOwner` would return the symbol `x`.
-       *  ```
+       *  ```scala
        *  val x = ${ ... Symbol.spliceOwner ... }
        *  ```
        *
-       *   For a macro splice, it is the symbol of the definition where the macro expansion happens.
+       *  For a macro splice, it is the symbol of the definition where the macro expansion happens.
+       *  @syntax markdown
        */
       def spliceOwner: Symbol
 
@@ -4109,12 +4127,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Customizable Tree accumulator.
     *
     *  Usage:
-    *  ```
+    *  ```scala
     *  import qctx.reflect._
     *  class MyTreeAccumulator extends TreeAccumulator[X] {
     *    def foldTree(x: X, tree: Tree)(owner: Symbol): X = ...
     *  }
     *  ```
+    *  @syntax markdown
     */
     trait TreeAccumulator[X]:
 
@@ -4212,12 +4231,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Customizable tree traverser.
     *
     *  Usage:
-    *  ```
+    *  ```scala
     *  import qctx.relfect._
     *  class MyTraverser extends TreeTraverser {
     *    override def traverseTree(tree: Tree)(owner: Symbol): Unit = ...
     *  }
     *  ```
+    *  @syntax markdown
     */
     trait TreeTraverser extends TreeAccumulator[Unit]:
 
@@ -4232,12 +4252,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Customizable tree mapper.
     *
     *  Usage:
-    *  ```
+    *  ```scala
     *  import quotes.reflect._
     *  class MyTreeMap extends TreeMap {
     *    override def transformTree(tree: Tree)(owner: Symbol): Tree = ...
     *  }
     *  ```
+    *  @syntax markdown
     */
     trait TreeMap:
 

--- a/library/src/scala/quoted/Varargs.scala
+++ b/library/src/scala/quoted/Varargs.scala
@@ -18,6 +18,7 @@ object Varargs {
    *  ```scala
    *  '{ List(${Varargs(List(1, 2, 3))}: _*) } // equvalent to '{ List(1, 2, 3) }
    *  ```
+   *  @syntax markdown
    */
   def apply[T](xs: Seq[Expr[T]])(using Type[T])(using Quotes): Expr[Seq[T]] = {
     import quotes.reflect._
@@ -35,6 +36,7 @@ object Varargs {
    *      ...
    *  }
    *  ```
+   *  @syntax markdown
    */
   def unapply[T](expr: Expr[Seq[T]])(using Quotes): Option[Seq[Expr[T]]] = {
     import quotes.reflect._

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -334,6 +334,7 @@ object TastyFormat {
    *   else invariant[file.experimental is non-0 and different than compiler.experimental]
    *     return incompatible
    * ```
+   * @syntax markdown
    */
   def isVersionCompatible(
     fileMajor: Int,


### PR DESCRIPTION
Before
![obraz](https://user-images.githubusercontent.com/32793002/110107131-d10af280-7daa-11eb-83cc-fe1b24104ede.png)

After
![obraz](https://user-images.githubusercontent.com/32793002/110107079-c2bcd680-7daa-11eb-93b7-ec18ca8f4a8f.png)
