### PR TITLE
Treat packages as flat when access checking Java-defined symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -818,8 +818,12 @@ object SymDenotations {
      */
     final def isAccessibleFrom(pre: Type, superAccess: Boolean = false, whyNot: StringBuffer = null)(using Context): Boolean = {
 
-      /** Are we inside definition of `boundary`? */
-      def accessWithin(boundary: Symbol) = ctx.owner.isContainedIn(boundary)
+      /** Are we inside definition of `boundary`?
+       *  If this symbol is Java defined, package structure is interpreted to be flat.
+       */
+      def accessWithin(boundary: Symbol) =
+        ctx.owner.isContainedIn(boundary)
+        && !(is(JavaDefined) && boundary.is(PackageClass) && ctx.owner.enclosingPackageClass != boundary)
 
       /** Are we within definition of linked class of `boundary`? */
       def accessWithinLinked(boundary: Symbol) = {
@@ -2209,8 +2213,8 @@ object SymDenotations {
         ensureCompleted()
       myCompanion
 
-    override def registeredCompanion_=(c: Symbol) = 
-      myCompanion = c 
+    override def registeredCompanion_=(c: Symbol) =
+      myCompanion = c
 
     private var myNestingLevel = -1
 

--- a/tests/neg/i11616/A.java
+++ b/tests/neg/i11616/A.java
@@ -1,0 +1,8 @@
+package pkg;
+
+public class A {
+
+    protected void fn1() { System.out.println("A#fn1()"); }
+              void fn2() { System.out.println("A#fn2()"); }
+
+}

--- a/tests/neg/i11616/B.scala
+++ b/tests/neg/i11616/B.scala
@@ -1,0 +1,16 @@
+package pkg.sub
+
+import pkg.A
+
+class B extends A {
+
+  def test(): Unit = {
+    super.fn1()
+    super.fn2() // error: cannot be acesssed
+
+    val b: B = new B()
+    b.fn1()
+    b.fn2()     // error: cannot be acesssed
+  }
+
+}


### PR DESCRIPTION
Treat packages as flat when checking Java-defined symbols for accessibility