### PR TITLE
Tighten requirements for migration mode

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2084,10 +2084,10 @@ object Parsers {
           val isVarargSplice = location.inArgs && followingIsVararg()
           in.nextToken()
           if isVarargSplice then
-            if sourceVersion.isAtLeast(future) then
-              report.errorOrMigrationWarning(
-                em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead${rewriteNotice("future")}",
-                in.sourcePos(uscoreStart))
+            report.errorOrMigrationWarning(
+              em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead${rewriteNotice("future")}",
+              in.sourcePos(uscoreStart),
+              future)
             if sourceVersion == `future-migration` then
               patch(source, Span(t.span.end, in.lastOffset), " *")
           else if opStack.nonEmpty then
@@ -2162,12 +2162,10 @@ object Parsers {
         val name = bindingName()
         val t =
           if (in.token == COLON && location == Location.InBlock) {
-            if sourceVersion.isAtLeast(future) then
-                // Don't error in non-strict mode, as the alternative syntax "implicit (x: T) => ... "
-                // is not supported by Scala2.x
-              report.errorOrMigrationWarning(
-                s"This syntax is no longer supported; parameter needs to be enclosed in (...)${rewriteNotice("future")}",
-                source.atSpan(Span(start, in.lastOffset)))
+            report.errorOrMigrationWarning(
+              s"This syntax is no longer supported; parameter needs to be enclosed in (...)${rewriteNotice("future")}",
+              source.atSpan(Span(start, in.lastOffset)),
+              from = future)
             in.nextToken()
             val t = infixType()
             if (sourceVersion == `future-migration`) {
@@ -2665,10 +2663,10 @@ object Parsers {
         p
 
     private def warnStarMigration(p: Tree) =
-      if sourceVersion.isAtLeast(future) then
-        report.errorOrMigrationWarning(
-          em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead",
-          in.sourcePos(startOffset(p)))
+      report.errorOrMigrationWarning(
+        em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead",
+        in.sourcePos(startOffset(p)),
+        from = future)
 
     /**  InfixPattern ::= SimplePattern {id [nl] SimplePattern}
      */
@@ -3124,7 +3122,8 @@ object Parsers {
         if in.token == USCORE && sourceVersion.isAtLeast(future) then
           report.errorOrMigrationWarning(
             em"`_` is no longer supported for a wildcard import; use `*` instead${rewriteNotice("future")}",
-            in.sourcePos())
+            in.sourcePos(),
+            from = future)
           patch(source, Span(in.offset, in.offset + 1), "*")
         ImportSelector(atSpan(in.skipToken()) { Ident(nme.WILDCARD) })
 
@@ -3142,7 +3141,8 @@ object Parsers {
           if in.token == ARROW && sourceVersion.isAtLeast(future) then
             report.errorOrMigrationWarning(
               em"The import renaming `a => b` is no longer supported ; use `a as b` instead${rewriteNotice("future")}",
-              in.sourcePos())
+              in.sourcePos(),
+              from = future)
             patch(source, Span(in.offset, in.offset + 2),
                 if testChar(in.offset - 1, ' ') && testChar(in.offset + 2, ' ') then "as"
                 else " as ")

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1824,7 +1824,7 @@ object Parsers {
         } :: contextBounds(pname)
       case VIEWBOUND =>
         report.errorOrMigrationWarning(
-          "view bounds `<%' are deprecated, use a context bound `:' instead",
+          "view bounds `<%' are no longer supported, use a context bound `:' instead",
           in.sourcePos())
         atSpan(in.skipToken()) {
           Function(Ident(pname) :: Nil, toplevelTyp())

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -78,7 +78,7 @@ object report:
   def errorOrMigrationWarning(msg: Message, pos: SrcPos = NoSourcePosition,
       from: SourceVersion = SourceVersion.defaultSourceVersion)(using Context): Unit =
     if sourceVersion.isAtLeast(from) then
-      if sourceVersion.ordinal < from.ordinal then migrationWarning(msg, pos)
+      if sourceVersion.isMigrating && sourceVersion.ordinal <= from.ordinal then migrationWarning(msg, pos)
       else error(msg, pos)
 
   def restrictionError(msg: Message, pos: SrcPos = NoSourcePosition)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -78,7 +78,7 @@ object report:
   def errorOrMigrationWarning(msg: Message, pos: SrcPos = NoSourcePosition,
       from: SourceVersion = SourceVersion.defaultSourceVersion)(using Context): Unit =
     if sourceVersion.isAtLeast(from) then
-      if sourceVersion.isMigrating then migrationWarning(msg, pos)
+      if sourceVersion.ordinal < from.ordinal then migrationWarning(msg, pos)
       else error(msg, pos)
 
   def restrictionError(msg: Message, pos: SrcPos = NoSourcePosition)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -89,8 +89,10 @@ class NonLocalReturns extends MiniPhase {
 
   override def transformReturn(tree: Return)(using Context): Tree =
     if isNonLocalReturn(tree) then
-      if sourceVersion.isAtLeast(future) then
-        report.errorOrMigrationWarning("Non local returns are no longer supported; use scala.util.control.NonLocalReturns instead", tree.srcPos)
+      report.errorOrMigrationWarning(
+          "Non local returns are no longer supported; use scala.util.control.NonLocalReturns instead",
+          tree.srcPos,
+          from = future)
       nonLocalReturnThrow(tree.expr, tree.from.symbol).withSpan(tree.span)
     else tree
 }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2472,8 +2472,11 @@ class Typer extends Namer
       def remedy =
         if ((prefix ++ suffix).isEmpty) "simply leave out the trailing ` _`"
         else s"use `$prefix<function>$suffix` instead"
-      report.errorOrMigrationWarning(i"""The syntax `<function> _` is no longer supported;
-                                     |you can $remedy""", tree.srcPos, future)
+      report.errorOrMigrationWarning(
+        i"""The syntax `<function> _` is no longer supported;
+           |you can $remedy""",
+        tree.srcPos,
+        from = future)
       if sourceVersion.isMigrating then
         patch(Span(tree.span.start), prefix)
         patch(Span(qual.span.end, tree.span.end), suffix)

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -167,7 +167,8 @@ class CompilationTests {
       compileFile("tests/neg-custom-args/i5498-postfixOps.scala", defaultOptions withoutLanguageFeature "postfixOps"),
       compileFile("tests/neg-custom-args/deptypes.scala", defaultOptions.and("-language:experimental.dependent")),
       compileFile("tests/neg-custom-args/matchable.scala", defaultOptions.and("-Xfatal-warnings", "-source", "future")),
-      compileFile("tests/neg-custom-args/i7314.scala", defaultOptions.and("-Xfatal-warnings", "-source", "future"))
+      compileFile("tests/neg-custom-args/i7314.scala", defaultOptions.and("-Xfatal-warnings", "-source", "future")),
+      compileFile("tests/neg-custom-args/feature-shadowing.scala", defaultOptions.and("-Xfatal-warnings", "-feature")),
     ).checkExpectedErrors()
   }
 

--- a/tests/neg-custom-args/feature-shadowing.scala
+++ b/tests/neg-custom-args/feature-shadowing.scala
@@ -1,0 +1,13 @@
+import language.implicitConversions
+given Conversion[Int, String] = _.toString
+
+object a:
+  val s: String = 1   // OK
+
+  object b:
+    import language.implicitConversions as _
+    val s: String = 2   // error
+
+    object c:
+      import language.implicitConversions
+      val s: String = 3   // OK again

--- a/tests/neg/i11567.scala
+++ b/tests/neg/i11567.scala
@@ -1,0 +1,5 @@
+import language.`future-migration`
+class Test
+object Test {
+  def foo[A <% Test](x: A) = x  // error
+}


### PR DESCRIPTION
We now issue a migration warning only if the source version is migrating and
exactly one before the current source. Previously, a migration warning intended
for 3.0-migration would also have been issued for future-migration.

Also, fix error message for viewbounds.

Fixes #11567 