### PR TITLE
syntax.md: update syntax of for-expressions

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2509,9 +2509,9 @@ object Parsers {
         GenFrom(pat, subExpr(), checkMode)
       }
 
-    /** ForExpr  ::= `for' (`(' Enumerators `)' | `{' Enumerators `}')
-     *                {nl} [`yield'] Expr
-     *            |  `for' Enumerators (`do' Expr | `yield' Expr)
+    /** ForExpr  ::=  ‘for’ ‘(’ Enumerators ‘)’ {nl} [‘do‘ | ‘yield’] Expr
+     *             |  ‘for’ ‘{’ Enumerators ‘}’ {nl} [‘do‘ | ‘yield’] Expr
+     *             |  ‘for’     Enumerators          (‘do‘ | ‘yield’) Expr
      */
     def forExpr(): Tree =
       atSpan(in.skipToken()) {

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -272,9 +272,10 @@ BlockStat         ::=  Import
                     |  Expr1
                     |  EndMarker
 
-ForExpr           ::=  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’)        ForYield(enums, expr)
-                       {nl} [‘yield’] Expr
-                    |  ‘for’ Enumerators (‘do’ Expr | ‘yield’ Expr)             ForDo(enums, expr)
+ForExpr           ::=  ‘for’ ‘(’ Enumerators0 ‘)’ {nl} [‘do‘ | ‘yield’] Expr     ForYield(enums, expr) / ForDo(enums, expr)
+                    |  ‘for’ ‘{’ Enumerators0 ‘}’ {nl} [‘do‘ | ‘yield’] Expr
+                    |  ‘for’     Enumerators0          (‘do‘ | ‘yield’) Expr
+Enumerators0      ::=  {nl} Enumerators [semi]
 Enumerators       ::=  Generator {semi Enumerator | Guard}
 Enumerator        ::=  Generator
                     |  Guard

--- a/docs/docs/reference/syntax.md
+++ b/docs/docs/reference/syntax.md
@@ -263,8 +263,10 @@ BlockStat         ::=  Import
                     |  Expr1
                     |  EndMarker
 
-ForExpr           ::=  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’) {nl} [‘yield’] Expr
-                    |  ‘for’ Enumerators (‘do’ Expr | ‘yield’ Expr)
+ForExpr           ::=  ‘for’ ‘(’ Enumerators0 ‘)’ {nl} [‘do‘ | ‘yield’] Expr
+                    |  ‘for’ ‘{’ Enumerators0 ‘}’ {nl} [‘do‘ | ‘yield’] Expr
+                    |  ‘for’     Enumerators0          (‘do‘ | ‘yield’) Expr
+Enumerators0      ::=  {nl} Enumerators [semi]
 Enumerators       ::=  Generator {semi Enumerator | Guard}
 Enumerator        ::=  Generator
                     |  Guard


### PR DESCRIPTION
Comments to `ForExpr ::=`
1. new line before `yield` or `do` is supported in braceless syntax as well
2. `do` can also go in for-expressions with braces/parenthesis
3. we could save some space and replace 3 lines with 2 by merging `(‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’)`
but I find my version more readable

Comments to `Enumerators0 ::=`
1. enumerators can be preceded by an arbitrary amount of newline character
2. `;` is possible after the last enumerator

All-in-one example with valid for-expressions which are accepted by Scala 3 compiler:
```scala
for x <- 0 to 1 do println(42)
for x <- 0 to 1 yield 42

for { x <- 0 to 1 } do println(42)
for { x <- 0 to 1 } yield 42

for (x <- 0 to 1) do println(42)
for (x <- 0 to 1) yield 42

////////////////////////////////////////

for x <- 0 to 1
do println(42)
for x <- 0 to 1
yield 42

for { x <- 0 to 1 }
do println(42)
for { x <- 0 to 1 }
yield 42

for (x <- 0 to 1)
do println(42)
for (x <- 0 to 1)
yield 42


for (x <- 0 to 1) println(42)
for (x <- 0 to 1)
  println(42)
// DO or YIELD is obligatory when no FOR is braceless
//for x <- 0 to 1 println(42)
//for x <- 0 to 1
// println(42)

for

x <- 0 to 1;

do println(42)
```