### PR TITLE
Improve skipping on syntax errors

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1383,6 +1383,22 @@ object Scanners {
     private def useOuterWidth(): Unit =
       if enclosing.knownWidth == null then enclosing.useOuterWidth()
       knownWidth = enclosing.knownWidth
+
+    private def delimiter = this match
+      case _: InString => "}(in string)"
+      case InParens(LPAREN, _) => ")"
+      case InParens(LBRACKET, _) => "]"
+      case _: InBraces => "}"
+      case _: InCase => "=>"
+      case _: Indented => "UNDENT"
+
+    /** Show open regions as list of lines with decreasing indentations */
+    def visualize: String =
+      indentWidth.toPrefix
+      + delimiter
+      + outer.match
+          case null => ""
+          case next: Region => "\n" + next.visualize
   end Region
 
   case class InString(multiLine: Boolean, outer: Region) extends Region

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -287,5 +287,7 @@ object Tokens extends TokensCommon {
 
   final val endMarkerTokens = identifierTokens | BitSet(IF, WHILE, FOR, MATCH, TRY, NEW, THROW, GIVEN, VAL, THIS)
 
+  final val skipStopTokens = BitSet(SEMI, NEWLINE, NEWLINES, RBRACE, RPAREN, RBRACKET, OUTDENT)
+
   final val softModifierNames = Set(nme.inline, nme.opaque, nme.open, nme.transparent, nme.infix)
 }

--- a/tests/neg/errpos.scala
+++ b/tests/neg/errpos.scala
@@ -1,11 +1,11 @@
 object Test {
   val x =     // error: expression expected
-  val y = 2   // error: ';' expected
+  val y = 2
 
   val z =     // error: expression expected
 
   // ...
-  val a = 3   // error: ';' expected
+  val a = 3
 
   val b = type // error: expression expected (on "type")
 

--- a/tests/neg/extensions-can-only-have-defs.scala
+++ b/tests/neg/extensions-can-only-have-defs.scala
@@ -1,5 +1,5 @@
 object Test {
   extension [T] (t: T) {
-    val v: T = ??? // error // error
+    val v: T = ??? // error
   }
 }

--- a/tests/neg/i10546.scala
+++ b/tests/neg/i10546.scala
@@ -2,4 +2,4 @@ object test:
   def times(num : Int)(block : => Unit) : Unit = ()
     times(10): println("ah") // error: end of statement expected but '(' found // error
 
-  def foo: Set(Int) = Set(1) // error: end of statement expected but '(' found // error // error
+  def foo: Set(Int) = Set(1)

--- a/tests/neg/i4373.scala
+++ b/tests/neg/i4373.scala
@@ -16,7 +16,7 @@ class A4 extends _ with Base // error
 object Test {
   type T1 = _ // error
   type T2 = _[Int] // error // error
-  type T3 = _ { type S } // error
+  type T3 = _ { type S } // error // error
   type T4 = [X] =>> _ // error
 
   // Open questions:

--- a/tests/neg/i4934.scala
+++ b/tests/neg/i4934.scala
@@ -8,4 +8,4 @@ object Main {
 
 object Foo {
   val a = ""); // error: `}` expected but `)` found
-} // error: eof expected
+}

--- a/tests/neg/i5004.scala
+++ b/tests/neg/i5004.scala
@@ -1,6 +1,6 @@
 object i0 {
 1 match {
-def this(): Int  // error // error
-  def this()     // error
-}                // error
+def this(): Int  // error
+  def this()
+}
 }

--- a/tests/neg/i5032b.scala
+++ b/tests/neg/i5032b.scala
@@ -1,2 +1,2 @@
 class a@
-class b@ // error // error
+class b@ // error

--- a/tests/neg/i7751.scala
+++ b/tests/neg/i7751.scala
@@ -1,2 +1,2 @@
 val a = Some(a=a,)=> // error // error
-val a = Some(x=y,)=> // error
+val a = Some(x=y,)=>

--- a/tests/neg/i8731.scala
+++ b/tests/neg/i8731.scala
@@ -3,7 +3,7 @@ object test:
   3 match
   case 3 => ???
   end match
-  case _ => () // error: missing parameter type
+  case _ => () // error: expected start of definition
   end match
 
   if 3 == 3 then
@@ -11,19 +11,9 @@ object test:
   end if
   else     // error: illegal start of definition
     ()
-  end if
+  end if   // error: misaligned end marker
 
   class Test {
     val test = 3
-  end Test   // error: misaligned end marker
-  }
-
-  while
-    3 == 3
-  end while  // error: `do` expected
-  do ()
-
-  for
-    a <- Seq()
-  end for    // error: `yield` or `do` expected
-  do ()
+  end Test // error: misaligned end marker
+  }  // error: eof expected, but unindent found

--- a/tests/neg/i8731a.scala
+++ b/tests/neg/i8731a.scala
@@ -1,0 +1,10 @@
+object test:
+  while
+    3 == 3
+  end while  // error: `do` expected
+  do ()
+
+  for
+    a <- Seq()
+  end for    // error: `yield` or `do` expected
+  do ()            // error: expression expected but eof found

--- a/tests/neg/i9328.scala
+++ b/tests/neg/i9328.scala
@@ -14,8 +14,8 @@ case class Foo()
 
 case class Bar(
 } { ;  // error
-object Bar { // error
+object Bar {
   class Foo(a: Int) extends AnyVal
   Foo()
 }
-type Bar // error
+type Bar

--- a/tests/neg/indent.scala
+++ b/tests/neg/indent.scala
@@ -4,6 +4,6 @@ object Test {
   val y3 =
     if (1) max 10 gt 0  // error: end of statement expected but integer literal found // error // error // error
       1
-    else  // error: end of statement expected but 'else' found
-      2   // error
-}
+    else
+      2
+} // error


### PR DESCRIPTION
Simplify and improve the algorithm used for skipping tokens when a syntax
error is encountered. The new algorithm is based on the region stack maintained
in Scanner instead of maintaining separate counters for open parentheses. This
improves the precision of skipping in general, since there's is no chance that
the two datastructures get out of sync. It seems that way we produce overall 
fewer follow-on errors after a syntax error.