### PR TITLE
Show expanded function for more missing parameter types errors

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -7,6 +7,7 @@ import Contexts._
 import Decorators._, Symbols._, Names._, NameOps._, Types._, Flags._, Phases._
 import Denotations.SingleDenotation
 import SymDenotations.SymDenotation
+import NameKinds.WildcardParamName
 import util.SourcePosition
 import parsing.Scanners.Token
 import parsing.Tokens
@@ -149,10 +150,10 @@ import transform.SymUtils._
   extends TypeMsg(AnonymousFunctionMissingParamTypeID) {
     def msg = {
       val ofFun =
-        if (MethodType.syntheticParamNames(args.length + 1) contains param.name)
-          i" of expanded function:\n$tree"
-        else
-          ""
+        if param.name.is(WildcardParamName)
+           || (MethodType.syntheticParamNames(args.length + 1) contains param.name)
+        then i" of expanded function:\n$tree"
+        else ""
 
       val inferred =
         if (pt == WildcardType) ""

--- a/tests/neg/i11561.check
+++ b/tests/neg/i11561.check
@@ -1,0 +1,13 @@
+-- [E081] Type Error: tests/neg/i11561.scala:2:32 ----------------------------------------------------------------------
+2 |  val updateText1 = copy(text = _) // error
+  |                                ^
+  |                                Missing parameter type
+  |
+  |                                I could not infer the type of the parameter _$1 of expanded function:
+  |                                _$1 => State.this.text = _$1.
+-- [E052] Type Error: tests/neg/i11561.scala:3:30 ----------------------------------------------------------------------
+3 |  val updateText2 = copy(text = (_: String)) // error
+  |                         ^^^^^^^^^^^^^^^^^^
+  |                         Reassignment to val text
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i11561.scala
+++ b/tests/neg/i11561.scala
@@ -1,0 +1,3 @@
+case class State(text: String):
+  val updateText1 = copy(text = _) // error
+  val updateText2 = copy(text = (_: String)) // error


### PR DESCRIPTION
Fixes #11561

It's the best I could do. The second error leads to code that's too far removed from what's
intended for it to be recoverable in a robust way.