### PR TITLE
Also run PostTyper and Inliner from completime.typechecks

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -67,7 +67,7 @@ class Inlining extends MacroTransform {
       case _ =>
     }
 
-  protected def newTransformer(using Context): Transformer = new Transformer {
+  def newTransformer(using Context): Transformer = new Transformer {
     override def transform(tree: tpd.Tree)(using Context): tpd.Tree =
       new InliningTreeMap().transform(tree)
   }

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -70,7 +70,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
 
   override def transformPhase(using Context): Phase = thisPhase.next
 
-  protected def newTransformer(using Context): Transformer =
+  def newTransformer(using Context): Transformer =
     new PostTyperTransformer
 
   val superAcc: SuperAccessors = new SuperAccessors(thisPhase)

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -293,7 +293,7 @@ object Inliner {
     private enum ErrorKind:
       case Parser, Typer
 
-    private def compileForErrors(tree: Tree, stopAfterParser: Boolean)(using Context): List[(ErrorKind, Error)] =
+    private def compileForErrors(tree: Tree)(using Context): List[(ErrorKind, Error)] =
       assert(tree.symbol == defn.CompiletimeTesting_typeChecks || tree.symbol == defn.CompiletimeTesting_typeCheckErrors)
       def stripTyped(t: Tree): Tree = t match {
         case Typed(t2, _) => stripTyped(t2)
@@ -317,7 +317,7 @@ object Inliner {
 
           val parseErrors = ctx2.reporter.allErrors.toList
           res ++= parseErrors.map(e => ErrorKind.Parser -> e)
-          if !stopAfterParser || res.isEmpty then
+          if res.isEmpty then
             ctx2.typer.typed(tree2)(using ctx2)
             val typerErrors = ctx2.reporter.allErrors.filterNot(parseErrors.contains)
             res ++= typerErrors.map(e => ErrorKind.Typer -> e)
@@ -346,12 +346,12 @@ object Inliner {
 
     /** Expand call to scala.compiletime.testing.typeChecks */
     def typeChecks(tree: Tree)(using Context): Tree =
-      val errors = compileForErrors(tree, true)
+      val errors = compileForErrors(tree)
       Literal(Constant(errors.isEmpty)).withSpan(tree.span)
 
     /** Expand call to scala.compiletime.testing.typeCheckErrors */
     def typeCheckErrors(tree: Tree)(using Context): Tree =
-      val errors = compileForErrors(tree, false)
+      val errors = compileForErrors(tree)
       packErrors(errors)
 
     /** Expand call to scala.compiletime.codeOf */

--- a/tests/run-macros/i11630.scala
+++ b/tests/run-macros/i11630.scala
@@ -1,0 +1,9 @@
+inline def failme1() = compiletime.error("fail")
+transparent inline def failme2() = compiletime.error("fail")
+
+@main def Test =
+  assert(!compiletime.testing.typeChecks("failme1()"))
+  assert(!compiletime.testing.typeChecks("failme2()"))
+  assert(!compiletime.testing.typeChecks("a b c"))
+  assert(!compiletime.testing.typeChecks("true: Int"))
+


### PR DESCRIPTION

For the moment we specialize this to PostTyper and Inliner. We could
run more phases (e.g. all phases up to erasure) but that would require
a different infrastructure where we encapsulate the parsed string in
a compilation unit.

Fixes #11630 