### PR TITLE
repl: Use the correct parent Classloader on Java 9+

### DIFF
--- a/compiler/test-resources/repl/defaultClassloader
+++ b/compiler/test-resources/repl/defaultClassloader
@@ -1,0 +1,3 @@
+scala> val d: java.sql.Date = new java.sql.Date(100L)
+val d: java.sql.Date = 1970-01-01
+

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -94,6 +94,6 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
 }
 
 object ReplTest:
-  val commonOptions = Array("-color:never", "-Yerased-terms")
+  val commonOptions = Array("-color:never", "-Yerased-terms", "-pagewidth", "80")
   val defaultOptions = commonOptions ++ Array("-classpath", TestConfiguration.basicClasspath)
   lazy val withStagingOptions = commonOptions ++ Array("-classpath", TestConfiguration.withStagingClasspath)


### PR DESCRIPTION
On Java 9+, `null` as a parent of a URLClassLoader means the parent is
the bootstrap classloader which doesn't contain modules like `java.sql`,
explicitly use the system classloader instead.

Fixes #11646.