### PR TITLE
Add cask to community build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -187,3 +187,6 @@
 [submodule "community-build/community-projects/protoquill"]
 	path = community-build/community-projects/protoquill
 	url = https://github.com/dotty-staging/protoquill.git
+[submodule "community-build/community-projects/cask"]
+	path = community-build/community-projects/cask
+	url = https://github.com/dotty-staging/cask.git

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -214,6 +214,12 @@ object projects:
     dependencies = List(geny, utest, ujson, upickleCore)
   )
 
+  lazy val cask = MillCommunityProject(
+    project = "cask",
+    baseCommand = s"cask[$compilerVersion]",
+    dependencies = List(utest, upickle, sourcecode, pprint, geny)
+  )
+
   lazy val scas = MillCommunityProject(
     project = "scas",
     baseCommand = "scas.application"
@@ -680,6 +686,7 @@ def allProjects = List(
   projects.perspective,
   projects.akka,
   projects.protoquill,
+  projects.cask
 )
 
 lazy val projectMap = allProjects.groupBy(_.project)

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -87,6 +87,7 @@ end CommunityBuildTest
 @Category(Array(classOf[TestCategory]))
 class CommunityBuildTestA extends CommunityBuildTest:
   @Test def akka = projects.akka.run()
+  @Test def cask = projects.cask.run()
   @Test def endpoints4s = projects.endpoints4s.run()
   @Test def fansi = projects.fansi.run()
   @Test def fastparse = projects.fastparse.run()


### PR DESCRIPTION
This includes a workaround for #11630, which was previously blocking. See https://github.com/com-lihaoyi/cask/pull/44 for a discussion on changes to cask, and why we can't include cask master in the community build.

cc @anatoliykmetyuk 