### PR TITLE
Script startup latency improvement

### DIFF
--- a/compiler/src/dotty/tools/scripting/Main.scala
+++ b/compiler/src/dotty/tools/scripting/Main.scala
@@ -49,9 +49,6 @@ object Main:
   private def writeJarfile(outDir: Path, scriptFile: File, scriptArgs:Array[String],
       classpathEntries:Seq[Path], mainClassName: String): Unit =
 
-    //val javaClasspath = sys.props("java.class.path")
-    //val runtimeClasspath = s"${classpath}$pathsep$javaClasspath"
-
     val jarTargetDir: Path = Option(scriptFile.toPath.toAbsolutePath.getParent) match {
       case None => sys.error(s"no parent directory for script file [$scriptFile]")
       case Some(parent) => parent
@@ -60,7 +57,6 @@ object Main:
     def scriptBasename = scriptFile.getName.takeWhile(_!='.')
     val jarPath = s"$jarTargetDir/$scriptBasename.jar"
 
-    //val cpPaths = runtimeClasspath.split(pathsep).map(_.toUrl)
     val cpPaths = classpathEntries.map { _.toString.toUrl }
 
     import java.util.jar.Attributes.Name

--- a/compiler/src/dotty/tools/scripting/Main.scala
+++ b/compiler/src/dotty/tools/scripting/Main.scala
@@ -32,10 +32,10 @@ object Main:
   def main(args: Array[String]): Unit =
     val (compilerArgs, scriptFile, scriptArgs, saveJar, invokeFlag) = distinguishArgs(args)
     val driver = ScriptingDriver(compilerArgs, scriptFile, scriptArgs)
-    try driver.compileAndRun { (outDir:Path, classpath:String, mainClass: String) =>
+    try driver.compileAndRun { (outDir:Path, classpathEntries:Seq[Path], mainClass: String) =>
       if saveJar then
         // write a standalone jar to the script parent directory
-        writeJarfile(outDir, scriptFile, scriptArgs, classpath, mainClass)
+        writeJarfile(outDir, scriptFile, scriptArgs, classpathEntries, mainClass)
       invokeFlag
     }
     catch
@@ -47,10 +47,10 @@ object Main:
         throw e.getCause
 
   private def writeJarfile(outDir: Path, scriptFile: File, scriptArgs:Array[String],
-      classpath:String, mainClassName: String): Unit =
+      classpathEntries:Seq[Path], mainClassName: String): Unit =
 
-    val javaClasspath = sys.props("java.class.path")
-    val runtimeClasspath = s"${classpath}$pathsep$javaClasspath"
+    //val javaClasspath = sys.props("java.class.path")
+    //val runtimeClasspath = s"${classpath}$pathsep$javaClasspath"
 
     val jarTargetDir: Path = Option(scriptFile.toPath.toAbsolutePath.getParent) match {
       case None => sys.error(s"no parent directory for script file [$scriptFile]")
@@ -60,7 +60,8 @@ object Main:
     def scriptBasename = scriptFile.getName.takeWhile(_!='.')
     val jarPath = s"$jarTargetDir/$scriptBasename.jar"
 
-    val cpPaths = runtimeClasspath.split(pathsep).map(_.toUrl)
+    //val cpPaths = runtimeClasspath.split(pathsep).map(_.toUrl)
+    val cpPaths = classpathEntries.map { _.toString.toUrl }
 
     import java.util.jar.Attributes.Name
     val cpString:String = cpPaths.distinct.mkString(" ")

--- a/compiler/src/dotty/tools/scripting/ScriptingDriver.scala
+++ b/compiler/src/dotty/tools/scripting/ScriptingDriver.scala
@@ -1,6 +1,6 @@
 package dotty.tools.scripting
 
-import java.nio.file.{ Files, Paths, Path }
+import java.nio.file.{ Files, Path }
 import java.io.File
 import java.net.{ URL, URLClassLoader }
 import java.lang.reflect.{ Modifier, Method }
@@ -17,7 +17,7 @@ import dotty.tools.dotc.config.Settings.Setting._
 import sys.process._
 
 class ScriptingDriver(compilerArgs: Array[String], scriptFile: File, scriptArgs: Array[String]) extends Driver:
-  def compileAndRun(pack:(Path, Seq[Path], String) => Boolean = null): Unit =
+  def compileAndRun(pack:(Path, String, String) => Boolean = null): Unit =
     val outDir = Files.createTempDirectory("scala3-scripting")
     setup(compilerArgs :+ scriptFile.getAbsolutePath, initCtx.fresh) match
       case Some((toCompile, rootCtx)) =>
@@ -28,23 +28,11 @@ class ScriptingDriver(compilerArgs: Array[String], scriptFile: File, scriptArgs:
           throw ScriptingException("Errors encountered during compilation")
 
         try
-          val classpath = s"${ctx.settings.classpath.value}${pathsep}${sys.props("java.class.path")}"
-          val classpathEntries: Seq[Path] =
-            classpath.split(pathsep).toIndexedSeq.flatMap { entry =>
-              val f = Paths.get(entry).toAbsolutePath.normalize.toFile
-              // expand wildcard classpath entries
-              if (f.getName == "*" && f.getParentFile.isDirectory){
-                f.getParentFile.listFiles.filter { _.getName.toLowerCase.endsWith(".jar") }.map { _.toPath }.toSeq
-              } else {
-                Seq(f.toPath)
-              }
-            }.toIndexedSeq
-
-          val (mainClass, mainMethod) = detectMainClassAndMethod(outDir, classpathEntries, scriptFile)
+          val (mainClass, mainMethod) = detectMainClassAndMethod(outDir, ctx.settings.classpath.value, scriptFile)
           val invokeMain: Boolean =
             Option(pack) match
               case Some(func) =>
-                func(outDir, classpathEntries, mainClass)
+                func(outDir, ctx.settings.classpath.value, mainClass)
               case None =>
                 true
             end match
@@ -64,12 +52,11 @@ class ScriptingDriver(compilerArgs: Array[String], scriptFile: File, scriptArgs:
     target.delete()
   end deleteFile
 
-  private def detectMainClassAndMethod(outDir: Path, classpathEntries: Seq[Path],
+  private def detectMainClassAndMethod(outDir: Path, classpath: String,
       scriptFile: File): (String, Method) =
-
-    val classpathUrls = (classpathEntries :+ outDir).map { _.toUri.toURL }
-
-    val cl = URLClassLoader(classpathUrls.toArray)
+    val outDirURL = outDir.toUri.toURL
+    val classpathUrls = classpath.split(pathsep).map(File(_).toURI.toURL)
+    val cl = URLClassLoader(classpathUrls :+ outDirURL)
 
     def collectMainMethods(target: File, path: String): List[(String, Method)] =
       val nameWithoutExtension = target.getName.takeWhile(_ != '.')

--- a/compiler/test/dotty/tools/scripting/ScriptingTests.scala
+++ b/compiler/test/dotty/tools/scripting/ScriptingTests.scala
@@ -3,6 +3,7 @@ package tools
 package scripting
 
 import java.io.File
+import java.nio.file.Path
 
 import org.junit.Test
 
@@ -65,7 +66,7 @@ class ScriptingTests:
         ),
         scriptFile = scriptFile,
         scriptArgs = scriptArgs
-      ).compileAndRun { (path:java.nio.file.Path,classpath:String, mainClass:String) =>
+      ).compileAndRun { (path:java.nio.file.Path,classpathEntries:Seq[Path], mainClass:String) =>
         printf("mainClass from ScriptingDriver: %s\n",mainClass)
         true // call compiled script main method
       }
@@ -128,7 +129,7 @@ class ScriptingTests:
       compilerArgs = Array("-classpath", TestConfiguration.basicClasspath),
       scriptFile = scriptFile,
       scriptArgs = Array.empty[String]
-    ).compileAndRun { (path:java.nio.file.Path,classpath:String, mainClass:String) =>
+    ).compileAndRun { (path:java.nio.file.Path,classpathEntries:Seq[Path], mainClass:String) =>
       printf("success: no call to main method in mainClass: %s\n",mainClass)
       false // no call to compiled script main method
     }
@@ -141,7 +142,7 @@ class ScriptingTests:
       compilerArgs = Array("-classpath", TestConfiguration.basicClasspath),
       scriptFile = scriptFile,
       scriptArgs = Array.empty[String]
-    ).compileAndRun { (path:java.nio.file.Path,classpath:String, mainClass:String) =>
+    ).compileAndRun { (path:java.nio.file.Path,classpathEntries:Seq[Path], mainClass:String) =>
       printf("call main method in mainClass: %s\n",mainClass)
       true // call compiled script main method, create touchedFile
     }

--- a/compiler/test/dotty/tools/scripting/ScriptingTests.scala
+++ b/compiler/test/dotty/tools/scripting/ScriptingTests.scala
@@ -3,7 +3,6 @@ package tools
 package scripting
 
 import java.io.File
-import java.nio.file.Path
 
 import org.junit.Test
 
@@ -66,7 +65,7 @@ class ScriptingTests:
         ),
         scriptFile = scriptFile,
         scriptArgs = scriptArgs
-      ).compileAndRun { (path:java.nio.file.Path,classpathEntries:Seq[Path], mainClass:String) =>
+      ).compileAndRun { (path:java.nio.file.Path,classpath:String, mainClass:String) =>
         printf("mainClass from ScriptingDriver: %s\n",mainClass)
         true // call compiled script main method
       }
@@ -129,7 +128,7 @@ class ScriptingTests:
       compilerArgs = Array("-classpath", TestConfiguration.basicClasspath),
       scriptFile = scriptFile,
       scriptArgs = Array.empty[String]
-    ).compileAndRun { (path:java.nio.file.Path,classpathEntries:Seq[Path], mainClass:String) =>
+    ).compileAndRun { (path:java.nio.file.Path,classpath:String, mainClass:String) =>
       printf("success: no call to main method in mainClass: %s\n",mainClass)
       false // no call to compiled script main method
     }
@@ -142,7 +141,7 @@ class ScriptingTests:
       compilerArgs = Array("-classpath", TestConfiguration.basicClasspath),
       scriptFile = scriptFile,
       scriptArgs = Array.empty[String]
-    ).compileAndRun { (path:java.nio.file.Path,classpathEntries:Seq[Path], mainClass:String) =>
+    ).compileAndRun { (path:java.nio.file.Path,classpath:String, mainClass:String) =>
       printf("call main method in mainClass: %s\n",mainClass)
       true // call compiled script main method, create touchedFile
     }

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -54,9 +54,9 @@ case "`uname`" in
 esac
 
 unset CYGPATHCMD
-if [[ $cygwin || $mingw || $msys ]]; then
+if [[ ${cygwin-} || ${mingw-} || ${msys-} ]]; then
   # ConEmu terminal is incompatible with jna-5.*.jar
-  [[ ($CONEMUANSI || $ConEmuANSI) ]] && conemu=true
+  [[ (${CONEMUANSI-} || ${ConEmuANSI-}) ]] && conemu=true
   # cygpath is used by various windows shells: cygwin, git-sdk, gitbash, msys, etc.
   CYGPATHCMD=`which cygpath 2>/dev/null`
   case "$TERM" in
@@ -111,14 +111,14 @@ CLASSPATH_SUFFIX=""
 PSEP=":"
 
 # translate paths to Windows-mixed format before running java
-if [ -n "$CYGPATHCMD" ]; then
-  [ -n "$PROG_HOME" ] &&
+if [ -n "${CYGPATHCMD-}" ]; then
+  [ -n "${PROG_HOME-}" ] &&
     PROG_HOME=`"$CYGPATHCMD" -am "$PROG_HOME"`
   [ -n "$JAVA_HOME" ] &&
     JAVA_HOME=`"$CYGPATHCMD" -am "$JAVA_HOME"`
   CLASSPATH_SUFFIX=";"
   PSEP=";"
-elif [[ $mingw || $msys ]]; then
+elif [[ ${mingw-} || ${msys-} ]]; then
   # For Mingw / Msys, convert paths from UNIX format before anything is touched
   [ -n "$PROG_HOME" ] &&
     PROG_HOME="`(cd "$PROG_HOME"; pwd -W | sed 's|/|\\\\|g')`"
@@ -134,9 +134,9 @@ fi
 
 find_lib () {
   local lib=$(find $PROG_HOME/lib/ -name "$1")
-  if [ -n "$CYGPATHCMD" ]; then
+  if [ -n "${CYGPATHCMD-}" ]; then
     $CYGPATHCMD -am $lib
-  elif [[ $mingw ||  $msys ]]; then
+  elif [[ ${mingw-} ||  ${msys-} ]]; then
     echo $lib | sed 's|/|\\\\|g'
   else
     echo $lib
@@ -155,8 +155,13 @@ SBT_INTF=$(find_lib "*compiler-interface*")
 JLINE_READER=$(find_lib "*jline-reader-3*")
 JLINE_TERMINAL=$(find_lib "*jline-terminal-3*")
 JLINE_TERMINAL_JNA=$(find_lib "*jline-terminal-jna-3*")
-[[ $conemu ]] || JNA=$(find_lib "*jna-5*")
+[[ ${conemu-} ]] || JNA=$(find_lib "*jna-5*")
 
 # debug
 
 DEBUG_STR=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
+
+export saved_stty PROG_HOME DEBUG_STR PSEP SCALA_LIB DOTTY_LIB SCALA_ASM SBT_INTF DOTTY_INTF DOTTY_COMP TASTY_CORE
+export DOTTY_STAGING DOTTY_TASTY_INSPECTOR JLINE_READER JLINE_TERMINAL JLINE_TERMINAL_JNA JNA JAVACMD SCALA_OPTS
+export cygwin mingw msys darwin conemu CLASSPATH_SUFFIX
+export -f onExit restoreSttySettings

--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # Try to autodetect real location of the script
-
-if [ -z "$PROG_HOME" ] ; then
+if [ -z "${PROG_HOME-}" ] ; then
   ## resolve links - $0 may be a link to PROG_HOME
   PRG="$0"
 
@@ -107,9 +106,15 @@ while [[ $# -gt 0 ]]; do
     *)
       if [ $execute_script == false ]; then
         # is a script if extension .scala or .sc or if has scala hash bang
-        if [[ -e "$1" && ("$1" == *.scala || "$1" == *.sc || -f "$1" && `head -n 1 -- "$1" | grep '#!.*scala'`) ]]; then
+        if [[ "$1" == *.scala || "$1" == *.sc || (-f "$1" && `head -n 1 -- "$1" | grep '#!.*scala'`) ]]; then
           execute_script=true
           target_script="$1"
+          if [ ! -f $target_script ]; then
+            # likely a typo or missing script file, quit early
+            echo "not found: $target_script" 1>&2
+            scala_exit_status=2
+            onExit
+          fi
         else
           residual_args+=("$1")
         fi

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -z "$PROG_HOME" ] ; then
+if [ -z "${PROG_HOME-}" ] ; then
   ## resolve links - $0 may be a link to PROG_HOME
   PRG="$0"
 
@@ -25,7 +25,8 @@ if [ -z "$PROG_HOME" ] ; then
   cd "$saveddir"
 fi
 
-source "$PROG_HOME/bin/common"
+# only source common if necessary
+[ -z "${DEBUG_STR-}" -a -z "${PSEP-}" ] && source "$PROG_HOME/bin/common"
 
 default_java_opts="-Xmx768m -Xms768m"
 withCompiler=true


### PR DESCRIPTION
When launching a scala3 script, there are two calls to [dist/bin/common](dist/bin/common), the first from within [dist/bin/scala](dist/bin/scala) and the 2nd when `dist/bin/scala` calls `dist/bin/scalac`. 

It turns out that the avoidable 2nd call is quite expensive in terms of what it adds to script startup latency.   Here are the reductions in startup time when running in `cygwin` and in `WSL Linux`:

```sh
cygwin:    837 mSec
WSL Linux:  66 mSec
```

The numbers are the difference in startup latency for calling a `hello-world.sc` script with and without the changes in this PR, averaged over 100 runs.

The categories of change in the PR are:

- exporting values initialized by `dist/bin/common` and required by scalac
- modification of `dist/bin/scalac` to conditionally source `dist/bin/common`
- changes to avoid spurious unset variable errors when testing with: `set -o nounset` 
- fail early if a script file doesn't exist

The third change is exemplified by line 114 in `dist/bin/common`:
```diff
-if [ -n "$CYGPATHCMD" ]; then
+if [ -n "${CYGPATHCMD-}" ]; then
```



