### PR TITLE
Rename -Ycheck-init to -Ysafe-init

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -130,7 +130,7 @@ final case class SbtCommunityProject(
 object SbtCommunityProject:
   def scalacOptions = List(
     "-Xcheck-macros",
-    "-Ycheck-init",
+    "-Ysafe-init",
   )
 
 object projects:
@@ -319,7 +319,7 @@ object projects:
     project       = "shapeless",
     sbtTestCommand   = "test",
     sbtDocCommand = forceDoc("typeable", "deriving", "data"),
-    scalacOptions = Nil // disable -Ycheck-init, due to -Xfatal-warnings
+    scalacOptions = Nil // disable -Ysafe-init, due to -Xfatal-warnings
   )
 
   lazy val xmlInterpolator = SbtCommunityProject(
@@ -480,7 +480,7 @@ object projects:
     sbtTestCommand = "test",
     sbtPublishCommand = "coreJVM/publishLocal;coreJS/publishLocal",
     dependencies = List(discipline),
-    scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Ycheck-init")
+    scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Ysafe-init")
   )
 
   lazy val simulacrumScalafixAnnotations = SbtCommunityProject(
@@ -494,7 +494,7 @@ object projects:
     sbtTestCommand = "set scalaJSStage in Global := FastOptStage;buildJVM;validateAllJS",
     sbtPublishCommand = "catsJVM/publishLocal;catsJS/publishLocal",
     dependencies = List(discipline, disciplineMunit, scalacheck, simulacrumScalafixAnnotations),
-    scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Ycheck-init") // disable -Ycheck-init, due to -Xfatal-warning
+    scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Ysafe-init") // disable -Ysafe-init, due to -Xfatal-warning
 
   )
 
@@ -611,7 +611,7 @@ object projects:
     sbtTestCommand = "test",
     sbtPublishCommand = "publishLocal",
     dependencies = List(), // TODO add scalatest and pprint (see protoquill/build.sbt)
-    scalacOptions = List("-language:implicitConversions"), // disabled -Ycheck-init, due to bug in macro
+    scalacOptions = List("-language:implicitConversions"), // disabled -Ysafe-init, due to bug in macro
   )
 
   lazy val onnxScala = SbtCommunityProject(

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -226,7 +226,7 @@ class ScalaSettings extends Settings.SettingGroup with CommonScalaSettings {
   val YnoKindPolymorphism: Setting[Boolean] = BooleanSetting("-Yno-kind-polymorphism", "Disable kind polymorphism.")
   val YexplicitNulls: Setting[Boolean] = BooleanSetting("-Yexplicit-nulls", "Make reference types non-nullable. Nullable types can be expressed with unions: e.g. String|Null.")
   val YerasedTerms: Setting[Boolean] = BooleanSetting("-Yerased-terms", "Allows the use of erased terms.")
-  val YcheckInit: Setting[Boolean] = BooleanSetting("-Ycheck-init", "Check initialization of objects")
+  val YcheckInit: Setting[Boolean] = BooleanSetting("-Ysafe-init", "Ensure safe initialization of objects")
   val YrequireTargetName: Setting[Boolean] = BooleanSetting("-Yrequire-targetName", "Warn if an operator is defined without a @targetName annotation")
 
   /** Area-specific debug output */

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -40,7 +40,7 @@ class CompilationTests {
       compileFilesInDir("tests/new", defaultOptions),
       compileFilesInDir("tests/pos-scala2", scala2CompatMode),
       compileFilesInDir("tests/pos-custom-args/erased", defaultOptions.and("-Yerased-terms")),
-      compileFilesInDir("tests/pos", defaultOptions.and("-Ycheck-init")),
+      compileFilesInDir("tests/pos", defaultOptions.and("-Ysafe-init")),
       compileFilesInDir("tests/pos-deep-subtype", allowDeepSubtypes),
       compileDir("tests/pos-special/java-param-names", defaultOptions.withJavacOnlyOptions("-parameters")),
       compileFile(
@@ -190,7 +190,7 @@ class CompilationTests {
       compileFile("tests/run-custom-args/defaults-serizaliable-no-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
       compileFilesInDir("tests/run-custom-args/erased", defaultOptions.and("-Yerased-terms")),
       compileFilesInDir("tests/run-deep-subtype", allowDeepSubtypes),
-      compileFilesInDir("tests/run", defaultOptions.and("-Ycheck-init"))
+      compileFilesInDir("tests/run", defaultOptions.and("-Ysafe-init"))
     ).checkRuns()
   }
 
@@ -315,7 +315,7 @@ class CompilationTests {
   // initialization tests
   @Test def checkInit: Unit = {
     implicit val testGroup: TestGroup = TestGroup("checkInit")
-    val options = defaultOptions.and("-Ycheck-init", "-Xfatal-warnings")
+    val options = defaultOptions.and("-Ysafe-init", "-Xfatal-warnings")
     compileFilesInDir("tests/init/neg", options).checkExpectedErrors()
     compileFilesInDir("tests/init/pos", options).checkCompile()
     compileFilesInDir("tests/init/crash", options.without("-Xfatal-warnings")).checkCompile()

--- a/docs/blog/_posts/2020-03-18-23rd-dotty-milestone-release.md
+++ b/docs/blog/_posts/2020-03-18-23rd-dotty-milestone-release.md
@@ -40,7 +40,7 @@ class RemoteFile(url: String) extends AbstractFile {
 Above, `extension` value is initialized prior to `localFile` because the fields of the parents of a class are initialized prior to the fields of the class. However, `extension` uses `localFile` during its initialization since it accesses this field from the `name` method. This scenario will lead to a `NullPointerException` on runtime when the access to uninitialized `localFile` happens.
 
 
-In this release, we have added an aid for the programmer to detect such mistakes automatically. If you compile the above program with the `-Ycheck-init` flag, you will get the following compile-time error:
+In this release, we have added an aid for the programmer to detect such mistakes automatically. If you compile the above program with the `-Ysafe-init` flag, you will get the following compile-time error:
 
 ```scala
 -- Error: /Users/kmetiuk/Projects/scala3/pg/release/snip_4.scala:8:7 -----------

--- a/docs/docs/reference/other-new-features/explicit-nulls.md
+++ b/docs/docs/reference/other-new-features/explicit-nulls.md
@@ -47,7 +47,7 @@ val c = new C()
 // c.f == "field is null"
 ```
 
-The unsoundness above can be caught by the compiler with the option `-Ycheck-init`.
+The unsoundness above can be caught by the compiler with the option `-Ysafe-init`.
 More details can be found in [safe initialization](./safe-initialization.md).
 
 ## Equality

--- a/docs/docs/reference/other-new-features/safe-initialization.md
+++ b/docs/docs/reference/other-new-features/safe-initialization.md
@@ -3,7 +3,7 @@ layout: doc-page
 title: "Safe Initialization"
 ---
 
-Scala 3 implements experimental safe initialization check, which can be enabled by the compiler option `-Ycheck-init`.
+Scala 3 implements experimental safe initialization check, which can be enabled by the compiler option `-Ysafe-init`.
 
 ## A Quick Glance
 


### PR DESCRIPTION
Rename `-Ycheck-init` to `-Ysafe-init` to avoid confusion with -Xcheckinit