### PR TITLE
Treat Scala.js pseudo-unions  as real unions

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -59,6 +59,8 @@ final class JSDefinitions()(using Context) {
     @threadUnsafe lazy val PseudoUnion_fromTypeConstructorR = PseudoUnionModule.requiredMethodRef("fromTypeConstructor")
     def PseudoUnion_fromTypeConstructor(using Context) = PseudoUnion_fromTypeConstructorR.symbol
 
+  @threadUnsafe lazy val UnionOpsModuleRef = requiredModuleRef("scala.scalajs.js.internal.UnitOps")
+
   @threadUnsafe lazy val JSArrayType: TypeRef = requiredClassRef("scala.scalajs.js.Array")
   def JSArrayClass(using Context) = JSArrayType.symbol.asClass
   @threadUnsafe lazy val JSDynamicType: TypeRef = requiredClassRef("scala.scalajs.js.Dynamic")

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2126,7 +2126,7 @@ import transform.SymUtils._
       val addendum =
         if (scrutTp != testTp) s" is a subtype of ${testTp.show}"
         else " is the same as the tested type"
-      s"The highlighted type test will always succeed since the scrutinee type ($scrutTp.show)" + addendum
+      s"The highlighted type test will always succeed since the scrutinee type ${scrutTp.show}" + addendum
     }
     def explain = ""
   }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -2,6 +2,7 @@ package dotty.tools
 package dotc
 package typer
 
+import backend.sjs.JSDefinitions
 import core._
 import ast.{Trees, TreeTypeMap, untpd, tpd, DesugarEnums}
 import util.Spans._
@@ -634,6 +635,14 @@ trait ImplicitRunInfo:
               else pre.member(sym.name.toTermName)
                 .suchThat(companion => companion.is(Module) && companion.owner == sym.owner)
                 .symbol)
+
+            // The companion of `js.|` defines an implicit conversions from
+            // `A | Unit` to `js.UndefOrOps[A]`. To keep this conversion in scope
+            // in Scala 3, where we re-interpret `js.|` as a real union, we inject
+            // it in the scope of `Unit`.
+            if t.isRef(defn.UnitClass) && ctx.settings.scalajs.value then
+              companions += JSDefinitions.jsdefn.UnionOpsModuleRef
+
             if sym.isClass then
               for p <- t.parents do companions ++= iscopeRefs(p)
             else

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -2,11 +2,13 @@ package dotty.tools
 package dotc
 package typer
 
+import backend.sjs.JSDefinitions
 import core._
 import Contexts._, Types._, Symbols._, Names._, Decorators._, ProtoTypes._
 import Flags._, SymDenotations._
 import NameKinds.FlatName
 import NameOps._
+import StdNames._
 import config.Printers.{implicits, implicitsDetailed}
 import util.Spans.Span
 import ast.{untpd, tpd}
@@ -64,6 +66,8 @@ trait ImportSuggestions:
         else !root.name.is(FlatName)
           && !root.name.lastPart.contains('$')
           && root.is(ModuleVal, butNot = JavaDefined)
+          // The implicits in `scalajs.js.|` are implementation details and shouldn't be suggested
+          && !(root.name == nme.raw.BAR && ctx.settings.scalajs.value && root == JSDefinitions.jsdefn.PseudoUnionModule)
       }
 
     def nestedRoots(site: Type)(using Context): List[Symbol] =

--- a/library-js/src/scala/scalajs/js/internal/UnitOps.scala
+++ b/library-js/src/scala/scalajs/js/internal/UnitOps.scala
@@ -1,0 +1,8 @@
+package scala.scalajs.js.internal
+
+import scala.scalajs.js
+
+/** Under -scalajs, this object is part of the implicit scope of `scala.Unit` */
+object UnitOps:
+  implicit def unitOrOps[A](x: A | Unit): js.UndefOrOps[A] =
+    new js.UndefOrOps(x)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1105,7 +1105,8 @@ object Build {
             -- "ObjectTest.scala" // compile errors caused by #9588
             -- "StackTraceTest.scala" // would require `npm install source-map-support`
             -- "UnionTypeTest.scala" // requires the Scala 2 macro defined in Typechecking*.scala
-            -- "PromiseMock.scala" -- "AsyncTest.scala" // TODO: Enable once we use a Scala.js with https://github.com/scala-js/scala-js/pull/4451 in
+            -- "PromiseMock.scala" // TODO: Enable once we use a Scala.js with https://github.com/scala-js/scala-js/pull/4451 in
+                                   // and remove copy in tests/sjs-junit
             )).get
 
           ++ (dir / "js/src/test/require-2.12" ** (("*.scala": FileFilter)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1105,9 +1105,12 @@ object Build {
             -- "ObjectTest.scala" // compile errors caused by #9588
             -- "StackTraceTest.scala" // would require `npm install source-map-support`
             -- "UnionTypeTest.scala" // requires the Scala 2 macro defined in Typechecking*.scala
+            -- "PromiseMock.scala" -- "AsyncTest.scala" // TODO: Enable once we use a Scala.js with https://github.com/scala-js/scala-js/pull/4451 in
             )).get
 
-          ++ (dir / "js/src/test/require-2.12" ** "*.scala").get
+          ++ (dir / "js/src/test/require-2.12" ** (("*.scala": FileFilter)
+            -- "JSOptionalTest212.scala" // TODO: Enable once we use a Scala.js with https://github.com/scala-js/scala-js/pull/4451 in
+            )).get
           ++ (dir / "js/src/test/require-sam" ** "*.scala").get
           ++ (dir / "js/src/test/scala-new-collections" ** "*.scala").get
         )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -698,7 +698,7 @@ object Build {
     settings(
       libraryDependencies +=
         ("org.scala-js" %% "scalajs-library" % scalaJSVersion).withDottyCompat(scalaVersion.value),
-      Compile / unmanagedSourceDirectories :=
+      Compile / unmanagedSourceDirectories ++=
         (`scala3-library-bootstrapped` / Compile / unmanagedSourceDirectories).value,
 
       // Configure the source maps to point to GitHub for releases

--- a/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/build.sbt
@@ -1,0 +1,16 @@
+lazy val scala2Lib = project.in(file("scala2Lib"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    // TODO: switch to 2.13.5 once we've upgrade sbt-scalajs to 1.5.0
+    scalaVersion := "2.13.4"
+  )
+
+lazy val dottyApp = project.in(file("dottyApp"))
+  .dependsOn(scala2Lib)
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+
+    scalaJSUseMainModuleInitializer := true,
+    scalaJSLinkerConfig ~= (_.withCheckIR(true)),
+  )

--- a/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/dottyApp/Main.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/dottyApp/Main.scala
@@ -1,0 +1,13 @@
+object Main {
+  def main(args: Array[String]): Unit = {
+    val a = new scala2Lib.A
+    assert(a.foo(1) == "1")
+    assert(a.foo("") == "1")
+    assert(a.foo(Array(1)) == "2")
+
+    val b = new scala2Lib.B
+    assert(b.foo(1) == "1")
+    assert(b.foo("") == "1")
+    assert(b.foo(Array(1)) == "2")
+  }
+}

--- a/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/project/plugins.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % sys.props("plugin.version"))
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.scalaJSVersion"))

--- a/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/scala2Lib/Api.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/scala2Lib/Api.scala
@@ -1,0 +1,15 @@
+// Keep synchronized with dottyApp/Api.scala
+package scala2Lib
+
+import scala.scalajs.js
+import js.|
+
+class A {
+  def foo(x: Int | String): String = "1"
+  def foo(x: Array[Int]): String = "2"
+}
+
+class B extends js.Object {
+  def foo(x: Int | String): String = "1"
+  def foo(x: Array[Int]): String = "2"
+}

--- a/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/test
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure-scalajs/test
@@ -1,0 +1,1 @@
+> dottyApp/run

--- a/sbt-dotty/sbt-test/scala2-compat/erasure/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure/build.sbt
@@ -6,10 +6,5 @@ lazy val scala2Lib = project.in(file("scala2Lib"))
 lazy val dottyApp = project.in(file("dottyApp"))
   .dependsOn(scala2Lib)
   .settings(
-    scalaVersion := sys.props("plugin.scalaVersion"),
-    // https://github.com/sbt/sbt/issues/5369
-    projectDependencies := {
-      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
-    }
+    scalaVersion := sys.props("plugin.scalaVersion")
   )
-

--- a/sbt-dotty/sbt-test/scala2-compat/erasure/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure/build.sbt
@@ -1,6 +1,6 @@
 lazy val scala2Lib = project.in(file("scala2Lib"))
   .settings(
-    scalaVersion := "2.13.2"
+    scalaVersion := "2.13.5"
   )
 
 lazy val dottyApp = project.in(file("dottyApp"))

--- a/sbt-dotty/sbt-test/scala2-compat/i8001/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i8001/build.sbt
@@ -7,9 +7,5 @@ lazy val lib = (project in file ("lib"))
 lazy val test = (project in file ("main"))
   .dependsOn(lib)
   .settings(
-    scalaVersion := scala3Version,
-    // https://github.com/sbt/sbt/issues/5369
-    projectDependencies := {
-      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
-    }
+    scalaVersion := scala3Version
   )

--- a/sbt-dotty/sbt-test/scala2-compat/i8847/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i8847/build.sbt
@@ -7,9 +7,5 @@ lazy val `i8847-lib` = (project in file ("lib"))
 lazy val `i8847-test` = (project in file ("main"))
   .dependsOn(`i8847-lib`)
   .settings(
-    scalaVersion := scala3Version,
-    // https://github.com/sbt/sbt/issues/5369
-    projectDependencies := {
-      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
-    }
+    scalaVersion := scala3Version
   )

--- a/sbt-dotty/sbt-test/scala2-compat/i9916a/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916a/build.sbt
@@ -7,9 +7,5 @@ lazy val `i9916a-lib` = (project in file ("lib"))
 lazy val `i9916a-test` = (project in file ("main"))
   .dependsOn(`i9916a-lib`)
   .settings(
-    scalaVersion := scala3Version,
-    // https://github.com/sbt/sbt/issues/5369
-    projectDependencies := {
-      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
-    }
+    scalaVersion := scala3Version
   )

--- a/sbt-dotty/sbt-test/scala2-compat/i9916b/build.sbt
+++ b/sbt-dotty/sbt-test/scala2-compat/i9916b/build.sbt
@@ -7,9 +7,5 @@ lazy val `i9916b-lib` = (project in file ("lib"))
 lazy val `i9916b-test` = (project in file ("main"))
   .dependsOn(`i9916b-lib`)
   .settings(
-    scalaVersion := scala3Version,
-    // https://github.com/sbt/sbt/issues/5369
-    projectDependencies := {
-      projectDependencies.value.map(_.withDottyCompat(scalaVersion.value))
-    }
+    scalaVersion := scala3Version
   )

--- a/tests/neg-scalajs/js-trait-members-wrong-kind.check
+++ b/tests/neg-scalajs/js-trait-members-wrong-kind.check
@@ -2,15 +2,15 @@
 5 |  lazy val a1: js.UndefOr[Int] = js.undefined // error
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |  A non-native JS trait cannot contain lazy vals
--- Error: tests/neg-scalajs/js-trait-members-wrong-kind.scala:7:29 -----------------------------------------------------
+-- Error: tests/neg-scalajs/js-trait-members-wrong-kind.scala:7:32 -----------------------------------------------------
 7 |  def a(): js.UndefOr[Int] = js.undefined // error
   |                             ^^^^^^^^^^^^
   |                             In non-native JS traits, defs with parentheses must be abstract.
--- Error: tests/neg-scalajs/js-trait-members-wrong-kind.scala:8:35 -----------------------------------------------------
+-- Error: tests/neg-scalajs/js-trait-members-wrong-kind.scala:8:38 -----------------------------------------------------
 8 |  def b(x: Int): js.UndefOr[Int] = js.undefined // error
   |                                   ^^^^^^^^^^^^
   |                                   In non-native JS traits, defs with parentheses must be abstract.
--- Error: tests/neg-scalajs/js-trait-members-wrong-kind.scala:9:26 -----------------------------------------------------
+-- Error: tests/neg-scalajs/js-trait-members-wrong-kind.scala:9:29 -----------------------------------------------------
 9 |  def c_=(v: Int): Unit = js.undefined // error
   |                          ^^^^^^^^^^^^
   |                          In non-native JS traits, defs with parentheses must be abstract.

--- a/tests/neg-scalajs/type-mismatch.check
+++ b/tests/neg-scalajs/type-mismatch.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg-scalajs/type-mismatch.scala:6:17 ----------------------------------------------
+6 |    val n: Int = msg // error message shouldn't mention implicits from `scalajs.js.|`
+  |                 ^^^
+  |                 Found:    (msg : String)
+  |                 Required: Int
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg-scalajs/type-mismatch.scala
+++ b/tests/neg-scalajs/type-mismatch.scala
@@ -1,0 +1,8 @@
+import scala.scalajs.js._
+
+object HelloWorld {
+  def main(args: Array[String]): Unit = {
+    val msg = "hello"
+    val n: Int = msg // error message shouldn't mention implicits from `scalajs.js.|`
+  }
+}

--- a/tests/sjs-junit/test/org/scalajs/testsuite/jsinterop/PromiseMock.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/jsinterop/PromiseMock.scala
@@ -1,0 +1,260 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import scala.scalajs.js.|
+
+import js.Thenable
+
+object PromiseMock {
+
+  @noinline
+  def withMockedPromise[A](body: (() => Unit) => A): A = {
+    val global = org.scalajs.testsuite.utils.JSUtils.globalObject
+
+    val oldPromise =
+      if (global.hasOwnProperty("Promise").asInstanceOf[Boolean]) Some(global.Promise)
+      else None
+
+    global.Promise = js.constructorOf[MockPromise[_]]
+    try {
+      body(MockPromise.processQueue _)
+    } finally {
+      oldPromise.fold {
+        js.special.delete(global, "Promise")
+      } { old =>
+        global.Promise = old
+      }
+    }
+  }
+
+  @noinline
+  def withMockedPromiseIfExists[A](body: (Option[() => Unit]) => A): A = {
+    val global = org.scalajs.testsuite.utils.JSUtils.globalObject
+
+    val oldPromise = global.Promise
+
+    if (js.isUndefined(oldPromise)) {
+      body(None)
+    } else {
+      global.Promise = js.constructorOf[MockPromise[_]]
+      try {
+        body(Some(MockPromise.processQueue _))
+      } finally {
+        global.Promise = oldPromise
+      }
+    }
+  }
+
+  private object MockPromise {
+    private val queue = js.Array[js.Function0[Any]]()
+
+    @JSExportStatic
+    def resolve[A](value: A | js.Thenable[A]): MockPromise[A] = {
+      new MockPromise[A]({
+        (resolve: js.Function1[A | js.Thenable[A], _],
+            reject: js.Function1[Any, _]) =>
+          resolve(value)
+      })
+    }
+
+    @JSExportStatic
+    def reject(reason: Any): MockPromise[Nothing] = {
+      new MockPromise[Nothing]({
+        (resolve: js.Function1[Nothing | js.Thenable[Nothing], _],
+            reject: js.Function1[Any, _]) =>
+          reject(reason)
+      })
+    }
+
+    def enqueue(f: js.Function0[Any]): Unit =
+      queue.push(f)
+
+    def processQueue(): Unit = {
+      while (queue.nonEmpty)
+        queue.shift()()
+    }
+
+    private sealed abstract class State[+A]
+
+    private case object Pending extends State[Nothing]
+    private case class Fulfilled[+A](value: A) extends State[A]
+    private case class Rejected(reason: Any) extends State[Nothing]
+
+    private def isNotAnObject(x: Any): Boolean = x match {
+      case null | () | _:Double | _:Boolean | _:String => true
+      case _                                           => false
+    }
+
+    private def isCallable(x: Any): Boolean =
+      js.typeOf(x.asInstanceOf[js.Any]) == "function"
+
+    private def throwAny(e: Any): Nothing = {
+      throw (e match {
+        case th: Throwable => th
+        case _             => js.JavaScriptException(e)
+      })
+    }
+
+    private def tryCatchAny[A](tryBody: => A)(catchBody: Any => A): A = {
+      try {
+        tryBody
+      } catch {
+        case th: Throwable =>
+          catchBody(th match {
+            case js.JavaScriptException(e) => e
+            case _                         => th
+          })
+      }
+    }
+  }
+
+  private class MockPromise[+A](
+      executor: js.Function2[js.Function1[A | Thenable[A], _], js.Function1[scala.Any, _], _])
+      extends js.Object with js.Thenable[A] {
+
+    import MockPromise._
+
+    private[this] var state: State[A] = Pending
+
+    private[this] var fulfillReactions = js.Array[js.Function1[A, Any]]()
+    private[this] var rejectReactions = js.Array[js.Function1[Any, Any]]()
+
+    init(executor)
+
+    // 25.4.3.1 Promise(executor)
+    private[this] def init(
+        executor: js.Function2[js.Function1[A | Thenable[A], _], js.Function1[scala.Any, _], _]) = {
+      tryCatchAny[Unit] {
+        executor(resolve _, reject _)
+      } { e =>
+        reject(e)
+      }
+    }
+
+    private[this] def fulfill(value: A): Unit = {
+      assert(state == Pending)
+      state = Fulfilled(value)
+      clearAndTriggerReactions(fulfillReactions, value)
+    }
+
+    private[this] def clearAndTriggerReactions[A](
+        reactions: js.Array[js.Function1[A, Any]],
+        argument: A): Unit = {
+
+      assert(state != Pending)
+
+      fulfillReactions = null
+      rejectReactions = null
+
+      for (reaction <- reactions)
+        enqueue(() => reaction(argument))
+    }
+
+    // 25.4.1.3.2 Promise Resolve Functions
+    private[this] def resolve(resolution: A | Thenable[A]): Unit = {
+      if (state == Pending) {
+        if (resolution.asInstanceOf[AnyRef] eq this) {
+          reject(new js.TypeError("Self resolution"))
+        } else if (isNotAnObject(resolution)) {
+          fulfill(resolution.asInstanceOf[A])
+        } else {
+          tryCatchAny {
+            val thenAction = resolution.asInstanceOf[js.Dynamic].`then`
+            if (!isCallable(thenAction)) {
+              fulfill(resolution.asInstanceOf[A])
+            } else {
+              val thenable = resolution.asInstanceOf[Thenable[A]]
+              val thenActionFun = thenAction.asInstanceOf[js.Function]
+              enqueue(() => promiseResolveThenableJob(thenable, thenActionFun))
+            }
+          } { e =>
+            reject(e)
+          }
+        }
+      }
+    }
+
+    // 25.4.2.2 PromiseResolveThenableJob
+    private[this] def promiseResolveThenableJob(thenable: Thenable[A],
+        thenAction: js.Function): Unit = {
+      thenAction.call(thenable, resolve _, reject _)
+    }
+
+    // 25.4.1.3.1 Promise Reject Functions
+    private[this] def reject(reason: Any): Unit = {
+      if (state == Pending) {
+        state = Rejected(reason)
+        clearAndTriggerReactions(rejectReactions, reason)
+      }
+    }
+
+    // 25.4.5.3 Promise.prototype.then
+    def `then`[B](
+        onFulfilled: js.Function1[A, B | Thenable[B]],
+        onRejected: js.UndefOr[js.Function1[scala.Any, B | Thenable[B]]]): MockPromise[B] = {
+
+      new MockPromise[B](
+        { (innerResolve: js.Function1[B | Thenable[B], _],
+            innerReject: js.Function1[scala.Any, _]) =>
+
+          def doFulfilled(value: A): Unit = {
+            tryCatchAny[Unit] {
+              innerResolve(onFulfilled(value))
+            } { e =>
+              innerReject(e)
+            }
+          }
+
+          def doRejected(reason: Any): Unit = {
+            tryCatchAny[Unit] {
+              onRejected.fold[Unit] {
+                innerReject(reason)
+              } { onRejectedFun =>
+                innerResolve(onRejectedFun(reason))
+              }
+            } { e =>
+              innerReject(e)
+            }
+          }
+
+          state match {
+            case Pending =>
+              fulfillReactions += doFulfilled _
+              rejectReactions += doRejected _
+
+            case Fulfilled(value) =>
+              enqueue(() => doFulfilled(value))
+
+            case Rejected(reason) =>
+              enqueue(() => doRejected(reason))
+          }
+        }
+      )
+    }
+
+    def `then`[B >: A](
+        onFulfilled: Unit,
+        onRejected: js.UndefOr[js.Function1[scala.Any, B | Thenable[B]]]): MockPromise[B] = {
+      `then`((x: A) => (x: B | Thenable[B]), onRejected)
+    }
+
+    // 25.4.5.1 Promise.prototype.catch
+    def `catch`[B >: A](
+        onRejected: js.UndefOr[js.Function1[scala.Any, B | Thenable[B]]]): MockPromise[B] = {
+      `then`((), onRejected)
+    }
+  }
+}


### PR DESCRIPTION
When unpickling a Scala 2 symbol, we now treat `scala.scalajs.js.|[A, B]`
as if it were a real `A | B`, this requires a special-case in erasure
to emit the correct signatures in SJSIR.

Unresolved issues:
- The companion object of `js.|` defines implicit conversions like
  `undefOr2ops`, those are no longer automatically in scope for values
  with a union type (which breaks many JUnitTests). Should we add a
  special-case in typer to handle this or can this be fixed on the
  scalajs-library side?
- When compiling Scala.js code from source, `A | B` is interpreted
  as `js.|[A, B]` if `js.|` is in scope (e.g. via an import),
  should we just ignore that import in typer?