### PR TITLE
Print singleton types like in source

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -248,7 +248,14 @@ class PlainPrinter(_ctx: Context) extends Printer {
   }.close
 
   def toTextSingleton(tp: SingletonType): Text =
-    "(" ~ toTextRef(tp) ~ " : " ~ toTextGlobal(tp.underlying) ~ ")"
+    tp match
+      case ConstantType(value) =>
+        if value.tag == Constants.ByteTag || value.tag == Constants.ShortTag then
+          toText(value) ~ s" /*${value.tpe.show}*/"
+        else
+          toText(value)
+      case _: TermRef => toTextRef(tp) ~ ".type /*" ~ toTextGlobal(tp.underlying) ~ "*/"
+      case _ => "(" ~ toTextRef(tp) ~ ": " ~ toTextGlobal(tp.underlying) ~ ")"
 
   protected def paramsText(lam: LambdaType): Text = {
     def paramText(name: Name, tp: Type) =
@@ -531,6 +538,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
     case ClazzTag => "classOf[" ~ toText(const.typeValue) ~ "]"
     case CharTag => literalText(s"'${escapedChar(const.charValue)}'")
     case LongTag => literalText(const.longValue.toString + "L")
+    case DoubleTag => literalText(const.doubleValue.toString + "d")
+    case FloatTag => literalText(const.floatValue.toString + "f")
     case _ => literalText(String.valueOf(const.value))
   }
 

--- a/compiler/test/dotty/tools/repl/TypeTests.scala
+++ b/compiler/test/dotty/tools/repl/TypeTests.scala
@@ -26,4 +26,12 @@ class TypeTests extends ReplTest {
     run(":type")
     assertEquals(":type <expression>", storedOutput().trim)
   }
+
+  @Test def typeOfUnion =
+    fromInitialState { implicit s => run("val x: Int = 0; val bit: \"abc\" | 1 | 2L | 1.0d | 1.3f | 'c' | x.type = 1") }
+    .andThen { implicit s =>
+      storedOutput() // discard output
+      run(":type bit")
+      assertEquals("\"abc\" | 1 | 2L | 1.0d | 1.3f | 'c' | x.type", storedOutput().trim)
+    }
 }

--- a/tests/neg-custom-args/explicit-nulls/byname-nullables.check
+++ b/tests/neg-custom-args/explicit-nulls/byname-nullables.check
@@ -1,7 +1,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/explicit-nulls/byname-nullables.scala:19:24 -----------------------
 19 |    if x != null then f(x)   // error: f is call-by-name
    |                        ^
-   |                        Found:    (x : String | Null)
+   |                        Found:    x.type /*String | Null*/
    |                        Required: String
 -- Error: tests/neg-custom-args/explicit-nulls/byname-nullables.scala:43:32 --------------------------------------------
 43 |    if x != null then f(identity(x), 1)   // error: dropping not null check fails typing
@@ -25,4 +25,4 @@
    |                      None of the overloaded alternatives of method f in object Test7 with types
    |                       (x: => String, y: Int): String
    |                       (x: String, y: String): String
-   |                      match arguments (String | Null, (1 : Int))
+   |                      match arguments (String | Null, 1)

--- a/tests/neg-custom-args/fatal-warnings/i9408a.check
+++ b/tests/neg-custom-args/fatal-warnings/i9408a.check
@@ -1,24 +1,24 @@
 -- Error: tests/neg-custom-args/fatal-warnings/i9408a.scala:16:20 ------------------------------------------------------
 16 |  val length: Int = "qwerty" // error
    |                    ^^^^^^^^
-   |The conversion (Test3.implicitLength : String => Int) will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
+   |The conversion Test3.implicitLength.type /*String => Int*/ will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
 -- Error: tests/neg-custom-args/fatal-warnings/i9408a.scala:21:20 ------------------------------------------------------
 21 |  val length: Int = "qwerty" // error
    |                    ^^^^^^^^
-   |The conversion (Test4.implicitLength : => String => Int) will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
+   |The conversion Test4.implicitLength.type /*=> String => Int*/ will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
 -- Error: tests/neg-custom-args/fatal-warnings/i9408a.scala:26:20 ------------------------------------------------------
 26 |  val length: Int = "qwerty" // error
    |                    ^^^^^^^^
-   |The conversion (Test5.implicitLength : [A] => String => Int) will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
+   |The conversion Test5.implicitLength.type /*[A] => String => Int*/ will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
 -- Error: tests/neg-custom-args/fatal-warnings/i9408a.scala:31:20 ------------------------------------------------------
 31 |  val length: Int = "qwerty" // error
    |                    ^^^^^^^^
-   |The conversion (Test6.implicitLength : Map[String, Int]) will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
+   |The conversion Test6.implicitLength.type /*Map[String, Int]*/ will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
 -- Error: tests/neg-custom-args/fatal-warnings/i9408a.scala:35:60 ------------------------------------------------------
 35 |  implicit def a2int[A](a: A)(implicit ev: A => Int): Int = a // error
    |                                                            ^
-   |The conversion (ev : A => Int) will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
+   |The conversion ev.type /*A => Int*/ will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
 -- Error: tests/neg-custom-args/fatal-warnings/i9408a.scala:59:2 -------------------------------------------------------
 59 |  123.foo // error
    |  ^^^
-   |The conversion (Test11.a2foo : [A] => A => Test11.Foo) will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
+   |The conversion Test11.a2foo.type /*[A] => A => Test11.Foo*/ will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.

--- a/tests/neg-custom-args/fatal-warnings/i9408b.check
+++ b/tests/neg-custom-args/fatal-warnings/i9408b.check
@@ -2,4 +2,4 @@
 -- Error: tests/neg-custom-args/fatal-warnings/i9408b/Test_2.scala:6:20 ------------------------------------------------
 6 |  val length: Int = "abc" // error
   |                    ^^^^^
-  |The conversion (test.conversions.Conv.implicitLength : String => Int) will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
+  |The conversion test.conversions.Conv.implicitLength.type /*String => Int*/ will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.

--- a/tests/neg-macros/beta-reduce-inline-result.check
+++ b/tests/neg-macros/beta-reduce-inline-result.check
@@ -3,4 +3,4 @@
 11 |  val x2: 4   = Macros.betaReduce(dummy1)(3) // error
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                Found:    Int
-   |                Required: (4 : Int)
+   |                Required: 4

--- a/tests/neg/cannot-reduce-inline-match.check
+++ b/tests/neg/cannot-reduce-inline-match.check
@@ -2,6 +2,6 @@
 9 |  foo("f") // error
   |  ^^^^^^^^
   |  cannot reduce inline match with
-  |   scrutinee:  "f" : ("f" : String)
+  |   scrutinee:  "f" : "f"
   |   patterns :  case _:Int
   | This location contains code that was inlined from cannot-reduce-inline-match.scala:3

--- a/tests/neg/exports.check
+++ b/tests/neg/exports.check
@@ -55,6 +55,6 @@
 -- [E120] Naming Error: tests/neg/exports.scala:46:15 ------------------------------------------------------------------
 46 |    export bar._  // error: double definition
    |               ^
-   |               Double definition:
-   |               val bar: Bar in class Baz at line 45 and
-   |               final def bar: => (Baz.this.bar.bar : => (Baz.this.bar.baz.bar : Bar)) in class Baz at line 46
+   |        Double definition:
+   |        val bar: Bar in class Baz at line 45 and
+   |        final def bar: => Baz.this.bar.bar.type /*=> Baz.this.bar.baz.bar.type /*Bar*/*/ in class Baz at line 46

--- a/tests/neg/i10901.check
+++ b/tests/neg/i10901.check
@@ -15,7 +15,7 @@
    |                 (x: T1)
    |                   (y: BugExp4Point2D.ColumnType[T2])
    |                     (implicit evidence$5: Numeric[T1], evidence$6: Numeric[T2]): BugExp4Point2D.Point2D[T1, T2]
-   |               both match arguments ((x : BugExp4Point2D.IntT.type))
+   |               both match arguments (x.type /*BugExp4Point2D.IntT.type*/)
 -- [E008] Not Found Error: tests/neg/i10901.scala:48:38 ----------------------------------------------------------------
 48 |    val pos4: Point2D[Int,Double] = x º 201.1   // error
    |                                    ^^^
@@ -29,7 +29,7 @@
    |          (x: BugExp4Point2D.ColumnType[T1])
    |            (y: T2)(implicit evidence$9: Numeric[T1], evidence$10: Numeric[T2]): BugExp4Point2D.Point2D[T1, T2]
    |         [T1, T2](x: T1)(y: T2)(implicit evidence$3: Numeric[T1], evidence$4: Numeric[T2]): BugExp4Point2D.Point2D[T1, T2]
-   |        both match arguments ((x : BugExp4Point2D.IntT.type))
+   |        both match arguments (x.type /*BugExp4Point2D.IntT.type*/)
 -- [E008] Not Found Error: tests/neg/i10901.scala:62:16 ----------------------------------------------------------------
 62 |  val y = "abc".foo  // error
    |          ^^^^^^^^^

--- a/tests/neg/i11544.check
+++ b/tests/neg/i11544.check
@@ -4,7 +4,7 @@
   |          Ambiguous overload. The overloaded alternatives of method (str: String, int: Int): Int with types
   |           (str: String, int: Int): Int
   |           (arg: Int): Int
-  |          both match arguments ((23 : Int))
+  |          both match arguments (23)
   |
   |          Note: Overloaded definitions introduced by refinements cannot be resolved
 

--- a/tests/neg/i6183.check
+++ b/tests/neg/i6183.check
@@ -9,13 +9,13 @@
   |            Ambiguous overload. The overloaded alternatives of method render in object Test with types
   |             [B](b: B)(using x$2: DummyImplicit): Char
   |             [A](a: A): String
-  |            both match arguments ((42 : Int))
+  |            both match arguments (42)
 -- [E051] Reference Error: tests/neg/i6183.scala:7:9 -------------------------------------------------------------------
 7 |    Test.render(42) // error
   |    ^^^^^^^^^^^
   |    Ambiguous overload. The overloaded alternatives of method render in object Test with types
   |     [B](b: B)(using x$2: DummyImplicit): Char
   |     [A](a: A): String
-  |    both match arguments ((42 : Int))
+  |    both match arguments (42)
 
 longer explanation available when compiling with `-explain`

--- a/tests/neg/i6779.check
+++ b/tests/neg/i6779.check
@@ -11,7 +11,7 @@
    |
    |                                 Test.f[G[T]](x)(given_Stuff)    failed with
    |
-   |                                     Found:    (x : T)
+   |                                     Found:    x.type /*T*/
    |                                     Required: G[T]
 -- [E007] Type Mismatch Error: tests/neg/i6779.scala:14:38 -------------------------------------------------------------
 14 |  def g3[T](x: T): F[G[T]] = this.f(x)(using summon[Stuff]) // error

--- a/tests/neg/i8569.check
+++ b/tests/neg/i8569.check
@@ -7,6 +7,6 @@ longer explanation available when compiling with `-explain`
 -- [E083] Type Error: tests/neg/i8569.scala:9:6 ------------------------------------------------------------------------
 9 |  new outer.Inner(2) // error
   |      ^^^^^
-  |      (Test.outer : => Outer) is not a valid type prefix, since it is not an immutable path
+  |      Test.outer.type /*=> Outer*/ is not a valid type prefix, since it is not an immutable path
 
 longer explanation available when compiling with `-explain`

--- a/tests/neg/i8736.check
+++ b/tests/neg/i8736.check
@@ -11,12 +11,12 @@
 -- [E051] Reference Error: tests/neg/i8736.scala:31:26 -----------------------------------------------------------------
 31 |  def res3: Boolean = rec.get("z") // error: ambiguous
    |                      ^^^^^^^
-   |                Ambiguous overload. The overloaded alternatives of method (k: ("k" : String)): String with types
-   |                 (k: ("k" : String)): String
-   |                 (k: ("v" : String)): Int
-   |                 (k: ("z" : String)): Boolean
-   |                all match arguments (("z" : String))
+   |                      Ambiguous overload. The overloaded alternatives of method (k: "k"): String with types
+   |                       (k: "k"): String
+   |                       (k: "v"): Int
+   |                       (k: "z"): Boolean
+   |                      all match arguments ("z")
    |
-   |                Note: Overloaded definitions introduced by refinements cannot be resolved
+   |                      Note: Overloaded definitions introduced by refinements cannot be resolved
 
 longer explanation available when compiling with `-explain`

--- a/tests/neg/i8988.check
+++ b/tests/neg/i8988.check
@@ -1,5 +1,5 @@
 -- [E007] Type Mismatch Error: tests/neg/i8988.scala:3:17 --------------------------------------------------------------
 3 |val zs: String = ys // error: (but type should not mention @uncheckedVariance)
   |                 ^^
-  |                 Found:    (ys : List[Int])
+  |                 Found:    ys.type /*List[Int]*/
   |                 Required: String

--- a/tests/neg/i9185.check
+++ b/tests/neg/i9185.check
@@ -21,5 +21,5 @@
    |
    |              M.len("abc")    failed with
    |
-   |                  Found:    ("abc" : String)
+   |                  Found:    "abc"
    |                  Required: Int

--- a/tests/neg/inline-error-pos.check
+++ b/tests/neg/inline-error-pos.check
@@ -2,6 +2,6 @@
 8 |  val b = foo(2) // error
   |          ^^^^^^
   |          cannot reduce inline match with
-  |           scrutinee:  2 : (2 : Int)
+  |           scrutinee:  2 : 2
   |           patterns :  case 1
   | This location contains code that was inlined from inline-error-pos.scala:3

--- a/tests/neg/singleton-ops-any.check
+++ b/tests/neg/singleton-ops-any.check
@@ -1,20 +1,20 @@
 -- [E007] Type Mismatch Error: tests/neg/singleton-ops-any.scala:6:23 --------------------------------------------------
 6 |  val t34: 10 == "5" = true // error
   |                       ^^^^
-  |                       Found:    (true : Boolean)
-  |                       Required: (false : Boolean)
+  |                       Found:    true
+  |                       Required: false
 -- [E007] Type Mismatch Error: tests/neg/singleton-ops-any.scala:7:22 --------------------------------------------------
 7 |  val t35: 10 == 10 = false // error
   |                      ^^^^^
-  |                      Found:    (false : Boolean)
-  |                      Required: (true : Boolean)
+  |                      Found:    false
+  |                      Required: true
 -- [E007] Type Mismatch Error: tests/neg/singleton-ops-any.scala:12:24 -------------------------------------------------
 12 |  val t38: false != 5 = false // error
    |                        ^^^^^
-   |                        Found:    (false : Boolean)
-   |                        Required: (true : Boolean)
+   |                        Found:    false
+   |                        Required: true
 -- [E007] Type Mismatch Error: tests/neg/singleton-ops-any.scala:13:22 -------------------------------------------------
 13 |  val t39: 10 != 10 = true // error
    |                      ^^^^
-   |                      Found:    (true : Boolean)
-   |                      Required: (false : Boolean)
+   |                      Found:    true
+   |                      Required: false


### PR DESCRIPTION
* Print singleton in a for that users can recognize
* Print extra type information as comments (only if needed)
* Print missing Double and Float type information

Fixes #9883

Based on code from #11135

Printed types

```diff
- (true: Boolean) | ("abc": String) | (1: Int) | (2L: Long) | (1.0: Double) | (1.3: Float) | ('c': Char) | (x: Int)       | (3: Byte)  | (4: Short)
+ true            | "abc"           | 1        | 2L         | 1.0d          | 1.3f         | 'c'         | x.type /*Int*/ | 3 /*Byte*/ | 4 /*Short*/
```