### PR TITLE
reduced number of Logarithm

### DIFF
--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -6,7 +6,7 @@ title: "Opaque Type Aliases"
 Opaque types aliases provide type abstraction without any overhead. Example:
 
 ```scala
-object Logarithms:
+object MyMath:
 
    opaque type Logarithm = Double
 
@@ -27,7 +27,7 @@ object Logarithms:
       def + (y: Logarithm): Logarithm = Logarithm(math.exp(x) + math.exp(y))
       def * (y: Logarithm): Logarithm = x + y
 
-end Logarithms
+end MyMath
 ```
 
 This introduces `Logarithm` as a new abstract type, which is implemented as `Double`.
@@ -41,7 +41,7 @@ They convert from `Double`s to `Logarithm` values. Moreover, an operation `toDou
 The following operations would be valid because they use functionality implemented in the `Logarithms` object.
 
 ```scala
-import Logarithms.Logarithm
+import MyMath.Logarithm
 
 val l = Logarithm(1.0)
 val l2 = Logarithm(2.0)

--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -32,13 +32,13 @@ end MyMath
 
 This introduces `Logarithm` as a new abstract type, which is implemented as `Double`.
 The fact that `Logarithm` is the same as `Double` is only known in the scope where
-`Logarithm` is defined which in the above example corresponds to the object `Logarithms`.
+`Logarithm` is defined which in the above example corresponds to the object `MyMath`.
 Or in other words, within the scope it is treated as type alias, but this is opaque to the outside world
 where in consequence `Logarithm` is seen as an abstract type and has nothing to do with `Double`.
 
 The public API of `Logarithm` consists of the `apply` and `safe` methods defined in the companion object.
 They convert from `Double`s to `Logarithm` values. Moreover, an operation `toDouble` that converts the other way, and operations `+` and `*` are defined as extension methods on `Logarithm` values.
-The following operations would be valid because they use functionality implemented in the `Logarithms` object.
+The following operations would be valid because they use functionality implemented in the `MyMath` object.
 
 ```scala
 import MyMath.Logarithm


### PR DESCRIPTION
In the example 3 logarithm(s) are used (object 2x and type). It makes reading hard. To make it simpler, I'd suggest:
1. Scala 3 can put anything top level, we dont need to have the upper `Object Logarithms` at all 
2. replace `Object Logarithms`  with  `MyMath` (this pull request)