### PR TITLE
Improve UnableToEmitSwitch warning message

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -24,6 +24,7 @@ import printing.Formatting.hl
 import ast.Trees._
 import ast.untpd
 import ast.tpd
+import transform.PatternMatcher.MinSwitchCases
 import transform.SymUtils._
 
 /**  Messages
@@ -2006,7 +2007,9 @@ import transform.SymUtils._
 
   class UnableToEmitSwitch(tooFewCases: Boolean)(using Context)
   extends SyntaxMsg(UnableToEmitSwitchID) {
-    def tooFewStr: String = if (tooFewCases) " since there are not enough cases" else ""
+    def tooFewStr: String =
+      if (tooFewCases) " since a minimum of " + MinSwitchCases + " cases (including the default) are required"
+      else ""
     def msg = em"Could not emit switch for ${hl("@switch")} annotated match$tooFewStr"
     def explain = {
       val codeExample =

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -57,7 +57,7 @@ object PatternMatcher {
   final val selfCheck = false // debug option, if on we check that no case gets generated twice
 
   /** Minimal number of cases to emit a switch */
-  final val MinSwitchCases = 4
+  inline val MinSwitchCases = 4
 
   val TrustedTypeTestKey: Key[Unit] = new StickyKey[Unit]
 


### PR DESCRIPTION
Previously it would read:

>  Could not emit switch for @switch annotated match since there are not enough cases

Now it reads:
>  Could not emit switch for @switch annotated match since a minimum of 4 cases (including the default) are required