### PR TITLE
Disable BSP in Jmh and vscode-dotty

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1237,6 +1237,7 @@ object Build {
       version := "0.1.17-snapshot", // Keep in sync with package.json
       autoScalaLibrary := false,
       publishArtifact := false,
+      bspEnabled := false,
       resourceGenerators in Compile += Def.task {
         // Resources that will be copied when bootstrapping a new project
         val buildSbtFile = baseDirectory.value / "out" / "build.sbt"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -348,6 +348,7 @@ object Build {
   )
 
   lazy val commonBenchmarkSettings = Seq(
+    Jmh / bspEnabled := false,
     mainClass in (Jmh, run) := Some("dotty.tools.benchmarks.Bench"), // custom main for jmh:run
     javaOptions += "-DBENCH_COMPILER_CLASS_PATH=" + Attributed.data((fullClasspath in (`scala3-bootstrapped`, Compile)).value).mkString("", File.pathSeparator, ""),
     javaOptions += "-DBENCH_CLASS_PATH=" + Attributed.data((fullClasspath in (`scala3-library-bootstrapped`, Compile)).value).mkString("", File.pathSeparator, "")


### PR DESCRIPTION
1. **Disable BSP in Jmh config**

sbt treats the Jmh configuration as a build target because it contains the `sbt.Defaults.configSettings` (sources, compile, scalaInstance...). The `buildTarget/sources` request triggers the project compilation to generate the benchmarking files. So the project import can fail if the compilation fails. To avoid this unpleasant situation we can disable BSP in Jmh.

2. **Disable BSP in vscode-dotty project**

This is not a Scala project so it doesn't make sense to import it via BSP.