### PR TITLE
avoid duplicate call to dist/bin/common on script startup

### DIFF
--- a/dist/bin/common
+++ b/dist/bin/common
@@ -134,9 +134,9 @@ fi
 
 find_lib () {
   local lib=$(find $PROG_HOME/lib/ -name "$1")
-  if [ -n "${CYGPATHCMD-}" ]; then
-    $CYGPATHCMD -am $lib
-  elif [[ ${mingw-} ||  ${msys-} ]]; then
+  if [ -n "$CYGPATHCMD" ]; then
+    "$CYGPATHCMD" -am $lib
+  elif [[ $mingw ||  $msys ]]; then
     echo $lib | sed 's|/|\\\\|g'
   else
     echo $lib

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -54,9 +54,9 @@ case "`uname`" in
 esac
 
 unset CYGPATHCMD
-if [[ $cygwin || $mingw || $msys ]]; then
+if [[ ${cygwin-} || ${mingw-} || ${msys-} ]]; then
   # ConEmu terminal is incompatible with jna-5.*.jar
-  [[ ($CONEMUANSI || $ConEmuANSI) ]] && conemu=true
+  [[ (${CONEMUANSI-} || ${ConEmuANSI-}) ]] && conemu=true
   # cygpath is used by various windows shells: cygwin, git-sdk, gitbash, msys, etc.
   CYGPATHCMD=`which cygpath 2>/dev/null`
   case "$TERM" in
@@ -111,14 +111,14 @@ CLASSPATH_SUFFIX=""
 PSEP=":"
 
 # translate paths to Windows-mixed format before running java
-if [ -n "$CYGPATHCMD" ]; then
-  [ -n "$PROG_HOME" ] &&
+if [ -n "${CYGPATHCMD-}" ]; then
+  [ -n "${PROG_HOME-}" ] &&
     PROG_HOME=`"$CYGPATHCMD" -am "$PROG_HOME"`
   [ -n "$JAVA_HOME" ] &&
     JAVA_HOME=`"$CYGPATHCMD" -am "$JAVA_HOME"`
   CLASSPATH_SUFFIX=";"
   PSEP=";"
-elif [[ $mingw || $msys ]]; then
+elif [[ ${mingw-} || ${msys-} ]]; then
   # For Mingw / Msys, convert paths from UNIX format before anything is touched
   [ -n "$PROG_HOME" ] &&
     PROG_HOME="`(cd "$PROG_HOME"; pwd -W | sed 's|/|\\\\|g')`"
@@ -134,9 +134,9 @@ fi
 
 find_lib () {
   local lib=$(find $PROG_HOME/lib/ -name "$1")
-  if [ -n "$CYGPATHCMD" ]; then
+  if [ -n "${CYGPATHCMD-}" ]; then
     $CYGPATHCMD -am $lib
-  elif [[ $mingw ||  $msys ]]; then
+  elif [[ ${mingw-} ||  ${msys-} ]]; then
     echo $lib | sed 's|/|\\\\|g'
   else
     echo $lib
@@ -155,8 +155,13 @@ SBT_INTF=$(find_lib "*compiler-interface*")
 JLINE_READER=$(find_lib "*jline-reader-3*")
 JLINE_TERMINAL=$(find_lib "*jline-terminal-3*")
 JLINE_TERMINAL_JNA=$(find_lib "*jline-terminal-jna-3*")
-[[ $conemu ]] || JNA=$(find_lib "*jna-5*")
+[[ ${conemu-} ]] || JNA=$(find_lib "*jna-5*")
 
 # debug
 
 DEBUG_STR=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
+
+export saved_stty PROG_HOME DEBUG_STR PSEP SCALA_LIB DOTTY_LIB SCALA_ASM SBT_INTF DOTTY_INTF DOTTY_COMP TASTY_CORE
+export DOTTY_STAGING DOTTY_TASTY_INSPECTOR JLINE_READER JLINE_TERMINAL JLINE_TERMINAL_JNA JNA JAVACMD SCALA_OPTS
+export cygwin mingw msys darwin conemu CLASSPATH_SUFFIX
+export -f onExit restoreSttySettings find_lib

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -161,7 +161,7 @@ JLINE_TERMINAL_JNA=$(find_lib "*jline-terminal-jna-3*")
 
 DEBUG_STR=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
 
-export saved_stty PROG_HOME DEBUG_STR PSEP SCALA_LIB DOTTY_LIB SCALA_ASM SBT_INTF DOTTY_INTF DOTTY_COMP TASTY_CORE
+export saved_stty DEBUG_STR PSEP SCALA_LIB DOTTY_LIB SCALA_ASM SBT_INTF DOTTY_INTF DOTTY_COMP TASTY_CORE
 export DOTTY_STAGING DOTTY_TASTY_INSPECTOR JLINE_READER JLINE_TERMINAL JLINE_TERMINAL_JNA JNA JAVACMD SCALA_OPTS
 export cygwin mingw msys darwin conemu CLASSPATH_SUFFIX
-export -f onExit restoreSttySettings find_lib
+export -f onExit find_lib

--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # Try to autodetect real location of the script
-
-if [ -z "$PROG_HOME" ] ; then
+if [ -z "${PROG_HOME-}" ] ; then
   ## resolve links - $0 may be a link to PROG_HOME
   PRG="$0"
 
@@ -107,9 +106,15 @@ while [[ $# -gt 0 ]]; do
     *)
       if [ $execute_script == false ]; then
         # is a script if extension .scala or .sc or if has scala hash bang
-        if [[ -e "$1" && ("$1" == *.scala || "$1" == *.sc || -f "$1" && `head -n 1 -- "$1" | grep '#!.*scala'`) ]]; then
+        if [[ "$1" == *.scala || "$1" == *.sc || (-f "$1" && `head -n 1 -- "$1" | grep '#!.*scala'`) ]]; then
           execute_script=true
           target_script="$1"
+          if [ ! -f $target_script ]; then
+            # likely a typo or missing script file, quit early
+            echo "not found: $target_script" 1>&2
+            scala_exit_status=2
+            onExit
+          fi
         else
           residual_args+=("$1")
         fi

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -z "$PROG_HOME" ] ; then
+if [ -z "${PROG_HOME-}" ] ; then
   ## resolve links - $0 may be a link to PROG_HOME
   PRG="$0"
 
@@ -25,7 +25,8 @@ if [ -z "$PROG_HOME" ] ; then
   cd "$saveddir"
 fi
 
-source "$PROG_HOME/bin/common"
+# only source common if necessary
+[ -z "${DEBUG_STR-}" -a -z "${PSEP-}" ] && source "$PROG_HOME/bin/common"
 
 default_java_opts="-Xmx768m -Xms768m"
 withCompiler=true


### PR DESCRIPTION
This supercedes #11660 

When launching a scala3 script, there are two calls to [dist/bin/common](dist/bin/common), the first from within [dist/bin/scala](dist/bin/scala) and the 2nd when `dist/bin/scala` calls `dist/bin/scalac`. 

It turns out that the avoidable 2nd call is quite expensive in terms of what it adds to script startup latency.   Here are the reductions in startup time when running in `cygwin` and in `WSL Linux`:

```sh
On a workstation:
cygwin:    837 mSec
WSL Linux:  66 mSec

On a laptop:
cygwin:  1.03 seconds
WSL Linux: 129 mSec
```

The numbers are the difference in startup latency for calling a `hello-world.sc` script with and without the changes in this PR, averaged over 100 runs.

The categories of change in the PR are:

- export variables initialized by `dist/bin/common` and required by scalac
- modify `dist/bin/scalac` to conditionally source `dist/bin/common`
- changes to avoid spurious unset variable errors when testing with: `set -o nounset` 
- fail early if a script file doesn't exist

The third change is exemplified by line 114 in `dist/bin/common`:
```diff
-if [ -n "$CYGPATHCMD" ]; then
+if [ -n "${CYGPATHCMD-}" ]; then
```

