### PR TITLE
Fix and improve the document for Explicit Nulls

### DIFF
--- a/docs/docs/reference/other-new-features/explicit-nulls.md
+++ b/docs/docs/reference/other-new-features/explicit-nulls.md
@@ -7,6 +7,7 @@ Explicit nulls is an opt-in feature that modifies the Scala type system, which m
 (anything that extends `AnyRef`) _non-nullable_.
 
 This means the following code will no longer typecheck:
+
 ```scala
 val x: String = null // error: found `Null`, but required `String`
 ```
@@ -34,7 +35,7 @@ When explicit nulls are enabled, the type hierarchy changes so that `Null` is on
 
 This is the new type hierarchy:
 
-![](../../../images/explicit-nulls/explicit-nulls-type-hierarchy.png "Type Hierarchy for Explicit Nulls")
+!["Type Hierarchy for Explicit Nulls"](../../../images/explicit-nulls/explicit-nulls-type-hierarchy.png)
 
 After erasure, `Null` remains a subtype of all reference types (as forced by the JVM).
 
@@ -43,25 +44,25 @@ After erasure, `Null` remains a subtype of all reference types (as forced by the
 To make working with nullable values easier, we propose adding a few utilities to the standard library.
 So far, we have found the following useful:
 
-  - An extension method `.nn` to "cast away" nullability
+- An extension method `.nn` to "cast away" nullability
 
-    ```scala
-     extension [T](x: T | Null)
-       inline def nn: T =
-         assert(x != null)
-         x.asInstanceOf[T]
-    ```
+  ```scala
+   extension [T](x: T | Null)
+     inline def nn: T =
+       assert(x != null)
+       x.asInstanceOf[T]
+  ```
 
-    This means that given `x: String|Null`, `x.nn` has type `String`, so we can call all the
-    usual methods on it. Of course, `x.nn` will throw a NPE if `x` is `null`.
+  This means that given `x: String | Null`, `x.nn` has type `String`, so we can call all the
+  usual methods on it. Of course, `x.nn` will throw a NPE if `x` is `null`.
 
-    Don't use `.nn` on mutable variables directly, because it may introduce an unknown type into the type of the variable.
+  Don't use `.nn` on mutable variables directly, because it may introduce an unknown type into the type of the variable.
 
-  - An `unsafeNulls` language feature
+- An `unsafeNulls` language feature.
 
-    When imported, `T | Null` can be used as `T`, similar to regular Scala (without explicit nulls).
+  When imported, `T | Null` can be used as `T`, similar to regular Scala (without explicit nulls).
 
-    See UnsafeNulls section for more details.
+  See [UnsafeNulls](#UnsafeNulls) section for more details.
 
 ## Unsoundness
 
@@ -111,153 +112,167 @@ when a Java class is loaded, we "patch" the type of its members to reflect that 
 remain implicitly nullable.
 
 Specifically, we patch
-* the type of fields
-* the argument type and return type of methods
+
+- the type of fields
+
+- the argument type and return type of methods
 
 We illustrate the rules with following examples:
 
-  * The first two rules are easy: we nullify reference types but not value types.
+- The first two rules are easy: we nullify reference types but not value types.
 
-    ```java
-    class C {
-       String s;
-       int x;
-    }
-    ```
-    ==>
-    ```scala
-    class C:
-       val s: String | Null
-       val x: Int
-    ```
+  ```java
+  class C {
+     String s;
+     int x;
+  }
+  ```
 
-  * We nullify type parameters because in Java a type parameter is always nullable, so the following code compiles.
+  ==>
 
-    ```java
-    class C<T> { T foo() { return null; } }
-    ```
-    ==>
-    ```scala
-    class C[T] { def foo(): T | Null }
-    ```
+  ```scala
+  class C:
+     val s: String | Null
+     val x: Int
+  ```
 
-    Notice this is rule is sometimes too conservative, as witnessed by
+- We nullify type parameters because in Java a type parameter is always nullable, so the following code compiles.
 
-    ```scala
-    class InScala:
-       val c: C[Bool] = ???  // C as above
-       val b: Bool = c.foo() // no longer typechecks, since foo now returns Bool|Null
-    ```
+  ```java
+  class C<T> { T foo() { return null; } }
+  ```
 
-  * This reduces the number of redundant nullable types we need to add. Consider
+  ==>
 
-    ```java
-    class Box<T> { T get(); }
-    class BoxFactory<T> { Box<T> makeBox(); }
-    ```
-    ==>
-    ```scala
-    class Box[T] { def get(): T | Null }
-    class BoxFactory[T] { def makeBox(): Box[T] | Null }
-    ```
+  ```scala
+  class C[T] { def foo(): T | Null }
+  ```
 
-    Suppose we have a `BoxFactory[String]`. Notice that calling `makeBox()` on it returns a
-    `Box[String] | Null`, not a `Box[String | Null] | Null`. This seems at first
-    glance unsound ("What if the box itself has `null` inside?"), but is sound because calling
-    `get()` on a `Box[String]` returns a `String | Null`.
+  Notice this is rule is sometimes too conservative, as witnessed by
 
-    Notice that we need to patch _all_ Java-defined classes that transitively appear in the
-    argument or return type of a field or method accessible from the Scala code being compiled.
-    Absent crazy reflection magic, we think that all such Java classes _must_ be visible to
-    the Typer in the first place, so they will be patched.
+  ```scala
+  class InScala:
+     val c: C[Bool] = ???  // C as above
+     val b: Bool = c.foo() // no longer typechecks, since foo now returns Bool | Null
+  ```
 
-  * We will append `Null` to the type arguments if the generic class is defined in Scala.
+- We can reduce the number of redundant nullable types we need to add. Consider
 
-    ```java
-    class BoxFactory<T> {
-      Box<T> makeBox(); // Box is Scala-defined
-      List<Box<List<T>>> makeCrazyBoxes(); // List is Java-defined
-    }
-    ```
-    ==>
-    ```scala
-    class BoxFactory[T]:
-       def makeBox(): Box[T | Null] | Null
-       def makeCrazyBoxes(): List[Box[List[T] | Null]] | Null
-    ```
+  ```java
+  class Box<T> { T get(); }
+  class BoxFactory<T> { Box<T> makeBox(); }
+  ```
 
-    In this case, since `Box` is Scala-defined, we will get `Box[T | Null] | Null`.
-    This is needed because our nullability function is only applied (modularly) to the Java
-    classes, but not to the Scala ones, so we need a way to tell `Box` that it contains a
-    nullable value.
+  ==>
 
-    The `List` is Java-defined, so we don't append `Null` to its type argument. But we
-    still need to nullify its inside.
+  ```scala
+  class Box[T] { def get(): T | Null }
+  class BoxFactory[T] { def makeBox(): Box[T] | Null }
+  ```
 
-  * We don't nullify _simple_ literal constant (`final`) fields, since they are known to be non-null
+  Suppose we have a `BoxFactory[String]`. Notice that calling `makeBox()` on it returns a
+  `Box[String] | Null`, not a `Box[String | Null] | Null`. This seems at first
+  glance unsound ("What if the box itself has `null` inside?"), but is sound because calling
+  `get()` on a `Box[String]` returns a `String | Null`.
 
-    ```java
-    class Constants {
-       final String NAME = "name";
-       final int AGE = 0;
-       final char CHAR = 'a';
+  Notice that we need to patch _all_ Java-defined classes that transitively appear in the
+  argument or return type of a field or method accessible from the Scala code being compiled.
+  Absent crazy reflection magic, we think that all such Java classes _must_ be visible to
+  the Typer in the first place, so they will be patched.
 
-       final String NAME_GENERATED = getNewName();
-    }
-    ```
-    ==>
-    ```scala
-    class Constants:
-       val NAME: String("name") = "name"
-       val AGE: Int(0) = 0
-       val CHAR: Char('a') = 'a'
+- We will append `Null` to the type arguments if the generic class is defined in Scala.
 
-       val NAME_GENERATED: String | Null = ???
-    ```
+  ```java
+  class BoxFactory<T> {
+    Box<T> makeBox(); // Box is Scala-defined
+    List<Box<List<T>>> makeCrazyBoxes(); // List is Java-defined
+  }
+  ```
 
-  * We don't append `Null` to a field nor to a return type of a method which is annotated with a
-    `NotNull` annotation.
+  ==>
 
-    ```java
-    class C {
-       @NotNull String name;
-       @NotNull List<String> getNames(String prefix); // List is Java-defined
-       @NotNull Box<String> getBoxedName(); // Box is Scala-defined
-    }
-    ```
-    ==>
-    ```scala
-    class C:
-       val name: String
-       def getNames(prefix: String | Null): List[String] // we still need to nullify the paramter types
-       def getBoxedName(): Box[String | Null] // we don't append `Null` to the outmost level, but we still need to nullify inside
-    ```
+  ```scala
+  class BoxFactory[T]:
+     def makeBox(): Box[T | Null] | Null
+     def makeCrazyBoxes(): java.util.List[Box[java.util.List[T] | Null]] | Null
+  ```
 
-    The annotation must be from the list below to be recognized as `NotNull` by the compiler.
-    Check `Definitions.scala` for an updated list.
+  In this case, since `Box` is Scala-defined, we will get `Box[T | Null] | Null`.
+  This is needed because our nullability function is only applied (modularly) to the Java
+  classes, but not to the Scala ones, so we need a way to tell `Box` that it contains a
+  nullable value.
 
-    ```scala
-    // A list of annotations that are commonly used to indicate
-    // that a field/method argument or return type is not null.
-    // These annotations are used by the nullification logic in
-    // JavaNullInterop to improve the precision of type nullification.
-    // We don't require that any of these annotations be present
-    // in the class path, but we want to create Symbols for the
-    // ones that are present, so they can be checked during nullification.
-    @tu lazy val NotNullAnnots: List[ClassSymbol] = ctx.getClassesIfDefined(
-      "javax.annotation.Nonnull" ::
-      "edu.umd.cs.findbugs.annotations.NonNull" ::
-      "androidx.annotation.NonNull" ::
-      "android.support.annotation.NonNull" ::
-      "android.annotation.NonNull" ::
-      "com.android.annotations.NonNull" ::
-      "org.eclipse.jdt.annotation.NonNull" ::
-      "org.checkerframework.checker.nullness.qual.NonNull" ::
-      "org.checkerframework.checker.nullness.compatqual.NonNullDecl" ::
-      "org.jetbrains.annotations.NotNull" ::
-      "lombok.NonNull" ::
-      "io.reactivex.annotations.NonNull" :: Nil map PreNamedString)
-    ```
+  The `List` is Java-defined, so we don't append `Null` to its type argument. But we
+  still need to nullify its inside.
+
+- We don't nullify _simple_ literal constant (`final`) fields, since they are known to be non-null
+
+  ```java
+  class Constants {
+     final String NAME = "name";
+     final int AGE = 0;
+     final char CHAR = 'a';
+
+     final String NAME_GENERATED = getNewName();
+  }
+  ```
+
+  ==>
+
+  ```scala
+  class Constants:
+     val NAME: String("name") = "name"
+     val AGE: Int(0) = 0
+     val CHAR: Char('a') = 'a'
+
+     val NAME_GENERATED: String | Null = getNewName()
+  ```
+
+- We don't append `Null` to a field nor to a return type of a method which is annotated with a
+  `NotNull` annotation.
+
+  ```java
+  class C {
+     @NotNull String name;
+     @NotNull List<String> getNames(String prefix); // List is Java-defined
+     @NotNull Box<String> getBoxedName(); // Box is Scala-defined
+  }
+  ```
+
+  ==>
+
+  ```scala
+  class C:
+     val name: String
+     def getNames(prefix: String | Null): java.util.List[String] // we still need to nullify the paramter types
+     def getBoxedName(): Box[String | Null] // we don't append `Null` to the outmost level, but we still need to nullify inside
+  ```
+
+  The annotation must be from the list below to be recognized as `NotNull` by the compiler.
+  Check `Definitions.scala` for an updated list.
+
+  ```scala
+  // A list of annotations that are commonly used to indicate
+  // that a field/method argument or return type is not null.
+  // These annotations are used by the nullification logic in
+  // JavaNullInterop to improve the precision of type nullification.
+  // We don't require that any of these annotations be present
+  // in the class path, but we want to create Symbols for the
+  // ones that are present, so they can be checked during nullification.
+  @tu lazy val NotNullAnnots: List[ClassSymbol] = ctx.getClassesIfDefined(
+    "javax.annotation.Nonnull" ::
+    "edu.umd.cs.findbugs.annotations.NonNull" ::
+    "androidx.annotation.NonNull" ::
+    "android.support.annotation.NonNull" ::
+    "android.annotation.NonNull" ::
+    "com.android.annotations.NonNull" ::
+    "org.eclipse.jdt.annotation.NonNull" ::
+    "org.checkerframework.checker.nullness.qual.NonNull" ::
+    "org.checkerframework.checker.nullness.compatqual.NonNullDecl" ::
+    "org.jetbrains.annotations.NotNull" ::
+    "lombok.NonNull" ::
+    "io.reactivex.annotations.NonNull" :: Nil map PreNamedString)
+  ```
 
 ### Override check
 
@@ -287,11 +302,11 @@ of an if-statement (among other places).
 Example:
 
 ```scala
-val s: String|Null = ???
+val s: String | Null = ???
 if s != null then
    // s: String
 
-// s: String|Null
+// s: String | Null
 
 assert(s != null)
 // s: String
@@ -301,7 +316,7 @@ A similar inference can be made for the `else` case if the test is `p == null`
 
 ```scala
 if s == null then
-   // s: String|Null
+   // s: String | Null
 else
    // s: String
 ```
@@ -313,15 +328,15 @@ else
 We also support logical operators (`&&`, `||`, and `!`):
 
 ```scala
-val s: String|Null = ???
-val s2: String|Null = ???
+val s: String | Null = ???
+val s2: String | Null = ???
 if s != null && s2 != null then
    // s: String
    // s2: String
 
 if s == null || s2 == null then
-   // s: String|Null
-   // s2: String|Null
+   // s: String | Null
+   // s2: String | Null
 else
    // s: String
    // s2: String
@@ -332,13 +347,13 @@ else
 We also support type specialization _within_ the condition, taking into account that `&&` and `||` are short-circuiting:
 
 ```scala
-val s: String|Null = ???
+val s: String | Null = ???
 
 if s != null && s.length > 0 then // s: String in `s.length > 0`
    // s: String
 
 if s == null || s.length > 0 then // s: String in `s.length > 0`
-   // s: String|Null
+   // s: String | Null
 else
    // s: String
 ```
@@ -348,7 +363,7 @@ else
 The non-null cases can be detected in match statements.
 
 ```scala
-val s: String|Null = ???
+val s: String | Null = ???
 
 s match
    case _: String => // s: String
@@ -360,9 +375,9 @@ s match
 We are able to detect the nullability of some local mutable variables. A simple example is:
 
 ```scala
-class C(val x: Int, val next: C|Null)
+class C(val x: Int, val next: C | Null)
 
-var xs: C|Null = C(1, C(2, null))
+var xs: C | Null = C(1, C(2, null))
 // xs is trackable, since all assignments are in the same method
 while xs != null do
    // xs: C
@@ -382,7 +397,7 @@ When dealing with local mutable variables, there are two questions:
    do flow typing on `x`.
 
    ```scala
-   var x: String|Null = ???
+   var x: String | Null = ???
    def y =
       x = null
 
@@ -394,12 +409,12 @@ When dealing with local mutable variables, there are two questions:
 2. Whether to generate and use flow typing on a specific _use_ of a local mutable variable.
    We only want to do flow typing on a use that belongs to the same method as the definition
    of the local variable.
-   For example, in the following code, even `x` is not assigned to by a closure, but we can only
-   use flow typing in one of the occurrences (because the other occurrence happens within a nested
-   closure).
+   For example, in the following code, even `x` is not assigned to by a closure, we can only
+   use flow typing in one of the occurrences (because the other occurrence happens within a
+   nested closure).
 
    ```scala
-   var x: String|Null = ???
+   var x: String | Null = ???
    def y =
       if x != null then
          // not safe to use the fact (x != null) here
@@ -410,7 +425,7 @@ When dealing with local mutable variables, there are two questions:
       x = null
    ```
 
-See more examples in `tests/explicit-nulls/neg/var-ref-in-closure.scala`.
+See [more examples](../../../../tests/explicit-nulls/neg/flow-varref-in-closure.scala).
 
 Currently, we are unable to track paths with a mutable variable prefix.
 For example, `x.a` if `x` is mutable.
@@ -421,9 +436,10 @@ We don't support:
 
 - flow facts not related to nullability (`if x == 0 then { // x: 0.type not inferred }`)
 - tracking aliasing between non-nullable paths
+
   ```scala
-  val s: String|Null = ???
-  val s2: String|Null = ???
+  val s: String | Null = ???
+  val s2: String | Null = ???
   if s != null && s == s2 then
      // s:  String inferred
      // s2: String not inferred
@@ -464,10 +480,10 @@ def head[T](xs: java.util.List[T]): T = xs.get(0) // error
 
 Since the compiler doesn’t know whether `T` is a reference type, it is unable to cast `T | Null`
 to `T`. A `.nn` need to be inserted after `xs.get(0)` by user manually to fix the error, which
-strips the `Nul`l from its type.
+strips the `Null` from its type.
 
 The intention of this `unsafeNulls` is to give users a better migration path for explicit nulls.
-Projects for Scala 2 or regular dotty can try this by adding `-Yexplicit-nulls -language:unsafeNulls`
+Projects for Scala 2 or regular Scala 3 can try this by adding `-Yexplicit-nulls -language:unsafeNulls`
 to the compile options. A small number of manual modifications are expected. To migrate to the full
 explicit nulls feature in the future, `-language:unsafeNulls` can be dropped and add
 `import scala.language.unsafeNulls` only when needed.
@@ -481,10 +497,10 @@ import scala.language.unsafeNulls
 val s: String | Null = ???
 val a: String = s // unsafely convert String | Null to String
 
-val b1 = s.trim() // call .trim() on String | Null unsafely
-val b2 = b1.length()
+val b1 = s.trim // call .trim on String | Null unsafely
+val b2 = b1.length
 
-f(s).trim() // pass String | Null as an argument of type String unsafely
+f(s).trim // pass String | Null as an argument of type String unsafely
 
 val c: String = null // Null to String
 


### PR DESCRIPTION
- Fix some text and adjust the markdown format.
- Insert one space before and after `|` to make the code examples have a consistent style.
- Adjust the link to the image "Type Hierarchy for Explicit Nulls": put this image name in the `[]` part instead of putting it after the hyperlink text.
- Convert "UnsafeNulls" to a in-file link that points to the subsection ###UnsafeNulls
- Update `tests/explicit-nulls/neg/flow-varref-in-closure.scala` to `tests/explicit-nulls/neg/flow-varref-in-closure.scala`, and also convert it to a link that points to file _../../../../tests/explicit-nulls/neg/flow-varref-in-closure.scala_.
- Remove `()`s from some side-effect free Scala method calls.