### PR TITLE
Improve our ability to override default parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1442,7 +1442,9 @@ class Namer { typer: Typer =>
         if (defaultTp eq pt) && (tp frozen_<:< defaultTp) then
           // When possible, widen to the default getter parameter type to permit a
           // larger choice of overrides (see `default-getter.scala`).
-          defaultTp
+          // For justification on the use of `@uncheckedVariance`, see
+          // `default-getter-variance.scala`.
+          AnnotatedType(defaultTp, Annotation(defn.UncheckedVarianceAnnot))
         else tp.widenTermRefExpr.simplified match
           case ctp: ConstantType if isInlineVal => ctp
           case tp =>

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1439,7 +1439,11 @@ class Namer { typer: Typer =>
         val defaultTp = defaultParamType
         val pt = inherited.orElse(wildApprox(defaultTp)).orElse(WildcardType).widenExpr
         val tp = typedAheadRhs(pt).tpe
-        tp.widenTermRefExpr.simplified match
+        if (defaultTp eq pt) && (tp frozen_<:< defaultTp) then
+          // When possible, widen to the default getter parameter type to permit a
+          // larger choice of overrides (see `default-getter.scala`).
+          defaultTp
+        else tp.widenTermRefExpr.simplified match
           case ctp: ConstantType if isInlineVal => ctp
           case tp =>
             TypeComparer.widenInferred(tp, pt)

--- a/tests/pos/default-getter-variance.scala
+++ b/tests/pos/default-getter-variance.scala
@@ -1,0 +1,45 @@
+class Foo[+A] {
+  def count(f: A => Boolean = _ => true): Unit = {}
+  // The preceding line is valid, even though the generated default getter
+  // has type `A => Boolean` which wouldn't normally pass variance checks
+  // because it's equivalent to the following overloads which are valid:
+  def count2(f: A => Boolean): Unit = {}
+  def count2(): Unit = count(_ => true)
+}
+
+class Bar1[+A] extends Foo[A] {
+  override def count(f: A => Boolean): Unit = {}
+  // This reasoning extends to overrides:
+  override def count2(f: A => Boolean): Unit = {}
+}
+
+class Bar2[+A] extends Foo[A] {
+  override def count(f: A => Boolean = _ => true): Unit = {}
+  // ... including overrides which also override the default getter:
+  override def count2(f: A => Boolean): Unit = {}
+  override def count2(): Unit = count(_ => true)
+}
+
+// This can be contrasted with the need for variance checks in
+// `protected[this] methods (cf tests/neg/t7093.scala),
+// default getters do not have the same problem since they cannot
+// appear in arbitrary contexts.
+
+
+// Crucially, this argument does not apply to situations in which the default
+// getter result type is not a subtype of the parameter type, for example (from
+// tests/neg/variance.scala):
+//
+//   class Foo[+A: ClassTag](x: A) {
+//     private[this] val elems: Array[A] = Array(x)
+//     def f[B](x: Array[B] = elems): Array[B] = x
+//   }
+//
+// If we tried to rewrite this with an overload, it would fail
+// compilation:
+//
+//  def f[B](): Array[B] = f(elems) // error: Found: Array[A], Expected: Array[B]
+//
+// So we only disable variance checking for default getters whose
+// result type is the method parameter type, this is checked by
+// `tests/neg/variance.scala`

--- a/tests/pos/default-getter.scala
+++ b/tests/pos/default-getter.scala
@@ -1,0 +1,10 @@
+class X
+class Y extends X
+
+class A {
+  def foo(param: X = new Y): X = param
+}
+
+class B extends A {
+  override def foo(param: X = new X): X = param
+}

--- a/tests/pos/i4659c.scala
+++ b/tests/pos/i4659c.scala
@@ -2,4 +2,4 @@ case class SourcePosition(outer: SourcePosition = NoSourcePosition) {
   assert(outer != null)  // crash
 }
 
-object NoSourcePosition extends SourcePosition() // error
+object NoSourcePosition extends SourcePosition()


### PR DESCRIPTION
Don't just use the type of the rhs of the default getter as its inferred
type, this can be more precise than the type of the corresponding
parameter and prevent seemingly valid overrides.