### PR TITLE
GADTs: widen only top-level variant params

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -189,16 +189,14 @@ trait PatternTypeConstrainer { self: TypeComparer =>
       case _ => false
     }
 
-    def widenVariantParams = new TypeMap {
-      def apply(tp: Type) = mapOver(tp) match {
-        case tp @ AppliedType(tycon, args) =>
-          val args1 = args.zipWithConserve(tycon.typeParams)((arg, tparam) =>
-            if (tparam.paramVarianceSign != 0) TypeBounds.empty else arg
-          )
-          tp.derivedAppliedType(tycon, args1)
-        case tp =>
-          tp
-      }
+    def widenVariantParams(tp: Type) = tp match {
+      case tp @ AppliedType(tycon, args) =>
+        val args1 = args.zipWithConserve(tycon.typeParams)((arg, tparam) =>
+          if (tparam.paramVarianceSign != 0) TypeBounds.empty else arg
+        )
+        tp.derivedAppliedType(tycon, args1)
+      case tp =>
+        tp
     }
 
     val widePt =

--- a/tests/neg/i11565.gadt.scala
+++ b/tests/neg/i11565.gadt.scala
@@ -1,0 +1,16 @@
+@main def test: Unit = {
+  trait TyCon[+A]
+  trait S[T]
+  trait P[T] extends S[TyCon[T]] {
+    def consume(t: T): Unit
+  }
+
+  def patmat(s: S[TyCon[Int]]) = s match {
+    case p: P[t] =>
+      p.consume("Hi") // error
+  }
+
+  patmat(new P[Int] {
+    override def consume(t: Int): Unit = t + 1
+  })
+}

--- a/tests/neg/invariant-gadt.scala
+++ b/tests/neg/invariant-gadt.scala
@@ -1,6 +1,10 @@
 object `invariant-gadt` {
   case class Invariant[T](value: T)
 
+  def soundInPrinciple[T](i: Invariant[T]) : Int = i match {
+    case _: Invariant[Int] => i.value
+  }
+
   def unsound0[T](t: T): T = Invariant(t) match {
     case Invariant(_: Int) =>
       (0: Any) // error


### PR DESCRIPTION
Fixes #11565.

The change to an unrelated test file is to clarify what should and shouldn't be inferred.