### PR TITLE
Use initialization checker for soundness

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checking.scala
@@ -326,14 +326,14 @@ object Checking {
 
           case Fun(pots, effs) =>
             val name = sym.name.toString
-            if (name == "apply") Summary(pots, Effects.empty)
-            else if (name == "tupled") Summary(Set(pot1), Effects.empty)
+            if (name == "apply") Summary(pots)
+            else if (name == "tupled") Summary(pot1)
             else if (name == "curried") {
               val arity = defn.functionArity(sym.info.finalResultType)
-              val pots = (1 until arity).foldLeft(Set(pot1)) { (acc, i) =>
-                Set(Fun(acc, Effects.empty)(pot1.source))
+              val pots = (1 until arity).foldLeft(Vector(pot1)) { (acc, i) =>
+                Vector(Fun(acc, Effects.empty)(pot1.source))
               }
-              Summary(pots, Effects.empty)
+              Summary(pots)
             }
             else Summary.empty
 

--- a/compiler/src/dotty/tools/dotc/transform/init/Effects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Effects.scala
@@ -12,8 +12,8 @@ import core.Contexts._
 import Potentials._
 
 object Effects {
-  type Effects = Set[Effect]
-  val empty: Effects = Set.empty
+  type Effects = Vector[Effect]
+  val empty: Effects = Vector.empty
 
   def show(effs: Effects)(using Context): String =
     effs.map(_.show).mkString(", ")
@@ -25,6 +25,8 @@ object Effects {
     def show(using Context): String
 
     def source: Tree
+
+    def toEffs: Effects = Vector(this)
   }
 
   /** An effect means that a value that's possibly under initialization
@@ -57,8 +59,6 @@ object Effects {
   }
 
   // ------------------ operations on effects ------------------
-
-  extension (eff: Effect) def toEffs: Effects = Effects.empty + eff
 
   def asSeenFrom(eff: Effect, thisValue: Potential)(implicit env: Env): Effect =
     trace(eff.show + " asSeenFrom " + thisValue.show + ", current = " + currentClass.show, init, _.asInstanceOf[Effect].show) { eff match {

--- a/compiler/src/dotty/tools/dotc/transform/init/Effects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Effects.scala
@@ -29,11 +29,11 @@ object Effects {
     def toEffs: Effects = Vector(this)
   }
 
-  /** An effect means that a value that's possibly under initialization
+  /** A promotion effect means that a value that's possibly under initialization
    *  is promoted from the initializing world to the fully-initialized world.
    *
    *  Essentially, this effect enforces that the object pointed to by
-   *  `potential` is fully initialized.
+   *  `potential` is transitively initialized.
    *
    *  This effect is trigger in several scenarios:
    *  - a potential is used as arguments to method calls or new-expressions

--- a/compiler/src/dotty/tools/dotc/transform/init/Potentials.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Potentials.scala
@@ -15,8 +15,8 @@ import Types._, Symbols._, Contexts._
 import Effects._, Summary._
 
 object Potentials {
-  type Potentials = Set[Potential]
-  val empty: Potentials = Set.empty
+  type Potentials = Vector[Potential]
+  val empty: Potentials = Vector.empty
 
   def show(pots: Potentials)(using Context): String =
     pots.map(_.show).mkString(", ")
@@ -31,6 +31,8 @@ object Potentials {
 
     def show(using Context): String
     def source: Tree
+
+    def toPots: Potentials = Vector(this)
   }
 
   sealed trait Refinable extends Potential {
@@ -152,8 +154,6 @@ object Potentials {
   }
 
   // ------------------ operations on potentials ------------------
-
-  extension (pot: Potential) def toPots: Potentials = Potentials.empty + pot
 
   /** Selection on a set of potentials
    *

--- a/compiler/src/dotty/tools/dotc/transform/init/Summarization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Summarization.scala
@@ -206,7 +206,7 @@ object Summarization {
           val tp = tdef.symbol.info
           val traverser = new TypeTraverser {
             def traverse(tp: Type): Unit = tp match {
-              case tp: TermRef =>
+              case TermRef(_: SingletonType, _) =>
                 summary = summary + analyze(tp, tdef.rhs)
               case _ =>
                 traverseChildren(tp)
@@ -257,8 +257,12 @@ object Summarization {
         }
         Summary(pots2, effs)
 
+      case _: TermParamRef =>
+        // possible from type definitions
+        Summary.empty
+
       case _ =>
-        throw new Exception("unexpected type: " + tp.show)
+        throw new Exception("unexpected type: " + tp)
     }
 
     if (env.isAlwaysInitialized(tp)) Summary(Potentials.empty, summary.effs)

--- a/compiler/src/dotty/tools/dotc/transform/init/Summarization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Summarization.scala
@@ -304,7 +304,7 @@ object Summarization {
       def parentArgEffsWithInit(stats: List[Tree], ctor: Symbol, source: Tree): Effects =
         val init =
           if env.canIgnoreMethod(ctor) then Effects.empty
-          else Effects.empty + MethodCall(ThisRef()(source), ctor)(source)
+          else Effects.empty :+ MethodCall(ThisRef()(source), ctor)(source)
         stats.foldLeft(init) { (acc, stat) =>
           val summary = Summarization.analyze(stat)
           acc ++ summary.effs
@@ -334,7 +334,7 @@ object Summarization {
                 if tref.prefix == NoPrefix then Effects.empty
                 else Summarization.analyze(tref.prefix, ref).effs
 
-              prefixEff +  MethodCall(ThisRef()(ref), ctor)(ref)
+              prefixEff :+ MethodCall(ThisRef()(ref), ctor)(ref)
             }
         })
       }

--- a/compiler/src/dotty/tools/dotc/transform/init/Summary.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Summary.scala
@@ -18,10 +18,10 @@ case class Summary(pots: Potentials, effs: Effects) {
     Summary(pots ++ summary2.pots, this.effs ++ summary2.effs)
 
   def +(pot: Potential): Summary =
-    Summary(pots + pot, effs)
+    Summary(pots :+ pot, effs)
 
   def +(eff: Effect): Summary =
-    Summary(pots, effs + eff)
+    Summary(pots, effs :+ eff)
 
   def dropPotentials: Summary =
     Summary(Potentials.empty, effs)
@@ -44,14 +44,14 @@ case class Summary(pots: Potentials, effs: Effects) {
 object Summary {
   val empty: Summary = Summary(Potentials.empty, Effects.empty)
 
-  def apply(pots: Potentials): Summary = new Summary(pots, Effects.empty)
+  def apply(pots: Potentials): Summary = empty ++ pots
 
   @targetName("withEffects")
-  def apply(effs: Effects): Summary = new Summary(Potentials.empty, effs)
+  def apply(effs: Effects): Summary = empty ++ effs
 
-  def apply(pot: Potential): Summary = new Summary(Potentials.empty + pot, Effects.empty)
+  def apply(pot: Potential): Summary = empty + pot
 
-  def apply(eff: Effect): Summary = new Summary(Potentials.empty, Effects.empty + eff)
+  def apply(eff: Effect): Summary = empty + eff
 }
 
 /** Summary of class.

--- a/compiler/src/dotty/tools/dotc/transform/init/Summary.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Summary.scala
@@ -14,7 +14,7 @@ import config.Printers.init
 import Potentials._, Effects._, Util._
 
 case class Summary(pots: Potentials, effs: Effects) {
-  def union(summary2: Summary): Summary =
+  def +(summary2: Summary): Summary =
     Summary(pots ++ summary2.pots, this.effs ++ summary2.effs)
 
   def +(pot: Potential): Summary =

--- a/tests/init/neg/i11572.scala
+++ b/tests/init/neg/i11572.scala
@@ -1,0 +1,17 @@
+class A {
+  trait Cov[+X] {
+    def get: X
+  }
+  trait Bounded {
+    type T >: Cov[Int] <: Cov[String]
+  }
+  val t: Bounded = new Bounded {     // error
+    // Note: using this instead of t produces an error (as expected)
+    override type T >: t.T <: t.T
+  }
+
+  val covInt = new Cov[Int] {
+    override def get: Int = 3
+  }
+  val str: String = ((covInt: t.T): Cov[String]).get // ClassCastException: class Integer cannot be cast to class String
+}

--- a/tests/init/neg/i4031.scala
+++ b/tests/init/neg/i4031.scala
@@ -1,0 +1,10 @@
+object App {
+  trait A { type L >: Any}
+  def upcast(a: A, x: Any): a.L = x
+  val p: A { type L <: Nothing } = p        // error
+  def coerce(x: Any): Int = upcast(p, x)
+
+  def main(args: Array[String]): Unit = {
+    println(coerce("Uh oh!"))
+  }
+}

--- a/tests/init/neg/i4042.scala
+++ b/tests/init/neg/i4042.scala
@@ -1,0 +1,18 @@
+object App {
+  def coerce[U, V](u: U): V = {
+    trait X { type R >: U }
+    trait Y { type R = V }
+
+    class T[A <: X](val a: A)(val value: a.R)
+
+    object O { val x : Y & X = x }  // error
+
+    val a = new T[Y & X](O.x)(u)
+    a.value
+  }
+
+  def main(args: Array[String]): Unit = {
+    val x: Int = coerce[String, Int]("a")
+    println(x + 1)
+  }
+}

--- a/tests/init/neg/i50.scala
+++ b/tests/init/neg/i50.scala
@@ -1,0 +1,5 @@
+class C[T] {
+  val a: T = method
+  def method = b
+  val b: T = a     // error
+}

--- a/tests/init/neg/i5854.scala
+++ b/tests/init/neg/i5854.scala
@@ -1,0 +1,5 @@
+class B {
+  val a: String = (((1: Any): b.A): Nothing): String
+  val b: { type A >: Any <: Nothing } = loop()         // error
+  def loop(): Nothing = loop()
+}

--- a/tests/neg-strict/i5854.scala
+++ b/tests/neg-strict/i5854.scala
@@ -1,0 +1,24 @@
+object bar {
+  trait Sub {
+    type M
+    type L <: M
+    type U >: M
+    type M2 >: L <: U
+  }
+  class Box[V](val v: V)
+
+  class Caster[LL, UU] {
+    trait S2 {
+      type L = LL
+      type U = UU
+    }
+    final lazy val nothing: Nothing = nothing
+    final lazy val sub: S2 & Sub = nothing
+    final lazy val box : Box[S2 & Sub] = new Box(nothing)
+    def upcast(t: box.v.M2): box.v.M2 = t  // error // error
+  }
+  def main(args : Array[String]) : Unit = {
+    val zero : String = (new Caster[Int,String]()).upcast(0)
+    println("...")
+  }
+}


### PR DESCRIPTION
Use initialization checker for soundness

Fix #5854, #4042 and part of #11572



```Scala
-- Warning: tests/init/neg/i11572.scala:8:6 ------------------------------------
8 |  val t: Bounded = new Bounded {
  |      ^
  |      Access non-initialized value t. Calling trace:
  |       -> }	[ i11572.scala:11 ]
  |        -> override type T >: t.T <: t.T	[ i11572.scala:10 ]
1 warning found
```

```Scala
-- Warning: tests/init/neg/i5854.scala:3:6 -------------------------------------
3 |  val b: { type A >: Any <: Nothing } = loop()         // error
  |      ^
  |  Access non-initialized value b. Calling trace:
  |   -> val a: String = (((1: Any): b.A): Nothing): String	[ i5854.scala:2 ]
1 warning found
```
