### PR TITLE
Safer exceptions

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1261,13 +1261,15 @@ object desugar {
       makeOp(left, right, Span(left.span.start, op.span.end, op.span.start))
   }
 
-  /** Translate throws type `A throws E1 | ... | En`
+  /** Translate throws type `A throws E1 | ... | En` to
+   *  $throws[... $throws[A, E1] ... , En].
    */
   def throws(tpt: Tree, op: Ident, excepts: Tree)(using Context): AppliedTypeTree = excepts match
     case InfixOp(l, bar @ Ident(tpnme.raw.BAR), r) =>
       throws(throws(tpt, op, l), bar, r)
     case e =>
-      AppliedTypeTree(cpy.Ident(op)(tpnme.THROWS), tpt :: excepts :: Nil)
+      AppliedTypeTree(
+        TypeTree(defn.throwsAlias.typeRef).withSpan(op.span), tpt :: excepts :: Nil)
 
   /** Translate tuple expressions of arity <= 22
    *

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1261,6 +1261,14 @@ object desugar {
       makeOp(left, right, Span(left.span.start, op.span.end, op.span.start))
   }
 
+  /** Translate throws type `A throws E1 | ... | En`
+   */
+  def throws(tpt: Tree, op: Ident, excepts: Tree)(using Context): AppliedTypeTree = excepts match
+    case InfixOp(l, bar @ Ident(tpnme.raw.BAR), r) =>
+      throws(throws(tpt, op, l), bar, r)
+    case e =>
+      AppliedTypeTree(cpy.Ident(op)(tpnme.THROWS), tpt :: excepts :: Nil)
+
   /** Translate tuple expressions of arity <= 22
    *
    *     ()             ==>   ()

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -27,6 +27,7 @@ object Feature:
   val erasedDefinitions = experimental("erasedDefinitions")
   val symbolLiterals = deprecated("symbolLiterals")
   val fewerBraces = experimental("fewerBraces")
+  val saferExceptions = experimental("saferExceptions")
 
   /** Is `feature` enabled by by a command-line setting? The enabling setting is
    *

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -657,8 +657,11 @@ class Definitions {
 
   // in scalac modified to have Any as parent
 
-  @tu lazy val ThrowableType: TypeRef          = requiredClassRef("java.lang.Throwable")
-  def ThrowableClass(using Context): ClassSymbol = ThrowableType.symbol.asClass
+  @tu lazy val ThrowableType: TypeRef             = requiredClassRef("java.lang.Throwable")
+  def ThrowableClass(using Context): ClassSymbol  = ThrowableType.symbol.asClass
+  @tu lazy val ExceptionClass: ClassSymbol        = requiredClass("java.lang.Exception")
+  @tu lazy val RuntimeExceptionClass: ClassSymbol = requiredClass("java.lang.RuntimeException")
+
   @tu lazy val SerializableType: TypeRef       = JavaSerializableClass.typeRef
   def SerializableClass(using Context): ClassSymbol = SerializableType.symbol.asClass
 
@@ -829,6 +832,8 @@ class Definitions {
     def CanEqual_canEqualAny(using Context): TermSymbol =
       val methodName = if CanEqualClass.name == tpnme.Eql then nme.eqlAny else nme.canEqualAny
       CanEqualClass.companionModule.requiredMethod(methodName)
+
+  @tu lazy val CanThrowClass: ClassSymbol = requiredClass("scala.CanThrow")
 
   @tu lazy val TypeBoxClass: ClassSymbol = requiredClass("scala.runtime.TypeBox")
     @tu lazy val TypeBox_CAP: TypeSymbol = TypeBoxClass.requiredType(tpnme.CAP)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -834,6 +834,7 @@ class Definitions {
       CanEqualClass.companionModule.requiredMethod(methodName)
 
   @tu lazy val CanThrowClass: ClassSymbol = requiredClass("scala.CanThrow")
+  @tu lazy val throwsAlias: Symbol = ScalaRuntimePackageVal.requiredType(tpnme.THROWS)
 
   @tu lazy val TypeBoxClass: ClassSymbol = requiredClass("scala.runtime.TypeBox")
     @tu lazy val TypeBox_CAP: TypeSymbol = TypeBoxClass.requiredType(tpnme.CAP)

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -305,6 +305,7 @@ object StdNames {
     val SPECIALIZED_INSTANCE: N     = "specInstance$"
     val THIS: N                     = "_$this"
     val TRAIT_CONSTRUCTOR: N        = "$init$"
+    val THROWS: N                   = "$throws"
     val U2EVT: N                    = "u2evt$"
     val ALLARGS: N                  = "$allArgs"
 
@@ -602,6 +603,7 @@ object StdNames {
     val this_ : N               = "this"
     val thisPrefix : N          = "thisPrefix"
     val throw_ : N              = "throw"
+    val throws: N               = "throws"
     val toArray: N              = "toArray"
     val toList: N               = "toList"
     val toObjectArray : N       = "toObjectArray"

--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -24,6 +24,16 @@ object TypeUtils {
     def isErasedClass(using Context): Boolean =
       self.underlyingClassRef(refinementOK = true).typeSymbol.is(Flags.Erased)
 
+    /** Is this type a checked exception? This is the case if the type
+     *  derives from Exception but not from RuntimeException. According to
+     *  that definition Throwable is unchecked. That makes sense since you should
+     *  neither throw nor catch `Throwable` anyway, so we should not define
+     *  an ability to do so.
+     */
+    def isCheckedException(using Context): Boolean =
+      self.derivesFrom(defn.ExceptionClass)
+      && !self.derivesFrom(defn.RuntimeExceptionClass)
+
     def isByName: Boolean =
       self.isInstanceOf[ExprType]
 

--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -28,7 +28,7 @@ object TypeUtils {
      *  derives from Exception but not from RuntimeException. According to
      *  that definition Throwable is unchecked. That makes sense since you should
      *  neither throw nor catch `Throwable` anyway, so we should not define
-     *  an ability to do so.
+     *  a capability to do so.
      */
     def isCheckedException(using Context): Boolean =
       self.derivesFrom(defn.ExceptionClass)

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -114,6 +114,9 @@ class ReTyper extends Typer with ReChecking {
       super.handleUnexpectedFunType(tree, fun)
   }
 
+  override def addCanThrowCapabilities(expr: untpd.Tree, cases: List[CaseDef])(using Context): untpd.Tree =
+    expr
+
   override def typedUnadapted(tree: untpd.Tree, pt: Type, locked: TypeVars)(using Context): Tree =
     try super.typedUnadapted(tree, pt, locked)
     catch {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2636,7 +2636,10 @@ class Typer extends Namer
     val untpd.InfixOp(l, op, r) = tree
     val result =
       if (ctx.mode.is(Mode.Type))
-        typedAppliedTypeTree(cpy.AppliedTypeTree(tree)(op, l :: r :: Nil))
+        typedAppliedTypeTree(
+          if op.name == tpnme.throws && Feature.enabled(Feature.saferExceptions)
+          then desugar.throws(l, op, r)
+          else cpy.AppliedTypeTree(tree)(op, l :: r :: Nil))
       else if (ctx.mode.is(Mode.Pattern))
         typedUnApply(cpy.Apply(tree)(op, l :: r :: Nil), pt)
       else {

--- a/docs/docs/reference/soft-modifier.md
+++ b/docs/docs/reference/soft-modifier.md
@@ -5,7 +5,7 @@ title: Soft Keywords
 
 A soft modifier is one of the identifiers `opaque`, `inline`, `open`, `transparent`, and `infix`.
 
-A soft keyword is a soft modifier, or one of `derives`, `end`, `extension`, `using`, `|`, `+`, `-`, `*`
+A soft keyword is a soft modifier, or one of `derives`, `end`, `extension`, `throws`, `using`, `|`, `+`, `-`, `*`
 
 A soft modifier is treated as potential modifier of a definition if it is followed by a hard modifier or a keyword combination starting a definition (`def`, `val`, `var`, `type`, `given`, `class`, `trait`, `object`, `enum`, `case class`, `case object`). Between the two words there may be a sequence of newline tokens and soft modifiers.
 

--- a/library/src-bootstrapped/scala/CanThrow.scala
+++ b/library/src-bootstrapped/scala/CanThrow.scala
@@ -7,15 +7,17 @@ import annotation.{implicitNotFound, experimental}
  *  a given of class `CanThrow[Ex]` to be available.
  */
 @experimental
-@implicitNotFound("The ability to throw exception ${E} is missing.\nThe ability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A `canThrow` clause in a result type such as `X canThrow ${E}`\n - an enclosing `try` that catches ${E}")
+@implicitNotFound("The ability to throw exception ${E} is missing.\nThe ability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A `throws` clause in a result type such as `X throws ${E}`\n - an enclosing `try` that catches ${E}")
 erased class CanThrow[-E <: Exception]
 
 /** A helper type to allow syntax like
  *
- *    def f(): T canThrow Ex
+ *    def f(): T throws Ex1 | Ex2
+ *
+ *  Used in desugar.throws.
  */
 @experimental
-infix type canThrow[R, +E <: Exception] = CanThrow[E] ?=> R
+infix type $throws[R, +E <: Exception] = CanThrow[E] ?=> R
 
 @experimental
 object unsafeExceptions:

--- a/library/src-bootstrapped/scala/CanThrow.scala
+++ b/library/src-bootstrapped/scala/CanThrow.scala
@@ -2,12 +2,12 @@ package scala
 import language.experimental.erasedDefinitions
 import annotation.{implicitNotFound, experimental}
 
-/** An ability class that allows to throw exception `E`. When used with the
+/** A capability class that allows to throw exception `E`. When used with the
  *  experimental.saferExceptions feature, a `throw Ex()` expression will require
  *  a given of class `CanThrow[Ex]` to be available.
  */
 @experimental
-@implicitNotFound("The ability to throw exception ${E} is missing.\nThe ability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A `throws` clause in a result type such as `X throws ${E}`\n - an enclosing `try` that catches ${E}")
+@implicitNotFound("The capability to throw exception ${E} is missing.\nThe capability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A `throws` clause in a result type such as `X throws ${E}`\n - an enclosing `try` that catches ${E}")
 erased class CanThrow[-E <: Exception]
 
 /** A helper type to allow syntax like

--- a/library/src-bootstrapped/scala/CanThrow.scala
+++ b/library/src-bootstrapped/scala/CanThrow.scala
@@ -10,15 +10,7 @@ import annotation.{implicitNotFound, experimental}
 @implicitNotFound("The capability to throw exception ${E} is missing.\nThe capability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A `throws` clause in a result type such as `X throws ${E}`\n - an enclosing `try` that catches ${E}")
 erased class CanThrow[-E <: Exception]
 
-/** A helper type to allow syntax like
- *
- *    def f(): T throws Ex1 | Ex2
- *
- *  Used in desugar.throws.
- */
-@experimental
-infix type $throws[R, +E <: Exception] = CanThrow[E] ?=> R
-
 @experimental
 object unsafeExceptions:
   given canThrowAny: CanThrow[Exception] = ???
+

--- a/library/src-bootstrapped/scala/CanThrow.scala
+++ b/library/src-bootstrapped/scala/CanThrow.scala
@@ -1,11 +1,12 @@
 package scala
 import language.experimental.erasedDefinitions
-import annotation.implicitNotFound
+import annotation.{implicitNotFound, experimental}
 
 /** An ability class that allows to throw exception `E`. When used with the
  *  experimental.saferExceptions feature, a `throw Ex()` expression will require
  *  a given of class `CanThrow[Ex]` to be available.
  */
+@experimental
 @implicitNotFound("The ability to throw exception ${E} is missing.\nThe ability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A `canThrow` clause in a result type such as `X canThrow ${E}`\n - an enclosing `try` that catches ${E}")
 erased class CanThrow[-E <: Exception]
 
@@ -13,7 +14,9 @@ erased class CanThrow[-E <: Exception]
  *
  *    def f(): T canThrow Ex
  */
+@experimental
 infix type canThrow[R, +E <: Exception] = CanThrow[E] ?=> R
 
+@experimental
 object unsafeExceptions:
   given canThrowAny: CanThrow[Exception] = ???

--- a/library/src-bootstrapped/scala/CanThrow.scala
+++ b/library/src-bootstrapped/scala/CanThrow.scala
@@ -1,0 +1,19 @@
+package scala
+import language.experimental.erasedDefinitions
+import annotation.implicitNotFound
+
+/** An ability class that allows to throw exception `E`. When used with the
+ *  experimental.saferExceptions feature, a `throw Ex()` expression will require
+ *  a given of class `CanThrow[Ex]` to be available.
+ */
+@implicitNotFound("The ability to throw exception ${E} is missing.\nThe ability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A `canThrow` clause in a result type such as `X canThrow ${E}`\n - an enclosing `try` that catches ${E}")
+erased class CanThrow[-E <: Exception]
+
+/** A helper type to allow syntax like
+ *
+ *    def f(): T canThrow Ex
+ */
+infix type canThrow[R, +E <: Exception] = CanThrow[E] ?=> R
+
+object unsafeExceptions:
+  given canThrowAny: CanThrow[Exception] = ???

--- a/library/src-bootstrapped/scala/runtime/$throws.scala
+++ b/library/src-bootstrapped/scala/runtime/$throws.scala
@@ -1,0 +1,11 @@
+package scala.runtime
+import annotation.experimental
+
+/** A helper type to allow syntax like
+ *
+ *    def f(): T throws Ex1 | Ex2
+ *
+ *  Used in desugar.throws.
+ */
+@experimental
+infix type $throws[R, +E <: Exception] = CanThrow[E] ?=> R

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -50,12 +50,14 @@ object language:
 
     /** Experimental support for using indentation for arguments
      */
+    @compileTimeOnly("`fewerBraces` can only be used at compile time in import statements")
     object fewerBraces
 
     /** Experimental support for typechecked exception capabilities
      *
      *  @see [[https://dotty.epfl.ch/docs/reference/experimental/canthrow]]
      */
+    @compileTimeOnly("`saferExceptions` can only be used at compile time in import statements")
     object saferExceptions
 
   end experimental

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -51,6 +51,13 @@ object language:
     /** Experimental support for using indentation for arguments
      */
     object fewerBraces
+
+    /** Experimental support for typechecked exception capabilities
+     *
+     *  @see [[https://dotty.epfl.ch/docs/reference/experimental/canthrow]]
+     */
+    object saferExceptions
+
   end experimental
 
   /** The deprecated object contains features that are no longer officially suypported in Scala.

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -4,6 +4,15 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object MiMaFilters {
   val Library: Seq[ProblemFilter] = Seq(
+    // Experimental API for saferExceptions
+    exclude[MissingClassProblem]("scala.CanThrow"),
+    exclude[MissingClassProblem]("scala.CanThrow$package"),
+    exclude[MissingClassProblem]("scala.CanThrow$package$"),
+    exclude[MissingClassProblem]("scala.unsafeExceptions"),
+    exclude[MissingClassProblem]("scala.unsafeExceptions$"),
+    exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.saferExceptions"),
+    exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$saferExceptions$"),
+
     // New APIs that will be introduced in 3.1.0
     exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule.Wildcard"),
     exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule.WildcardTypeTest"),

--- a/tests/neg/safeThrowsStrawman.check
+++ b/tests/neg/safeThrowsStrawman.check
@@ -4,7 +4,7 @@
    |                                The capability to throw exception scalax.Fail is missing.
    |                                The capability can be provided by one of the following:
    |                                 - A using clause `(using CanThrow[scalax.Fail])`
-   |                                 - A throws clause in a result type such as `X throws scalax.Fail`
+   |                                 - A raises clause in a result type such as `X raises scalax.Fail`
    |                                 - an enclosing `try` that catches scalax.Fail
 -- Error: tests/neg/safeThrowsStrawman.scala:27:15 ---------------------------------------------------------------------
 27 |    println(bar)        // error
@@ -12,5 +12,5 @@
    |               The capability to throw exception Exception is missing.
    |               The capability can be provided by one of the following:
    |                - A using clause `(using CanThrow[Exception])`
-   |                - A throws clause in a result type such as `X throws Exception`
+   |                - A raises clause in a result type such as `X raises Exception`
    |                - an enclosing `try` that catches Exception

--- a/tests/neg/safeThrowsStrawman.scala
+++ b/tests/neg/safeThrowsStrawman.scala
@@ -2,21 +2,21 @@ import language.experimental.erasedDefinitions
 import annotation.implicitNotFound
 
 object scalax:
-  @implicitNotFound("The capability to throw exception ${E} is missing.\nThe capability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A throws clause in a result type such as `X throws ${E}`\n - an enclosing `try` that catches ${E}")
+  @implicitNotFound("The capability to throw exception ${E} is missing.\nThe capability can be provided by one of the following:\n - A using clause `(using CanThrow[${E}])`\n - A raises clause in a result type such as `X raises ${E}`\n - an enclosing `try` that catches ${E}")
   erased class CanThrow[-E <: Exception]
 
-  infix type throws[R, +E <: Exception] = CanThrow[E] ?=> R
+  infix type raises[R, +E <: Exception] = CanThrow[E] ?=> R
 
   class Fail extends Exception
 
-  def raise[E <: Exception](e: E): Nothing throws E = throw e
+  def raise[E <: Exception](e: E): Nothing raises E = throw e
 
 import scalax._
 
 def foo(x: Boolean): Int =
   if x then 1 else raise(Fail())  // error
 
-def bar: Int throws Exception =
+def bar: Int raises Exception =
   raise(Fail())
 
 @main def Test =

--- a/tests/neg/safeThrowsStrawman2.scala
+++ b/tests/neg/safeThrowsStrawman2.scala
@@ -4,15 +4,15 @@ object scalax:
   erased class CanThrow[E <: Exception]
   type CTF = CanThrow[Fail]
 
-  infix type throws[R, E <: Exception] = CanThrow[E] ?=> R
+  infix type raises[R, E <: Exception] = CanThrow[E] ?=> R
 
   class Fail extends Exception
 
-  def raise[E <: Exception](e: E): Nothing throws E = throw e
+  def raise[E <: Exception](e: E): Nothing raises E = throw e
 
 import scalax._
 
-def foo(x: Boolean, y: CanThrow[Fail]): Int throws Fail =
+def foo(x: Boolean, y: CanThrow[Fail]): Int raises Fail =
   if x then 1 else raise(Fail())
 
 def bar(x: Boolean)(using CanThrow[Fail]): Int =

--- a/tests/neg/saferExceptions.check
+++ b/tests/neg/saferExceptions.check
@@ -1,0 +1,26 @@
+-- Error: tests/neg/saferExceptions.scala:14:16 ------------------------------------------------------------------------
+14 |      case 4 => throw Exception()             // error
+   |                ^^^^^^^^^^^^^^^^^
+   |                The ability to throw exception Exception is missing.
+   |                The ability can be provided by one of the following:
+   |                 - A using clause `(using CanThrow[Exception])`
+   |                 - A `canThrow` clause in a result type such as `X canThrow Exception`
+   |                 - an enclosing `try` that catches Exception
+   |
+   |                The following import might fix the problem:
+   |
+   |                  import unsafeExceptions.canThrowAny
+   |
+-- Error: tests/neg/saferExceptions.scala:19:48 ------------------------------------------------------------------------
+19 |  def baz(x: Int): Int canThrow Failure = bar(x)  // error
+   |                                                ^
+   |                                The ability to throw exception java.io.IOException is missing.
+   |                                The ability can be provided by one of the following:
+   |                                 - A using clause `(using CanThrow[java.io.IOException])`
+   |                                 - A `canThrow` clause in a result type such as `X canThrow java.io.IOException`
+   |                                 - an enclosing `try` that catches java.io.IOException
+   |
+   |                                The following import might fix the problem:
+   |
+   |                                  import unsafeExceptions.canThrowAny
+   |

--- a/tests/neg/saferExceptions.check
+++ b/tests/neg/saferExceptions.check
@@ -1,8 +1,8 @@
 -- Error: tests/neg/saferExceptions.scala:12:16 ------------------------------------------------------------------------
 12 |      case 4 => throw Exception()             // error
    |                ^^^^^^^^^^^^^^^^^
-   |                The ability to throw exception Exception is missing.
-   |                The ability can be provided by one of the following:
+   |                The capability to throw exception Exception is missing.
+   |                The capability can be provided by one of the following:
    |                 - A using clause `(using CanThrow[Exception])`
    |                 - A `throws` clause in a result type such as `X throws Exception`
    |                 - an enclosing `try` that catches Exception
@@ -14,8 +14,8 @@
 -- Error: tests/neg/saferExceptions.scala:17:46 ------------------------------------------------------------------------
 17 |  def baz(x: Int): Int throws Failure = bar(x)  // error
    |                                              ^
-   |                                    The ability to throw exception java.io.IOException is missing.
-   |                                    The ability can be provided by one of the following:
+   |                                    The capability to throw exception java.io.IOException is missing.
+   |                                    The capability can be provided by one of the following:
    |                                     - A using clause `(using CanThrow[java.io.IOException])`
    |                                     - A `throws` clause in a result type such as `X throws java.io.IOException`
    |                                     - an enclosing `try` that catches java.io.IOException

--- a/tests/neg/saferExceptions.check
+++ b/tests/neg/saferExceptions.check
@@ -1,26 +1,26 @@
--- Error: tests/neg/saferExceptions.scala:14:16 ------------------------------------------------------------------------
-14 |      case 4 => throw Exception()             // error
+-- Error: tests/neg/saferExceptions.scala:12:16 ------------------------------------------------------------------------
+12 |      case 4 => throw Exception()             // error
    |                ^^^^^^^^^^^^^^^^^
    |                The ability to throw exception Exception is missing.
    |                The ability can be provided by one of the following:
    |                 - A using clause `(using CanThrow[Exception])`
-   |                 - A `canThrow` clause in a result type such as `X canThrow Exception`
+   |                 - A `throws` clause in a result type such as `X throws Exception`
    |                 - an enclosing `try` that catches Exception
    |
    |                The following import might fix the problem:
    |
    |                  import unsafeExceptions.canThrowAny
    |
--- Error: tests/neg/saferExceptions.scala:19:48 ------------------------------------------------------------------------
-19 |  def baz(x: Int): Int canThrow Failure = bar(x)  // error
-   |                                                ^
-   |                                The ability to throw exception java.io.IOException is missing.
-   |                                The ability can be provided by one of the following:
-   |                                 - A using clause `(using CanThrow[java.io.IOException])`
-   |                                 - A `canThrow` clause in a result type such as `X canThrow java.io.IOException`
-   |                                 - an enclosing `try` that catches java.io.IOException
+-- Error: tests/neg/saferExceptions.scala:17:46 ------------------------------------------------------------------------
+17 |  def baz(x: Int): Int throws Failure = bar(x)  // error
+   |                                              ^
+   |                                    The ability to throw exception java.io.IOException is missing.
+   |                                    The ability can be provided by one of the following:
+   |                                     - A using clause `(using CanThrow[java.io.IOException])`
+   |                                     - A `throws` clause in a result type such as `X throws java.io.IOException`
+   |                                     - an enclosing `try` that catches java.io.IOException
    |
-   |                                The following import might fix the problem:
+   |                                    The following import might fix the problem:
    |
-   |                                  import unsafeExceptions.canThrowAny
+   |                                      import unsafeExceptions.canThrowAny
    |

--- a/tests/neg/saferExceptions.scala
+++ b/tests/neg/saferExceptions.scala
@@ -1,0 +1,19 @@
+object test:
+  import language.experimental.saferExceptions
+  import java.io.IOException
+
+  class Failure extends Exception
+
+  def bar(x: Int): Int
+      `canThrow` Failure
+      `canThrow` IOException =
+    x match
+      case 1 => throw AssertionError()
+      case 2 => throw Failure()               // ok
+      case 3 => throw java.io.IOException()   // ok
+      case 4 => throw Exception()             // error
+      case 5 => throw Throwable()             // ok: Throwable is treated as unchecked
+      case _ => 0
+
+  def foo(x: Int): Int canThrow Exception = bar(x)
+  def baz(x: Int): Int canThrow Failure = bar(x)  // error

--- a/tests/neg/saferExceptions.scala
+++ b/tests/neg/saferExceptions.scala
@@ -4,9 +4,7 @@ object test:
 
   class Failure extends Exception
 
-  def bar(x: Int): Int
-      `canThrow` Failure
-      `canThrow` IOException =
+  def bar(x: Int): Int throws Failure | IOException =
     x match
       case 1 => throw AssertionError()
       case 2 => throw Failure()               // ok
@@ -15,5 +13,5 @@ object test:
       case 5 => throw Throwable()             // ok: Throwable is treated as unchecked
       case _ => 0
 
-  def foo(x: Int): Int canThrow Exception = bar(x)
-  def baz(x: Int): Int canThrow Failure = bar(x)  // error
+  def foo(x: Int): Int throws Exception = bar(x)
+  def baz(x: Int): Int throws Failure = bar(x)  // error

--- a/tests/pos/reference/saferExceptions.scala
+++ b/tests/pos/reference/saferExceptions.scala
@@ -5,7 +5,7 @@ class LimitExceeded extends Exception
 
 val limit = 10e9
 
-def f(x: Double): Double canThrow LimitExceeded =
+def f(x: Double): Double throws LimitExceeded =
   if x < limit then x * x else throw LimitExceeded()
 
 @main def test(xs: Double*) =

--- a/tests/pos/reference/saferExceptions.scala
+++ b/tests/pos/reference/saferExceptions.scala
@@ -1,0 +1,15 @@
+import language.experimental.saferExceptions
+
+
+class LimitExceeded extends Exception
+
+val limit = 10e9
+
+def f(x: Double): Double canThrow LimitExceeded =
+  if x < limit then x * x else throw LimitExceeded()
+
+@main def test(xs: Double*) =
+  try println(xs.map(f).sum)
+  catch case ex: LimitExceeded => println("too large")
+
+

--- a/tests/run/safeThrowsStrawman.scala
+++ b/tests/run/safeThrowsStrawman.scala
@@ -3,19 +3,19 @@ import language.experimental.erasedDefinitions
 object scalax:
   erased class CanThrow[-E <: Exception]
 
-  infix type throws[R, +E <: Exception] = CanThrow[E] ?=> R
+  infix type raises[R, +E <: Exception] = CanThrow[E] ?=> R
 
   class Fail extends Exception
 
-  def raise[E <: Exception](e: E): Nothing throws E = throw e
+  def raise[E <: Exception](e: E): Nothing raises E = throw e
 
 import scalax._
 
-def foo(x: Boolean): Int throws Fail =
+def foo(x: Boolean): Int raises Fail =
   if x then 1 else raise(Fail())
 
 def bar(x: Boolean)(using CanThrow[Fail]): Int = foo(x)
-def baz: Int throws Exception = foo(false)
+def baz: Int raises Exception = foo(false)
 
 @main def Test =
   try

--- a/tests/run/safeThrowsStrawman2.scala
+++ b/tests/run/safeThrowsStrawman2.scala
@@ -3,19 +3,19 @@ import language.experimental.erasedDefinitions
 object scalax:
   erased class CanThrow[-E <: Exception]
 
-  infix type throws[R, +E <: Exception] = CanThrow[E] ?=> R
+  infix type raises[R, +E <: Exception] = CanThrow[E] ?=> R
 
   class Fail extends Exception
 
-  def raise[E <: Exception](e: E): Nothing throws E = throw e
+  def raise[E <: Exception](e: E): Nothing raises E = throw e
 
   private class Result[T]:
     var value: T = scala.compiletime.uninitialized
 
-  def try1[R, E <: Exception](body: => R throws E)(c: E => Unit): R =
+  def try1[R, E <: Exception](body: => R raises E)(c: E => Unit): R =
     try2(body)(c) {}
 
-  def try2[R, E <: Exception](body: => R throws E)(c: E => Unit)(f: => Unit): R =
+  def try2[R, E <: Exception](body: => R raises E)(c: E => Unit)(f: => Unit): R =
     val res = new Result[R]
     try
       given CanThrow[E] = ???
@@ -30,11 +30,11 @@ object scalax:
 
 import scalax._
 
-def foo(x: Boolean): Int throws Fail =
+def foo(x: Boolean): Int raises Fail =
   if x then 1 else raise(Fail())
 
 def bar(x: Boolean)(using CanThrow[Fail]): Int = foo(x)
-def baz: Int throws Exception = foo(false)
+def baz: Int raises Exception = foo(false)
 
 @main def Test =
   try1 {

--- a/tests/run/saferExceptions.scala
+++ b/tests/run/saferExceptions.scala
@@ -1,0 +1,34 @@
+import language.experimental.saferExceptions
+
+class Fail extends Exception
+
+def foo(x: Int) =
+  try x match
+    case 1 => throw AssertionError()
+    case 2 => throw Fail()
+    case 3 => throw java.io.IOException()
+    case 4 => throw Exception()
+    case 5 => throw Throwable()
+    case _ => 0
+  catch
+    case ex: AssertionError => 1
+    case ex: Fail => 2
+    case ex: java.io.IOException => 3
+    case ex: Exception => 4
+    case ex: Throwable => 5
+
+def bar(x: Int): Int canThrow Exception =
+  x match
+    case 1 => throw AssertionError()
+    case 2 => throw Fail()
+    case 3 => throw java.io.IOException()
+    case 4 => throw Exception()
+    case _ => 0
+
+@main def Test =
+  assert(foo(1) + foo(2) + foo(3) + foo(4) + foo(5) + foo(6) == 15)
+  import unsafeExceptions.canThrowAny
+  val x =
+    try bar(2)
+    catch case ex: Fail => 3 // OK
+  assert(x == 3)

--- a/tests/run/saferExceptions.scala
+++ b/tests/run/saferExceptions.scala
@@ -17,7 +17,7 @@ def foo(x: Int) =
     case ex: Exception => 4
     case ex: Throwable => 5
 
-def bar(x: Int): Int canThrow Exception =
+def bar(x: Int): Int throws Exception =
   x match
     case 1 => throw AssertionError()
     case 2 => throw Fail()


### PR DESCRIPTION
Introduce a flexible scheme for declaring and checking which exceptions can be thrown.
It relies on the _effects as implicit capabilities_ pattern.

The scheme is not 100% safe yet since it does not track and prevent capability capture.
Nevertheless, it's already useful for declaring thrown exceptions and finding mismatches
between provided and required capabilities.

Link to [Doc page](https://github.com/lampepfl/dotty/blob/b65958f139a0a818d36ee04468ada93b8fb472ac/docs/docs/reference/experimental/canthrow.md)

Everything is enabled under
```scala
import language.experimental.saferExceptions
```


Based on #11695 

### For Release Notes:

Safer exceptions 

  A new experimental feature that allows declaring and checking which exceptions can be thrown.
  It relies on the _effects as implicit capabilities_ pattern. 


