### PR TITLE
more fixes in Markdown files

### DIFF
--- a/docs/docs/reference/changed-features/eta-expansion.md
+++ b/docs/docs/reference/changed-features/eta-expansion.md
@@ -28,7 +28,7 @@ def next(): T
 ```
 
 Given a simple reference to `next` does not auto-convert to a function.
-One has to write explicitly `() => next()` to achieve that
+One has to write explicitly `() => next()` to achieve that.
 Once again since the `_` is going to be deprecated it's better to write it this way
 rather than `next _`.
 

--- a/docs/docs/reference/dropped-features/limit22.md
+++ b/docs/docs/reference/dropped-features/limit22.md
@@ -7,10 +7,10 @@ The limits of 22 for the maximal number of parameters of function types and the
 maximal number of fields in tuple types have been dropped.
 
 * Functions can now have an arbitrary number of parameters. Functions beyond
-  `Function22` are erased to a new trait `scala.FunctionXXL`
+  [`scala.Function22`](https://www.scala-lang.org/api/current/scala/Function22.html) are erased to a new trait [`scala.runtime.FunctionXXL`](https://dotty.epfl.ch/api/scala/runtime/FunctionXXL.html).
 
-* Tuples can also have an arbitrary number of fields. Tuples beyond `Tuple22`
-  are erased to a new trait `scala.TupleXXL`. Furthermore, they support generic
+* Tuples can also have an arbitrary number of fields. Tuples beyond [`scala.Tuple22`](https://www.scala-lang.org/api/current/scala/Tuple22.html)
+  are erased to a new class [`scala.runtime.TupleXXL`](https://dotty.epfl.ch/api/scala/runtime/TupleXXL.html) (which extends the trait [`scala.Product`](https://dotty.epfl.ch/api/scala/Product.html)). Furthermore, they support generic
   operation such as concatenation and indexing.
 
 Both of these are implemented using arrays.

--- a/docs/docs/reference/dropped-features/xml.md
+++ b/docs/docs/reference/dropped-features/xml.md
@@ -4,7 +4,35 @@ title: "Dropped: XML Literals"
 ---
 
 XML Literals are still supported, but will be dropped in the near future, to
-be replaced with XML string interpolation:
+be replaced with [XML string interpolation](https://github.com/lampepfl/xml-interpolator):
+
 ```scala
-xml""" ... """
+import dotty.xml.interpolator.*
+
+case class Person(name: String) { override def toString = name }
+
+@main def test: Unit =
+  val bill = Person("Bill")
+  val john = Person("John")
+  val mike = Person("Mike")
+  val todoList = List(
+    (bill, john, "Meeting", "Room 203, 11:00am"),
+    (john, mike, "Holiday", "March 22-24")
+  )
+  // XML literals (to be dropped)
+  val mails1 = for (from, to, heading, body) <- todoList yield
+    <message>
+      <from>{from}</from><to>{to}</to>
+      <heading>{heading}</heading><body>{body}</body>
+    </message>
+  println(mails1)
+  // XML string interpolation
+  val mails2 = for (from, to, heading, body) <- todoList yield xml"""
+    <message>
+      <from>${from}</from><to>${to}</to>
+      <heading>${heading}</heading><body>${body}</body>
+    </message>"""
+  println(mails2)
 ```
+
+For more information, see the semester project [XML String Interpolator for Dotty](https://infoscience.epfl.ch/record/267527) by Yassin Kammoun (2019).

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -181,11 +181,12 @@ Inline methods can override other non-inline methods. The rules are as follows:
 
 ### Relationship to `@inline`
 
-Scala 2 also defines a `@inline` annotation which is used as a hint
-for the backend to inline code. The `inline` modifier is a more powerful
-option: Expansion is guaranteed instead of best effort,
-it happens in the frontend instead of in the backend, and it also applies
-to recursive methods.
+Scala 2 also defines a `@inline` annotation which is used as a hint for the
+backend to inline code. The `inline` modifier is a more powerful option:
+
+- expansion is guaranteed instead of best effort,
+- expansion happens in the frontend instead of in the backend and
+- expansion also applies to recursive methods.
 
 To cross compile between both Scala 3 and Scala 2, we introduce a new `@forceInline`
 annotation which is equivalent to the new `inline` modifier. Note that
@@ -379,7 +380,7 @@ val intTwo: 2 = natTwo
 
 ## The `scala.compiletime` Package
 
-The `scala.compiletime` package contains helper definitions that provide support for compile time operations over values. They are described in the following.
+The [`scala.compiletime`](https://dotty.epfl.ch/api/scala/compiletime.html) package contains helper definitions that provide support for compile time operations over values. They are described in the following.
 
 ### `constValue`, `constValueOpt`, and the `S` combinator
 
@@ -499,7 +500,7 @@ fail(identity("foo")) // error: failed on: identity("foo")
 
 ### The `scala.compiletime.ops` package
 
-The `scala.compiletime.ops` package contains types that provide support for
+The [`scala.compiletime.ops`](https://dotty.epfl.ch/api/scala/compiletime/ops.html) package contains types that provide support for
 primitive operations on singleton types. For example,
 `scala.compiletime.ops.int.*` provides support for multiplying two singleton
 `Int` types, and `scala.compiletime.ops.boolean.&&` for the conjunction of two

--- a/docs/docs/reference/overview.md
+++ b/docs/docs/reference/overview.md
@@ -2,7 +2,7 @@
 layout: doc-page
 title: "Overview"
 ---
-The forthcoming Scala 3 implements many language changes and improvements over Scala 2.
+Scala 3 implements many language changes and improvements over Scala 2.
 In this reference, we discuss design decisions and present important differences compared to Scala 2.
 
 ## Goals
@@ -18,7 +18,7 @@ The language redesign was guided by three main goals:
 - Further improve the consistency and expressiveness of Scala's language constructs.
 
 Corresponding to these goals, the language changes fall into seven categories:
-(1) Core constructs to strengthen foundations, (2) simplifications and (3) [restrictions](#restrictions), to make the language easier and safer to use, (4) dropped constructs to make the language smaller and more regular, (5) [changed constructs](#changes) to remove warts, and increase consistency and usability, (6) [new constructs](#new-constructs) to fill gaps and increase expressiveness, (7) a new, principled approach to metaprogramming that replaces [Scala 2 experimental macros](https://docs.scala-lang.org/overviews/macros/overview.html).
+(1) Core constructs to strengthen foundations, (2) simplifications and (3) [restrictions](#restrictions), to make the language easier and safer to use, (4) [dropped constructs](#dropped-constructs) to make the language smaller and more regular, (5) [changed constructs](#changes) to remove warts, and increase consistency and usability, (6) [new constructs](#new-constructs) to fill gaps and increase expressiveness, (7) a new, principled approach to metaprogramming that replaces [Scala 2 experimental macros](https://docs.scala-lang.org/overviews/macros/overview.html).
 
 ## Essential Foundations
 


### PR DESCRIPTION
Follow up of PR #10767, #10826, #10860, #10875, #10953, #11016, #11062, #11158, #11235 and #11480.

Fixes more issues found in Markdown files in [`docs/reference/`](https://github.com/lampepfl/dotty/tree/master/docs/docs/reference), e.g.
- `limit22.md` : corrected `FunctionXXL` and `TupleXXL`
- `xml.md` : added XML code example et reference
- added some (internal/external) hyperlinks

**PS.** The above changes can also be viewed in the PDF document [`scala3_reference.pdf`](https://github.com/michelou/dotty-examples/blob/master/docs/scala3_reference.pdf) (968 Kb) generated with [Pandoc 2.11](https://pandoc.org/releases.html) in ~1:29 minute.
