### PR TITLE
Refine `hasCommonParent` criterion in OverridingPairs

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -20,6 +20,11 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
 
   private class BridgesCursor(using Context) extends OverridingPairs.Cursor(root) {
 
+    override def isSubParent(parent: Symbol, bc: Symbol)(using Context) =
+      true
+      	// Never consider a bridge if there is a superclass that would contain it
+      	// See run/t2857.scala for a test that would break with a VerifyError otherwise.
+
     /** Only use the superclass of `root` as a parent class. This means
      *  overriding pairs that have a common implementation in a trait parent
      *  are also counted. This is necessary because we generate bridge methods

--- a/tests/neg/i11130.scala
+++ b/tests/neg/i11130.scala
@@ -9,7 +9,7 @@
   trait PBar extends S[Bar] {
     override type T = Bar
   }
-  class PFooBar extends PBar with PFoo {
+  class PFooBar extends PBar with PFoo { // error
     override type T >: Bar  // error
   }
 

--- a/tests/neg/i11719.scala
+++ b/tests/neg/i11719.scala
@@ -1,0 +1,12 @@
+class Base
+class Sub extends Base
+
+trait A[+T] {
+  def get: T = ???
+}
+
+trait B extends A[Base] {
+  override def get: Base = new Base
+}
+
+class C extends B with A[Sub] // error: method get in trait B is not a legal implementation

--- a/tests/neg/i11719a.scala
+++ b/tests/neg/i11719a.scala
@@ -1,0 +1,19 @@
+class Base
+class Sub extends Base
+
+trait A[+T] {
+  def get(f: T => Boolean): Unit = {}
+}
+
+trait B extends A[Base] {
+  override def get(f: Base => Boolean): Unit = f(new Base)
+}
+
+class C extends B with A[Sub] // error: Name clash between inherited members:
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new C
+    c.get((x: Sub) => true) // ClassCastException: Base cannot be cast to Sub
+  }
+}


### PR DESCRIPTION
Fixes #11719

`hasCommonParent` is used to avoid re-visiting overriding pairs that were
already accounted for in a parent. But that only works if the base types
of the classes forming an overriding pair are the same for the parent and
the class itself. Otherwise we might miss an overriding relationship.