### PR TITLE
Allow for missing type symbols in needsRewire

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -119,7 +119,8 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
       /** Only rewire types that are owned by the current Hoister and is an param or accessor */
       def needsRewire(tp: Type) = tp match {
         case ntp: NamedType =>
-          (ntp.symbol.owner == cls || ntp.symbol.owner == constr) && ntp.symbol.isParamOrAccessor
+          val owner = ntp.symbol.maybeOwner
+          (owner == cls || owner == constr) && ntp.symbol.isParamOrAccessor
         case _ => false
       }
 

--- a/tests/pos/i11732.scala
+++ b/tests/pos/i11732.scala
@@ -1,0 +1,23 @@
+import scala.deriving._
+
+trait TupleConversion[A, B] {
+  def to(a: A): B
+  def from(b: B): A
+}
+
+object TupleConversion  {
+  inline given autoTupleConversion[Prod <: Product](using m: Mirror.ProductOf[Prod]): TupleConversion[Prod, m.MirroredElemTypes] =
+    new TupleConversion[Prod, m.MirroredElemTypes] {
+      def to(a: Prod): m.MirroredElemTypes = Tuple.fromProductTyped(a)
+      def from(b: m.MirroredElemTypes): Prod = m.fromProduct(b)
+    }
+}
+
+final case class Data(s0: Int, s1: Int)
+
+abstract class BaseSpec(f: () => Unit)
+
+object ProductBuilderTest
+  extends BaseSpec(() => {
+    val conv = implicitly[TupleConversion[Data, (Int, Int)]]
+  })


### PR DESCRIPTION
These can come up from refined types.

Fixes #11732