### PR TITLE
Do not allow calls to inline metthods directly in macro splice

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -161,7 +161,7 @@ object Splicer {
         case SeqLiteral(elems, _) =>
           elems.foreach(checkIfValidArgument)
 
-        case tree: Ident if tree.symbol.is(Inline) || summon[Env].contains(tree.symbol) =>
+        case tree: Ident if summon[Env].contains(tree.symbol) =>
           // OK
 
         case _ =>
@@ -185,6 +185,9 @@ object Splicer {
 
         case Typed(expr, _) =>
           checkIfValidStaticCall(expr)
+
+        case Apply(Select(Apply(fn, quoted :: Nil), nme.apply), _) if fn.symbol == defn.QuotedRuntime_exprQuote =>
+          // OK, canceled and warning emitted
 
         case Call(fn, args)
             if (fn.symbol.isConstructor && fn.symbol.owner.owner.is(Package)) ||

--- a/tests/neg-macros/i11688.scala
+++ b/tests/neg-macros/i11688.scala
@@ -1,0 +1,6 @@
+import scala.quoted._
+
+def myMacro(a: Int)(using Quotes) = Expr(a)
+def baz = 42
+inline def bar = baz
+inline def foo = ${myMacro(bar)} // error

--- a/tests/neg-macros/i4431.scala
+++ b/tests/neg-macros/i4431.scala
@@ -1,5 +1,0 @@
-import scala.quoted.*
-
-object Macros {
-  inline def h(f: => Int => String): String = ${'{f(42)}} // error
-}

--- a/tests/neg-macros/i4492/quoted_1.scala
+++ b/tests/neg-macros/i4492/quoted_1.scala
@@ -1,6 +1,0 @@
-
-trait Index
-
-object Index {
-  inline def succ(prev: Index): Unit = ${ '{println("Ok")} } // error
-}

--- a/tests/neg-macros/i4493-b.scala
+++ b/tests/neg-macros/i4493-b.scala
@@ -3,6 +3,6 @@ class Index[K]
 object Index {
   inline def succ[K](x: K): Unit = ${
     implicit val t: Type[K] = Type.of[K] // error
-    '{new Index[K]} // error
+    '{new Index[K]}
   }
 }

--- a/tests/neg-macros/i4493.scala
+++ b/tests/neg-macros/i4493.scala
@@ -3,6 +3,6 @@ class Index[K]
 object Index {
   inline def succ[K]: Unit = ${
     implicit val t: Type[K] = Type.of[K] // error
-    '{new Index[K]} // error
+    '{new Index[K]}
   }
 }

--- a/tests/pos-macros/i4431.scala
+++ b/tests/pos-macros/i4431.scala
@@ -1,0 +1,6 @@
+import scala.quoted.*
+
+object Macros {
+  inline def h(f: => Int => String): String = ${'{f(42)}}
+  val a = h(_.toString)
+}

--- a/tests/pos-macros/i4493-c.scala
+++ b/tests/pos-macros/i4493-c.scala
@@ -1,6 +1,6 @@
 class Index[K]
 object Index {
   inline def succ[K]: Unit = ${
-    '{new Index[K]} // error
+    '{new Index[K]}
   }
 }

--- a/tests/run-macros/i4492/quoted_1.scala
+++ b/tests/run-macros/i4492/quoted_1.scala
@@ -1,0 +1,6 @@
+
+trait Index
+
+object Index {
+  inline def succ(prev: Index): Unit = ${ '{println("Ok")} }
+}

--- a/tests/run-macros/i4492/quoted_2.scala
+++ b/tests/run-macros/i4492/quoted_2.scala
@@ -1,6 +1,6 @@
 
 object Test {
   def main(args: Array[String]): Unit = {
-    Index.succ(null) // error
+    Index.succ(null)
   }
 }


### PR DESCRIPTION
Also properly support canceled macro splices. These will warn the user and compile as if
they where a normal inline method.

Fixes #11688