### PR TITLE
Fix #10930: no Matchable check for @unchecked patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -40,7 +40,7 @@ object TypeUtils {
     /** The arity of this tuple type, which can be made up of EmptyTuple, TupleX and `*:` pairs,
      *  or -1 if this is not a tuple type.
      */
-    def tupleArity(using Context): Int = self match {
+    def tupleArity(using Context): Int = self.stripTypeVar.stripAnnots match {
       case AppliedType(tycon, _ :: tl :: Nil) if tycon.isRef(defn.PairClass) =>
         val arity = tl.tupleArity
         if (arity < 0) arity else arity + 1
@@ -53,7 +53,7 @@ object TypeUtils {
     }
 
     /** The element types of this tuple type, which can be made up of EmptyTuple, TupleX and `*:` pairs */
-    def tupleElementTypes(using Context): List[Type] = self match {
+    def tupleElementTypes(using Context): List[Type] = self.stripTypeVar.stripAnnots match {
       case AppliedType(tycon, hd :: tl :: Nil) if tycon.isRef(defn.PairClass) =>
         hd :: tl.tupleElementTypes
       case self: SingletonType =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1311,7 +1311,7 @@ trait Applications extends Compatibility {
         val unapplyPatterns = bunchedArgs.lazyZip(argTypes) map (typed(_, _))
         val result = assignType(cpy.UnApply(tree)(unapplyFn, unapplyImplicits(unapplyApp), unapplyPatterns), ownType)
         unapp.println(s"unapply patterns = $unapplyPatterns")
-        if ((ownType eq selType) || ownType.isError) result
+        if ownType =:= selType || ownType.isError then result
         else tryWithTypeTest(Typed(result, TypeTree(ownType)), selType)
       case tp =>
         val unapplyErr = if (tp.isError) unapplyFn else notAnExtractor(unapplyFn)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -857,6 +857,7 @@ class Typer extends Namer
         val result = tryWithTypeTest(matched, pt)
         if (result eq matched)
            && pt != defn.ImplicitScrutineeTypeRef
+           && !pt.hasAnnotation(defn.UncheckedAnnot)
            && !(pt <:< tpt1.tpe)
         then
           // no check for matchability if TestTest was applied
@@ -1447,7 +1448,9 @@ class Typer extends Namer
       case _ =>
         if tree.isInline then checkInInlineContext("inline match", tree.srcPos)
         val sel1 = typedExpr(tree.selector)
-        val selType = fullyDefinedType(sel1.tpe, "pattern selector", tree.span).widen
+        var selType = fullyDefinedType(sel1.tpe, "pattern selector", tree.span).widen
+        if sel1.tpe.hasAnnotation(defn.UncheckedAnnot) then
+          selType = AnnotatedType(selType, Annotation(defn.UncheckedAnnot))
 
         /** Extractor for match types hidden behind an AppliedType/MatchAlias */
         object MatchTypeInDisguise {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -52,6 +52,7 @@ class CompilationTests {
       compileFile("tests/pos-special/i7296.scala", defaultOptions.and("-source", "future", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/pos-special/notNull.scala", defaultOptions.and("-Yexplicit-nulls")),
       compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-source", "future", "-feature", "-Xfatal-warnings")),
+      compileFile("tests/pos/10930.scala", defaultOptions.and("-source", "future", "-feature", "-Xfatal-warnings")),
       compileFile("tests/pos-special/i7575.scala", defaultOptions.andLanguageFeature("dynamics")),
       compileFile("tests/pos-special/kind-projector.scala", defaultOptions.and("-Ykind-projector")),
       compileFile("tests/run/i5606.scala", defaultOptions.and("-Yretain-trees")),

--- a/tests/pos/10930.scala
+++ b/tests/pos/10930.scala
@@ -1,0 +1,13 @@
+object Test {
+  type LeafElem[X] = X match
+    case String => Char
+    case Array[t] => LeafElem[t]
+    case Iterable[t] => LeafElem[t]
+    case AnyVal => X
+
+  def leafElem[X](x: X): LeafElem[X] = (x: @unchecked) match
+    case x: String      => x.charAt(0)
+    case x: Array[t]    => leafElem(x(9))
+    case x: Iterable[t] => leafElem(x.head)
+    case x: AnyVal      => x
+}

--- a/tests/pos/i10930.scala
+++ b/tests/pos/i10930.scala
@@ -1,0 +1,13 @@
+object Test {
+  type LeafElem[X] = X match
+    case String => Char
+    case Array[t] => LeafElem[t]
+    case Iterable[t] => LeafElem[t]
+    case AnyVal => X
+
+  def leafElem[X](x: X): LeafElem[X] = (x: @unchecked) match
+    case x: String      => x.charAt(0)
+    case x: Array[t]    => leafElem(x(9))
+    case x: Iterable[t] => leafElem(x.head)
+    case x: AnyVal      => x
+}


### PR DESCRIPTION
This PR fixes #10930 by adding an @unchecked annotation to the prototype while typing unchecked match expressions.