### PR TITLE
Allow \" in single-quoted interpolated string literals

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1053,6 +1053,7 @@ object Scanners {
         getRawStringLit()
       }
 
+    // for interpolated strings
     @annotation.tailrec private def getStringPart(multiLine: Boolean): Unit =
       if (ch == '"')
         if (multiLine) {
@@ -1069,6 +1070,14 @@ object Scanners {
           setStrVal()
           token = STRINGLIT
         }
+      else if (ch == '\\' && !multiLine) {
+        putChar(ch)
+        nextRawChar()
+        if (ch == '"' || ch == '\\')
+          putChar(ch)
+          nextRawChar()
+        getStringPart(multiLine)
+      } 
       else if (ch == '$') {
         nextRawChar()
         if (ch == '$' || ch == '"') {

--- a/docs/docs/internals/syntax-3.1.md
+++ b/docs/docs/internals/syntax-3.1.md
@@ -70,8 +70,10 @@ stringElement    ::=  printableChar \ (‘"’ | ‘\’)
                    |  charEscapeSeq
 multiLineChars   ::=  {[‘"’] [‘"’] char \ ‘"’} {‘"’}
 processedStringLiteral
-                 ::=  alphaid ‘"’ {printableChar \ (‘"’ | ‘$’) | escape} ‘"’
+                 ::=  alphaid ‘"’ {[‘\’] processedStringPart | ‘\\’ | ‘\"’} ‘"’
                    |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘$’) | escape} {‘"’} ‘"""’
+processedStringPart
+                 ::= printableChar \ (‘"’ | ‘$’ | ‘\’) | escape
 escape           ::=  ‘$$’
                    |  ‘$’ letter { letter | digit }
                    |  ‘{’ Block  [‘;’ whiteSpace stringFormat whiteSpace] ‘}’

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -69,8 +69,10 @@ stringElement    ::=  printableChar \ (‘"’ | ‘\’)
                    |  charEscapeSeq
 multiLineChars   ::=  {[‘"’] [‘"’] char \ ‘"’} {‘"’}
 processedStringLiteral
-                 ::=  alphaid ‘"’ {printableChar \ (‘"’ | ‘$’) | escape} ‘"’
+                 ::=  alphaid ‘"’ {[‘\’] processedStringPart | ‘\\’ | ‘\"’} ‘"’
                    |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘$’) | escape} {‘"’} ‘"""’
+processedStringPart
+                 ::= printableChar \ (‘"’ | ‘$’ | ‘\’) | escape
 escape           ::=  ‘$$’
                    |  ‘$’ letter { letter | digit }
                    |  ‘{’ Block  [‘;’ whiteSpace stringFormat whiteSpace] ‘}’

--- a/docs/docs/reference/syntax.md
+++ b/docs/docs/reference/syntax.md
@@ -69,8 +69,10 @@ stringElement    ::=  printableChar \ (‘"’ | ‘\’)
                    |  charEscapeSeq
 multiLineChars   ::=  {[‘"’] [‘"’] char \ ‘"’} {‘"’}
 processedStringLiteral
-                 ::=  alphaid ‘"’ {printableChar \ (‘"’ | ‘$’) | escape} ‘"’
+                 ::=  alphaid ‘"’ {[‘\’] processedStringPart | ‘\\’ | ‘\"’} ‘"’
                    |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘$’) | escape} {‘"’} ‘"""’
+processedStringPart
+                 ::= printableChar \ (‘"’ | ‘$’ | ‘\’) | escape
 escape           ::=  ‘$$’
                    |  ‘$’ letter { letter | digit }
                    |  ‘{’ Block  [‘;’ whiteSpace stringFormat whiteSpace] ‘}’

--- a/tests/neg/t6476.scala
+++ b/tests/neg/t6476.scala
@@ -1,0 +1,9 @@
+// only the last one doesn't parse
+class C {
+  s"""\ """
+  s"""\\"""
+  s"""\"""
+  s"\ "
+  s"\\"
+  s"\" // error
+}      // error (should not be one)

--- a/tests/neg/t6476b.scala
+++ b/tests/neg/t6476b.scala
@@ -1,0 +1,8 @@
+class C {
+  val sa = s"""\""" // error: invalid escape
+  val sb = s"""\\"""
+  val sc = s"""\ """ // error: invalid escape
+  val ra = raw"""\"""
+  val rb = raw"""\\"""
+  val rc = raw"""\ """
+}

--- a/tests/run/t6476.check
+++ b/tests/run/t6476.check
@@ -1,0 +1,13 @@
+"Hello", Alice
+"Hello", Alice
+\"Hello\", Alice
+\"Hello\", Alice
+\"Hello\", Alice
+\"Hello\", Alice
+\TILT\
+\\TILT\\
+\\TILT\\
+\TILT\
+\\TILT\\
+\\TILT\\
+\TILT\

--- a/tests/run/t6476.scala
+++ b/tests/run/t6476.scala
@@ -1,0 +1,23 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val person = "Alice"
+    println(s"\"Hello\", $person")
+    println(s"""\"Hello\", $person""")
+
+    println(f"\"Hello\", $person")
+    println(f"""\"Hello\", $person""")
+
+    println(raw"\"Hello\", $person")
+    println(raw"""\"Hello\", $person""")
+
+    println(s"\\TILT\\")
+    println(f"\\TILT\\")
+    println(raw"\\TILT\\")
+
+    println(s"""\\TILT\\""")
+    println(f"""\\TILT\\""")
+    println(raw"""\\TILT\\""")
+
+    println(raw"""\TILT\""")
+  }
+}


### PR DESCRIPTION
`\"` no longer closes single-quoted interpolated string literals.
The escape sequence is not processed by the scanner.

Forward-port of https://github.com/scala/scala/pull/8830