### PR TITLE
Update -Yindent-colons functionality

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -25,7 +25,8 @@ object Feature:
 
   val dependent = experimental("dependent")
   val erasedDefinitions = experimental("erasedDefinitions")
-  val symbolLiterals: TermName = deprecated("symbolLiterals")
+  val symbolLiterals = deprecated("symbolLiterals")
+  val fewerBraces = experimental("fewerBraces")
 
 /** Is `feature` enabled by by a command-line setting? The enabling setting is
    *

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -121,7 +121,7 @@ class ScalaSettings extends Settings.SettingGroup with CommonScalaSettings {
   val oldSyntax: Setting[Boolean] = BooleanSetting("-old-syntax", "Require `(...)` around conditions.")
   val indent: Setting[Boolean] = BooleanSetting("-indent", "Together with -rewrite, remove {...} syntax when possible due to significant indentation.")
   val noindent: Setting[Boolean] = BooleanSetting("-no-indent", "Require classical {...} syntax, indentation is not significant.", aliases = List("-noindent"))
-  val YindentColons: Setting[Boolean] = BooleanSetting("-Yindent-colons", "Allow colons at ends-of-lines to start indentation blocks.")
+  val YindentColons: Setting[Boolean] = BooleanSetting("-Yindent-colons", "(disabled: use -language:experimental.fewerBraces instead)")
 
   /** Decompiler settings */
   val printTasty: Setting[Boolean] = BooleanSetting("-print-tasty", "Prints the raw tasty.", aliases = List("--print-tasty"))

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1971,7 +1971,6 @@ object Parsers {
         atSpan(in.skipToken()) { Throw(expr()) }
       case RETURN =>
         atSpan(in.skipToken()) {
-          colonAtEOLOpt()
           Return(if (isExprIntro) expr() else EmptyTree, EmptyTree)
         }
       case FOR =>
@@ -2240,10 +2239,6 @@ object Parsers {
         case MACRO =>
           val start = in.skipToken()
           MacroTree(simpleExpr())
-        case COLONEOL =>
-          syntaxError("':' not allowed here")
-          in.nextToken()
-          simpleExpr()
         case _ =>
           if (isLiteral) literal()
           else {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -934,7 +934,6 @@ object Parsers {
           val op = if (isType) typeIdent() else termIdent()
           val top1 = reduceStack(base, top, precedence(op.name), !op.name.isRightAssocOperatorName, op.name, isType)
           opStack = OpInfo(top1, op, in.offset) :: opStack
-          colonAtEOLOpt()
           newLineOptWhenFollowing(canStartOperand)
           if (maybePostfix && !canStartOperand(in.token)) {
             val topInfo = opStack.head

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2246,11 +2246,15 @@ object Parsers {
           val start = in.skipToken()
           MacroTree(simpleExpr(Location.ElseWhere))
         case _ =>
-          if (isLiteral) literal()
-          else {
+          if isLiteral then
+            literal()
+          else if in.isColon() then
+            syntaxError(IllegalStartSimpleExpr(tokenString(in.token)))
+            in.nextToken()
+            simpleExpr(location)
+          else
             syntaxErrorOrIncomplete(IllegalStartSimpleExpr(tokenString(in.token)), expectedOffset)
             errorTermTree
-          }
       }
       simpleExprRest(t, location, canApply)
     }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -743,7 +743,7 @@ object Parsers {
         }
       })
       canRewrite &= (in.isAfterLineEnd || statCtdTokens.contains(in.token)) // test (5)
-      if (canRewrite && (!underColonSyntax || in.colonSyntax)) {
+      if (canRewrite && (!underColonSyntax || in.fewerBracesEnabled)) {
         val openingPatchStr =
           if !colonRequired then ""
           else if testChar(startOpening - 1, Chars.isOperatorPart(_)) then " :"

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -539,10 +539,10 @@ object Scanners {
             currentRegion.knownWidth = nextWidth
         else if (lastWidth != nextWidth)
           errorButContinue(spaceTabMismatchMsg(lastWidth, nextWidth))
-      currentRegion match {
+      currentRegion match
         case Indented(curWidth, others, prefix, outer)
         if curWidth < nextWidth && !others.contains(nextWidth) && nextWidth != lastWidth =>
-          if (token == OUTDENT)
+          if token == OUTDENT && next.token != COLON then
             errorButContinue(
               i"""The start of this line does not match any of the previous indentation widths.
                   |Indentation width of current line : $nextWidth
@@ -550,7 +550,6 @@ object Scanners {
           else
             currentRegion = Indented(curWidth, others + nextWidth, prefix, outer)
         case _ =>
-      }
     end handleNewLine
 
     def spaceTabMismatchMsg(lastWidth: IndentWidth, nextWidth: IndentWidth) =

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -76,6 +76,14 @@ object Scanners {
     def isNestedStart = token == LBRACE || token == INDENT
     def isNestedEnd = token == RBRACE || token == OUTDENT
 
+    /** Is token a COLON, after having converted COLONEOL to COLON?
+     *  The conversion means that indentation is not significant after `:`
+     *  anymore. So, warning: this is a side-effecting operation.
+     */
+    def isColon() =
+      if token == COLONEOL then token = COLON
+      token == COLON
+
     /** Is current token first one after a newline? */
     def isAfterLineEnd: Boolean = lineOffset >= 0
 

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -182,9 +182,6 @@ object Scanners {
       ((if (Config.defaultIndent) !noindentSyntax else ctx.settings.indent.value)
        || rewriteNoIndent)
       && !isInstanceOf[LookaheadScanner]
-    val colonSyntax =
-      ctx.settings.YindentColons.value
-      || rewriteNoIndent
 
     if (rewrite) {
       val s = ctx.settings
@@ -200,6 +197,15 @@ object Scanners {
 
     def featureEnabled(name: TermName) = Feature.enabled(name)(using languageImportContext)
     def erasedEnabled = featureEnabled(Feature.erasedDefinitions) || ctx.settings.YerasedTerms.value
+
+    private var fewerBracesEnabledCache = false
+    private var fewerBracesEnabledCtx: Context = NoContext
+
+    def fewerBracesEnabled =
+      if fewerBracesEnabledCtx ne myLanguageImportContext then
+        fewerBracesEnabledCache = featureEnabled(Feature.fewerBraces)
+        fewerBracesEnabledCtx = myLanguageImportContext
+      fewerBracesEnabledCache
 
     /** All doc comments kept by their end position in a `Map`.
       *
@@ -635,7 +641,7 @@ object Scanners {
               else
                 reset()
         case COLON =>
-          if colonSyntax then observeColonEOL()
+          if fewerBracesEnabled then observeColonEOL()
         case RBRACE | RPAREN | RBRACKET =>
           closeIndented()
         case EOF =>

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -401,8 +401,8 @@ object Scanners {
         true
       }
 
-    def isContinuingParens() =
-      openParensTokens.contains(token)
+    def isContinuing(lastToken: Token) =
+      (openParensTokens.contains(token) || lastToken == RETURN)
       && !pastBlankLine
       && !migrateTo3
       && !noindentSyntax
@@ -504,7 +504,7 @@ object Scanners {
          && canEndStatTokens.contains(lastToken)
          && canStartStatTokens.contains(token)
          && !isLeadingInfixOperator()
-         && !(lastWidth < nextWidth && isContinuingParens())
+         && !(lastWidth < nextWidth && isContinuing(lastToken))
       then
         insert(if (pastBlankLine) NEWLINES else NEWLINE, lineOffset)
       else if indentIsSignificant then

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -89,6 +89,9 @@ object Scanners {
 
     def isOperator =
       token == IDENTIFIER && isOperatorPart(name(name.length - 1))
+
+    def isArrow =
+      token == ARROW || token == CTXARROW
   }
 
   abstract class ScannerCommon(source: SourceFile)(using Context) extends CharArrayReader with TokenData {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -88,7 +88,8 @@ object Scanners {
     def isAfterLineEnd: Boolean = lineOffset >= 0
 
     def isOperator =
-      token == IDENTIFIER && isOperatorPart(name(name.length - 1))
+      token == BACKQUOTED_IDENT
+      || token == IDENTIFIER && isOperatorPart(name(name.length - 1))
 
     def isArrow =
       token == ARROW || token == CTXARROW
@@ -370,8 +371,7 @@ object Scanners {
       */
     def isLeadingInfixOperator(inConditional: Boolean = true) =
       allowLeadingInfixOperators
-      && (  token == BACKQUOTED_IDENT
-         || token == IDENTIFIER && isOperatorPart(name(name.length - 1)))
+      && isOperator
       && (isWhitespace(ch) || ch == LF)
       && !pastBlankLine
       && {
@@ -389,7 +389,7 @@ object Scanners {
         // leading infix operator.
         def assumeStartsExpr(lexeme: TokenData) =
           canStartExprTokens.contains(lexeme.token)
-          && (token != BACKQUOTED_IDENT || !lexeme.isOperator || nme.raw.isUnary(lexeme.name))
+          && (!lexeme.isOperator || nme.raw.isUnary(lexeme.name))
         val lookahead = LookaheadScanner()
         lookahead.allowLeadingInfixOperators = false
           // force a NEWLINE a after current token if it is on its own line

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -273,7 +273,7 @@ object Tokens extends TokensCommon {
   final val closingRegionTokens = BitSet(RBRACE, RPAREN, RBRACKET, CASE) | statCtdTokens
 
   final val canStartIndentTokens: BitSet =
-    statCtdTokens | BitSet(COLONEOL, WITH, EQUALS, ARROW, CTXARROW, LARROW, WHILE, TRY, FOR, IF, THROW)
+    statCtdTokens | BitSet(COLONEOL, WITH, EQUALS, ARROW, CTXARROW, LARROW, WHILE, TRY, FOR, IF, THROW, RETURN)
 
   /** Faced with the choice between a type and a formal parameter, the following
    *  tokens determine it's a formal parameter.

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -49,7 +49,6 @@ class CompilationTests {
         defaultOptions.and("-nowarn", "-Xfatal-warnings")
       ),
       compileFile("tests/pos-special/typeclass-scaling.scala", defaultOptions.and("-Xmax-inlines", "40")),
-      compileFile("tests/pos-special/indent-colons.scala", defaultOptions.and("-Yindent-colons")),
       compileFile("tests/pos-special/i7296.scala", defaultOptions.and("-source", "future", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/pos-special/notNull.scala", defaultOptions.and("-Yexplicit-nulls")),
       compileDir("tests/pos-special/adhoc-extension", defaultOptions.and("-source", "future", "-feature", "-Xfatal-warnings")),

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -227,6 +227,7 @@ Catches           ::=  ‘catch’ (Expr | ExprCaseClause)
 PostfixExpr       ::=  InfixExpr [id]                                           PostfixOp(expr, op)
 InfixExpr         ::=  PrefixExpr
                     |  InfixExpr id [nl] InfixExpr                              InfixOp(expr, op, expr)
+                    |  InfixExpr id ‘:’ IndentedExpr
                     |  InfixExpr MatchClause
 MatchClause       ::=  ‘match’ <<< CaseClauses >>>                              Match(expr, cases)
 PrefixExpr        ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr                       PrefixOp(expr, op)
@@ -244,10 +245,11 @@ SimpleExpr        ::=  SimpleRef
                     |  SimpleExpr ‘.’ MatchClause
                     |  SimpleExpr TypeArgs                                      TypeApply(expr, args)
                     |  SimpleExpr ArgumentExprs                                 Apply(expr, args)
-                    |  SimpleExpr1 :<<< (CaseClauses | Block) >>>               -- under language.experimental.fewerBraces
-                    |  SimpleExpr1 FunParams (‘=>’ | ‘?=>’) indent Block outdent -- under language.experimental.fewerBraces
+                    |  SimpleExpr1 ‘:’ IndentedExpr                             -- under language.experimental.fewerBraces
+                    |  SimpleExpr1 FunParams (‘=>’ | ‘?=>’) IndentedExpr        -- under language.experimental.fewerBraces
                     |  SimpleExpr ‘_’                                           PostfixOp(expr, _) (to be dropped)
                     |  XmlExpr													                        -- to be dropped
+IndentedExpr      ::=  indent CaseClauses | Block outdent
 Quoted            ::=  ‘'’ ‘{’ Block ‘}’
                     |  ‘'’ ‘[’ Type ‘]’
 ExprsInParens     ::=  ExprInParens {‘,’ ExprInParens}
@@ -257,7 +259,7 @@ ParArgumentExprs  ::=  ‘(’ [‘using’] ExprsInParens ‘)’              
                     |  ‘(’ [ExprsInParens ‘,’] PostfixExpr ‘*’ ‘)’              exprs :+ Typed(expr, Ident(wildcardStar))
 ArgumentExprs     ::=  ParArgumentExprs
                     |  BlockExpr
-BlockExpr         ::=  <<< (CaseClauses | Block) >>>
+BlockExpr         ::=  <<< CaseClauses | Block >>>
 Block             ::=  {BlockStat semi} [BlockResult]                           Block(stats, expr?)
 BlockStat         ::=  Import
                     |  {Annotation {nl}} {LocalModifier} Def

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -244,8 +244,10 @@ SimpleExpr        ::=  SimpleRef
                     |  SimpleExpr ‘.’ MatchClause
                     |  SimpleExpr TypeArgs                                      TypeApply(expr, args)
                     |  SimpleExpr ArgumentExprs                                 Apply(expr, args)
+                    |  SimpleExpr1 :<<< BlockExpr >>>                           -- under language.experimental.fewerBraces
+                    |  SimpleExpr1 FunParams (‘=>’ | ‘?=>’) indent Block outdent -- under language.experimental.fewerBraces
                     |  SimpleExpr ‘_’                                           PostfixOp(expr, _) (to be dropped)
-                    |  XmlExpr													(to be dropped)
+                    |  XmlExpr													                        -- to be dropped
 Quoted            ::=  ‘'’ ‘{’ Block ‘}’
                     |  ‘'’ ‘[’ Type ‘]’
 ExprsInParens     ::=  ExprInParens {‘,’ ExprInParens}

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -244,7 +244,7 @@ SimpleExpr        ::=  SimpleRef
                     |  SimpleExpr ‘.’ MatchClause
                     |  SimpleExpr TypeArgs                                      TypeApply(expr, args)
                     |  SimpleExpr ArgumentExprs                                 Apply(expr, args)
-                    |  SimpleExpr1 :<<< BlockExpr >>>                           -- under language.experimental.fewerBraces
+                    |  SimpleExpr1 :<<< (CaseClauses | Block) >>>               -- under language.experimental.fewerBraces
                     |  SimpleExpr1 FunParams (‘=>’ | ‘?=>’) indent Block outdent -- under language.experimental.fewerBraces
                     |  SimpleExpr ‘_’                                           PostfixOp(expr, _) (to be dropped)
                     |  XmlExpr													                        -- to be dropped

--- a/docs/docs/reference/other-new-features/indentation-experimental.md
+++ b/docs/docs/reference/other-new-features/indentation-experimental.md
@@ -1,0 +1,77 @@
+---
+layout: doc-page
+title: "Fewer Braces"
+---
+
+By and large, the possible indentation regions coincide with those regions where braces `{...}` are also legal, no matter whether the braces enclose an expression or a set of definitions. There is one exception, though: Arguments to function can be enclosed in braces but they cannot be simply indented instead. Making indentation always significant for function arguments would be too restrictive and fragile.
+
+To allow such arguments to be written without braces, a variant of the indentation scheme is implemented under language import
+```scala
+import language.experimental.fewerBraces
+```
+Alternatively, it can be enabled with command line option `-language:experimental.fewerBraces`.
+
+This variant is more contentious and less stable than the rest of the significant indentation scheme. It allows to replace a function argument in braces by a `:` at the end of a line and indented code, similar to the convention for class bodies. It also allows to leave out braces around arguments that are multi-line function values.
+
+## Using `:` At End Of Line
+
+
+Similar to what is done for classes and objects, a `:` that follows a function reference at the end of a line means braces can be omitted for function arguments. Example:
+```scala
+times(10):
+   println("ah")
+   println("ha")
+```
+
+Function calls that take multiple argument lists can also be handled this way:
+
+```scala
+val firstLine = files.get(fileName).fold:
+      val fileNames = files.values
+      s"""no file named $fileName found among
+         |${values.mkString(\n)}""".stripMargin
+   :
+      f =>
+         val lines = f.iterator.map(_.readLine)
+         lines.mkString("\n)
+```
+
+
+## Lambda Arguments Without Braces
+
+Braces can also be omitted around multiple line function value arguments. Examples
+```scala
+val xs = elems.map x =>
+   val y = x - 1
+   y * y
+xs.foldLeft (x, y) =>
+   x + y
+```
+Braces can be omitted if the lambda starts with a parameter list and `=>` or `=>?` at the end of one line and it has an indented body on the following lines.
+
+## Syntax Changes
+
+```
+SimpleExpr  ::=  ...
+              |  SimpleExpr : indent (CaseClauses | Block) outdent
+              |  SimpleExpr FunParams (‘=>’ | ‘?=>’) indent Block outdent
+```
+
+Note that indented blocks after `:` or `=>` only work when following a simple expression, they are not allowed after an infix operator. So the following examples
+would be incorrect:
+
+```scala
+   x + :      // error
+      y
+
+   f `andThen` y =>  // error
+      y + 1
+```
+
+Note also that a lambda argument must have the `=>` at the end of a line for braces
+to be optional. For instance, the following would also be incorrect:
+
+```scala
+  xs.map x => x + 1   // error: braces or parentheses are required
+  xs.map(x => x + 1)  // ok
+```

--- a/docs/docs/reference/other-new-features/indentation-experimental.md
+++ b/docs/docs/reference/other-new-features/indentation-experimental.md
@@ -23,6 +23,16 @@ times(10):
    println("ha")
 ```
 
+The colon can also follow an infix operator:
+
+```scala
+credentials ++ :
+   val file = Path.userHome / ".credentials"
+   if file.exists
+   then Seq(Credentials(file))
+   else Seq()
+```
+
 Function calls that take multiple argument lists can also be handled this way:
 
 ```scala
@@ -39,7 +49,7 @@ val firstLine = files.get(fileName).fold:
 
 ## Lambda Arguments Without Braces
 
-Braces can also be omitted around multiple line function value arguments. Examples
+Braces can also be omitted around multiple line function value arguments:
 ```scala
 val xs = elems.map x =>
    val y = x - 1
@@ -52,26 +62,21 @@ Braces can be omitted if the lambda starts with a parameter list and `=>` or `=>
 ## Syntax Changes
 
 ```
-SimpleExpr  ::=  ...
-              |  SimpleExpr : indent (CaseClauses | Block) outdent
-              |  SimpleExpr FunParams (‘=>’ | ‘?=>’) indent Block outdent
+SimpleExpr       ::=  ...
+                   |  SimpleExpr `:` IndentedArgument
+                   |  SimpleExpr FunParams (‘=>’ | ‘?=>’) IndentedArgument
+InfixExpr        ::=  ...
+                   |  InfixExpr id `:` IndentedArgument
+IndentedArgument ::=  indent (CaseClauses | Block) outdent
 ```
 
-Note that indented blocks after `:` or `=>` only work when following a simple expression, they are not allowed after an infix operator. So the following examples
-would be incorrect:
-
-```scala
-   x + :      // error
-      y
-
-   f `andThen` y =>  // error
-      y + 1
-```
-
-Note also that a lambda argument must have the `=>` at the end of a line for braces
+Note that a lambda argument must have the `=>` at the end of a line for braces
 to be optional. For instance, the following would also be incorrect:
 
 ```scala
   xs.map x => x + 1   // error: braces or parentheses are required
+```
+The lambda has to be enclosed in braces or parentheses:
+```scala
   xs.map(x => x + 1)  // ok
 ```

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -391,8 +391,11 @@ The `-indent` option only works on [new-style syntax](./control-syntax.md). So t
 
 Generally, the possible indentation regions coincide with those regions where braces `{...}` are also legal, no matter whether the braces enclose an expression or a set of definitions. There is one exception, though: Arguments to function can be enclosed in braces but they cannot be simply indented instead. Making indentation always significant for function arguments would be too restrictive and fragile.
 
-To allow such arguments to be written without braces, a variant of the indentation scheme is implemented under
-option `-Yindent-colons`. This variant is more contentious and less stable than the rest of the significant indentation scheme. In this variant, a colon `:` at the end of a line is also one of the possible tokens that opens an indentation region. Examples:
+To allow such arguments to be written without braces, a variant of the indentation scheme is implemented under language import
+```scala
+import language.experimental.fewerBraces
+```
+This variant is more contentious and less stable than the rest of the significant indentation scheme. In this variant, a colon `:` at the end of a line is also one of the possible tokens that opens an indentation region. Examples:
 
 ```scala
 times(10):

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -43,6 +43,9 @@ object language:
      */
     object erasedDefinitions
 
+    /** Experimental support for using indentation for arguments
+     */
+    object fewerBraces
   end experimental
 
   /** The deprecated object contains features that are no longer officially suypported in Scala.

--- a/tests/neg/closure-args.scala
+++ b/tests/neg/closure-args.scala
@@ -1,0 +1,7 @@
+val x = List().map (x: => Int) => // error
+  ???
+val y = List() map x =>  // error
+  x + 1   // error
+val z = List() map + => // error
+  ???
+

--- a/tests/neg/closure-args.scala
+++ b/tests/neg/closure-args.scala
@@ -1,3 +1,5 @@
+import language.experimental.fewerBraces
+
 val x = List().map (x: => Int) => // error
   ???
 val y = List() map x =>  // error

--- a/tests/neg/i1779.scala
+++ b/tests/neg/i1779.scala
@@ -8,6 +8,6 @@ object Test {
   def f = {
     val _parent = 3
     q"val hello = $_parent"
-    q"class $_" // error // error
-  } // error
+    q"class $_" // error // error // error
+  }
 }

--- a/tests/neg/i6059.scala
+++ b/tests/neg/i6059.scala
@@ -1,3 +1,3 @@
 def I0(I1: Int ) = I1
-val I1 = I0(I0 i2  // error
-) => true
+val I1 = I0(I0 i2) => // error
+  true

--- a/tests/neg/i7751.scala
+++ b/tests/neg/i7751.scala
@@ -1,2 +1,3 @@
+import language.experimental.fewerBraces
 val a = Some(a=a,)=> // error // error // error
 val a = Some(x=y,)=>

--- a/tests/neg/i7751.scala
+++ b/tests/neg/i7751.scala
@@ -1,2 +1,2 @@
-val a = Some(a=a,)=> // error // error
+val a = Some(a=a,)=> // error // error // error
 val a = Some(x=y,)=>

--- a/tests/neg/indent-colons.scala
+++ b/tests/neg/indent-colons.scala
@@ -1,7 +1,0 @@
-import language.experimental.fewerBraces
-
-val x = 1.+ :  // ok
-  2
-
-val y = 1 + : // error // error
-  2  // error

--- a/tests/neg/indent-colons.scala
+++ b/tests/neg/indent-colons.scala
@@ -1,0 +1,7 @@
+import language.experimental.fewerBraces
+
+val x = 1.+ :  // ok
+  2
+
+val y = 1 + : // error // error
+  2  // error

--- a/tests/neg/indent-experimental.scala
+++ b/tests/neg/indent-experimental.scala
@@ -1,0 +1,15 @@
+import language.experimental.fewerBraces
+
+val x =
+  if true then:  // error
+    1
+  else:  // error
+    2
+
+
+val credentials = List("OK")
+val all = credentials ++ :  // error
+  val file = "file"  // error
+  if file.isEmpty    // error
+  then Seq("none")
+  else Seq(file)

--- a/tests/neg/indent-experimental.scala
+++ b/tests/neg/indent-experimental.scala
@@ -6,10 +6,3 @@ val x =
   else:  // error
     2
 
-
-val credentials = List("OK")
-val all = credentials ++ :  // error
-  val file = "file"  // error
-  if file.isEmpty    // error
-  then Seq("none")
-  else Seq(file)

--- a/tests/pos/closure-args.scala
+++ b/tests/pos/closure-args.scala
@@ -1,0 +1,14 @@
+val xs = List(1, 2, 3)
+val ys = xs.map x =>
+  x + 1
+val x = ys.foldLeft(0) (x, y) =>
+  x + y
+val y = ys.foldLeft(0) (x: Int, y: Int) =>
+  val z = x + y
+  z * z
+val as: Int = xs
+  .map x =>
+    x * x
+  .filter y =>
+    y > 0
+  (0)

--- a/tests/pos/closure-args.scala
+++ b/tests/pos/closure-args.scala
@@ -1,3 +1,5 @@
+import language.experimental.fewerBraces
+
 val xs = List(1, 2, 3)
 val ys = xs.map x =>
   x + 1

--- a/tests/pos/indent-colons.scala
+++ b/tests/pos/indent-colons.scala
@@ -117,3 +117,25 @@ end Coder
 
 object Test22:
   def foo: Int = 22
+
+def tryEither[T](x: T)(y: Int => T): T = ???
+
+def test1 =
+  tryEither:
+      "hello"
+    :
+      y => y.toString
+
+def test2 =
+  tryEither:
+    "hello"
+  :
+    _.toString
+
+
+val o =
+  Some(3).fold:
+    "nothing"
+  :
+    x => x.toString
+

--- a/tests/pos/indent-colons.scala
+++ b/tests/pos/indent-colons.scala
@@ -139,3 +139,30 @@ val o =
   :
     x => x.toString
 
+object Test23:
+  val x = 1.+ :  // ok
+    2
+
+  val y = 1 + : // ok
+    2
+
+  val r = 1 to:
+    100
+
+  val credentials = List("OK")
+  val all = credentials ++ :
+    val file = "file"
+    if file.isEmpty
+    then Seq("none")
+    else Seq(file)
+
+extension (x: Boolean)
+  infix def or (y: => Boolean) = x || y
+
+def test24(x: Int, y: Int) =
+  x < y or:
+    x > y
+  or:
+    x == y
+
+

--- a/tests/pos/indent-colons.scala
+++ b/tests/pos/indent-colons.scala
@@ -1,3 +1,4 @@
+import language.experimental.fewerBraces
 object Test:
 
   locally:

--- a/tests/run/returns.scala
+++ b/tests/run/returns.scala
@@ -1,0 +1,16 @@
+def foo(x: Int): Int =
+  if x == 1 then
+    return
+      x
+  else
+    2
+
+def bar(): Unit =
+  return
+  assert(false)
+
+@main def Test =
+  assert(foo(1) == 1)
+  bar()
+
+

--- a/tests/run/returns.scala
+++ b/tests/run/returns.scala
@@ -1,7 +1,8 @@
 def foo(x: Int): Int =
   if x == 1 then
     return
-      x
+      val y = 2
+      x + y
   else
     2
 
@@ -10,7 +11,7 @@ def bar(): Unit =
   assert(false)
 
 @main def Test =
-  assert(foo(1) == 1)
+  assert(foo(1) == 3)
   bar()
 
 


### PR DESCRIPTION
Move functionality under -Yindent-colons closer to what we discussed in the contributors thread

 - [x] Replace -Yindent-colons with `experimental.fewerBraces` language feature
 - [x] Accept `:` at EOL as a normal `:` if it cannot start an argument
 - [x] Use normal indentation rules after `return`; no `:` required or allowed
 - [x] Allow closure arguments to be passed without enclosing braces

NOTE: The changes to indentation after `return` are in standard Scala 3. The other implemented functionality is under an language import `import experimental.fewerBraces`. It's not part of Scala 3.0 and might still change in the future.

I also attempted a change to make indentation significant after symbolic operators. But I had to abandon that part, since it changes semantics. Consider
```scala
  val x = a -
     b + c
```
If we made indentation significant after `-`, the expression would be parsed as `a - (b + c)` instead of `(a - b) + c`. So we can't do that.

