### PR TITLE
Move to sbt slash syntax

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -328,7 +328,7 @@ object projects:
     project       = "stdLib213",
     extraSbtArgs  = List("-Dscala.build.compileWithDotty=true"),
     sbtTestCommand   = """library/compile""",
-    sbtPublishCommand = """set publishArtifact in (library, Compile, packageDoc) := false ;library/publishLocal""",
+    sbtPublishCommand = """set library/Compile/packageDoc/publishArtifact := false; library/publishLocal""",
     // sbtDocCommand = "library/doc" // Does no compile? No idea :/
   )
 

--- a/project/NoBloopExport.scala
+++ b/project/NoBloopExport.scala
@@ -23,8 +23,8 @@ object NoBloopExport {
         Nil
       case Some(key) =>
         Seq(
-            key in Compile := None,
-            key in Test := None,
+            Compile / key := None,
+            Test / key := None,
         )
     }
   }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -5,12 +5,12 @@ libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "4.11.0.2018030
 // so that we can use the current in-development version of the plugin
 // in our build instead of a released version.
 
-unmanagedSourceDirectories in Compile += baseDirectory.value / "../sbt-dotty/src"
+Compile / unmanagedSourceDirectories += baseDirectory.value / "../sbt-dotty/src"
 
 // Keep in sync with `sbt-dotty` config in Build.scala
 libraryDependencies ++= Seq(
   Dependencies.`jackson-databind`,
   Dependencies.newCompilerInterface
 )
-unmanagedSourceDirectories in Compile +=
+Compile / unmanagedSourceDirectories +=
   baseDirectory.value / "../language-server/src/dotty/tools/languageserver/config"

--- a/sbt-dotty/sbt-test/compilerReporter/i7442/project/Reporter.scala
+++ b/sbt-dotty/sbt-test/compilerReporter/i7442/project/Reporter.scala
@@ -23,7 +23,7 @@ object Reporter {
     }
 
   lazy val checkSettings = Seq(
-    compilerReporter in (Compile, compile) := reporter,
+    Compile / compile / compilerReporter := reporter,
     check := (compile in Compile).failure.map(_ => {
       println(reporter.problems.toList)
       assert(reporter.problems.length == 1)

--- a/sbt-dotty/sbt-test/compilerReporter/simple/project/Reporter.scala
+++ b/sbt-dotty/sbt-test/compilerReporter/simple/project/Reporter.scala
@@ -23,7 +23,7 @@ object Reporter {
     }
 
   lazy val checkSettings = Seq(
-    compilerReporter in (Compile, compile) := reporter,
+    Compile / compile / compilerReporter := reporter,
     check := (compile in Compile).failure.map(_ => {
       val problems = reporter.problems
       println(problems.toList)
@@ -32,11 +32,11 @@ object Reporter {
       // make sure position reported by zinc are proper
       val mainProblem = problems.head
 
-      val line = mainProblem.position().line() 
+      val line = mainProblem.position().line()
       assert(line.isPresent() == true)
       assert(line.get() == 9)
 
-      val pointer = mainProblem.position().pointer() 
+      val pointer = mainProblem.position().pointer()
       assert(pointer.isPresent() == true)
       assert(pointer.get() == 10)
 

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyIDEPlugin.scala
@@ -51,7 +51,7 @@ object DottyIDEPlugin extends AutoPlugin {
     val extracted = Project.extract(state)
     val settings = extracted.structure.data
 
-    if (projRefs.forall(projRef => scalaVersion.in(projRef).get(settings).get == newScalaVersion))
+    if (projRefs.forall(projRef => (projRef / scalaVersion).get(settings).get == newScalaVersion))
       state
     else {
       def matchingSetting(setting: Setting[_]) =
@@ -60,7 +60,7 @@ object DottyIDEPlugin extends AutoPlugin {
 
       val newSettings = extracted.session.mergeSettings.collect {
         case setting if matchingSetting(setting) =>
-          scalaVersion in setting.key.scope := newScalaVersion
+          setting.key.scope / scalaVersion := newScalaVersion
       }
       val newSession = extracted.session.appendRaw(newSettings)
       BuiltinCommands.reapply(newSession, extracted.structure, state)
@@ -82,14 +82,14 @@ object DottyIDEPlugin extends AutoPlugin {
 
     val (dottyVersions, dottyProjRefs) =
       structure.allProjectRefs.flatMap { projRef =>
-        if (excludeFromIDE.in(projRef).get(settings) == Some(true))
+        if ((projRef / excludeFromIDE).get(settings) == Some(true))
           None
         else {
-          val version = scalaVersion.in(projRef).get(settings).get
+          val version = (projRef / scalaVersion).get(settings).get
           if (isDottyVersion(version))
             Some((version, projRef))
           else
-            crossScalaVersions.in(projRef).get(settings).get.filter(isDottyVersion).sorted.lastOption match {
+            (projRef / crossScalaVersions).get(settings).get.filter(isDottyVersion).sorted.lastOption match {
               case Some(v) =>
                 Some((v, projRef))
               case _ =>
@@ -134,11 +134,11 @@ object DottyIDEPlugin extends AutoPlugin {
     val joinedTask = projRefs.flatMap { projRef =>
       val project = Project.getProjectForReference(projRef, structure).get
       project.configurations.flatMap { config =>
-        excludeFromIDE.in(projRef, config).get(settings) match {
+        (projRef / config / excludeFromIDE).get(settings) match {
           case Some(true) =>
             None // skip this configuration
           case _ =>
-            key.in(projRef, config).get(settings)
+            (projRef / config / key).get(settings)
         }
       }
     }.join
@@ -288,7 +288,7 @@ object DottyIDEPlugin extends AutoPlugin {
   private def makeId(name: String, config: String): String = s"$name/$config"
 
   private def projectConfigTask(config: Configuration): Initialize[Task[Option[ProjectConfig]]] = Def.taskDyn {
-    val depClasspath = Attributed.data((dependencyClasspath in config).value)
+    val depClasspath = Attributed.data((config / dependencyClasspath).value)
     val projectName = name.value
 
     // Try to detect if this is a real Scala project or not. This is pretty
@@ -314,14 +314,14 @@ object DottyIDEPlugin extends AutoPlugin {
       // Not needed to generate the config, but this guarantees that the
       // generated config is usable by an IDE without any extra compilation
       // step.
-      val _ = (compile in config).value
+      val _ = (config / compile).value
 
       val project = thisProject.value
       val id = makeId(project.id, config.name)
-      val compilerVersion = (scalaVersion in config).value
-      val compilerArguments = (scalacOptions in config).value
-      val sourceDirectories = (unmanagedSourceDirectories in config).value ++ (managedSourceDirectories in config).value
-      val classDir = (classDirectory in config).value
+      val compilerVersion = (config / scalaVersion).value
+      val compilerArguments = (config / scalacOptions).value
+      val sourceDirectories = (config / unmanagedSourceDirectories).value ++ (config / managedSourceDirectories).value
+      val classDir = (config / classDirectory).value
       val extracted = Project.extract(state.value)
       val settings = extracted.structure.data
 
@@ -331,7 +331,7 @@ object DottyIDEPlugin extends AutoPlugin {
         // We filter out dependencies that do not compile using Dotty
         val classpathProjectDependencies =
           project.dependencies.filter { d =>
-            val version = scalaVersion.in(d.project).get(settings).get
+            val version = (d.project / scalaVersion).get(settings).get
             isDottyVersion(version)
           }.map(d => projectDependencyName(d, config, project, logger))
         val configDependencies =
@@ -361,8 +361,8 @@ object DottyIDEPlugin extends AutoPlugin {
     // TODO: It would be better to use Def.derive to define projectConfig in
     // every configuration where the keys it depends on exist, however this
     // currently breaks aggregated tasks: https://github.com/sbt/sbt/issues/3580
-    projectConfig in Compile := projectConfigTask(Compile).value,
-    projectConfig in Test := projectConfigTask(Test).value
+    Compile / projectConfig := projectConfigTask(Compile).value,
+    Test / projectConfig := projectConfigTask(Test).value
   )
 
   override def buildSettings: Seq[Setting[_]] = Seq(
@@ -432,7 +432,7 @@ object DottyIDEPlugin extends AutoPlugin {
       val eligibleConfigs = activeProjectConfigs.filter { c =>
         val configKey = ConfigKey.configurationToKey(c)
         // Consider only configurations where the `compile` key is defined
-        val eligibleKey = compile in (thisProjectRef, configKey)
+        val eligibleKey = (thisProjectRef / configKey / compile)
         eligibleKey.get(data) match {
           case Some(t) =>
             // Sbt seems to return tasks for the extended configurations (looks like a big bug)

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -173,7 +173,7 @@ object DottyPlugin extends AutoPlugin {
   }
 
   override val globalSettings: Seq[Def.Setting[_]] = Seq(
-    onLoad in Global := onLoad.in(Global).value.andThen { state =>
+    Global / onLoad := (Global / onLoad).value.andThen { state =>
 
       val requiredVersion = ">=1.4.4"
 
@@ -231,8 +231,8 @@ object DottyPlugin extends AutoPlugin {
           scalaOrganization.value
       },
 
-      incOptions in Compile := {
-        val inc = (incOptions in Compile).value
+      Compile / incOptions := {
+        val inc = (Compile / incOptions).value
         if (isDotty.value)
           dottyPatchIncOptions(inc)
         else
@@ -246,7 +246,7 @@ object DottyPlugin extends AutoPlugin {
             dependencyResolution.value,
             scalaModuleInfo.value,
             updateConfiguration.value,
-            (unresolvedWarningConfiguration in update).value,
+            (update / unresolvedWarningConfiguration).value,
             streams.value.log,
           )
           Option(getJar(updateReport, scalaOrganization.value, scala3Artefact(scalaVersion.value, "sbt-bridge"), scalaVersion.value))
@@ -318,11 +318,11 @@ object DottyPlugin extends AutoPlugin {
       // so we need to manually set `classpathOptions in console` to something sensible,
       // ideally this would be "whatever would be set if this plugin was not enabled",
       // but I can't find a way to do this, so we default to whatever is set in ThisBuild.
-      classpathOptions in console := {
+      console / classpathOptions := {
         if (isDotty.value)
           classpathOptions.value // The Dotty REPL doesn't require anything special on its classpath
         else
-          (classpathOptions in console in ThisBuild).value
+          (ThisBuild / console / classpathOptions).value
       },
       classpathOptions := {
         val old = classpathOptions.value
@@ -377,7 +377,7 @@ object DottyPlugin extends AutoPlugin {
         v.startsWith("3.0.0") && !v.startsWith("3.0.0-M1") && !v.startsWith("3.0.0-M2")
       },
       // We need to add doctool classes to the classpath so they can be called
-      scalaInstance in doc := Def.taskDyn {
+      doc / scalaInstance := Def.taskDyn {
         if (isDotty.value)
           if (useScaladoc.value) {
             val v = scalaVersion.value
@@ -387,7 +387,7 @@ object DottyPlugin extends AutoPlugin {
             dottyScalaInstanceTask(name)
           } else dottyScalaInstanceTask(scala3Artefact(scalaVersion.value, "doc"))
         else
-          Def.valueStrict { (scalaInstance in doc).taskValue }
+          Def.valueStrict { (doc / scalaInstance).taskValue }
       }.value,
 
       // Because managedScalaInstance is false, sbt won't add the standard library to our dependencies for us
@@ -525,7 +525,7 @@ object DottyPlugin extends AutoPlugin {
         dependencyResolution.value,
         scalaModuleInfo.value,
         updateConfiguration.value,
-        (unresolvedWarningConfiguration in update).value,
+        (update / unresolvedWarningConfiguration).value,
         streams.value.log)
     val scalaLibraryJar = getJar(updateReport,
       "org.scala-lang", "scala-library", revision = AllPassFilter)


### PR DESCRIPTION
The old syntax will be deprecated in sbt 1.5: https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+to+slash+syntax