### PR TITLE
Extract the function type and SAM in union type

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1651,6 +1651,24 @@ object Types {
       case _ => resultType
     }
 
+    /** Find the function type in union.
+     *  If there are multiple function types, NoType is returned.
+     */
+    def findFuntionTypeInUnion(using Context): Type = this match {
+      case t: OrType =>
+        val t1 = t.tp1.findFuntionTypeInUnion
+        if t1 == NoType then t.tp2.findFuntionTypeInUnion else
+          val t2 = t.tp2.findFuntionTypeInUnion
+          // Returen NoType if the union contains multiple function types
+          if t2 == NoType then t1 else NoType
+      case t if defn.isNonRefinedFunction(t) =>
+        t
+      case t @ SAMType(_: MethodType) =>
+        t
+      case _ =>
+        NoType
+    }
+
     /** This type seen as a TypeBounds */
     final def bounds(using Context): TypeBounds = this match {
       case tp: TypeBounds => tp

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1654,16 +1654,16 @@ object Types {
     /** Find the function type in union.
      *  If there are multiple function types, NoType is returned.
      */
-    def findFuntionTypeInUnion(using Context): Type = this match {
+    def findFunctionTypeInUnion(using Context): Type = this match {
       case t: OrType =>
-        val t1 = t.tp1.findFuntionTypeInUnion
-        if t1 == NoType then t.tp2.findFuntionTypeInUnion else
-          val t2 = t.tp2.findFuntionTypeInUnion
+        val t1 = t.tp1.findFunctionTypeInUnion
+        if t1 == NoType then t.tp2.findFunctionTypeInUnion else
+          val t2 = t.tp2.findFunctionTypeInUnion
           // Returen NoType if the union contains multiple function types
           if t2 == NoType then t1 else NoType
       case t if defn.isNonRefinedFunction(t) =>
         t
-      case t @ SAMType(_: MethodType) =>
+      case t @ SAMType(_) =>
         t
       case _ =>
         NoType

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1138,7 +1138,7 @@ class Typer extends Namer
     pt1 match {
       case tp: TypeParamRef =>
         decomposeProtoFunction(ctx.typerState.constraint.entry(tp).bounds.hi, defaultArity, tree)
-      case _ => pt1.findFuntionTypeInUnion match {
+      case _ => pt1.findFunctionTypeInUnion match {
         case pt1 if defn.isNonRefinedFunction(pt1) =>
           // if expected parameter type(s) are wildcards, approximate from below.
           // if expected result type is a wildcard, approximate from above.
@@ -1403,7 +1403,7 @@ class Typer extends Namer
       if (tree.tpt.isEmpty)
         meth1.tpe.widen match {
           case mt: MethodType =>
-            pt.findFuntionTypeInUnion match {
+            pt.findFunctionTypeInUnion match {
               case pt @ SAMType(sam)
               if !defn.isFunctionType(pt) && mt <:< sam =>
                 // SAMs of the form C[?] where C is a class cannot be conversion targets.

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1125,6 +1125,7 @@ class Typer extends Namer
           newTypeVar(apply(bounds.orElse(TypeBounds.empty)).bounds)
         case _ => mapOver(t)
     }
+
     val pt1 = pt.stripTypeVar.dealias
     if (pt1 ne pt1.dropDependentRefinement)
        && defn.isContextFunctionType(pt1.nonPrivateMember(nme.apply).info.finalResultType)
@@ -1133,22 +1134,25 @@ class Typer extends Namer
         i"""Implementation restriction: Expected result type $pt1
            |is a curried dependent context function type. Such types are not yet supported.""",
         tree.srcPos)
+
     pt1 match {
-      case pt1 if defn.isNonRefinedFunction(pt1) =>
-        // if expected parameter type(s) are wildcards, approximate from below.
-        // if expected result type is a wildcard, approximate from above.
-        // this can type the greatest set of admissible closures.
-        (pt1.argTypesLo.init, typeTree(interpolateWildcards(pt1.argTypesHi.last)))
-      case SAMType(sam @ MethodTpe(_, formals, restpe)) =>
-        (formals,
-         if (sam.isResultDependent)
-           untpd.DependentTypeTree(syms => restpe.substParams(sam, syms.map(_.termRef)))
-         else
-           typeTree(restpe))
       case tp: TypeParamRef =>
         decomposeProtoFunction(ctx.typerState.constraint.entry(tp).bounds.hi, defaultArity, tree)
-      case _ =>
-        (List.tabulate(defaultArity)(alwaysWildcardType), untpd.TypeTree())
+      case _ => pt1.findFuntionTypeInUnion match {
+        case pt1 if defn.isNonRefinedFunction(pt1) =>
+          // if expected parameter type(s) are wildcards, approximate from below.
+          // if expected result type is a wildcard, approximate from above.
+          // this can type the greatest set of admissible closures.
+          (pt1.argTypesLo.init, typeTree(interpolateWildcards(pt1.argTypesHi.last)))
+        case SAMType(sam @ MethodTpe(_, formals, restpe)) =>
+          (formals,
+            if sam.isResultDependent then
+              untpd.DependentTypeTree(syms => restpe.substParams(sam, syms.map(_.termRef)))
+            else
+              typeTree(restpe))
+        case _ =>
+          (List.tabulate(defaultArity)(alwaysWildcardType), untpd.TypeTree())
+      }
     }
   }
 
@@ -1399,7 +1403,7 @@ class Typer extends Namer
       if (tree.tpt.isEmpty)
         meth1.tpe.widen match {
           case mt: MethodType =>
-            pt.stripNull match {
+            pt.findFuntionTypeInUnion match {
               case pt @ SAMType(sam)
               if !defn.isFunctionType(pt) && mt <:< sam =>
                 // SAMs of the form C[?] where C is a class cannot be conversion targets.

--- a/tests/explicit-nulls/pos/i11694.scala
+++ b/tests/explicit-nulls/pos/i11694.scala
@@ -1,0 +1,4 @@
+def test = {
+  val x = new java.util.ArrayList[String]()
+  val y = x.stream().nn.filter(s => s.nn.length > 0)
+}

--- a/tests/neg/i11694.scala
+++ b/tests/neg/i11694.scala
@@ -1,0 +1,19 @@
+def test1 = {
+  def f11: (Int => Int) | Unit = x => x + 1
+  def f12: Null | (Int => Int) = x => x + 1
+
+  def f21: (Int => Int) | Null = x => x + 1
+  def f22: Null | (Int => Int) = x => x + 1
+}
+
+def test2 = {
+  def f1: (Int => String) | (Int => Int) | Null = x => x + 1 // error
+  def f2: (Int => String) | Function[String, Int] | Null = x => "" + x // error
+  def f3: Function[Int, Int] | Function[String, Int] | Null = x => x + 1 // error
+}
+
+def test3 = {
+  import java.util.function.Function
+  val f1: Function[String, Int] | Unit = x => x.length
+  val f2: Function[String, Int] | Null = x => x.length
+}


### PR DESCRIPTION
This PR fixs #11694 by extracting the function type and SAM in union type.

When there are multiple function types (or SAMs), the type will be abandoned.