### PR TITLE
Fix #11178: remove unsound tweak for F-bounds in isInstanceOf check

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2687,8 +2687,8 @@ object TypeComparer {
   def dropTransparentTraits(tp: Type, bound: Type)(using Context): Type =
     comparing(_.dropTransparentTraits(tp, bound))
 
-  def constrainPatternType(pat: Type, scrut: Type)(using Context): Boolean =
-    comparing(_.constrainPatternType(pat, scrut))
+  def constrainPatternType(pat: Type, scrut: Type, widenParams: Boolean = true)(using Context): Boolean =
+    comparing(_.constrainPatternType(pat, scrut, widenParams))
 
   def explained[T](op: ExplainingTypeComparer => T, header: String = "Subtype trace:")(using Context): String =
     comparing(_.explained(op, header))

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -80,15 +80,25 @@ object TypeTestsCasts {
       debug.println("P1 : " + P1.show)
       debug.println("X : " + X.show)
 
-      // It does not matter if P1 is not a subtype of X.
+      // It does not matter whether P1 is a subtype of X or not.
       // It just tries to infer type arguments of P1 from X if the value x
       // conforms to the type skeleton pre.F[_]. Then it goes on to check
       // if P1 <: P, which means the type arguments in P are trivial,
       // thus no runtime checks are needed for them.
       withMode(Mode.GadtConstraintInference) {
+        // Why not widen type arguments here? Given the following program
+        //
+        //   trait Tree[-T] class Ident[-T] extends Tree[T] def foo1(tree:
+        //   Tree[Int]) = tree.isInstanceOf[Ident[Int]]
+        //
+        // In checking whether the test tree.isInstanceOf[Ident[Int]]
+        // is realizable, we want to constrain Ident[X] <: Tree[Int],
+        // such that we can infer X = Int and Ident[X] <:< Ident[Int].
+        //
+        // If we perform widening, we will get X = Nothing, and we don't have
+        // Ident[X] <:< Ident[Int] any more.
         TypeComparer.constrainPatternType(P1, X, widenParams = false)
         debug.println(TypeComparer.explained(_.constrainPatternType(P1, X, widenParams = false)))
-        true
       }
 
       // Maximization of the type means we try to cover all possible values

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -133,7 +133,7 @@ object TypeTestsCasts {
           case _                   => recur(defn.AnyType, tpT)
         }
       case tpe: AppliedType     =>
-        X.widen match {
+        X.widenDealias match {
           case OrType(tp1, tp2) =>
             // This case is required to retrofit type inference,
             // which cut constraints in the following two cases:

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -34,10 +34,6 @@ object TypeTestsCasts {
    *
    *  First do the following substitution:
    *  (a) replace `T @unchecked` and pattern binder types (e.g., `_$1`) in P with WildcardType
-   *  (b) replace pattern binder types (e.g., `_$1`) in X:
-   *      - variance = 1  : hiBound
-   *      - variance = -1 : loBound
-   *      - variance = 0  : OrType(Any, Nothing) // TODO: use original type param bounds
    *
    *  Then check:
    *
@@ -63,16 +59,6 @@ object TypeTestsCasts {
           WildcardType
         case AnnotatedType(_, annot) if annot.symbol == defn.UncheckedAnnot =>
           WildcardType
-        case _ => mapOver(tp)
-      }
-    }.apply(tp)
-
-    def replaceX(tp: Type)(using Context) = new TypeMap {
-      def apply(tp: Type) = tp match {
-        case tref: TypeRef if tref.typeSymbol.isPatternBound =>
-          if (variance == 1) tref.info.hiBound
-          else if (variance == -1) tref.info.loBound
-          else OrType(defn.AnyType, defn.NothingType, soft = true) // TODO: what does this line do?
         case _ => mapOver(tp)
       }
     }.apply(tp)
@@ -154,7 +140,7 @@ object TypeTestsCasts {
       case _                    => true
     })
 
-    val res = recur(replaceX(X.widen), replaceP(P))
+    val res = recur(X.widen, replaceP(P))
 
     debug.println(i"checking  ${X.show} isInstanceOf ${P} = $res")
 

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -748,7 +748,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         tpd.Closure(meth, tss => xCheckMacroedOwners(xCheckMacroValidExpr(rhsFn(meth, tss.head.map(withDefaultPos))), meth))
 
       def unapply(tree: Block): Option[(List[ValDef], Term)] = tree match {
-        case Block((ddef @ DefDef(_, TermParamClause(params) :: Nil, _, Some(body))) :: Nil, Closure(meth, _))
+        case Block((ddef @ DefDef(_, tpd.ValDefs(params) :: Nil, _, Some(body))) :: Nil, Closure(meth, _))
         if ddef.symbol == meth.symbol =>
           Some((params, body))
         case _ => None

--- a/compiler/test/dotty/tools/dotc/parsing/StringInterpolationPositionTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/StringInterpolationPositionTest.scala
@@ -23,8 +23,8 @@ class StringInterpolationPositionTest extends ParserTest {
   def interpolationLiteralPosition: Unit = {
     val t = parseText(program)
     t match {
-      case PackageDef(_, List(TypeDef(_, Template(_, _, _, statements: List[Tree])))) => {
-        val interpolations = statements.collect{ case ValDef(_, _, InterpolatedString(_, int)) => int }
+      case PackageDef(_, List(TypeDef(_, tpl: Template))) => {
+        val interpolations = tpl.body.collect{ case ValDef(_, _, InterpolatedString(_, int)) => int }
         val lits = interpolations.flatten.flatMap {
           case l @ Literal(_) => List(l)
           case Thicket(trees) => trees.collect { case l @ Literal(_) => l }

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/WikiDocRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/WikiDocRenderer.scala
@@ -13,7 +13,7 @@ class DocRender(signatureRenderer: SignatureRenderer)(using DocContext):
     case md: MdNode => renderMarkdown(md)
     case Nil => raw("")
     case Seq(elem: WikiDocElement) => renderElement(elem)
-    case list: Seq[WikiDocElement] => div(list.map(renderElement))
+    case list: Seq[WikiDocElement @unchecked] => div(list.map(renderElement))
 
   private def renderMarkdown(el: MdNode): AppliedTag =
     raw(DocFlexmarkRenderer.render(el)( (link,name) =>

--- a/tests/neg-custom-args/isInstanceOf/html.scala
+++ b/tests/neg-custom-args/isInstanceOf/html.scala
@@ -1,0 +1,18 @@
+object HTML:
+  type AttrArg = AppliedAttr | Seq[AppliedAttr]
+  opaque type AppliedAttr = String
+  opaque type AppliedTag = StringBuilder
+
+  case class Tag(name: String):
+    def apply(attrs: AttrArg*): AppliedTag = {
+      val sb = StringBuilder()
+      sb.append(s"<$name")
+      attrs.filter(_ != Nil).foreach{
+        case s: Seq[AppliedAttr] =>
+          s.foreach(sb.append(" ").append)
+        case s: Seq[Int] => // error
+        case e: AppliedAttr =>
+          sb.append(" ").append(e)
+      }
+      sb
+    }

--- a/tests/neg-custom-args/isInstanceOf/i11178.scala
+++ b/tests/neg-custom-args/isInstanceOf/i11178.scala
@@ -1,0 +1,39 @@
+trait Box[+T]
+case class Foo[+S](s: S) extends Box[S]
+
+def unwrap2[A](b: Box[A]): A =
+  b match
+  case _: Foo[Int] => 0 // error
+
+object Test1 {
+  // Invariant case, OK
+  sealed trait Bar[A]
+
+  def test[A](bar: Bar[A]) =
+    bar match {
+      case _: Bar[Boolean] => ??? // error
+      case _ => ???
+    }
+}
+
+object Test2 {
+  // Covariant case
+  sealed trait Bar[+A]
+
+  def test[A](bar: Bar[A]) =
+    bar match {
+      case _: Bar[Boolean] => ??? // error
+      case _ => ???
+    }
+}
+
+object Test3 {
+  // Contravariant case
+  sealed trait Bar[-A]
+
+  def test[A](bar: Bar[A]) =
+    bar match {
+      case _: Bar[Boolean] => ??? // error
+      case _ => ???
+    }
+}


### PR DESCRIPTION
Fix #11178: remove unsound tweak for F-bounds

This reverts #9789. We have made several improvements to F-bounds,
the unsound tweak is no longer needed.