### PR TITLE
fix for #11776 to correct handling of scalac -script target_script args

### DIFF
--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -79,7 +79,6 @@ classpathArgs () {
   jvm_cp_args="-classpath \"$toolchain\""
 }
 
-in_scripting_args=false
 while [[ $# -gt 0 ]]; do
 case "$1" in
            --) shift; for arg; do addResidual "$arg"; done; set -- ;;
@@ -90,7 +89,8 @@ case "$1" in
     # Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
     -Oshort) addJava "-XX:+TieredCompilation -XX:TieredStopAtLevel=1" && shift ;;
         -repl) PROG_NAME="$ReplMain" && shift ;;
-      -script) PROG_NAME="$ScriptingMain" && target_script="$2" && in_scripting_args=true && shift && shift ;;
+      -script) PROG_NAME="$ScriptingMain" && target_script="$2" && shift && shift
+               while [[ $# -gt 0 ]]; do addScripting "$1" && shift ; done ;;
      -compile) PROG_NAME="$CompilerMain" && shift ;;
    -decompile) PROG_NAME="$DecompilerMain" && shift ;;
  -print-tasty) PROG_NAME="$DecompilerMain" && addScala "-print-tasty" && shift ;;
@@ -104,13 +104,7 @@ case "$1" in
           # will be available as system properties.
           -D*) addJava "$1" && shift ;;
           -J*) addJava "${1:2}" && shift ;;
-            *) if [ $in_scripting_args == false ]; then
-                addResidual "$1"
-               else
-                addScripting "$1"
-               fi
-               shift
-               ;;
+            *) addResidual "$1" && shift ;;
   esac
 done
 


### PR DESCRIPTION
The fix consists of this:

When `-script target_script` is first encountered, immediately transfer all remaining args to the script.
remove `in_scripting_args`

To verify the fix, I used these two scripts:
showargs.sc:
```scala
def main(args: Array[String]): Unit =
  for a <- args do
    println(s"[$a]")
```

hello.sc:
```scala
def main(args: Array[String]): Unit =
  println("hello!")
```

Command line to test for #11776:
```bash
$ scalac -script showargs.sc a b c -script hello.sc
```
Before the fix, the output would be:
```bash
$ hello!
```
With this fix, the output is:
```bash
[a]
[b]
[c]
[-script]
[hello.sc]
```






