### PR TITLE
Fix #9166: Harden check for values in patterns based on class inheritance info

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3808,10 +3808,25 @@ class Typer extends Namer
               mapOver(tp)
         }
 
-        if tree.symbol.isOneOf(Module | Enum)
-           && !(tree.tpe frozen_<:< pt) // fast track
-           && !(tree.tpe frozen_<:< approx(pt))
-        then
+        val sym = tree.tpe.widen.classSymbol
+
+        // Is it certain that a value of `tree.tpe` is never a subtype of `pt`?
+        // It is true if either
+        // - the class of `tree.tpe` and class of `pt` cannot have common subclass, or
+        // - `tree` is an object or enum value, which cannot possibly be a subtype of `pt`
+        val isDefiniteNotSubtype = {
+          val clsA = tree.tpe.widenDealias.classSymbol
+          val clsB = pt.dealias.classSymbol
+          clsA.exists && clsB.exists
+            && clsA != defn.NullClass
+            && (!clsA.isNumericValueClass && !clsB.isNumericValueClass) // approximation for numeric conversion and boxing
+            && !clsA.asClass.mayHaveCommonChild(clsB.asClass)
+          || tree.symbol.isOneOf(Module | Enum)
+             && !(tree.tpe frozen_<:< pt) // fast track
+             && !(tree.tpe frozen_<:< approx(pt))
+        }
+
+        if isDefiniteNotSubtype then
           // We could check whether `equals` is overriden.
           // Reasons for not doing so:
           // - it complicates the protocol

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3808,8 +3808,6 @@ class Typer extends Namer
               mapOver(tp)
         }
 
-        val sym = tree.tpe.widen.classSymbol
-
         // Is it certain that a value of `tree.tpe` is never a subtype of `pt`?
         // It is true if either
         // - the class of `tree.tpe` and class of `pt` cannot have common subclass, or

--- a/tests/neg/i9166.scala
+++ b/tests/neg/i9166.scala
@@ -1,0 +1,6 @@
+object UnitTest extends App {
+  def foo(m: Unit) = m match {
+    case runtime.BoxedUnit.UNIT => println("ok") // error
+  }
+  foo(())
+}


### PR DESCRIPTION
Fix #9166: Harden check for values in patterns based on class inheritance info