### PR TITLE
Move classType checks for new expressions to PostTyper

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -295,6 +295,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
             case Select(nu: New, nme.CONSTRUCTOR) if isCheckable(nu) =>
               // need to check instantiability here, because the type of the New itself
               // might be a type constructor.
+              ctx.typer.checkClassType(tree.tpe, tree.srcPos, traitReq = false, stablePrefixReq = true)
               Checking.checkInstantiable(tree.tpe, nu.srcPos)
               withNoCheckNews(nu :: Nil)(app1)
             case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -772,10 +772,6 @@ class Typer extends Namer
       case _ =>
         var tpt1 = typedType(tree.tpt)
         tpt1 = tpt1.withType(ensureAccessible(tpt1.tpe, superAccess = false, tpt1.srcPos))
-
-        if (checkClassType(typeOfNew(tpt1), tpt1.srcPos, traitReq = false, stablePrefixReq = true) eq defn.ObjectType)
-          tpt1 = TypeTree(defn.ObjectType).withSpan(tpt1.span)
-
         tpt1 match {
           case AppliedTypeTree(_, targs) =>
             for case targ: TypeBoundsTree <- targs do

--- a/tests/neg-custom-args/fatal-warnings/pureStatement.scala
+++ b/tests/neg-custom-args/fatal-warnings/pureStatement.scala
@@ -26,7 +26,7 @@ object Test {
 
   doSideEffects(1) // error: pure expression does nothing in statement position
 
-  val broken = new IDontExist("") // error // error
+  val broken = new IDontExist("") // error
   broken.foo // no extra error, and no pure expression warning
   broken.foo() // same
 }

--- a/tests/neg/alloc-abstract.scala
+++ b/tests/neg/alloc-abstract.scala
@@ -3,13 +3,13 @@ class Test[T] {
 
   type Foo[T] = Array[T]
 
-  new T                   // error: not a class type
-  new T()                 // error: not a class type
-  new U                   // error: not a class type
-  new U()                 // error: not a class type
-  new IArray[String]      // error: not a class type
-  new IArray[String]()    // error: not a class type
-  new IArray[String](10)  // error: not a class type // error: too mamy arguments
+  new T                   // error: does not have a constructor
+  new T()                 // error: does not have a constructor
+  new U                   // error: does not have a constructor
+  new U()                 // error: does not have a constructor
+  new IArray[String]      // error: does not have a constructor
+  new IArray[String]()    // error: does not have a constructor
+  new IArray[String](10)  // error: does not have a constructor
 
   new Foo[String](10)     // ok
 }

--- a/tests/neg/creator-applys.scala
+++ b/tests/neg/creator-applys.scala
@@ -10,26 +10,8 @@ class Test {
     def run = s"C $x $y"
   }
 
-  val x1 = new Test().A()      // error: object A does not take parameters
-  val x2 = new Test().B()      // error: value B is not a member of Test
-  val x3 = new Test().B[Int]() // error: value B is not a member of Test
+  val x1 = new Test().A()      // error: not stable
+  val x2 = new Test().B()      // error: not stable
+  val x3 = new Test().B[Int]() // error: not stable
 }
 
-
-object Test2 {
-  class A(s: String = "A") {
-    def run = s
-  }
-  object A {
-    def apply() = A("X")  // error: recursive method needs return type
-  }
-}
-
-object Test3 {
-  class A(s: String = "A") {
-    def run = s
-  }
-  object A {
-    def apply(): A = A("X")  // error too many arguments
-  }
-}

--- a/tests/neg/creator-applys2.scala
+++ b/tests/neg/creator-applys2.scala
@@ -1,0 +1,18 @@
+
+object Test2 {
+  class A(s: String = "A") {
+    def run = s
+  }
+  object A {
+    def apply() = A("X")  // error: recursive method needs return type
+  }
+}
+
+object Test3 {
+  class A(s: String = "A") {
+    def run = s
+  }
+  object A {
+    def apply(): A = A("X")  // error too many arguments
+  }
+}

--- a/tests/neg/i11781.scala
+++ b/tests/neg/i11781.scala
@@ -1,0 +1,4 @@
+
+trait A:
+  type Foo
+  new Foo  // error: does not have a constructor

--- a/tests/neg/i8569.check
+++ b/tests/neg/i8569.check
@@ -1,12 +1,6 @@
--- [E083] Type Error: tests/neg/i8569.scala:8:8 ------------------------------------------------------------------------
-8 |  outer.Inner(2) // error
-  |  ^^^^^^^^^^^
-  |  Outer is not a valid class prefix, since it is not an immutable path
-
-longer explanation available when compiling with `-explain`
--- [E083] Type Error: tests/neg/i8569.scala:9:6 ------------------------------------------------------------------------
-9 |  new outer.Inner(2) // error
-  |      ^^^^^
-  |      (Test.outer : => Outer) is not a valid type prefix, since it is not an immutable path
+-- [E083] Type Error: tests/neg/i8569.scala:13:21 ----------------------------------------------------------------------
+13 |  val x = outer.Inner(2) // error (at posttyper)
+   |          ^^^^^^^^^^^^^^
+   |          Outer is not a valid class prefix, since it is not an immutable path
 
 longer explanation available when compiling with `-explain`

--- a/tests/neg/i8569a.check
+++ b/tests/neg/i8569a.check
@@ -1,0 +1,6 @@
+-- [E083] Type Error: tests/neg/i8569a.scala:13:14 ---------------------------------------------------------------------
+13 |  val x = new outer2.Inner(2) // error (at typer)
+   |              ^^^^^^
+   |              (Test.outer2 : => Outer2) is not a valid type prefix, since it is not an immutable path
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i8569a.scala
+++ b/tests/neg/i8569a.scala
@@ -10,5 +10,5 @@ object Test {
   def outer = Outer(1)
   def outer2 = Outer2(1)
 
-  val x = outer.Inner(2) // error (at posttyper)
+  val x = new outer2.Inner(2) // error (at typer)
 }

--- a/tests/neg/iarrays.scala
+++ b/tests/neg/iarrays.scala
@@ -1,7 +1,7 @@
 object Test {
 
   // Can't allocate an IArray
-  new IArray[String](10)  // error: not a class type // error: too many arguments
+  new IArray[String](10)  // error: does not have a constructor
 
   val xs = IArray(1, 2, 3)
 

--- a/tests/pos/i11781.scala
+++ b/tests/pos/i11781.scala
@@ -1,0 +1,24 @@
+object Test:
+  class C1[A](a: A)
+  type D1[A] = C1[A]
+  new D1(1)
+
+  class C2[B, A](a: A)
+  type D2[A] = C2[Int, A]
+  new D2(1)
+  new D2[Int](1)
+
+  class E(x: Int) extends D2[Int](x)
+  class F(x: Int) extends D2(x)
+
+object Ah {
+  final case class Values[B, +A](a: A)
+
+  trait Object[B] {
+    final type Values[+A] = Ah.Values[B, A]
+    object Values {
+      def blah: Values[Unit] =
+        new Values(())
+    }
+  }
+}


### PR DESCRIPTION
When typechecking a new expression, we cannot reliably tell what the actual underlying
type is since this might depend on type inference that still has to happen at this point.

Fixes #11781 