### PR TITLE
Fix #11201: special handling for rendering parameterless methods signatures

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -252,7 +252,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   protected def paramsText(lam: LambdaType): Text = {
     def paramText(name: Name, tp: Type) =
-      toText(name) ~ lambdaHash(lam) ~ toTextRHS(tp)
+      toText(name) ~ lambdaHash(lam) ~ toTextRHS(tp, isParameter = true)
     Text(lam.paramNames.lazyZip(lam.paramInfos).map(paramText), ", ")
   }
 
@@ -370,7 +370,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   end decomposeLambdas
 
   /** String representation of a definition's type following its name */
-  protected def toTextRHS(tp: Type): Text = controlled {
+  protected def toTextRHS(tp: Type, isParameter: Boolean = false): Text = controlled {
     homogenize(tp) match {
       case tp: TypeBounds =>
         val (tparamStr, rhs) = decomposeLambdas(tp)
@@ -400,7 +400,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case mt: MethodType =>
         toTextGlobal(mt)
       case tp: ExprType =>
-        ": => " ~ toTextGlobal(tp.widenExpr)
+        // parameterless methods require special treatment, see #11201
+        (if (isParameter) ": => " else ": ") ~ toTextGlobal(tp.widenExpr)
       case tp =>
         ": " ~ toTextGlobal(tp)
     }


### PR DESCRIPTION
Fix for #11201