### PR TITLE
Fix invented names causing incorrect spans in semanticdb

### DIFF
--- a/tests/semanticdb/expect/Enums.expect.scala
+++ b/tests/semanticdb/expect/Enums.expect.scala
@@ -47,7 +47,7 @@ object Enums/*<-_empty_::Enums.*/:
     case Refl/*<-_empty_::Enums.`<:<`.Refl#*/[C/*<-_empty_::Enums.`<:<`.Refl#[C]*/]() extends (C/*->_empty_::Enums.`<:<`.Refl#[C]*/ <:</*->_empty_::Enums.`<:<`#*/ C/*->_empty_::Enums.`<:<`.Refl#[C]*/)
 
   object <:</*<-_empty_::Enums.`<:<`.*/ :
-    given [T]: (T <:< T/*<-_empty_::Enums.`<:<`.`given_<:<_T_T`().*//*<-_empty_::Enums.`<:<`.`given_<:<_T_T`().[T]*//*->_empty_::Enums.`<:<`.`given_<:<_T_T`().[T]*//*->_empty_::Enums.`<:<`#*//*->_empty_::Enums.`<:<`.`given_<:<_T_T`().[T]*/) = Refl/*->_empty_::Enums.`<:<`.Refl.*//*->_empty_::Enums.`<:<`.Refl.apply().*/()
+    given /*<-_empty_::Enums.`<:<`.`given_<:<_T_T`().*/[T/*<-_empty_::Enums.`<:<`.`given_<:<_T_T`().[T]*/]: (T/*->_empty_::Enums.`<:<`.`given_<:<_T_T`().[T]*/ <:</*->_empty_::Enums.`<:<`#*/ T/*->_empty_::Enums.`<:<`.`given_<:<_T_T`().[T]*/) = Refl/*->_empty_::Enums.`<:<`.Refl.*//*->_empty_::Enums.`<:<`.Refl.apply().*/()
 
   extension [A/*<-_empty_::Enums.unwrap().[A]*/, B/*<-_empty_::Enums.unwrap().[B]*/](opt/*<-_empty_::Enums.unwrap().(opt)*/: Option/*->scala::Option#*/[A/*->_empty_::Enums.unwrap().[A]*/]) def unwrap/*<-_empty_::Enums.unwrap().*/(using ev/*<-_empty_::Enums.unwrap().(ev)*/: A/*->_empty_::Enums.unwrap().[A]*/ <:</*->_empty_::Enums.`<:<`#*/ Option/*->scala::Option#*/[B/*->_empty_::Enums.unwrap().[B]*/]): Option/*->scala::Option#*/[B/*->_empty_::Enums.unwrap().[B]*/] = ev/*->_empty_::Enums.unwrap().(ev)*/ match
     case Refl/*->_empty_::Enums.`<:<`.Refl.*//*->_empty_::Enums.`<:<`.Refl.unapply().*/() => opt/*->_empty_::Enums.unwrap().(opt)*/.flatMap/*->scala::Option#flatMap().*/(identity/*->scala::Predef.identity().*//*->local0*/[Option/*->scala::Option#*/[B/*->_empty_::Enums.unwrap().[B]*/]])

--- a/tests/semanticdb/expect/InventedNames.expect.scala
+++ b/tests/semanticdb/expect/InventedNames.expect.scala
@@ -1,0 +1,42 @@
+package givens
+
+trait X/*<-givens::X#*/:
+  def doX/*<-givens::X#doX().*/: Int/*->scala::Int#*/
+
+trait Y/*<-givens::Y#*/:
+  def doY/*<-givens::Y#doY().*/: String/*->scala::Predef.String#*/
+
+trait Z/*<-givens::Z#*/[T/*<-givens::Z#[T]*/]:
+  def doZ/*<-givens::Z#doZ().*/: List/*->scala::package.List#*/[T/*->givens::Z#[T]*/]
+
+
+
+/*<-givens::InventedNames$package.*/given intValue/*<-givens::InventedNames$package.intValue.*/: Int/*->scala::Int#*/ = 4
+given /*<-givens::InventedNames$package.given_String.*/String/*->scala::Predef.String#*/ = "str"
+given /*<-givens::InventedNames$package.given_Double().*/(using Int/*->scala::Int#*/): Double/*->scala::Double#*/ = 4.0
+given /*<-givens::InventedNames$package.given_List_T().*/[T/*<-givens::InventedNames$package.given_List_T().[T]*/]: List/*->scala::package.List#*/[T/*->givens::InventedNames$package.given_List_T().[T]*/] = Nil/*->scala::package.Nil.*/
+given given_Char/*<-givens::InventedNames$package.given_Char.*/: Char/*->scala::Char#*/ = '?'
+given `given_Float/*<-givens::InventedNames$package.given_Float.*/`: Float/*->scala::Float#*/ = 3.0
+given `* */*<-givens::InventedNames$package.`* *`.*/`: Long/*->scala::Long#*/ = 5
+
+given X with
+/*<-givens::InventedNames$package.given_X.*//*->givens::X#*/  def doX/*<-givens::InventedNames$package.given_X.doX().*/ = 7
+
+given (using X/*->givens::X#*/): Y/*->givens::Y#*/ with
+  def doY/*<-givens::InventedNames$package.given_Y#doY().*/ = "7"
+
+given [T/*<-givens::InventedNames$package.given_Z_T#[T]*/]: Z/*->givens::Z#*/[T/*->givens::InventedNames$package.given_Z_T#[T]*/] with
+  def doZ/*<-givens::InventedNames$package.given_Z_T#doZ().*/: List/*->scala::package.List#*/[T/*->givens::InventedNames$package.given_Z_T#[T]*/] = Nil/*->scala::package.Nil.*/
+
+
+
+val a/*<-givens::InventedNames$package.a.*/ = intValue/*->givens::InventedNames$package.intValue.*/
+val b/*<-givens::InventedNames$package.b.*/ = given_String/*->givens::InventedNames$package.given_String.*/
+val c/*<-givens::InventedNames$package.c.*/ = given_Double/*->givens::InventedNames$package.given_Double().*//*->givens::InventedNames$package.intValue.*/
+val d/*<-givens::InventedNames$package.d.*/ = given_List_T/*->givens::InventedNames$package.given_List_T().*/[Int/*->scala::Int#*/]
+val e/*<-givens::InventedNames$package.e.*/ = given_Char/*->givens::InventedNames$package.given_Char.*/
+val f/*<-givens::InventedNames$package.f.*/ = given_Float/*->givens::InventedNames$package.given_Float.*/
+val g/*<-givens::InventedNames$package.g.*/ = `* *`/*->givens::InventedNames$package.`* *`.*/
+val x/*<-givens::InventedNames$package.x.*/ = given_X/*->givens::InventedNames$package.given_X.*/
+val y/*<-givens::InventedNames$package.y.*/ = given_Y/*->givens::InventedNames$package.given_Y().*//*->givens::InventedNames$package.given_X.*/
+val z/*<-givens::InventedNames$package.z.*/ = given_Z_T/*->givens::InventedNames$package.given_Z_T().*/[String/*->scala::Predef.String#*/]

--- a/tests/semanticdb/expect/InventedNames.scala
+++ b/tests/semanticdb/expect/InventedNames.scala
@@ -1,0 +1,42 @@
+package givens
+
+trait X:
+  def doX: Int
+
+trait Y:
+  def doY: String
+
+trait Z[T]:
+  def doZ: List[T]
+
+
+
+given intValue: Int = 4
+given String = "str"
+given (using Int): Double = 4.0
+given [T]: List[T] = Nil
+given given_Char: Char = '?'
+given `given_Float`: Float = 3.0
+given `* *`: Long = 5
+
+given X with
+  def doX = 7
+
+given (using X): Y with
+  def doY = "7"
+
+given [T]: Z[T] with
+  def doZ: List[T] = Nil
+
+
+
+val a = intValue
+val b = given_String
+val c = given_Double
+val d = given_List_T[Int]
+val e = given_Char
+val f = given_Float
+val g = `* *`
+val x = given_X
+val y = given_Y
+val z = given_Z_T[String]

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -962,7 +962,7 @@ Occurrences:
 [46:34..46:35): C -> _empty_/Enums.`<:<`.Refl#[C]
 [46:35..46:35): -> _empty_/Enums.`<:<`#`<init>`().
 [48:9..48:12): <:< <- _empty_/Enums.`<:<`.
-[49:10..49:23): [T]: (T <:< T <- _empty_/Enums.`<:<`.`given_<:<_T_T`().
+[49:10..49:10): <- _empty_/Enums.`<:<`.`given_<:<_T_T`().
 [49:11..49:12): T <- _empty_/Enums.`<:<`.`given_<:<_T_T`().[T]
 [49:16..49:17): T -> _empty_/Enums.`<:<`.`given_<:<_T_T`().[T]
 [49:18..49:21): <:< -> _empty_/Enums.`<:<`#
@@ -1598,6 +1598,139 @@ Occurrences:
 [24:22..24:29): classOf -> scala/Predef.classOf().
 [24:30..24:36): Option -> scala/Option#
 [24:37..24:40): Int -> scala/Int#
+
+expect/InventedNames.scala
+--------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => InventedNames.scala
+Text => empty
+Language => Scala
+Symbols => 45 entries
+Occurrences => 73 entries
+
+Symbols:
+givens/InventedNames$package. => final package object givens
+givens/InventedNames$package.`* *`. => final implicit lazy val method * *
+givens/InventedNames$package.a. => val method a
+givens/InventedNames$package.b. => val method b
+givens/InventedNames$package.c. => val method c
+givens/InventedNames$package.d. => val method d
+givens/InventedNames$package.e. => val method e
+givens/InventedNames$package.f. => val method f
+givens/InventedNames$package.g. => val method g
+givens/InventedNames$package.given_Char. => final implicit lazy val method given_Char
+givens/InventedNames$package.given_Double(). => final implicit method given_Double
+givens/InventedNames$package.given_Double().(x$1) => implicit param x$1
+givens/InventedNames$package.given_Float. => final implicit lazy val method given_Float
+givens/InventedNames$package.given_List_T(). => final implicit method given_List_T
+givens/InventedNames$package.given_List_T().[T] => typeparam T
+givens/InventedNames$package.given_String. => final implicit lazy val method given_String
+givens/InventedNames$package.given_X. => final implicit object given_X
+givens/InventedNames$package.given_X.doX(). => method doX
+givens/InventedNames$package.given_Y# => class given_Y
+givens/InventedNames$package.given_Y#`<init>`(). => primary ctor <init>
+givens/InventedNames$package.given_Y#`<init>`().(x$1) => implicit val param x$1
+givens/InventedNames$package.given_Y#doY(). => method doY
+givens/InventedNames$package.given_Y#x$1. => implicit val method x$1
+givens/InventedNames$package.given_Y(). => final implicit method given_Y
+givens/InventedNames$package.given_Y().(x$1) => implicit param x$1
+givens/InventedNames$package.given_Z_T# => class given_Z_T
+givens/InventedNames$package.given_Z_T#[T] => typeparam T
+givens/InventedNames$package.given_Z_T#`<init>`(). => primary ctor <init>
+givens/InventedNames$package.given_Z_T#doZ(). => method doZ
+givens/InventedNames$package.given_Z_T(). => final implicit method given_Z_T
+givens/InventedNames$package.given_Z_T().[T] => typeparam T
+givens/InventedNames$package.intValue. => final implicit lazy val method intValue
+givens/InventedNames$package.x. => val method x
+givens/InventedNames$package.y. => val method y
+givens/InventedNames$package.z. => val method z
+givens/X# => trait X
+givens/X#`<init>`(). => primary ctor <init>
+givens/X#doX(). => abstract method doX
+givens/Y# => trait Y
+givens/Y#`<init>`(). => primary ctor <init>
+givens/Y#doY(). => abstract method doY
+givens/Z# => trait Z
+givens/Z#[T] => typeparam T
+givens/Z#`<init>`(). => primary ctor <init>
+givens/Z#doZ(). => abstract method doZ
+
+Occurrences:
+[0:8..0:14): givens <- givens/
+[2:6..2:7): X <- givens/X#
+[3:2..3:2): <- givens/X#`<init>`().
+[3:6..3:9): doX <- givens/X#doX().
+[3:11..3:14): Int -> scala/Int#
+[5:6..5:7): Y <- givens/Y#
+[6:2..6:2): <- givens/Y#`<init>`().
+[6:6..6:9): doY <- givens/Y#doY().
+[6:11..6:17): String -> scala/Predef.String#
+[8:6..8:7): Z <- givens/Z#
+[8:7..8:7): <- givens/Z#`<init>`().
+[8:8..8:9): T <- givens/Z#[T]
+[9:6..9:9): doZ <- givens/Z#doZ().
+[9:11..9:15): List -> scala/package.List#
+[9:16..9:17): T -> givens/Z#[T]
+[13:0..13:0): <- givens/InventedNames$package.
+[13:6..13:14): intValue <- givens/InventedNames$package.intValue.
+[13:16..13:19): Int -> scala/Int#
+[14:6..14:6): <- givens/InventedNames$package.given_String.
+[14:6..14:12): String -> scala/Predef.String#
+[15:6..15:6): <- givens/InventedNames$package.given_Double().
+[15:13..15:16): Int -> scala/Int#
+[15:19..15:25): Double -> scala/Double#
+[16:6..16:6): <- givens/InventedNames$package.given_List_T().
+[16:7..16:8): T <- givens/InventedNames$package.given_List_T().[T]
+[16:11..16:15): List -> scala/package.List#
+[16:16..16:17): T -> givens/InventedNames$package.given_List_T().[T]
+[16:21..16:24): Nil -> scala/package.Nil.
+[17:6..17:16): given_Char <- givens/InventedNames$package.given_Char.
+[17:18..17:22): Char -> scala/Char#
+[18:7..18:18): given_Float <- givens/InventedNames$package.given_Float.
+[18:21..18:26): Float -> scala/Float#
+[19:7..19:10): * * <- givens/InventedNames$package.`* *`.
+[19:13..19:17): Long -> scala/Long#
+[21:6..22:0): <- givens/InventedNames$package.given_X.
+[21:6..21:7): X -> givens/X#
+[22:6..22:9): doX <- givens/InventedNames$package.given_X.doX().
+[24:13..24:13): <- givens/InventedNames$package.given_Y#`<init>`().
+[24:13..24:14): X -> givens/X#
+[24:17..24:18): Y -> givens/Y#
+[25:6..25:9): doY <- givens/InventedNames$package.given_Y#doY().
+[27:7..27:7): <- givens/InventedNames$package.given_Z_T#`<init>`().
+[27:7..27:8): T <- givens/InventedNames$package.given_Z_T#[T]
+[27:11..27:12): Z -> givens/Z#
+[27:13..27:14): T -> givens/InventedNames$package.given_Z_T#[T]
+[28:6..28:9): doZ <- givens/InventedNames$package.given_Z_T#doZ().
+[28:11..28:15): List -> scala/package.List#
+[28:16..28:17): T -> givens/InventedNames$package.given_Z_T#[T]
+[28:21..28:24): Nil -> scala/package.Nil.
+[32:4..32:5): a <- givens/InventedNames$package.a.
+[32:8..32:16): intValue -> givens/InventedNames$package.intValue.
+[33:4..33:5): b <- givens/InventedNames$package.b.
+[33:8..33:20): given_String -> givens/InventedNames$package.given_String.
+[34:4..34:5): c <- givens/InventedNames$package.c.
+[34:8..34:20): given_Double -> givens/InventedNames$package.given_Double().
+[34:20..34:20): -> givens/InventedNames$package.intValue.
+[35:4..35:5): d <- givens/InventedNames$package.d.
+[35:8..35:20): given_List_T -> givens/InventedNames$package.given_List_T().
+[35:21..35:24): Int -> scala/Int#
+[36:4..36:5): e <- givens/InventedNames$package.e.
+[36:8..36:18): given_Char -> givens/InventedNames$package.given_Char.
+[37:4..37:5): f <- givens/InventedNames$package.f.
+[37:8..37:19): given_Float -> givens/InventedNames$package.given_Float.
+[38:4..38:5): g <- givens/InventedNames$package.g.
+[38:8..38:13): `* *` -> givens/InventedNames$package.`* *`.
+[39:4..39:5): x <- givens/InventedNames$package.x.
+[39:8..39:15): given_X -> givens/InventedNames$package.given_X.
+[40:4..40:5): y <- givens/InventedNames$package.y.
+[40:8..40:15): given_Y -> givens/InventedNames$package.given_Y().
+[40:15..40:15): -> givens/InventedNames$package.given_X.
+[41:4..41:5): z <- givens/InventedNames$package.z.
+[41:8..41:17): given_Z_T -> givens/InventedNames$package.given_Z_T().
+[41:18..41:24): String -> scala/Predef.String#
 
 expect/Issue1749.scala
 ----------------------


### PR DESCRIPTION
Fixes #11692.

Anonymous given instances and anonymous given aliases have their names invented during the desugaring. Those names are not treated as being synthetic neither they are present in sources. This results in incorrect spans being assigned to them, which is a problem for tools that are using semanticdb. This pr fixes that problem by comparing name spans with corresponding spans in sources. Other parts of the compiler can still call `NamedDefTree#nameSpan` and get an incorrect result.

I've tried to solve that problem without reading sources, by adding abstract `def hasNamePresentInSource: Boolean` to `NamedDefTree`, so it can be used in `nameSpan` method and fix this problem globally. It turned out that this method cannot be correctly implemented for `DefDef`s and some anonymous given aliases are desugared to defs, so this approach was not successful. If we really want to solve this problem globally we will need to add some attachment during desugaring.