### PR TITLE
Associative, commutative, Java-friendly intersection erasure

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2128,7 +2128,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     else {
       val t2 = distributeAnd(tp2, tp1)
       if (t2.exists) t2
-      else if (isErased) erasedGlb(tp1, tp2, isJava = false)
+      else if (isErased) erasedGlb(tp1, tp2)
       else liftIfHK(tp1, tp2, op, original, _ | _)
         // The ` | ` on variances is needed since variances are associated with bounds
         // not lambdas. Example:

--- a/sbt-dotty/sbt-test/scala2-compat/erasure/dottyApp/Api.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure/dottyApp/Api.scala
@@ -22,7 +22,7 @@ class Outer {
 // This is enforced by dottyApp/Main.scala
 class Z {
   def a_01(a: A with B): Unit = {}
-  def b_02X(b: B with A): Unit = {}
+  def a_02X(b: B with A): Unit = {}
   def a_02(a: A with B with A): Unit = {}
   def a_03(a: A with (B with A)): Unit = {}
   def a_04(b: A with (B with A) @foo): Unit = {}
@@ -33,15 +33,15 @@ class Z {
   def a_06(a: T1): Unit = {}
 
   type S <: B with T1
-  def b_07(a: S): Unit = {}
+  def a_07(a: S): Unit = {}
 
   type T2 <: B with A
   type U <: T2 with S
-  def b_08(b: U): Unit = {}
+  def a_08(b: U): Unit = {}
 
   val singB: B = new B {}
   def a_09(a: A with singB.type): Unit = {}
-  def b_10(b: singB.type with A): Unit = {}
+  def a_10(b: singB.type with A): Unit = {}
 
   type V >: SubB <: B
   def b_11(b: V): Unit = {}
@@ -71,11 +71,11 @@ class Z {
 
   type W1 <: A with Cov[Any]
   type X1 <: Cov[Int] with W1
-  def cov_21(a: X1): Unit = {}
+  def a_21(a: X1): Unit = {}
 
   type W2 <: A with Cov[Any]
   type X2 <: Cov[Int] with W2
-  def cov_22(a: X2): Unit = {}
+  def a_22(a: X2): Unit = {}
 
   def z_23(z: A with this.type): Unit = {}
   def z_24(z: this.type with A): Unit = {}
@@ -83,34 +83,34 @@ class Z {
   def a_25(b: A with (B { type T })): Unit = {}
   def a_26(a: (A { type T }) with ((B with A) { type T })): Unit = {}
 
-  def b_27(a: VC with B): Unit = {}
-  def b_28(a: B with VC): Unit = {}
+  def a_27(a: VC with B): Unit = {}
+  def a_28(a: B with VC): Unit = {}
 
   val o1: Outer = new Outer
   val o2: Outer = new Outer
-  def f_29(f: o1.E with o1.F): Unit = {}
-  def f_30(f: o1.F with o1.E): Unit = {}
-  def f_31(f: o1.E with o2.F): Unit = {}
-  def f_32(f: o2.F with o1.E): Unit = {}
-  def f_33(f: Outer#E with Outer#F): Unit = {}
-  def f_34(f: Outer#F with Outer#E): Unit = {}
+  def e_29(f: o1.E with o1.F): Unit = {}
+  def e_30(f: o1.F with o1.E): Unit = {}
+  def e_31(f: o1.E with o2.F): Unit = {}
+  def e_32(f: o2.F with o1.E): Unit = {}
+  def e_33(f: Outer#E with Outer#F): Unit = {}
+  def e_34(f: Outer#F with Outer#E): Unit = {}
 
   val structural1: { type DSub <: D } = new { type DSub <: D }
   def d_35(a: A with structural1.DSub): Unit = {}
   def d_36(a: structural1.DSub with A): Unit = {}
-  def z_37(z: Z with structural1.DSub): Unit = {}
+  def d_37(z: Z with structural1.DSub): Unit = {}
   def d_38(z: structural1.DSub with Z): Unit = {}
 
   val structural2: { type SubCB <: C with B } = new { type SubCB <: C with B }
-  def c_39(c: structural2.SubCB with B): Unit = {}
+  def b_39(c: structural2.SubCB with B): Unit = {}
   def b_40(c: B with structural2.SubCB): Unit = {}
 
   val structural3a: { type SubB <: B; type SubCB <: C with SubB } = new { type SubB <: B; type SubCB <: C with SubB }
   val structural3b: { type SubB <: B; type SubCB <: C with SubB } = new { type SubB <: B; type SubCB <: C with SubB }
   def b_41(c: structural3a.SubB with structural3a.SubCB): Unit = {}
-  def c_42(c: structural3a.SubCB with structural3a.SubB): Unit = {}
+  def b_42(c: structural3a.SubCB with structural3a.SubB): Unit = {}
   def b_43(b: structural3a.SubB with structural3b.SubCB): Unit = {}
-  def c_44(c: structural3b.SubCB with structural3a.SubB): Unit = {}
+  def b_44(c: structural3b.SubCB with structural3a.SubB): Unit = {}
 
   type SubStructural <: C with structural3a.SubB
   def b_45(x: structural3a.SubB with SubStructural): Unit = {}
@@ -146,4 +146,11 @@ class Z {
   type AEq = A
   type Bla2 = AEq { type M[X] <: A }
   def a_57(x: Bla2#M[Any] with ({ type N <: B with Bla2#M[Int] })#N): Unit = {}
+
+  def int_58(x: Int with Singleton): Unit = {}
+  def int_59(x: Singleton with Int): Unit = {}
+  def int_60(x: Int with Any): Unit = {}
+  def int_61(x: Any with Int): Unit = {}
+  def int_62(x: Int with AnyVal): Unit = {}
+  def int_63(x: AnyVal with Int): Unit = {}
 }

--- a/sbt-dotty/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
@@ -68,6 +68,12 @@ object Main {
     z.b_55(dummy)
     // z.b_56(dummy)
     // z.a_57(dummy)
+    z.int_58(1)
+    z.int_59(1)
+    z.int_60(1)
+    z.int_61(1)
+    z.int_62(1)
+    z.int_63(1)
 
     val methods = classOf[scala2Lib.Z].getDeclaredMethods.toList ++ classOf[dottyApp.Z].getDeclaredMethods.toList
     methods.foreach { m =>

--- a/sbt-dotty/sbt-test/scala2-compat/erasure/scala2Lib/Api.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure/scala2Lib/Api.scala
@@ -146,4 +146,11 @@ class Z {
   type AEq = A
   type Bla2 = AEq { type M[X] <: A }
   def a_57(x: Bla2#M[Any] with ({ type N <: B with Bla2#M[Int] })#N): Unit = {}
+
+  def int_58(x: Int with Singleton): Unit = {}
+  def int_59(x: Singleton with Int): Unit = {}
+  def int_60(x: Int with Any): Unit = {}
+  def int_61(x: Any with Int): Unit = {}
+  def int_62(x: Int with AnyVal): Unit = {}
+  def int_63(x: AnyVal with Int): Unit = {}
 }

--- a/tests/neg/i5139.scala
+++ b/tests/neg/i5139.scala
@@ -1,0 +1,7 @@
+trait A
+trait B
+
+class Overload {
+  def m(ab: A&B) = ab
+  def m(ab: B&A) = ab // error: double definition
+}

--- a/tests/neg/ostermann.scala
+++ b/tests/neg/ostermann.scala
@@ -1,0 +1,5 @@
+trait A { def foo(a: A) : Unit }
+
+trait C extends A {
+  override def foo(a: A with Any): Unit // error: method foo has a different signature than the overridden declaration
+}

--- a/tests/neg/t8300-overloading.scala
+++ b/tests/neg/t8300-overloading.scala
@@ -1,4 +1,3 @@
-// cf. neg/t8300-overloading.scala
 trait Universe {
   type Name >: Null <: AnyRef with NameApi
   trait NameApi
@@ -12,5 +11,5 @@ object Test extends App {
   import u.*
 
   def foo(name: Name) = ???
-  def foo(name: TermName) = ???
+  def foo(name: TermName) = ??? // error: double definition, same type after erasure
 }

--- a/tests/pos/i5139.scala
+++ b/tests/pos/i5139.scala
@@ -1,0 +1,9 @@
+trait A
+trait B
+
+class Base{
+  def m(ab: A&B) = ab
+}
+class Derived extends Base{
+  override def m(ab: B&A) = ab // unexpected error
+}

--- a/tests/pos/ostermann.scala
+++ b/tests/pos/ostermann.scala
@@ -1,3 +1,0 @@
-trait A { def foo(a: A) : Unit }
-
-trait C extends A { override def foo(a: A with Any) : Unit  }

--- a/tests/run/t12300/A_1.scala
+++ b/tests/run/t12300/A_1.scala
@@ -1,0 +1,18 @@
+trait One
+trait Two
+
+class X
+class Y extends X
+
+trait YSub extends Y
+
+class A {
+  def foo1[T <: Object with One](x: T): Unit = {}
+  def foo2[T <: One with Object](x: T): Unit = {}
+  def foo3[T <: One with Two](x: T): Unit = {}
+  def foo4[T <: Two with One](x: T): Unit = {}
+  def foo5[T <: X with Y](x: T): Unit = {}
+  def foo6[T <: Y with X](x: T): Unit = {}
+  def foo7[T <: X with YSub](x: T): Unit = {}
+  def foo8[T <: YSub with X](x: T): Unit = {}
+}

--- a/tests/run/t12300/B_2.java
+++ b/tests/run/t12300/B_2.java
@@ -1,0 +1,17 @@
+class OneTwo implements One, Two {}
+// Java doesn't seen class parents of traits
+class YSubX extends Y implements YSub {}
+
+public class B_2 {
+  public static void foo() {
+    A a = new A();
+    a.foo1(new One() {});
+    a.foo2(new One() {});
+    a.foo3(new OneTwo());
+    a.foo4(new OneTwo());
+    a.foo5(new Y());
+    a.foo6(new Y());
+    a.foo7(new YSubX());
+    a.foo8(new YSubX());
+  }
+}

--- a/tests/run/t12300/Test_2.scala
+++ b/tests/run/t12300/Test_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  def main(args: Array[String]): Unit =
+    B_2.foo()
+}


### PR DESCRIPTION
Thanks to #11603, we can now freely decide how we erase our intersection
types without compromising compatibility with Scala 2. We take advantage
of this by designing a new erasedGlb algorithm which respects
associativity and commutativity and can also erase Java intersections
without any special case.

This commit also improves the way we handle intersections in Java
generic signature to produce more precise types when possible and to
ensure that we never emit a type that would lead to javac emitting
invalid bytecode (which can happen with Scala 2:
https://github.com/scala/bug/issues/12300).

Fixes #5139.