### PR TITLE
Fix #11709: Do not depend on non-boostrapped Scala.js library.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -38,6 +38,14 @@ object MyScalaJSPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = Def.settings(
     commonBootstrappedSettings,
 
+    /* #11709 Remove the dependency on scala3-library that ScalaJSPlugin adds.
+     * Instead, in this build, we use `.dependsOn` relationships to depend on
+     * the appropriate, locally-defined, scala3-library-bootstrappedJS.
+     */
+    libraryDependencies ~= {
+      _.filter(!_.name.startsWith("scala3-library_sjs1"))
+    },
+
     // Replace the JVM JUnit dependency by the Scala.js one
     libraryDependencies ~= {
       _.filter(!_.name.startsWith("junit-interface"))


### PR DESCRIPTION
The POM generated by `scala3-library-bootstrappedJS/makePom` does not contain a reference a nonbootstrapped self anymore:
```xml
    <dependencies>
        <dependency>
            <groupId>org.scala-js</groupId>
            <artifactId>scalajs-library_2.13</artifactId>
            <version>1.4.0</version>
        </dependency>
        <dependency>
            <groupId>org.scala-js</groupId>
            <artifactId>scalajs-test-bridge_2.13</artifactId>
            <version>1.4.0</version>
            <scope>test</scope>
        </dependency>
        <dependency>
            <groupId>org.scala-js</groupId>
            <artifactId>scalajs-junit-test-runtime_2.13</artifactId>
            <version>1.4.0</version>
            <scope>test</scope>
        </dependency>
        <dependency>
            <groupId>com.novocode</groupId>
            <artifactId>junit-interface</artifactId>
            <version>0.11</version>
            <scope>test</scope>
        </dependency>
        <dependency>
            <groupId>org.scala-lang</groupId>
            <artifactId>scala-library</artifactId>
            <version>2.13.5</version>
        </dependency>
    </dependencies>
```
(it did before this commit)