### PR TITLE
Array erasure: Better Java and Scala 2 compat

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -10,7 +10,7 @@ import core.Flags._
 import core.Names.{DerivedName, Name, SimpleName, TypeName}
 import core.Symbols._
 import core.TypeApplications.TypeParamInfo
-import core.TypeErasure.{erasedGlb, erasure, isUnboundedGeneric}
+import core.TypeErasure.{erasedGlb, erasure, isGenericArrayElement}
 import core.Types._
 import core.classfile.ClassfileConstants
 import ast.Trees._
@@ -246,7 +246,7 @@ object GenericSignatures {
           typeParamSig(ref.paramName.lastPart)
 
         case defn.ArrayOf(elemtp) =>
-          if (isUnboundedGeneric(elemtp))
+          if (isGenericArrayElement(elemtp, isScala2 = false))
             jsig(defn.ObjectType)
           else
             builder.append(ClassfileConstants.ARRAY_TAG)

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -322,7 +322,7 @@ object TypeTestsCasts {
               transformTypeTest(e, tp1, flagUnrelated)
                 .and(transformTypeTest(e, tp2, flagUnrelated))
             }
-          case defn.MultiArrayOf(elem, ndims) if isUnboundedGeneric(elem) =>
+          case defn.MultiArrayOf(elem, ndims) if isGenericArrayElement(elem, isScala2 = false) =>
             def isArrayTest(arg: Tree) =
               ref(defn.runtimeMethodRef(nme.isArray)).appliedTo(arg, Literal(Constant(ndims)))
             if (ndims == 1) isArrayTest(expr)

--- a/sbt-dotty/sbt-test/scala2-compat/erasure/dottyApp/Api.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure/dottyApp/Api.scala
@@ -8,6 +8,7 @@ trait B
 trait SubB extends B
 trait C
 trait Cov[+T]
+trait Univ extends Any
 
 class D
 
@@ -153,4 +154,45 @@ class Z {
   def int_61(x: Any with Int): Unit = {}
   def int_62(x: Int with AnyVal): Unit = {}
   def int_63(x: AnyVal with Int): Unit = {}
+
+  def intARRAY_64(x: Array[Int with Singleton]): Unit = {}
+  def intARRAY_65(x: Array[_ <: Int]): Unit = {}
+  def intARRAY_66(x: Array[_ <: Int with Singleton]): Unit = {}
+  def intARRAY_67(x: Array[_ <: Singleton with Int]): Unit = {}
+  def intARRAY_68(x: Array[_ <: Int with Any]): Unit = {}
+  def intARRAY_69(x: Array[_ <: Any with Int]): Unit = {}
+  def intARRAY_70(x: Array[_ <: Int with AnyVal]): Unit = {}
+  def intARRAY_71(x: Array[_ <: AnyVal with Int]): Unit = {}
+  def intARRAY_71a(x: Array[_ <: Int | Int]): Unit = {}
+  def intARRAY_71b(x: Array[_ <: 1 | 2]): Unit = {}
+
+  def stringARRAY_72(x: Array[String with Singleton]): Unit = {}
+  def stringARRAY_73(x: Array[_ <: String]): Unit = {}
+  def stringARRAY_74(x: Array[_ <: String with Singleton]): Unit = {}
+  def stringARRAY_75(x: Array[_ <: Singleton with String]): Unit = {}
+  def stringARRAY_76(x: Array[_ <: String with Any]): Unit = {}
+  def stringARRAY_77(x: Array[_ <: Any with String]): Unit = {}
+  def stringARRAY_78(x: Array[_ <: String with AnyRef]): Unit = {}
+  def stringARRAY_79(x: Array[_ <: AnyRef with String]): Unit = {}
+  def stringARRAY_79a(x: Array[_ <: String | String]): Unit = {}
+  def stringARRAY_79b(x: Array[_ <: "a" | "b"]): Unit = {}
+
+  def object_80(x: Array[_ <: Singleton]): Unit = {}
+  def object_81(x: Array[_ <: AnyVal]): Unit = {}
+  def objectARRAY_82(x: Array[_ <: AnyRef]): Unit = {}
+  def object_83(x: Array[_ <: Any]): Unit = {}
+  def object_83a(x: Array[_ <: Matchable]): Unit = {}
+  def object_83b(x: Array[_ <: Int | Double]): Unit = {}
+  def object_83c(x: Array[_ <: String | Int]): Unit = {}
+  def object_83d(x: Array[_ <: Int | Matchable]): Unit = {}
+  def object_83e(x: Array[_ <: AnyRef | AnyVal]): Unit = {}
+
+  def serializableARRAY_84(x: Array[_ <: Serializable]): Unit = {}
+  def univARRAY_85(x: Array[_ <: Univ]): Unit = {}
+  def aARRAY_86(x: Array[_ <: A]): Unit = {}
+  def aARRAY_87(x: Array[_ <: A with B]): Unit = {}
+
+  def objectARRAY_88(x: Array[Any]): Unit = {}
+  def objectARRAY_89(x: Array[AnyRef]): Unit = {}
+  def objectARRAY_90(x: Array[AnyVal]): Unit = {}
 }

--- a/sbt-dotty/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure/dottyApp/Main.scala
@@ -74,13 +74,40 @@ object Main {
     z.int_61(1)
     z.int_62(1)
     z.int_63(1)
+    z.intARRAY_64(dummy)
+    z.object_65(dummy)
+    z.object_66(dummy)
+    z.object_67(dummy)
+    z.object_68(dummy)
+    z.object_69(dummy)
+    z.object_70(dummy)
+    z.object_71(dummy)
+    z.stringARRAY_72(dummy)
+    z.stringARRAY_73(dummy)
+    z.stringARRAY_74(dummy)
+    z.stringARRAY_75(dummy)
+    z.stringARRAY_76(dummy)
+    z.stringARRAY_77(dummy)
+    z.stringARRAY_78(dummy)
+    z.stringARRAY_79(dummy)
+    z.object_80(dummy)
+    z.object_81(dummy)
+    z.objectARRAY_82(dummy)
+    z.object_83(dummy)
+    z.object_84(dummy)
+    z.object_85(dummy)
+    z.aARRAY_86(dummy)
+    z.aARRAY_87(dummy)
+    z.objectARRAY_88(dummy)
+    z.objectARRAY_89(dummy)
+    z.objectARRAY_90(dummy)
 
     val methods = classOf[scala2Lib.Z].getDeclaredMethods.toList ++ classOf[dottyApp.Z].getDeclaredMethods.toList
     methods.foreach { m =>
       m.getName match {
         case s"${prefix}_${suffix}" =>
-          val paramClass = m.getParameterTypes()(0).getSimpleName
-          assert(prefix == paramClass.toLowerCase, s"Method `$m` erased to `$paramClass` which does not match its prefix `$prefix`")
+          val paramClass = m.getParameterTypes()(0).getSimpleName.toLowerCase.replaceAll("""\[\]""", "ARRAY")
+          assert(prefix == paramClass, s"Method `$m` erased to `$paramClass` which does not match its prefix `$prefix`")
         case _ =>
       }
     }

--- a/sbt-dotty/sbt-test/scala2-compat/erasure/scala2Lib/Api.scala
+++ b/sbt-dotty/sbt-test/scala2-compat/erasure/scala2Lib/Api.scala
@@ -8,6 +8,7 @@ trait B
 trait SubB extends B
 trait C
 trait Cov[+T]
+trait Univ extends Any
 
 class D
 
@@ -153,4 +154,36 @@ class Z {
   def int_61(x: Any with Int): Unit = {}
   def int_62(x: Int with AnyVal): Unit = {}
   def int_63(x: AnyVal with Int): Unit = {}
+
+  def intARRAY_64(x: Array[Int with Singleton]): Unit = {}
+  def object_65(x: Array[_ <: Int]): Unit = {}
+  def object_66(x: Array[_ <: Int with Singleton]): Unit = {}
+  def object_67(x: Array[_ <: Singleton with Int]): Unit = {}
+  def object_68(x: Array[_ <: Int with Any]): Unit = {}
+  def object_69(x: Array[_ <: Any with Int]): Unit = {}
+  def object_70(x: Array[_ <: Int with AnyVal]): Unit = {}
+  def object_71(x: Array[_ <: AnyVal with Int]): Unit = {}
+
+  def stringARRAY_72(x: Array[String with Singleton]): Unit = {}
+  def stringARRAY_73(x: Array[_ <: String]): Unit = {}
+  def stringARRAY_74(x: Array[_ <: String with Singleton]): Unit = {}
+  def stringARRAY_75(x: Array[_ <: Singleton with String]): Unit = {}
+  def stringARRAY_76(x: Array[_ <: String with Any]): Unit = {}
+  def stringARRAY_77(x: Array[_ <: Any with String]): Unit = {}
+  def stringARRAY_78(x: Array[_ <: String with AnyRef]): Unit = {}
+  def stringARRAY_79(x: Array[_ <: AnyRef with String]): Unit = {}
+
+  def object_80(x: Array[_ <: Singleton]): Unit = {}
+  def object_81(x: Array[_ <: AnyVal]): Unit = {}
+  def objectARRAY_82(x: Array[_ <: AnyRef]): Unit = {}
+  def object_83(x: Array[_ <: Any]): Unit = {}
+
+  def object_84(x: Array[_ <: Serializable]): Unit = {}
+  def object_85(x: Array[_ <: Univ]): Unit = {}
+  def aARRAY_86(x: Array[_ <: A]): Unit = {}
+  def aARRAY_87(x: Array[_ <: A with B]): Unit = {}
+
+  def objectARRAY_88(x: Array[Any]): Unit = {}
+  def objectARRAY_89(x: Array[AnyRef]): Unit = {}
+  def objectARRAY_90(x: Array[AnyVal]): Unit = {}
 }

--- a/tests/run/array-erasure.scala
+++ b/tests/run/array-erasure.scala
@@ -35,11 +35,35 @@ object Test {
     }
   }
 
+  def arr3[T <: Int](x: Array[T]) = {
+    x(0) == 2
+    x.sameElements(x)
+  }
+
+  def arr4[T <: Int | Double](x: Array[T]) = {
+    x(0) == 2
+    x.sameElements(x)
+  }
+
+  def arr5[T <: Int | String](x: Array[T]) = {
+    x(0) == 2
+    x.sameElements(x)
+  }
+
+  def arr6[T <: Matchable](x: Array[T]) = {
+    x(0) == 2
+    x.sameElements(x)
+  }
+
   def main(args: Array[String]): Unit = {
     val x: Array[Int] = Array(0)
 
     arr0(x)
     arr1(x)
     arr2(x)
+    arr3(x)
+    arr4(x)
+    arr5(x)
+    arr6(x)
   }
 }

--- a/tests/run/arrays-from-java/A_1.scala
+++ b/tests/run/arrays-from-java/A_1.scala
@@ -1,0 +1,4 @@
+class A {
+  def foo1[T <: Serializable](x: Array[T]): Unit = {}
+  def foo2[T <: Object & Serializable](x: Array[T]): Unit = {}
+}

--- a/tests/run/arrays-from-java/C_2.java
+++ b/tests/run/arrays-from-java/C_2.java
@@ -1,0 +1,21 @@
+import java.io.Serializable;
+
+class B extends A {
+  @Override
+  public <T extends Serializable> void foo1(T[] x) {}
+  @Override
+  public <T extends Object & Serializable> void foo2(T[] x) {}
+}
+
+public class C_2 {
+  public static void test() {
+    A a = new A();
+    B b = new B();
+    String[] arr = { "" };
+    a.foo1(arr);
+    a.foo2(arr);
+
+    b.foo1(arr);
+    b.foo2(arr);
+  }
+}

--- a/tests/run/arrays-from-java/Test_2.scala
+++ b/tests/run/arrays-from-java/Test_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  def main(args: Array[String]): Unit =
+    C_2.test()
+}


### PR DESCRIPTION
We sometimes need to erase `Array[T]` to `Object` instead of
`Array[erasure(T)]` in method signatures, this happens when both
primitive and reference arrays, or two different sort of primitive
arrays could be passed as arguments because the lub of those types on
the JVM is `Object`. But before this commit, we additionally erased
Arrays whose element type is upper-bounded by a universal trait to
Object (like `Array[_ <: Serializable]`), this isn't necessary since
primitives do not extend those traits (except for compiler fictions like
`Singleton`) and derived value classes in arrays are always boxed.

Since having matching Scala 2 and 3 erasure is a lost cause (cf #11603),
this commit align ourselves with Java which improves Java
interop (because we can emit more accurate Java generic signatures) and
should let us simplify erasure more in the future.

It also turns out than even before this commit, we did not match Scala 2
erasure perfectly since we erase `Array[_ <: Int]` to `Array[Int]`
whereas Scala 2 erases to `Object` (this is important since we want
`IArray[Int]` to be erased to `Array[Int]`), so we need to special case
Scala 2 array erasure anyway to handle this.

This commit renames `isUnboundedGeneric` to `isGenericArrayElement`
since the former was somewhat misleading, `T <: String | Any` is
bounded, but `Array[T]` cannot be represented with a specific JVM array
type.