### PR TITLE
Include sealed traits and classes as elements of Sum Mirrors

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -95,7 +95,7 @@ object SymUtils:
     *   - none of its children are anonymous classes
     *   - all of its children are addressable through a path from the parent class
     *     and also the location of the generated mirror.
-    *   - all of its children are generic products or singletons
+    *   - all of its children are generic products, singletons, or sealed traits ar classes
     */
     def whyNotGenericSum(declScope: Symbol)(using Context): String =
       if (!self.is(Sealed))
@@ -112,7 +112,7 @@ object SymUtils:
 
           if (child == self) "it has anonymous or inaccessible subclasses"
           else if (!isAccessible(child.owner)) i"its child $child is not accessible"
-          else if (!child.isClass) ""
+          else if !child.isClass || child.is(Sealed) then ""
           else {
             val s = child.whyNotGenericProduct
             if (s.isEmpty) s

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -278,12 +278,12 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
 
       def solve(sym: Symbol): Type = sym match
-        case caseClass: ClassSymbol =>
-          assert(caseClass.is(Case))
-          if caseClass.is(Module) then
-            caseClass.sourceModule.termRef
+        case childClass: ClassSymbol =>
+          assert(childClass.isOneOf(Case | Sealed))
+          if childClass.is(Module) then
+            childClass.sourceModule.termRef
           else
-            caseClass.primaryConstructor.info match
+            childClass.primaryConstructor.info match
               case info: PolyType =>
                 // Compute the the full child type by solving the subtype constraint
                 // `C[X1, ..., Xn] <: P`, where
@@ -300,13 +300,13 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
                     case tp => tp
                   resType <:< target
                   val tparams = poly.paramRefs
-                  val variances = caseClass.typeParams.map(_.paramVarianceSign)
+                  val variances = childClass.typeParams.map(_.paramVarianceSign)
                   val instanceTypes = tparams.lazyZip(variances).map((tparam, variance) =>
                     TypeComparer.instanceType(tparam, fromBelow = variance < 0))
                   resType.substParams(poly, instanceTypes)
-                instantiate(using ctx.fresh.setExploreTyperState().setOwner(caseClass))
+                instantiate(using ctx.fresh.setExploreTyperState().setOwner(childClass))
               case _ =>
-                caseClass.typeRef
+                childClass.typeRef
         case child => child.termRef
       end solve
 

--- a/tests/i9276.scala
+++ b/tests/i9276.scala
@@ -1,0 +1,13 @@
+import scala.deriving.*
+
+sealed trait A
+
+case class C() extends A
+
+sealed trait B extends A
+
+case class D() extends B
+
+@main def Test =
+  summon[Mirror.Of[A]]
+  summon[Mirror.Of[B]]


### PR DESCRIPTION
Addresses feature request #161

https://github.com/lampepfl/dotty-feature-requests/issues/161

This is just the immediate fix. We need more tests and use cases to see whether it works. @dwijnand if we can get some corrobation by Wednesday we might be able to roll this into 3.0. Otherwise it will have to wait.


