### PR TITLE
Improve error message for `inline val`s with non-constants

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InlineVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InlineVals.scala
@@ -4,6 +4,7 @@ package transform
 
 import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Decorators._
+import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.Types._
 import dotty.tools.dotc.transform.MegaPhase.MiniPhase
@@ -37,7 +38,10 @@ class InlineVals extends MiniPhase:
           if !isPureExpr(rhs) then
             val details = if enclosingInlineds.isEmpty then "" else em"but was: $rhs"
             report.error(s"inline value must be pure$details", rhs.srcPos)
-        case _ =>
-          val pos = if tpt.span.isZeroExtent then rhs.srcPos else tpt.srcPos
-          report.error(em"inline value must have a literal constant type", pos)
+        case tp =>
+          if tp.derivesFrom(defn.StringClass) || defn.ScalaValueClasses().exists(tp.derivesFrom(_)) then
+            val pos = if tpt.span.isZeroExtent then rhs.srcPos else tpt.srcPos
+            report.error(em"inline value must have a literal constant type", pos)
+          else
+            report.error(em"inline value must contain a literal constant value.\n\nTo inline more complex types consider using `inline def`", rhs)
   }

--- a/tests/neg/i11854.check
+++ b/tests/neg/i11854.check
@@ -1,0 +1,24 @@
+-- Error: tests/neg/i11854.scala:4:14 ----------------------------------------------------------------------------------
+4 |inline val j: Int = 2 // error
+  |              ^^^
+  |              inline value must have a literal constant type
+-- Error: tests/neg/i11854.scala:5:14 ----------------------------------------------------------------------------------
+5 |inline val b: Boolean = true // error
+  |              ^^^^^^^
+  |              inline value must have a literal constant type
+-- Error: tests/neg/i11854.scala:6:14 ----------------------------------------------------------------------------------
+6 |inline val s: String = "" // error
+  |              ^^^^^^
+  |              inline value must have a literal constant type
+-- Error: tests/neg/i11854.scala:7:18 ----------------------------------------------------------------------------------
+7 |inline val bagA = new Bag(Seq('a', 'b', 'c')) // error
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                  inline value must contain a literal constant value.
+  |
+  |                  To inline more complex types consider using `inline def`
+-- Error: tests/neg/i11854.scala:8:23 ----------------------------------------------------------------------------------
+8 |inline val bagB: Bag = new Bag(Seq('a', 'b', 'c')) // error
+  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                       inline value must contain a literal constant value.
+  |
+  |                       To inline more complex types consider using `inline def`

--- a/tests/neg/i11854.scala
+++ b/tests/neg/i11854.scala
@@ -1,0 +1,8 @@
+class Bag(seq: Seq[Char])
+
+inline val i = 2
+inline val j: Int = 2 // error
+inline val b: Boolean = true // error
+inline val s: String = "" // error
+inline val bagA = new Bag(Seq('a', 'b', 'c')) // error
+inline val bagB: Bag = new Bag(Seq('a', 'b', 'c')) // error

--- a/tests/neg/i11854.scala
+++ b/tests/neg/i11854.scala
@@ -1,8 +1,0 @@
-class Bag(seq: Seq[Char])
-
-inline val i = 2
-inline val j: Int = 2 // error
-inline val b: Boolean = true // error
-inline val s: String = "" // error
-inline val bagA = new Bag(Seq('a', 'b', 'c')) // error
-inline val bagB: Bag = new Bag(Seq('a', 'b', 'c')) // error

--- a/tests/run-macros/expr-map-1.check
+++ b/tests/run-macros/expr-map-1.check
@@ -6,9 +6,9 @@ kcolb
 neht
 esle
 lav
-vals
+slav
 fed
-defs
+sfed
 fed
 rab
 yrt

--- a/tests/run-macros/expr-map-1/Test_2.scala
+++ b/tests/run-macros/expr-map-1/Test_2.scala
@@ -31,7 +31,7 @@ object Test {
 
     rewrite {
       val s: "vals" = "vals"
-      println(s) // prints "foo" not "oof"
+      println(s)
     }
 
     rewrite {
@@ -41,7 +41,7 @@ object Test {
 
     rewrite {
       def s: "defs" = "defs"
-      println(s) // prints "foo" not "oof"
+      println(s)
     }
 
     rewrite {

--- a/tests/run-macros/i11856/Main_2.scala
+++ b/tests/run-macros/i11856/Main_2.scala
@@ -1,0 +1,8 @@
+@main def Test: Unit =
+  inline def str1 = "Hello, "
+  inline val str2 = "Scala 3"
+  println(Str.concat(str1, str2))
+
+  inline def i1 = 1
+  inline val i2 = 2
+  println(I.sum(i1, i2))

--- a/tests/run-macros/i11856/Test_1.scala
+++ b/tests/run-macros/i11856/Test_1.scala
@@ -1,0 +1,19 @@
+import scala.quoted.*
+
+object Str:
+    inline def concat(inline a: String, inline b: String): String =
+        ${ evalConcat('a, 'b) }
+
+    def evalConcat(expra: Expr[String], exprb: Expr[String])(using Quotes): Expr[String] =
+        val a = expra.valueOrError
+        val b = exprb.valueOrError
+        Expr(a ++ b)
+
+object I:
+  inline def sum(inline a: Int, inline b: Int): Int =
+      ${ evalConcat('a, 'b) }
+
+  def evalConcat(expra: Expr[Int], exprb: Expr[Int])(using Quotes): Expr[Int] =
+      val a = expra.valueOrError
+      val b = exprb.valueOrError
+      Expr(a + b)


### PR DESCRIPTION
* Improve error message for `inline val`s with non-constants 
* Check type when matching primitive expressions. Make the `Expr` extractor or `Expr.value` match a reference to an `inline val`.

Fixes #11854