### PR TITLE
Fix #11592: Scala.js: Handle default params of native JS classes.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
@@ -158,6 +158,13 @@ object JSSymUtils {
       }
     }
 
+    /** Is this symbol a default param accessor for the constructor of a native JS class? */
+    def isJSNativeCtorDefaultParam(using Context): Boolean = {
+      sym.name.is(DefaultGetterName)
+        && sym.name.exclude(DefaultGetterName) == nme.CONSTRUCTOR
+        && sym.owner.linkedClass.hasAnnotation(jsdefn.JSNativeAnnot)
+    }
+
     def jsCallingConvention(using Context): JSCallingConvention =
       JSCallingConvention.of(sym)
 

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -4,6 +4,7 @@ import org.junit.Assert.*
 import org.junit.Test
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 class RegressionTestScala3 {
   import RegressionTestScala3.*
@@ -21,6 +22,11 @@ class RegressionTestScala3 {
     assertEquals(-1, obj2.y)
     assertEquals(4, obj2.foo(5))
   }
+
+  @Test def testJSNativeDefaultCtorParamIssue11592(): Unit = {
+    assertEquals("foo", new RangeErrorIssue11592("foo").message)
+    assertEquals("", new RangeErrorIssue11592().message)
+  }
 }
 
 object RegressionTestScala3 {
@@ -32,6 +38,12 @@ object RegressionTestScala3 {
     private class ChildClass extends ParentTrait // must be class *and* private
 
     def foo(x: Int): Int = new ChildClass().concreteMethod(x)
+  }
+
+  @js.native
+  @JSGlobal("RangeError")
+  class RangeErrorIssue11592(msg: String = js.native) extends js.Object {
+    val message: String = js.native
   }
 }
 


### PR DESCRIPTION
They must not be emitted, just like regular methods inside native JS classes are not emitted.

This ensures that if the default value is `= js.native`, it is not emitted, and therefore does not report an error tha calling `js.native` is illegal in non-native code.

---

This is in fact a blocker to upgrade scalajs-dom to Scala 3, so I'm assigning it to 3.0.0-RC2. It should be straightforward.