### PR TITLE
Fix PatmatExhaustivityTest failing depending on pagewidth

### DIFF
--- a/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
@@ -18,7 +18,7 @@ import org.junit.Test
 class PatmatExhaustivityTest {
   val testsDir = "tests/patmat"
   // stop-after: patmatexhaust-huge.scala crash compiler
-  val options = List("-color:never", "-Ystop-after:explicitSelf", "-Ycheck-all-patmat", "-classpath", TestConfiguration.basicClasspath)
+  val options = List("-pagewidth", "80", "-color:never", "-Ystop-after:explicitSelf", "-Ycheck-all-patmat", "-classpath", TestConfiguration.basicClasspath)
 
   private def compile(files: Seq[String]): Seq[String] = {
     val stringBuffer = new StringWriter()


### PR DESCRIPTION
Now that pagewidth is computed based on the terminal size, it needs to
be hardcoded for tests that compare the compiler output against a
checkfile.