### PR TITLE
CI: turn off option that runs git submodule foreach

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,12 +54,16 @@ jobs:
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -99,12 +103,16 @@ jobs:
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -134,6 +142,8 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Test
         run: sbt ";scala3-bootstrapped/compile"
@@ -159,6 +169,8 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Test
         run: sbt ";scala3-bootstrapped/compile ;scala3-bootstrapped/test"
@@ -192,12 +204,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -232,12 +248,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -272,12 +292,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -312,12 +336,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -360,12 +388,16 @@ jobs:
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -396,12 +428,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -430,12 +466,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -476,12 +516,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -558,12 +602,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
@@ -603,12 +651,16 @@ jobs:
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,4 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - run: ./project/scripts/check-cla.sh

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Cache Coursier
         uses: actions/cache@v1
@@ -86,6 +88,8 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1


### PR DESCRIPTION
Because this is run without running git submodule update first, it seems
to break whenever a submodule is deleted.