### PR TITLE
CI: deinit submodules before running actions/checkout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -197,7 +197,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -240,7 +240,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -283,7 +283,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -326,7 +326,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -377,7 +377,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -416,7 +416,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -453,7 +453,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -502,7 +502,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -587,7 +587,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -635,7 +635,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,9 @@ jobs:
       - name: Set JDK 16 as default
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -97,6 +100,9 @@ jobs:
       - name: Set JDK 16 as default
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -132,6 +138,9 @@ jobs:
          )"
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -157,6 +166,9 @@ jobs:
          )"
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -190,6 +202,9 @@ jobs:
          )"
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -230,6 +245,9 @@ jobs:
          )"
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -270,6 +288,9 @@ jobs:
          )"
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -310,6 +331,9 @@ jobs:
          )"
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -358,6 +382,9 @@ jobs:
       - name: Set JDK 8 as default
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
 
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -394,6 +421,9 @@ jobs:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER_ORGSCALALANG }}
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -428,6 +458,9 @@ jobs:
                                            # Make sure you have the write permissions to the repo: https://github.com/lampepfl/dotty-website
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -474,6 +507,9 @@ jobs:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER_ORGSCALALANG }}
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -556,6 +592,9 @@ jobs:
                                            # Make sure you have the write permissions to the repo: https://github.com/lampepfl/dotty-website
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -601,6 +640,9 @@ jobs:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
 
     steps:
+      - name: Cleanup submodules
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -138,9 +138,6 @@ jobs:
          )"
 
     steps:
-      - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
-
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -166,9 +163,6 @@ jobs:
          )"
 
     steps:
-      - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
-
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -203,7 +197,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -219,7 +213,7 @@ jobs:
 
       - name: Test
         run: |
-          git submodule sync
+          git submodule sync && cat .gitmodules
           git submodule update --init --recursive --jobs 7
           ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestA"
 
@@ -246,7 +240,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -262,7 +256,7 @@ jobs:
 
       - name: Test
         run: |
-          git submodule sync
+          git submodule sync && cat .gitmodules
           git submodule update --init --recursive --jobs 7
           ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestB"
 
@@ -289,7 +283,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -305,7 +299,7 @@ jobs:
 
       - name: Test
         run: |
-          git submodule sync
+          git submodule sync && cat .gitmodules
           git submodule update --init --recursive --jobs 7
           ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestC"
 
@@ -332,7 +326,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -383,7 +377,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -422,7 +416,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -459,7 +453,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -508,7 +502,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -593,7 +587,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -641,7 +635,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -197,7 +197,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -240,7 +240,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -283,7 +283,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -326,7 +326,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -377,7 +377,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -416,7 +416,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -453,7 +453,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -502,7 +502,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -587,7 +587,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -635,7 +635,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && cat .gitmodules && git submodule deinit -f . || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && rm -rf community-build/community-projects/* || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -197,7 +197,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -240,7 +240,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -283,7 +283,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -326,7 +326,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -377,7 +377,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -416,7 +416,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -453,7 +453,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -502,7 +502,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -587,7 +587,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -635,7 +635,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && ls -l .git/modules || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -197,7 +197,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -240,7 +240,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -283,7 +283,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -326,7 +326,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -377,7 +377,7 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -416,7 +416,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -453,7 +453,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -502,7 +502,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -587,7 +587,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2
@@ -635,7 +635,7 @@ jobs:
 
     steps:
       - name: Cleanup submodules
-        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule update --init --jobs 7 || true
+        run: git reset --hard HEAD && git submodule sync && git submodule deinit -f . && git submodule status && git status && git diff || true
 
       - name: Checkout cleanup script
         uses: actions/checkout@v2


### PR DESCRIPTION
This action runs "git submodule foreach" early which will fail if a
submodule has been deleted but is still present in the repo (see
https://github.com/actions/checkout/issues/354).