### PR TITLE
Fix #11872, correct error msg when modifier flag is not allowed

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2455,7 +2455,7 @@ import transform.SymUtils._
            |""".stripMargin
   }
 
-  class ModifierNotAllowedForDefinition(flag: Flag)(using Context)
+  class ModifierNotAllowedForDefinition(flag: FlagSet)(using Context)
     extends SyntaxMsg(ModifierNotAllowedForDefinitionID) {
     def msg = s"Modifier `${flag.flagsString}` is not allowed for this definition"
     def explain = ""

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -435,7 +435,7 @@ object Checking {
       if sym.isAllOf(flag1 | flag2) then fail(i"illegal combination of modifiers: `${flag1.flagsString}` and `${flag2.flagsString}` for: $sym")
     def checkApplicable(flag: FlagSet, ok: Boolean) =
       if (!ok && !sym.is(Synthetic))
-        fail(ModifierNotAllowedForDefinition(Erased))
+        fail(ModifierNotAllowedForDefinition(flag))
 
     if (sym.is(Inline) &&
           (  sym.is(ParamAccessor) && sym.owner.isClass


### PR DESCRIPTION
`ModifierNotAllowedForDefinition` now takes a `FlagSet` instead of just a `Flag`, which makes sense as it should report error for the flags used even if more than one and `Flag <: FlagSet`. And then the hard-coded `Erased` is replaced by the actual `flag: FlagSet`.