### PR TITLE
CI: reset existing repo to known state

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,9 @@ jobs:
       - name: Set JDK 16 as default
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -97,6 +100,9 @@ jobs:
       - name: Set JDK 16 as default
         run: echo "/usr/lib/jvm/java-16-openjdk-amd64/bin" >> $GITHUB_PATH
 
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -132,6 +138,10 @@ jobs:
          )"
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+        shell: cmd
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -157,6 +167,10 @@ jobs:
          )"
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+        shell: cmd
+
       - name: Git Checkout
         uses: actions/checkout@v2
 
@@ -190,6 +204,9 @@ jobs:
          )"
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -230,6 +247,9 @@ jobs:
          )"
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -270,6 +290,9 @@ jobs:
          )"
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -310,6 +333,9 @@ jobs:
          )"
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -358,6 +384,9 @@ jobs:
       - name: Set JDK 8 as default
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
 
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -394,6 +423,9 @@ jobs:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER_ORGSCALALANG }}
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -428,6 +460,9 @@ jobs:
                                            # Make sure you have the write permissions to the repo: https://github.com/lampepfl/dotty-website
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -474,6 +509,9 @@ jobs:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER_ORGSCALALANG }}
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -556,6 +594,9 @@ jobs:
                                            # Make sure you have the write permissions to the repo: https://github.com/lampepfl/dotty-website
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 
@@ -601,6 +642,9 @@ jobs:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
 
     steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
       - name: Checkout cleanup script
         uses: actions/checkout@v2
 


### PR DESCRIPTION
If at some point a PR accidentally deletes a git submodule without
deleting it from .gitmodules, subsequent PRs using the same runner will
fail because the checkout action will try to run `git submodule foreach
...` before updating the git repo to match the current PR and fail, we
can avoid the problem by always resetting to origin/master which
hopefully is always in a good state.

Ideally the checkout action would be more robust: https://github.com/actions/checkout/issues/354