### PR TITLE
Check GADT ordering for HKTs in TypeComparer

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1045,12 +1045,10 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                     }
                   }
 
-                  var usedGadtOrdering: Boolean = false
                   def byGadtOrdering: Boolean =
                     ctx.gadt.contains(tycon1sym)
                     && ctx.gadt.contains(tycon2sym)
                     && ctx.gadt.isLess(tycon1sym, tycon2sym)
-                    && { usedGadtOrdering = true; true }
 
                   val res = (
                     tycon1sym == tycon2sym && isSubPrefix(tycon1.prefix, tycon2.prefix)
@@ -1066,11 +1064,9 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                     // 2) if we touched GADTs, then the _other_ symbol (class syms
                     //    cannot have GADT constraints), the one w/ GADT cstrs,
                     //    must be instantiated, making the two tycons equal
-                    // 3) if we used GADT ordering, which means that neither symbol
-                    //    has been instantiated, we should not assume injectivity
                     val tyconIsInjective =
                       (tycon1sym.isClass || tycon2sym.isClass)
-                      && (!touchedGADTs || gadtIsInstantiated && !usedGadtOrdering)
+                      && (!touchedGADTs || gadtIsInstantiated)
 
                     inFrozenGadtIf(!tyconIsInjective) {
                       if tycon1sym == tycon2sym && tycon1sym.isAliasType then

--- a/tests/pos/gadt-hkt-ordering.scala
+++ b/tests/pos/gadt-hkt-ordering.scala
@@ -1,0 +1,10 @@
+object test {
+  final class HKTVar[+T[_]]
+
+  def foo[F[_], G[_], X](m : HKTVar[G]) = m match {
+    case _ : HKTVar[F] =>
+      val fx : F[X] = ???
+      val gx : G[X] = fx
+  }
+
+}

--- a/tests/pos/gadt-hkt-ordering.scala
+++ b/tests/pos/gadt-hkt-ordering.scala
@@ -6,5 +6,4 @@ object test {
       val fx : F[X] = ???
       val gx : G[X] = fx
   }
-
 }


### PR DESCRIPTION
Since the current TypeComparer calls `GadtConstraint.bounds` to check GADT bounds of HKTs, the GADT ordering between two HK type parameters will not be available when comparing them. The following snippet illustrates the issue.
```scala
final class HktInv[F[_]]
final class HktVar[+F[_]]

def foo[F[_], G[_], X](m : HktInv[G]) = m match {
  case _ : HktInv[F] =>
    val fx : F[X] = ???
    val gx : G[X] = fx  // pass! `F` has been instantiated to `G` 
                        // and thus the bound F =:= G is accessible from `bounds`.
}

def baz[F[_], G[_], X](m : HktVar[G]) = m match {
  case _ : HktVar[F] =>
    val fx : F[X] = ???
    val gx : G[X] = fx  // error. `F` has only ordering constraints F <:< G 
                        // and such ordering will not be available to TypeComparer via `bounds`.
}
```

The orderings will be available via `fullBounds`, but this method may result in dead loops if used in TypeComparer. This PR fixes this issue by checking ordering constraints between HKTs with `isLess` in TypeComparer.

@abgruszecki 