### PR TITLE
Fixes for transitive inlining

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -22,6 +22,8 @@ import core.tasty.TreePickler.Hole
  *  @param newOwners New owners, replacing previous owners.
  *  @param substFrom The symbols that need to be substituted.
  *  @param substTo   The substitution targets.
+ *  @param stopAtInlinedArgument  Whether one should stop at an inlined argument,
+ *                    i.e. a node of form Inlined(EmptyTree, _, _).
  *
  *  The reason the substitution is broken out from the rest of the type map is
  *  that all symbols have to be substituted at the same time. If we do not do this,
@@ -31,14 +33,19 @@ import core.tasty.TreePickler.Hole
  *  do S2 we get outer#2.inner#4. But that means that the named type outer#2.inner
  *  gets two different denotations in the same period. Hence, if -Yno-double-bindings is
  *  set, we would get a data race assertion error.
+ *
+ *  Note: TreeTypeMap is final, since derived maps are created dynamically for
+ *  nested scopes. Any subclass of TreeTypeMap would revert to the standard
+ *  TreeTypeMap in these recursive invocations.
  */
-class TreeTypeMap(
+final class TreeTypeMap(
   val typeMap: Type => Type = IdentityTypeMap,
   val treeMap: tpd.Tree => tpd.Tree = identity _,
   val oldOwners: List[Symbol] = Nil,
   val newOwners: List[Symbol] = Nil,
   val substFrom: List[Symbol] = Nil,
-  val substTo: List[Symbol] = Nil)(using Context) extends tpd.TreeMap {
+  val substTo: List[Symbol] = Nil,
+  stopAtInlinedArgument: Boolean = false)(using Context) extends tpd.TreeMap {
   import tpd._
 
   /** If `sym` is one of `oldOwners`, replace by corresponding symbol in `newOwners` */
@@ -76,8 +83,11 @@ class TreeTypeMap(
       updateDecls(prevStats.tail, newStats.tail)
     }
 
-  /** If true, stop return Inlined(Empty, _, _) nodes unchanged */
-  def stopAtInlinedArgument: Boolean = false
+  def transformInlined(tree: tpd.Inlined)(using Context): tpd.Tree =
+    val Inlined(call, bindings, expanded) = tree
+    val (tmap1, bindings1) = transformDefs(bindings)
+    val expanded1 = tmap1.transform(expanded)
+    cpy.Inlined(tree)(call, bindings1, expanded1)
 
   override def transform(tree: tpd.Tree)(using Context): tpd.Tree = treeMap(tree) match {
     case impl @ Template(constr, parents, self, _) =>
@@ -111,7 +121,9 @@ class TreeTypeMap(
           cpy.Block(blk)(stats1, expr1)
         case inlined @ Inlined(call, bindings, expanded) =>
           if stopAtInlinedArgument && call.isEmpty then
-            inlined
+            expanded match
+              case expanded: TypeTree => assert(bindings.isEmpty); expanded
+              case _ => inlined
           else
             val (tmap1, bindings1) = transformDefs(bindings)
             val expanded1 = tmap1.transform(expanded)
@@ -177,7 +189,8 @@ class TreeTypeMap(
         from ++ oldOwners,
         to ++ newOwners,
         from ++ substFrom,
-        to ++ substTo)
+        to ++ substTo,
+        stopAtInlinedArgument)
     }
 
   /** Apply `typeMap` and `ownerMap` to given symbols `syms`

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -706,11 +706,40 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
     def inlinedFromOutside(tree: Tree)(span: Span): Tree =
       Inlined(EmptyTree, Nil, tree)(using ctx.withSource(inlinedMethod.topLevelClass.source)).withSpan(span)
 
+    // InlinerMap is a TreeTypeMap with special treatment for inlined arguments:
+    // They are generally left alone (not mapped further, and if they wrap a type
+    // the type Inlined wrapper gets dropped
+    class InlinerMap(
+        typeMap: Type => Type,
+        treeMap: Tree => Tree,
+        oldOwners: List[Symbol],
+        newOwners: List[Symbol],
+        substFrom: List[Symbol],
+        substTo: List[Symbol])(using Context)
+      extends TreeTypeMap(typeMap, treeMap, oldOwners, newOwners, substFrom, substTo):
+
+      override def copy(
+          typeMap: Type => Type,
+          treeMap: Tree => Tree,
+          oldOwners: List[Symbol],
+          newOwners: List[Symbol],
+          substFrom: List[Symbol],
+          substTo: List[Symbol])(using Context) =
+        new InlinerMap(typeMap, treeMap, oldOwners, newOwners, substFrom, substTo)
+
+      override def transformInlined(tree: Inlined)(using Context) =
+        if tree.call.isEmpty then
+          tree.expansion match
+            case expansion: TypeTree => expansion
+            case _ => tree
+        else super.transformInlined(tree)
+    end InlinerMap
+
     // A tree type map to prepare the inlined body for typechecked.
     // The translation maps references to `this` and parameters to
     // corresponding arguments or proxies on the type and term level. It also changes
     // the owner from the inlined method to the current owner.
-    val inliner = new TreeTypeMap(
+    val inliner = new InlinerMap(
       typeMap =
         new DeepTypeMap {
           def apply(t: Type) = t match {
@@ -753,7 +782,8 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
       },
       oldOwners = inlinedMethod :: Nil,
       newOwners = ctx.owner :: Nil,
-      stopAtInlinedArgument = true
+      substFrom = Nil,
+      substTo = Nil
     )(using inlineCtx)
 
     // Apply inliner to `rhsToInline`, split off any implicit bindings from result, and

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -746,16 +746,15 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
               val inlinedSingleton = singleton(t).withSpan(argSpan)
               inlinedFromOutside(inlinedSingleton)(tree.span)
             case Some(t) if tree.isType =>
-              TypeTree(t).withSpan(argSpan)
+              inlinedFromOutside(TypeTree(t).withSpan(argSpan))(tree.span)
             case _ => tree
           }
         case tree => tree
       },
       oldOwners = inlinedMethod :: Nil,
-      newOwners = ctx.owner :: Nil
-    )(using inlineCtx) {
-      override def stopAtInlinedArgument: Boolean = true
-    }
+      newOwners = ctx.owner :: Nil,
+      stopAtInlinedArgument = true
+    )(using inlineCtx)
 
     // Apply inliner to `rhsToInline`, split off any implicit bindings from result, and
     // make them part of `bindingsBuf`. The expansion is then the tree that remains.

--- a/tests/pos/i11350.scala
+++ b/tests/pos/i11350.scala
@@ -1,0 +1,5 @@
+//case class A[T](action: A[T] ?=> String) // now disallowed
+
+class A1[T](action: A1[T] ?=> String = (_: A1[T]) ?=> "") // works
+//case class A2[T](action: A2[?] ?=> String) // now disallowed
+//case class A3[T](action: A3[T] => String) // now disallowed

--- a/tests/pos/i11894.scala
+++ b/tests/pos/i11894.scala
@@ -1,0 +1,7 @@
+class CallbackTo[A](val x: A):
+  inline def runNow(): A = x
+  inline def toScalaFn: () => A = () => runNow()
+  def toOption(): Option[A] =
+    val y: CallbackTo[Option[A]] = ???
+    val f: () => Option[A] = y.toScalaFn // error
+    f()

--- a/tests/pos/i11894a.scala
+++ b/tests/pos/i11894a.scala
@@ -1,0 +1,24 @@
+object CallbackTo {
+  extension [A](self: CallbackTo[Option[A]]) {
+    transparent inline def asOption: Option[A] =
+      self.toScalaFn()
+  }
+}
+
+final class CallbackTo[A] (val x: List[A]) {
+
+  transparent inline def runNow(): A =
+    x.head
+
+  transparent inline def toScalaFn: () => A =
+    () => runNow()
+
+  def map[B](f: A => B): CallbackTo[B] =
+    ???
+
+  def toOption: Option[A] = {
+    val x = map[Option[A]](Some(_))
+    val y = x: CallbackTo[Option[A]] // ok: type is what we expect
+    y.asOption // error
+  }
+}

--- a/tests/pos/i11894b.scala
+++ b/tests/pos/i11894b.scala
@@ -1,0 +1,24 @@
+object CallbackTo {
+  extension [A](self: CallbackTo[Option[A]]) {
+    inline def asOption: Option[A] =
+      self.toScalaFn()
+  }
+}
+
+final class CallbackTo[A] (val x: List[A]) {
+
+  inline def runNow(): A =
+    x.head
+
+  inline def toScalaFn: () => A =
+    () => runNow()
+
+  def map[B](f: A => B): CallbackTo[B] =
+    ???
+
+  def toOption: Option[A] = {
+    val x = map[Option[A]](Some(_))
+    val y = x: CallbackTo[Option[A]] // ok: type is what we expect
+    y.asOption // error
+  }
+}


### PR DESCRIPTION
Fixes #11894

Two classes of problems:

 1. an Inlined node around a closure was forgotten since the `closureDef` is too general
 2. inlined type arguments were transformed again, which lead to the double `Option` application

(2) only appeared for normal inlines, not for transparent inlines. I believe this has to do with the fact that recursive inlines are invoked in different order in the Typer and Inlining phases. In the typer it's during adapt in the Inline typer itself whereas in the inlining phase it is in `InliningTreeMap` after the first inline has been fully expanded. That makes a difference in that we see already all parameter bindings as regular code.

