### PR TITLE
Don't generate paths with outer accessors to stable references

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -508,14 +508,9 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
   private def computeThisBindings() = {
     // All needed this-proxies, paired-with and sorted-by nesting depth of
     // the classes they represent (innermost first)
-    val sortedProxies = thisProxy.toList.map {
-      case (cls, proxy) =>
-        // The class that the this-proxy `selfSym` represents
-        def classOf(selfSym: Symbol) = selfSym.info.classSymbol
-        // The total nesting depth of the class represented by `selfSym`.
-        def outerLevel(selfSym: Symbol): Int = classOf(selfSym).ownersIterator.length
-        (outerLevel(cls), proxy.symbol)
-    }.sortBy(-_._1)
+    val sortedProxies = thisProxy.toList
+      .map((cls, proxy) => (cls.ownersIterator.length, proxy.symbol))
+      .sortBy(-_._1)
 
     var lastSelf: Symbol = NoSymbol
     var lastLevel: Int = 0

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -522,9 +522,13 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
     for ((level, selfSym) <- sortedProxies) {
       lazy val rhsClsSym = selfSym.info.widenDealias.classSymbol
       val rhs =
-        if (lastSelf.exists)
-          ref(lastSelf).outerSelect(lastLevel - level, selfSym.info)
-        else if (rhsClsSym.is(Module) && rhsClsSym.isStatic)
+        if lastSelf.exists then
+          selfSym.info match
+            case info: TermRef if info.isStable =>
+              ref(info)
+            case _ =>
+              ref(lastSelf).outerSelect(lastLevel - level, selfSym.info)
+        else if rhsClsSym.is(Module) && rhsClsSym.isStatic then
           ref(rhsClsSym.sourceModule)
         else
           inlineCallPrefix

--- a/tests/run/i11914.scala
+++ b/tests/run/i11914.scala
@@ -1,0 +1,17 @@
+class Wrapper[E <: Throwable]:
+  object syntax:
+    extension [A <: Matchable](a: E | A)
+      transparent inline def foreach(f: A => Any): Unit =
+        a match
+          case e: E => ()
+          case a: A => f(a)
+
+  def _catch[A](a: => A): E | A =
+    try a
+    catch case e: E => e
+
+object throwables extends Wrapper[Throwable]
+import throwables.syntax.*
+
+@main def Test(): Unit =
+  for x <- throwables._catch(1/1) do println(x)

--- a/tests/run/i11914a.scala
+++ b/tests/run/i11914a.scala
@@ -1,0 +1,23 @@
+object Wrapper:
+  type E <: Throwable
+  class C:
+    object syntax:
+        extension [A <: Matchable](a: E | A)
+          transparent inline def foreach(f: A => Any): Unit =
+            a match
+              case e: E =>
+                Wrapper.this.n + m
+              case a: A => f(a)
+        val m: Int = 4
+
+  def _catch[A](a: => A): E | A =
+    try a
+    catch case e: E => e
+
+  val n: Int = 3
+
+object throwables extends Wrapper.C
+import throwables.syntax.*
+
+@main def Test(): Unit =
+  for x <- Wrapper._catch(1/1) do println(x)


### PR DESCRIPTION
In that case we can generate directly a reference without going though
an inner this proxy and an outer accessor.

This optimization is necessary since outer accessors are not generated for objects.

Fixes #11914.