### PR TITLE
WIP - Fix 11924

### DIFF
--- a/tests/pos/i11924.scala
+++ b/tests/pos/i11924.scala
@@ -1,0 +1,10 @@
+object i11924:
+  type A
+  class B { def foo = 0 }
+  trait Ev { type T >: A <: B }
+
+  inline def test(ev: Ev)(x: ev.T): Int = x.foo
+
+  def trial(ev: Ev, a: A) = {
+    test(ev)(a)
+  }


### PR DESCRIPTION
Just a quick trial to see if https://github.com/lampepfl/dotty/issues/11924 can be fixed simply by always creating a type-annotated binding for inlined method arguments.

I did not try to make the change for transparent inline methods (thus the `ctx.phase == Phases.typerPhase`), as that would likely raise many problems, since these inline methods do influence type checking. I suspect more extensive changes would be needed to support these.