### PR TITLE
Fix #11731: Remove symbols with targetName correctly

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1899,7 +1899,9 @@ object SymDenotations {
      *  someone does a findMember on a subclass.
      */
     def delete(sym: Symbol)(using Context): Unit = {
-      info.decls.openForMutations.unlink(sym)
+      val scope = info.decls.openForMutations
+      scope.unlink(sym, sym.name)
+      if sym.name != sym.originalName then scope.unlink(sym, sym.originalName)
       if (myMemberCache != null) myMemberCache.remove(sym.name)
       if (!sym.flagsUNSAFE.is(Private)) invalidateMemberNamesCache()
     }

--- a/tests/pos/i11731.scala
+++ b/tests/pos/i11731.scala
@@ -1,0 +1,5 @@
+import scala.annotation.targetName
+
+trait Example:
+  @targetName("funfun")
+  inline def fun: Unit = ???


### PR DESCRIPTION
Fix #11731: Remove symbols with targetName correctly

The symbol might have original name in scope other than its current
target name (after erasure).