### PR TITLE
Fix broken script on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,12 +154,12 @@ jobs:
         shell: cmd
 
       - name: cygwin tests
-        run: bash ./project/scripts/winCmdTests
+        run: '"C:\Program Files\cygwin64\bin\bash" ./project/scripts/winCmdTests'
         shell: cmd
 
-      # - name: msys tests
-      #   run: 'C:\Program Files\Git\bin\bash' ./project/scripts/winCmdTests
-      #   shell: cmd
+      - name: msys tests
+        run: '"C:\Program Files\Git\bin\bash" ./project/scripts/winCmdTests'
+        shell: cmd
 
       - name: Scala.js Test
         run: sbt ";sjsJUnitTests/test ;sjsCompilerTests/test"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,18 @@ jobs:
         run: sbt ";scala3-bootstrapped/compile"
         shell: cmd
 
+      - name: build binary
+        run: sbt "dist/pack" & bash -version
+        shell: cmd
+
+      - name: cygwin tests
+        run: bash ./project/scripts/winCmdTests
+        shell: cmd
+
+      # - name: msys tests
+      #   run: 'C:\Program Files\Git\bin\bash' ./project/scripts/winCmdTests
+      #   shell: cmd
+
       - name: Scala.js Test
         run: sbt ";sjsJUnitTests/test ;sjsCompilerTests/test"
         shell: cmd

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -7,7 +7,7 @@
 # save terminal settings
 saved_stty=$(stty -g 2>/dev/null)
 # clear on error so we don't later try to restore them
-if [[ ! $? ]]; then  
+if [[ ! $? ]]; then
   saved_stty=""
 fi
 
@@ -135,7 +135,7 @@ fi
 find_lib () {
   local lib=$(find $PROG_HOME/lib/ -name "$1")
   if [ -n "$CYGPATHCMD" ]; then
-    $CYGPATHCMD -am $lib
+    "$CYGPATHCMD" -am $lib
   elif [[ $mingw ||  $msys ]]; then
     echo $lib | sed 's|/|\\\\|g'
   else

--- a/project/scripts/bootstrapCmdTests
+++ b/project/scripts/bootstrapCmdTests
@@ -64,3 +64,6 @@ echo "testing i11644"
 cwd=$(pwd)
 clear_out "$OUT"
 (cd "$OUT" && "$cwd/bin/scalac" "$cwd/tests/pos/i11644.scala" && "$cwd/bin/scalac" "$cwd/tests/pos/i11644.scala")
+
+# check options specified in files
+./bin/scalac @project/scripts/options "$SOURCE"

--- a/project/scripts/options
+++ b/project/scripts/options
@@ -1,0 +1,2 @@
+-Xprint:frontend -Ylog:frontend
+-Ycheck:all

--- a/project/scripts/winCmdTests
+++ b/project/scripts/winCmdTests
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+PREFIX="dist/target/pack"
+SOURCE="tests/pos/HelloWorld.scala"
+$PREFIX/bin/scalac @project/scripts/options "$SOURCE"
+$PREFIX/bin/scalac -d out "$SOURCE"
+$PREFIX/bin/scala -classpath out HelloWorld
+$PREFIX/bin/scala -classpath out -J-Xmx512m HelloWorld
+mkdir -p _site && $PREFIX/bin/scaladoc -siteroot _site -project Hello "$SOURCE"

--- a/project/scripts/winCmdTests
+++ b/project/scripts/winCmdTests
@@ -7,4 +7,4 @@ $PREFIX/bin/scalac @project/scripts/options "$SOURCE"
 $PREFIX/bin/scalac -d out "$SOURCE"
 $PREFIX/bin/scala -classpath out HelloWorld
 $PREFIX/bin/scala -classpath out -J-Xmx512m HelloWorld
-mkdir -p _site && $PREFIX/bin/scaladoc -siteroot _site -project Hello "$SOURCE"
+mkdir -p _site && $PREFIX/bin/scaladoc -d _site -project Hello "$SOURCE"


### PR DESCRIPTION
Fix broken script on Windows & add script test to CI

Normally it should not affect Windows users, as the recommended installation path for Cygwin does not contain spaces.