### PR TITLE
Better handling of leading infix operators in indented code

### DIFF
--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -80,8 +80,11 @@ There are two rules:
       ```
       then  else  do  catch  finally  yield  match
       ```
-    - the first token on the next line is not a
+    - if the first token on the next line is a
         [leading infix operator](../changed-features/operators.md).
+      then its indentation width is less then the current indentation width,
+      and it either matches a previous indentation width or is also less
+      than the enclosing indentation width.
 
     If an `<outdent>` is inserted, the top element is popped from `IW`.
     If the indentation width of the token on the next line is still less than the new current indentation width, step (2) repeats. Therefore, several `<outdent>` tokens
@@ -104,6 +107,24 @@ if x < 0 then
 
 Indentation tokens are only inserted in regions where newline statement separators are also inferred:
 at the top-level, inside braces `{...}`, but not inside parentheses `(...)`, patterns or types.
+
+**Note:** The rules for leading infix operators above are there to make sure that
+```scala
+  one
+  + two.match
+      case 1 => b
+      case 2 => c
+  + three
+```
+is parsed as `one + (two.match ...) + three`. Also, that
+```scala
+if x then
+    a
+  + b
+  + c
+else d
+```
+is parsed as `if x then a + b + c else d`.
 
 ### Optional Braces Around Template Bodies
 

--- a/tests/run/indent.scala
+++ b/tests/run/indent.scala
@@ -1,0 +1,12 @@
+@main def Test =
+  val x = false
+  val y = 1
+  val result =
+    x
+    || y.match
+        case 1 => false
+        case 3 => false
+        case _ => true
+    || !x
+  assert(result)
+


### PR DESCRIPTION
```scala
@main def Test =
  val x = false
  val y = 1
  val result =
    x
    || y.match
        case 1 => false
        case 3 => false
        case _ => true
    || !x
  assert(result)
```
In this code, the last `|| !x` was seen as a part of the previous case, so the code was parsed as
```scala
@main def Test =
  val x = false
  val y = 1
  val result =
    x
    || y.match
        case 1 => false
        case 3 => false
        case _ => true || !x
  assert(result)
```
This is highly surprising and unintuitive. The fix will insert an `<outdent>` token instead
if the leading infix operator is too far to the left. Too far means: (1) left of the current indentation
region, (2) and not to the right of any outer indentation widths.

(2) allows to still parse code like this
```scala
if xyz then
    one
  + two
  + three
```
Here, the width of the indentation region after `then` is 4, but the `+` operator is to the right
of the outer indentation width of 0., so the indentation region is not closed. In other words,
we do not close an indentation region if the result would not be legal, since it matches none of
the previous indentation widths.