### PR TITLE
Fix #11885: Always clone trees if position already set 

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -65,12 +65,11 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
     if (span == mySpan) this
     else {
       val newpd: this.type =
-        if (mySpan.isSynthetic) {
-          if (!mySpan.exists && span.exists)
-            envelope(source, span.startPos) // fill in children spans
+        if !mySpan.exists then
+          if span.exists then envelope(source, span.startPos) // fill in children spans
           this
-        }
-        else cloneIn(source)
+        else
+          cloneIn(source)
       newpd.span = span
       newpd
     }

--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -18,9 +18,8 @@ class IdempotencyTests {
   import IdempotencyTests._
   import CompilationTest.aggregateTests
 
-  // Flaky test on Windows
-  // https://github.com/lampepfl/dotty/issues/11885
-  val filter = FileFilter.exclude("i6507b.scala")
+  // ignore flaky tests
+  val filter = FileFilter.NoFilter
 
   @Category(Array(classOf[SlowTests]))
   @Test def idempotency: Unit = {


### PR DESCRIPTION
Fix #11885: Always clone trees if position already set

The cause of the problem is that we use parallelism in Pickler:

      if !Pickler.ParallelPickling || ctx.settings.YtestPickler.value then force()

Sometimes on Windows, the futures run a little slower, and the later
phase `Inlining` can change the positions of the trees to be pickled,
thus non-determinism.

For the Dotty project, the statistics is as follows:

- Before: ntrees = 5331539
- After:  ntrees = 5334075

Performance-wise, this should be better than synchronizing the pickling tasks.

[test_windows_full]