### PR TITLE
CI: Automatically open an issue if nightly build fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -672,3 +672,23 @@ jobs:
       - name: Publish Dotty SBT Plugin Release
         run: |
           ./project/scripts/sbtPublish ";project sbt-dotty ;publishSigned ;sonatypeBundleRelease"
+
+  open_issue_on_failure:
+    runs-on: [self-hosted, Linux]
+    container:
+      image: lampepfl/dotty:2021-03-22
+    needs: [nightly_documentation, test_windows_full]
+    # The `failure()` expression is true iff at least one of the dependencies
+    # of this job (including transitive dependencies) has failed.
+    if: "failure() && github.event_name == 'schedule'"
+    steps:
+      - name: Checkout issue template
+        uses: actions/checkout@v2
+
+      - name: Open an issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/workflows/issue_nightly_failed.md

--- a/.github/workflows/issue_nightly_failed.md
+++ b/.github/workflows/issue_nightly_failed.md
@@ -1,0 +1,5 @@
+---
+title: Nightly {{ workflow }} workflow of {{ date | date('YYYY-MM-DD') }} failed
+labels: itype:bug, prio:blocker
+---
+See {{ env.WORKFLOW_RUN_URL }}


### PR DESCRIPTION
Tests of this in action may be seen at https://github.com/griggt/trial-open-issue-on-ci-failure

Closes #8734