### PR TITLE
Fix type NamedArg of annotations when pt is nullable

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -905,8 +905,9 @@ class Typer extends Namer
      * of annotation defined as `@interface Annot { int[] value() }`
      * We assume that calling `typedNamedArg` in context of Java implies that we are dealing
      * with annotation contructor, as named arguments are not allowed anywhere else in Java.
+     * Under explicit nulls, the pt could be nullable. We need to strip `Null` type first.
      */
-    val arg1 = pt match {
+    val arg1 = pt.stripNull match {
       case AppliedType(a, typ :: Nil) if ctx.isJava && a.isRef(defn.ArrayClass) =>
         tryAlternatively { typed(tree.arg, pt) } {
             val elemTp = untpd.TypedSplice(TypeTree(typ))

--- a/tests/explicit-nulls/pos/annotaions-args/JAnnots.java
+++ b/tests/explicit-nulls/pos/annotaions-args/JAnnots.java
@@ -1,0 +1,7 @@
+public class JAnnots {
+  @SuppressWarnings("unused")
+  public void f1() {}
+
+  @SuppressWarnings({"unused"})
+  public void f2() {}
+}

--- a/tests/explicit-nulls/pos/annotaions-args/SAnnots.scala
+++ b/tests/explicit-nulls/pos/annotaions-args/SAnnots.scala
@@ -1,0 +1,4 @@
+class SAnnots {
+  @SuppressWarnings(Array("unused"))
+  def f() = {}
+}


### PR DESCRIPTION
Thie PR fixs typing NamedArg of annotations when pt is nullable.

```
scalac -Yexplicit-nulls Jtest.java
```
```java
public class Jtest {
  @SuppressWarnings("unused")
  public void f() {}
}
```

Without the fix:

```
-- [E007] Type Mismatch Error: Jtest.java:2:19 ---------------------------------
2 |  @SuppressWarnings("unused")
  |                   ^
  |                   Found:    ("SuppressWarnings" : String)
  |                   Required: scala.Array[String | scala.Null] | scala.Null
```

Since the argument type of the annotation is nullable under explicit nulls, we need to strip the `Null` type first in order to try the Array transformation.