### PR TITLE
Reset GADT constraint on failing isSubType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -118,6 +118,7 @@ class CheckRealizable(using Context) {
     case tp =>
       def isConcrete(tp: Type): Boolean = tp.dealias match {
         case tp: TypeRef => tp.symbol.isClass
+        case tp: TypeParamRef => false
         case tp: TypeProxy => isConcrete(tp.underlying)
         case tp: AndType => isConcrete(tp.tp1) && isConcrete(tp.tp2)
         case tp: OrType  => isConcrete(tp.tp1) && isConcrete(tp.tp2)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -919,6 +919,7 @@ class Definitions {
   @tu lazy val ParamMetaAnnot: ClassSymbol = requiredClass("scala.annotation.meta.param")
   @tu lazy val SetterMetaAnnot: ClassSymbol = requiredClass("scala.annotation.meta.setter")
   @tu lazy val ShowAsInfixAnnot: ClassSymbol = requiredClass("scala.annotation.showAsInfix")
+  @tu lazy val StableAnnot: ClassSymbol = requiredClass("scala.annotation.internal.Stable")
   @tu lazy val FunctionalInterfaceAnnot: ClassSymbol = requiredClass("java.lang.FunctionalInterface")
   @tu lazy val TargetNameAnnot: ClassSymbol = requiredClass("scala.annotation.targetName")
   @tu lazy val VarargsAnnot: ClassSymbol = requiredClass("scala.annotation.varargs")

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -54,6 +54,9 @@ sealed abstract class GadtConstraint extends Showable {
   /** Restore the state from other [[GadtConstraint]], probably copied using [[fresh]] */
   def restore(other: GadtConstraint): Unit
 
+  def constraint: Constraint
+  def constraint_=(c: Constraint): Unit
+
   def debugBoundsDescription(using Context): String
 }
 
@@ -217,8 +220,8 @@ final class ProperGadtConstraint private(
 
   // ---- Protected/internal -----------------------------------------------
 
-  override protected def constraint = myConstraint
-  override protected def constraint_=(c: Constraint) = myConstraint = c
+  override def constraint = myConstraint
+  override def constraint_=(c: Constraint) = myConstraint = c
 
   override protected def isSub(tp1: Type, tp2: Type)(using Context): Boolean = TypeComparer.isSubType(tp1, tp2)
   override protected def isSame(tp1: Type, tp2: Type)(using Context): Boolean = TypeComparer.isSameType(tp1, tp2)
@@ -305,6 +308,9 @@ final class ProperGadtConstraint private(
   override def fresh = new ProperGadtConstraint
   override def restore(other: GadtConstraint): Unit =
     if (!other.isEmpty) sys.error("cannot restore a non-empty GADTMap")
+
+  override def constraint: Constraint = OrderingConstraint.empty
+  override def constraint_=(c: Constraint): Unit = ()
 
   override def debugBoundsDescription(using Context): String = "EmptyGadtConstraint"
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1260,6 +1260,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     else if tp1 eq tp2 then true
     else
       val saved = constraint
+      val savedGadtConstraint = ctx.gadt.constraint
+      val savedGADTused = GADTused
       val savedSuccessCount = successCount
       try
         recCount += 1
@@ -1268,6 +1270,10 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         recCount -= 1
         if !result then
           state.constraint = saved
+          ctx.gadt.constraint = savedGadtConstraint
+            // it seems we need to reset the GADT constraint in case a subtype test fails.
+            // or is this done elsewhere?
+          GADTused = savedGADTused
         else if recCount == 0 && needsGc then
           state.gc()
           needsGc = false

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -168,7 +168,7 @@ object Types {
       case _: SingletonType | NoPrefix => true
       case tp: RefinedOrRecType => tp.parent.isStable
       case tp: ExprType => tp.resultType.isStable
-      case tp: AnnotatedType => tp.parent.isStable
+      case tp: AnnotatedType => tp.annot.symbol == defn.StableAnnot || tp.parent.isStable
       case tp: AndType =>
         // TODO: fix And type check when tp contains type parames for explicit-nulls flow-typing
         // see: tests/explicit-nulls/pos/flow-stable.scala.disabled

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3532,7 +3532,12 @@ class Typer extends Namer
                 adaptToSubType(wtp)
           case CompareResult.OKwithGADTUsed
           if pt.isValueType
-             && !inContext(ctx.fresh.setGadt(EmptyGadtConstraint)) { tree.tpe.widenExpr frozen_<:< pt } =>
+             && !inContext(ctx.fresh.setGadt(EmptyGadtConstraint)) {
+               (tree.tpe.widenExpr frozen_<:< pt)
+                // we overshot; a cast is not needed, after all. (this happens a lot. We should
+                // find out whether we can make GADTused more precise)
+                .showing(i"false alarm for $tree: ${tree.tpe.widenExpr} vs $pt in ${ctx.source}", gadts)
+              } =>
             // Insert an explicit cast, so that -Ycheck in later phases succeeds.
             // I suspect, but am not 100% sure that this might affect inferred types,
             // if the expected type is a supertype of the GADT bound. It would be good to come

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3530,12 +3530,25 @@ class Typer extends Namer
                 typr.println(i"adapt to subtype ${tree.tpe} !<:< $pt")
                 //typr.println(TypeComparer.explained(tree.tpe <:< pt))
                 adaptToSubType(wtp)
-          case CompareResult.OKwithGADTUsed if pt.isValueType =>
+          case CompareResult.OKwithGADTUsed
+          if pt.isValueType
+             && !inContext(ctx.fresh.setGadt(EmptyGadtConstraint)) { tree.tpe.widenExpr frozen_<:< pt } =>
             // Insert an explicit cast, so that -Ycheck in later phases succeeds.
             // I suspect, but am not 100% sure that this might affect inferred types,
             // if the expected type is a supertype of the GADT bound. It would be good to come
             // up with a test case for this.
-            tree.cast(pt)
+            val target =
+              if tree.tpe.isSingleton then
+                val conj = AndType(tree.tpe, pt)
+                if tree.tpe.isStable && !conj.isStable then
+                  // this is needed for -Ycheck. Without the annotation Ycheck will
+                  // skolemize the result type which will lead to different types before
+                  // and after checking. See i11955.scala.
+                  AnnotatedType(conj, Annotation(defn.StableAnnot))
+                else conj
+              else pt
+            gadts.println(i"insert GADT cast from $tree to $target")
+            tree.cast(target)
           case _ =>
             tree
     }

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -64,3 +64,7 @@ i8182.scala
 
 # local lifted value in annotation argument has different position after pickling
 i2797a
+
+# GADT cast applied to singleton type difference
+i4176-gadt.scala
+

--- a/library/src/scala/annotation/internal/Stable.scala
+++ b/library/src/scala/annotation/internal/Stable.scala
@@ -1,0 +1,6 @@
+package scala.annotation.internal
+
+import scala.annotation.Annotation
+
+/** An annotation asserting that the annotated type is stable */
+final class Stable() extends Annotation

--- a/tests/pos/i11220.scala
+++ b/tests/pos/i11220.scala
@@ -1,0 +1,8 @@
+import scala.annotation.tailrec
+class Context {
+  type Tree
+}
+
+final def loop3[C <: Context](): Unit =
+  @tailrec
+  def loop4[A <: C](c: A): c.Tree = loop4(c)

--- a/tests/pos/i11955.scala
+++ b/tests/pos/i11955.scala
@@ -1,0 +1,25 @@
+object Hello {
+
+  sealed abstract class X[+A] {
+    type This[+A] <: X[A]
+    def asThis: This[A]
+  }
+
+  class Y[+A] extends X[A] {
+    override type This[+AA] = Y[AA]
+    override def asThis: This[A] = this
+  }
+
+  def hackBackToSelf[F[+u] <: X[u], A](f: F[Any])(f2: f.This[A]): F[A] =
+    f2.asInstanceOf[F[A]]
+
+  case class G[F[+u] <: X[u], A](wrapped: F[A]) {
+
+    def mapF[F2[+u] <: X[u]](f: F[A] => F2[A]): G[F2, A] =
+      G[F2, A](f(wrapped))
+
+    def test_ko_1: G[F, A] = mapF(ct => hackBackToSelf(ct)(ct.asThis)) // error
+    def test_ko_2: G[F, A] = mapF[F](ct => hackBackToSelf(ct)(ct.asThis)) // error
+    def test_ok  : G[F, A] = mapF(ct => hackBackToSelf[F, A](ct)(ct.asThis)) // ok
+  }
+}


### PR DESCRIPTION

The normal constraint gets reset when isSubType fails - should the GADT constraint
not get reset as well? Subtyping is an exploration with backtracking where
some branches do not lead to a result. It seems unsound that failing explorations
can nevertheless introduce new GADT bounds.

I tried to change this in this commit, but it makes the following tests
fail with stack overflows:

    tests/pos/i9740b.scala failed
    tests/pos/i9740c.scala failed

I must admit I am not quite sure about whether it is enough to reset just the constraint
part of a GadtConstraint, or whether the whole constraint has to be copied. I hope not the
latter, since that would impose a heavy complexity price on subtype checking.


