### PR TITLE
Refine resultTypeApprox

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -658,7 +658,7 @@ object ProtoTypes {
   def resultTypeApprox(mt: MethodType, wildcardOnly: Boolean = false)(using Context): Type =
     if mt.isResultDependent then
       // First, try to widen all covariant occurrences of parameters in `mt`.
-      // If the resulting method type is no longer result-dependend, return it.
+      // If the resulting method type is no longer result-dependent, return it.
       val tryInterpolate = new TypeMap:
         override def apply(tp: Type) = tp match
           case tp: TermParamRef if tp.binder == mt && variance > 0 => tp.widen

--- a/tests/pos/i12005.scala
+++ b/tests/pos/i12005.scala
@@ -1,0 +1,6 @@
+  trait Trait1[F[_]]
+  trait Trait2[F[_], E]
+
+  def apply[F[_]: Trait1, E](using h: Trait2[F, E]): Trait2[F, E] = summon
+
+  def apply2[F[_]: Trait1, E](using h: Trait2[F, E]): Trait2[F, E] = implicitly


### PR DESCRIPTION
Add a special case to `resultTypeApprox` for method types where
the parameters appear only co-variantly in the result.

This allows types to be propagated enough to make `summon` work as well as
`implicitly`. Note that `summon` is result-dependent, but `implicitly` is not:

    def summon[T](using x: T): x.type = x
    def implicitly[T](implicit x: T): T = x

The tweak to `resultTypeApprox` makes `summon` behave like `implicitly`
for the purposes of type inference.

Fixes #12005