### PR TITLE
Remove call to `constValue` if it fails to expand

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -684,8 +684,11 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
     if (callTypeArgs.length == 1)
       if (inlinedMethod == defn.Compiletime_constValue) {
         val constVal = tryConstValue
-        if (!constVal.isEmpty) return constVal
-        report.error(em"not a constant type: ${callTypeArgs.head}; cannot take constValue", call.srcPos)
+        if constVal.isEmpty then
+          val msg = em"not a constant type: ${callTypeArgs.head}; cannot take constValue"
+          return ref(defn.Predef_undefined).withSpan(call.span).withType(ErrorType(msg))
+        else
+          return constVal
       }
       else if (inlinedMethod == defn.Compiletime_constValueOpt) {
         val constVal = tryConstValue

--- a/tests/neg/i11985.scala
+++ b/tests/neg/i11985.scala
@@ -1,0 +1,24 @@
+import compiletime._
+import compiletime.ops.int._
+
+object Test {
+  type TupleTypeIndex[T <: Tuple, C] <: Int = T match {
+    case C *: t => 0
+    case h *: t => S[TupleTypeIndex[t, C]]
+  }
+
+  trait TupleExtractor[TT <: Tuple, C] {
+    def get(t: TT): C
+  }
+
+  given [T <: Tuple, C, EV <: TupleTypeIndex[T, C]]: TupleExtractor[T, C] with {
+    def get(t: T): C = t.toArray.apply(toIntC[TupleTypeIndex[T, C]]).asInstanceOf[C] // error
+  }
+
+
+  transparent inline def toIntC[N <: Int]: Int =
+    inline constValue[N] match
+      case 0        => 0
+      case _: S[n1] => 1 + toIntC[n1]
+
+}


### PR DESCRIPTION
This avoids subsequet failures on this call.

Fixes #11985