### PR TITLE
Fix selceting type member in unsafe nulls

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -237,7 +237,7 @@ object Types {
     }
 
     def isBottomType(using Context): Boolean =
-      if ctx.explicitNulls && !ctx.phase.erasedTypes then hasClassSymbol(defn.NothingClass)
+      if ctx.mode.is(Mode.SafeNulls) && !ctx.phase.erasedTypes then hasClassSymbol(defn.NothingClass)
       else isBottomTypeAfterErasure
 
     def isBottomTypeAfterErasure(using Context): Boolean =

--- a/tests/explicit-nulls/unsafe-common/unsafe-select-type-member.scala
+++ b/tests/explicit-nulls/unsafe-common/unsafe-select-type-member.scala
@@ -1,0 +1,7 @@
+import java.util.ArrayList
+
+def f[T]: ArrayList[T] = {
+  val cz = Class.forName("java.util.ArrayList")
+  val o = cz.newInstance() // error: T of Class[?] | Null
+  o.asInstanceOf[ArrayList[T]]
+}


### PR DESCRIPTION
Fix:

```
scalac -Yexplicit-nulls -language:unsafeNulls tests/explicit-nulls/unsafe-common/unsafe-select-type-member.scala
```

```scala
import java.util.ArrayList

def f[T]: ArrayList[T] = {
  val cz = Class.forName("java.util.ArrayList")
  val o = cz.newInstance() // error: T of Class[?] | Null
  o.asInstanceOf[ArrayList[T]]
}
```
