### PR TITLE
Fix #11481: Count signature names as consistent if one of them is a wildcard

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Signature.scala
+++ b/compiler/src/dotty/tools/dotc/core/Signature.scala
@@ -50,7 +50,8 @@ case class Signature(paramsSig: List[ParamSig], resSig: TypeName) {
 
   /** Two names are consistent if they are the same or one of them is tpnme.Uninstantiated */
   private def consistent(name1: ParamSig, name2: ParamSig) =
-    name1 == name2 || name1 == tpnme.Uninstantiated || name2 == tpnme.Uninstantiated
+    name1 == name2 || name1 == tpnme.Uninstantiated || name2 == tpnme.Uninstantiated ||
+    name1 == tpnme.WILDCARD || name2 == tpnme.WILDCARD
 
   /** Does this signature coincide with that signature on their parameter parts?
    *  This is the case if all parameter signatures are _consistent_, i.e. they are either

--- a/tests/pos/i11481a.scala
+++ b/tests/pos/i11481a.scala
@@ -1,0 +1,1 @@
+case class Baz[F[_]](f: {def f(x: F[Int]): Object})

--- a/tests/pos/i11481b.scala
+++ b/tests/pos/i11481b.scala
@@ -1,0 +1,1 @@
+case class Baz[F[_], G[_]](f: [B] => F[B] => G[B])


### PR DESCRIPTION
If the `i11481a.scala` test ("Bad" example) is modified to the following ("Good" example), it works:

```scala
case class Baz[F](f: {def f(x: F): Object})
```

In the Bad case, at [some point](https://github.com/lampepfl/dotty/blob/a0707985bfdb40a29e79b1f034e6caa0570374f8/compiler/src/dotty/tools/dotc/typer/Typer.scala#L3531 ), the typer tries to check if the following subtyping holds:

```scala
(Baz.this.f : Object{f(x: F[Int]): Object}) <: Object{f(x: <?>): Object}
```

It fails in the Bad case. In the Good case, it checks for:

```scala
(Baz.this.f : Object{f(x: F): Object}) <:< Object{f(x: <?>): Object}
```

And succeeds.

The reason for failure can be traced to here:

https://github.com/lampepfl/dotty/blob/a0707985bfdb40a29e79b1f034e6caa0570374f8/compiler/src/dotty/tools/dotc/core/TypeComparer.scala#L684

Typer checks the signatures of the involved methods. The following is the debug of the variables involved in that line:

```scala
Bad
001 tp1 = (x: F[Int]): Object
002 tp1.signature = Signature(List(java.lang.Object),java.lang.Object)
003 tp2 = (x: <?>): Object
004 tp2.signature = Signature(List(_),java.lang.Object)
005 tp1.signature consistentParams tp2.signature = false

Good
001 tp1 = (x: F): Object
002 tp1.signature = Signature(List(java.lang.Object),java.lang.Object)
003 tp2 = (x: <?>): Object
004 tp2.signature = Signature(List(java.lang.Object),java.lang.Object)
005 tp1.signature consistentParams tp2.signature = true
```

Note `004` line for each output, the signatures for Bad and Good cases vary: it is Object for Good case but wildcard for bad case.

It seems this is because for the Good case, the wildcard in question has bounds which is not the case for the Bad case:

```scala
Good
001 tp2 = MethodType(List(x), List(WildcardType(TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Nothing),TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Any)))), TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class java)),object lang),class Object))

Bad
001 tp2 = MethodType(List(x), List(WildcardType), TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class java)),object lang),class Object))
```

It seems having bounds makes the signatures assume the form of those bounds whereas not having bounds means leaving a wildcard as a wildcard:

https://github.com/lampepfl/dotty/blob/a0707985bfdb40a29e79b1f034e6caa0570374f8/compiler/src/dotty/tools/dotc/core/TypeErasure.scala#L824-L827

In this PR I chose to simply treat the signatures as consistent if the names being compared involve a wildcard. I am not sure if this is the right fix or a more elaborate fix involving bounds should be devised.