### PR TITLE
Avoid wildcards when typing default parameters of context function type

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1501,7 +1501,7 @@ class Namer { typer: Typer =>
         val approxTp = wildApprox(originalTp)
         approxTp.stripPoly match
           case atp @ defn.ContextFunctionType(_, resType, _)
-          if !defn.isNonRefinedFunction(approxTp) // in this case `resType` is lying, gives us only the non-dependent upper bound
+          if !defn.isNonRefinedFunction(atp) // in this case `resType` is lying, gives us only the non-dependent upper bound
               || resType.existsPart(_.isInstanceOf[WildcardType], stopAtStatic = true, forceLazy = false) =>
             originalTp
           case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1485,7 +1485,7 @@ class Namer { typer: Typer =>
 
       /** The expected type for a default argument. This is normally the `defaultParamType`
        *  with references to internal parameters replaced by wildcards. This replacement
-       *  makes it possible that the default argument can be a more specific type than the
+       *  makes it possible that the default argument can have a more specific type than the
        *  parameter. For instance, we allow
        *
        *      class C[A](a: A) { def copy[B](x: B = a): C[B] = C(x) }

--- a/tests/neg/i12019.scala
+++ b/tests/neg/i12019.scala
@@ -1,0 +1,20 @@
+object test1:
+  trait A
+  type B <: AnyRef
+  val test1: A ?=> B = null // error
+  val test2: A ?=> B = A ?=> null // error
+
+import scala.quoted.*
+
+object Eg1 {
+
+  // no default arg: ok
+  def ok  (f: (q: Quotes) ?=> q.reflect.Term) = ()
+
+  // default the function *reference* to null: compilation error
+  def ko_1(f: (q: Quotes) ?=> q.reflect.Term = null) = ()  // error
+
+  // default the function *result* to null: compilation error
+  def ko_2(f: (q: Quotes) ?=> q.reflect.Term = (_: Quotes) ?=> null) = () // error
+}
+

--- a/tests/pos/i12019.scala
+++ b/tests/pos/i12019.scala
@@ -1,0 +1,21 @@
+trait A:
+  type X >: Null
+
+def ko1(f: (q: A) ?=> Int => q.X = null) = ()
+def ko2(f: (q: A) ?=> Int => q.X = (_: A) ?=> null) = ()
+def ko3(f: (q: A) => q.X = (q => null)) = ()
+
+
+import scala.quoted.*
+
+object Eg2 {
+
+  // no default arg: ok
+  def ok  (f: (q: Quotes) ?=> q.reflect.ValDef => q.reflect.Term) = ()
+
+  // default the function *reference* to null: crash!
+  def ko_1(f: (q: Quotes) ?=> q.reflect.ValDef => q.reflect.Term = null) = ()
+
+  // default the function *result* to null: crash!
+  def ko_2(f: (q: Quotes) ?=> q.reflect.ValDef => q.reflect.Term = (_: Quotes) ?=> null) = ()
+}


### PR DESCRIPTION
Fixes #12019 