### PR TITLE
Explain match type reduction failures in error messages

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/MatchTypeTrace.scala
+++ b/compiler/src/dotty/tools/dotc/core/MatchTypeTrace.scala
@@ -1,0 +1,86 @@
+package dotty.tools
+package dotc
+package core
+
+import Types._, Contexts._, Symbols._, Decorators._
+import util.Property
+
+object MatchTypeTrace:
+  private enum TraceEntry:
+    case TryReduce(scrut: Type)
+    case NoMatches(scrut: Type, cases: List[Type])
+    case Stuck(scrut: Type, stuckCase: Type, otherCases: List[Type])
+  import TraceEntry._
+
+  private class MatchTrace:
+    var entries: List[TraceEntry] = Nil
+
+  private val MatchTrace = new Property.Key[MatchTrace]
+
+  def record(op: Context ?=> Any)(using Context): String =
+    val trace = new MatchTrace
+    inContext(ctx.fresh.setProperty(MatchTrace, trace)) {
+      op
+      if trace.entries.isEmpty then ""
+      else
+        i"""
+           |
+           |Note: a match type could not be fully reduced:
+           |
+           |${trace.entries.reverse.map(explainEntry)}%\n%"""
+    }
+
+  def isRecording(using Context): Boolean =
+    ctx.property(MatchTrace).isDefined
+
+  private def matchTypeFail(entry: TraceEntry)(using Context) =
+    ctx.property(MatchTrace) match
+      case Some(trace) =>
+        trace.entries match
+          case (e: TryReduce) :: es => trace.entries = entry :: trace.entries
+          case _ =>
+      case _ =>
+
+  def noMatches(scrut: Type, cases: List[Type])(using Context) =
+    matchTypeFail(NoMatches(scrut, cases))
+
+  def stuck(scrut: Type, stuckCase: Type, otherCases: List[Type])(using Context) =
+    matchTypeFail(Stuck(scrut, stuckCase, otherCases))
+
+  def recurseWith(scrut: Type)(op: => Type)(using Context): Type =
+    ctx.property(MatchTrace) match
+      case Some(trace) =>
+        val prev = trace.entries
+        trace.entries = TryReduce(scrut) :: prev
+        val res = op
+        if res.exists then trace.entries = prev
+        res
+      case _ =>
+        op
+
+  private def caseText(tp: Type)(using Context): String = tp match
+    case tp: HKTypeLambda => caseText(tp.resultType)
+    case defn.MatchCase(pat, body) => i"case $pat => $body"
+    case _ => i"case $tp"
+
+  private def casesText(cases: List[Type])(using Context) =
+    i"${cases.map(caseText)}%\n    %"
+
+  private def explainEntry(entry: TraceEntry)(using Context): String = entry match
+    case TryReduce(scrut: Type) =>
+      i"  trying to reduce  $scrut"
+    case NoMatches(scrut, cases) =>
+      i"""  failed since selector  $scrut
+         |  matches none of the cases
+         |
+         |    ${casesText(cases)}"""
+    case Stuck(scrut, stuckCase, otherCases) =>
+      i"""  failed since selector  $scrut
+         |  does not match  ${caseText(stuckCase)}
+         |  and cannot be shown to be disjoint from it either.
+         |  Therefore, reduction cannot advance to the remaining case${if otherCases.length == 1 then "" else "s"}
+         |
+         |    ${casesText(otherCases)}"""
+
+end MatchTypeTrace
+

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2798,10 +2798,20 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
         Some(NoType)
     }
 
-    def recur(cases: List[Type]): Type = cases match {
-      case cas :: cases1 => matchCase(cas).getOrElse(recur(cases1))
-      case Nil => NoType
-    }
+    def recur(remaining: List[Type]): Type = remaining match
+      case cas :: remaining1 =>
+        matchCase(cas) match
+          case None =>
+            recur(remaining1)
+          case Some(NoType) =>
+            if remaining1.isEmpty then MatchTypeTrace.noMatches(scrut, cases)
+            else MatchTypeTrace.stuck(scrut, cas, remaining1)
+            NoType
+          case Some(tp) =>
+            tp
+      case Nil =>
+        MatchTypeTrace.noMatches(scrut, cases)
+        NoType
 
     inFrozenConstraint {
       // Empty types break the basic assumption that if a scrutinee and a

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4025,7 +4025,9 @@ object Types {
         def tryMatchAlias = tycon.info match {
           case MatchAlias(alias) =>
             trace(i"normalize $this", typr, show = true) {
-              alias.applyIfParameterized(args).tryNormalize
+              MatchTypeTrace.recurseWith(this) {
+                alias.applyIfParameterized(args).tryNormalize
+              }
             }
           case _ =>
             NoType
@@ -4537,7 +4539,11 @@ object Types {
         }
 
       record("MatchType.reduce called")
-      if (!Config.cacheMatchReduced || myReduced == null || !isUpToDate) {
+      if !Config.cacheMatchReduced
+          || myReduced == null
+          || !isUpToDate
+          || MatchTypeTrace.isRecording
+      then
         record("MatchType.reduce computed")
         if (myReduced != null) record("MatchType.reduce cache miss")
         myReduced =
@@ -4549,7 +4555,6 @@ object Types {
               finally updateReductionContext(cmp.footprint)
             TypeComparer.tracked(matchCases)
           }
-      }
       myReduced
     }
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -182,9 +182,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
             case _ => "case " ~ toText(tp)
           }
           def casesText = Text(cases.map(caseText), "\n")
-            atPrec(InfixPrec) { toText(scrutinee) } ~
-            keywordStr(" match ") ~ "{" ~ casesText ~ "}" ~
-            (" <: " ~ toText(bound) provided !bound.isAny)
+          atPrec(InfixPrec) { toText(scrutinee) } ~
+          keywordStr(" match ") ~ "{" ~ casesText ~ "}" ~
+          (" <: " ~ toText(bound) provided !bound.isAny)
         }.close
       case tp: PreviousErrorType if ctx.settings.XprintTypes.value =>
         "<error>" // do not print previously reported error message because they may try to print this error type again recuresevely

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -178,6 +178,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case MatchType(bound, scrutinee, cases) =>
         changePrec(GlobalPrec) {
           def caseText(tp: Type): Text = tp match {
+            case tp: HKTypeLambda => caseText(tp.resultType)
             case defn.MatchCase(pat, body) => "case " ~ toText(pat) ~ " => " ~ toText(body)
             case _ => "case " ~ toText(tp)
           }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -241,6 +241,9 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         toTextParents(tp.parents) ~~ "{...}"
       case JavaArrayType(elemtp) =>
         toText(elemtp) ~ "[]"
+      case tp: LazyRef if !printDebug =>
+        try toText(tp.ref)
+        catch case ex: Throwable => "..."
       case tp: SelectionProto =>
         "?{ " ~ toText(tp.name) ~
            (Str(" ") provided !tp.name.toSimpleName.last.isLetterOrDigit) ~

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -105,15 +105,16 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 
   override def toTextPrefix(tp: Type): Text = controlled {
     def isOmittable(sym: Symbol) =
-      if (printDebug) false
-      else if (homogenizedView) isEmptyPrefix(sym) // drop <root> and anonymous classes, but not scala, Predef.
+      if printDebug then false
+      else if homogenizedView then isEmptyPrefix(sym) // drop <root> and anonymous classes, but not scala, Predef.
+      else if sym.isPackageObject then isOmittablePrefix(sym.owner)
       else isOmittablePrefix(sym)
     tp match {
       case tp: ThisType if isOmittable(tp.cls) =>
         ""
       case tp @ TermRef(pre, _) =>
         val sym = tp.symbol
-        if (sym.isPackageObject && !homogenizedView) toTextPrefix(pre)
+        if sym.isPackageObject && !homogenizedView && !printDebug then toTextPrefix(pre)
         else if (isOmittable(sym)) ""
         else super.toTextPrefix(tp)
       case _ => super.toTextPrefix(tp)

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -58,6 +58,9 @@ abstract class Message(val errorId: ErrorMessageID) { self =>
     */
   protected def explain: String
 
+  /** A message suffix that can be added for certain subclasses */
+  protected def msgSuffix: String = ""
+
   /** Does this message have an explanation?
    *  This is normally the same as `explain.nonEmpty` but can be overridden
    *  if we need a way to return `true` without actually calling the
@@ -82,7 +85,7 @@ abstract class Message(val errorId: ErrorMessageID) { self =>
   def rawMessage = message
 
   /** The message to report. <nonsensical> tags are filtered out */
-  lazy val message: String = dropNonSensical(msg)
+  lazy val message: String = dropNonSensical(msg + msgSuffix)
 
   /** The explanation to report. <nonsensical> tags are filtered out */
   lazy val explanation: String = dropNonSensical(explain)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -50,6 +50,17 @@ import transform.SymUtils._
     def explain = err.whyNoMatchStr(found, expected)
     override def canExplain = true
 
+    override def msgSuffix: String =
+      val collectMatchTrace = new TypeAccumulator[String]:
+        def apply(s: String, tp: Type): String =
+          if s.nonEmpty then s
+          else tp match
+            case tp: AppliedType if tp.isMatchAlias => MatchTypeTrace.record(tp.tryNormalize)
+            case tp: MatchType => MatchTypeTrace.record(tp.tryNormalize)
+            case _ => foldOver(s, tp)
+      collectMatchTrace(collectMatchTrace("", found), expected)
+  end TypeMismatchMsg
+
   abstract class NamingMsg(errorId: ErrorMessageID) extends Message(errorId):
     def kind = "Naming"
 

--- a/compiler/test-resources/repl/i5218
+++ b/compiler/test-resources/repl/i5218
@@ -4,4 +4,4 @@ scala> 0.0 *: tuple
 val res0: (Double, Int, String, Long) = (0.0,1,2,3)
 scala> tuple ++ tuple
 val res1: Int *: String *: Long *:
-  scala.Tuple.Concat[scala.Tuple$package.EmptyTuple.type, tuple.type] = (1,2,3,1,2,3)
+  scala.Tuple.Concat[EmptyTuple.type, tuple.type] = (1,2,3,1,2,3)

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -42,8 +42,8 @@ class CompletionTest {
 
   @Test def completionFromSyntheticPackageObject: Unit = {
     code"class Foo { val foo: IArr${m1} }".withSource
-      .completion(m1, Set(("IArray", Field, "scala.IArray"),
-                          ("IArray", Module, "scala.IArray$package.IArray$")))
+      .completion(m1, Set(("IArray", Module, "IArray$"),
+                          ("IArray", Field, "scala.IArray")))
   }
 
   @Test def completionFromJavaDefaults: Unit = {

--- a/tests/neg/i12049.check
+++ b/tests/neg/i12049.check
@@ -48,3 +48,58 @@ longer explanation available when compiling with `-explain`
    |                        case EmptyTuple => EmptyTuple
 
 longer explanation available when compiling with `-explain`
+-- Error: tests/neg/i12049.scala:24:20 ---------------------------------------------------------------------------------
+24 |val _ = summon[M[B]]  // error
+   |                    ^
+   |                   no implicit argument of type M[B] was found for parameter x of method summon in object Predef
+   |
+   |                   Note: a match type could not be fully reduced:
+   |
+   |                     trying to reduce  M[B]
+   |                     failed since selector  B
+   |                     does not match  case A => Int
+   |                     and cannot be shown to be disjoint from it either.
+   |                     Therefore, reduction cannot advance to the remaining case
+   |
+   |                       case B => String
+-- Error: tests/neg/i12049.scala:25:78 ---------------------------------------------------------------------------------
+25 |val _ = summon[String =:= Last[Int *: Int *: Boolean *: String *: EmptyTuple]] // error
+   |                                                                              ^
+   |                                                             Cannot prove that String =:= Last[EmptyTuple.type].
+   |
+   |                                                             Note: a match type could not be fully reduced:
+   |
+   |                                                               trying to reduce  Last[EmptyTuple.type]
+   |                                                               failed since selector  EmptyTuple.type
+   |                                                               matches none of the cases
+   |
+   |                                                                 case _ *: _ *: t => Last[t]
+   |                                                                 case t *: EmptyTuple => t
+-- Error: tests/neg/i12049.scala:26:48 ---------------------------------------------------------------------------------
+26 |val _ = summon[(A, B, A) =:= Reverse[(A, B, A)]] // error
+   |                                                ^
+   |                            Cannot prove that (A, B, A) =:= Tuple.Concat[Reverse[A *: EmptyTuple.type], (B, A)].
+   |
+   |                            Note: a match type could not be fully reduced:
+   |
+   |                              trying to reduce  Tuple.Concat[Reverse[A *: EmptyTuple.type], (B, A)]
+   |                              trying to reduce  Reverse[A *: EmptyTuple.type]
+   |                              failed since selector  A *: EmptyTuple.type
+   |                              matches none of the cases
+   |
+   |                                case t1 *: t2 *: ts => Tuple.Concat[Reverse[ts], (t2, t1)]
+   |                                case EmptyTuple => EmptyTuple
+-- [E008] Not Found Error: tests/neg/i12049.scala:28:21 ----------------------------------------------------------------
+28 |val _ = (??? : M[B]).length // error
+   |        ^^^^^^^^^^^^^^^^^^^
+   |        value length is not a member of M[B]
+   |
+   |        Note: a match type could not be fully reduced:
+   |
+   |          trying to reduce  M[B]
+   |          failed since selector  B
+   |          does not match  case A => Int
+   |          and cannot be shown to be disjoint from it either.
+   |          Therefore, reduction cannot advance to the remaining case
+   |
+   |            case B => String

--- a/tests/neg/i12049.check
+++ b/tests/neg/i12049.check
@@ -1,0 +1,50 @@
+-- [E007] Type Mismatch Error: tests/neg/i12049.scala:6:16 -------------------------------------------------------------
+6 |val x: String = ??? : M[B] // error
+  |                ^^^^^^^^^^
+  |                Found:    M[B]
+  |                Required: String
+  |
+  |                Note: a match type could not be fully reduced:
+  |
+  |                  trying to reduce  M[B]
+  |                  failed since selector  B
+  |                  does not match  case A => Int
+  |                  and cannot be shown to be disjoint from it either.
+  |                  Therefore, reduction cannot advance to the remaining case
+  |
+  |                    case B => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i12049.scala:14:17 ------------------------------------------------------------
+14 |val y3: String = ??? : Last[Int *: Int *: Boolean *: String *: EmptyTuple]  // error
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 Found:    Last[EmptyTuple.type]
+   |                 Required: String
+   |
+   |                 Note: a match type could not be fully reduced:
+   |
+   |                   trying to reduce  Last[EmptyTuple.type]
+   |                   failed since selector  EmptyTuple.type
+   |                   matches none of the cases
+   |
+   |                     case _ *: _ *: t => Last[t]
+   |                     case t *: EmptyTuple => t
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i12049.scala:22:20 ------------------------------------------------------------
+22 |val z3: (A, B, A) = ??? : Reverse[(A, B, A)] // error
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    Found:    Tuple.Concat[Reverse[A *: EmptyTuple.type], (B, A)]
+   |                    Required: (A, B, A)
+   |
+   |                    Note: a match type could not be fully reduced:
+   |
+   |                      trying to reduce  Tuple.Concat[Reverse[A *: EmptyTuple.type], (B, A)]
+   |                      trying to reduce  Reverse[A *: EmptyTuple.type]
+   |                      failed since selector  A *: EmptyTuple.type
+   |                      matches none of the cases
+   |
+   |                        case t1 *: t2 *: ts => Tuple.Concat[Reverse[ts], (t2, t1)]
+   |                        case EmptyTuple => EmptyTuple
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i12049.scala
+++ b/tests/neg/i12049.scala
@@ -20,3 +20,10 @@ type Reverse[X <: Tuple] = X match
 val z1: (B, A) = ??? : Reverse[(A, B)]
 val z2: (B, A, B, A) = ??? : Reverse[(A, B, A, B)]
 val z3: (A, B, A) = ??? : Reverse[(A, B, A)] // error
+
+val _ = summon[M[B]]
+val _ = summon[String =:= Last[Int *: Int *: Boolean *: String *: EmptyTuple]]
+val _ = summon[(A, B, A) =:= Reverse[(A, B, A)]]
+
+val _ = (??? : M[B]).length
+

--- a/tests/neg/i12049.scala
+++ b/tests/neg/i12049.scala
@@ -21,9 +21,9 @@ val z1: (B, A) = ??? : Reverse[(A, B)]
 val z2: (B, A, B, A) = ??? : Reverse[(A, B, A, B)]
 val z3: (A, B, A) = ??? : Reverse[(A, B, A)] // error
 
-val _ = summon[M[B]]
-val _ = summon[String =:= Last[Int *: Int *: Boolean *: String *: EmptyTuple]]
-val _ = summon[(A, B, A) =:= Reverse[(A, B, A)]]
+val _ = summon[M[B]]  // error
+val _ = summon[String =:= Last[Int *: Int *: Boolean *: String *: EmptyTuple]] // error
+val _ = summon[(A, B, A) =:= Reverse[(A, B, A)]] // error
 
-val _ = (??? : M[B]).length
+val _ = (??? : M[B]).length // error
 

--- a/tests/neg/i12049.scala
+++ b/tests/neg/i12049.scala
@@ -3,5 +3,20 @@ trait B
 type M[X] = X match
   case A => Int
   case B => String
-val x: String = ??? : M[B]
+val x: String = ??? : M[B] // error
 
+type Last[X <: Tuple] = X match
+  case _ *: _ *: t => Last[t]
+  case t *: EmptyTuple => t
+
+val y1: Int = ??? : Last[Int *: EmptyTuple]
+val y2: String = ??? : Last[Int *: Boolean *: String *: EmptyTuple]
+val y3: String = ??? : Last[Int *: Int *: Boolean *: String *: EmptyTuple]  // error
+
+type Reverse[X <: Tuple] = X match
+  case t1 *: t2 *: ts => Tuple.Concat[Reverse[ts], (t2, t1)]
+  case EmptyTuple => EmptyTuple
+
+val z1: (B, A) = ??? : Reverse[(A, B)]
+val z2: (B, A, B, A) = ??? : Reverse[(A, B, A, B)]
+val z3: (A, B, A) = ??? : Reverse[(A, B, A)] // error

--- a/tests/neg/i12049.scala
+++ b/tests/neg/i12049.scala
@@ -1,0 +1,7 @@
+trait A
+trait B
+type M[X] = X match
+  case A => Int
+  case B => String
+val x: String = ??? : M[B]
+

--- a/tests/neg/i7056.check
+++ b/tests/neg/i7056.check
@@ -4,4 +4,4 @@
    |        value idnt1 is not a member of B.
    |        An extension method was tried, but could not be fully constructed:
    |
-   |            i7056$package.given_T1_T[T](given_PartialId_B).idnt1()
+   |            given_T1_T[T](given_PartialId_B).idnt1()

--- a/tests/neg/matchtype-seq.check
+++ b/tests/neg/matchtype-seq.check
@@ -1,0 +1,481 @@
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:9:18 ------------------------------------------------------
+9 |  identity[T1[3]]("") // error
+  |                  ^^
+  |                  Found:    ("" : String)
+  |                  Required: Test.T1[(3 : Int)]
+  |
+  |                  Note: a match type could not be fully reduced:
+  |
+  |                    trying to reduce  Test.T1[(3 : Int)]
+  |                    failed since selector  (3 : Int)
+  |                    matches none of the cases
+  |
+  |                      case (1 : Int) => Int
+  |                      case (2 : Int) => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:10:18 -----------------------------------------------------
+10 |  identity[T1[3]](1) // error
+   |                  ^
+   |                  Found:    (1 : Int)
+   |                  Required: Test.T1[(3 : Int)]
+   |
+   |                  Note: a match type could not be fully reduced:
+   |
+   |                    trying to reduce  Test.T1[(3 : Int)]
+   |                    failed since selector  (3 : Int)
+   |                    matches none of the cases
+   |
+   |                      case (1 : Int) => Int
+   |                      case (2 : Int) => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:11:20 -----------------------------------------------------
+11 |  identity[T1[Int]]("") // error
+   |                    ^^
+   |                    Found:    ("" : String)
+   |                    Required: Test.T1[Int]
+   |
+   |                    Note: a match type could not be fully reduced:
+   |
+   |                      trying to reduce  Test.T1[Int]
+   |                      failed since selector  Int
+   |                      does not match  case (1 : Int) => Int
+   |                      and cannot be shown to be disjoint from it either.
+   |                      Therefore, reduction cannot advance to the remaining case
+   |
+   |                        case (2 : Int) => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:12:20 -----------------------------------------------------
+12 |  identity[T1[Int]](1) // error
+   |                    ^
+   |                    Found:    (1 : Int)
+   |                    Required: Test.T1[Int]
+   |
+   |                    Note: a match type could not be fully reduced:
+   |
+   |                      trying to reduce  Test.T1[Int]
+   |                      failed since selector  Int
+   |                      does not match  case (1 : Int) => Int
+   |                      and cannot be shown to be disjoint from it either.
+   |                      Therefore, reduction cannot advance to the remaining case
+   |
+   |                        case (2 : Int) => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:21:20 -----------------------------------------------------
+21 |  identity[T2[Int]]("") // error
+   |                    ^^
+   |                    Found:    ("" : String)
+   |                    Required: Test.T2[Int]
+   |
+   |                    Note: a match type could not be fully reduced:
+   |
+   |                      trying to reduce  Test.T2[Int]
+   |                      failed since selector  Int
+   |                      does not match  case (1 : Int) => Int
+   |                      and cannot be shown to be disjoint from it either.
+   |                      Therefore, reduction cannot advance to the remaining case
+   |
+   |                        case _ => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:22:18 -----------------------------------------------------
+22 |  identity[T2[2]](1) // error
+   |                  ^
+   |                  Found:    (1 : Int)
+   |                  Required: String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:23:20 -----------------------------------------------------
+23 |  identity[T2[Int]](1) // error
+   |                    ^
+   |                    Found:    (1 : Int)
+   |                    Required: Test.T2[Int]
+   |
+   |                    Note: a match type could not be fully reduced:
+   |
+   |                      trying to reduce  Test.T2[Int]
+   |                      failed since selector  Int
+   |                      does not match  case (1 : Int) => Int
+   |                      and cannot be shown to be disjoint from it either.
+   |                      Therefore, reduction cannot advance to the remaining case
+   |
+   |                        case _ => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:36:18 -----------------------------------------------------
+36 |  identity[T3[A]](1) // error
+   |                  ^
+   |                  Found:    (1 : Int)
+   |                  Required: Test.T3[Test.A]
+   |
+   |                  Note: a match type could not be fully reduced:
+   |
+   |                    trying to reduce  Test.T3[Test.A]
+   |                    failed since selector  Test.A
+   |                    does not match  case Test.B => Int
+   |                    and cannot be shown to be disjoint from it either.
+   |                    Therefore, reduction cannot advance to the remaining case
+   |
+   |                      case Test.C => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:37:18 -----------------------------------------------------
+37 |  identity[T3[A]]("") // error
+   |                  ^^
+   |                  Found:    ("" : String)
+   |                  Required: Test.T3[Test.A]
+   |
+   |                  Note: a match type could not be fully reduced:
+   |
+   |                    trying to reduce  Test.T3[Test.A]
+   |                    failed since selector  Test.A
+   |                    does not match  case Test.B => Int
+   |                    and cannot be shown to be disjoint from it either.
+   |                    Therefore, reduction cannot advance to the remaining case
+   |
+   |                      case Test.C => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:55:18 -----------------------------------------------------
+55 |  identity[T5[A]](1) // error
+   |                  ^
+   |                  Found:    (1 : Int)
+   |                  Required: Test.T5[Test.A]
+   |
+   |                  Note: a match type could not be fully reduced:
+   |
+   |                    trying to reduce  Test.T5[Test.A]
+   |                    failed since selector  Test.A
+   |                    does not match  case Test.C => String
+   |                    and cannot be shown to be disjoint from it either.
+   |                    Therefore, reduction cannot advance to the remaining case
+   |
+   |                      case Test.A => Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:56:18 -----------------------------------------------------
+56 |  identity[T5[A]]("") // error
+   |                  ^^
+   |                  Found:    ("" : String)
+   |                  Required: Test.T5[Test.A]
+   |
+   |                  Note: a match type could not be fully reduced:
+   |
+   |                    trying to reduce  Test.T5[Test.A]
+   |                    failed since selector  Test.A
+   |                    does not match  case Test.C => String
+   |                    and cannot be shown to be disjoint from it either.
+   |                    Therefore, reduction cannot advance to the remaining case
+   |
+   |                      case Test.A => Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:82:18 -----------------------------------------------------
+82 |  identity[T7[D]]("") // error
+   |                  ^^
+   |                  Found:    ("" : String)
+   |                  Required: Test.T7[Test.D]
+   |
+   |                  Note: a match type could not be fully reduced:
+   |
+   |                    trying to reduce  Test.T7[Test.D]
+   |                    failed since selector  Test.D
+   |                    does not match  case Test.A2 => Int
+   |                    and cannot be shown to be disjoint from it either.
+   |                    Therefore, reduction cannot advance to the remaining case
+   |
+   |                      case Test.D => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:83:18 -----------------------------------------------------
+83 |  identity[T7[D]](1) // error
+   |                  ^
+   |                  Found:    (1 : Int)
+   |                  Required: Test.T7[Test.D]
+   |
+   |                  Note: a match type could not be fully reduced:
+   |
+   |                    trying to reduce  Test.T7[Test.D]
+   |                    failed since selector  Test.D
+   |                    does not match  case Test.A2 => Int
+   |                    and cannot be shown to be disjoint from it either.
+   |                    Therefore, reduction cannot advance to the remaining case
+   |
+   |                      case Test.D => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:94:19 -----------------------------------------------------
+94 |  identity[T8[E2]](1) // error
+   |                   ^
+   |                   Found:    (1 : Int)
+   |                   Required: Test.T8[Test.E2]
+   |
+   |                   Note: a match type could not be fully reduced:
+   |
+   |                     trying to reduce  Test.T8[Test.E2]
+   |                     failed since selector  Test.E2
+   |                     does not match  case Test.E1 => Int
+   |                     and cannot be shown to be disjoint from it either.
+   |                     Therefore, reduction cannot advance to the remaining case
+   |
+   |                       case Test.E2 => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:95:19 -----------------------------------------------------
+95 |  identity[T8[E1]]("") // error
+   |                   ^^
+   |                   Found:    ("" : String)
+   |                   Required: Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:96:19 -----------------------------------------------------
+96 |  identity[T8[E2]]("") // error
+   |                   ^^
+   |                   Found:    ("" : String)
+   |                   Required: Test.T8[Test.E2]
+   |
+   |                   Note: a match type could not be fully reduced:
+   |
+   |                     trying to reduce  Test.T8[Test.E2]
+   |                     failed since selector  Test.E2
+   |                     does not match  case Test.E1 => Int
+   |                     and cannot be shown to be disjoint from it either.
+   |                     Therefore, reduction cannot advance to the remaining case
+   |
+   |                       case Test.E2 => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:105:40 ----------------------------------------------------
+105 |  identity[T9[Tuple2[Nothing, String]]](1) // error
+    |                                        ^
+    |                                        Found:    (1 : Int)
+    |                                        Required: Test.T9[(Nothing, String)]
+    |
+    |                                        Note: a match type could not be fully reduced:
+    |
+    |                                          trying to reduce  Test.T9[(Nothing, String)]
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:106:40 ----------------------------------------------------
+106 |  identity[T9[Tuple2[String, Nothing]]]("1") // error
+    |                                        ^^^
+    |                                        Found:    ("1" : String)
+    |                                        Required: Test.T9[(String, Nothing)]
+    |
+    |                                        Note: a match type could not be fully reduced:
+    |
+    |                                          trying to reduce  Test.T9[(String, Nothing)]
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:107:37 ----------------------------------------------------
+107 |  identity[T9[Tuple2[Int, Nothing]]](1) // error
+    |                                     ^
+    |                                     Found:    (1 : Int)
+    |                                     Required: Test.T9[(Int, Nothing)]
+    |
+    |                                     Note: a match type could not be fully reduced:
+    |
+    |                                       trying to reduce  Test.T9[(Int, Nothing)]
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:108:37 ----------------------------------------------------
+108 |  identity[T9[Tuple2[Nothing, Int]]]("1") // error
+    |                                     ^^^
+    |                                     Found:    ("1" : String)
+    |                                     Required: Test.T9[(Nothing, Int)]
+    |
+    |                                     Note: a match type could not be fully reduced:
+    |
+    |                                       trying to reduce  Test.T9[(Nothing, Int)]
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:109:29 ----------------------------------------------------
+109 |  identity[T9[Tuple2[_, _]]]("") // error
+    |                             ^^
+    |                             Found:    ("" : String)
+    |                             Required: Test.T9[(?, ?)]
+    |
+    |                             Note: a match type could not be fully reduced:
+    |
+    |                               trying to reduce  Test.T9[(?, ?)]
+    |                               failed since selector  (?, ?)
+    |                               does not match  case (Int, String) => Int
+    |                               and cannot be shown to be disjoint from it either.
+    |                               Therefore, reduction cannot advance to the remaining case
+    |
+    |                                 case (String, Int) => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:110:29 ----------------------------------------------------
+110 |  identity[T9[Tuple2[_, _]]](1) // error
+    |                             ^
+    |                             Found:    (1 : Int)
+    |                             Required: Test.T9[(?, ?)]
+    |
+    |                             Note: a match type could not be fully reduced:
+    |
+    |                               trying to reduce  Test.T9[(?, ?)]
+    |                               failed since selector  (?, ?)
+    |                               does not match  case (Int, String) => Int
+    |                               and cannot be shown to be disjoint from it either.
+    |                               Therefore, reduction cannot advance to the remaining case
+    |
+    |                                 case (String, Int) => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:111:33 ----------------------------------------------------
+111 |  identity[T9[Tuple2[Any, Any]]]("") // error
+    |                                 ^^
+    |                                 Found:    ("" : String)
+    |                                 Required: Test.T9[(Any, Any)]
+    |
+    |                                 Note: a match type could not be fully reduced:
+    |
+    |                                   trying to reduce  Test.T9[(Any, Any)]
+    |                                   failed since selector  (Any, Any)
+    |                                   does not match  case (Int, String) => Int
+    |                                   and cannot be shown to be disjoint from it either.
+    |                                   Therefore, reduction cannot advance to the remaining case
+    |
+    |                                     case (String, Int) => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:112:33 ----------------------------------------------------
+112 |  identity[T9[Tuple2[Any, Any]]](1) // error
+    |                                 ^
+    |                                 Found:    (1 : Int)
+    |                                 Required: Test.T9[(Any, Any)]
+    |
+    |                                 Note: a match type could not be fully reduced:
+    |
+    |                                   trying to reduce  Test.T9[(Any, Any)]
+    |                                   failed since selector  (Any, Any)
+    |                                   does not match  case (Int, String) => Int
+    |                                   and cannot be shown to be disjoint from it either.
+    |                                   Therefore, reduction cannot advance to the remaining case
+    |
+    |                                     case (String, Int) => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:122:39 ----------------------------------------------------
+122 |  identity[TA[Box2[Int, Int, String]]](1) // error
+    |                                       ^
+    |                                       Found:    (1 : Int)
+    |                                       Required: Test.TA[Test.Box2[Int, Int, String]]
+    |
+    |                                       Note: a match type could not be fully reduced:
+    |
+    |                                         trying to reduce  Test.TA[Test.Box2[Int, Int, String]]
+    |                                         failed since selector  Test.Box2[Int, Int, String]
+    |                                         does not match  case Test.Box2[Int, Int, Int] => Int
+    |                                         and cannot be shown to be disjoint from it either.
+    |                                         Therefore, reduction cannot advance to the remaining case
+    |
+    |                                           case Test.Box2[Int, Int, String] => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:123:39 ----------------------------------------------------
+123 |  identity[TA[Box2[Int, Int, String]]]("") // error
+    |                                       ^^
+    |                                       Found:    ("" : String)
+    |                                       Required: Test.TA[Test.Box2[Int, Int, String]]
+    |
+    |                                       Note: a match type could not be fully reduced:
+    |
+    |                                         trying to reduce  Test.TA[Test.Box2[Int, Int, String]]
+    |                                         failed since selector  Test.Box2[Int, Int, String]
+    |                                         does not match  case Test.Box2[Int, Int, Int] => Int
+    |                                         and cannot be shown to be disjoint from it either.
+    |                                         Therefore, reduction cannot advance to the remaining case
+    |
+    |                                           case Test.Box2[Int, Int, String] => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:144:41 ----------------------------------------------------
+144 |  identity[TD[Box2_C[Int, Int, String]]]("") // error
+    |                                         ^^
+    |                                         Found:    ("" : String)
+    |                                         Required: Test.TD[Test.Box2_C[Int, Int, String]]
+    |
+    |                                         Note: a match type could not be fully reduced:
+    |
+    |                                           trying to reduce  Test.TD[Test.Box2_C[Int, Int, String]]
+    |                                           failed since selector  Test.Box2_C[Int, Int, String]
+    |                                           does not match  case Test.Box2_C[Int, Int, Int] => Int
+    |                                           and cannot be shown to be disjoint from it either.
+    |                                           Therefore, reduction cannot advance to the remaining case
+    |
+    |                                             case Test.Box2_C[Int, Int, String] => String
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:153:25 ----------------------------------------------------
+153 |  def a[A]: M[Some[A]] = 1  // error
+    |                         ^
+    |                         Found:    (1 : Int)
+    |                         Required: Test2.M[Some[A]]
+    |
+    |                         Note: a match type could not be fully reduced:
+    |
+    |                           trying to reduce  Test2.M[Some[A]]
+    |                           failed since selector  Some[A]
+    |                           does not match  case Option[Int] => String
+    |                           and cannot be shown to be disjoint from it either.
+    |                           Therefore, reduction cannot advance to the remaining case
+    |
+    |                             case Some[_] => Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:154:25 ----------------------------------------------------
+154 |  def b[A]: M[Some[A]] = "" // error
+    |                         ^^
+    |                         Found:    ("" : String)
+    |                         Required: Test2.M[Some[A]]
+    |
+    |                         Note: a match type could not be fully reduced:
+    |
+    |                           trying to reduce  Test2.M[Some[A]]
+    |                           failed since selector  Some[A]
+    |                           does not match  case Option[Int] => String
+    |                           and cannot be shown to be disjoint from it either.
+    |                           Therefore, reduction cannot advance to the remaining case
+    |
+    |                             case Some[_] => Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:168:23 ----------------------------------------------------
+168 |    val a: M[Inv[A]] = 1 // error
+    |                       ^
+    |                       Found:    (1 : Int)
+    |                       Required: Test3.M[Test3.Inv[A]]
+    |
+    |                       Note: a match type could not be fully reduced:
+    |
+    |                         trying to reduce  Test3.M[Test3.Inv[A]]
+    |                         failed since selector  Test3.Inv[A]
+    |                         does not match  case Test3.Inv[Int] => String
+    |                         and cannot be shown to be disjoint from it either.
+    |                         Therefore, reduction cannot advance to the remaining case
+    |
+    |                           case _ => Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/matchtype-seq.scala:187:25 ----------------------------------------------------
+187 |      val a: M[Inv[A]] = 1 // error
+    |                         ^
+    |                         Found:    (1 : Int)
+    |                         Required: Test4.M[Test4.Inv[Foo.this.A]]
+    |
+    |                         Note: a match type could not be fully reduced:
+    |
+    |                           trying to reduce  Test4.M[Test4.Inv[Foo.this.A]]
+    |                           failed since selector  Test4.Inv[Foo.this.A]
+    |                           does not match  case Test4.Inv[Int] => String
+    |                           and cannot be shown to be disjoint from it either.
+    |                           Therefore, reduction cannot advance to the remaining case
+    |
+    |                             case _ => Int
+
+longer explanation available when compiling with `-explain`


### PR DESCRIPTION
Fixes #12049

Also: Some tweaks for better printing

 - improve elision of package objects
 - don't print LazyRef nodes
 - fix display of match type cases that bind variables
 