### PR TITLE
Backport: When simplifying match types, ensure fully defined before reducing

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -139,6 +139,10 @@ object TypeOps:
           case tp1 => tp1
         }
       case tp: AppliedType =>
+        tp.tycon match
+          case tycon: TypeRef if tycon.info.isInstanceOf[MatchAlias] =>
+            isFullyDefined(tp, ForceDegree.all)
+          case _ =>
         val normed = tp.tryNormalize
         if normed.exists then normed else tp.map(simplify(_, theMap))
       case tp: TypeParamRef =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1816,10 +1816,12 @@ object Types {
     /** A simplified version of this type which is equivalent wrt =:= to this type.
      *  This applies a typemap to the type which (as all typemaps) follows type
      *  variable instances and reduces typerefs over refined types. It also
-     *  re-evaluates all occurrences of And/OrType with &/| because
-     *  what was a union or intersection of type variables might be a simpler type
-     *  after the type variables are instantiated. Finally, it
-     *  maps poly params in the current constraint set back to their type vars.
+     *
+     *   - re-evaluates all occurrences of And/OrType with &/| because
+     *     what was a union or intersection of type variables might be a simpler type
+     *     after the type variables are instantiated.
+     *   - maps poly params in the current constraint set back to their type vars.
+     *   - forces match types to be fully defined and tries to normalize them.
      *
      *  NOTE: Simplifying an intersection type might change its erasure (for
      *  example, the Java erasure of `Object & Serializable` is `Object`,

--- a/compiler/test-resources/repl/i5218
+++ b/compiler/test-resources/repl/i5218
@@ -3,4 +3,5 @@ val tuple: (Int, String, Long) = (1,2,3)
 scala> 0.0 *: tuple
 val res0: (Double, Int, String, Long) = (0.0,1,2,3)
 scala> tuple ++ tuple
-val res1: Int *: scala.Tuple.Concat[(String, Long), tuple.type] = (1,2,3,1,2,3)
+val res1: Int *: String *: Long *:
+  scala.Tuple.Concat[scala.Tuple$package.EmptyTuple.type, tuple.type] = (1,2,3,1,2,3)

--- a/tests/pos/i11977.scala
+++ b/tests/pos/i11977.scala
@@ -1,0 +1,7 @@
+object Test:
+
+  def add0(a : (Int, String), b : (Int, String)): Int =
+    val x = 3
+    x + b(0)
+
+  def add(a : (Int, String), b : (Int, String)) : (Int, String) = (a(0) + b(0), a(1) + b(1))


### PR DESCRIPTION
Backport of #11980 