### PR TITLE
Fix #12046: skip publishing nightly build when no new commits since last publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -447,7 +447,20 @@ jobs:
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
+      - name: Get version string for this build
+        run: |
+          ver=$(./project/scripts/sbt "print scala3-compiler-bootstrapped/version" | tail -n1)
+          echo "This build version: $ver"
+          echo "THISBUILD_VERSION=$ver" >> $GITHUB_ENV
+
+      - name: Check whether not yet published
+        id: not_yet_published
+        continue-on-error: true
+        run: |
+          ! ./project/scripts/is-version-published.sh "$THISBUILD_VERSION"
+
       - name: Publish Nightly
+        if: "steps.not_yet_published.outcome == 'success'"
         run: |
           ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
 

--- a/project/scripts/is-version-published.sh
+++ b/project/scripts/is-version-published.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Check whether a specific version of the Scala 3 compiler is published to Maven Central
+#
+# Usage:
+#   is-version-published.sh <version_string>
+# e.g.
+#   ./is-version-published.sh 3.0.1-RC1-bin-20210413-f3c1468-NIGHTLY
+#
+# Exit status:
+#   zero      if the specified version is published on Maven Central
+#   non-zero  otherwise
+#
+# Notes:
+#   Will always say 'not yet published' for versions prior to 3.0.1-RC1-bin-20210413-f3c1468-NIGHTLY
+#   since the binary version scheme was changed at that point.
+
+ver=$1
+if [[ -z "$ver" ]]; then
+  echo "error: missing version parameter"
+  echo "usage: $0 <version_string>"
+  exit 2
+fi
+
+set -eu
+
+# binary version is everything up to the first dot
+binaryVersion="${ver%%.*}"
+
+artifactId="scala3-compiler_$binaryVersion"
+pom="$artifactId-$ver.pom"
+
+maven_url=https://repo1.maven.org/maven2/org/scala-lang/$artifactId/$ver/$pom
+
+echo "Checking whether $ver is published"
+echo "at $maven_url"
+echo ""
+
+if curl --head --fail -L "$maven_url" ; then
+  echo "Version $ver is already published."
+  exit 0
+else
+  echo "Version $ver is not yet published."
+  exit 10
+fi


### PR DESCRIPTION
Attempting to publish an already published version using `sbt-sonatype`
fails with a "Failed to promote the repository" error.

There don't appear to be any configuration settings in `sbt-sontaype`
for avoiding this, so instead we ask for published versions from the
Maven Central metadata and skip the publish step if we find a match.

Fixes #12046