### PR TITLE
Backport: sbt-dotty: the binary version is 3 for Scala >= 3.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -348,11 +348,8 @@ jobs:
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
-      - name: Test sbt 1.4.x
+      - name: Test sbt
         run: ./project/scripts/sbt "sbt-dotty/scripted; sbt-community-build/scripted"
-
-      - name: Test sbt 1.5.x
-        run: ./project/scripts/sbt "set \`sbt-dotty\`/scriptedSbt := \"1.5.0-RC1\"; sbt-dotty/scripted sbt-dotty/*"
 
   test_java8:
     runs-on: [self-hosted, Linux]

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -124,7 +124,7 @@ final case class SbtCommunityProject(
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
     extraSbtArgs ++ sbtProps ++ List(
-      "-sbt-version", "1.4.9",
+      "-sbt-version", "1.5.0",
       "-Dsbt.supershell=false",
       s"-Ddotty.communitybuild.dir=$communitybuildDir",
       s"--addPluginSbtFile=$sbtPluginFilePath"
@@ -140,7 +140,7 @@ object projects:
 
   private def forceDoc(projects: String*) =
     projects.map(project =>
-      s""";set $project/Compile/doc/sources ++= ($project/Compile/doc/tastyFiles).value ;$project/doc"""
+      s""";set $project/Compile/doc/sources ++= ($project/Compile/doc/dotty.tools.sbtplugin.DottyPlugin.autoImport.tastyFiles).value ;$project/doc"""
     ).mkString(" ")
 
   private def aggregateDoc(in: String)(projects: String*) =

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -21,10 +21,12 @@ lazy val sbtPluginFilePath: String =
 def log(msg: String) = println(Console.GREEN + msg + Console.RESET)
 
 /** Executes shell command, returns false in case of error. */
-def exec(projectDir: Path, binary: String, arguments: String*): Int =
+def exec(projectDir: Path, binary: String, arguments: Seq[String], environment: Map[String, String]): Int =
+  import collection.JavaConverters._
   val command = binary +: arguments
   log(command.mkString(" "))
   val builder = new ProcessBuilder(command: _*).directory(projectDir.toFile).inheritIO()
+  builder.environment.putAll(environment.asJava)
   val process = builder.start()
   val exitCode = process.waitFor()
   exitCode
@@ -40,6 +42,7 @@ sealed trait CommunityProject:
   val dependencies: List[CommunityProject]
   val binaryName: String
   val runCommandsArgs: List[String] = Nil
+  val environment: Map[String, String] = Map.empty
 
   final val projectDir = communitybuildDir.resolve("community-projects").resolve(project)
 
@@ -53,7 +56,7 @@ sealed trait CommunityProject:
       log(s"Publishing $project")
       if publishCommand eq null then
         throw RuntimeException(s"Publish command is not specified for $project. Project details:\n$this")
-      val exitCode = exec(projectDir, binaryName, (runCommandsArgs :+ publishCommand): _*)
+      val exitCode = exec(projectDir, binaryName, (runCommandsArgs :+ publishCommand), environment)
       if exitCode != 0 then
         throw RuntimeException(s"Publish command exited with code $exitCode for project $project. Project details:\n$this")
       published = true
@@ -63,11 +66,11 @@ sealed trait CommunityProject:
     log(s"Documenting $project")
     if docCommand eq null then
       throw RuntimeException(s"Doc command is not specified for $project. Project details:\n$this")
-    val exitCode = exec(projectDir, binaryName, (runCommandsArgs :+ docCommand): _*)
+    val exitCode = exec(projectDir, binaryName, (runCommandsArgs :+ docCommand), environment)
     if exitCode != 0 then
       throw RuntimeException(s"Doc command exited with code $exitCode for project $project. Project details:\n$this")
 
-  final def build(): Int = exec(projectDir, binaryName, buildCommands: _*)
+  final def build(): Int = exec(projectDir, binaryName, buildCommands, environment)
 
   final def buildCommands = runCommandsArgs :+ testCommand
 
@@ -86,6 +89,7 @@ final case class MillCommunityProject(
     // uncomment once mill is released
     // if ignoreDocs then null else s"$baseCommand.docJar"
   override val runCommandsArgs = List("-i", "-D", s"dottyVersion=$compilerVersion")
+  override val environment = Map("MILL_VERSION" -> "0.9.6-16-a5da34")
 
 final case class SbtCommunityProject(
     project: String,

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -145,7 +145,7 @@ object projects:
 
   private def aggregateDoc(in: String)(projects: String*) =
     val tastyFiles =
-      (in +: projects).map(p => s"($p/Compile/doc/tastyFiles).value").mkString(" ++ ")
+      (in +: projects).map(p => s"($p/Compile/doc/dotty.tools.sbtplugin.DottyPlugin.autoImport.tastyFiles).value").mkString(" ++ ")
     s""";set $in/Compile/doc/sources ++= file("a.scala") +: ($tastyFiles) ;$in/doc"""
 
   lazy val utest = MillCommunityProject(

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -102,12 +102,12 @@ final case class SbtCommunityProject(
     scalacOptions.map("\"" + _ + "\"").mkString("List(", ",", ")")
 
   private val baseCommand =
-    "clean; set logLevel in Global := Level.Error; set updateOptions in Global ~= (_.withLatestSnapshots(false)); "
-    ++ (if scalacOptions.isEmpty then "" else s"""set scalacOptions in Global ++= $scalacOptionsString;""")
+    "clean; set Global/logLevel := Level.Error; set Global/updateOptions ~= (_.withLatestSnapshots(false)); "
+    ++ (if scalacOptions.isEmpty then "" else s"""set Global/scalacOptions ++= $scalacOptionsString;""")
     ++ s"++$compilerVersion!; "
 
   override val testCommand =
-    """set testOptions in Global += Tests.Argument(TestFramework("munit.Framework"), "+l"); """
+    """set Global/testOptions += Tests.Argument(TestFramework("munit.Framework"), "+l"); """
     ++ s"$baseCommand$sbtTestCommand"
 
   override val publishCommand =
@@ -512,7 +512,7 @@ object projects:
 
   lazy val cats = SbtCommunityProject(
     project = "cats",
-    sbtTestCommand = "set scalaJSStage in Global := FastOptStage;buildJVM;validateAllJS",
+    sbtTestCommand = "set Global/scalaJSStage := FastOptStage;buildJVM;validateAllJS",
     sbtPublishCommand = "catsJVM/publishLocal;catsJS/publishLocal",
     dependencies = List(discipline, disciplineMunit, scalacheck, simulacrumScalafixAnnotations),
     scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Ysafe-init") // disable -Ysafe-init, due to -Xfatal-warning

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1243,6 +1243,9 @@ object Build {
         baseDirectory.value / "../language-server/src/dotty/tools/languageserver/config",
       sbtTestDirectory := baseDirectory.value / "sbt-test",
 
+      // ensure that sbt-dotty is built on sbt 1.4
+      pluginCrossBuild / sbtVersion := "1.4.9",
+
       // The batch mode accidentally became the default with no way to disable
       // it in sbt 1.4 (https://github.com/sbt/sbt/issues/5913#issuecomment-716003195).
       // We enable it explicitly here to make it clear that we're using it.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1243,8 +1243,11 @@ object Build {
         baseDirectory.value / "../language-server/src/dotty/tools/languageserver/config",
       sbtTestDirectory := baseDirectory.value / "sbt-test",
 
-      // ensure that sbt-dotty is built on sbt 1.4
+      // ensure that sbt-dotty is built with sbt 1.4
       pluginCrossBuild / sbtVersion := "1.4.9",
+
+      // scritped tests are run with current sbt version
+      scriptedSbt := sbtVersion.value,
 
       // The batch mode accidentally became the default with no way to disable
       // it in sbt 1.4 (https://github.com/sbt/sbt/issues/5913#issuecomment-716003195).

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.0

--- a/sbt-dotty/sbt-test/source-dependencies/value-class/pending
+++ b/sbt-dotty/sbt-test/source-dependencies/value-class/pending
@@ -1,3 +1,5 @@
+## This failing test is pending because it will be solved by removing sbt-dotty
+
 ## Case 1: value class as parameter of method
 $ copy-file changes/A0.scala src/main/scala/A.scala
 $ copy-file changes/B0.scala src/main/scala/B.scala

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -264,11 +264,10 @@ object DottyPlugin extends AutoPlugin {
       scalaBinaryVersion := {
         scalaVersion.value.split("[\\.-]").toList match {
           case "0" :: minor :: _ => s"0.$minor"
-          case "3" :: minor :: patch :: suffix =>
-            s"3.$minor.$patch" + (suffix match {
-              case milestone :: _ => s"-$milestone"
-              case Nil => ""
-            })
+          case "3" :: "0" :: "0" :: milestone :: _ =>
+            s"3.0.0-$milestone"
+          case "3" :: _ =>
+            "3"
           case _ => scalaBinaryVersion.value
         }
       },


### PR DESCRIPTION
Backport #11844 and #11952

This will be needed when releasing 3.0.0, so that the cross version is 3.

Some minor comments:
- sbt 1.5.0 is needed to run the tests with Scala >= 3.0.0
- Mill 0.9.6-16-a5da34 is needed to build the Mill community projects with Scala >= 3.0.0
- stdLib213 is updated so that it can be built with sbt 1.5.0 