### PR TITLE
remove 3 deprecation warnings during sbt build

### DIFF
--- a/sbt-bridge/src/dotty/tools/xsbt/CompilerBridgeDriver.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/CompilerBridgeDriver.java
@@ -29,13 +29,13 @@ public class CompilerBridgeDriver extends Driver {
     super();
     this.scalacOptions = scalacOptions;
 
-    if (!output.getSingleOutput().isPresent())
+    if (!output.getSingleOutputAsPath().isPresent())
       throw new IllegalArgumentException("output should be a SingleOutput, was a " + output.getClass().getName());
 
     this.args = new String[scalacOptions.length + 2];
     System.arraycopy(scalacOptions, 0, args, 0, scalacOptions.length);
     args[scalacOptions.length] = "-d";
-    args[scalacOptions.length + 1] = output.getSingleOutput().get().getAbsolutePath();
+    args[scalacOptions.length + 1] = output.getSingleOutputAsPath().get().toAbsolutePath().toString();
   }
 
   private static final String StopInfoError =

--- a/sbt-bridge/src/xsbt/CachedCompilerImpl.java
+++ b/sbt-bridge/src/xsbt/CachedCompilerImpl.java
@@ -26,7 +26,7 @@ public class CachedCompilerImpl implements CachedCompiler {
       throw new IllegalArgumentException("output should be a SingleOutput, was a " + output.getClass().getName());
 
     this.outputArgs =
-      new String[] { "-d", ((SingleOutput) output).getOutputDirectory().getAbsolutePath() };
+      new String[] { "-d", ((SingleOutput) output).getOutputDirectoryAsPath().toAbsolutePath().toString() };
   }
 
   public String[] commandArguments(File[] sources) {


### PR DESCRIPTION
Running the command `sbt compile and sbt test` currently produces several deprecation warnings, e.g.

```scala
$ sbt compile and sbt test
[info] welcome to sbt 1.5.0 (AdoptOpenJDK Java 1.8.0_282)
[info] loading global plugins from C:\Users\michelou\.sbt\1.0\plugins
[info] loading settings for project dotty-build-build from build.sbt ...
[info] loading project definition from W:\dotty\project\project
[info] loading settings for project dotty-build from build.sbt,plugins.sbt ...
[info] loading project definition from W:\dotty\project
[info] loading settings for project scala3 from build.sbt ...
[info] resolving key references (33388 settings) ...
[info] set current project to scala3 (in build file:/W:/dotty/)
[warn] The sbt-dotty plugin is no longer neeeded with sbt >= 1.5, please remove it from your build.
[info] Executing in batch mode. For better performance use sbt's shell
[info] compiling 66 Scala sources and 25 Java sources to W:\dotty\library\target\scala-3.0.0-RC2\classes ...
[info] compiling 7 Java sources to W:\dotty\interfaces\target\classes ...
[info] done compiling
[info] Unpacking scalajs-ir sources to W:\dotty\compiler\target\scala-3.0.0-RC2\src_managed\main\scalajs-ir-src...
[info] compiling 66 Scala sources and 25 Java sources to W:\dotty\library-js\target\scala-3.0.0-RC2\classes ...
[info] done compiling
[info] compiling 7 Scala sources to W:\dotty\tasty\target\scala-3.0.0-RC2\classes ...
[info] done compiling
[info] compiling 10 Scala sources to W:\dotty\scaladoc-js\target\scala-3.0.0-RC2\classes ...
[info] done compiling
[info] compiling 481 Scala sources and 6 Java sources to W:\dotty\compiler\target\scala-3.0.0-RC2\classes ...
[info] done compiling
[info] Full optimizing W:\dotty\scaladoc-js\target\scala-3.0.0-RC2\scaladoc-js-nonbootstrapped-opt
[info] Closure: 0 error(s), 0 warning(s)
[info] done compiling
[info] compiling 3 Scala sources to W:\dotty\tasty-inspector\target\scala-3.0.0-RC2\classes ...
[info] done compiling
[info] compiling 64 Scala sources and 1 Java source to W:\dotty\scaladoc\target\scala-3.0.0-RC2\classes ...
[info] done compiling
[info] compiling 14 Java sources to W:\dotty\sbt-bridge\src\target\classes ...
[warn] W:\dotty\sbt-bridge\src\dotty\tools\xsbt\CompilerBridgeDriver.java:32:1: getSingleOutput() in xsbti.compile.Output has been deprecated
[warn] output.getSingleOutput
[warn] W:\dotty\sbt-bridge\src\dotty\tools\xsbt\CompilerBridgeDriver.java:38:1: getSingleOutput() in xsbti.compile.Output has been deprecated
[warn] output.getSingleOutput
[warn] W:\dotty\sbt-bridge\src\dotty\tools\xsbt\DelegatingReporter.java:14:1: dotty$tools$dotc$reporting$UniqueMessagePositions$$positions() in dotty.tools.dotc.reporting.AbstractReporter implements dotty$tools$dotc$reporting$UniqueMessagePositions$$positions() in dotty.tools.dotc.reporting.UniqueMessagePositions
[warn]   return type requires unchecked conversion from scala.collection.mutable.HashMap to scala.collection.mutable.HashMap<scala.Tuple2<dotty.tools.dotc.util.SourceFile,java.lang.Object>,java.lang.Object>
[warn] final public class DelegatingReporter extends AbstractReporter {
[warn]   private xsbti.Reporter delegate;
[warn]
[warn]   public DelegatingReporter(xsbti.Reporter delegate) {
[warn]     super();
[warn]     this.delegate = delegate;
[warn]   }
[warn]
[warn]   public void dropDelegate() {
[warn]     delegate = null;
[warn]   }
[warn]
[warn]   @Override
[warn]   public void printSummary(Context ctx) {
[warn]     delegate.printSummary();
[warn]   }
[warn]
[warn]   public void doReport(Diagnostic dia, Context ctx) {
[warn]     Severity severity = severityOf(dia.level());
[warn]     Position position = positionOf(dia.pos());
[warn]
[warn]     Message message = dia.msg();
[warn]     StringBuilder rendered = new StringBuilder();
[warn]     rendered.append(messageAndPos(message, dia.pos(), diagnosticLevel(dia), ctx));
[warn]     boolean shouldExplain = Diagnostic.shouldExplain(dia, ctx);
[warn]     if (shouldExplain && !message.explanation().isEmpty()) {
[warn]       rendered.append(explanation(message, ctx));
[warn]     }
[warn]
[warn]     delegate.log(new Problem(position, message.msg(), severity, rendered.toString()));
[warn]   }
[warn]
[warn]   private static Severity severityOf(int level) {
[warn]     Severity severity;
[warn]     switch (level) {
[warn]       case dotty.tools.dotc.interfaces.Diagnostic.ERROR: severity = Severity.Error; break;
[warn]       case dotty.tools.dotc.interfaces.Diagnostic.WARNING: severity = Severity.Warn; break;
[warn]       case dotty.tools.dotc.interfaces.Diagnostic.INFO: severity = Severity.Info; break;
[warn]       default:
[warn]         throw new IllegalArgumentException(String.format("Bad diagnostic level: %s", level));
[warn]     }
[warn]     return severity;
[warn]   }
[warn]
[warn]   private static Position positionOf(SourcePosition pos) {
[warn]     if (pos.exists()){
[warn]       return new PositionBridge(pos, pos.source());
[warn]     } else {
[warn]       return PositionBridge.noPosition;
[warn]     }
[warn]   }
[warn] }
[warn] W:\dotty\sbt-bridge\src\xsbt\CachedCompilerImpl.java:51:1: run(java.io.File[],xsbti.compile.DependencyChanges,xsbti.AnalysisCallback,xsbti.Logger,xsbti.Reporter,xsbti.compile.CompileProgress) in xsbti.compile.CachedCompiler has been deprecated
[warn] synchronized public void run(File[] sources, DependencyChanges changes, AnalysisCallback callback, Logger log,
[warn]     Reporter delegate, CompileProgress progress) {
[warn]     log.debug(() -> {
[warn]       String msg = "Calling Dotty compiler with arguments  (CompilerInterface):";
[warn]       for (String arg : args)
[warn]         msg = msg + "\n\t" + arg;
[warn]       return msg;
[warn]     });
[warn]
[warn]     Context ctx = new ContextBase().initialCtx().fresh()
[warn]       .setSbtCallback(callback)
[warn]       .setReporter(new DelegatingReporter(delegate));
[warn]
[warn]     dotty.tools.dotc.reporting.Reporter reporter = Main.process(commandArguments(sources), ctx);
[warn]     if (reporter.hasErrors()) {
[warn]       throw new InterfaceCompileFailed(args, new Problem[0], "Compilation failed");
[warn]     }
[warn]   }
[warn] W:\dotty\sbt-bridge\src\xsbt\CachedCompilerImpl.java:29:1: getOutputDirectory() in xsbti.compile.SingleOutput has been deprecated

[warn] ((SingleOutput) output).getOutputDirectory
[warn] W:\dotty\sbt-bridge\src\xsbt\CompilerInterface.java:59:1: run(java.io.File[],xsbti.compile.DependencyChanges,xsbti.AnalysisCallback,xsbti.Logger,xsbti.Reporter,xsbti.compile.CompileProgress) in xsbti.compile.CachedCompiler has been deprecated
[warn] cached.run
[info] done compiling
[...]
```

This PR fixes 3 of them: 
- `getSingleOutput() in xsbti.compile.Output has been deprecated` (2 occurences)
- `getOutputDirectory() in xsbti.compile.SingleOutput has been deprecated`.

**PS.** Another deprecation to be fixed is : 
`run(java.io.File[],xsbti.compile.DependencyChanges,xsbti.AnalysisCallback,xsbti.Logger,xsbti.Reporter,xsbti.compile.CompileProgress) in xsbti.compile.CachedCompiler has been deprecated`
