### PR TITLE
Overloading resolution: Handle SAM types more like Java and Scala 2

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -133,8 +133,7 @@ class Definitions {
           ClassInfo(ScalaPackageClass.thisType, cls, ObjectType :: Nil, decls)
       }
     }
-    val flags0 = Trait | NoInits
-    val flags = if (name.isContextFunction) flags0 | Final else flags0
+    val flags = Trait | NoInits
     newPermanentClassSymbol(ScalaPackageClass, name, flags, completer)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5043,7 +5043,7 @@ object Types {
         NoType
     }
     def isInstantiatable(tp: Type)(using Context): Boolean = zeroParamClass(tp) match {
-      case cinfo: ClassInfo =>
+      case cinfo: ClassInfo if !cinfo.cls.isOneOf(FinalOrSealed) =>
         val selfType = cinfo.selfType.asSeenFrom(tp, cinfo.cls)
         tp <:< selfType
       case _ =>

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -173,7 +173,8 @@ enum ErrorMessageID extends java.lang.Enum[ErrorMessageID] {
     CaseClassInInlinedCodeID,
     OverrideTypeMismatchErrorID,
     OverrideErrorID,
-    MatchableWarningID
+    MatchableWarningID,
+    CannotExtendFunctionID
 
   def errorNumber = ordinal - 2
 }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1558,6 +1558,12 @@ import transform.SymUtils._
       def explain = ""
     }
 
+  class CannotExtendContextFunction(sym: Symbol)(using Context)
+    extends SyntaxMsg(CannotExtendFunctionID) {
+      def msg = em"""$sym cannot extend a context function class"""
+      def explain = ""
+    }
+
   class JavaEnumParentArgs(parent: Type)(using Context)
     extends TypeMsg(JavaEnumParentArgsID) {
       def msg = em"""not enough arguments for constructor Enum: ${hl("(name: String, ordinal: Int)")}: ${hl(parent.show)}"""

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -96,7 +96,7 @@ object RefChecks {
 
   /** Check that self type of this class conforms to self types of parents
    *  and required classes. Also check that only `enum` constructs extend
-   *  `java.lang.Enum`.
+   *  `java.lang.Enum` and no user-written class extends ContextFunctionN.
    */
   private def checkParents(cls: Symbol, parentTrees: List[Tree])(using Context): Unit = cls.info match {
     case cinfo: ClassInfo =>
@@ -132,6 +132,8 @@ object RefChecks {
             case _ =>
               false
           }
+      if psyms.exists(defn.isContextFunctionClass) then
+        report.error(CannotExtendContextFunction(cls), cls.sourcePos)
 
       /** Check that arguments passed to trait parameters conform to the parameter types
        *  in the current class. This is necessary since parameter types might be narrowed

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1399,10 +1399,6 @@ class Typer extends Namer
                   else
                     report.error(ex"result type of lambda is an underspecified SAM type $pt", tree.srcPos)
                     pt
-                if (pt.classSymbol.isOneOf(FinalOrSealed)) {
-                  val offendingFlag = pt.classSymbol.flags & FinalOrSealed
-                  report.error(ex"lambda cannot implement $offendingFlag ${pt.classSymbol}", tree.srcPos)
-                }
                 TypeTree(targetTpe)
               case _ =>
                 if (mt.isParamDependent)

--- a/tests/neg/i11938.scala
+++ b/tests/neg/i11938.scala
@@ -1,0 +1,16 @@
+import java.util.function.Function
+
+object Test {
+  def foo[V](v: V): Int = 1
+  def foo[U](fn: Function[Int, U]): Int = 2
+
+  def main(args: Array[String]): Unit = {
+    val f: Int => Int = x => x
+    foo(f) // error
+      // Like Scala 2, we emit an error here because the Function1 argument was
+      // deemed SAM-convertible to Function, even though it's not a lambda
+      // expression and therefore not convertible. If we wanted to support this,
+      // we would have to tweak TestApplication#argOK to look at the shape of
+      // `arg` and turn off SAM conversions when it's a non-closure tree.
+  }
+}

--- a/tests/run/i11938.scala
+++ b/tests/run/i11938.scala
@@ -1,0 +1,22 @@
+import java.util.function.Function
+
+object Test {
+  def foo[V](v: V): Int = 1
+  def foo[U](fn: Function[Int, U]): Int = 2
+
+  def foo2(a: Int => Int): Int = 1
+  def foo2(a: PartialFunction[Int, Int]): Int = 2
+
+  def main(args: Array[String]): Unit = {
+    assert(foo((x: Int) => x) == 2)
+    val jf: Function[Int, Int] = x => x
+    assert(foo(jf) == 2)
+
+    assert(foo2(x => x) == 1)
+    val f: Int => Int = x => x
+    assert(foo2(f) == 1)
+    assert(foo2({ case x if x % 2 == 0 => x }) == 2)
+    val pf: PartialFunction[Int, Int] = { case x if x % 2 == 0 => x }
+    assert(foo2(pf) == 2)
+  }
+}


### PR DESCRIPTION
`resolveOverloaded` is called twice, first with implicit conversions
off, then on. Before this commit, turning off implicit conversions also
turned off SAM conversions, this behavior does not match Java or Scala 2
which means we could end up picking a different overload than they
do (cf #11938).

This commit enables SAM conversions in the first pass, _except_ for
conversions to PartialFunction as that would break a lot of existing
code and wouldn't match how either Java or Scala 2 pick overloads.

This is an alternative to #11945 (which special-cased
SAM types with an explicit `@FunctionalInterfaces` annotation) and #11990
(which special-cased SAM types that subtype a scala Function type).
Special-casing PartialFunction instead seems more defensible since it's
already special-cased in Scala 2 and is not considered a SAM type by
Java.

Fixes #11938.