### PR TITLE
Fix isInstanceOf[Array[?]] returning true on non-Array

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1030,13 +1030,13 @@ class Definitions {
 
   /** An extractor for multi-dimensional arrays.
    *  Note that this will also extract the high bound if an
-   *  element type is a wildcard. E.g.
+   *  element type is a wildcard upper-bounded by an array. E.g.
    *
    *     Array[? <: Array[? <: Number]]
    *
    *  would match
    *
-   *     MultiArrayOf(<Number>, 2)
+   *     MultiArrayOf(<? <: Number>, 2)
    */
   object MultiArrayOf {
     def apply(elem: Type, ndims: Int)(using Context): Type =
@@ -1044,7 +1044,8 @@ class Definitions {
     def unapply(tp: Type)(using Context): Option[(Type, Int)] = tp match {
       case ArrayOf(elemtp) =>
         def recur(elemtp: Type): Option[(Type, Int)] = elemtp.dealias match {
-          case TypeBounds(lo, hi) => recur(hi)
+          case tp @ TypeBounds(lo, hi @ MultiArrayOf(finalElemTp, n)) =>
+            Some(finalElemTp, n)
           case MultiArrayOf(finalElemTp, n) => Some(finalElemTp, n + 1)
           case _ => Some(elemtp, 1)
         }

--- a/tests/run/array-erasure.scala
+++ b/tests/run/array-erasure.scala
@@ -65,5 +65,11 @@ object Test {
     arr4(x)
     arr5(x)
     arr6(x)
+
+
+    val str: Any = ""
+    assert(!str.isInstanceOf[Array[?]])
+    assert(!str.isInstanceOf[Array[Array[?]]])
+    assert(!str.isInstanceOf[Array[? <: Array[?]]])
   }
 }


### PR DESCRIPTION
Before this commit, the `MultiArrayOf(elem, ndims)` extractor used to
strip wildcards from the element type, this was surprising since it does
not match what the `ArrayOf(elem)` extractor does, and lead to a bug in
`TypeTestCasts.interceptTypeApply` which contains the following code:

    case defn.MultiArrayOf(elem, ndims) if isGenericArrayElement(elem, isScala2 = false) =>

`isGenericArrayElement` returns false for `Any` but true for
`_ >: Nothing <: Any`, so the stripped wildcard means that this case was
skipped, resulting in:

    x.isInstanceOf[Array[?]]

being erased to:

    x.isInstanceOf[Object]
instead of:

    scala.runtime.ScalaRunTime.isArray(x, 1)

Fixed by tweaking `MultiArrayOf` to keep any final wildcard around like
`ArrayOf` does.