### PR TITLE
Fix typo in sample of opaques.md

### DIFF
--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -81,7 +81,7 @@ object Access:
    val NoPermission: Permission = 0
    val Read: Permission = 1
    val Write: Permission = 2
-   val ReadWrite: Permissions = Read | Write
+   val ReadWrite: Permissions = Read & Write
    val ReadOrWrite: PermissionChoice = Read | Write
 
 end Access


### PR DESCRIPTION
In the sample of opaques.md we actually have:
```scala
   val NoPermission: Permission = 0
   val Read: Permission = 1
   val Write: Permission = 2
   val ReadWrite: Permissions = Read | Write
   val ReadOrWrite: PermissionChoice = Read | Write
```

The two last lines are actually the same so I assume ReadWrite means "Can read AND write" and replacing `|` to `&`
```scala
   val NoPermission: Permission = 0
   val Read: Permission = 1
   val Write: Permission = 2
   val ReadWrite: Permissions = Read & Write
   val ReadOrWrite: PermissionChoice = Read | Write
```