### PR TITLE
Streamline given syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3585,7 +3585,10 @@ object Parsers {
           val tparams1 = tparams.map(tparam => tparam.withMods(tparam.mods | PrivateLocal))
           val vparamss1 = vparamss.map(_.map(vparam =>
             vparam.withMods(vparam.mods &~ Param | ParamAccessor | Protected)))
-          val templ = withTemplate(makeConstructor(tparams1, vparamss1), parents)
+          val constr = makeConstructor(tparams1, vparamss1)
+          val templ =
+            if in.token == WITH then withTemplate(constr, parents)
+            else Template(constr, parents, Nil, EmptyValDef, Nil)
           if noParams then ModuleDef(name, templ)
           else TypeDef(name.toTypeName, templ)
       end gdef

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -410,7 +410,7 @@ ObjectDef         ::=  id [Template]                                            
 EnumDef           ::=  id ClassConstr InheritClauses EnumBody
 GivenDef          ::=  [GivenSig] (AnnotType [‘=’ Expr] | StructuralInstance)
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’         -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
-StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody
+StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} [‘with’ TemplateBody]
 Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’
                        {UsingParamClause} ExtMethods
 ExtMethods        ::=  ExtMethod | [nl] <<< ExtMethod {semi ExtMethod} >>>

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -209,7 +209,7 @@ trait SafeDiv:
 By the second rule, an extension method can be made available by defining a given instance containing it, like this:
 
 ```scala
-given ops1: IntOps with {}  // brings safeMod into scope
+given ops1: IntOps()  // brings safeMod into scope
 
 1.safeMod(2)
 ```

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -135,7 +135,7 @@ object Foo:
    given fooNotTagged[A](using NotGiven[Tagged[A]]): Foo[A] = Foo(false)
 
 @main def test(): Unit =
-   given Tagged[Int] with {}
+   given Tagged[Int]()
    assert(summon[Foo[Int]].value) // fooTagged is found
    assert(!summon[Foo[String]].value) // fooNotTagged is found
 ```

--- a/docs/docs/reference/syntax.md
+++ b/docs/docs/reference/syntax.md
@@ -396,7 +396,7 @@ ObjectDef         ::=  id [Template]
 EnumDef           ::=  id ClassConstr InheritClauses EnumBody
 GivenDef          ::=  [GivenSig] (AnnotType [‘=’ Expr] | StructuralInstance)
 GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’         -- one of `id`, `DefParamClause`, `UsingParamClause` must be present
-StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody
+StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} [‘with’ TemplateBody]
 Extension         ::=  ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’
                        {UsingParamClause} ExtMethods
 ExtMethods        ::=  ExtMethod | [nl] <<< ExtMethod {semi ExtMethod} >>>

--- a/tests/neg/implicit-params.scala
+++ b/tests/neg/implicit-params.scala
@@ -11,8 +11,8 @@ object Test {
 
   def h(x: Int) given () = x // error: missing return type
 
-  given C: C(11) with {}
-  given D: D(11) with {}
+  given C: C(11)
+  given D: D(11)
 
   f(1)
   f(1)(using C)

--- a/tests/neg/multi-param-derives.scala
+++ b/tests/neg/multi-param-derives.scala
@@ -4,10 +4,10 @@ object Test extends App {
   {
     trait Show[T]
     object Show {
-      given Show[Int] with {}
-      given [T](using st: Show[T]): Show[Tuple1[T]] with {}
-      given t2[T, U](using st: Show[T], su: Show[U]): Show[(T, U)] with {}
-      given t3[T, U, V](using st: Show[T], su: Show[U], sv: Show[V]): Show[(T, U, V)] with {}
+      given Show[Int]()
+      given [T](using st: Show[T]): Show[Tuple1[T]]()
+      given t2[T, U](using st: Show[T], su: Show[U]): Show[(T, U)]()
+      given t3[T, U, V](using st: Show[T], su: Show[U], sv: Show[V]): Show[(T, U, V)]()
 
       def derived[T](using m: Mirror.Of[T], r: Show[m.MirroredElemTypes]): Show[T] = new Show[T] {}
     }
@@ -22,10 +22,10 @@ object Test extends App {
   {
     trait Functor[F[_]]
     object Functor {
-      given [C]: Functor[[T] =>> C] with {}
-      given Functor[[T] =>> Tuple1[T]] with {}
-      given t2 [T]: Functor[[U] =>> (T, U)] with {}
-      given t3 [T, U]: Functor[[V] =>> (T, U, V)] with {}
+      given [C]: Functor[[T] =>> C]()
+      given Functor[[T] =>> Tuple1[T]]()
+      given t2 [T]: Functor[[U] =>> (T, U)]()
+      given t3 [T, U]: Functor[[V] =>> (T, U, V)]()
 
       def derived[F[_]](using m: Mirror { type MirroredType[X] = F[X] ; type MirroredElemTypes[_] }, r: Functor[m.MirroredElemTypes]): Functor[F] = new Functor[F] {}
     }
@@ -40,8 +40,8 @@ object Test extends App {
   {
     trait FunctorK[F[_[_]]]
     object FunctorK {
-      given [C]: FunctorK[[F[_]] =>> C] with {}
-      given [T]: FunctorK[[F[_]] =>> Tuple1[F[T]]] with {}
+      given [C]: FunctorK[[F[_]] =>> C]()
+      given [T]: FunctorK[[F[_]] =>> Tuple1[F[T]]]()
 
       def derived[F[_[_]]](using m: Mirror { type MirroredType[X[_]] = F[X] ; type MirroredElemTypes[_[_]] }, r: FunctorK[m.MirroredElemTypes]): FunctorK[F] = new FunctorK[F] {}
     }
@@ -56,10 +56,10 @@ object Test extends App {
   {
     trait Bifunctor[F[_, _]]
     object Bifunctor {
-      given [C]: Bifunctor[[T, U] =>> C] with {}
-      given Bifunctor[[T, U] =>> Tuple1[U]] with {}
-      given t2: Bifunctor[[T, U] =>> (T, U)] with {}
-      given t3 [T]: Bifunctor[[U, V] =>> (T, U, V)] with {}
+      given [C]: Bifunctor[[T, U] =>> C]()
+      given Bifunctor[[T, U] =>> Tuple1[U]]()
+      given t2: Bifunctor[[T, U] =>> (T, U)]()
+      given t3 [T]: Bifunctor[[U, V] =>> (T, U, V)]()
 
       def derived[F[_, _]](using m: Mirror { type MirroredType[X, Y] = F[X, Y] ; type MirroredElemTypes[_, _] }, r: Bifunctor[m.MirroredElemTypes]): Bifunctor[F] = ???
     }

--- a/tests/neg/overloading-specifity.scala
+++ b/tests/neg/overloading-specifity.scala
@@ -12,7 +12,7 @@ object Generic {
 
 object Test extends App {
   trait Context
-  //given ctx: Context with {}
+  //given ctx: Context()
 
   object a {
     def foo[T](implicit gen: Generic): Show[T] = new Show[T](1)

--- a/tests/neg/transparent.scala
+++ b/tests/neg/transparent.scala
@@ -5,5 +5,5 @@ transparent class c // error
 transparent object y // error
 transparent trait t // ok
 transparent type T = c  // error
-transparent given c with {} // error
+transparent given c() // error
 

--- a/tests/neg/type-qmark.check
+++ b/tests/neg/type-qmark.check
@@ -27,7 +27,7 @@
    |       ^
    |       `?` is not a valid type name
 -- Error: tests/neg/type-qmark.scala:31:8 ------------------------------------------------------------------------------
-31 |  given ?[T]: Foo[T] with {} // error
+31 |  given ?[T]: Foo[T]() // error
    |        ^
    |        `?` is not a valid type name
 -- Error: tests/neg/type-qmark.scala:3:8 -------------------------------------------------------------------------------

--- a/tests/neg/type-qmark.scala
+++ b/tests/neg/type-qmark.scala
@@ -28,5 +28,5 @@ object J {
 }
 object K {
   class Foo[T]
-  given ?[T]: Foo[T] with {} // error
+  given ?[T]: Foo[T]() // error
 }

--- a/tests/pos-macros/i11479/Macro_1.scala
+++ b/tests/pos-macros/i11479/Macro_1.scala
@@ -1,9 +1,9 @@
 trait Foo
-given Foo: Foo with {}
+given Foo: Foo()
 inline def summonFoo(): Foo = scala.compiletime.summonInline[Foo]
 
 package p:
   trait Bar
-  given Bar: Bar with {}
+  given Bar: Bar()
   inline def summonBar(): Bar = scala.compiletime.summonInline[Bar]
 

--- a/tests/pos/X.scala
+++ b/tests/pos/X.scala
@@ -2,8 +2,8 @@ import scala.deriving.*
 
 trait FunctorK[F[_[_]]]
 object FunctorK {
-  given [C]: FunctorK[[F[_]] =>> C] with {}
-  given [T]: FunctorK[[F[_]] =>> Tuple1[F[T]]] with {}
+  given [C]: FunctorK[[F[_]] =>> C]()
+  given [T]: FunctorK[[F[_]] =>> Tuple1[F[T]]]()
 
   def derived[F[_[_]]](using m: Mirror { type MirroredType[X[_]] = F[X] ; type MirroredElemTypes[_[_]] }, r: FunctorK[m.MirroredElemTypes]): FunctorK[F] = new FunctorK[F] {}
 }

--- a/tests/pos/i11168.scala
+++ b/tests/pos/i11168.scala
@@ -1,5 +1,5 @@
 trait Foo
-given foo: Foo with {}
+given foo: Foo()
 
 extension (using Foo)(x: Any)
   def foo1[A] = ???

--- a/tests/pos/i6864.scala
+++ b/tests/pos/i6864.scala
@@ -1,17 +1,17 @@
 class A
 class B
 
-given A with {}
-given B with {}
+given A()
+given B()
 
 trait Foo
 trait Bar
 
-given Foo with {}
-given Bar with {}
+given Foo()
+given Bar()
 
 trait C
 trait Baz[A]
 
-given C with {}
-given [A]: Baz[A] with {}
+given C()
+given [A]: Baz[A]()

--- a/tests/pos/inlined-the.scala
+++ b/tests/pos/inlined-the.scala
@@ -5,7 +5,7 @@ object Instances {
   class C {
     def f() = {
       locally {
-        given d[T]: D[T] with {}
+        given d[T]: D[T]()
         summon[D[Int]]
         implicit val s: 3 = ???
         val a: 3 = summon[3]
@@ -14,7 +14,7 @@ object Instances {
       }
 
       locally {
-        given d[T]: D[T] with {}
+        given d[T]: D[T]()
         the2[D[Int]]
         implicit val s: 3 = ???
         val a: 3 = the2[3]

--- a/tests/pos/multi-given.scala
+++ b/tests/pos/multi-given.scala
@@ -5,6 +5,6 @@ trait C
 def fancy(using a: A, b: B, c: C) = "Fancy!"
 def foo(implicit a: A, b: B, c: C) = "foo"
 
-given A with B with {}
+given A() with B
 
-given ops: A with B with {}
+given ops: A() with B()

--- a/tests/pos/reference/delegates.scala
+++ b/tests/pos/reference/delegates.scala
@@ -110,11 +110,11 @@ object Instances extends Common:
         println(summon[Context].value)
       }
       locally {
-        given d[T]: D[T] with {}
+        given d[T]: D[T]()
         println(summon[D[Int]])
       }
       locally {
-        given (using Context): D[Int] with {}
+        given (using Context): D[Int]()
         println(summon[D[Int]])
       }
   end C

--- a/tests/pos/reference/extension-methods.scala
+++ b/tests/pos/reference/extension-methods.scala
@@ -70,7 +70,7 @@ object ExtMethods:
   end SafeDiv
 
   def test1 =
-    given ops1: IntOps with {} // brings safeMod into scope
+    given ops1: IntOps() // brings safeMod into scope
     1.safeMod(2)
 
   class Lst[T](xs: T*):

--- a/tests/pos/the-given.scala
+++ b/tests/pos/the-given.scala
@@ -1,7 +1,7 @@
 object Test {
 
   class Encoder { def apply(x: Int): Int = x }
-  given Encoder with {}
+  given Encoder()
 
   summon[Encoder](2)
 

--- a/tests/run/exports.scala
+++ b/tests/run/exports.scala
@@ -7,7 +7,7 @@ object Test extends App {
   class Printer {
     def print() = println("printing")
     object cfg extends Config
-    given config: Config with {}
+    given config: Config()
   }
 
   class Scanner {

--- a/tests/run/extmethod-overload.scala
+++ b/tests/run/extmethod-overload.scala
@@ -61,7 +61,7 @@ object Test extends App {
       extension [T](xs: List[T]) def +++ (ys: List[T]): List[T] = xs ++ ys ++ ys
       extension [T](xs: List[T]) def +++ (ys: Iterator[T]): List[T] = xs ++ ys ++ ys
     }
-    given Bar: Foo with {}
+    given Bar: Foo()
 
     assert((1 |+| 2) == 3)
     assert((1 |+| "2") == 2)

--- a/tests/run/extra-implicits.scala
+++ b/tests/run/extra-implicits.scala
@@ -1,8 +1,8 @@
 
 case class A(x: String)
 case class B(x: String)
-given a1: A("default") with {}
-given b1: B("default") with {}
+given a1: A("default")
+given b1: B("default")
 val a2 = A("explicit")
 val b2 = B("explicit")
 

--- a/tests/run/given-eta.scala
+++ b/tests/run/given-eta.scala
@@ -8,7 +8,7 @@ def f(x: Int)(using c: C) (y: Int) = x + c.x + y
 def g(x: Int)(using d: D) (y: d.T): d.T = d.trans(y)
 
 @main def Test =
-  given C(1) with {}
+  given C(1)
   val x = f
   assert(x(2)(3) == 6)
 

--- a/tests/run/i11542.scala
+++ b/tests/run/i11542.scala
@@ -2,7 +2,7 @@ object demo {
 
   trait Reader[A]
 
-  given Reader[Int] with {}
+  given Reader[Int]()
 
   inline def summonReader[T <: Tuple]: List[Reader[_]] = inline compiletime.erasedValue[T] match {
     case _: EmptyTuple => Nil

--- a/tests/run/i2567.scala
+++ b/tests/run/i2567.scala
@@ -1,6 +1,6 @@
 class TC
 
-given tc: TC with {}
+given tc: TC()
 
 class Foo(using TC) {
   println("hi")

--- a/tests/run/i8396.scala
+++ b/tests/run/i8396.scala
@@ -6,9 +6,9 @@ object Prefix:
   type UpperBoundedType <: String
   type FullyBoundedType >: String <: String
 
-  given A: Show[AbstractType] with {}
-  given B: Show[UpperBoundedType] with {}
-  given C: Show[FullyBoundedType] with {}
+  given A: Show[AbstractType]()
+  given B: Show[UpperBoundedType]()
+  given C: Show[FullyBoundedType]()
 
 @main def Test =
   summon[Show[Prefix.AbstractType]]

--- a/tests/run/implicit-alias.scala
+++ b/tests/run/implicit-alias.scala
@@ -6,7 +6,7 @@ object Test extends App {
 
   class TC1
 
-  given TC1 with {}
+  given TC1()
 
   class TV(val tc: TC) extends AnyVal
 

--- a/tests/run/implicit-disambiguation.scala
+++ b/tests/run/implicit-disambiguation.scala
@@ -14,7 +14,7 @@ object M {
   }
 }
 object Test extends App {
-  given b: B with {}
-  given c: C with {}
+  given b: B()
+  given c: C()
   println(M.f)
 }

--- a/tests/run/implicit-specifity.scala
+++ b/tests/run/implicit-specifity.scala
@@ -20,12 +20,12 @@ object Generic2 {
 
 class SubGen extends Generic
 object SubGen {
-  given SubGen with {}
+  given SubGen()
 }
 object Contextual {
   trait Context
 
-  given ctx: Context with {}
+  given ctx: Context()
 
   given showGen[T](using Generic): Show[T] = new Show[T](2)
 

--- a/tests/run/implied-divergence.scala
+++ b/tests/run/implied-divergence.scala
@@ -2,11 +2,11 @@
 // recursions.
 case class E(x: E | Null)
 
-given e: E(null) with {}
+given e: E(null)
 
 object Test extends App {
 
-  given f(using e: E): E(e) with {}
+  given f(using e: E): E(e)
 
   assert(summon[E].toString == "E(E(null))")
 

--- a/tests/run/implied-for.scala
+++ b/tests/run/implied-for.scala
@@ -6,10 +6,10 @@ object A {
   class C extends T
   class D[T]
 
-  given b: B with {}
-  given c: C with {}
-  given t: T with {}
-  given d: D[Int] with {}
+  given b: B()
+  given c: C()
+  given t: T()
+  given d: D[Int]()
 }
 
 object Test extends App {
@@ -29,11 +29,11 @@ class ExecutionContext
 class Monoid[T]
 
 object Instances {
-  given intOrd: Ordering[Int] with {}
+  given intOrd: Ordering[Int]()
 
-  given listOrd[T](using Ordering[T]): Ordering[List[T]] with {}
-  given ec: ExecutionContext with {}
-  given im: Monoid[Int] with {}
+  given listOrd[T](using Ordering[T]): Ordering[List[T]]()
+  given ec: ExecutionContext()
+  given im: Monoid[Int]()
 }
 
 object Test2 {

--- a/tests/run/implied-priority.scala
+++ b/tests/run/implied-priority.scala
@@ -11,18 +11,18 @@ class Arg[T]  // An argument that we use as a given for some given instances bel
  * Traditional scheme: prioritize with location in class hierarchy
  */
 class LowPriorityImplicits {
-  given t1[T]: E[T]("low") with {}
+  given t1[T]: E[T]("low")
 }
 
 object NormalImplicits extends LowPriorityImplicits {
-  given t2[T](using Arg[T]): E[T]("norm") with {}
+  given t2[T](using Arg[T]): E[T]("norm")
 }
 
 def test1 = {
   import NormalImplicits.given
   assert(summon[E[String]].str == "low") // No Arg available, so only t1 applies
 
-  { given Arg[String] with {}
+  { given Arg[String]()
     assert(summon[E[String]].str == "norm")  // Arg available, t2 takes priority
   }
 }
@@ -31,22 +31,22 @@ def test1 = {
  */
 object Priority {
   class Low
-  object Low { given Low with {} }
+  object Low { given Low() }
 
   class High extends Low
-  object High { given High with {} }
+  object High { given High() }
 }
 
 object Impl2 {
-  given t1[T](using Priority.Low): E[T]("low") with {}
-  given t2[T](using Priority.High)(using Arg[T]): E[T]("norm") with {}
+  given t1[T](using Priority.Low): E[T]("low")
+  given t2[T](using Priority.High)(using Arg[T]): E[T]("norm")
 }
 
 def test2 = {
   import Impl2.given
   assert(summon[E[String]].str == "low") // No Arg available, so only t1 applies
 
-  { given Arg[String] with {}
+  { given Arg[String]()
     assert(summon[E[String]].str == "norm") // Arg available, t2 takes priority
   }
 }
@@ -60,14 +60,14 @@ def test2 = {
  * an alternative without implicit arguments would override all of them.
  */
 object Impl2a {
-  given t3[T]: E[T]("hi") with {}
+  given t3[T]: E[T]("hi")
 }
 
 def test2a = {
   import Impl2.given
   import Impl2a.given
 
-  given Arg[String] with {}
+  given Arg[String]()
   assert(summon[E[String]].str == "hi")
 }
 
@@ -75,13 +75,13 @@ def test2a = {
  * result type of the given instance, e.g. like this:
  */
 object Impl3 {
-  given t1[T]: E[T]("low") with {}
+  given t1[T]: E[T]("low")
 }
 
 object Override {
   trait HighestPriority  // A marker trait to indicate a higher priority
 
-  given over[T]: E[T]("hi") with HighestPriority with {}
+  given over[T]: E[T]("hi") with HighestPriority()
 }
 
 def test3 = {
@@ -101,9 +101,9 @@ def test3 = {
  * with a default argument.
  */
 object Impl4 {
-  given t1: E[String]("string") with {}
+  given t1: E[String]("string")
 
-  given t2[T](using Arg[T]): E[T]("generic") with {}
+  given t2[T](using Arg[T]): E[T]("generic")
 }
 
 object fallback4 {
@@ -116,7 +116,7 @@ def test4 = {
   assert(withFallback[String].str == "string")  // t1 is applicable
   assert(withFallback[Int].str == "fallback")   // No applicable instances, pick the default
 
-  { given Arg[Int] with {}
+  { given Arg[Int]()
     assert(withFallback[Int].str == "generic")  // t2 is applicable
   }
 }
@@ -146,7 +146,7 @@ def test5 = {
   assert(summon[E[String]].str == "string")  // t1 is applicable
   assert(summon[E[Int]].str == "fallback")   // No applicable instances, pick the default
 
-  { given Arg[Int] with {}
+  { given Arg[Int]()
     assert(summon[E[Int]].str == "generic")  // t2 is applicable
   }
 }

--- a/tests/run/implied-specifity-2.scala
+++ b/tests/run/implied-specifity-2.scala
@@ -1,58 +1,58 @@
 class Low
 object Low {
-  given low: Low with {}
+  given low: Low()
 }
 class Medium extends Low
 object Medium {
-  given medium: Medium with {}
+  given medium: Medium()
 }
 class High extends Medium
 object High {
-  given high: High with {}
+  given high: High()
 }
 
 class Foo[T](val i: Int)
 object Foo {
   def apply[T](using fooT: Foo[T]): Int = fooT.i
 
-  given foo[T](using Low): Foo[T](0) with {}
-  given foobar[T](using Low): Foo[Bar[T]](1) with {}
-  given foobarbaz(using Low): Foo[Bar[Baz]](2) with {}
+  given foo[T](using Low): Foo[T](0)
+  given foobar[T](using Low): Foo[Bar[T]](1)
+  given foobarbaz(using Low): Foo[Bar[Baz]](2)
 }
 class Bar[T]
 object Bar {
-  given foobar[T](using Medium): Foo[Bar[T]](3) with {}
-  given foobarbaz(using Medium): Foo[Bar[Baz]](4) with {}
+  given foobar[T](using Medium): Foo[Bar[T]](3)
+  given foobarbaz(using Medium): Foo[Bar[Baz]](4)
 }
 class Baz
 object Baz {
-  given baz(using High): Foo[Bar[Baz]](5) with {}
+  given baz(using High): Foo[Bar[Baz]](5)
 }
 
 class Arg
 
-given Arg with {}
+given Arg()
 
 class Bam(val str: String)
 
-given lo(using Low): Bam("lo") with {}
+given lo(using Low): Bam("lo")
 
-given hi(using High)(using Arg): Bam("hi") with {}
+given hi(using High)(using Arg): Bam("hi")
 
 class Bam2(val str: String)
 
-given lo2(using Low): Bam2("lo") with {}
+given lo2(using Low): Bam2("lo")
 
-given mid2(using High)(using Arg): Bam2("mid") with {}
+given mid2(using High)(using Arg): Bam2("mid")
 
-given hi2: Bam2("hi") with {}
+given hi2: Bam2("hi")
 
 class Arg2
 class Red(val str: String)
 
-given normal(using Arg2): Red("normal") with {}
+given normal(using Arg2): Red("normal")
 
-given reduced(using ev: Arg2 | Low): Red("reduced") with {}
+given reduced(using ev: Arg2 | Low): Red("reduced")
 
 object Test extends App {
   assert(Foo[Int] == 0)
@@ -62,7 +62,7 @@ object Test extends App {
   assert(summon[Bam2].str == "hi")
   assert(summon[Red].str == "reduced")
 
-  { given Arg2 with {}
+  { given Arg2()
     assert(summon[Red].str == "normal")
   }
 }

--- a/tests/run/inline-override-num.scala
+++ b/tests/run/inline-override-num.scala
@@ -6,7 +6,7 @@ object Num {
   class IntNum extends Num[Int] {
     inline def plus(x: Int, y: Int): Int = x + y
   }
-  given IntNum with {}
+  given IntNum()
 
   extension [T](inline x: T)(using inline num: Num[T]) {
     inline def +(inline y: T): T = num.plus(x, y)

--- a/tests/run/overloading-specifity.scala
+++ b/tests/run/overloading-specifity.scala
@@ -11,7 +11,7 @@ object Generic {
 object Test extends App {
   trait Context
 
-  given ctx: Context with {}
+  given ctx: Context()
 
   object b {
     def foo[T](implicit gen: Generic): Show[T] = new Show[T](1)

--- a/tests/run/poly-kinded-derives.scala
+++ b/tests/run/poly-kinded-derives.scala
@@ -4,10 +4,10 @@ object Test extends App {
   {
     trait Show[T]
     object Show {
-      given Show[Int] with {}
-      given [T](using st: Show[T]): Show[Tuple1[T]] with {}
-      given t2[T, U](using st: Show[T], su: Show[U]): Show[(T, U)] with {}
-      given t3 [T, U, V](using st: Show[T], su: Show[U], sv: Show[V]): Show[(T, U, V)] with {}
+      given Show[Int]()
+      given [T](using st: Show[T]): Show[Tuple1[T]]()
+      given t2[T, U](using st: Show[T], su: Show[U]): Show[(T, U)]()
+      given t3 [T, U, V](using st: Show[T], su: Show[U], sv: Show[V]): Show[(T, U, V)]()
 
       def derived[T](using m: Mirror.Of[T], r: Show[m.MirroredElemTypes]): Show[T] = new Show[T] {}
     }
@@ -22,10 +22,10 @@ object Test extends App {
   {
     trait Functor[F[_]]
     object Functor {
-      given [C]: Functor[[T] =>> C] with {}
-      given Functor[[T] =>> Tuple1[T]] with {}
-      given t2 [T]: Functor[[U] =>> (T, U)] with {}
-      given t3 [T, U]: Functor[[V] =>> (T, U, V)] with {}
+      given [C]: Functor[[T] =>> C]()
+      given Functor[[T] =>> Tuple1[T]]()
+      given t2 [T]: Functor[[U] =>> (T, U)]()
+      given t3 [T, U]: Functor[[V] =>> (T, U, V)]()
 
       def derived[F[_]](using m: Mirror { type MirroredType[X] = F[X] ; type MirroredElemTypes[_] }, r: Functor[m.MirroredElemTypes]): Functor[F] = new Functor[F] {}
     }
@@ -40,8 +40,8 @@ object Test extends App {
   {
     trait FunctorK[F[_[_]]]
     object FunctorK {
-      given [C]: FunctorK[[F[_]] =>> C] with {}
-      given [T]: FunctorK[[F[_]] =>> Tuple1[F[T]]] with {}
+      given [C]: FunctorK[[F[_]] =>> C]()
+      given [T]: FunctorK[[F[_]] =>> Tuple1[F[T]]]()
 
       def derived[F[_[_]]](using m: Mirror { type MirroredType[X[_]] = F[X] ; type MirroredElemTypes[_[_]] }, r: FunctorK[m.MirroredElemTypes]): FunctorK[F] = new FunctorK[F] {}
     }
@@ -56,10 +56,10 @@ object Test extends App {
   {
     trait Bifunctor[F[_, _]]
     object Bifunctor {
-      given [C]: Bifunctor[[T, U] =>> C] with {}
-      given Bifunctor[[T, U] =>> Tuple1[U]] with {}
-      given t2: Bifunctor[[T, U] =>> (T, U)] with {}
-      given t3 [T]: Bifunctor[[U, V] =>> (T, U, V)] with {}
+      given [C]: Bifunctor[[T, U] =>> C]()
+      given Bifunctor[[T, U] =>> Tuple1[U]]()
+      given t2: Bifunctor[[T, U] =>> (T, U)]()
+      given t3 [T]: Bifunctor[[U, V] =>> (T, U, V)]()
 
       def derived[F[_, _]](using m: Mirror { type MirroredType[X, Y] = F[X, Y] ; type MirroredElemTypes[_, _] }, r: Bifunctor[m.MirroredElemTypes]): Bifunctor[F] = ???
     }

--- a/tests/run/tagless.scala
+++ b/tests/run/tagless.scala
@@ -103,7 +103,7 @@ object Test extends App {
     private class Exc(msg: String) extends Exception(msg)
     def _throw(msg: String)(using CanThrow): Nothing = throw new Exc(msg)
     def _try[T](op: Maybe[T])(handler: String => T): T = {
-      given CanThrow with {}
+      given CanThrow()
       try op
       catch {
         case ex: Exception => handler(ex.getMessage)


### PR DESCRIPTION
A simple fix for the problem that
```scala
given SomeClass with {}
```
is ugly and
```scala
given SomeClass = SomeClass()
```
is repetitive: We now also allow
```scala
given SomeClass()
```
It can't be confused for an abstract given clause because of the `()`.