### PR TITLE
Backport: Set file filter correctly

### DIFF
--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -18,9 +18,9 @@ class IdempotencyTests {
   import IdempotencyTests._
   import CompilationTest.aggregateTests
 
-  val filter = FileFilter.exclude(
-    s"pos${JFile.separator}i6507b"
-  )
+  // Flaky test on Windows
+  // https://github.com/lampepfl/dotty/issues/11885
+  val filter = FileFilter.exclude("i6507b")
 
   @Category(Array(classOf[SlowTests]))
   @Test def idempotency: Unit = {


### PR DESCRIPTION
Set file filter correctly

File filter only works for names not paths.

See https://github.com/lampepfl/dotty/issues/11885#issuecomment-821032666