### PR TITLE
More robust handling of auto-tupling

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3198,37 +3198,6 @@ class Typer extends Namer
       }
     }
 
-    def isUnary(tp: Type): Boolean = tp match {
-      case tp: MethodicType =>
-        tp.firstParamTypes match {
-          case ptype :: Nil => !ptype.isRepeatedParam
-          case _ => false
-        }
-      case tp: TermRef =>
-        tp.denot.alternatives.forall(alt => isUnary(alt.info))
-      case _ =>
-        false
-    }
-
-    /** Should we tuple or untuple the argument before application?
-     *  If auto-tupling is enabled then
-     *
-     *   - we tuple n-ary arguments where n > 0 if the function consists
-     *     only of unary alternatives
-     *   - we untuple tuple arguments of infix operations if the function
-     *     does not consist only of unary alternatives.
-     */
-    def needsTupledDual(funType: Type, pt: FunProto): Boolean =
-      pt.args match
-        case untpd.Tuple(elems) :: Nil =>
-          elems.length > 1
-          && pt.applyKind == ApplyKind.InfixTuple
-          && !isUnary(funType)
-        case args =>
-          args.lengthCompare(1) > 0
-          && isUnary(funType)
-          && autoTuplingEnabled
-
     def adaptToArgs(wtp: Type, pt: FunProto): Tree = wtp match {
       case wtp: MethodOrPoly =>
         def methodStr = methPart(tree).symbol.showLocated

--- a/tests/pos/i12133.scala
+++ b/tests/pos/i12133.scala
@@ -1,0 +1,15 @@
+class B
+
+class A {
+  def foo(x: B) = ???
+  def foo(str: String) = ???
+}
+
+//implicit class C(x: A) {
+//  def foo(s: Int*) = s.size
+//}
+extension (x: A) def foo(s: Int*) = s.size
+
+val a = new A
+
+def test: Unit = a.foo(1, 2)


### PR DESCRIPTION
Instead of a state based hidden side channel between adapt and realApply,
use only a hint, and check again.

Fixes #12133