### PR TITLE
Avoid exponential retries on inlining overflow

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -922,6 +922,9 @@ object Contexts {
 
     private[core] var denotTransformers: Array[DenotTransformer] = _
 
+    /** Flag to suppress inlining, set after overflow */
+    private[dotc] var stopInlining: Boolean = false
+
     // Reporters state
     private[dotc] var indent: Int = 0
 

--- a/tests/neg/i12116.scala
+++ b/tests/neg/i12116.scala
@@ -1,0 +1,15 @@
+import compiletime.erasedValue
+
+object test1:
+
+  transparent inline def length[T]: Int =
+      erasedValue[T] match
+          case _: (h *: t) => 1 + length[t]
+          case _: EmptyTuple => 0
+
+  transparent inline def foo(): Int = 1 + foo()
+
+  val y = length[(1, 2, 3)] // error
+  val x = foo() // error
+
+

--- a/tests/neg/i12116a.scala
+++ b/tests/neg/i12116a.scala
@@ -1,0 +1,15 @@
+import compiletime.erasedValue
+
+object test1:
+
+  inline def length[T]: Int =
+      erasedValue[T] match
+          case _: (h *: t) => 1 + length[t]
+          case _: EmptyTuple => 0
+
+  inline def foo(): Int = 1 + foo()
+
+  val y = length[(1, 2, 3)] // error
+  val x = foo() // error
+
+


### PR DESCRIPTION
In some situations Typer tries several alternatives around an inlined call. If overflow is detected
at depth 32 then this could cause 2^32 different retries which leads to OOM.

Prevent this with a switch that stops further inline calls as long as an overflowing call stack
is not completely unwound.

Fixes #12116