### PR TITLE
Add `@experimental` annotation (not enforced yet)

### DIFF
--- a/library/src/scala/annotation/experimental.scala
+++ b/library/src/scala/annotation/experimental.scala
@@ -1,0 +1,14 @@
+package scala.annotation
+
+/** An annotation that can be used to mark a definition as experimental.
+ *
+ *  This class is experimental as well as if it was defined as
+ *  ```scala
+ *  @experimental
+ *  class experimental extends StaticAnnotation
+ *  ```
+ *
+ *  @syntax markdown
+ */
+// @experimental
+class experimental extends StaticAnnotation

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -18,6 +18,7 @@ object language:
    *
    *  @group experimental
    */
+  @scala.annotation.experimental
   object experimental:
 
     /* Experimental support for richer dependent types (disabled for now)

--- a/library/src/scala/util/FromDigits.scala
+++ b/library/src/scala/util/FromDigits.scala
@@ -2,9 +2,12 @@ package scala.util
 import scala.math.{BigInt}
 import quoted._
 import annotation.internal.sharable
+import annotation.experimental
+
 
 /** A type class for types that admit numeric literals.
  */
+@experimental
 trait FromDigits[T] {
 
   /** Convert `digits` string to value of type `T`
@@ -20,6 +23,7 @@ trait FromDigits[T] {
   def fromDigits(digits: String): T
 }
 
+@experimental
 object FromDigits {
 
   /** A subclass of `FromDigits` that also allows to convert whole number literals


### PR DESCRIPTION
The `@exerimental` annotation marks definitions as experimental feature.
These can be used in the same situations where `languange.experimental` can be used.

These restictions will be enforced in `3.0.x` for some `x > 0` (see #12102).