### PR TITLE
Fix trait setter validity

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -147,7 +147,7 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
         // !decl.isClass avoids forcing nested traits, preventing cycles
         if !decl.isClass && needsTraitSetter(decl) then
           val setter = makeTraitSetter(decl.asTerm)
-          setter.validFor = Period(ctx.runId, thisPhase.next.id, decl.validFor.lastPhaseId)
+          setter.validFor = thisPhase.validFor // validity of setter = next phase up to next transformer afterwards
           decls1.enter(setter)
           modified = true
       if modified then

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -10,6 +10,7 @@ import SymUtils._
 import Symbols._
 import SymDenotations._
 import Types._
+import Periods._
 import Decorators._
 import DenotTransformers._
 import StdNames._
@@ -146,6 +147,7 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
         // !decl.isClass avoids forcing nested traits, preventing cycles
         if !decl.isClass && needsTraitSetter(decl) then
           val setter = makeTraitSetter(decl.asTerm)
+          setter.validFor = Period(ctx.runId, thisPhase.next.id, decl.validFor.lastPhaseId)
           decls1.enter(setter)
           modified = true
       if modified then

--- a/tests/pos/i12140/Test.scala
+++ b/tests/pos/i12140/Test.scala
@@ -1,0 +1,1 @@
+@main def Test = println(example.Trait.get)

--- a/tests/pos/i12140/Trait.scala
+++ b/tests/pos/i12140/Trait.scala
@@ -1,0 +1,14 @@
+// Trait.scala
+package example
+
+import quoted._
+
+trait Trait {
+  implicit val foo: Int = 23
+}
+
+object Trait {
+  inline def get: Trait = ${ getImpl }
+
+  def getImpl(using Quotes): Expr[Trait] = '{ new Trait {} }
+}


### PR DESCRIPTION
Trait setters had a validity interval that started before they were created.
This caused stale symbol errors in macro compilations.

Fixes #12140 