### PR TITLE
Fix usage example in Quotes for TypeRepr.asType

### DIFF
--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -2342,7 +2342,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         *  Usage:
         *  ```scala
         *  typeRepr.asType match
-        *    case '[$t] =>
+        *    case '[t] =>
         *      '{ val x: t = ... }
         *  ```
         *  @syntax markdown


### PR DESCRIPTION
Using the example gave the following error: `$` for quote pattern varable is not supported anymore. Use lower cased variable name without the `$` instead.