### PR TITLE
Make translucentSuperType handle match types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4011,7 +4011,7 @@ object Types {
       case tycon: TypeRef if tycon.symbol.isOpaqueAlias =>
         tycon.translucentSuperType.applyIfParameterized(args)
       case _ =>
-        superType
+        tryNormalize.orElse(superType)
     }
 
     inline def map(inline op: Type => Type)(using Context) =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1888,7 +1888,15 @@ object Types {
       case st => st
     }
 
-    /** Same as superType, except that opaque types are treated as transparent aliases */
+    /** Same as superType, except for two differences:
+     *   - opaque types are treated as transparent aliases
+     *   - applied type are matchtype-reduced if possible
+     *
+     *  Note: the reason to reduce match type aliases here and not in `superType`
+     *  is that `superType` is context-independent and cached, whereas matchtype
+     *  reduction depends on context and should not be cached (at least not without
+     *  the very specific cache invalidation condition for matchtypes).
+     */
     def translucentSuperType(using Context): Type = superType
   }
 

--- a/tests/pos/i7894.scala
+++ b/tests/pos/i7894.scala
@@ -1,0 +1,16 @@
+case class Box[T](t: T)
+
+type Boxed[T <: Tuple] <: Tuple = T match {
+  case EmptyTuple => EmptyTuple
+  case h *: t => Box[h] *: Boxed[t]
+}
+
+trait Cmp[T <: Tuple] { def cmp(t: T, b: Boxed[T]): Boolean }
+
+object UnitCmp extends Cmp[EmptyTuple] {
+  def cmp(t: EmptyTuple, b: EmptyTuple): Boolean = true
+}
+
+object UnitCmp2 extends Cmp[EmptyTuple] {
+  def cmp(t: EmptyTuple, b: Boxed[EmptyTuple]): Boolean = true
+}

--- a/tests/pos/i8666.scala
+++ b/tests/pos/i8666.scala
@@ -1,0 +1,10 @@
+class Foo[A, B]()
+
+type FooSnd[X] = X match
+  case Foo[_, b] => b
+
+trait Bar[A]:
+  def bar(h: FooSnd[A]): Int
+
+val foo: Bar[Foo[String, Int]] = new Bar[Foo[String, Int]]:
+  def bar(h: FooSnd[Foo[String, Int]]) = h


### PR DESCRIPTION
This fixes several erasure related things, such as signature, or erasure itself.

Fixes #8666
Fixes #7894

