### PR TITLE
Backport: Fix typo in file name

### DIFF
--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -20,7 +20,7 @@ class IdempotencyTests {
 
   // Flaky test on Windows
   // https://github.com/lampepfl/dotty/issues/11885
-  val filter = FileFilter.exclude("i6507b")
+  val filter = FileFilter.exclude("i6507b.scala")
 
   @Category(Array(classOf[SlowTests]))
   @Test def idempotency: Unit = {


### PR DESCRIPTION
This is a backport of #12164 

[test_windows_full]