### PR TITLE
Detect given bindings in for generators

### DIFF
--- a/tests/run/i12170.scala
+++ b/tests/run/i12170.scala
@@ -1,7 +1,7 @@
 import scala.compiletime.error
 
 object BadFilters:
-  def withFilter(f: Int => Boolean): BadFilters.type = ???//error("Unexpected withFilter call")
+  inline def withFilter(f: Int => Boolean): BadFilters.type = error("Unexpected withFilter call")
   def foreach(f: Int => Unit): Unit = f(42)
 
 @main def Test =

--- a/tests/run/i12170.scala
+++ b/tests/run/i12170.scala
@@ -1,0 +1,13 @@
+import scala.compiletime.error
+
+object BadFilters:
+  def withFilter(f: Int => Boolean): BadFilters.type = ???//error("Unexpected withFilter call")
+  def foreach(f: Int => Unit): Unit = f(42)
+
+@main def Test =
+  for
+    x: Int <- BadFilters
+  do println(x)
+  for
+    given Int <- BadFilters
+  do println(summon[Int])


### PR DESCRIPTION
These are considered irrefutable, just like normal bindings.

Fixes #12170