### PR TITLE
Fix #12188: Use ascribed type for bindings

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -402,8 +402,8 @@ class SpaceEngine(using Context) extends SpaceLogic {
     case Typed(pat @ UnApply(_, _, _), _) =>
       project(pat)
 
-    case Typed(expr, _) =>
-      Typ(erase(expr.tpe.stripAnnots), true)
+    case Typed(_, tpt) =>
+      Typ(erase(tpt.tpe.stripAnnots), true)
 
     case This(_) =>
       Typ(pat.tpe.stripAnnots, false)

--- a/tests/neg-custom-args/fatal-warnings/i12188/Macro.scala
+++ b/tests/neg-custom-args/fatal-warnings/i12188/Macro.scala
@@ -1,0 +1,20 @@
+import scala.quoted.*
+
+object MatchTest {
+  inline def test[T](inline obj: T): Unit = ${testImpl('obj)}
+
+  def testImpl[T](objExpr: Expr[T])(using qctx: Quotes, t: Type[T]): Expr[Unit] = {
+    import qctx.reflect.*
+
+    val obj = objExpr.asTerm
+
+    val cases = obj.tpe.typeSymbol.children.map { child =>
+      val subtype = TypeIdent(child)
+      val bind = Symbol.newBind(Symbol.spliceOwner, "c", Flags.EmptyFlags, subtype.tpe)
+      CaseDef(Bind(bind, Typed(Ref(bind), subtype)), None, '{()}.asTerm)
+    }
+    val result = Match(obj, cases)
+    println(result.show(using Printer.TreeAnsiCode))
+    result.asExprOf[Unit]
+  }
+}

--- a/tests/neg-custom-args/fatal-warnings/i12188/Test.scala
+++ b/tests/neg-custom-args/fatal-warnings/i12188/Test.scala
@@ -3,3 +3,7 @@ case class PC1(a: String) extends P
 case class PC2(b: Int) extends P
 
 def Test = MatchTest.test(PC2(10): P)
+
+def foo(x: P): Unit =
+  x match           // error
+  case _: PC1 =>

--- a/tests/neg-custom-args/fatal-warnings/i12188/Test.scala
+++ b/tests/neg-custom-args/fatal-warnings/i12188/Test.scala
@@ -1,0 +1,5 @@
+sealed trait P
+case class PC1(a: String) extends P
+case class PC2(b: Int) extends P
+
+def Test = MatchTest.test(PC2(10): P)


### PR DESCRIPTION
Fix #12188: Use ascribed type for bindings