### PR TITLE
sbt-dotty: Require sbt >= 1.5.0, deprecate withDottyCompat

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -51,7 +51,7 @@ abstract class DottyJSPlugin(settings: Seq[Setting[_]]) extends AutoPlugin {
       _.filter(!_.name.startsWith("junit-interface"))
     },
     libraryDependencies +=
-      ("org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion  % "test").withDottyCompat(scalaVersion.value),
+      ("org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion  % "test").cross(CrossVersion.for3Use2_13),
 
     // Typecheck the Scala.js IR found on the classpath
     scalaJSLinkerConfig ~= (_.withCheckIR(true)),
@@ -610,7 +610,7 @@ object Build {
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       libraryDependencies +=
-        ("org.scala-js" %% "scalajs-ir" % scalaJSVersion % "sourcedeps").withDottyCompat(scalaVersion.value),
+        ("org.scala-js" %% "scalajs-ir" % scalaJSVersion % "sourcedeps").cross(CrossVersion.for3Use2_13),
       (Compile / sourceGenerators) += Def.task {
         val s = streams.value
         val cacheDir = s.cacheDirectory
@@ -720,9 +720,9 @@ object Build {
     enablePlugins(NonBootstrappedDottyJSPlugin).
     settings(
       libraryDependencies +=
-        ("org.scala-js" %% "scalajs-library" % scalaJSVersion).withDottyCompat(scalaVersion.value),
-      unmanagedSourceDirectories in Compile :=
-        (unmanagedSourceDirectories in (`scala3-library`, Compile)).value
+        ("org.scala-js" %% "scalajs-library" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
+      Compile / unmanagedSourceDirectories :=
+        (`scala3-library` / Compile / unmanagedSourceDirectories).value
     )
 
   /** The dotty standard library compiled with the Scala.js back-end, to produce
@@ -739,7 +739,7 @@ object Build {
     enablePlugins(BootstrappedDottyJSPlugin).
     settings(
       libraryDependencies +=
-        ("org.scala-js" %% "scalajs-library" % scalaJSVersion).withDottyCompat(scalaVersion.value),
+        ("org.scala-js" %% "scalajs-library" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
       Compile / unmanagedSourceDirectories ++=
         (`scala3-library-bootstrapped` / Compile / unmanagedSourceDirectories).value,
 
@@ -1071,7 +1071,7 @@ object Build {
 
       // We need JUnit in the Compile configuration
       libraryDependencies +=
-        ("org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion).withDottyCompat(scalaVersion.value),
+        ("org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
 
       (Compile / sourceGenerators) += Def.task {
         import org.scalajs.linker.interface.CheckedBehavior
@@ -1740,7 +1740,7 @@ object Build {
       pr.settings(
         Test / fork := false,
         scalaJSUseMainModuleInitializer := true,
-        libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "1.1.0").withDottyCompat(scalaVersion.value)
+        libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "1.1.0").cross(CrossVersion.for3Use2_13)
       )
     }
 

--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -16,7 +16,7 @@ import java.util.Optional
 import java.util.{Enumeration, Collections}
 import java.net.URL
 import scala.util.Properties.isJavaAtLeast
-
+import scala.annotation.nowarn
 
 object DottyPlugin extends AutoPlugin {
   object autoImport {
@@ -106,6 +106,7 @@ object DottyPlugin extends AutoPlugin {
        *  libraryDependencies ~= (_.map(_.withDottyCompat(scalaVersion.value)))
        *  }}}
        */
+      @deprecated("Use `.cross(CrossVersion.for3Use2_13)` instead, available in sbt >= 1.5.0 (cf https://eed3si9n.com/sbt-1.5.0)", "0.5.5")
       def withDottyCompat(scalaVersion: String): ModuleID = {
         val name = moduleID.name
         if (name != "scala3-library" && name != "scala3-compiler" &&
@@ -181,10 +182,12 @@ object DottyPlugin extends AutoPlugin {
       if (!VersionNumber(sbtV).matchesSemVer(SemanticSelector(requiredVersion)))
         sys.error(s"The sbt-dotty plugin cannot work with this version of sbt ($sbtV), sbt $requiredVersion is required.")
 
-      val deprecatedVersion = ">=1.5.0-RC2"
+      val deprecatedVersion = ">=1.5.0"
       val logger = sLog.value
-      if (VersionNumber(sbtV).matchesSemVer(SemanticSelector(deprecatedVersion)))
-        logger.warn(s"The sbt-dotty plugin is no longer neeeded with sbt >= 1.5, please remove it from your build.")
+      if (VersionNumber(sbtV).matchesSemVer(SemanticSelector(deprecatedVersion))) {
+        logger.warn(s"The sbt-dotty plugin is no longer neeeded with sbt >= 1.5.0, please remove it from your build.")
+        logger.warn(s"For more information, see https://eed3si9n.com/sbt-1.5.0")
+      }
 
       state
     }
@@ -434,7 +437,7 @@ object DottyPlugin extends AutoPlugin {
             // Apply withDottyCompat to the dependency on scalajs-test-bridge
             .map { moduleID =>
               if (moduleID.organization == "org.scala-js" && moduleID.name == "scalajs-test-bridge")
-                moduleID.withDottyCompat(scalaVersion.value)
+                moduleID.withDottyCompat(scalaVersion.value): @nowarn
               else
                 moduleID
             }


### PR DESCRIPTION
And fix deprecation warnings in the dotty build.