### PR TITLE
avoid duplicate call to dist/bin/common via refactored scalac

### DIFF
--- a/compiler/test-resources/repl/defaultClassloader
+++ b/compiler/test-resources/repl/defaultClassloader
@@ -1,3 +1,2 @@
-scala> val d: java.sql.Date = new java.sql.Date(100L)
-val d: java.sql.Date = 1970-01-01
-
+scala> val d: Long = (new java.sql.Date(100L)).getTime
+val d: Long = 100

--- a/compiler/test/dotty/tools/scripting/ClasspathTests.scala
+++ b/compiler/test/dotty/tools/scripting/ClasspathTests.scala
@@ -18,6 +18,7 @@ class ClasspathTests:
   val packBinDir = "dist/target/pack/bin"
   val scalaCopy = makeTestableScriptCopy("scala")
   val scalacCopy = makeTestableScriptCopy("scalac")
+  val commonCopy = makeTestableScriptCopy("common")
 
   // only interested in classpath test scripts
   def testFiles = scripts("/scripting").filter { _.getName.matches("classpath.*[.]sc") }
@@ -38,7 +39,8 @@ class ClasspathTests:
     if Files.exists(scriptPath) then
       val lines = Files.readAllLines(scriptPath).asScala.map {
         _.replaceAll("/scalac", "/scalac-copy").
-        replaceFirst("^eval(.*JAVACMD.*)", "echo $1")
+        replaceAll("/common", "/common-copy").
+        replaceFirst("^ *eval(.*JAVACMD.*)", "echo $1")
       }
       val bytes = (lines.mkString("\n")+"\n").getBytes
       Files.write(scriptCopy, bytes)

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -54,15 +54,15 @@ case "`uname`" in
 esac
 
 unset CYGPATHCMD
-if [[ $cygwin || $mingw || $msys ]]; then
+if [[ ${cygwin-} || ${mingw-} || ${msys-} ]]; then
   # ConEmu terminal is incompatible with jna-5.*.jar
-  [[ ($CONEMUANSI || $ConEmuANSI) ]] && conemu=true
+  [[ (${CONEMUANSI-} || ${ConEmuANSI-}) ]] && conemu=true
   # cygpath is used by various windows shells: cygwin, git-sdk, gitbash, msys, etc.
   CYGPATHCMD=`which cygpath 2>/dev/null`
   case "$TERM" in
     rxvt* | xterm* | cygwin*)
       stty -icanon min 1 -echo
-      SCALA_OPTS="$SCALA_OPTS -Djline.terminal=unix"
+      JAVA_OPTS="$JAVA_OPTS -Djline.terminal=unix"
     ;;
   esac
 fi
@@ -111,14 +111,14 @@ CLASSPATH_SUFFIX=""
 PSEP=":"
 
 # translate paths to Windows-mixed format before running java
-if [ -n "$CYGPATHCMD" ]; then
-  [ -n "$PROG_HOME" ] &&
+if [ -n "${CYGPATHCMD-}" ]; then
+  [ -n "${PROG_HOME-}" ] &&
     PROG_HOME=`"$CYGPATHCMD" -am "$PROG_HOME"`
   [ -n "$JAVA_HOME" ] &&
     JAVA_HOME=`"$CYGPATHCMD" -am "$JAVA_HOME"`
   CLASSPATH_SUFFIX=";"
   PSEP=";"
-elif [[ $mingw || $msys ]]; then
+elif [[ ${mingw-} || ${msys-} ]]; then
   # For Mingw / Msys, convert paths from UNIX format before anything is touched
   [ -n "$PROG_HOME" ] &&
     PROG_HOME="`(cd "$PROG_HOME"; pwd -W | sed 's|/|\\\\|g')`"
@@ -155,8 +155,95 @@ SBT_INTF=$(find_lib "*compiler-interface*")
 JLINE_READER=$(find_lib "*jline-reader-3*")
 JLINE_TERMINAL=$(find_lib "*jline-terminal-3*")
 JLINE_TERMINAL_JNA=$(find_lib "*jline-terminal-jna-3*")
-[[ $conemu ]] || JNA=$(find_lib "*jna-5*")
+[[ ${conemu-} ]] || JNA=$(find_lib "*jna-5*")
 
 # debug
 
 DEBUG_STR=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
+
+classpathArgs () {
+  # echo "dotty-compiler: $DOTTY_COMP"
+  # echo "dotty-interface: $DOTTY_INTF"
+  # echo "dotty-library: $DOTTY_LIB"
+  # echo "tasty-core: $TASTY_CORE"
+  # echo "scala-asm: $SCALA_ASM"
+  # echo "scala-lib: $SCALA_LIB"
+  # echo "sbt-intface: $SBT_INTF"
+
+  toolchain=""
+  toolchain+="$SCALA_LIB$PSEP"
+  toolchain+="$DOTTY_LIB$PSEP"
+  toolchain+="$SCALA_ASM$PSEP"
+  toolchain+="$SBT_INTF$PSEP"
+  toolchain+="$DOTTY_INTF$PSEP"
+  toolchain+="$DOTTY_COMP$PSEP"
+  toolchain+="$TASTY_CORE$PSEP"
+  toolchain+="$DOTTY_STAGING$PSEP"
+  toolchain+="$DOTTY_TASTY_INSPECTOR$PSEP"
+
+  # jine
+  toolchain+="$JLINE_READER$PSEP"
+  toolchain+="$JLINE_TERMINAL$PSEP"
+  toolchain+="$JLINE_TERMINAL_JNA$PSEP"
+  toolchain+="$JNA$PSEP"
+
+  jvm_cp_args="-classpath \"$toolchain\""
+}
+
+default_java_opts="-Xmx768m -Xms768m"
+
+addJava () {
+  java_args+=("'$1'")
+}
+addScala () {
+  scala_args+=("'$1'")
+}
+addResidual () {
+  residual_args+=("'$1'")
+}
+addScripting () {
+  scripting_args+=("'$1'")
+}
+prepScalacCommandLine () {
+  withCompiler=true
+
+  CompilerMain=dotty.tools.dotc.Main
+  DecompilerMain=dotty.tools.dotc.decompiler.Main
+  ReplMain=dotty.tools.repl.Main
+  ScriptingMain=dotty.tools.scripting.Main
+
+  while [[ $# -gt 0 ]]; do
+  case "$1" in
+             --) shift; for arg; do addResidual "$arg"; done; set -- ;;
+    -v|-verbose) verbose=true && addScala "-verbose" && shift ;;
+         -debug) DEBUG="$DEBUG_STR" && shift ;;
+      -q|-quiet) quiet=true && shift ;;
+
+      # Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
+      -Oshort) addJava "-XX:+TieredCompilation -XX:TieredStopAtLevel=1" && shift ;;
+          -repl) PROG_NAME="$ReplMain" && shift ;;
+        -script) PROG_NAME="$ScriptingMain" && target_script="$2" && shift && shift
+                 while [[ $# -gt 0 ]]; do addScripting "$1" && shift ; done ;;
+       -compile) PROG_NAME="$CompilerMain" && shift ;;
+     -decompile) PROG_NAME="$DecompilerMain" && shift ;;
+   -print-tasty) PROG_NAME="$DecompilerMain" && addScala "-print-tasty" && shift ;;
+           -run) PROG_NAME="$ReplMain" && shift ;;
+        -colors) colors=true && shift ;;
+     -no-colors) unset colors && shift ;;
+    -with-compiler) jvm_cp_args="$PSEP$DOTTY_COMP$PSEP$TASTY_CORE" && shift ;;
+
+            # break out -D and -J options and add them to java_args so
+            # they reach the JVM in time to do some good. The -D options
+            # will be available as system properties.
+            -D*) addJava "$1" && shift ;;
+            -J*) addJava "${1:2}" && shift ;;
+              *) addResidual "$1" && shift ;;
+    esac
+  done
+
+  classpathArgs
+
+  if [ "$PROG_NAME" == "$ScriptingMain" ]; then
+    scripting_string="-script $target_script ${scripting_args[@]}"
+  fi
+}

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -185,9 +185,9 @@ classpathArgs () {
   toolchain+="$JLINE_READER$PSEP"
   toolchain+="$JLINE_TERMINAL$PSEP"
   toolchain+="$JLINE_TERMINAL_JNA$PSEP"
-  toolchain+="$JNA$PSEP"
+  [ -n "${JNA-}" ] && toolchain+="$JNA$PSEP"
 
-  if [ -n "$jvm_cp_args" ]; then
+  if [ -n "${jvm_cp_args-}" ]; then
     jvm_cp_args="$toolchain$jvm_cp_args"
   else
     jvm_cp_args="$toolchain$PSEP"
@@ -201,6 +201,9 @@ DecompilerMain=dotty.tools.dotc.decompiler.Main
 ReplMain=dotty.tools.repl.Main
 ScriptingMain=dotty.tools.scripting.Main
 
+declare -a residual_args
+declare -a script_args
+
 addJava () {
   java_args+=("'$1'")
 }
@@ -210,44 +213,6 @@ addScala () {
 addResidual () {
   residual_args+=("'$1'")
 }
-addScripting () {
-  scripting_args+=("'$1'")
-}
-prepScalacCommandLine () {
-  withCompiler=true
-
-  while [[ $# -gt 0 ]]; do
-  case "$1" in
-             --) shift; for arg; do addResidual "$arg"; done; set -- ;;
-    -v|-verbose) verbose=true && addScala "-verbose" && shift ;;
-         -debug) DEBUG="$DEBUG_STR" && shift ;;
-      -q|-quiet) quiet=true && shift ;;
-
-      # Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
-      -Oshort) addJava "-XX:+TieredCompilation -XX:TieredStopAtLevel=1" && shift ;;
-          -repl) PROG_NAME="$ReplMain" && shift ;;
-        -script) PROG_NAME="$ScriptingMain" && target_script="$2" && shift && shift
-                 while [[ $# -gt 0 ]]; do addScripting "$1" && shift ; done ;;
-       -compile) PROG_NAME="$CompilerMain" && shift ;;
-     -decompile) PROG_NAME="$DecompilerMain" && shift ;;
-   -print-tasty) PROG_NAME="$DecompilerMain" && addScala "-print-tasty" && shift ;;
-           -run) PROG_NAME="$ReplMain" && shift ;;
-        -colors) colors=true && shift ;;
-     -no-colors) unset colors && shift ;;
-    -with-compiler) jvm_cp_args="$PSEP$DOTTY_COMP$PSEP$TASTY_CORE" && shift ;;
-
-            # break out -D and -J options and add them to java_args so
-            # they reach the JVM in time to do some good. The -D options
-            # will be available as system properties.
-            -D*) addJava "$1" && shift ;;
-            -J*) addJava "${1:2}" && shift ;;
-              *) addResidual "$1" && shift ;;
-    esac
-  done
-
-  classpathArgs
-
-  if [ "$PROG_NAME" == "$ScriptingMain" ]; then
-    scripting_string="-script $target_script ${scripting_args[@]}"
-  fi
+addScript () {
+  script_args+=("'$1'")
 }

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -187,7 +187,11 @@ classpathArgs () {
   toolchain+="$JLINE_TERMINAL_JNA$PSEP"
   toolchain+="$JNA$PSEP"
 
-  jvm_cp_args="-classpath \"$toolchain\""
+  if [ -n "$jvm_cp_args" ]; then
+    jvm_cp_args="$toolchain$jvm_cp_args"
+  else
+    jvm_cp_args="$toolchain$PSEP"
+  fi
 }
 
 default_java_opts="-Xmx768m -Xms768m"

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -192,6 +192,11 @@ classpathArgs () {
 
 default_java_opts="-Xmx768m -Xms768m"
 
+CompilerMain=dotty.tools.dotc.Main
+DecompilerMain=dotty.tools.dotc.decompiler.Main
+ReplMain=dotty.tools.repl.Main
+ScriptingMain=dotty.tools.scripting.Main
+
 addJava () {
   java_args+=("'$1'")
 }
@@ -206,11 +211,6 @@ addScripting () {
 }
 prepScalacCommandLine () {
   withCompiler=true
-
-  CompilerMain=dotty.tools.dotc.Main
-  DecompilerMain=dotty.tools.dotc.decompiler.Main
-  ReplMain=dotty.tools.repl.Main
-  ScriptingMain=dotty.tools.scripting.Main
 
   while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -201,6 +201,8 @@ DecompilerMain=dotty.tools.dotc.decompiler.Main
 ReplMain=dotty.tools.repl.Main
 ScriptingMain=dotty.tools.scripting.Main
 
+declare -a java_args
+declare -a scala_args
 declare -a residual_args
 declare -a script_args
 

--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -151,9 +151,19 @@ if [ $execute_script == true ]; then
   else
     [[ $save_compiled == true ]] && rm -f $target_jar
     set -- ${cp_arg-} ${java_options[@]} ${residual_args[@]} -script "$target_script" ${script_args[@]}
+    PROG_MAIN=$ScriptingMain
     prepScalacCommandLine "$@"
     # exec here would prevent onExit from being called, leaving terminal in unusable state
-    eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$cp_arg\"" "${java_args[@]}" "${residual_args[@]}"
+    eval "\"$JAVACMD\"" \
+         ${JAVA_OPTS:-$default_java_opts} \
+         "${DEBUG-}" \
+         "${java_args[@]}" \
+         "-classpath \"$jvm_cp_args\"" \
+         -Dscala.usejavacp=true \
+         "$PROG_NAME"  \
+         "${scala_args[@]}" \
+         "${residual_args[@]}" \
+         "${scripting_string-}"
     scala_exit_status=$?
   fi
 elif [ $execute_repl == true ] || ([ $execute_run == false ] && [ $options_indicator == 0 ]); then

--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -26,25 +26,30 @@ if [ -z "${PROG_HOME-}" ] ; then
   cd "$saveddir"
 fi
 
-addJava () {
-  java_args+=("'$1'")
-}
-
-addScalacOptions () {
-  java_options+=("'$1'")
-}
-
 source "$PROG_HOME/bin/common"
 
-declare -a residual_args
-declare -a script_args
-execute_repl=false
-execute_run=false
-execute_script=false
-with_compiler=false
-class_path_count=0
-CLASS_PATH=""
-save_compiled=false
+# This script operates in one of 3 usage modes:
+#   script
+#   repl
+#   run
+# execute_mode replaces mutually exclusive booleans:
+#  execute_repl=false
+#  execute_run=false
+#  execute_script=false
+setExecuteMode () {
+  case "${execute_mode-}" in
+  "") execute_mode="$1" ; shift ;;
+  *) echo "execute_mode==[${execute_mode-}], attempted overwrite by [$1]" 1>&2
+    exit 1
+    ;;
+  esac
+}
+
+
+with_compiler=false             # to add compiler jars to repl classpath
+let class_path_count=0 || true  # count classpath args, warning if more than 1
+save_compiled=false             # to save compiled script jar in script directory
+CLASS_PATH="" || true           # scala classpath
 
 # Little hack to check if all arguments are options
 all_params="$*"
@@ -52,28 +57,28 @@ truncated_params="${*#-}"
 # options_indicator != 0 if at least one parameter is not an option
 options_indicator=$(( ${#all_params} - ${#truncated_params} - $# ))
 
-[ -n "$SCALA_OPTS" ] && set -- $SCALA_OPTS "$@"
+[ -n "${SCALA_OPTS-}" ] && set -- $SCALA_OPTS "$@"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -repl)
-      execute_repl=true
+      setExecuteMode 'repl'
       shift
       ;;
     -run)
-      execute_run=true
+      setExecuteMode 'run'
       shift
       ;;
     -cp | -classpath)
       CLASS_PATH="$2${PSEP}"
-      class_path_count+=1
+      let class_path_count+=1
       shift
       shift
       ;;
-    -cp*|-classpath*)
+    -cp*|-classpath*) # partial fix for #10761
       # hashbang can combine args, e.g. "-classpath 'lib/*'"
       CLASS_PATH="${1#* *}${PSEP}"
-      class_path_count+=1
+      let class_path_count+=1
       shift
       ;;
     -with-compiler)
@@ -81,22 +86,21 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     @*|-color:*)
-      addScalacOptions "${1}"
+      addScala "${1}"
       shift
       ;;
     -save|-savecompiled)
       save_compiled=true
-      scala_script_options+=("$1")
+      addScala "$1"
       shift
       ;;
     -compile-only)
-      scala_script_options+=("$1")
+      addScala "$1"
       shift
       ;;
-    -d)
+    -d|-debug)
       DEBUG="$DEBUG_STR"
-      shift
-      ;;
+      shift ;;
     -version)
       # defer to scalac, then exit
       shift
@@ -106,17 +110,32 @@ while [[ $# -gt 0 ]]; do
       ;;
     -J*)
       addJava "${1:2}"
-      addScalacOptions "${1}"
+      addScala "${1}"
       shift ;;
+    -v|-verbose)
+      verbose=true
+      addScala "-verbose"
+      shift ;;
+    -run|-repl)
+      PROG_NAME="$ReplMain"
+      shift ;;
+
     *)
-      if [ $execute_script == false ]; then
+      if [ "${execute_mode-}" == 'script' ]; then
+        addScript "$1"
+      else
+        # script if extension .scala or .sc, or if has scala hashbang line
+
+        # no -f test, issue meaningful error message (file not found)
         if [[ "$1" == *.scala || "$1" == *.sc ]]; then
-          # is a script if extension .scala or .sc
-          # (even if file not found, to avoid adding likely typo to residual_args)
-          execute_script=true
-          target_script="$1"
+          setExecuteMode 'script' # execute_script=true
+
+        # -f test needed before we examine the hashbang line
         elif [[ (-f "$1" && `head -n 1 -- "$1" | grep '#!.*scala'`) ]]; then
-          execute_script=true
+          setExecuteMode 'script' # execute_script=true
+        fi
+
+        if [ "${execute_mode-}" == 'script' ]; then
           target_script="$1"
           if [ ! -f $target_script ]; then
             # likely a typo or missing script file, quit early
@@ -125,11 +144,9 @@ while [[ $# -gt 0 ]]; do
             onExit
           fi
         else
-          # unrecognized args appearing prior to a script name
-          residual_args+=("$1")
+          # all unrecognized args appearing prior to a script name
+          addResidual "$1"
         fi
-      else
-        script_args+=("$1")
       fi
       shift
       ;;
@@ -137,12 +154,24 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[ -n "${script_trace-}" ] && set -x
-if [ $execute_script == true ]; then
-  if [ "$CLASS_PATH" ]; then
-    cp_arg="-classpath \"$CLASS_PATH\""
+#[ -n "${dump_args}" ] && dumpArgs ; exit 2
+
+if [ -z "${execute_mode-}" ]; then
+  # no script was specified, set run or repl mode
+  if [[ $options_indicator -ne 0 || ${#residual_args[@]} -ne 0 ]]; then
+    setExecuteMode 'run'
+  else
+    setExecuteMode 'repl'
   fi
-  java_options+=(${scala_script_options})
+fi
+
+[ -n "${script_trace-}" ] && set -x
+
+case "${execute_mode-}" in
+script)
+  if [ "$CLASS_PATH" ]; then
+    script_cp_arg="-classpath '$CLASS_PATH'"
+  fi
   setScriptName="-Dscript.path=$target_script"
   target_jar="${target_script%.*}.jar"
   if [[ $save_compiled == true && "$target_jar" -nt "$target_script" ]]; then
@@ -150,45 +179,58 @@ if [ $execute_script == true ]; then
     scala_exit_status=$?
   else
     [[ $save_compiled == true ]] && rm -f $target_jar
-    set -- ${cp_arg-} ${java_options[@]} ${residual_args[@]} -script "$target_script" ${script_args[@]}
-    PROG_MAIN=$ScriptingMain
-    prepScalacCommandLine "$@"
-    # exec here would prevent onExit from being called, leaving terminal in unusable state
+    PROG_NAME=$ScriptingMain
+    classpathArgs # initialize jvm_cp_args with toolchain classpath 
+    scripting_string="-script $target_script ${script_args[@]}"
+    # use eval instead of exec, to insure that onExit is subsequently called
+
+    # $script_cp_arg must be the first argument to $ScriptingMain
+    # $scripting_string  must be last
     eval "\"$JAVACMD\"" \
-         ${JAVA_OPTS:-$default_java_opts} \
-         "${DEBUG-}" \
-         "${java_args[@]}" \
-         "-classpath \"$jvm_cp_args\"" \
-         -Dscala.usejavacp=true \
-         "$PROG_NAME"  \
-         "${scala_args[@]}" \
-         "${residual_args[@]}" \
-         "${scripting_string-}"
+       ${JAVA_OPTS:-$default_java_opts} \
+       "${DEBUG-}" \
+       "${java_args[@]}" \
+       "-classpath \"$jvm_cp_args\"" \
+       -Dscala.usejavacp=true \
+       "$setScriptName" \
+       "$ScriptingMain"  \
+        ${script_cp_arg-} \
+       "${scala_args[@]}" \
+       "${residual_args[@]}" \
+       "${scripting_string-}"    # must be the last arguments
     scala_exit_status=$?
   fi
-elif [ $execute_repl == true ] || ([ $execute_run == false ] && [ $options_indicator == 0 ]); then
+  ;;
+
+repl)
   if [ "$CLASS_PATH" ]; then
-    cp_arg="-classpath \"$CLASS_PATH\""
+    repl_cparg="-classpath \"$CLASS_PATH\""
   fi
-  eval "\"$PROG_HOME/bin/scalac\" ${cp_arg-} ${java_options[@]} -repl ${residual_args[@]}"
+  eval "\"$PROG_HOME/bin/scalac\" ${repl_cparg-} ${scalac_options[@]} -repl ${residual_args[@]}"
   scala_exit_status=$?
-elif [ ${#residual_args[@]} -ne 0 ]; then
-  cp_arg="$DOTTY_LIB$PSEP$SCALA_LIB"
+  ;;
+
+run)
+  repl_cparg="$DOTTY_LIB$PSEP$SCALA_LIB"
   if [ -z "$CLASS_PATH" ]; then
-    cp_arg+="$PSEP."
+    repl_cparg+="$PSEP."
   else
-    cp_arg+="$PSEP$CLASS_PATH"
+    repl_cparg+="$PSEP$CLASS_PATH"
   fi
   if [ "$class_path_count" -gt 1 ]; then
     echo "warning: multiple classpaths are found, scala only use the last one."
   fi
   if [ $with_compiler == true ]; then
-    cp_arg+="$PSEP$DOTTY_COMP$PSEP$TASTY_CORE$PSEP$DOTTY_INTF$PSEP$SCALA_ASM$PSEP$DOTTY_STAGING$PSEP$DOTTY_TASTY_INSPECTOR"
+    repl_cparg+="$PSEP$DOTTY_COMP$PSEP$TASTY_CORE$PSEP$DOTTY_INTF$PSEP$SCALA_ASM$PSEP$DOTTY_STAGING$PSEP$DOTTY_TASTY_INSPECTOR"
   fi
   # exec here would prevent onExit from being called, leaving terminal in unusable state
-  eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$cp_arg\"" "${java_args[@]}" "${residual_args[@]}"
+  eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$repl_cparg\"" "${java_args[@]}" "${residual_args[@]}"
   scala_exit_status=$?
-else
+  ;;
+
+*)
   echo "warning: command option is not correct."
-fi
+  ;;
+esac
+
 onExit

--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # Try to autodetect real location of the script
-
-if [ -z "$PROG_HOME" ] ; then
+if [ -z "${PROG_HOME-}" ] ; then
   ## resolve links - $0 may be a link to PROG_HOME
   PRG="$0"
 
@@ -27,8 +26,8 @@ if [ -z "$PROG_HOME" ] ; then
   cd "$saveddir"
 fi
 
-addJvmOptions () {
-  jvm_options+=("'$1'")
+addJava () {
+  java_args+=("'$1'")
 }
 
 addScalacOptions () {
@@ -65,7 +64,7 @@ while [[ $# -gt 0 ]]; do
       execute_run=true
       shift
       ;;
-    -cp | -classpath )
+    -cp | -classpath)
       CLASS_PATH="$2${PSEP}"
       class_path_count+=1
       shift
@@ -100,23 +99,27 @@ while [[ $# -gt 0 ]]; do
       ;;
     -version)
       # defer to scalac, then exit
-      addScalacOptions "${1}"
       shift
-      eval "\"$PROG_HOME/bin/scalac\" ${cp_arg-} ${java_options[@]}"
+      eval "\"$PROG_HOME/bin/scalac\" -version"
       scala_exit_status=$?
       onExit
       ;;
     -J*)
-      addJvmOptions "${1:2}"
+      addJava "${1:2}"
       addScalacOptions "${1}"
       shift ;;
     *)
       if [ $execute_script == false ]; then
-        # is a script if extension .scala or .sc or if has scala hash bang
-        if [[ -e "$1" && ("$1" == *.scala || "$1" == *.sc || -f "$1" && `head -n 1 -- "$1" | grep '#!.*scala'`) ]]; then
+        if [[ "$1" == *.scala || "$1" == *.sc ]]; then
+          # is a script if extension .scala or .sc
+          # (even if file not found, to avoid adding likely typo to residual_args)
+          execute_script=true
+          target_script="$1"
+        elif [[ (-f "$1" && `head -n 1 -- "$1" | grep '#!.*scala'`) ]]; then
           execute_script=true
           target_script="$1"
         else
+          # unrecognized args appearing prior to a script name
           residual_args+=("$1")
         fi
       else
@@ -128,8 +131,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+[ -n "${script_trace-}" ] && set -x
 if [ $execute_script == true ]; then
-  [ -n "${script_trace-}" ] && set -x
   if [ "$CLASS_PATH" ]; then
     cp_arg="-classpath \"$CLASS_PATH\""
   fi
@@ -141,8 +144,10 @@ if [ $execute_script == true ]; then
     scala_exit_status=$?
   else
     [[ $save_compiled == true ]] && rm -f $target_jar
-    residual_args+=($setScriptName)
-    eval "\"$PROG_HOME/bin/scalac\" ${cp_arg-} ${java_options[@]} ${residual_args[@]} -script $target_script ${script_args[@]}"
+    set -- ${cp_arg-} ${java_options[@]} ${residual_args[@]} -script "$target_script" ${script_args[@]}
+    prepScalacCommandLine "$@"
+    # exec here would prevent onExit from being called, leaving terminal in unusable state
+    eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$cp_arg\"" "${java_args[@]}" "${residual_args[@]}"
     scala_exit_status=$?
   fi
 elif [ $execute_repl == true ] || ([ $execute_run == false ] && [ $options_indicator == 0 ]); then
@@ -151,7 +156,7 @@ elif [ $execute_repl == true ] || ([ $execute_run == false ] && [ $options_indic
   fi
   eval "\"$PROG_HOME/bin/scalac\" ${cp_arg-} ${java_options[@]} -repl ${residual_args[@]}"
   scala_exit_status=$?
-elif [ $execute_repl == true ] || [ ${#residual_args[@]} -ne 0 ]; then
+elif [ ${#residual_args[@]} -ne 0 ]; then
   cp_arg="$DOTTY_LIB$PSEP$SCALA_LIB"
   if [ -z "$CLASS_PATH" ]; then
     cp_arg+="$PSEP."
@@ -165,7 +170,7 @@ elif [ $execute_repl == true ] || [ ${#residual_args[@]} -ne 0 ]; then
     cp_arg+="$PSEP$DOTTY_COMP$PSEP$TASTY_CORE$PSEP$DOTTY_INTF$PSEP$SCALA_ASM$PSEP$DOTTY_STAGING$PSEP$DOTTY_TASTY_INSPECTOR"
   fi
   # exec here would prevent onExit from being called, leaving terminal in unusable state
-  eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$cp_arg\"" "${jvm_options[@]}" "${residual_args[@]}"
+  eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$cp_arg\"" "${java_args[@]}" "${residual_args[@]}"
   scala_exit_status=$?
 else
   echo "warning: command option is not correct."

--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -99,7 +99,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     -d|-debug)
-      DEBUG="$DEBUG_STR"
+      DEBUG="${DEBUG_STR-}"
       shift ;;
     -version)
       # defer to scalac, then exit
@@ -155,13 +155,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 #[ -n "${dump_args}" ] && dumpArgs ; exit 2
-
 if [ -z "${execute_mode-}" ]; then
   # no script was specified, set run or repl mode
-  if [[ $options_indicator -ne 0 || ${#residual_args[@]} -ne 0 ]]; then
-    setExecuteMode 'run'
-  else
+  if [[ $options_indicator -eq 0 && "${residual_args[@]-}" == "" ]]; then
     setExecuteMode 'repl'
+  else
+    setExecuteMode 'run'
   fi
 fi
 
@@ -224,7 +223,7 @@ run)
     repl_cparg+="$PSEP$DOTTY_COMP$PSEP$TASTY_CORE$PSEP$DOTTY_INTF$PSEP$SCALA_ASM$PSEP$DOTTY_STAGING$PSEP$DOTTY_TASTY_INSPECTOR"
   fi
   # exec here would prevent onExit from being called, leaving terminal in unusable state
-  eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$repl_cparg\"" "${java_args[@]}" "${residual_args[@]}"
+  eval "\"$JAVACMD\"" "${DEBUG-}"  "-classpath \"$repl_cparg\"" "${java_args[@]}" "${residual_args[@]}"
   scala_exit_status=$?
   ;;
 

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-if [ -z "$PROG_HOME" ] ; then
+# Try to autodetect real location of the script
+if [ -z "${PROG_HOME-}" ] ; then
   ## resolve links - $0 may be a link to PROG_HOME
   PRG="$0"
 
@@ -27,102 +28,11 @@ fi
 
 source "$PROG_HOME/bin/common"
 
-default_java_opts="-Xmx768m -Xms768m"
-withCompiler=true
-
-CompilerMain=dotty.tools.dotc.Main
-DecompilerMain=dotty.tools.dotc.decompiler.Main
-ReplMain=dotty.tools.repl.Main
-ScriptingMain=dotty.tools.scripting.Main
-
 PROG_NAME=$CompilerMain
 
-addJava () {
-  java_args+=("'$1'")
-}
-addScala () {
-  scala_args+=("'$1'")
-}
-addResidual () {
-  residual_args+=("'$1'")
-}
-addScripting () {
-  scripting_args+=("'$1'")
-}
+prepScalacCommandLine "$@"
 
-classpathArgs () {
-  # echo "dotty-compiler: $DOTTY_COMP"
-  # echo "dotty-interface: $DOTTY_INTF"
-  # echo "dotty-library: $DOTTY_LIB"
-  # echo "tasty-core: $TASTY_CORE"
-  # echo "scala-asm: $SCALA_ASM"
-  # echo "scala-lib: $SCALA_LIB"
-  # echo "sbt-intface: $SBT_INTF"
-
-  toolchain=""
-  toolchain+="$SCALA_LIB$PSEP"
-  toolchain+="$DOTTY_LIB$PSEP"
-  toolchain+="$SCALA_ASM$PSEP"
-  toolchain+="$SBT_INTF$PSEP"
-  toolchain+="$DOTTY_INTF$PSEP"
-  toolchain+="$DOTTY_COMP$PSEP"
-  toolchain+="$TASTY_CORE$PSEP"
-  toolchain+="$DOTTY_STAGING$PSEP"
-  toolchain+="$DOTTY_TASTY_INSPECTOR$PSEP"
-
-  # jine
-  toolchain+="$JLINE_READER$PSEP"
-  toolchain+="$JLINE_TERMINAL$PSEP"
-  toolchain+="$JLINE_TERMINAL_JNA$PSEP"
-  toolchain+="$JNA$PSEP"
-
-  jvm_cp_args="-classpath \"$toolchain\""
-}
-
-while [[ $# -gt 0 ]]; do
-case "$1" in
-           --) shift; for arg; do addResidual "$arg"; done; set -- ;;
-  -v|-verbose) verbose=true && addScala "-verbose" && shift ;;
-       -debug) DEBUG="$DEBUG_STR" && shift ;;
-    -q|-quiet) quiet=true && shift ;;
-
-    # Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
-    -Oshort) addJava "-XX:+TieredCompilation -XX:TieredStopAtLevel=1" && shift ;;
-        -repl) PROG_NAME="$ReplMain" && shift ;;
-      -script) PROG_NAME="$ScriptingMain" && target_script="$2" && shift && shift
-               while [[ $# -gt 0 ]]; do addScripting "$1" && shift ; done ;;
-     -compile) PROG_NAME="$CompilerMain" && shift ;;
-   -decompile) PROG_NAME="$DecompilerMain" && shift ;;
- -print-tasty) PROG_NAME="$DecompilerMain" && addScala "-print-tasty" && shift ;;
-         -run) PROG_NAME="$ReplMain" && shift ;;
-      -colors) colors=true && shift ;;
-   -no-colors) unset colors && shift ;;
-  -with-compiler) jvm_cp_args="$PSEP$DOTTY_COMP$PSEP$TASTY_CORE" && shift ;;
-
-          # break out -D and -J options and add them to java_args so
-          # they reach the JVM in time to do some good. The -D options
-          # will be available as system properties.
-          -D*) addJava "$1" && shift ;;
-          -J*) addJava "${1:2}" && shift ;;
-            *) addResidual "$1" && shift ;;
-  esac
-done
-
-classpathArgs
-
-if [ "$PROG_NAME" == "$ScriptingMain" ]; then
-  scripting_string="-script $target_script ${scripting_args[@]}"
-fi
-
-eval "\"$JAVACMD\"" \
-     ${JAVA_OPTS:-$default_java_opts} \
-     "${DEBUG-}" \
-     "${java_args[@]}" \
-     "$jvm_cp_args" \
-     -Dscala.usejavacp=true \
-     "$PROG_NAME"  \
-     "${scala_args[@]}" \
-     "${residual_args[@]}" \
-     "${scripting_string-}"
+# exec here would prevent onExit from being called, leaving terminal in unusable state
+eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$cp_arg\"" "${java_args[@]}" "${residual_args[@]}"
 scala_exit_status=$?
-onExit
+

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -38,7 +38,7 @@ eval "\"$JAVACMD\"" \
      ${JAVA_OPTS:-$default_java_opts} \
      "${DEBUG-}" \
      "${java_args[@]}" \
-     -classpath "$jvm_cp_args" \
+     "-classpath \"$jvm_cp_args\"" \
      -Dscala.usejavacp=true \
      "$PROG_NAME"  \
      "${scala_args[@]}" \

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -33,6 +33,15 @@ PROG_NAME=$CompilerMain
 prepScalacCommandLine "$@"
 
 # exec here would prevent onExit from being called, leaving terminal in unusable state
-eval "\"$JAVACMD\"" "$DEBUG"  "-classpath \"$cp_arg\"" "${java_args[@]}" "${residual_args[@]}"
+eval "\"$JAVACMD\"" \
+     ${JAVA_OPTS:-$default_java_opts} \
+     "${DEBUG-}" \
+     "${java_args[@]}" \
+     "$jvm_cp_args" \
+     -Dscala.usejavacp=true \
+     "$PROG_NAME"  \
+     "${scala_args[@]}" \
+     "${residual_args[@]}" \
+     "${scripting_string-}"
 scala_exit_status=$?
 

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -28,16 +28,17 @@ fi
 
 source "$PROG_HOME/bin/common"
 
-PROG_NAME=$CompilerMain
+[ -z "$PROG_NAME" ] && PROG_NAME=$CompilerMain
 
 prepScalacCommandLine "$@"
 
 # exec here would prevent onExit from being called, leaving terminal in unusable state
+[ -n "$script_trace" ] && set -x
 eval "\"$JAVACMD\"" \
      ${JAVA_OPTS:-$default_java_opts} \
      "${DEBUG-}" \
      "${java_args[@]}" \
-     "$jvm_cp_args" \
+     -classpath "$jvm_cp_args" \
      -Dscala.usejavacp=true \
      "$PROG_NAME"  \
      "${scala_args[@]}" \

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -30,19 +30,56 @@ source "$PROG_HOME/bin/common"
 
 [ -z "$PROG_NAME" ] && PROG_NAME=$CompilerMain
 
-prepScalacCommandLine "$@"
+withCompiler=true
+
+while [[ $# -gt 0 ]]; do
+case "$1" in
+           --) shift; for arg; do addResidual "$arg"; done; set -- ;;
+  -v|-verbose) verbose=true && addScala "-verbose" && shift ;;
+       -debug) DEBUG="$DEBUG_STR" && shift ;;
+    -q|-quiet) quiet=true && shift ;;
+
+    # Optimize for short-running applications, see https://github.com/lampepfl/dotty/issues/222
+    -Oshort) addJava "-XX:+TieredCompilation -XX:TieredStopAtLevel=1" && shift ;;
+        -repl) PROG_NAME="$ReplMain" && shift ;;
+      -script) PROG_NAME="$ScriptingMain" && target_script="$2" && shift && shift
+               while [[ $# -gt 0 ]]; do addScripting "$1" && shift ; done ;;
+     -compile) PROG_NAME="$CompilerMain" && shift ;;
+   -decompile) PROG_NAME="$DecompilerMain" && shift ;;
+ -print-tasty) PROG_NAME="$DecompilerMain" && addScala "-print-tasty" && shift ;;
+         -run) PROG_NAME="$ReplMain" && shift ;;
+      -colors) colors=true && shift ;;
+   -no-colors) unset colors && shift ;;
+  -with-compiler) jvm_cp_args="$PSEP$DOTTY_COMP$PSEP$TASTY_CORE" && shift ;;
+
+          # break out -D and -J options and add them to java_args so
+          # they reach the JVM in time to do some good. The -D options
+          # will be available as system properties.
+          -D*) addJava "$1" && shift ;;
+          -J*) addJava "${1:2}" && shift ;;
+            *) addResidual "$1" && shift ;;
+  esac
+done
+
+classpathArgs
+
+if [ "$PROG_NAME" == "$ScriptingMain" ]; then
+  setScriptName="-Dscript.path=$target_script"
+  scripting_string="-script $target_script ${scripting_args[@]}"
+fi
 
 # exec here would prevent onExit from being called, leaving terminal in unusable state
 [ -n "$script_trace" ] && set -x
 eval "\"$JAVACMD\"" \
-     ${JAVA_OPTS:-$default_java_opts} \
-     "${DEBUG-}" \
-     "${java_args[@]}" \
-     "-classpath \"$jvm_cp_args\"" \
-     -Dscala.usejavacp=true \
-     "$PROG_NAME"  \
-     "${scala_args[@]}" \
-     "${residual_args[@]}" \
-     "${scripting_string-}"
+   ${JAVA_OPTS:-$default_java_opts} \
+   "${DEBUG-}" \
+   "${java_args[@]}" \
+   "-classpath \"$jvm_cp_args\"" \
+   -Dscala.usejavacp=true \
+   "$setScriptName" \
+   "$PROG_NAME"  \
+   "${scala_args[@]}" \
+   "${residual_args[@]}" \
+   "${scripting_string-}"
 scala_exit_status=$?
 

--- a/dist/bin/scaladoc
+++ b/dist/bin/scaladoc
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+#set -o nounset ; set -o errexit
+
 # Try to autodetect real location of the script
-if [ -z "$PROG_HOME" ] ; then
+if [ -z "${PROG_HOME-}" ] ; then
   ## resolve links - $0 may be a link to PROG_HOME
   PRG="$0"
 
@@ -46,8 +48,8 @@ addScala () {
 addResidual () {
   residual_args+=("'$1'")
 }
-addScripting () {
-  scripting_args+=("'$1'")
+addScrip() {
+  script_args+=("'$1'")
 }
 
 classpathArgs () {
@@ -98,7 +100,8 @@ classpathArgs () {
   jvm_cp_args="-classpath \"$CLASS_PATH\""
 }
 
-in_scripting_args=false
+#for A in "$@" ; do echo "A[$A]" ; done ; exit 2
+
 while [[ $# -gt 0 ]]; do
 case "$1" in
            --) shift; for arg; do addResidual "$arg"; done; set -- ;;
@@ -113,11 +116,7 @@ case "$1" in
           # will be available as system properties.
           -D*) addJava "$1" && shift ;;
           -J*) addJava "${1:2}" && shift ;;
-            *) if [ $in_scripting_args == false ]; then
-                addResidual "$1"
-               else
-                addScripting "$1"
-               fi
+            *) addResidual "$1"
                shift
                ;;
   esac
@@ -127,12 +126,12 @@ classpathArgs
 
 eval "\"$JAVACMD\"" \
      ${JAVA_OPTS:-$default_java_opts} \
-     "$DEBUG" \
+     "${DEBUG-}" \
      "${java_args[@]}" \
-     "$jvm_cp_args" \
+     "${jvm_cp_args-}" \
      "dotty.tools.scaladoc.Main"  \
      "${scala_args[@]}" \
      "${residual_args[@]}" \
-     "$scripting_string"
+     "${scripting_string-}"
 scala_exit_status=$?
 onExit

--- a/dist/bin/scaladoc
+++ b/dist/bin/scaladoc
@@ -27,7 +27,7 @@ if [ -z "$PROG_HOME" ] ; then
 fi
 
 source "$PROG_HOME/bin/common"
-
+default_java_opts="-Xmx768m -Xms768m"
 withCompiler=true
 
 CompilerMain=dotty.tools.dotc.Main

--- a/dist/bin/scaladoc
+++ b/dist/bin/scaladoc
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Try to autodetect real location of the script
 if [ -z "$PROG_HOME" ] ; then
   ## resolve links - $0 may be a link to PROG_HOME
   PRG="$0"
@@ -27,7 +28,6 @@ fi
 
 source "$PROG_HOME/bin/common"
 
-default_java_opts="-Xmx768m -Xms768m"
 withCompiler=true
 
 CompilerMain=dotty.tools.dotc.Main


### PR DESCRIPTION
This is an alternate fix for script startup latency caused by redundant sourcing of `bin/common` within `bin/scala` when launching a script.   See #11698 for the original proposal, based on exporting relevant environment variables and conditionally sourcing `bin/common`.

This PR instead moves additional common code from `bin/scalac` to functions in `bin/common`.
The new functions are used to launch the compiler directly from within `bin/scala`.

In addition, one test was updated to accommodate the change:
```scala
dotty.tools.scripting.ClasspathTests
```
Another test was updated to remove a timezone dependency:

```scala
dotty.tools.repl.ScriptedTests
```