### PR TITLE
Correct generic signature for intersection involving Array

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -131,10 +131,10 @@ object GenericSignatures {
      */
     def splitIntersection(parents: List[Type])(using Context): (List[Type], List[Type]) =
       val erasedParents = parents.map(erasure)
-      val erasedCls = erasedGlb(erasedParents).classSymbol
+      val erasedTp = erasedGlb(erasedParents)
       parents.zip(erasedParents)
         .partitionMap((parent, erasedParent) =>
-          if erasedParent.classSymbol eq erasedCls then
+          if erasedParent =:= erasedTp then
             Left(parent)
           else
             Right(parent))

--- a/tests/run/i12204/A_1.scala
+++ b/tests/run/i12204/A_1.scala
@@ -1,0 +1,3 @@
+object A {
+  def intARRAY_131(x: Array[String] with Array[Int]): Unit = {}
+}

--- a/tests/run/i12204/B_2.java
+++ b/tests/run/i12204/B_2.java
@@ -1,0 +1,5 @@
+public class B_2 {
+  public static void test() {
+    A.intARRAY_131(null); // shouldn't throw a NoSuchMethodError
+  }
+}

--- a/tests/run/i12204/Test_3.scala
+++ b/tests/run/i12204/Test_3.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    B_2.test()
+  }
+}


### PR DESCRIPTION
We can't just check the class symbol since both `Array[Int]` and
`Array[String]` have the same symbol but different erasure.

Fixes #12204.