### PR TITLE
Fix isMatch

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -432,8 +432,8 @@ object SymDenotations {
           TypeBounds.empty
 
       info match
-        case TypeAlias(alias) if isOpaqueAlias && owner.isClass =>
-          setAlias(alias)
+        case info: AliasingBounds if isOpaqueAlias && owner.isClass =>
+          setAlias(info.alias)
           HKTypeLambda.boundsFromParams(tparams, bounds(rhs))
         case _ =>
           info

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -420,47 +420,45 @@ object TypeOps:
           sym.is(Package) || sym.isStatic && isStaticPrefix(pre.prefix)
         case _ => true
 
-      def apply(tp: Type): Type =
-        val tp1 = tp match
-          case tp: TermRef
-          if toAvoid(tp.symbol) || partsToAvoid(Nil, tp.info).nonEmpty =>
-            tp.info.widenExpr.dealias match {
-              case info: SingletonType => apply(info)
-              case info => range(defn.NothingType, apply(info))
-            }
-          case tp: TypeRef if toAvoid(tp.symbol) =>
-            tp.info match {
-              case info: AliasingBounds =>
-                apply(info.alias)
-              case TypeBounds(lo, hi) =>
-                range(atVariance(-variance)(apply(lo)), apply(hi))
-              case info: ClassInfo =>
-                range(defn.NothingType, apply(classBound(info)))
-              case _ =>
-                emptyRange // should happen only in error cases
-            }
-          case tp: ThisType =>
-            // ThisType is only used inside a class.
-            // Therefore, either they don't appear in the type to be avoided, or
-            // it must be a class that encloses the block whose type is to be avoided.
-            tp
-          case tp: SkolemType if partsToAvoid(Nil, tp.info).nonEmpty =>
-            range(defn.NothingType, apply(tp.info))
-          case tp: TypeVar if mapCtx.typerState.constraint.contains(tp) =>
-            val lo = TypeComparer.instanceType(
-              tp.origin, fromBelow = variance > 0 || variance == 0 && tp.hasLowerBound)(using mapCtx)
-            val lo1 = apply(lo)
-            if (lo1 ne lo) lo1 else tp
-          case tp: LazyRef =>
-            if localParamRefs.contains(tp.ref) then tp
-            else if isExpandingBounds then emptyRange
-            else mapOver(tp)
-          case tl: HKTypeLambda =>
-            localParamRefs ++= tl.paramRefs
-            mapOver(tl)
-          case _ =>
-            mapOver(tp)
-        if tp1 ne tp then tp1.normalized else tp
+      def apply(tp: Type): Type = tp match
+        case tp: TermRef
+        if toAvoid(tp.symbol) || partsToAvoid(Nil, tp.info).nonEmpty =>
+          tp.info.widenExpr.dealias match {
+            case info: SingletonType => apply(info)
+            case info => range(defn.NothingType, apply(info))
+          }
+        case tp: TypeRef if toAvoid(tp.symbol) =>
+          tp.info match {
+            case info: AliasingBounds =>
+              apply(info.alias)
+            case TypeBounds(lo, hi) =>
+              range(atVariance(-variance)(apply(lo)), apply(hi))
+            case info: ClassInfo =>
+              range(defn.NothingType, apply(classBound(info)))
+            case _ =>
+              emptyRange // should happen only in error cases
+          }
+        case tp: ThisType =>
+          // ThisType is only used inside a class.
+          // Therefore, either they don't appear in the type to be avoided, or
+          // it must be a class that encloses the block whose type is to be avoided.
+          tp
+        case tp: SkolemType if partsToAvoid(Nil, tp.info).nonEmpty =>
+          range(defn.NothingType, apply(tp.info))
+        case tp: TypeVar if mapCtx.typerState.constraint.contains(tp) =>
+          val lo = TypeComparer.instanceType(
+            tp.origin, fromBelow = variance > 0 || variance == 0 && tp.hasLowerBound)(using mapCtx)
+          val lo1 = apply(lo)
+          if (lo1 ne lo) lo1 else tp
+        case tp: LazyRef =>
+          if localParamRefs.contains(tp.ref) then tp
+          else if isExpandingBounds then emptyRange
+          else mapOver(tp)
+        case tl: HKTypeLambda =>
+          localParamRefs ++= tl.paramRefs
+          mapOver(tl)
+        case _ =>
+          mapOver(tp)
       end apply
 
       /** Three deviations from standard derivedSelect:

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -423,6 +423,10 @@ object Types {
     def isMatch(using Context): Boolean = stripped match {
       case _: MatchType => true
       case tp: HKTypeLambda => tp.resType.isMatch
+      case tp: AppliedType =>
+        tp.tycon match
+          case tycon: TypeRef => tycon.info.isInstanceOf[MatchAlias]
+          case _ => false
       case _ => false
     }
 

--- a/compiler/test/dotc/run-test-pickling.blacklist
+++ b/compiler/test/dotc/run-test-pickling.blacklist
@@ -33,3 +33,4 @@ typeclass-derivation2d.scala
 typeclass-derivation3.scala
 varargs-abstract
 zero-arity-case-class.scala
+i12194.scala

--- a/tests/pos/i12178.scala
+++ b/tests/pos/i12178.scala
@@ -1,0 +1,24 @@
+opaque type LabelTagged[TLabel <: Singleton & String, TValue] = TValue
+
+object LabelTagged:
+  def apply[TLabel <: Singleton & String, TValue]
+  (
+    label: TLabel,
+    value: TValue,
+  )
+  : LabelTagged[TLabel, TValue] = value
+
+extension[TLabel <: Singleton & String, TValue] (labelTagged: LabelTagged[TLabel, TValue])
+  def value
+  : TValue = labelTagged
+
+  def label
+  (using label: ValueOf[TLabel])
+  : TLabel
+  = label.value
+
+@main def hello(): Unit = {
+  val foo: LabelTagged["foo", Int] = LabelTagged("foo", 10)
+  println(label(foo))  // OK
+  //println(foo.label)   // not OK
+}

--- a/tests/pos/i12194-opaque.scala
+++ b/tests/pos/i12194-opaque.scala
@@ -1,0 +1,3 @@
+opaque type ProductK[F[_], T <: Tuple] = Tuple.Map[T, F]
+object ProductK:
+  def of[F[_], T <: Tuple](t: Tuple.Map[T, F]): ProductK[F, T] = t

--- a/tests/run/i12194.check
+++ b/tests/run/i12194.check
@@ -1,0 +1,1 @@
+List(foo, bar)

--- a/tests/run/i12194.scala
+++ b/tests/run/i12194.scala
@@ -1,0 +1,16 @@
+import scala.annotation.implicitNotFound
+import scala.compiletime.package$package.summonAll
+import scala.util.Try
+import scala.util.Success
+import scala.util.Failure
+import scala.util.NotGiven
+import scala.deriving.*
+
+def f(): Unit =
+  var t = (??? : Tuple1[ValueOf["foo"]]); t.toList.map(identity)
+  (??? : Tuple1[ValueOf["foo"]]).toList.map(identity)
+
+@main def Test(): Unit =
+  println(summonAll[Tuple.Map[("foo", "bar"), ValueOf]].toList.map{
+    case str: ValueOf[_] ⇒ str.value
+  })


### PR DESCRIPTION

An applied type that is an alias of an applied match type is an applied match type itself.
Previously that was not the case, which led to typed that could logically be reduced but were
not.

Fixes #12194

There, the  case was that we had a Tuple.Union type that was an alias of a Tuple.Fold type instance, which was an alias
of a match type. The Tuple.Union did did not get reduced since it was not regarded as a match type alias itself.