### PR TITLE
Recognize leading infix operator in front of `:` at eol

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -377,8 +377,8 @@ object Scanners {
       && {
         // Is current lexeme  assumed to start an expression?
         // This is the case if the lexime is one of the tokens that
-        // starts an expression. Furthermore, if the previous token is
-        // in backticks, the lexeme may not be a binary operator.
+        // starts an expression or it is a COLONEOL. Furthermore, if
+        // the previous token is in backticks, the lexeme may not be a binary operator.
         // I.e. in
         //
         //   a
@@ -388,7 +388,7 @@ object Scanners {
         // in backticks and is a binary operator. Hence, `x` is not classified as a
         // leading infix operator.
         def assumeStartsExpr(lexeme: TokenData) =
-          canStartExprTokens.contains(lexeme.token)
+          (canStartExprTokens.contains(lexeme.token) || lexeme.token == COLONEOL)
           && (!lexeme.isOperator || nme.raw.isUnary(lexeme.name))
         val lookahead = LookaheadScanner()
         lookahead.allowLeadingInfixOperators = false

--- a/tests/pos/i12218.scala
+++ b/tests/pos/i12218.scala
@@ -1,0 +1,10 @@
+import language.experimental.fewerBraces
+@main def runTest(): Unit =
+  val arr = Array(1,2,3)
+  if
+    arr.isEmpty
+    || :
+      val first = arr(0)
+      first != 1
+  then println("invalid arr")
+  else println("valid arr")


### PR DESCRIPTION
Fixes #12218