### PR TITLE
Scaladoc: silence undefined variable msgs

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/CommentExpander.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/CommentExpander.scala
@@ -259,8 +259,9 @@ class CommentExpander {
             case vname  =>
               lookupVariable(vname, site) match {
                 case Some(replacement) => replaceWith(replacement)
-                case None              => ;
-                  println(s"Variable $vname undefined in comment for $sym in $site")
+                case None              =>
+                  // TODO add a CLI setting for enabling this message
+                  // println(s"Variable $vname undefined in comment for $sym in $site")
               }
           }
         }


### PR DESCRIPTION
Those messages aren't very useful, and they pollute our logs.

They get emitted whenever in any part of the docstring, we see something like `$var`. Seeing as Scala snippets using quotes have a lot of text that looks like that, we get a lot of warnings.

Note that these will, right now, get expanded. Variable expansion happens before we parse comments, so without a refactor we cannot really do much better than to silence the warnings.