### PR TITLE
Show tvar bounds in "no implicit argument" message

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -315,7 +315,7 @@ class ImplicitSearchError(
   }
 
   private def defaultImplicitNotFoundMessage = {
-    em"no implicit argument of type $pt was found${location("for")}"
+    ex"no implicit argument of type $pt was found${location("for")}"
   }
 
   /** Construct a custom error message given an ambiguous implicit

--- a/tests/neg/i12232.check
+++ b/tests/neg/i12232.check
@@ -1,0 +1,12 @@
+-- Error: tests/neg/i12232.scala:17:15 ---------------------------------------------------------------------------------
+17 |  foo(min(3, 4)) // error: works in Scala 2, not in 3
+   |               ^
+   |             no implicit argument of type Op[Int, Int, V] was found for parameter op of method min in object Foo
+   |
+   |             where:    V is a type variable with constraint <: Double
+-- Error: tests/neg/i12232.scala:19:16 ---------------------------------------------------------------------------------
+19 |  foo(minR(3, 4)) // error: works in Scala 2, not in 3
+   |                ^
+   |            no implicit argument of type Op[Int, Int, R] was found for parameter op of method minR in object Foo
+   |
+   |            where:    R is a type variable with constraint <: Double

--- a/tests/neg/i12232.scala
+++ b/tests/neg/i12232.scala
@@ -1,0 +1,20 @@
+trait Op[T1, T2, +R] {
+  def apply(t1: T1, t2: T2): R
+}
+
+object Op {
+  implicit val compInt: Op[Int, Int, Int] = new Op[Int, Int, Int] {
+    def apply(x: Int, y: Int) = scala.math.min(x, y)
+  }
+}
+
+object Foo {
+  def foo(x: Double) = x + 1.0
+  def min[T, U, V](x: T, y: U)(implicit op: Op[T, U, V]): V = op(x, y)
+  def minInt(x: Int, y: Int)(implicit op: Op[Int, Int, Int]): Int = op(x, y)
+  def minR[R](x: Int, y: Int)(implicit op: Op[Int, Int, R]): R = op(x, y)
+  min(3, 4) // works in both
+  foo(min(3, 4)) // error: works in Scala 2, not in 3
+  foo(minInt(3, 4)) // works in both
+  foo(minR(3, 4)) // error: works in Scala 2, not in 3
+}

--- a/tests/neg/i9568.check
+++ b/tests/neg/i9568.check
@@ -1,7 +1,10 @@
 -- Error: tests/neg/i9568.scala:13:10 ----------------------------------------------------------------------------------
 13 |  blaMonad.foo(bla) // error: diverges
    |          ^
-   |          no implicit argument of type => Monad[F] was found for parameter ev of method blaMonad in object Test.
+   |          no implicit argument of type => Monad[F] was found for parameter ev of method blaMonad in object Test
+   |
+   |          where:    F is a type variable with constraint <: [_] =>> Any
+   |          .
    |          I found:
    |
    |              Test.blaMonad[Nothing, S](Test.blaMonad[F, S])


### PR DESCRIPTION
Otherwise it's not clear why no implicit of that type was found.

Fixes #12232.