### PR TITLE
 Fix internal definition of `Unapply`

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -530,6 +530,9 @@ object SourceCode {
       case Closure(meth, _) =>
         printTree(meth)
 
+      case _:Unapply | _:Alternatives | _:Bind =>
+        printPattern(tree)
+
       case _ =>
         throw new MatchError(tree.show(using Printer.TreeStructure))
 

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -4359,7 +4359,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           case New(tpt) =>
             New.copy(tree)(transformTypeTree(tpt)(owner))
           case Typed(expr, tpt) =>
-            Typed.copy(tree)(transformTerm(expr)(owner), transformTypeTree(tpt)(owner))
+            Typed.copy(tree)(/*FIXME #12222: transformTerm(expr)(owner)*/transformTree(expr)(owner).asInstanceOf[Term], transformTypeTree(tpt)(owner))
           case tree: NamedArg =>
             NamedArg.copy(tree)(tree.name, transformTerm(tree.value)(owner))
           case Assign(lhs, rhs) =>

--- a/tests/run-staging/i5161.check
+++ b/tests/run-staging/i5161.check
@@ -1,6 +1,6 @@
 run : Some(2)
 show : scala.Tuple2.apply[scala.Option[scala.Int], scala.Option[scala.Int]](scala.Some.apply[scala.Int](1), scala.Some.apply[scala.Int](1)) match {
-  case scala.Tuple2(scala.Some(x), scala.Some(y)) =>
+  case scala.Tuple2((scala.Some(x): scala.Some[scala.Int]), (scala.Some(y): scala.Some[scala.Int])) =>
     scala.Some.apply[scala.Int](x.+(y))
   case _ =>
     scala.None


### PR DESCRIPTION
Users may see an extra `Typed` in the trees of patterns

Fixes #12221
Backported from #12200