### PR TITLE
log(a)+log(b)=log(ab) with same base, log(a)*log(b)!=log(a)+log(b)

### DIFF
--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -24,8 +24,8 @@ object MyMath:
    // Extension methods define opaque types' public APIs
    extension (x: Logarithm)
       def toDouble: Double = math.exp(x)
-      def + (y: Logarithm): Logarithm = Logarithm(math.exp(x) + math.exp(y))
-      def * (y: Logarithm): Logarithm = x + y
+      def + (y: Logarithm): Logarithm = Logarithm(math.exp(x) * math.exp(y))
+      def * (y: Logarithm): Logarithm = x * y
 
 end MyMath
 ```


### PR DESCRIPTION
while it's for presentation proposes,I think, that logarithm of product (not the sum) of two numbers equals sum of logarithms for each number; I have not found simple formula how represent log(a)*log(b) through manipulations with a and/or b, and multiplication in commit will work without extension Logarithm. So I don't know should or shouldn't * method be in extension.

Excuse me, if I haven't properly initiated change into this repo. I'm on the start of contributing to open-source