### PR TITLE
Silence a debug println

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -791,8 +791,6 @@ object Denotations {
       val currentPeriod = ctx.period
       val valid = myValidFor
 
-      def signalError() = println(s"error while transforming $this")
-
       def assertNotPackage(d: SingleDenotation, transformer: DenotTransformer) = d match
         case d: ClassDenotation =>
           assert(!d.is(Package), s"illegal transformation of package denotation by transformer $transformer")
@@ -836,7 +834,7 @@ object Denotations {
                 // To work correctly, we need to demand that the context with the new phase
                 // is not retained in the result.
             catch case ex: CyclicReference =>
-              signalError()
+              // println(s"error while transforming $this")
               throw ex
             finally
               mutCtx.setPeriod(savedPeriod)


### PR DESCRIPTION
Currently, when running testCompilation i1286, the following always gets printed:

error while transforming method splitAt
error while transforming method tuple2ToZippedOps

It seems that the associated error gets caught and handled, so we shouldn't print this message.