### PR TITLE
Fix #12260: Add underscore to match type syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/MatchTypeTrace.scala
+++ b/compiler/src/dotty/tools/dotc/core/MatchTypeTrace.scala
@@ -84,6 +84,7 @@ object MatchTypeTrace:
 
   private def caseText(tp: Type)(using Context): String = tp match
     case tp: HKTypeLambda => caseText(tp.resultType)
+    case defn.MatchCase(any, body) if any eq defn.AnyType => i"case _ => $body"
     case defn.MatchCase(pat, body) => i"case $pat => $body"
     case _ => i"case $tp"
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4755,14 +4755,6 @@ object Types {
   object MatchType {
     def apply(bound: Type, scrutinee: Type, cases: List[Type])(using Context): MatchType =
       unique(new CachedMatchType(bound, scrutinee, cases))
-
-    /** Extractor for `case _ =>` match type patterns */
-    object WildcardPattern {
-      def unapply(tp: Type)(using Context): Option[Type] = tp match {
-        case HKTypeLambda(LambdaParam(tl1, 0) :: Nil, defn.MatchCase(TypeParamRef(tl2, 0), bodyTp)) => Some(bodyTp)
-        case _ => None
-      }
-    }
   }
 
   // ------ ClassInfo, Type Bounds --------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4755,6 +4755,14 @@ object Types {
   object MatchType {
     def apply(bound: Type, scrutinee: Type, cases: List[Type])(using Context): MatchType =
       unique(new CachedMatchType(bound, scrutinee, cases))
+
+    /** Extractor for `case _ =>` match type patterns */
+    object WildcardPattern {
+      def unapply(tp: Type)(using Context): Option[Type] = tp match {
+        case HKTypeLambda(LambdaParam(tl1, 0) :: Nil, defn.MatchCase(TypeParamRef(tl2, 0), bodyTp)) => Some(bodyTp)
+        case _ => None
+      }
+    }
   }
 
   // ------ ClassInfo, Type Bounds --------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1824,7 +1824,7 @@ object Parsers {
 
     def typeDependingOn(location: Location): Tree =
       if location.inParens then typ()
-      else if location.inPattern then refinedType()
+      else if location.inPattern then rejectWildcardType(refinedType())
       else infixType()
 
 /* ----------- EXPRESSIONS ------------------------------------------------ */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2618,8 +2618,7 @@ object Parsers {
         in.token match {
           case USCORE if in.lookahead.isArrow =>
             val start = in.skipToken()
-            typeBounds().withSpan(Span(start, in.lastOffset, start))
-
+            Ident(tpnme.WILDCARD).withSpan(Span(start, in.lastOffset, start))
           case _ =>
             infixType()
         }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2620,11 +2620,11 @@ object Parsers {
             val start = in.skipToken()
             Ident(tpnme.WILDCARD).withSpan(Span(start, in.lastOffset, start))
           case _ =>
-            infixType()
+            rejectWildcardType(infixType())
         }
       }
       CaseDef(pat, EmptyTree, atSpan(accept(ARROW)) {
-        val t = typ()
+        val t = rejectWildcardType(typ())
         if in.token == SEMI then in.nextToken()
         newLinesOptWhenFollowedBy(CASE)
         t

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2610,12 +2610,19 @@ object Parsers {
       })
     }
 
-    /** TypeCaseClause     ::= ‘case’ InfixType ‘=>’ Type [semi]
+    /** TypeCaseClause     ::= ‘case’ (InfixType | ‘_’) ‘=>’ Type [semi]
      */
     def typeCaseClause(): CaseDef = atSpan(in.offset) {
       val pat = inSepRegion(InCase) {
         accept(CASE)
-        infixType()
+        in.token match {
+          case USCORE if in.lookahead.isArrow =>
+            val start = in.skipToken()
+            typeBounds().withSpan(Span(start, in.lastOffset, start))
+
+          case _ =>
+            infixType()
+        }
       }
       CaseDef(pat, EmptyTree, atSpan(accept(ARROW)) {
         val t = typ()

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -485,6 +485,8 @@ class Typer extends Namer
     if ctx.mode.is(Mode.Pattern) then
       if name == nme.WILDCARD then
         return tree.withType(pt)
+      if name == tpnme.WILDCARD then
+        return tree.withType(defn.AnyType)
       if untpd.isVarPattern(tree) && name.isTermName then
         return typed(desugar.patternVar(tree), pt)
     else if ctx.mode.is(Mode.QuotedPattern) then
@@ -1546,13 +1548,11 @@ class Typer extends Namer
                 val Typed(_, tpt) = tpd.unbind(tpd.unsplice(pat1))
                 instantiateMatchTypeProto(pat1, pt) match {
                   case defn.MatchCase(patternTp, _) => tpt.tpe frozen_=:= patternTp
-                  case MatchType.WildcardPattern(_) => tpt.tpe frozen_=:= defn.AnyType
                   case _ => false
                 }
               case (id @ Ident(nme.WILDCARD), pt) =>
                 pt match {
                   case defn.MatchCase(patternTp, _) => defn.AnyType frozen_=:= patternTp
-                  case MatchType.WildcardPattern(_) => true
                   case _ => false
                 }
               case _ => false
@@ -1664,7 +1664,6 @@ class Typer extends Namer
     def caseRest(pat: Tree)(using Context) = {
       val pt1 = instantiateMatchTypeProto(pat, pt) match {
         case defn.MatchCase(_, bodyPt) => bodyPt
-        case MatchType.WildcardPattern(bodyPt) => bodyPt
         case pt => pt
       }
       val pat1 = indexPattern(tree).transform(pat)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1546,6 +1546,13 @@ class Typer extends Namer
                 val Typed(_, tpt) = tpd.unbind(tpd.unsplice(pat1))
                 instantiateMatchTypeProto(pat1, pt) match {
                   case defn.MatchCase(patternTp, _) => tpt.tpe frozen_=:= patternTp
+                  case MatchType.WildcardPattern(_) => tpt.tpe frozen_=:= defn.AnyType
+                  case _ => false
+                }
+              case (id @ Ident(nme.WILDCARD), pt) =>
+                pt match {
+                  case defn.MatchCase(patternTp, _) => defn.AnyType frozen_=:= patternTp
+                  case MatchType.WildcardPattern(_) => true
                   case _ => false
                 }
               case _ => false
@@ -1657,6 +1664,7 @@ class Typer extends Namer
     def caseRest(pat: Tree)(using Context) = {
       val pt1 = instantiateMatchTypeProto(pat, pt) match {
         case defn.MatchCase(_, bodyPt) => bodyPt
+        case MatchType.WildcardPattern(bodyPt) => bodyPt
         case pt => pt
       }
       val pat1 = indexPattern(tree).transform(pat)

--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -289,7 +289,7 @@ CaseClauses       ::=  CaseClause { CaseClause }                                
 CaseClause        ::=  ‘case’ Pattern [Guard] ‘=>’ Block                        CaseDef(pat, guard?, block)   // block starts at =>
 ExprCaseClause    ::=  ‘case’ Pattern [Guard] ‘=>’ Expr
 TypeCaseClauses   ::=  TypeCaseClause { TypeCaseClause }
-TypeCaseClause    ::=  ‘case’ InfixType ‘=>’ Type [semi]
+TypeCaseClause    ::=  ‘case’ (InfixType | ‘_’) ‘=>’ Type [semi]
 
 Pattern           ::=  Pattern1 { ‘|’ Pattern1 }                                Alternative(pats)
 Pattern1          ::=  Pattern2 [‘:’ RefinedType]                               Bind(name, Typed(Ident(wildcard), tpe))

--- a/tests/neg/12261.scala
+++ b/tests/neg/12261.scala
@@ -1,0 +1,11 @@
+type M0[X] = X match {
+  case ? => String // error: Unbound wildcard type
+}
+
+type M1[X] = X match {
+  case Any => _ // error: Unbound wildcard type
+}
+
+type M2[X] = X match {
+  case Any => ? // error: Unbound wildcard type
+}

--- a/tests/neg/12261.scala
+++ b/tests/neg/12261.scala
@@ -9,3 +9,7 @@ type M1[X] = X match {
 type M2[X] = X match {
   case Any => ? // error: Unbound wildcard type
 }
+
+val a = "" match { case _: _ => () } // error: Unbound wildcard type
+
+val b = try { } catch { case _: _ => () } // error: Unbound wildcard type

--- a/tests/pos/9239.scala
+++ b/tests/pos/9239.scala
@@ -24,5 +24,5 @@ object ABug:
     N match
       case Zero => One
       case One => One
-      case ? => ![--[N]] × (N)
+      case _ => ![--[N]] × (N)
       case ? :: ? => ![--[N]] × (N)

--- a/tests/pos/unify-wildcard-patterns.scala
+++ b/tests/pos/unify-wildcard-patterns.scala
@@ -1,0 +1,13 @@
+// `case _ => expr` in a match expression should be equivalant to
+// `case _: Any => expr`. Likewise, in a match type, `case _ => T`
+// should be equivalant to `case Any => T`.
+
+object Test0 {
+  type M[X] =            X match { case String => Int   case Any => String }
+  def m[X](x: X): M[X] = x match { case _: String => 1  case _: Any => "s" }
+}
+
+object Test2 {
+  type M[X] =            X match { case String => Int   case _ => String   }
+  def m[X](x: X): M[X] = x match { case _: String => 1  case _: Any => "s" }
+}

--- a/tests/pos/unify-wildcard-patterns.scala
+++ b/tests/pos/unify-wildcard-patterns.scala
@@ -7,7 +7,17 @@ object Test0 {
   def m[X](x: X): M[X] = x match { case _: String => 1  case _: Any => "s" }
 }
 
+object Test1 {
+  type M[X] =            X match { case String => Int   case Any => String }
+  def m[X](x: X): M[X] = x match { case _: String => 1  case _ => "s"      }
+}
+
 object Test2 {
   type M[X] =            X match { case String => Int   case _ => String   }
   def m[X](x: X): M[X] = x match { case _: String => 1  case _: Any => "s" }
+}
+
+object Test3 {
+  type M[X] =            X match { case String => Int   case _ => String   }
+  def m[X](x: X): M[X] = x match { case _: String => 1  case _ => "s"      }
 }


### PR DESCRIPTION
Also subsumes #9172 by fixing #9171.