### PR TITLE
Suppress nonsensical follow-on error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -962,7 +962,9 @@ trait Checking {
           def doubleDefError(decl: Symbol, other: Symbol): Unit =
             if (!decl.info.isErroneous && !other.info.isErroneous)
               report.error(DoubleDefinition(decl, other, cls), decl.srcPos)
-          if (decl is Synthetic) doubleDefError(other, decl)
+          if decl.name.is(DefaultGetterName) && ctx.reporter.errorsReported then
+            () // do nothing; we already have reported an error that overloaded variants cannot have default arguments
+          else if (decl is Synthetic) doubleDefError(other, decl)
           else doubleDefError(decl, other)
         }
         if decl.hasDefaultParams && other.hasDefaultParams then

--- a/tests/neg/i12245.scala
+++ b/tests/neg/i12245.scala
@@ -1,0 +1,5 @@
+package dotty.tools.dotc.core
+
+def round(f: Float, digits: Int = 0): Float = ???
+//@scala.annotation.targetName("roundDouble") // does not change anything
+def round(d: Double, digits: Int = 0): Double = ???  // error


### PR DESCRIPTION
Suppress nonsensical follow-on error message about doubly-defined
default getters.

Fixes #12245 
