### PR TITLE
Allow braces just on the outside of polymorphic lambdas

### DIFF
--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -205,8 +205,10 @@ Types             ::=  Type {‘,’ Type}
 ### Expressions
 ```ebnf
 Expr              ::=  FunParams (‘=>’ | ‘?=>’) Expr                            Function(args, expr), Function(ValDef([implicit], id, TypeTree(), EmptyTree), expr)
+                    |  HkTypeParamClause ‘=>’ Expr                              PolyFunction(ts, expr)
                     |  Expr1
 BlockResult       ::=  FunParams (‘=>’ | ‘?=>’) Block
+                    |  HkTypeParamClause ‘=>’ Block
                     |  Expr1
 FunParams         ::=  Bindings
                     |  id
@@ -220,7 +222,6 @@ Expr1             ::=  [‘inline’] ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[
                     |  ‘throw’ Expr                                             Throw(expr)
                     |  ‘return’ [Expr]                                          Return(expr?)
                     |  ForExpr
-                    |  HkTypeParamClause ‘=>’ Expr                              PolyFunction(ts, expr)
                     |  [SimpleExpr ‘.’] id ‘=’ Expr                             Assign(expr, expr)
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr                       Assign(expr, expr)
                     |  PostfixExpr [Ascription]

--- a/docs/docs/reference/syntax.md
+++ b/docs/docs/reference/syntax.md
@@ -202,8 +202,10 @@ Types             ::=  Type {‘,’ Type}
 ### Expressions
 ```ebnf
 Expr              ::=  FunParams (‘=>’ | ‘?=>’) Expr
+                    |  HkTypeParamClause ‘=>’ Expr
                     |  Expr1
 BlockResult       ::=  FunParams (‘=>’ | ‘?=>’) Block
+                    |  HkTypeParamClause ‘=>’ Block
                     |  Expr1
 FunParams         ::=  Bindings
                     |  id
@@ -217,7 +219,6 @@ Expr1             ::=  [‘inline’] ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[
                     |  ‘throw’ Expr
                     |  ‘return’ [Expr]
                     |  ForExpr
-                    |  HkTypeParamClause ‘=>’ Expr
                     |  [SimpleExpr ‘.’] id ‘=’ Expr
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr
                     |  PostfixExpr [Ascription]

--- a/tests/neg/tuple-ops.scala
+++ b/tests/neg/tuple-ops.scala
@@ -12,13 +12,13 @@ val r3: ((2, 1), (8, 2)) = c.zip(a)  // error
 // Map
 case class Foo[X](x: X)
 
-val r6: (Int, Int, String) = a.map[[t] =>> Int]([t] => x: t => x match {  // error
+val r6: (Int, Int, String) = a.map[[t] =>> Int]([t] => (x: t) => x match {  // error
   case x: Int => x * x
   case _ => ???
 })
 
 val r7: ((1, Foo[1]), (2), (3, Foo[3])) =
-  a.map[[t] =>> (t, Foo[t])]( [t] => x: t => (x, Foo(x)) )  // error
+  a.map[[t] =>> (t, Foo[t])]( [t] => (x: t) => (x, Foo(x)) )  // error
 
 // More Zip
 val t1: Int *: Long *: Tuple = (1, 2l, 100, 200)

--- a/tests/pos/i12277.scala
+++ b/tests/pos/i12277.scala
@@ -1,0 +1,18 @@
+def foo(f: => () => Unit): Unit = ???
+def boo(f: [A] => () => Unit): Unit = ???
+
+object test:
+  foo { () =>  // okay
+    println(1)
+    println(2)
+  }
+
+  boo { [A] => () => // error
+    println(1)
+    println(2)
+  }
+
+  boo { [A] => () => { // okay
+    println(1)
+    println(2)
+  }}


### PR DESCRIPTION
Also refactor grammar so that polymorphic lambdas and regular lambdas have the same
level of precedence.

Fixes #12277