### PR TITLE
Fix #12278: Also tryNormalize LazyRefs

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2816,6 +2816,8 @@ object Types {
     private var myRef: Type = null
     private var computed = false
 
+    override def tryNormalize(using Context): Type = ref.tryNormalize
+
     def ref(using Context): Type =
       if computed then
         if myRef == null then

--- a/tests/pos/12278.scala
+++ b/tests/pos/12278.scala
@@ -1,0 +1,16 @@
+import scala.compiletime.ops.int.*
+
+object Test {
+  type Fib[N <: Int] <: Int = N match {
+    case 0 => 0
+    case 1 => 1
+    case Any => Fib[N - 1] + Fib[N - 2]
+  }
+  val fib0: Fib[0] = 0
+  val fib1: Fib[1] = 1
+  val fib2: Fib[2] = 1
+  val fib3: Fib[3] = 2
+  val fib4: Fib[4] = 3
+  val fib5: Fib[5] = 5
+  val fib6: Fib[6] = 8
+}


### PR DESCRIPTION
Prior to this PR, LazyRefs were left untouched by `tryNormalize` but did get mapped over in `Type.simplified`. If acceptable, I think this is the simplest solution. Alternatively I tried to turn `Type.simplified` into a fix point computation, but that turned out to be quite complicated...