### PR TITLE
Fix #12267: Constraints should not cross phases 

### DIFF
--- a/bench/profiles/stdlib.yml
+++ b/bench/profiles/stdlib.yml
@@ -1,0 +1,15 @@
+charts:
+
+    - name: "scala stdlib-2.13"
+      url: https://github.com/dotty-staging/scala/commits/stdLib213-dotty-community-build
+      lines:
+        - key: stdlib213
+          label: bootstrapped
+
+scripts:
+
+    stdlib213:
+        - source $PROG_HOME/dotty/bench/scripts/stdlib213
+
+config:
+    pr_base_url: "https://github.com/lampepfl/dotty/pull/"

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -202,7 +202,16 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
           Stats.trackTime(s"$phase ms ") {
             val start = System.currentTimeMillis
             val profileBefore = profiler.beforePhase(phase)
+
+            // invariant: constraint should not cross phase boundary
+            ctx.typerState.constraint = OrderingConstraint.empty
+
             units = phase.runOn(units)
+
+            // force instantiate tvars
+            // see tests/pos/t2619b.scala
+            ctx.typerState.gc()
+
             profiler.afterPhase(phase, profileBefore)
             if (ctx.settings.Xprint.value.containsPhase(phase))
               for (unit <- units)

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -204,13 +204,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
             val profileBefore = profiler.beforePhase(phase)
 
             // invariant: constraint should not cross phase boundary
-            ctx.typerState.constraint = OrderingConstraint.empty
-
-            units = phase.runOn(units)
-
-            // force instantiate tvars
-            // see tests/pos/t2619b.scala
-            ctx.typerState.gc()
+            ctx.typerState.ensureClosedConstraint { units = phase.runOn(units) }
 
             profiler.afterPhase(phase, profileBefore)
             if (ctx.settings.Xprint.value.containsPhase(phase))

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -204,7 +204,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
             val profileBefore = profiler.beforePhase(phase)
 
             // invariant: constraint should not cross phase boundary
-            ctx.typerState.ensureClosedConstraint { units = phase.runOn(units) }
+            ctx.typerState.ensureSegregated { units = phase.runOn(units) }
 
             profiler.afterPhase(phase, profileBefore)
             if (ctx.settings.Xprint.value.containsPhase(phase))

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -159,5 +159,18 @@ class TyperState() {
     s"TS[${ids(this).mkString(", ")}]"
   }
 
+  /** Execute the operation with an empty constraint and make sure no leak
+   *  of constraints.
+   *
+   *  Side effect: the method will reset the constraint associated with the context.
+   */
+  def ensureClosedConstraint[T](op: => T)(using Context): T =
+    this.constraint = OrderingConstraint.empty
+    val res = op
+    // force instantiate tvars
+    // see tests/pos/t2619b.scala
+    ctx.typerState.gc()
+    res
+
   def stateChainStr: String = s"$this${if (previous == null) "" else previous.stateChainStr}"
 }

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -164,7 +164,7 @@ class TyperState() {
    *
    *  Side effect: the method will reset the constraint associated with the context.
    */
-  def ensureClosedConstraint[T](op: => T)(using Context): T =
+  def ensureSegregated[T](op: => T)(using Context): T =
     this.constraint = OrderingConstraint.empty
     val res = op
     // force instantiate tvars

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4019,7 +4019,14 @@ object Types {
       case tycon: TypeRef if tycon.symbol.isOpaqueAlias =>
         tycon.translucentSuperType.applyIfParameterized(args)
       case _ =>
-        tryNormalize.orElse(superType)
+        val x = tryNormalize
+        if x.exists then
+          record("try norm OK")
+          record(i"try norm OK $x")
+          x
+        else
+          record("try norm KO")
+          superType
     }
 
     inline def map(inline op: Type => Type)(using Context) =
@@ -4038,6 +4045,9 @@ object Types {
       case tycon: TypeRef =>
         def tryMatchAlias = tycon.info match {
           case MatchAlias(alias) =>
+            record(i"try match alias")
+            record(i"try match alias $this in ${ctx.owner.ownersIterator.toList}%, %")
+            //new Error().printStackTrace()
             trace(i"normalize $this", typr, show = true) {
               MatchTypeTrace.recurseWith(this) {
                 alias.applyIfParameterized(args).tryNormalize

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -9,7 +9,7 @@ import collection.mutable
 
 @sharable object Stats {
 
-  final val enabled = false
+  final val enabled = true
 
   var monitored: Boolean = false
 

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -9,7 +9,7 @@ import collection.mutable
 
 @sharable object Stats {
 
-  final val enabled = true
+  final val enabled = false
 
   var monitored: Boolean = false
 

--- a/tests/pos/t2619b.scala
+++ b/tests/pos/t2619b.scala
@@ -1,0 +1,8 @@
+abstract class AbstractModule
+
+object ModuleBE extends AbstractModule
+object ModuleBF extends AbstractModule
+
+object ModuleBM extends AbstractModule {
+    def ms: List[AbstractModule] = List(ModuleBE) ::: List(ModuleBF)
+}


### PR DESCRIPTION
Use these changes to compile the stdlib. You need to comment out AnyVal.scala and then
use the following command on community-projects/stdLib213:

    scalac -Ydetailed-stats *.scala */*.scala */*/*.scala */*/*/*.scala

What I see is:

Calls to `translucentSuperType` 53152:

    try norm KO -> 53086
    try norm OK -> 66

The only computationally relevant part of this are calls to tryMatchAlias

    try match alias -> 528

Those calls suceed in 66 cases

    try norm OK -> 66

The successful normalizations all return types like this:

    try norm OK F[T1] *: scala.Tuple.Map[(T2, T3, T4, T5, T6, T7, T8), F] -> 3

Now it could be that trying the normalizations is costly, or that the normalized types
cause exhaustivity checking to explode. Tht remains to be found out.