### PR TITLE
Fix #11146: Don't re-add root imports to context in REPLFrontEnd

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
+++ b/compiler/src/dotty/tools/repl/ReplFrontEnd.scala
@@ -4,7 +4,6 @@ package repl
 import dotc.typer.FrontEnd
 import dotc.CompilationUnit
 import dotc.core.Contexts._
-import dotc.typer.ImportInfo.withRootImports
 
 /** A customized `FrontEnd` for the REPL
  *
@@ -19,7 +18,7 @@ private[repl] class REPLFrontEnd extends FrontEnd {
   override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] = {
     assert(units.size == 1) // REPl runs one compilation unit at a time
     val unit = units.head
-    val unitContext = ctx.fresh.setCompilationUnit(unit).withRootImports
+    val unitContext = ctx.fresh.setCompilationUnit(unit)
     enterSyms(using unitContext)
     typeCheck(using unitContext)
     List(unit)

--- a/compiler/test-resources/repl/i11146
+++ b/compiler/test-resources/repl/i11146
@@ -1,0 +1,25 @@
+scala> class Appendable { def foo = println("Appendable.foo") }
+// defined class Appendable
+
+scala> (new Appendable).foo
+Appendable.foo
+
+scala> def assert(x: Boolean) = println(if x then "not asserted" else "asserted")
+def assert(x: Boolean): Unit
+
+scala> assert(false)
+asserted
+
+scala> class Option; object Option { val baz = 42 }
+// defined class Option
+// defined object Option
+
+scala> Option.baz
+val res0: Int = 42
+
+scala> object fs2 { class Stream[T] { override def toString = "fs2.Stream(..)" }; object Stream { def apply[T](x: T) = new Stream[T] }}
+// defined object fs2
+
+scala> import fs2.Stream
+scala> Stream(1)
+val res1: fs2.Stream[Int] = fs2.Stream(..)


### PR DESCRIPTION
The root context for REPL compiler runs is initialized by `ReplCompiler#newRun`,
which contains special handling to:

  1. first add the default root imports (`java.lang._`, `scala._`, `Predef._`)
  2. then import each previous REPL wrapper in order (incl. its imports)

The result is the innermost context imports the most recent REPL wrapper
and the (nearly) outermost contexts contain the default imports.

Before this commit, the default root imports were also being added to the
(innermost) context in `REPLFrontEnd#runOn`, resulting in REPL definitions
being shadowed by those in `java.lang._`, `scala._` and `Predef._`

The context before this PR as seen by the frontend would look something like the below (this is after two previous lines of REPL input.)  Note the undesirable imports of `java.lang._`, `scala._` and `Predef._` in the innermost contexts.

```
Context(
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@619c93ca, import = import Predef.{...}, implicits = ...
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@619c93ca, import = import scala.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@619c93ca, import = import java.lang.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@619c93ca, import = import rs$line$2.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@619c93ca, import = import rs$line$2.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@619c93ca, import = import rs$line$2.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@619c93ca, import = import rs$line$1.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@3b2c4a8b, import = import rs$line$1.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@3b2c4a8b, import = import Predef.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@7f2c57fe, import = import Predef.{...}, implicits = ...
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@7f2c57fe, import = import scala.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@7f2c57fe, import = import java.lang.{...}
  owner = module class <root>, scope = dotty.tools.dotc.core.Scopes$MutableScope@7f2c57fe, import =
  owner = val <none>, scope = dotty.tools.dotc.core.Scopes$MutableScope@43935e9c, import =
  owner = val <none>, scope = null, import =
  owner = val <none>, scope = null, import =
  owner = val <none>, scope = null, import =
  owner = val <none>, scope = null, import =
  owner = val <none>, scope = null, import = )
```

Fixes #11146 
Fixes #9720