### PR TITLE
Avoid necessaryEither because it could constrain too much

### DIFF
--- a/tests/pos/i12306.scala
+++ b/tests/pos/i12306.scala
@@ -1,0 +1,22 @@
+class Record(elems: Map[String, Any]) extends Selectable:
+  val fields = elems.toMap
+  def selectDynamic(name: String): Any = fields(name)
+
+extension [A <: Record] (a:A) {
+  def join[B <: Record] (b:B): A & B = {
+    Record(a.fields ++ b.fields).asInstanceOf[A & B]
+  }
+}
+
+type Person = Record { val name: String; val age: Int }
+type Child = Record { val parent: String }
+type PersonAndChild = Record { val name: String; val age: Int; val parent: String }
+
+@main def hello = {
+  val person = Record(Map("name" -> "Emma", "age" -> 42)).asInstanceOf[Person]
+  val child = Record(Map("parent" -> "Alice")).asInstanceOf[Child]
+  //val personAndChild = person.join(child)
+
+  //val v1: PersonAndChild = personAndChild
+  val v2: PersonAndChild = person.join(child)
+}


### PR DESCRIPTION
In a comparison A & B <: C { x: D, y: E }

we cannot reduce the problem in a sound way to necessaryEither. Example:

    A = C { x: D }
    B is a constrainable type variable

Here, the strongest constraint that follows from `A & B <: C { x: D, y: E }` is

    B <: C { y: E }

But necessaryEither would give in this case

    B <: C { x: D, y: E }

Fixes #12306

But a better fix could be to decompose the refinement type on the right into its constituents and
run a necessaryEither for both `A & B <: C { x: D }` and `A & B <: C { y: E }`