### PR TITLE
Treat Refinements more like AndTypes

### DIFF
--- a/tests/pos/i12306.scala
+++ b/tests/pos/i12306.scala
@@ -1,0 +1,22 @@
+class Record(elems: Map[String, Any]) extends Selectable:
+  val fields = elems.toMap
+  def selectDynamic(name: String): Any = fields(name)
+
+extension [A <: Record] (a:A) {
+  def join[B <: Record] (b:B): A & B = {
+    Record(a.fields ++ b.fields).asInstanceOf[A & B]
+  }
+}
+
+type Person = Record { val name: String; val age: Int }
+type Child = Record { val parent: String }
+type PersonAndChild = Record { val name: String; val age: Int; val parent: String }
+
+@main def hello = {
+  val person = Record(Map("name" -> "Emma", "age" -> 42)).asInstanceOf[Person]
+  val child = Record(Map("parent" -> "Alice")).asInstanceOf[Child]
+  val personAndChild = person.join(child)
+
+  val v1: PersonAndChild = personAndChild
+  val v2: PersonAndChild = person.join(child)
+}

--- a/tests/pos/i12306.scala
+++ b/tests/pos/i12306.scala
@@ -1,7 +1,8 @@
 class Record(elems: Map[String, Any]) extends Selectable:
   val fields = elems.toMap
   def selectDynamic(name: String): Any = fields(name)
-
+object Record:
+  def apply(elems: Map[String, Any]): Record = new Record(elems)
 extension [A <: Record] (a:A) {
   def join[B <: Record] (b:B): A & B = {
     Record(a.fields ++ b.fields).asInstanceOf[A & B]


### PR DESCRIPTION
Fixes #12306

When comparing with an AndType on the left and a RefinedType on the right,
decompose the right hand side into an AndType of types that have a single
refinement each. This makes sure we lose the least possible information in the
necessary subsequent `either` call.

This is a much better fix than #12316. 
