### PR TITLE
Don't let caseLambda bindings accumulate in constraint

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2879,7 +2879,9 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
       if (provablyEmpty(scrut))
         NoType
       else
-        recur(cases)
+        val savedConstraint = constraint
+        try recur(cases)
+        finally constraint = savedConstraint // caseLambda additions are dropped
     }
   }
 }

--- a/tests/neg/6697.check
+++ b/tests/neg/6697.check
@@ -1,0 +1,14 @@
+-- [E057] Type Mismatch Error: tests/neg/6697.scala:6:35 ---------------------------------------------------------------
+6 |  type Copy[O <: Off] = Of[Sup[O], Sub[O]]  // error
+  |                                   ^
+  |                                   Type argument Test.Sub[O] does not conform to upper bound Test.Sup[O]
+  |
+  |                                   Note: a match type could not be fully reduced:
+  |
+  |                                     trying to reduce  Test.Sub[O]
+  |                                     failed since selector  O
+  |                                     matches none of the cases
+  |
+  |                                       case Test.Of[sup, sub] => sub
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/6697.scala
+++ b/tests/neg/6697.scala
@@ -3,5 +3,5 @@ object Test {
   case class Of[sup, sub <: sup]() extends Off
   type Sup[O <: Off] = O match { case Of[sup, sub] => sup }
   type Sub[O <: Off] = O match { case Of[sup, sub] => sub }
-  type Copy[O <: Off] = Of[Sup[O], Sub[O]]
+  type Copy[O <: Off] = Of[Sup[O], Sub[O]]  // error
 }

--- a/tests/neg/9107.scala
+++ b/tests/neg/9107.scala
@@ -1,0 +1,14 @@
+trait M[F[_]]
+trait Inv[T]
+
+object Test {
+  def ev[X] = implicitly[
+    (X match { case Inv[t] => Int }) =:=
+    (X match { case Inv[t] => t })
+  ] // error
+
+  def ev2[X] = implicitly[
+    (M[[t] =>> runtime.MatchCase[Inv[t], Int]])  =:=
+    (M[[t] =>> runtime.MatchCase[Inv[t], t]])
+  ] // error
+}


### PR DESCRIPTION
Remove them when a `matchCases` has finished.

Fixes #9107
