### PR TITLE
Rename `reflect.Type { memberXyz => xyzMember }`

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2475,12 +2475,14 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
         def declaredFields: List[Symbol] = self.unforcedDecls.filter(isField)
 
-        def memberField(name: String): Symbol =
+        def memberField(name: String): Symbol = fieldMember(name)
+        def fieldMember(name: String): Symbol =
           appliedTypeRef(self).allMembers.iterator.map(_.symbol).find {
             sym => isField(sym) && sym.name.toString == name
           }.getOrElse(dotc.core.Symbols.NoSymbol)
 
-        def memberFields: List[Symbol] =
+        def memberFields: List[Symbol] = fieldMembers
+        def fieldMembers: List[Symbol] =
           appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
             case sym if isField(sym) => sym.asTerm
           }.toList
@@ -2495,12 +2497,14 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
             case sym if isMethod(sym) => sym.asTerm
           }.toList
 
-        def memberMethod(name: String): List[Symbol] =
+        def memberMethod(name: String): List[Symbol] = methodMember(name)
+        def methodMember(name: String): List[Symbol] =
           appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
             case sym if isMethod(sym) && sym.name.toString == name => sym.asTerm
           }.toList
 
-        def memberMethods: List[Symbol] =
+        def memberMethods: List[Symbol] = methodMembers
+        def methodMembers: List[Symbol] =
           appliedTypeRef(self).allMembers.iterator.map(_.symbol).collect {
             case sym if isMethod(sym) => sym.asTerm
           }.toList
@@ -2515,10 +2519,12 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
             case sym if sym.isType => sym.asType
           }.toList
 
-        def memberType(name: String): Symbol =
+        def memberType(name: String): Symbol = typeMember(name)
+        def typeMember(name: String): Symbol =
           self.unforcedDecls.find(sym => sym.name == name.toTypeName)
 
-        def memberTypes: List[Symbol] =
+        def memberTypes: List[Symbol] = typeMembers
+        def typeMembers: List[Symbol] =
           self.unforcedDecls.filter(_.isType)
 
         def declarations: List[Symbol] =

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3578,10 +3578,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def declaredFields: List[Symbol]
 
         /** Get named non-private fields declared or inherited */
+        // TODO: deprecate in 3.1.0 and remove @experimental from fieldMember
+        // @deprecated("Use fieldMember", "3.1")
         def memberField(name: String): Symbol
 
+        /** Get named non-private fields declared or inherited */
+        @experimental
+        def fieldMember(name: String): Symbol
+
         /** Get all non-private fields declared or inherited */
+        // TODO: deprecate in 3.1.0 and remove @experimental from fieldMembers
+        // @deprecated("Use fieldMembers", "3.1")
         def memberFields: List[Symbol]
+
+        /** Get all non-private fields declared or inherited */
+        @experimental
+        def fieldMembers: List[Symbol]
 
         /** Get non-private named methods defined directly inside the class */
         def declaredMethod(name: String): List[Symbol]
@@ -3590,10 +3602,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def declaredMethods: List[Symbol]
 
         /** Get named non-private methods declared or inherited */
+        // TODO: deprecate in 3.1.0 and remove @experimental from methodMember
+        // @deprecated("Use methodMember", "3.1")
         def memberMethod(name: String): List[Symbol]
 
+        /** Get named non-private methods declared or inherited */
+        @experimental
+        def methodMember(name: String): List[Symbol]
+
         /** Get all non-private methods declared or inherited */
+        // TODO: deprecate in 3.1.0 and remove @experimental from methodMembers
+        // @deprecated("Use methodMembers", "3.1")
         def memberMethods: List[Symbol]
+
+        /** Get all non-private methods declared or inherited */
+        @experimental
+        def methodMembers: List[Symbol]
 
         /** Get non-private named methods defined directly inside the class */
         def declaredType(name: String): List[Symbol]
@@ -3602,10 +3626,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def declaredTypes: List[Symbol]
 
         /** Type member with the given name directly declared in the class */
+        // TODO: deprecate in 3.1.0 and remove @experimental from typeMember
+        // @deprecated("Use typeMember", "3.1")
         def memberType(name: String): Symbol
 
+        /** Type member with the given name directly declared in the class */
+        @experimental
+        def typeMember(name: String): Symbol
+
         /** Type member directly declared in the class */
+        // TODO: deprecate in 3.1.0 and remove @experimental from typeMembers
+        // @deprecated("Use typeMembers", "3.1")
         def memberTypes: List[Symbol]
+
+        /** Type member directly declared in the class */
+        @experimental
+        def typeMembers: List[Symbol]
 
         /** All members directly declared in the class */
         def declarations: List[Symbol]

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -5,9 +5,21 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 object MiMaFilters {
   val Library: Seq[ProblemFilter] = Seq(
     // New APIs marked @experimental in 3.0.1
+    exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.fieldMember"),
+    exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.fieldMembers"),
+    exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.methodMember"),
+    exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.methodMembers"),
+    exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.typeMember"),
+    exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.typeMembers"),
     exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TermParamClauseMethods.isErased"),
-    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TermParamClauseMethods.isErased"),
-    exclude[MissingClassProblem]("scala.annotation.internal.ErasedParam"),
     exclude[MissingClassProblem]("scala.annotation.experimental"),
+    exclude[MissingClassProblem]("scala.annotation.internal.ErasedParam"),
+    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.fieldMember"),
+    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.fieldMembers"),
+    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.methodMember"),
+    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.methodMembers"),
+    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.typeMember"),
+    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.typeMembers"),
+    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TermParamClauseMethods.isErased"),
   )
 }


### PR DESCRIPTION
Avoid ambigouity between `Type.memberType` and `Symbol.memberType`

Add replacements
* `memberField` -> `fieldMember`
* `memberFields` -> `fieldMembers`
* `memberMethod` -> `methodMember`
* `memberMethods` -> `methodMembers`
* `memberType` -> `typeMember`
* `memberTypes` -> `typeMembers`

Closes #12299