### PR TITLE
Allow constraining GADTs from above with unions

### DIFF
--- a/tests/pos/gadt-union-instantiation.scala
+++ b/tests/pos/gadt-union-instantiation.scala
@@ -1,0 +1,22 @@
+object Test {
+  trait C
+  trait D extends C
+  trait E extends C
+  trait F extends C
+  trait G extends C
+
+  sealed trait Expr[T]
+  case class FooExpr() extends Expr[D | E]
+
+  object Test {
+    def foo[T](x: Expr[T]): T = x match {
+      case x: FooExpr =>
+        val d : D | E = new D {}
+        val t : T = d
+        val d1: D | E = t
+        d
+    }
+
+    val x: D | E = foo(FooExpr())
+  }
+}


### PR DESCRIPTION
Before this PR, if we had type comparison like A <: T | S, we would handle T|S
before even considering if we can record GADT cstrs for A. This makes no sense,
as we don't do that for normal type variables.

To do that, we actually needed to add a jump from thirdTry to fourthTry, as this
comment explains:

```
    // If we can GADT-constrain tp1 AND we can't normal-constrain tp2,
    // jump to fourthTry (where we constrain tp1). We can't do that in
    // secondTry, since there we _need_ to handle tp1:NamedType before
    // handling tp2:TypeParamRef.
```