### PR TITLE
Print infix types as infix

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package printing
 
 import core._
@@ -166,13 +167,17 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       ~ " "
       ~ toText(appType.resultType)
 
-    def isInfixType(tp: Type): Boolean = tp match {
+    def isInfixType(tp: Type): Boolean = tp match
       case AppliedType(tycon, args) =>
-        args.length == 2 &&
-        tycon.typeSymbol.getAnnotation(defn.ShowAsInfixAnnot).map(_.argumentConstant(0).forall(_.booleanValue))
-          .getOrElse(!Character.isUnicodeIdentifierStart(tycon.typeSymbol.name.toString.head))
+        args.length == 2
+        && {
+          val sym = tycon.typeSymbol
+          sym.is(Infix)
+          || sym.getAnnotation(defn.ShowAsInfixAnnot)
+              .exists(_.argumentConstant(0).forall(_.booleanValue))
+          || !Character.isUnicodeIdentifierStart(tycon.typeSymbol.name.toString.head)
+        }
       case _ => false
-    }
 
     def tyconName(tp: Type): Name = tp.typeSymbol.name
     def checkAssocMismatch(tp: Type, isRightAssoc: Boolean) = tp match {

--- a/compiler/test-resources/type-printer/infix
+++ b/compiler/test-resources/type-printer/infix
@@ -40,7 +40,7 @@ def foo: Int Mappy Boolean && String
 scala> @scala.annotation.showAsInfix(false) class ||[T,U]
 // defined class ||
 scala> def foo: Int || Boolean = ???
-def foo: ||[Int, Boolean]
+def foo: Int || Boolean
 scala> def foo: Int && Boolean & String = ???
 def foo: Int && Boolean & String
 scala> def foo: (Int && Boolean) & String = ???

--- a/tests/neg/print-infix-type.check
+++ b/tests/neg/print-infix-type.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/print-infix-type.scala:8:29 ---------------------------------------------------
+8 |  val x: over[String, Int] = f // error
+  |                             ^
+  |                             Found:    Int over String
+  |                             Required: String over Int
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/print-infix-type.scala
+++ b/tests/neg/print-infix-type.scala
@@ -1,0 +1,8 @@
+object A:
+
+  opaque infix type over[A, B] = (A, B)
+  def f: over[Int, String] = (1, "")
+
+object B:
+  import A.*
+  val x: over[String, Int] = f // error


### PR DESCRIPTION
No showAsInfix annotation needed for them to be printed in infix form.