### PR TITLE
Fix #11939: Set up MiMa for scala3-interfaces in scala3-library.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,10 @@ jobs:
           ./project/scripts/sbt ";scala3-bootstrapped/compile ;scala3-bootstrapped/test;sjsSandbox/run;sjsSandbox/test;sjsJUnitTests/test;sjsCompilerTests/test ;sbt-test/scripted scala2-compat/* ;configureIDE ;stdlib-bootstrapped/test:run ;stdlib-bootstrapped-tasty-tests/test"
           ./project/scripts/bootstrapCmdTests
 
+      - name: MiMa
+        run: |
+          ./project/scripts/sbt ";scala3-interfaces/mimaReportBinaryIssues ;scala3-library-bootstrapped/mimaReportBinaryIssues ;scala3-library-bootstrappedJS/mimaReportBinaryIssues"
+
   test_windows_fast:
     runs-on: [self-hosted, Windows]
     if: "(

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -1,0 +1,13 @@
+
+import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.core.ProblemFilters._
+
+object MiMaFilters {
+  val Library: Seq[ProblemFilter] = Seq(
+    // New APIs marked @experimental in 3.0.1
+    exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TermParamClauseMethods.isErased"),
+    exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TermParamClauseMethods.isErased"),
+    exclude[MissingClassProblem]("scala.annotation.internal.ErasedParam"),
+    exclude[MissingClassProblem]("scala.annotation.experimental"),
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.13")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.0")


### PR DESCRIPTION
This already detects a couple things that break the backward source compatibility guarantee. They are excluded in `project/MiMaFilters.scala`. They should be reverted before we publish 3.0.1, or we should jump straight to 3.1.0.