### PR TITLE
Fix #12361: Handle MacroTree from ill-formed code

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2724,6 +2724,7 @@ class Typer extends Namer
           case tree: untpd.Quote => typedQuote(tree, pt)
           case tree: untpd.Splice => typedSplice(tree, pt)
           case tree: untpd.TypSplice => typedTypSplice(tree, pt)
+          case tree: untpd.MacroTree => report.error("Unexpected macro", tree.srcPos); tpd.nullLiteral  // ill-formed code may reach here
           case _ => typedUnadapted(desugar(tree), pt, locked)
         }
 

--- a/tests/fuzzy/07b22d72e723607d8f0dfef3f4c8fb8076387a7b.scala
+++ b/tests/fuzzy/07b22d72e723607d8f0dfef3f4c8fb8076387a7b.scala
@@ -1,0 +1,1 @@
+val a = macro ??? // error

--- a/tests/neg/i12361.scala
+++ b/tests/neg/i12361.scala
@@ -1,0 +1,3 @@
+object Test {
+    foo = macro Impls . foo [ U ] +=    // error  // error
+}


### PR DESCRIPTION
Fix #12361: Handle MacroTree from ill-formed code
