### PR TITLE
Fix #12337: Enable exhaustivity check for case classes with checkable components

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -228,7 +228,7 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
       resKind
     }
 
-    def genPrimitiveOp(tree: Apply, expectedType: BType): BType = tree match {
+    def genPrimitiveOp(tree: Apply, expectedType: BType): BType = (tree: @unchecked) match {
       case Apply(fun @ DesugaredSelect(receiver, _), _) =>
       val sym = tree.symbol
 
@@ -610,7 +610,7 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
       }
     }
 
-    def genTypeApply(t: TypeApply): BType = t match {
+    def genTypeApply(t: TypeApply): BType = (t: @unchecked) match {
       case TypeApply(fun@DesugaredSelect(obj, _), targs) =>
 
         val sym = fun.symbol

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSyncAndTry.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSyncAndTry.scala
@@ -27,7 +27,7 @@ trait BCodeSyncAndTry extends BCodeBodyBuilder {
    */
   abstract class SyncAndTryBuilder(cunit: CompilationUnit) extends PlainBodyBuilder(cunit) {
 
-    def genSynchronized(tree: Apply, expectedType: BType): BType = tree match {
+    def genSynchronized(tree: Apply, expectedType: BType): BType = (tree: @unchecked) match {
       case Apply(TypeApply(fun, _), args) =>
       val monitor = locals.makeLocal(ObjectReference, "monitor", defn.ObjectType, tree.span)
       val monCleanup = new asm.Label

--- a/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
@@ -121,7 +121,7 @@ class StringInterpolatorOpt extends MiniPhase {
       (sym.name == nme.f && sym.eq(defn.StringContext_f)) ||
       (sym.name == nme.s && sym.eq(defn.StringContext_s))
     if (isInterpolatedMethod)
-      tree match {
+      (tree: @unchecked) match {
         case StringContextIntrinsic(strs: List[Literal], elems: List[Tree]) =>
           val stri = strs.iterator
           val elemi = elems.iterator

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -990,7 +990,7 @@ trait Applications extends Compatibility {
      *     { val xs = es; e' = e' + args }
      */
     def typedOpAssign(using Context): Tree = {
-      val (lhs1, name, rhss) = tree match
+      val (lhs1, name, rhss) = (tree: @unchecked) match
         case Apply(Select(lhs, name), rhss) => (typedExpr(lhs), name, rhss)
         case Apply(untpd.TypedSplice(Select(lhs1, name)), rhss) => (lhs1, name, rhss)
       val liftedDefs = new mutable.ListBuffer[Tree]

--- a/tests/neg-custom-args/isInstanceOf/enum-approx2.scala
+++ b/tests/neg-custom-args/isInstanceOf/enum-approx2.scala
@@ -5,5 +5,6 @@ class Test {
   def eval(e: Fun[Int, Int]) = e match {
     case Fun(x: Fun[Int, Double]) => ???          // error
     case Fun(x: Exp[Int => String]) => ???        // error
+    case _ =>
   }
 }

--- a/tests/patmat/i12337.check
+++ b/tests/patmat/i12337.check
@@ -1,1 +1,2 @@
 8: Pattern Match Exhaustivity: Foo(Inactive)
+17: Pattern Match Exhaustivity: Foo(Status.Active(_))

--- a/tests/patmat/i12337.check
+++ b/tests/patmat/i12337.check
@@ -1,0 +1,1 @@
+8: Pattern Match Exhaustivity: Foo(Inactive)

--- a/tests/patmat/i12337.scala
+++ b/tests/patmat/i12337.scala
@@ -1,0 +1,12 @@
+sealed trait Status
+object Status {
+  case object Active   extends Status
+  case object Inactive extends Status
+}
+
+case class Foo(status: Status)
+def bar(user: Foo): Unit = user match {
+  case Foo(Status.Active) =>
+    println("active")
+    // no compile-time warning for missing Status.Inactive case
+}

--- a/tests/patmat/i12337.scala
+++ b/tests/patmat/i12337.scala
@@ -1,12 +1,26 @@
 sealed trait Status
 object Status {
-  case object Active   extends Status
+  case class Active(since: Int) extends Status
   case object Inactive extends Status
 }
 
 case class Foo(status: Status)
-def bar(user: Foo): Unit = user match {
-  case Foo(Status.Active) =>
-    println("active")
-    // no compile-time warning for missing Status.Inactive case
+def bar(foo: Foo): Unit = foo match {
+  case Foo(Status.Active(since)) =>
+    println(s"active since $since")
 }
+// Expected:
+// warning: match may not be exhaustive.
+// It would fail on the following input: Foo(Inactive)
+// def bar(foo: Foo): Unit = foo match {
+
+def baz(foo: Foo): Unit = foo match {
+  case Foo(Status.Active(2000)) =>
+    println("active since 2000")
+  case Foo(Status.Inactive) =>
+    println("inactive")
+}
+// Expected:
+// warning: match may not be exhaustive.
+// It would fail on the following input: Foo(Active((x: Int forSome x not in 2000)))
+// def baz(foo: Foo): Unit = foo match {


### PR DESCRIPTION
Fix #12337: Enable exhaustivity check for case classes with checkable components

This aligns with Scala 2 behavior.