### PR TITLE
Fix #12385 - MessageRendering.explanation may have duplicate EOL Chars

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -138,7 +138,7 @@ trait MessageRendering {
           |${Blue("===========").show}""".stripMargin
     )
     sb.append(EOL).append(m.explanation)
-    if (m.explanation.lastOption != Some(EOL)) sb.append(EOL)
+    if (!m.explanation.endsWith(EOL)) sb.append(EOL)
     sb.toString
   }
 


### PR DESCRIPTION
Fix #12385 - MessageRendering.explanation may have duplicate EOL Chars