### PR TITLE
GADTs: consider singletons when checking invariant refinement

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -196,6 +196,7 @@ trait PatternTypeConstrainer { self: TypeComparer =>
    */
   def constrainSimplePatternType(patternTp: Type, scrutineeTp: Type, widenParams: Boolean): Boolean = {
     def refinementIsInvariant(tp: Type): Boolean = tp match {
+      case tp: SingletonType => true
       case tp: ClassInfo => tp.cls.is(Final) || tp.cls.is(Case)
       case tp: TypeProxy => refinementIsInvariant(tp.underlying)
       case _ => false

--- a/tests/pos/i12390-gadt.scala
+++ b/tests/pos/i12390-gadt.scala
@@ -1,0 +1,9 @@
+enum Func[-A, +B] {
+  case Double extends Func[Int, Int]
+  case ToString extends Func[Float, String]
+
+  def run: A => B = this match {
+    case Double => (x: Int) => x * 2
+    case ToString => (x: Float) => x.toString
+  }
+}


### PR DESCRIPTION
We need to consider singleton types as well when checking for invariant refinement.

Fixes #12390.