### PR TITLE
Fix #12405 - workaround for fragile jline3 console detection in REPL

### DIFF
--- a/dist/bin/common
+++ b/dist/bin/common
@@ -162,7 +162,6 @@ JLINE_TERMINAL_JNA=$(find_lib "*jline-terminal-jna-3*")
 
 # jna-5 only appropriate for some combinations
 [[ ${conemu-} && ${msys-} ]] || JNA=$(find_lib "*jna-5*")
-#echo "conemu[${conemu}] msys[$msys] cygwin[$cygwin] JNA[$JNA]" 1>&2
 
 compilerJavaClasspathArgs () {
   # echo "dotty-compiler: $DOTTY_COMP"

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -159,8 +159,10 @@ SBT_INTF=$(find_lib "*compiler-interface*")
 JLINE_READER=$(find_lib "*jline-reader-3*")
 JLINE_TERMINAL=$(find_lib "*jline-terminal-3*")
 JLINE_TERMINAL_JNA=$(find_lib "*jline-terminal-jna-3*")
-[[ ${conemu-} ]] || JNA=$(find_lib "*jna-5*")
 
+# jna-5 only appropriate for some combinations
+[[ ${conemu-} && ${msys-} ]] || JNA=$(find_lib "*jna-5*")
+#echo "conemu[${conemu}] msys[$msys] cygwin[$cygwin] JNA[$JNA]" 1>&2
 
 compilerJavaClasspathArgs () {
   # echo "dotty-compiler: $DOTTY_COMP"

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -67,8 +67,10 @@ if [ "$PROG_NAME" == "$ScriptingMain" ]; then
   scripting_string="-script $target_script ${scripting_args[@]}"
 fi
 
-# exec here would prevent onExit from being called, leaving terminal in unusable state
 [ -n "$script_trace" ] && set -x
+[ -z "${ConEmuPID-}" -o -n "${cygwin-}" ] && export MSYSTEM= PWD= # workaround for #12405
+
+# exec here would prevent onExit from being called, leaving terminal in unusable state
 eval "\"$JAVACMD\"" \
    ${JAVA_OPTS:-$default_java_opts} \
    "${java_args[@]}" \


### PR DESCRIPTION
This fixes 2 issues:

1. add workaround for console detection issues (see #12405)
2. refine the handling of `JNA` classpath variable for various combinations of `ConEmu` and `shell`

In `Windows Console`, these `REPL` combinations are made fully functional:

```sc
MINGW64_NT-10.0-19042 d5 3.1.7-340.x86_64 2020-11-08 12:32 UTC x86_64 Msys
MINGW32_NT-10.0-19042 d5 3.1.7-340.x86_64 2020-11-08 12:32 UTC x86_64 Msys
MSYS_NT-10.0-19042 d5 3.1.7-340.x86_64 2020-11-08 12:32 UTC x86_64 Msys
CYGWIN_NT-10.0 d5 3.2.0(0.340/5/3) 2021-03-29 08:42 x86_64 Cygwin
```

In `ConEmu`, these are fully functional:
```sc
MINGW64_NT-10.0-19042 d5 3.1.7-340.x86_64 2020-10-23 13:08 UTC x86_64 Msys
CYGWIN_NT-10.0 d5 3.2.0(0.340/5/3) 2021-03-29 08:42 x86_64 Cygwin
```

In `mintty`, cygwin64 is fully functional
```sc
CYGWIN_NT-10.0 d5 3.2.0(0.340/5/3) 2021-03-29 08:42 x86_64 Cygwin
```

Some other combinations are partially functional (arrow keys don't work).
