### PR TITLE
Fix #12408: Parameterized classes should be applied for prefix inference

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -769,7 +769,8 @@ object TypeOps:
             this(tref)
           else {
             prefixTVar = WildcardType  // prevent recursive call from assigning it
-            prefixTVar = newTypeVar(TypeBounds.upper(this(tref)))
+            val tref2 = this(tref.applyIfParameterized(tref.typeParams.map(_ => TypeBounds.empty)))
+            prefixTVar = newTypeVar(TypeBounds.upper(tref2))
             prefixTVar
           }
         case tp => mapOver(tp)

--- a/tests/patmat/i12408.check
+++ b/tests/patmat/i12408.check
@@ -1,0 +1,2 @@
+13: Pattern Match Exhaustivity: A(_), C(_)
+21: Pattern Match

--- a/tests/patmat/i12408.scala
+++ b/tests/patmat/i12408.scala
@@ -1,0 +1,24 @@
+class X[T] {
+  sealed trait P
+
+  case class A(id: Long)          extends P
+  case class B(id: Long, x: Long) extends P
+  case class C(id: Long)          extends P
+
+  def m(p: P): Unit = p match {
+    case B(_, x) =>
+    case _       =>
+  }
+
+  def n(p: P): Unit = p match {
+    case B(_, x) =>
+  }
+
+  def o(p: P): Unit = p match {
+    case A(_)    =>
+    case B(_, x) =>
+    case C(_)    =>
+    case _       =>
+  }
+
+}


### PR DESCRIPTION
Fix #12408: Parameterized classes should be applied for prefix inference