### PR TITLE
Uninline diagnostic position before passing it into xsbti.Reporter

### DIFF
--- a/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
@@ -30,7 +30,7 @@ final public class DelegatingReporter extends AbstractReporter {
 
   public void doReport(Diagnostic dia, Context ctx) {
     Severity severity = severityOf(dia.level());
-    Position position = positionOf(dia.pos());
+    Position position = positionOf(dia.pos().nonInlined());
 
     Message message = dia.msg();
     StringBuilder rendered = new StringBuilder();


### PR DESCRIPTION
Originally was found in https://github.com/scalameta/metals/issues/2769 .
Without this fix, metals receives diagnostic that points into the wrong source file