### PR TITLE
update indentation.md: fix flags `-` prefix

### DIFF
--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -403,7 +403,7 @@ end IndentWidth
 
 ### Settings and Rewrites
 
-Significant indentation is enabled by default. It can be turned off by giving any of the options `-no-indent`, `old-syntax` and `language:Scala2`. If indentation is turned off, it is nevertheless checked that indentation conforms to the logical program structure as defined by braces. If that is not the case, the compiler issues a warning.
+Significant indentation is enabled by default. It can be turned off by giving any of the options `-no-indent`, `-old-syntax` and `-language:Scala2`. If indentation is turned off, it is nevertheless checked that indentation conforms to the logical program structure as defined by braces. If that is not the case, the compiler issues a warning.
 
 The Scala 3 compiler can rewrite source code to indented code and back.
 When invoked with options `-rewrite -indent` it will rewrite braces to


### PR DESCRIPTION
Also, looks like `-language:Scala2` doesn't disable indentation-based-syntax.
For example, this is compiled fine and prints `123123123`:
```scala
@main
def main1(): Unit = {
  def foo() =
    println(1)
    println(2)
    println(3)

  foo()
  foo()
  foo()
}
```