### PR TITLE
Disallow experimental CB projects on release builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,6 +221,11 @@ jobs:
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
+      - name: Disable experimental features on release
+        if: "github.event_name == 'push'
+            && startsWith(github.event.ref, 'refs/tags/')"
+        run: echo "DISALLOW_EXPERIMENTAL_FEATURES=true" >> $GITHUB_ENV
+
       - name: Test
         run: |
           git submodule sync
@@ -264,6 +269,11 @@ jobs:
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
+      - name: Disable experimental features on release
+        if: "github.event_name == 'push'
+            && startsWith(github.event.ref, 'refs/tags/')"
+        run: echo "DISALLOW_EXPERIMENTAL_FEATURES=true" >> $GITHUB_ENV
+
       - name: Test
         run: |
           git submodule sync
@@ -306,6 +316,11 @@ jobs:
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
+
+      - name: Disable experimental features on release
+        if: "github.event_name == 'push'
+            && startsWith(github.event.ref, 'refs/tags/')"
+        run: echo "DISALLOW_EXPERIMENTAL_FEATURES=true" >> $GITHUB_ENV
 
       - name: Test
         run: |

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -11,7 +11,7 @@ lazy val compilerVersion: String =
   new String(Files.readAllBytes(file), UTF_8)
 
 lazy val compilerSupportExperimental: Boolean =
-  compilerVersion.contains("SNAPSHOT") || compilerVersion.contains("NIGHTLY")
+  sys.env.get("DISALLOW_EXPERIMENTAL_FEATURES") != Some("true")
 
 lazy val sbtPluginFilePath: String =
   // Workaround for https://github.com/sbt/sbt/issues/4395


### PR DESCRIPTION
Previous mechanism for this inferred experimental capabilities
from the version of the compiler (SNAPSHOT or NIGHTLY permits
experimental). However this doesn't work in practice:
the version of the compiler is set by CI to a stable version only
when publish task is executed (not when test tasks are executed).
If we set the version as stable for community build as well,
the community projects will not be able to resolve it as they operate
against the locally published snapshot and not the official stable
release version.

Hence this solution adds another env var specifically to track
experimental features allowance.