### PR TITLE
sbt-dotty: Fix the binary suffix used for publishing

### DIFF
--- a/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
+++ b/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala
@@ -264,7 +264,7 @@ object DottyPlugin extends AutoPlugin {
       scalaBinaryVersion := {
         scalaVersion.value.split("[\\.-]").toList match {
           case "0" :: minor :: _ => s"0.$minor"
-          case "3" :: "0" :: "0" :: milestone :: _ =>
+          case "3" :: "0" :: "0" :: milestone :: _ if milestone.startsWith("M") || milestone.startsWith("RC") =>
             s"3.0.0-$milestone"
           case "3" :: _ =>
             "3"


### PR DESCRIPTION
The compiler we publish is compiled with a non-bootstrapped compiler, so
its scalaBinaryVersion suffix is computed from the version number of the
non-bootstrapped compiler, for 3.0.0-RC3 this was
`3.0.0-RC3-nonboostrapped` and we correctly return `3.0.0-RC3` as a
binary version, but for 3.0.0 this is `3.0.0-nonbootstrapped` for which
we return again `3.0.0-nonbootstrapped` when we really want just `3`.
This is why we incorrectly published https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3.0.0-nonbootstrapped/

Fixed by special-casing RCs and milestones which are the only special
suffixes that get their own binary suffix.

This fix is specific to the release-3.0.0 branch since the master branch
does not use sbt-dotty anymore (and will need its own fix to publish
3.0.1-RC1 correctly due to a different issue with how sbt computes
the suffix for `3.0.1-RC1-nonbootstrapped`).