### PR TITLE
Rename documentation references of 'compilation unit' to 'source file'.

### DIFF
--- a/docs/docs/reference/other-new-features/open-classes.md
+++ b/docs/docs/reference/other-new-features/open-classes.md
@@ -72,7 +72,7 @@ to mock classes in tests, or to apply temporary patches that add features or fix
 
 ### Relationship with `sealed`
 
-A class that is neither `abstract` nor `open` is similar to a `sealed` class: it can still be extended, but only in the same compilation unit. The difference is what happens if an extension of the class is attempted in another compilation unit. For a `sealed` class, this is an error, whereas for a simple non-open class, this is still permitted provided the `adhocExtensions` feature is enabled, and it gives a warning otherwise.
+A class that is neither `abstract` nor `open` is similar to a `sealed` class: it can still be extended, but only in the same source file. The difference is what happens if an extension of the class is attempted in another source file. For a `sealed` class, this is an error, whereas for a simple non-open class, this is still permitted provided the `adhocExtensions` feature is enabled, and it gives a warning otherwise.
 
 ### Migration
 

--- a/docs/docs/usage/language-versions.md
+++ b/docs/docs/usage/language-versions.md
@@ -21,7 +21,7 @@ The default Scala language version currently supported by the Dotty compiler is 
 There are two ways to specify a language version.
 
  - With a `-source` command line setting, e.g. `-source 3.0-migration`.
- - With a `scala.language` import at the top of a compilation unit, e.g:
+ - With a `scala.language` import at the top of a source file, e.g:
 
 ```scala
 package p
@@ -30,5 +30,5 @@ import scala.language.`future-migration`
 class C { ... }
 ```
 
-Language imports supersede command-line settings in the compilation units where they are specified. Only one language import specifying a source version is allowed in a compilation unit, and it must come before any definitions in that unit.
+Language imports supersede command-line settings in the source files where they are specified. Only one language import specifying a source version is allowed in a source file, and it must come before any definitions in that file.
 


### PR DESCRIPTION
This includes everything under the /docs folder and nothing else: sources and scaladoc still refer to 'compilation unit'