### PR TITLE
Compute debug messages lazily in safe init

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Util.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Util.scala
@@ -10,13 +10,14 @@ import config.Printers.Printer
 import annotation.tailrec
 
 object Util {
-  def traceIndented(msg: String, printer: Printer)(using Context): Unit =
+  def traceIndented(msg: => String, printer: Printer)(using Context): Unit =
     printer.println(s"${ctx.base.indentTab * ctx.base.indent} $msg")
 
-  def traceOp(msg: String, printer: Printer)(op: => Unit)(using Context): Unit = {
-    traceIndented(s"==> ${msg}", printer)
+  def traceOp(msg: => String, printer: Printer)(op: => Unit)(using Context): Unit = {
+    lazy val computedMsg = msg // Make sure we only compute msg once
+    traceIndented(s"==> ${computedMsg}", printer)
     op
-    traceIndented(s"<== ${msg}", printer)
+    traceIndented(s"<== ${computedMsg}", printer)
   }
 
   extension (symbol: Symbol) def hasSource(using Context): Boolean =


### PR DESCRIPTION
I noticed that a significant amount of time was spent pretty-printing
Strings that were never displayed when compiling scalatest in the
community-build, fixed by making the message parameter of traceIndented
and traceOp by-name, just like printer.println itself already is.