### PR TITLE
Fix #12485: Avoid cycles in testing feasibility of exhaustivity check

### DIFF
--- a/tests/patmat/i12485.scala
+++ b/tests/patmat/i12485.scala
@@ -1,0 +1,4 @@
+case class A(a: A)
+
+def foo(x: A) = x match
+  case A(a) =>


### PR DESCRIPTION
Fix #12485: Avoid cycles in testing feasibility of exhaustivity check

This is a regression introduced in #12377.