### PR TITLE
Properly re-own type variables when merging constraints

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -162,6 +162,11 @@ abstract class Constraint extends Showable {
    */
   def & (other: Constraint, otherHasErrors: Boolean)(using Context): Constraint
 
+  /** Whether `tl` is present in both `this` and `that` but is associated with
+   *  different TypeVars there, meaning that the constraints cannot be merged.
+   */
+  def hasConflictingTypeVarsFor(tl: TypeLambda, that: Constraint): Boolean
+
   /** Check that no constrained parameter contains itself as a bound */
   def checkNonCyclic()(using Context): this.type
 

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -493,6 +493,12 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         merge(this.upperMap, that.upperMap, mergeParams))
   }.showing(i"constraint merge $this with $other = $result", constr)
 
+  def hasConflictingTypeVarsFor(tl: TypeLambda, that: Constraint): Boolean =
+    contains(tl) && that.contains(tl) &&
+    // Since TypeVars are allocated in bulk for each type lambda, we only have
+    // to check the first one to find out if some of them are different.
+    (this.typeVarOfParam(tl.paramRefs(0)) ne that.typeVarOfParam(tl.paramRefs(0)))
+
   def subst(from: TypeLambda, to: TypeLambda)(using Context): OrderingConstraint =
     def swapKey[T](m: ArrayValuedMap[T]) = m.remove(from).updated(to, m(from))
     var current = newConstraint(swapKey(boundsMap), swapKey(lowerMap), swapKey(upperMap))

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -159,7 +159,7 @@ class TyperState() {
    *  in this constraint and its predecessors where necessary.
    */
   def ensureNotConflicting(other: Constraint)(using Context): Unit =
-    val conflicting = constraint.domainLambdas.find(constraint.hasConflictingTypeVarsFor(_, other))
+    val conflicting = constraint.domainLambdas.filter(constraint.hasConflictingTypeVarsFor(_, other))
     for tl <- conflicting do
       val tl1 = constraint.ensureFresh(tl)
       for case (tvar: TypeVar, pref1) <- tl.paramRefs.map(constraint.typeVarOfParam).lazyZip(tl1.paramRefs) do

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -979,8 +979,10 @@ trait Implicits:
       val result =
         result0 match {
           case result: SearchSuccess =>
-            result.tstate.commit()
-            ctx.gadt.restore(result.gstate)
+            if result.tstate ne ctx.typerState then
+              result.tstate.commit()
+            if result.gstate ne ctx.gadt then
+              ctx.gadt.restore(result.gstate)
             if hasSkolem(false, result.tree) then
               report.error(SkolemInInferred(result.tree, pt, argument), ctx.source.atSpan(span))
             implicits.println(i"success: $result")


### PR DESCRIPTION
The documentation for myOwnedVars used to say that it could contain
already instantiated variables because "weak references can have
spurious nulls" but I think that's incorrect: the documentation of
WeakReference makes no mention of spurious nulls, the object it
references should only be replaced by null if it cannot be reached
through a non-weak reference. Instead I believe the issue was that
`mergeConstraintWith` did not set the `owningState` of type variables
that it now owns.