### PR TITLE
Fix #12507: Scala.js: Mangle param names in closures.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -3041,7 +3041,7 @@ class JSCodeGen()(using genCtx: Context) {
     val formalAndActualCaptures = allCaptureValues.map { value =>
       implicit val pos = value.span
       val (formalIdent, originalName) = value match {
-        case Ident(name) => (freshLocalIdent(name.toString), OriginalName(name.toString))
+        case Ident(name) => (freshLocalIdent(name.toTermName), OriginalName(name.toString))
         case This(_)     => (freshLocalIdent("this"), thisOriginalName)
         case _           => (freshLocalIdent(), NoOriginalName)
       }
@@ -3069,7 +3069,7 @@ class JSCodeGen()(using genCtx: Context) {
 
     val formalAndActualParams = formalParamNames.lazyZip(formalParamTypes).lazyZip(formalParamRepeateds).map {
       (name, tpe, repeated) =>
-        val formalParam = js.ParamDef(freshLocalIdent(name.toString),
+        val formalParam = js.ParamDef(freshLocalIdent(name),
             OriginalName(name.toString), jstpe.AnyType, mutable = false)
         val actualParam =
           if (repeated) genJSArrayToVarArgs(formalParam.ref)(tree.sourcePos)

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -27,6 +27,14 @@ class RegressionTestScala3 {
     assertEquals("foo", new RangeErrorIssue11592("foo").message)
     assertEquals("", new RangeErrorIssue11592().message)
   }
+
+  @Test def testNonJVMCharsInClosureParametersIssue12507(): Unit = {
+    def foo(`[-3, 3]`: Int): Int => Int = { x =>
+      `[-3, 3]`
+    }
+
+    assertEquals(5, foo(5)(4))
+  }
 }
 
 object RegressionTestScala3 {


### PR DESCRIPTION
Instead of calling `name.toString`, we use the overload of
`freshLocalIdent` that takes a `TermName`, already used elsewhere,
and which correctly calls `mangledString`.