### PR TITLE
Sort implicits with a proper comparison function

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1806,6 +1806,11 @@ object SymDenotations {
     def baseClasses(implicit onBehalf: BaseData, ctx: Context): List[ClassSymbol] =
       baseData._1
 
+    /** Like `baseClasses.length` but more efficient. */
+    def baseClassesLength(using BaseData, Context): Int =
+      // `+ 1` because the baseClassSet does not include the current class unlike baseClasses
+      baseClassSet.classIds.length + 1
+
     /** A bitset that contains the superId's of all base classes */
     private def baseClassSet(implicit onBehalf: BaseData, ctx: Context): BaseClassSet =
       baseData._2


### PR DESCRIPTION
Before this commit, we sorted implicits using `prefer` which relied on
`compareOwner`, but compareOwner does not induce a total ordering: just
because `compareOwner(x, y) == 0` does not mean that `compareOwner(x,
z)` and `compareOwner(y, z)` have the same sign, this violates the
contract of `java.util.Comparator#compare` and lead to an
IllegalArgumentException sometimes being thrown (although I wasn't able
to reproduce that, see #12479)

This commit fixes by this by replacing the usage of `compareOwner` by a
new `compareBaseClassesLength` which does induce a total ordering while
still hopefully approximating `compareOwner` well enough for our
purposes.

We also replace `prefer` which returned a Boolean by `compareEligibles`
which is directly usable as an Ordering we can pass to `sorted`, this is
more efficient than using `sortWith(prefer)` because the latter might end
up calling `prefer` twice for a single comparison.

Fixes #12479 (I hope).