### PR TITLE
Add dark/light theme swapper, make light theme less harsh, and some other small style changes

### DIFF
--- a/docs/css/dottydoc.css
+++ b/docs/css/dottydoc.css
@@ -43,7 +43,7 @@ ul.post-list {
 
 /* headings anchors */
 a.anchor {
-  color: white;
+  color: transparent;
   margin-left: -23px;
   padding-right: 3px;
   transition: color .4s ease-out;

--- a/scaladoc/resources/dotty_res/scripts/theme.js
+++ b/scaladoc/resources/dotty_res/scripts/theme.js
@@ -1,0 +1,33 @@
+;(function () {
+  const supportsLocalStorage = (() => {
+    try {
+      localStorage.setItem('test', 'test');
+      localStorage.removeItem('test');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  })();
+
+  function toggleDarkTheme(isDark) {
+    currentlyDark = isDark
+    // this triggers the `:root.theme-dark` rule from scalastyle.css,
+    // which changes the values of a bunch of CSS color variables
+    document.documentElement.classList.toggle("theme-dark", isDark);
+    supportsLocalStorage && localStorage.setItem("use-dark-theme", isDark);
+  }
+
+  /* This needs to happen ASAP so we don't get a FOUC of bright colors before the dark theme is applied */
+  const initiallyDark = supportsLocalStorage && (localStorage.getItem("use-dark-theme") === "true");
+  let currentlyDark = initiallyDark;
+  toggleDarkTheme(initiallyDark);
+
+  /* Wait for the DOM to be loaded before we try to attach event listeners to things in the DOM */
+  window.addEventListener("DOMContentLoaded", () => {
+    const themeToggler = document.querySelector('#theme-toggle input');
+    themeToggler.checked = !currentlyDark;
+    themeToggler.addEventListener("change", e => {
+      toggleDarkTheme(!e.target.checked);
+    });
+  });
+})();

--- a/scaladoc/resources/dotty_res/styles/filter-bar.css
+++ b/scaladoc/resources/dotty_res/styles/filter-bar.css
@@ -1,6 +1,6 @@
 .documentableFilter {
   padding: 24px 12px;
-  background-color: var(--leftbar-bg);
+  background-color: var(--code-bg);
 }
 
 .documentableFilter.active .filterToggleButton svg {
@@ -26,13 +26,13 @@
 }
 
 .filterToggleButton svg {
-  fill: var(--code-bg);
+  fill: var(--body-fg);
   transition: fill 0.1s ease-in, transform 0.1s ease-in-out;
 }
 
 .filterToggleButton:hover svg,
 .filterToggleButton:focus svg {
-  fill: var(--active-tab-color);
+  fill: var(--active-fg);
 }
 
 .filterableInput {
@@ -41,7 +41,7 @@
   outline: 0;
   border: 0;
   border-radius: 3px;
-  background-color: var(--code-bg);
+  background-color: var(--body-bg);
 }
 
 .filterLowerContainer {
@@ -50,12 +50,11 @@
 }
 
 .filterGroup {
-  display: flex;
   margin-bottom: 16px;
 }
 
 .filterList {
-  margin-left: 10px;
+  margin: 0.5em;
 }
 
 .filterButtonItem {
@@ -66,12 +65,12 @@
   outline: 0;
   border: 0;
   border-radius: 3px;
-  color: var(--leftbar-bg);
-  background-color: var(--code-bg);
+  color: var(--inactive-fg);
+  background-color: var(--inactive-bg);
   font-size: 12px;
   font-weight: 700;
   cursor: pointer;
-  border-bottom: 2px solid var(--inactive-fg);
+  border-bottom: 2px solid var(--inactive-bg-shadow);
   transition: all 0.1s ease-in;
 }
 
@@ -81,9 +80,9 @@
 }
 
 .filterButtonItem.active {
-  color: var(--code-bg);
-  border-bottom-color: var(--link-fg);
-  background-color: var(--active-tab-color);
+  color: var(--active-fg);
+  border-bottom-color: var(--active-bg-shadow);
+  background-color: var(--active-bg);
 }
 
 .filterButtonItem.visible {
@@ -91,17 +90,19 @@
 }
 
 .groupTitle {
-  min-width: 98px;
-  margin-top: 4px;
+  margin-bottom: 4px;
   font-weight: 700;
-  font-size: 14px;
-  color: var(--code-bg);
+  color: var(--body-fg);
+}
+.groupTitle > span {
+  display: inline-block;
+  vertical-align: baseline;
 }
 
 .groupButtonsContainer {
-  display: flex;
-  align-items: center;
-  margin-top: 4px;
+  display: inline-block;
+  vertical-align: baseline;
+  margin-left: 1em;
 }
 
 .selectAll {
@@ -114,8 +115,8 @@
   border: 0;
   background-color: transparent;
   padding: 0;
-  color: var(--code-bg);
-  font-size: 8px;
+  color: var(--active-fg);
+  font-size: 0.7em;
   cursor: pointer;
   transition: all 0.1s ease-in;
 }
@@ -123,7 +124,7 @@
 .selectAll {
   padding: 4px;
   border-radius: 2px;
-  background-color: var(--active-tab-color);
+  background-color: var(--active-bg);
 }
 
 .selectAll:hover,
@@ -133,5 +134,5 @@
 
 .deselectAll:hover,
 .deselectAll:focus {
-  color: var(--active-tab-color);
+  color: var(--active-bg);
 }

--- a/scaladoc/resources/dotty_res/styles/nord-light.css
+++ b/scaladoc/resources/dotty_res/styles/nord-light.css
@@ -1,14 +1,37 @@
 /* Theme inspired by nordtheme. The colors have been darkened to work on light backgrounds. */
+:root {
+  --hljs-bg: var(--code-bg);
+  --hljs-fg: var(--code-fg);
+  --hljs-comment: #90A1C1;
+  --hljs-doctag: #4B6B92;
+  --hljs-meta: hsl(40, 100%, 40%);
+  --hljs-subst: hsl(40, 100%, 40%);
+  --hljs-title: hsl(193, 60%, 42%);
+  --hljs-type: hsl(179, 61%, 30%);
+  --hljs-keyword: hsl(213, 60%, 45%);
+  --hljs-string: hsl(92, 46%, 43%);
+  --hljs-literal: hsl(311, 30%, 47%);
+}
+:root.theme-dark {
+  --hljs-meta: hsl(40, 100%, 49%);
+  --hljs-subst: hsl(40, 100%, 49%);
+  --hljs-title: hsl(193, 60%, 58%);
+  --hljs-keyword: hsl(213, 60%, 60%);
+  --hljs-type: hsl(179, 61%, 45%);
+  --hljs-string: hsl(92, 46%, 68%);
+  --hljs-literal: hsl(311, 30%, 62%);
+}
+
 pre, .hljs {
-  background: #F4F5FA;
-  color: #4C566A;
+  background: var(--hljs-bg);
+  color: var(--code-fg);
 }
 
 .hljs-comment {
-  color: #90A1C1;
+  color: var(--hljs-comment);
 }
 .hljs-doctag {
-  color: #4B6B92;
+  color: var(--hljs-doctag);
   font-weight: 500;
 }
 .hljs-emphasis {
@@ -19,26 +42,26 @@ pre, .hljs {
 }
 
 .hljs-meta {
-  color: #F9A600;
+  color: var(--hljs-meta);
   font-weight: 500;
 }
 .hljs-subst {
-  color: #F9A600;
+  color: var(--hljs-subst);
 }
 .hljs-title {
-  color: #2B8FAC;
+  color: var(--hljs-title);
   font-weight: 500;
 }
 .hljs-type {
-  color: #1E7C7A;
+  color: var(--hljs-type);
 }
 .hljs-keyword {
-  color: #2E6BB8;
+  color: var(--hljs-keyword);
   font-weight: 500;
 }
 .hljs-string {
-  color: #6AA13B;
+  color: var(--hljs-string);
 }
 .hljs-built_in, .hljs-number, .hljs-literal {
-  color: #9D5490;
+  color: var(--hljs-literal);
 }

--- a/scaladoc/resources/dotty_res/styles/scalastyle.css
+++ b/scaladoc/resources/dotty_res/styles/scalastyle.css
@@ -5,26 +5,35 @@
   --border-light: #DADFE6;
   --border-medium: #abc;
 
-  --code-bg: #F4F5FA;
-  --symbol-fg: #333;
+  --body-bg: #eee;
+  --body-fg: #333;
+  --title-fg: hsl(200, 80%, 30%);
+
+  --active-bg: var(--leftbar-current-bg);
+  --active-bg-shadow: hsl(200, 38%, 50%);
+  --active-fg: var(--body-fg);
+
+  --inactive-bg: #bbb;
+  --inactive-bg-shadow: var(--inactive-fg);
+  --inactive-fg: #777;
+
+  --code-bg: hsl(200, 10%, 90%);
+  --code-fg: #4C566A;
+  --symbol-fg: var(--body-fg);
   --link-fg: #00607D;
   --link-hover-fg: #00A0D0;
-  --inactive-fg: #777;
-  --title-fg: #00485E;
 
   --link-sig-fd: #2da0d1;
   --link-sig-hover-fd: #7c99a5;
 
-  --leftbar-bg: #003048;
-  --leftbar-fg: #fff;
-  --leftbar-current-bg: #0090BB;
+  --leftbar-bg: hsl(200, 65%, 75%);
+  --leftbar-fg: #333;
+  --leftbar-current-bg: hsl(200, 80%, 65%);
   --leftbar-current-fg: #fff;
-  --leftbar-hover-bg: #00485E;
-  --leftbar-hover-fg: #fff;
-  --logo-fg: var(--leftbar-fg);
+  --leftbar-hover-bg: hsl(200, 65%, 65%);
+  --leftbar-hover-fg: #333;
 
   --icon-color: #00485E;
-  --active-tab-color: #00A0D0;
   --selected-fg: #00303E;
   --selected-bg: #BFE7F3;
 
@@ -39,12 +48,54 @@
   --content-padding: 24px 42px;
   --footer-height: 42px;
 }
+:root.theme-dark {
+  /* Color Settings */
+  --border-light: #DADFE6;
+  --border-medium: #abc;
+
+  --body-bg: hsl(200, 100%, 3%);
+  --body-fg: #CCC;
+  --title-fg: hsl(200, 50%, 80%);
+
+  --active-bg: hsl(200, 80%, 25%);
+  --active-bg-shadow: hsl(200, 38%, 50%);
+  --active-fg: var(--body-fg);
+
+  --inactive-bg: #444;
+  --inactive-bg-shadow: var(--inactive-fg);
+  --inactive-fg: #777;
+
+  --code-bg: hsl(200, 30%, 10%);
+  --code-fg: #bfbfbf;
+  --symbol-fg: var(--body-fg);
+  --link-fg: hsl(200, 100%, 70%);
+  --link-hover-fg: #00A0D0;
+
+  --link-sig-fd: #2da0d1;
+  --link-sig-hover-fd: #7c99a5;
+
+  --leftbar-bg: hsl(200, 100%, 14%);
+  --leftbar-fg: #CCC;
+  --leftbar-current-bg: hsl(200, 100%, 35%);
+  --leftbar-current-fg: #CCC;
+  --leftbar-hover-bg: hsl(200, 80%, 25%);
+  --leftbar-hover-fg: #CCC;
+
+  --icon-color: #00485E;
+  --selected-fg: #00303E;
+  --selected-bg: #BFE7F3;
+
+}
 
 body {
   margin: 0;
   padding: 0;
   font-family: "Lato", sans-serif;
   font-size: 16px;
+  background: var(--body-bg);
+}
+body, button, input {
+  color: var(--body-fg);
 }
 
 /* Page layout */
@@ -273,7 +324,7 @@ th {
 .section-tab[data-active=""] {
   color: unset;
   font-weight: bold;
-  border-bottom: 2px solid var(--active-tab-color);
+  border-bottom: 2px solid var(--active-bg);
 }
 .tabs-section-body > :not([data-active]) {
   display: none;
@@ -462,6 +513,67 @@ footer .pull-right {
   margin-left: auto;
 }
 
+/* Theme Toggle */
+.switch {
+  /* The switch - the box around the slider */
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+  margin-bottom: 0;
+}
+.switch input {
+  /* Hide default HTML checkbox */
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.switch .slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 34px;
+  background-color: #ccc;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+}
+.switch .slider:before {
+  position: absolute;
+  content: "🌘";
+  height: 40px;
+  width: 40px;
+  line-height:40px;
+  font-size:20px;
+  text-align: center;
+  left: 0px;
+  bottom: 4px;
+  top: 0;
+  bottom: 0;
+  border-radius: 50%;
+  margin: auto 0;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  box-shadow: 0 0px 15px #2020203d;
+
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.switch input:checked + .slider {
+  background-color: hsl(200, 80%, 65%); /* --active-bg, but not affected by the theme */
+}
+.switch input:focus + .slider {
+  box-shadow: 0 0 1px #2196f3;
+}
+.switch input:checked + .slider:before {
+  content: "🌞";
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background: white;
+}
 
 .documentableElement .modifiers {
   display: table-cell;
@@ -492,7 +604,7 @@ footer .pull-right {
 }
 
 .documentableElement .signature {
-  color: #5a5a5a;
+  color: var(--code-fg);
   display: table-cell;
   white-space: pre-wrap;
 }
@@ -515,7 +627,8 @@ footer .pull-right {
   font-weight: 500;
   font-size: 12px;
   background: var(--code-bg);
-  border: 0.25em solid white;
+  border-left: 0.25em solid transparent;
+  margin: 0.25em;
 }
 
 .documentableElement>div {
@@ -551,11 +664,11 @@ footer .pull-right {
 
 .documentableElement:hover {
   cursor: pointer;
-  border-left: 0.25em solid var(--leftbar-bg);
+  border-left-color: var(--active-bg);
 }
 
 .expand.documentableElement {
-  border-left: 0.25em solid var(--leftbar-bg);
+  border-left-color: var(--active-bg);
 }
 .documentableElement .annotations {
   color: gray;
@@ -598,7 +711,7 @@ footer .pull-right {
 .tabs .names .tab.selected {
   color: unset;
   font-weight: bold;
-  border-bottom: 2px solid var(--active-tab-color);
+  border-bottom: 2px solid var(--active-bg);
 }
 
 .tabs .names {
@@ -630,6 +743,9 @@ footer .pull-right {
   height: 5.7em;
   width: 5.7em;
   color:transparent;
+}
+.theme-dark .micon {
+  filter: brightness(120%);
 }
 
 .micon.c {

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -130,6 +130,10 @@ class HtmlRenderer(rootPackage: Member, val members: Map[DRI, Member])(using ctx
       case _ =>
         memberResourcesPaths
 
+    val earlyResources = page.content match
+      case t: ResolvedTemplate => if t.hasFrame then earlyMemberResourcePaths else Nil
+      case _ => earlyMemberResourcePaths
+
     head(
       meta(charset := "utf-8"),
       meta(util.HTML.name := "viewport", content := "width=device-width, initial-scale=1"),
@@ -140,7 +144,8 @@ class HtmlRenderer(rootPackage: Member, val members: Map[DRI, Member])(using ctx
         `type` := "image/x-icon",
         href := resolveLink(page.link.dri, "favicon.ico")
       ),
-      linkResources(page.link.dri, resources).toList,
+      linkResources(page.link.dri, earlyResources, deferJs = false).toList,
+      linkResources(page.link.dri, resources, deferJs = true).toList,
       script(raw(s"""var pathToRoot = "${pathToRoot(page.link.dri)}";"""))
     )
 
@@ -249,6 +254,10 @@ class HtmlRenderer(rootPackage: Member, val members: Map[DRI, Member])(using ctx
               span(cls:="icon-vertical_align_top"),
               raw("&nbsp;Back to top")
             )
+          ),
+          label(id := "theme-toggle", cls := "switch")(
+            input(`type` := "checkbox"),
+            span(cls := "slider")
           ),
           div(cls := "socials")(
             if hasSocialLinks then Seq(raw("Social links&nbsp;")) else Nil,

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -38,7 +38,7 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
 
   private def dottyRes(path: String) = Resource.Classpath(path, s"dotty_res/$path")
 
-  def linkResources(dri: DRI, resources: Iterable[String]): Iterable[AppliedTag] =
+  def linkResources(dri: DRI, resources: Iterable[String], deferJs: Boolean): Iterable[AppliedTag] =
     def fileExtension(url: String): String =
       val param = url.indexOf('?')
       val end = if param < 0 then url.length else param
@@ -48,8 +48,13 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
     for res <- resources yield
       fileExtension(res) match
         case "css" => link(rel := "stylesheet", href := resolveLink(dri, res))
-        case "js" => script(`type` := "text/javascript", src := resolveLink(dri, res), defer := "true")
+        case "js" => script(`type` := "text/javascript", src := resolveLink(dri, res), if (deferJs) Seq(defer := "true") else Nil)
         case _ => raw("")
+
+  val earlyMemberResources: Seq[Resource] =
+    List(
+      "scripts/theme.js"
+    ).map(dottyRes)
 
   val memberResources: Seq[Resource] =
     val fromResources = List(
@@ -85,7 +90,7 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
 
   val searchDataPath = "scripts/searchData.js"
   val memberResourcesPaths = Seq(searchDataPath) ++ memberResources.map(_.path)
-
+  val earlyMemberResourcePaths = earlyMemberResources.map(_.path)
 
   def searchData(pages: Seq[Page]) =
     def flattenToText(signature: Signature): String =
@@ -124,7 +129,7 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
     Resource.Text(searchDataPath, s"pages = ${jsonList(entries)};")
 
 
-  def allResources(pages: Seq[Page]): Seq[Resource] = memberResources ++ Seq(
+  def allResources(pages: Seq[Page]): Seq[Resource] = earlyMemberResources ++ memberResources ++ Seq(
     dottyRes("favicon.ico"),
     dottyRes("fonts/dotty-icons.woff"),
     dottyRes("fonts/dotty-icons.ttf"),

--- a/scaladoc/src/dotty/tools/scaladoc/util/html.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/util/html.scala
@@ -65,6 +65,7 @@ object HTML:
   val svg = Tag("svg")
   val button = Tag("button")
   val input = Tag("input")
+  val label = Tag("label")
   val script = Tag("script")
   val link = Tag("link")
   val footer = Tag("footer")


### PR DESCRIPTION
Aims to address #12525 

The highlights:

- Add a dark theme.
  - Added a switch next to the "back to top" link to swap between dark and light mode.
- Adjusted colors for the default (light) theme.
  - The sidebar is now a much lighter shade of the original color, with dark text/foreground.
  - Use a light shade of gray instead of pure white for the background, and a dark shade of gray instead of pure black for the foreground (text).
  - Use HSL notation for the highlighter colors, so it's easier to tell the difference between the "dark" and "light" versions (for the most part it's a difference of about 15% on the "L" channel)
  - Slightly tweaked the syntax highlighting colors. I thought the orange used for string-interpolated expressions was too bright so I darkened it a tiny bit. Also converted the hljs-related css color constants to variables in order to play nice with theme swapping.
  - Tweaked the appearance of the filtering widget.
    - The buttons now become gray when disabled instead of white. 
    - Made the select/deselect button text larger (it was so small as to be unreadable, before). Moved those buttons to be inline with their associated "title" text, which makes things work better when there's less horizontal space to work with.
    - Made the section background the same color as the member backgrounds (gray) instead of the sidebar color, which I think works better for both dark/light themes.
    - Made the `>` icon match the body text color instead of the blue "active" color since that seemed to work better for both dark/light themes.
- Cleaned up the border style on the member blocks. If you look closely at the original docs, the colored left border pokes out beyond the top/bottom of the blocks, like you're seeing just the left chunk of a picture frame. That was due to the margin between the blocks being implemented as a border. By using an actual `margin` to separate the blocks, and only setting `border-left`, you don't get the little spikes.

# Before
![image](https://user-images.githubusercontent.com/1355958/119234200-a18e9b00-bafa-11eb-956c-da941697fec5.png)

# After
![image](https://user-images.githubusercontent.com/1355958/119234234-cedb4900-bafa-11eb-8a84-a8ea9a6d53fd.png)

# Dark
![image](https://user-images.githubusercontent.com/1355958/119234250-e1558280-bafa-11eb-8781-55c49e7d7f97.png)

# Syntax Highlighting Before/After/Dark
![image](https://user-images.githubusercontent.com/1355958/119234683-28dd0e00-bafd-11eb-8d13-aceb57d141d9.png)
![image](https://user-images.githubusercontent.com/1355958/119234815-c8020580-bafd-11eb-9c31-675ea4f42cd7.png)
![image](https://user-images.githubusercontent.com/1355958/119234819-d4865e00-bafd-11eb-8993-ee597d45e920.png)

I don't claim to be an expert in making choosing colors, but I think this is an improvement. My methodology was to start with the original sidebar color, which was `hsl(200deg 100% 14%)` aka `#003047`, keep that hue, and adjust the saturation/lightness values to make sure the overall theme was relatively cohesive.

One caveat about the dark theme is that the footer doesn't swap colors due to image-related difficulties. The "social links" icons are hard-coded to either black or white, and the Scala3doc logo is black, so making the footer dark would just make them harder to see. I briefly experimented with a CSS solution for the social icons, using `background-image: url(...)`, but then realized that the approach wouldn't work with `Custom` icons (since the background-images needed to be hard-coded in the CSS). Eventually I decided not to have the footer swap from light to dark with the theme. As for the icons in the sidebar, the white icons seem to work just fine in either theme.

For the theme swapper, I'm making it work by toggling a `class` attribute on the `<html>` element, and setting up a `:root.theme-dark` selector in scalastyle.css to override the color variables. I had to make some changes in the "backend" since it was hard-coded to set `defer="true"` on all scripts in the header, but in order to avoid a very jarring <abbr title="Flash of Unstyled Content">FOUC</abbr> on page load, where you see the light theme before the script runs and swaps to dark theme, I had to make sure the "theme.js" runs ASAP, by omitting the `defer` attribute.

