### PR TITLE
Use the correct scalaBinaryVersion for releases

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -123,7 +123,11 @@ object Build {
     else
       baseVersion + "-bin-SNAPSHOT"
   }
-  val dottyNonBootstrappedVersion = dottyVersion + "-nonbootstrapped"
+  val dottyNonBootstrappedVersion = {
+    // Make sure sbt always computes the scalaBinaryVersion correctly
+    val bin = if (!dottyVersion.contains("-bin")) "-bin" else ""
+    dottyVersion + bin + "-nonbootstrapped"
+  }
 
   val sbtCommunityBuildVersion = "0.1.0-SNAPSHOT"
 


### PR DESCRIPTION
Previously, the non-bootstrapped 3.0.1-RC1 would have had version
`3.0.1-nonbootstrapped` for which sbt would compute the binary version
`3.0.1-nonbootstrapped` since we publish a compiler compiled with that
version, this is the binary version that would have ended up on Maven.

Fixed by instead making sure the non-bootstrapped release version is
`3.0.1-bin-nonbootstrapped` which sbt will interpret correctly.