### PR TITLE
handle export forwarders in Scala.js

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -105,8 +105,6 @@ final class JSDefinitions()(using Context) {
   @threadUnsafe lazy val ExposedJSMemberAnnotType: TypeRef = requiredClassRef("scala.scalajs.js.annotation.internal.ExposedJSMember")
   def ExposedJSMemberAnnot(using Context) = ExposedJSMemberAnnotType.symbol.asClass
 
-  def JSAnnotInternalPackage(using Context) = JSTypeAnnot.owner.asClass
-
   @threadUnsafe lazy val JSImportNamespaceModuleRef = requiredModuleRef("scala.scalajs.js.annotation.JSImport.Namespace")
   def JSImportNamespaceModule(using Context) = JSImportNamespaceModuleRef.symbol
 

--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -95,12 +95,17 @@ final class JSDefinitions()(using Context) {
   def JSExportStaticAnnot(using Context) = JSExportStaticAnnotType.symbol.asClass
   @threadUnsafe lazy val JSExportAllAnnotType: TypeRef = requiredClassRef("scala.scalajs.js.annotation.JSExportAll")
   def JSExportAllAnnot(using Context) = JSExportAllAnnotType.symbol.asClass
+
+  def JSAnnotPackage(using Context) = JSGlobalAnnot.owner.asClass
+
   @threadUnsafe lazy val JSTypeAnnotType: TypeRef = requiredClassRef("scala.scalajs.js.annotation.internal.JSType")
   def JSTypeAnnot(using Context) = JSTypeAnnotType.symbol.asClass
   @threadUnsafe lazy val JSOptionalAnnotType: TypeRef = requiredClassRef("scala.scalajs.js.annotation.internal.JSOptional")
   def JSOptionalAnnot(using Context) = JSOptionalAnnotType.symbol.asClass
   @threadUnsafe lazy val ExposedJSMemberAnnotType: TypeRef = requiredClassRef("scala.scalajs.js.annotation.internal.ExposedJSMember")
   def ExposedJSMemberAnnot(using Context) = ExposedJSMemberAnnotType.symbol.asClass
+
+  def JSAnnotInternalPackage(using Context) = JSTypeAnnot.owner.asClass
 
   @threadUnsafe lazy val JSImportNamespaceModuleRef = requiredModuleRef("scala.scalajs.js.annotation.JSImport.Namespace")
   def JSImportNamespaceModule(using Context) = JSImportNamespaceModuleRef.symbol

--- a/tests/neg-scalajs/js-native-exports.check
+++ b/tests/neg-scalajs/js-native-exports.check
@@ -1,0 +1,12 @@
+-- Error: tests/neg-scalajs/js-native-exports.scala:15:11 --------------------------------------------------------------
+15 |    export bag.{str, int} // error
+   |    ^^^^^^^^^^^^^^^^^^^^^
+   |    Native JS traits, classes and objects cannot contain exported definitions.
+-- Error: tests/neg-scalajs/js-native-exports.scala:21:11 --------------------------------------------------------------
+21 |    export bag.{str, int} // error
+   |    ^^^^^^^^^^^^^^^^^^^^^
+   |    Native JS traits, classes and objects cannot contain exported definitions.
+-- Error: tests/neg-scalajs/js-native-exports.scala:28:11 --------------------------------------------------------------
+28 |    export bag.{str, int} // error
+   |    ^^^^^^^^^^^^^^^^^^^^^
+   |    Native JS traits, classes and objects cannot contain exported definitions.

--- a/tests/neg-scalajs/js-native-exports.check
+++ b/tests/neg-scalajs/js-native-exports.check
@@ -1,12 +1,16 @@
--- Error: tests/neg-scalajs/js-native-exports.scala:15:11 --------------------------------------------------------------
-15 |    export bag.{str, int} // error
-   |    ^^^^^^^^^^^^^^^^^^^^^
+-- Error: tests/neg-scalajs/js-native-exports.scala:17:11 --------------------------------------------------------------
+17 |    export bag.{str, int, bool, dbl} // error
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |    Native JS traits, classes and objects cannot contain exported definitions.
--- Error: tests/neg-scalajs/js-native-exports.scala:21:11 --------------------------------------------------------------
-21 |    export bag.{str, int} // error
-   |    ^^^^^^^^^^^^^^^^^^^^^
+-- Error: tests/neg-scalajs/js-native-exports.scala:23:11 --------------------------------------------------------------
+23 |    export bag.{str, int, bool, dbl} // error
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |    Native JS traits, classes and objects cannot contain exported definitions.
--- Error: tests/neg-scalajs/js-native-exports.scala:28:11 --------------------------------------------------------------
-28 |    export bag.{str, int} // error
-   |    ^^^^^^^^^^^^^^^^^^^^^
+-- Error: tests/neg-scalajs/js-native-exports.scala:30:11 --------------------------------------------------------------
+30 |    export bag.{str, int, bool, dbl} // error
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |    Native JS traits, classes and objects cannot contain exported definitions.
+-- Error: tests/neg-scalajs/js-native-exports.scala:35:11 --------------------------------------------------------------
+35 |    export bag.{str, int, bool, dbl} // error
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    Non-native JS traits cannot contain exported definitions.

--- a/tests/neg-scalajs/js-native-exports.scala
+++ b/tests/neg-scalajs/js-native-exports.scala
@@ -6,26 +6,33 @@ object A {
   @js.native
   trait Bag extends js.Any {
     val str: String
-    val int: Int
+    def int: Int
+    def bool(): Boolean
+    def dbl(dbl: Double): Double
   }
 
   @js.native
   @JSGlobal("BagHolder_GlobalClass")
   final class BagHolder(val bag: Bag) extends js.Object {
-    export bag.{str, int} // error
+    export bag.{str, int, bool, dbl} // error
   }
 
   @js.native
   trait BagHolderTrait extends js.Any {
     val bag: Bag
-    export bag.{str, int} // error
+    export bag.{str, int, bool, dbl} // error
   }
 
   @js.native
   @JSGlobal("BagHolderModule_GlobalVar")
   object BagHolderModule extends js.Object {
     val bag: Bag = js.native
-    export bag.{str, int} // error
+    export bag.{str, int, bool, dbl} // error
+  }
+
+  trait NonNativeBagHolderTrait extends js.Any {
+    val bag: Bag
+    export bag.{str, int, bool, dbl} // error
   }
 
 }

--- a/tests/neg-scalajs/js-native-exports.scala
+++ b/tests/neg-scalajs/js-native-exports.scala
@@ -1,0 +1,31 @@
+import scala.scalajs.js
+import scala.scalajs.js.annotation.*
+
+object A {
+
+  @js.native
+  trait Bag extends js.Any {
+    val str: String
+    val int: Int
+  }
+
+  @js.native
+  @JSGlobal("BagHolder_GlobalClass")
+  final class BagHolder(val bag: Bag) extends js.Object {
+    export bag.{str, int} // error
+  }
+
+  @js.native
+  trait BagHolderTrait extends js.Any {
+    val bag: Bag
+    export bag.{str, int} // error
+  }
+
+  @js.native
+  @JSGlobal("BagHolderModule_GlobalVar")
+  object BagHolderModule extends js.Object {
+    val bag: Bag = js.native
+    export bag.{str, int} // error
+  }
+
+}

--- a/tests/sjs-junit/test/org/scalajs/testsuite/jsinterop/ExportedJSNativeMembersScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/jsinterop/ExportedJSNativeMembersScala3.scala
@@ -48,9 +48,13 @@ object ExportedJSNativeMembersScala3:
     @JSGlobal("quxxInstance_GlobalThatWillBeExported")
     val quxxInstance: QuxHolderHolderTrait = js.native
 
+    @js.native
+    @JSGlobal("addOne_GlobalThatWillBeExported")
+    def addOne(i: Int): Int = js.native
+
   }
 
-  object B {
+  object B extends js.Object {
     export A.FooModule            // trait  (native)
     export A.Foo                  // val    (native)
     export A.Bar                  // object (native)
@@ -59,6 +63,19 @@ object ExportedJSNativeMembersScala3:
     export A.QuxHolderHolder      // class  (native)
     export A.QuxHolderHolderTrait // trait  (native)
     export A.quxxInstance         // val    (native)
+    export A.addOne               // def    (native)
+  }
+
+  final class C extends js.Object {
+    export A.FooModule            // trait  (native)
+    export A.Foo                  // val    (native)
+    export A.Bar                  // object (native)
+    export A.Baz                  // class  (native)
+    export A.QuxHolder            // class  (native)
+    export A.QuxHolderHolder      // class  (native)
+    export A.QuxHolderHolderTrait // trait  (native)
+    export A.quxxInstance         // val    (native)
+    export A.addOne               // def    (native)
   }
 
 class ExportedJSNativeMembersScala3:
@@ -87,12 +104,20 @@ class ExportedJSNativeMembersScala3:
           new QuxHolder_GlobalThatWillBeExported("quxxInstance")
         )
       )
+      function addOne_GlobalThatWillBeExported(i) {
+        return i + 1;
+      }
     """)
+
+    val C = ExportedJSNativeMembersScala3.C()
+
     assertEquals("foo", A.Foo.foo)
     assertEquals("foo", B.Foo.foo)
+    assertEquals("foo", C.Foo.foo)
 
     assertEquals(23, A.Bar.bar)
     assertEquals(23, B.Bar.bar)
+    assertEquals(23, C.Bar.bar)
 
     val abaz = A.Baz("abaz1")
     assertEquals("abaz1", abaz.baz)
@@ -104,6 +129,11 @@ class ExportedJSNativeMembersScala3:
     bbaz.baz = "bbaz2"
     assertEquals("bbaz2", bbaz.baz)
 
+    val cbaz = C.Baz("cbaz1")
+    assertEquals("cbaz1", cbaz.baz)
+    cbaz.baz = "cbaz2"
+    assertEquals("cbaz2", cbaz.baz)
+
     val quxHolderHolderA = A.QuxHolderHolder(A.QuxHolder("quxHolderHolderA"))
     assertEquals("quxHolderHolderA", quxHolderHolderA.qux)
     assertEquals("quxHolderHolderA", quxHolderHolderA.quxHolder.qux)
@@ -112,10 +142,20 @@ class ExportedJSNativeMembersScala3:
     assertEquals("quxHolderHolderB", quxHolderHolderB.qux)
     assertEquals("quxHolderHolderB", quxHolderHolderB.quxHolder.qux)
 
+    val quxHolderHolderC = C.QuxHolderHolder(C.QuxHolder("quxHolderHolderC"))
+    assertEquals("quxHolderHolderC", quxHolderHolderC.qux)
+    assertEquals("quxHolderHolderC", quxHolderHolderC.quxHolder.qux)
+
     assertEquals("quxxInstance", A.quxxInstance.qux)
     assertEquals("quxxInstance", A.quxxInstance.quxHolder.qux)
     assertEquals("quxxInstance", B.quxxInstance.qux)
     assertEquals("quxxInstance", B.quxxInstance.quxHolder.qux)
+    assertEquals("quxxInstance", C.quxxInstance.qux)
+    assertEquals("quxxInstance", C.quxxInstance.quxHolder.qux)
+
+    assertEquals(2, A.addOne(1))
+    assertEquals(3, B.addOne(2))
+    assertEquals(4, C.addOne(3))
   }
 
 end ExportedJSNativeMembersScala3

--- a/tests/sjs-junit/test/org/scalajs/testsuite/jsinterop/ExportedJSNativeMembersScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/jsinterop/ExportedJSNativeMembersScala3.scala
@@ -1,0 +1,121 @@
+package org.scalajs.testsuite.jsinterop
+
+import org.junit.Assert.*
+import org.junit.Test
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.*
+
+object ExportedJSNativeMembersScala3:
+
+  object A {
+
+    @js.native
+    trait FooModule extends js.Any { self: Foo.type =>
+      val foo: String
+    }
+
+    @js.native
+    @JSGlobal("Foo_GlobalThatWillBeExported")
+    val Foo: FooModule = js.native
+
+    @js.native
+    @JSGlobal("Bar_GlobalThatWillBeExported")
+    object Bar extends js.Any {
+      val bar: Int = js.native
+    }
+
+    @js.native
+    @JSGlobal("Baz_GlobalThatWillBeExported")
+    final class Baz(var baz: String) extends js.Object
+
+    @js.native
+    @JSGlobal("QuxHolder_GlobalThatWillBeExported")
+    final class QuxHolder(val qux: String) extends js.Object
+
+    @js.native
+    @JSGlobal("QuxHolderHolder_GlobalThatWillBeExported")
+    final class QuxHolderHolder(val quxHolder: QuxHolder) extends js.Object {
+      val qux: quxHolder.qux.type = js.native
+    }
+
+    @js.native // structurally equivalent to QuxHolderHolder, but a trait
+    trait QuxHolderHolderTrait(val quxHolder: QuxHolder) extends js.Any {
+      val qux: quxHolder.qux.type
+    }
+
+    @js.native
+    @JSGlobal("quxxInstance_GlobalThatWillBeExported")
+    val quxxInstance: QuxHolderHolderTrait = js.native
+
+  }
+
+  object B {
+    export A.FooModule            // trait  (native)
+    export A.Foo                  // val    (native)
+    export A.Bar                  // object (native)
+    export A.Baz                  // class  (native)
+    export A.QuxHolder            // class  (native)
+    export A.QuxHolderHolder      // class  (native)
+    export A.QuxHolderHolderTrait // trait  (native)
+    export A.quxxInstance         // val    (native)
+  }
+
+class ExportedJSNativeMembersScala3:
+  import ExportedJSNativeMembersScala3.*
+
+  @Test def forward_top_level_JS_var_with_export(): Unit = {
+    js.eval("""
+      var Foo_GlobalThatWillBeExported = {
+        foo: "foo"
+      }
+      var Bar_GlobalThatWillBeExported = {
+        bar: 23
+      }
+      function Baz_GlobalThatWillBeExported(baz) {
+        this.baz = baz
+      }
+      function QuxHolder_GlobalThatWillBeExported(qux) {
+        this.qux = qux
+      }
+      function QuxHolderHolder_GlobalThatWillBeExported(quxHolder) {
+        this.quxHolder = quxHolder;
+        this.qux = quxHolder.qux;
+      }
+      var quxxInstance_GlobalThatWillBeExported = (
+        new QuxHolderHolder_GlobalThatWillBeExported(
+          new QuxHolder_GlobalThatWillBeExported("quxxInstance")
+        )
+      )
+    """)
+    assertEquals("foo", A.Foo.foo)
+    assertEquals("foo", B.Foo.foo)
+
+    assertEquals(23, A.Bar.bar)
+    assertEquals(23, B.Bar.bar)
+
+    val abaz = A.Baz("abaz1")
+    assertEquals("abaz1", abaz.baz)
+    abaz.baz = "abaz2"
+    assertEquals("abaz2", abaz.baz)
+
+    val bbaz = B.Baz("bbaz1")
+    assertEquals("bbaz1", bbaz.baz)
+    bbaz.baz = "bbaz2"
+    assertEquals("bbaz2", bbaz.baz)
+
+    val quxHolderHolderA = A.QuxHolderHolder(A.QuxHolder("quxHolderHolderA"))
+    assertEquals("quxHolderHolderA", quxHolderHolderA.qux)
+    assertEquals("quxHolderHolderA", quxHolderHolderA.quxHolder.qux)
+
+    val quxHolderHolderB = B.QuxHolderHolder(B.QuxHolder("quxHolderHolderB"))
+    assertEquals("quxHolderHolderB", quxHolderHolderB.qux)
+    assertEquals("quxHolderHolderB", quxHolderHolderB.quxHolder.qux)
+
+    assertEquals("quxxInstance", A.quxxInstance.qux)
+    assertEquals("quxxInstance", A.quxxInstance.quxHolder.qux)
+    assertEquals("quxxInstance", B.quxxInstance.qux)
+    assertEquals("quxxInstance", B.quxxInstance.quxHolder.qux)
+  }
+
+end ExportedJSNativeMembersScala3


### PR DESCRIPTION
- prevent export forwarders in JS native types and JS non-native traits
- remove annotations `js.native`, `js.annotation.*` from export forwarders
  in `PrepJSInterop`

fixes #12111 