### PR TITLE
Typecheck imports with import symbol as owner

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -703,7 +703,7 @@ class Namer { typer: Typer =>
         typer1.defDefSig(original, sym)(using localContext(sym).setTyper(typer1))
       case imp: Import =>
         try
-          val expr1 = typedImportQualifier(imp, typedAheadExpr)
+          val expr1 = typedImportQualifier(imp, typedAheadExpr(_, _)(using ctx.withOwner(sym)))
           ImportType(expr1)
         catch case ex: CyclicReference =>
           typr.println(s"error while completing ${imp.expr}")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2450,7 +2450,7 @@ class Typer extends Namer
     else typd(imp.expr, AnySelectionProto)
 
   def typedImport(imp: untpd.Import, sym: Symbol)(using Context): Import =
-    val expr1 = typedImportQualifier(imp, typedExpr)
+    val expr1 = typedImportQualifier(imp, typedExpr(_, _)(using ctx.withOwner(sym)))
     checkLegalImportPath(expr1)
     val selectors1 = typedSelectors(imp.selectors)
     assignType(cpy.Import(imp)(expr1, selectors1), sym)

--- a/tests/neg/i12606.scala
+++ b/tests/neg/i12606.scala
@@ -1,0 +1,8 @@
+import scala.quoted._
+
+trait ReflectModule {
+  implicit def q: Quotes
+  import quotes.reflect._ // error
+
+  def foo(x: TypeRepr): Unit = ???
+}


### PR DESCRIPTION
Fixes #12606

This broke before since the inliner is not prepared to operate with a class as owner.