### PR TITLE
Fix hole in scan for outer references

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -295,7 +295,7 @@ object TypeTestsCasts {
             derivedTree(expr, defn.Any_asInstanceOf, testType)
         }
 
-        /** Transform isInstanceOf OrType
+        /** Transform isInstanceOf
          *
          *    expr.isInstanceOf[A | B]  ~~>  expr.isInstanceOf[A] | expr.isInstanceOf[B]
          *    expr.isInstanceOf[A & B]  ~~>  expr.isInstanceOf[A] & expr.isInstanceOf[B]

--- a/tests/pos/i12616.scala
+++ b/tests/pos/i12616.scala
@@ -1,0 +1,9 @@
+class Foo:
+
+  //object Bar
+  val Bar = 22
+
+  object Baz:
+    def f(x: Any): Unit =
+      x match
+        case s: (Bar.type & x.type) =>


### PR DESCRIPTION
Type tests of singletons need to be considered as well.

Fixes #12616 