### PR TITLE
fix #12634 - port sbt/zinc#979 - add sealedDescendants to zinc sealed children

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -221,7 +221,7 @@ private class ExtractAPICollector(using Context) extends ThunkHolder {
     val modifiers = apiModifiers(sym)
     val anns = apiAnnotations(sym).toArray
     val topLevel = sym.isTopLevelClass
-    val childrenOfSealedClass = sym.children.sorted(classFirstSort).map(c =>
+    val childrenOfSealedClass = sym.sealedDescendants.sorted(classFirstSort).map(c =>
       if (c.isClass)
         apiType(c.typeRef)
       else

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -7,6 +7,11 @@ object HashSet:
    */
   inline val DenseLimit = 8
 
+  def from[T](xs: IterableOnce[T]): HashSet[T] =
+    val set = new HashSet[T]()
+    set ++= xs
+    set
+
 /** A hash set that allows some privileged protected access to its internals
  *  @param  initialCapacity  Indicates the initial number of slots in the hash table.
  *                           The actual number of slots is always a power of 2, so the

--- a/compiler/test/dotty/tools/dotc/core/SealedDescendantsTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/SealedDescendantsTest.scala
@@ -1,0 +1,108 @@
+package dotty.tools.dotc.core
+
+import dotty.tools.dotc.core.Contexts.{Context, ctx}
+import dotty.tools.dotc.core.Symbols.*
+
+import org.junit.Assert._
+import org.junit.Test
+
+import dotty.tools.DottyTest
+
+class SealedDescendantsTest extends DottyTest {
+
+  @Test
+  def zincIssue979: Unit =
+    val source =
+      """
+      sealed trait Z
+      sealed trait A extends Z
+      class B extends A
+      class C extends A
+      class D extends A
+      """
+
+    expectedDescendents(source, "Z",
+      "Z" ::
+      "A" ::
+      "B" ::
+      "C" ::
+      "D" :: Nil
+    )
+  end zincIssue979
+
+  @Test
+  def enumOpt: Unit =
+    val source =
+      """
+      enum Opt[+T] {
+        case Some(t: T)
+        case None
+      }
+      """
+
+    expectedDescendents(source, "Opt",
+      "Opt"       ::
+      "Some"      ::
+      "None.type" :: Nil
+    )
+  end enumOpt
+
+  @Test
+  def hierarchicalSharedChildren: Unit =
+    // Q is a child of both Z and A and should appear once
+    // X is a child of both A and Q and should appear once
+    val source =
+      """
+      sealed trait Z
+      sealed trait A extends Z
+      sealed trait Q extends A with Z
+      trait X extends A with Q
+      case object Y extends Q
+      """
+
+    expectedDescendents(source, "Z",
+      "Z"      ::
+      "A"      ::
+      "Q"      ::
+      "X"      ::
+      "Y.type" :: Nil
+    )
+  end hierarchicalSharedChildren
+
+  @Test
+  def hierarchicalSharedChildrenB: Unit =
+    val source =
+      """
+      sealed trait Z
+      case object A extends Z with D with E
+      sealed trait B extends Z
+      trait C extends B
+      sealed trait D extends B
+      sealed trait E extends D
+      """
+
+    expectedDescendents(source, "Z",
+      "Z"      ::
+      "A.type" ::
+      "B"      ::
+      "C"      ::
+      "D"      ::
+      "E"      :: Nil
+    )
+  end hierarchicalSharedChildrenB
+
+  def expectedDescendents(source: String, root: String, expected: List[String]) =
+    exploreRoot(source, root) { rootCls =>
+      val descendents = rootCls.sealedDescendants.map(sym => s"${sym.name}${if (sym.isTerm) ".type" else ""}")
+      assertEquals(expected.toString, descendents.toString)
+    }
+
+  def exploreRoot(source: String, root: String)(op: Context ?=> ClassSymbol => Unit) =
+    val source0 = source.linesIterator.map(_.trim).mkString("\n|")
+    val source1 = s"""package testsealeddescendants
+                     |$source0""".stripMargin
+    checkCompile("typer", source1) { (_, context) =>
+      given Context = context
+      op(requiredClass(s"testsealeddescendants.$root"))
+    }
+}

--- a/sbt-test/source-dependencies/sealed-extends-sealed/A.scala
+++ b/sbt-test/source-dependencies/sealed-extends-sealed/A.scala
@@ -1,0 +1,4 @@
+sealed trait Z
+sealed trait A extends Z
+class B extends A
+class C extends A

--- a/sbt-test/source-dependencies/sealed-extends-sealed/App.scala
+++ b/sbt-test/source-dependencies/sealed-extends-sealed/App.scala
@@ -1,0 +1,6 @@
+object App {
+	def foo(z: Z) = z match {
+		case _: B =>
+		case _: C =>
+	}
+}

--- a/sbt-test/source-dependencies/sealed-extends-sealed/changes/A.scala
+++ b/sbt-test/source-dependencies/sealed-extends-sealed/changes/A.scala
@@ -1,0 +1,5 @@
+sealed trait Z
+sealed trait A extends Z
+class B extends A
+class C extends A
+class D extends A

--- a/sbt-test/source-dependencies/sealed-extends-sealed/project/DottyInjectedPlugin.scala
+++ b/sbt-test/source-dependencies/sealed-extends-sealed/project/DottyInjectedPlugin.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+    scalacOptions ++= Seq("-source:3.0-migration", "-Xfatal-warnings")
+  )
+}

--- a/sbt-test/source-dependencies/sealed-extends-sealed/test
+++ b/sbt-test/source-dependencies/sealed-extends-sealed/test
@@ -1,0 +1,8 @@
+> compile
+
+# Introduce a new class C that also extends A
+$ copy-file changes/A.scala A.scala
+
+# App.scala needs recompiling because the pattern match in it
+# is no longer exhaustive, which emits a warning
+-> compile


### PR DESCRIPTION
Add sealedDescendants method to SymDenotation - get recursive children of a symbol

fixes #12634