### PR TITLE
Preserve hard unions in more situations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -309,8 +309,11 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         val r1 = recur(tp.tp1, fromBelow)
         val r2 = recur(tp.tp2, fromBelow)
         if (r1 eq tp.tp1) && (r2 eq tp.tp2) then tp
-        else if tp.isAnd then r1 & r2
-        else r1 | r2
+        else tp.match
+          case tp: OrType =>
+            TypeComparer.lub(r1, r2, isSoft = tp.isSoft)
+          case _ =>
+            r1 & r2
       case tp: TypeParamRef =>
         if tp eq param then
           if fromBelow then defn.NothingType else defn.AnyType

--- a/tests/pos/preserve-union.scala
+++ b/tests/pos/preserve-union.scala
@@ -1,0 +1,7 @@
+class A {
+  val a: Int | String = 1
+  val b: AnyVal = 2
+
+  val c = List(a, b)
+  val c1: List[AnyVal | String] = c
+}


### PR DESCRIPTION
There's multiple places where we take apart a union, apply some
transformation to its parts, then either return the original union if
nothing changed or recombine the transformed parts into a new union. The
problem is that to check if nothing changed we use referential equality
when `=:=` would be more correct, so we sometimes end up returning a
union equivalent to the original one except the new one is a soft union.

I've seen this lead to subtle type inference differences both when
experimenting with changes to constraint solving and when trying to
replace our Uniques hashmaps by weak hashmaps.

We could fix this by replacing these `eq` calls by `=:=` but instead
this commit takes the approach of preserving the softness of a union
even when its components are modified, see the test case.