### PR TITLE
Scala2Unpickler: Don't trust the owner field of tparams

### DIFF
--- a/sbt-test/scala2-compat/i12641/app/App.scala
+++ b/sbt-test/scala2-compat/i12641/app/App.scala
@@ -1,0 +1,9 @@
+import cek.Async
+
+
+object demo {
+
+  def test1[F[_]](ev: Async[F]): Unit = ???
+  def test2[F[_]](ev: Async[F]): Unit = ???
+
+}

--- a/sbt-test/scala2-compat/i12641/build.sbt
+++ b/sbt-test/scala2-compat/i12641/build.sbt
@@ -1,0 +1,13 @@
+val scala3Version = sys.props("plugin.scalaVersion")
+val scala2Version = sys.props("plugin.scala2Version")
+
+lazy val lib = project.in(file("lib"))
+  .settings(
+    scalaVersion := scala2Version
+  )
+
+lazy val app = project.in(file("app"))
+  .dependsOn(lib)
+  .settings(
+    scalaVersion := scala3Version
+  )

--- a/sbt-test/scala2-compat/i12641/lib/Lib.scala
+++ b/sbt-test/scala2-compat/i12641/lib/Lib.scala
@@ -1,0 +1,29 @@
+package cek
+
+trait Async[F[_]]
+
+object Async {
+  trait WriterTAsync[F[_], L1]
+      extends Async[({ type LL[A] = WriterT[F, L1, A] })#LL]
+      with MonadCancel.WriterTMonadCancel[F, L1] {
+
+    override def delegate = super.delegate
+  }
+
+}
+
+case class WriterT[F[_], L0, V]()
+
+trait MonadError[F[_]]
+trait MonadCancel[F[_]]
+
+object MonadCancel {
+
+  trait WriterTMonadCancel[F[_], L2]
+      extends MonadCancel[({ type LL[A] = WriterT[F, L2, A] })#LL] {
+
+    def delegate: MonadError[({ type LL[A] = WriterT[F, L2, A] })#LL] =
+      ???
+
+  }
+}

--- a/sbt-test/scala2-compat/i12641/test
+++ b/sbt-test/scala2-compat/i12641/test
@@ -1,0 +1,1 @@
+> app/compile


### PR DESCRIPTION
When a type parameter of a class external to the current pickle is
referenced, Scala 2 will sometimes pickle it as if it was a type
parameter of the current class. When we unpickle such a type parameter
on our side, we enter it in the class, this leads the compiler to
believe the class has more type parameters than it actually has. This
doesn't happen in Scala 2 itself because it never enters unpickled type
parameters in the class that owns them (it must be recreating them in
some way, but I don't know how).

It would be interesting to dig deeper to understand exactly how Scala 2
handles type parameter unpickling so we could emulate it given that this
is not the first time we run into trouble here (cf #12120), but for now
we fix the problem with the following heuristic: once we've loaded all
the type parameters of a class (which we do eagerly via
`ClassUnpickler#init()`), we simply stop from being entered any
subsequent type parameter we see for this class. Time will tell if this
is good enough.

While I was touching that code, I also made
ClassCompleter#completerTypeParams idempotent as one would expect it to
be.

Fixes #12641.