### PR TITLE
Harden type comparer in presence of kind errors

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1422,7 +1422,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
 
     def recurArgs(args1: List[Type], args2: List[Type], tparams2: List[ParamInfo]): Boolean =
       if (args1.isEmpty) args2.isEmpty
-      else args2.nonEmpty && {
+      else args2.nonEmpty && tparams2.nonEmpty && {
         val tparam = tparams2.head
         val v = tparam.paramVarianceSign
 

--- a/tests/neg/i12664.scala
+++ b/tests/neg/i12664.scala
@@ -1,0 +1,14 @@
+trait Step {
+  type Self
+  type Next[A]
+}
+
+trait DynamicNextStep {
+  type OneOf[Self, Next[_]]
+  def apply(s: Step): OneOf[s.Self, s.Next]
+}
+
+object X extends DynamicNextStep {
+  override type OneOf[Self] = Self  // error
+  override def apply(s: Step) = ???
+}


### PR DESCRIPTION
It should not crash when an override has the wrong kind.

Fixes #12664