### PR TITLE
Correctly check experimental features

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -84,11 +84,11 @@ trait PropertiesTrait {
 
   /** Whether the current version of compiler is experimental
    *
-   *  1. Snapshot and nightly releases are experimental.
+   *  1. Snapshot, nightly releases and non-bootstrapped compiler are experimental.
    *  2. Features supported by experimental versions of the compiler:
    *     - research plugins
    */
-  val experimental: Boolean = versionString.contains("SNAPSHOT") || versionString.contains("NIGHTLY")
+  val experimental: Boolean = versionString.contains("SNAPSHOT") || versionString.contains("NIGHTLY") || versionString.contains("nonbootstrapped")
 
   val copyrightString: String       = scalaPropOrElse("copyright.string", "(c) 2002-2017 LAMP/EPFL")
 

--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -94,7 +94,8 @@ object Inliner {
       if (tree.symbol == defn.CompiletimeTesting_typeChecks) return Intrinsics.typeChecks(tree)
       if (tree.symbol == defn.CompiletimeTesting_typeCheckErrors) return Intrinsics.typeCheckErrors(tree)
 
-    Feature.checkExperimentalDef(tree.symbol, tree)
+    if tree.symbol.isExperimental then
+      Feature.checkExperimentalDef(tree.symbol, tree)
 
     /** Set the position of all trees logically contained in the expansion of
      *  inlined call `call` to the position of `call`. This transform is necessary


### PR DESCRIPTION
- When inlining: emit "experimental" error only when
  the feature in question is actually annotated as
  experimental
- Compiler-wide: treat non-bootstrapped compiler as
  experimental-friendly. The motivation is to compile
  the standard library with experimental features enabled
  at all times. This change isn't supposed to introduce any
  experimental features leaks into stable builds since
  we do not publish non-bootstrapped compiler.

This is supposed to fix the 3.0.1-RC1 release which failed due to broken experimental feature checks: https://github.com/lampepfl/dotty/runs/2717422630?check_suite_focus=true