### PR TITLE
Fix #10242: Avoid lambda params in typedAppliedTypeTree

### DIFF
--- a/tests/pos/10242.scala
+++ b/tests/pos/10242.scala
@@ -1,0 +1,8 @@
+
+object Test {
+  type Foo[A, B <: A] = A
+
+  type Bar[X] = X match {
+    case Foo[String, x] => Unit
+  }
+}


### PR DESCRIPTION
I'm not sure this the correct place to do this sort of avoidance, but it seems to fix the issue in question.

The problem comes from `paramInfoAsSeenFrom` which still has a reference to a bound from its definition site. What is surpizing is the documentation of `paramInfoAsSeenFrom` states that `asSeenFrom` has already been applied, but it seems that this bound still managed to slip through the cracks...

https://github.com/lampepfl/dotty/blob/fa3657708183167e9d927f4118065aabcddabb79/compiler/src/dotty/tools/dotc/core/ParamInfo.scala#L26-L31