### PR TITLE
Fix typo in syntax.md

### DIFF
--- a/docs/docs/internals/syntax.md
+++ b/docs/docs/internals/syntax.md
@@ -116,7 +116,7 @@ given     if        implicit  import    lazy      match     new
 null      object    override  package   private   protected return
 sealed    super     then      throw     trait     true      try
 type      val       var       while     with      yield
-:         =         <-        =>        <:        :>        #
+:         =         <-        =>        <:        >:        #
 @         =>>       ?=>
 ```
 


### PR DESCRIPTION
The supertype symbol was ':>' and it was changed to '>:' .

The typo only occurred in subsection 'Keywords'. It did not occur in subsection 'Context-free Syntax'.
