### PR TITLE
Add Matchable to the parents of Null in explicit nulls

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -455,8 +455,9 @@ class Definitions {
     ScalaPackageClass, tpnme.Nothing, AbstractFinal, List(AnyType))
   def NothingType: TypeRef = NothingClass.typeRef
   @tu lazy val NullClass: ClassSymbol = {
-    val parent = if ctx.explicitNulls then AnyType else ObjectType
-    enterCompleteClassSymbol(ScalaPackageClass, tpnme.Null, AbstractFinal, parent :: Nil)
+    // When explicit-nulls is enabled, Null becomes a direct subtype of Any and Matchable
+    val parents = if ctx.explicitNulls then AnyType :: MatchableType :: Nil else ObjectType :: Nil
+    enterCompleteClassSymbol(ScalaPackageClass, tpnme.Null, AbstractFinal, parents)
   }
   def NullType: TypeRef = NullClass.typeRef
 

--- a/tests/explicit-nulls/neg/basic.scala
+++ b/tests/explicit-nulls/neg/basic.scala
@@ -9,6 +9,9 @@ class Basic {
   val any1: Any  = null
   val any2: Any  = n
 
+  val matchable1: Matchable = null
+  val matchable2: Matchable = n
+
   val s1: String = null // error
   val s2: String = n // error
   val s3: String | Null = null

--- a/tests/explicit-nulls/pos/matchable.scala
+++ b/tests/explicit-nulls/pos/matchable.scala
@@ -1,0 +1,3 @@
+def foo1[T <: Matchable](t: T) = t match { case t: Null => () }
+
+def foo2[T <: Matchable](t: T) = t match { case null => () }


### PR DESCRIPTION
`Matchable` should be a parent of `Null` in explicit nulls.

Fix the errors created by @bishabosha:

```scala
$ scala -Yexplicit-nulls
scala> def foo[T <: Matchable](t: T) = t match { case t: Null => () }
1 |def foo[T <: Matchable](t: T) = t match { case t: Null => () }
  |                                               ^
  |        this case is unreachable since type T and class Null are unrelated

scala> def foo[T <: Matchable](t: T) = t match { case null => () }                                               
1 |def foo[T <: Matchable](t: T) = t match { case null => () }
  |                                               ^^^^
  |Values of types Null and T
  |
  |where:    T is a type in method foo with bounds >: (?1 : Null) and <: Matchable
  | cannot be compared with == or !=
```