### PR TITLE
Re-enable the Scala.js test JSOptionalTest212FunParamInference.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1178,9 +1178,7 @@ object Build {
             -- "UnionTypeTest.scala" // requires the Scala 2 macro defined in Typechecking*.scala
             )).get
 
-          ++ (dir / "js/src/test/require-2.12" ** (("*.scala": FileFilter)
-            -- "JSOptionalTest212FunParamInference.scala" // TODO: #11694
-            )).get
+          ++ (dir / "js/src/test/require-2.12" ** "*.scala").get
           ++ (dir / "js/src/test/require-sam" ** "*.scala").get
           ++ (dir / "js/src/test/scala-new-collections" ** "*.scala").get
         )


### PR DESCRIPTION
The issue #11694, which prevented this test from compiling, was fixed in #11760.

The source of the test is at https://github.com/scala-js/scala-js/blob/v1.5.1/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212FunParamInference.scala