### PR TITLE
Support leak non-hot values to constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -48,10 +48,7 @@ class Checker extends MiniPhase {
     if (instantiable && cls.enclosingPackageClass != defn.StdLibPatchesPackage.moduleClass) {
       import semantic._
       val tpl = tree.rhs.asInstanceOf[Template]
-      val thisRef = ThisRef(cls)
-
-      val obj = Objekt(cls, fields = mutable.Map.empty, outers = mutable.Map(cls -> Hot))
-      heap.update(thisRef, obj)
+      val thisRef = ThisRef(cls).ensureExists
 
       val paramValues = tpl.constr.termParamss.flatten.map(param => param.symbol -> Hot).toMap
 

--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -52,6 +52,7 @@ class Checker extends MiniPhase {
       val obj = Objekt(cls, fields = mutable.Map.empty, outers = mutable.Map(cls -> Hot))
       given Promoted = Promoted.empty
       given Trace = Trace.empty
+      given Env = Env.empty
       heap.update(thisRef, obj)
       val res = eval(tpl, thisRef, cls)
       res.errors.foreach(_.issue)

--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -49,11 +49,16 @@ class Checker extends MiniPhase {
       import semantic._
       val tpl = tree.rhs.asInstanceOf[Template]
       val thisRef = ThisRef(cls)
+
       val obj = Objekt(cls, fields = mutable.Map.empty, outers = mutable.Map(cls -> Hot))
+      heap.update(thisRef, obj)
+
+      val paramValues = tpl.constr.termParamss.flatten.map(param => param.symbol -> Hot).toMap
+
       given Promoted = Promoted.empty
       given Trace = Trace.empty
-      given Env = Env.empty
-      heap.update(thisRef, obj)
+      given Env = Env(paramValues)
+
       val res = eval(tpl, thisRef, cls)
       res.errors.foreach(_.issue)
     }

--- a/compiler/src/dotty/tools/dotc/transform/init/Errors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Errors.scala
@@ -69,7 +69,7 @@ object Errors {
 
   /** Promote `this` under initialization to fully-initialized */
   case class PromoteError(msg: String, source: Tree, trace: Seq[Tree]) extends Error {
-    def show(using Context): String = "Promote the value under initialization to fully-initialized. " + msg
+    def show(using Context): String = "Promote the value under initialization to fully-initialized. " + msg + "."
   }
 
   case class AccessCold(field: Symbol, source: Tree, trace: Seq[Tree]) extends Error {

--- a/compiler/src/dotty/tools/dotc/transform/init/Errors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Errors.scala
@@ -74,7 +74,7 @@ object Errors {
 
   case class AccessCold(field: Symbol, source: Tree, trace: Seq[Tree]) extends Error {
     def show(using Context): String =
-      "Access field " + source.show + " on a value with an unknown initialization status" + "."
+      "Access field " + source.show + " on a value with an unknown initialization status."
   }
 
   case class CallCold(meth: Symbol, source: Tree, trace: Seq[Tree]) extends Error {

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -183,7 +183,7 @@ class Semantic {
 
       def union(other: Env): Env = env ++ other
 
-      def isHot: Boolean = env.values.exists(_ != Hot)
+      def isHot: Boolean = env.values.forall(_ == Hot)
   }
 
   type Env = Env.Env

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -419,10 +419,14 @@ class Semantic {
             else
               value.select(target, source, needResolve = false)
 
-        case Fun(body, params, thisV, klass, env) =>
+        case Fun(body, params, thisV, klass, env2) =>
           // meth == NoSymbol for poly functions
           if meth.name.toString == "tupled" then Result(value, Nil) // a call like `fun.tupled`
-          else eval(body, thisV, klass, cacheResult = true)
+          else
+            val env3 = Env(params.zip(args.widen).toMap).union(env2)
+            use(env3) {
+              eval(body, thisV, klass, cacheResult = true)
+            }
 
         case RefSet(refs) =>
           val resList = refs.map(_.call(meth, args, superType, source))

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -146,10 +146,18 @@ class Semantic {
    *  or `Hot`.
    *
    *  Despite that we have environment for evaluating expressions in secondary
-   *  constructors (currently we restrict method arguments to be hot), we don't
-   *  need to put environment as the cache key. The reason is that constructor
-   *  parameters are determined by the value of `this` --- it suffices to make
-   *  the value of `this` as part of the cache key.
+   *  constructors, we don't need to put environment as the cache key. The
+   *  reason is that constructor parameters are determined by the value of
+   *  `this` --- it suffices to make the value of `this` as part of the cache
+   *  key.
+   *
+   *  This crucially depends on the fact that in the initialization process
+   *  there can be exactly one call to a specific constructor for a given
+   *  receiver. However, once we relax the design to allow non-hot values to
+   *  methods and functions, we have to put the environment as part of the cache
+   *  key. The reason is that given the same receiver, a method or function may
+   *  be called with different arguments -- they are not decided by the receiver
+   *  anymore.
    */
   object Env {
     opaque type Env = Map[Symbol, Value]
@@ -453,7 +461,7 @@ class Semantic {
               val obj = Objekt(klass, fields = mutable.Map.empty, outers = mutable.Map(klass -> Hot))
               heap.update(value, obj)
             val res = value.call(ctor, args, superType = NoType, source)
-            Result(res.value, res.errors)
+            Result(value, res.errors)
 
         case Cold =>
           val error = CallCold(ctor, source, trace1.toVector)

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -73,6 +73,7 @@ class Semantic {
 
     def withSource(source: Tree): Value =
       if mySource.isEmpty then attachSource(source)
+      else if this == Hot || this == Cold then this
       else {
         val value2 = this.clone.asInstanceOf[Value]
         value2.mySource = source

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -892,7 +892,7 @@ class Semantic {
         case Hot => Hot
         case addr: Addr =>
           val obj = heap(addr)
-          val outerCls = klass.owner.enclosingClass.asClass
+          val outerCls = klass.owner.lexicallyEnclosingClass.asClass
           if !obj.outers.contains(klass) then
             val error = PromoteError("outer not yet initialized, target = " + target + ", klass = " + klass, source, trace.toVector)
             report.error(error.show + error.stacktrace, source)

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -138,7 +138,10 @@ class Semantic {
   import Heap._
   val heap: Heap = Heap.empty
 
-  /** The environment for method parameters */
+  /** The environment for method parameters
+   *
+   *  For performance and usability, we restrict parameters to be either `Cold` or `Hot`.
+   */
   object Env {
     opaque type Env = Map[Symbol, Value]
 

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -55,7 +55,7 @@ class Semantic {
    *         V ⊑ R if V ∈ R
    *
    */
-  sealed abstract class Value extends Cloneable {
+  sealed abstract class Value {
     def show: String = this.toString()
   }
 
@@ -142,7 +142,14 @@ class Semantic {
 
   /** The environment for method parameters
    *
-   *  For performance and usability, we restrict parameters to be either `Cold` or `Hot`.
+   *  For performance and usability, we restrict parameters to be either `Cold`
+   *  or `Hot`.
+   *
+   *  Despite that we have environment for evaluating expressions in secondary
+   *  constructors (currently we restrict method arguments to be hot), we don't
+   *  need to put environment as the cache key. The reason is that constructor
+   *  parameters are determined by the value of `this` --- it suffices to make
+   *  the value of `this` as part of the cache key.
    */
   object Env {
     opaque type Env = Map[Symbol, Value]

--- a/docs/docs/reference/other-new-features/safe-initialization.md
+++ b/docs/docs/reference/other-new-features/safe-initialization.md
@@ -185,13 +185,13 @@ With the established principles and design goals, following rules are imposed:
    initialization in order to enforce different rules. Scala
    has different syntax for them, it thus is not an issue.
 
-2. References to objects under initialization may not be passed as arguments to method calls or constructors.
+2. Objects under initialization may not be passed as arguments to method calls.
 
-   Escape of `this` in the constructor is commonly regarded as an
-   anti-pattern, and it's rarely used in practice. This rule is simple
-   for the programmer to reason about initialization and it simplifies
-   implementation. The theory supports safe escape of `this` with the help of
-   annotations, we delay the extension until there is a strong need.
+   Escape of `this` in the constructor is commonly regarded as an anti-pattern.
+   However, escape of `this` as constructor arguments are allowed, to support
+   creation of cyclic data structures. The checker will ensure that the escaped
+   non-initialized object is not used, i.e. calling methods or accessing fields
+   on the escaped object is not allowed.
 
 3. Local definitions may only refer to transitively initialized objects.
 

--- a/tests/init/neg/cycle.scala
+++ b/tests/init/neg/cycle.scala
@@ -1,0 +1,11 @@
+class A(x: B) {
+  println(x.b) // error
+  val a = new B(this)
+  val d = a.b
+}
+
+class B(x: A) {
+  println(x.a) // error
+  val b = new A(this)
+  val d = b.a
+}

--- a/tests/init/neg/early-promote2.scala
+++ b/tests/init/neg/early-promote2.scala
@@ -1,0 +1,6 @@
+class M {
+  println(this)       // error
+  foo()
+  private val a = 5   // error
+  def foo() = a
+}

--- a/tests/init/neg/early-promote3.scala
+++ b/tests/init/neg/early-promote3.scala
@@ -1,0 +1,11 @@
+abstract class A {
+  bar()
+  private val a = 5
+  def foo() = a
+  def bar(): Unit
+}
+
+class M extends A {
+  def bar() = promote(this)    // error
+  def promote(m: M) = m.foo()
+}

--- a/tests/init/neg/early-promote4.scala
+++ b/tests/init/neg/early-promote4.scala
@@ -1,0 +1,20 @@
+abstract class A {
+  bar()
+  def bar(): Unit
+}
+
+class Outer {
+  val a: Int = 5
+  trait B {
+    def bar() = assert(a == 5)
+  }
+}
+
+class M(val o: Outer) extends A with o.B {
+  val n: Int = 10
+}
+
+class Dummy {
+  val m: Int = n + 4
+  val n: Int = 10     // error
+}

--- a/tests/init/neg/early-promote5.scala
+++ b/tests/init/neg/early-promote5.scala
@@ -1,0 +1,25 @@
+abstract class A {
+  bar(this)
+  def bar(x: A): Unit
+}
+
+class Outer {
+  val a: Int = 4
+  trait B {
+    def bar(x: A) = println(a)
+  }
+}
+
+class M(val o: Outer, c: Container) extends A with o.B
+
+class Container {
+  val o = new Outer
+  val m = new M(o, this)
+  val s = "hello"
+}
+
+class Dummy {
+  val m: Int = n + 4
+  val n: Int = 10     // error
+}
+

--- a/tests/init/neg/i12544.scala
+++ b/tests/init/neg/i12544.scala
@@ -1,0 +1,19 @@
+enum Enum:
+  case Case
+  case Case2(x: Int)
+
+def g(b: Enum.B): Int = b.foo()
+
+object Enum:
+  object nested:
+    val a: Enum = Case
+
+  val b: Enum = f(nested.a)
+
+  def f(e: Enum): Enum = e
+
+  class B() { def foo() = n + 1 }
+  g(new B())                       // error
+  val n: Int = 10
+
+@main def main(): Unit = println(Enum.b)

--- a/tests/init/neg/promotion-loop.check
+++ b/tests/init/neg/promotion-loop.check
@@ -5,5 +5,5 @@
    |
    |The unsafe promotion may cause the following problem(s):
    |
-   |1. Promote the value under initialization to fully-initialized. May only use initialized value as arguments Calling trace:
+   |1. Promote the value under initialization to fully-initialized. May only use initialized value as arguments. Calling trace:
    | -> val outer = test	[ promotion-loop.scala:12 ]

--- a/tests/init/neg/secondary-ctor.scala
+++ b/tests/init/neg/secondary-ctor.scala
@@ -1,0 +1,19 @@
+class A(b: B, x: Int) {
+  def this(b: B) = {
+    this(b, 5)
+    println(b.n)  // error
+  }
+}
+
+class B(val d: D) {
+  val n: Int = 10
+}
+
+class C(b: B) extends A(b) {
+  def this(b: B, x: Int) = this(b)
+}
+
+class D {
+  val b = new B(this)
+  val c = new C(b, 5)
+}

--- a/tests/init/neg/secondary-ctor2.scala
+++ b/tests/init/neg/secondary-ctor2.scala
@@ -2,9 +2,9 @@ class A(b: B, x: Int) {
   def this(b: B) = {
     this(b, 5)
     class Inner() {
-      def foo() = println(b.n)
+      def foo() = println(b.n) // error: calling method on cold
     }
-    Inner().foo() // error: calling method on cold
+    Inner().foo()
 
     val f = () => new A(b, 3)
     f() // ok

--- a/tests/init/neg/secondary-ctor2.scala
+++ b/tests/init/neg/secondary-ctor2.scala
@@ -1,0 +1,25 @@
+class A(b: B, x: Int) {
+  def this(b: B) = {
+    this(b, 5)
+    class Inner() {
+      def foo() = println(b.n)
+    }
+    Inner().foo() // error: calling method on cold
+
+    val f = () => new A(b, 3)
+    f() // ok
+  }
+}
+
+class B(val d: D) {
+  val n: Int = 10
+}
+
+class C(b: B) extends A(b) {
+  def this(b: B, x: Int) = this(b)
+}
+
+class D {
+  val b = new B(this)
+  val c = new C(b, 5)
+}

--- a/tests/init/neg/secondary-ctor3.scala
+++ b/tests/init/neg/secondary-ctor3.scala
@@ -7,9 +7,9 @@ def foo() =
     def this(b: B) = {
       this(b, 5)
       class Inner() {
-        def foo() = println(b.n)
+        def foo() = println(b.n) // error
       }
-      Inner().foo() // error: calling method on cold
+      Inner().foo()
 
       val l1 = new L1(3)
       println(l1.n)

--- a/tests/init/neg/secondary-ctor3.scala
+++ b/tests/init/neg/secondary-ctor3.scala
@@ -1,0 +1,39 @@
+def foo() =
+  class L1(x: Int) { val n: Int = 5 }
+
+  class A(b: B, x: Int) {
+    class L2(x: Int) { val n: Int = 5 }
+
+    def this(b: B) = {
+      this(b, 5)
+      class Inner() {
+        def foo() = println(b.n)
+      }
+      Inner().foo() // error: calling method on cold
+
+      val l1 = new L1(3)
+      println(l1.n)
+
+      val l2 = new L2(3)
+      println(l2.n)
+
+      (() => new A(b, 3))()  // ok
+    }
+  }
+
+  class B(val d: D) {
+    val n: Int = 10
+  }
+
+  trait T {
+    val m: Int = 10
+  }
+
+  class C(b: B) extends A(b) with T {
+    def this(b: B, x: Int) = this(b)
+  }
+
+  class D {
+    val b = new B(this)
+    val c = new C(b, 5)
+  }

--- a/tests/init/neg/secondary-ctor4.scala
+++ b/tests/init/neg/secondary-ctor4.scala
@@ -1,0 +1,61 @@
+trait D {
+  val n: Int = 10
+}
+
+class M(x: Int) {
+
+  def this(d: D) = {
+    this(d.n)
+
+    class L1(x: Int) { val n: Int = 5 }
+
+    class A(b: B, x: Int) {
+      println(d.n)      // error
+
+      class L2(x: Int) { val n: Int = 5 }
+
+      def this(b: B) = {
+        this(b, 5)
+        println(d.n)  // error
+
+        class Inner() {
+          println(d.n)   // error
+          println(b.n)   // error
+          def foo() = println(b.n)  // error
+        }
+        Inner().foo()
+
+        val l1 = new L1(3)
+        println(l1.n)
+
+        val l2 = new L2(3)
+        println(l2.n)
+
+        (() => new A(b, 3))()  // ok
+      }
+    }
+
+    class B(val d: D) {
+      val n: Int = 10
+    }
+
+    new A(new B(new D))
+
+    trait T {
+      val m: Int = 10
+    }
+
+    class C(b: B) extends A(b) with T {
+      def this(b: B, x: Int) = this(b)
+    }
+
+    class D {
+      val b = new B(this)
+      val c = new C(b, 5)
+    }
+  }
+}
+
+class N(d: D) extends M(d) {
+  val msg = "Scala"
+}

--- a/tests/init/neg/soundness1.scala
+++ b/tests/init/neg/soundness1.scala
@@ -1,7 +1,29 @@
 class A(b: B) {
-  val b2 = new B(this) // error
+  val b2 = new B(this)
 }
 
 class B(a: A) {
-  val a2 = new A(this) // error
+  val a2 = new A(this)
 }
+
+object Test2:
+  class A(b: B) {
+    val b2 = new B(this)
+    val c = b2.a2
+  }
+
+  class B(a: A) {
+    val a2 = new A(this)
+    val c = a2.b2
+  }
+
+object Test3:
+  class A(b: B) {
+    println(b.a2)           // error
+    val b2 = new B(this)
+  }
+
+  class B(a: A) {
+    println(a.b2)           // error
+    val a2 = new A(this)
+  }

--- a/tests/init/neg/soundness2.scala
+++ b/tests/init/neg/soundness2.scala
@@ -1,3 +1,4 @@
 class C(c: C) {
-  val c2 = new C(this)   // error
+  val d = c.c2          // error
+  val c2 = new C(this)
 }

--- a/tests/init/neg/soundness6.scala
+++ b/tests/init/neg/soundness6.scala
@@ -1,5 +1,5 @@
 class C(c: C) {
-  println(c.n)
-  val c2 = new C(this)  // error
+  println(c.n)          // error
+  val c2 = new C(this)
   val n = 10
 }

--- a/tests/init/pos/Parsers.scala
+++ b/tests/init/pos/Parsers.scala
@@ -1,0 +1,10 @@
+object Parsers {
+  enum Location(val inParens: Boolean, val inPattern: Boolean, val inArgs: Boolean):
+    case InParens      extends Location(true, false, false)
+    case InArgs        extends Location(true, false, true)
+    case InPattern     extends Location(false, true, false)
+    case InGuard       extends Location(false, false, false)
+    case InPatternArgs extends Location(false, true, true) // InParens not true, since it might be an alternative
+    case InBlock       extends Location(false, false, false)
+    case ElseWhere     extends Location(false, false, false)
+}

--- a/tests/init/pos/enums.scala
+++ b/tests/init/pos/enums.scala
@@ -1,0 +1,6 @@
+enum Color(val x: Int) {
+  case Green  extends Color(3)
+  // case Red    extends Color(2)
+  case Violet extends Color(Green.x + 1)
+  // case RGB(xx: Int) extends Color(xx)
+}

--- a/tests/init/pos/features-doublelist.scala
+++ b/tests/init/pos/features-doublelist.scala
@@ -1,6 +1,6 @@
 class DoubleList {
   class Node(var prev: Node, var next: Node, data: Int)
-  object sentinel extends Node(sentinel, sentinel, 0)  // error // error
+  object sentinel extends Node(sentinel, sentinel, 0)
 
   def insert(x: Int) = ???
 }

--- a/tests/init/pos/lazylist1.scala
+++ b/tests/init/pos/lazylist1.scala
@@ -2,7 +2,7 @@ class LazyList[A]
 
 object LazyList {
   inline implicit def toDeferred[A](l: LazyList[A]): Deferred[A] =
-    new Deferred(l)  // error
+    new Deferred(l)
 
   final class Deferred[A](l: => LazyList[A]) {
     def #:: [B >: A](elem: => B): LazyList[B] = ???


### PR DESCRIPTION
The following code will be OK:

```Scala
  class A(b: B) {
    val b2 = new B(this)
    val c = b2.a2
  }

  class B(a: A) {
    val a2 = new A(this)
    val c = a2.b2
  }
```

The following will get an error:

```Scala
  class A(b: B) {
    println(b.a2)           // error
    val b2 = new B(this)
  }

  class B(a: A) {
    println(a.b2)           // error
    val a2 = new A(this)
  }
```