### PR TITLE
Deleted unnecessary explanations

### DIFF
--- a/scaladoc/README.md
+++ b/scaladoc/README.md
@@ -1,8 +1,8 @@
 # Scaladoc
 
 Scaladoc  is the documentation tool for
-[Scala 3](https://github.com/lampepfl/dotty), which is scheduled to become
-Scala 3.  It uses the TastyInspector to access definitions,
+[Scala 3](https://github.com/lampepfl/dotty).
+It uses the TastyInspector to access definitions,
 which is an officially supported way to access Scala 3's perspective of a
 codebase.
 


### PR DESCRIPTION
As a result of replacing 'Dotty' with 'Scala 3' in the following commit,
the explanation 'which is scheduled to become Scala 3' is no longer needed.

https://github.com/lampepfl/dotty/commit/ccb76da991bfbb882e1e91e5c6051d91ed4b86f3