### PR TITLE
Insert conversions also on selections wrapped in type applications

### DIFF
--- a/tests/neg/i8861.scala
+++ b/tests/neg/i8861.scala
@@ -20,7 +20,7 @@ object Test {
   )
   def minimalFail[M](c: Container { type A = M }): M = c.visit(
     int = vi => vi.i : vi.A,
-    str = vs => vs.t : vs.A  // error
+    str = vs => vs.t : vs.A  // error // error
   )
 
   def main(args: Array[String]): Unit = {

--- a/tests/pos/i12708.scala
+++ b/tests/pos/i12708.scala
@@ -1,0 +1,37 @@
+import language.implicitConversions
+
+trait AdditiveSemigroup[A]
+
+final class AdditiveSemigroupOps[A](lhs: A)(implicit as: AdditiveSemigroup[A]) {
+  def +(rhs: A): A = ???
+  def ^(rhs: A): A = ???
+}
+
+trait AdditiveSemigroupSyntax {
+  implicit def additiveSemigroupOps[A: AdditiveSemigroup](a: A): AdditiveSemigroupOps[A] =
+     new AdditiveSemigroupOps(a)
+}
+
+object syntax {
+  object additiveSemigroup extends AdditiveSemigroupSyntax
+}
+
+object App {
+
+  def main(args: Array[String]): Unit = {
+    import syntax.additiveSemigroup._
+
+    implicit def IntAlgebra[A]: AdditiveSemigroup[Map[Int, A]] = ???
+
+    def res[A]: Map[Int, A] = {
+      val a: Map[Int, A] = Map.empty
+      val b: Map[Int, A] = Map.empty
+      // Calls the operator on AdditiveSemigroupOps
+      a ^ b
+      // Calls the operator + on AdditiveSemigroupOps only in Scala 2
+      // In Scala 3 tries to call `+` on Map
+      a + b
+    }
+  }
+
+}

--- a/tests/pos/zipped.scala
+++ b/tests/pos/zipped.scala
@@ -22,17 +22,14 @@ object Test {
   xs.lazyZip(xs).lazyZip(xs)
     .map( (x: Int, y: Int, z: Int) => x + y + z )     // OK
 
-  // 4. The single parameter map does not work.
+  // 4. The single parameter map works through an inserted conversion
   xs.lazyZip(xs).lazyZip(xs)
-    .map( (x: (Int, Int, Int)) => x match { case (x, y, z) => x + y + z })     // error
+    .map( (x: (Int, Int, Int)) => x match { case (x, y, z) => x + y + z })     // now also OK
 
-  // 5. If we leave out the parameter type, we get a "Wrong number of parameters" error instead
+  // 5. If we leave out the parameter type, it now works as well.
   xs.lazyZip(xs).lazyZip(xs)
-    .map( x => x match { case (x, y, z) => x + y + z })     // error
+    .map( x => x match { case (x, y, z) => x + y + z })     // now also OK
 
-  // This means that the following works in Dotty in normal mode, since a `withFilter`
-  // is inserted. But it does no work under -strict. And it will not work in Scala 3.1.
-  // The reason is that without -strict, the code below is mapped to (1), but with -strict
-  // it is mapped to (5).
+  // This means that the following works in Dotty 3.0 as well as 3.x
   for ((x, y, z) <- xs.lazyZip(xs).lazyZip(xs)) yield x + y + z
 }


### PR DESCRIPTION
In i12708.scala, the problematic function was a selection `qual.m[tvs]` that was already
applied to type variables. In that case we need to backtrack, forget the type variables
and try to insert a conversion or extension method on `qual`.

Fixes #12708