### PR TITLE
macros.md: Fix htmlized variant of first source code example

### DIFF
--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -40,7 +40,7 @@ def assertImpl(expr: Expr[Boolean])(using Quotes) = '{
 }
 
 def showExpr(expr: Expr[Boolean])(using Quotes): Expr[String] =
-  '{ "<some source code>" } // Better implementation later in this document
+  '{ [actual implementation later in this document] }
 ```
 
 If `e` is an expression, then `'{e}` represents the typed


### PR DESCRIPTION
Confusingly, the last part of the first source code example would
appear as

def showExpr(expr: Expr[Boolean])(using Quotes): Expr[String] =
  '{ "

         " }

in the htmlized version of the markdown documentation source. Which
reads as follows:

def showExpr(expr: Expr[Boolean])(using Quotes): Expr[String] =
  '{ "<some source code>" } // Better implementation later in this document

This seems to be cause by the usage of angle brackets. Also note that
the code comment does not appear in the htmlized output.