### PR TITLE
macros.md: fix parentheses/braces in inlined Macros.assert() example

### DIFF
--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -414,7 +414,7 @@ Inlining the `assert` function would give the following program:
 ```scala
 @main def program =
   val x = 1
-  ${ Macros.assertImpl('{ x != 0) } }
+  ${ Macros.assertImpl('{ x != 0}) }
 ```
 
 The example is only phase correct because `Macros` is a global value and


### PR DESCRIPTION
The parantheses and braces where swapped. Also align the style with
the follow up example to make it easier to spot the differences.