### PR TITLE
For extension label, avoid scala style

### DIFF
--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -24,7 +24,7 @@ circle.circumference
 An extension method translates to a specially labelled method that takes the leading parameter section as its first argument list. The label, expressed
 as `<extension>` here, is compiler-internal. So, the definition of `circumference` above translates to the following method, and can also be invoked as such:
 
-```scala
+```
 <extension> def circumference(c: Circle): Double = c.radius * math.Pi * 2
 
 assert(circle.circumference == circumference(circle))
@@ -49,7 +49,7 @@ x min 3
 
 The three definitions above translate to
 
-```scala
+```
 <extension> def < (x: String)(y: String): Boolean = ...
 <extension> def +: (xs: Seq[Elem])(x: Elem): Seq[Elem] = ...
 <extension> infix def min(x: Number)(y: Number): Number = ...


### PR DESCRIPTION
The text intends to demonstrate the `<extension>` label. The angle brackets are correctly translated in single backticks, but in a code block, the scala styling somehow converts them to xml with closing tags. Obviously, this doesn't render.

Just removing the scala style for these two code blocks seems sufficient. I don't really know how any of this works, so maybe there is a better solution, of course.

https://dotty.epfl.ch/docs/reference/contextual/extension-methods.html
