### PR TITLE
Fix toString for PositionBridge

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -68,7 +68,7 @@ extends SrcPos, interfaces.SourcePosition, Showable {
     if outer == null || outer == NoSourcePosition then this else outer.outermost
 
   /** Inner most position that is contained within the `outermost` position.
-   *  Most precise position that that comes from the call site.
+   *  Most precise position that comes from the call site.
    */
   def nonInlined: SourcePosition = {
     val om = outermost

--- a/sbt-bridge/src/dotty/tools/xsbt/PositionBridge.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/PositionBridge.java
@@ -39,6 +39,10 @@ public class PositionBridge implements Position {
     public Optional<String> pointerSpace() {
       return Optional.empty();
     }
+
+    public String toString() {
+      return "";
+    }
   };
 
   public PositionBridge(SourcePosition pos, SourceFile src) {
@@ -115,5 +119,10 @@ public class PositionBridge implements Position {
     for (int i = 0; i < fixedPointer; i++)
       result.append(lineContent.charAt(i) == '\t' ? '\t' : ' ');
     return Optional.of(result.toString());
+  }
+
+  @Override
+  public String toString() {
+      return pos.toString();
   }
 }


### PR DESCRIPTION
I migrated a small project to Scala3, using https://github.com/davidB/scala-maven-plugin.
If everything compiles fine, all good.
But if their is a compile error or warning, instead of showing the source position eg. `path/file.scala:120` of the compilation problem, the following is shown instead: `[ERROR] dotty.tools.xsbt.PositionBridge@767bb276: could not find Lazy implicit value of type ....`
It looks like a specific toString impl is missing, and the `Object.toString` is used instead, which is not very helpful for the user to  fix compilation problem. 😅 Check for more examples: https://github.com/davidB/scala-maven-plugin/issues/477
I debugged the compilation and I think I found the place where the toString of the position is called: https://github.com/sbt/sbt/blob/develop/internal/util-logging/src/main/scala/sbt/util/InterfaceUtil.scala#L176

Even if SBT is relying on an undocumented behavior of the toString of some classes, which should probably be fixed in SBT, a more helpful toString for PositionBridge should not make any harm either.

This PR therefor adds a very basic, but helpful toString impl to PositionBridge. 
Note that the other field src is also part of pos, so I skipped it in the toString, to not get the information twice.

Example call path:
```
log:45, SbtLogger (sbt_inc)
log:47, Logger (sbt.util)
warn:43, Logger (sbt.util)
logWarning:159, LoggedReporter (sbt.internal.inc)
display:168, LoggedReporter (sbt.internal.inc)
log:142, LoggedReporter (sbt.internal.inc)
doReport:43, DelegatingReporter (dotty.tools.xsbt)
report:150, Reporter (dotty.tools.dotc.reporting)
issueWarning:32, report$ (dotty.tools.dotc)
warning:67, report$ (dotty.tools.dotc)
checkExhaustivity:847, SpaceEngine (dotty.tools.dotc.transform.patmat)
transformMatch:45, PatternMatcher (dotty.tools.dotc.transform)

...
handleCompilationError:332, IncrementalCompilerImpl (sbt.internal.inc)
compileIncrementally:420, IncrementalCompilerImpl (sbt.internal.inc)
compile:137, IncrementalCompilerImpl (sbt.internal.inc)
compile:179, SbtIncrementalCompiler (sbt_inc)
incrementalCompile:356, ScalaCompilerSupport (scala_maven)
compile:113, ScalaCompilerSupport (scala_maven)
doExecute:88, ScalaCompilerSupport (scala_maven)
execute:308, ScalaMojoSupport (scala_maven)
executeMojo:137, DefaultBuildPluginManager (org.apache.maven.plugin)

```
