### PR TITLE
Fix #9588: Enable Scala.js test ObjectTest.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1173,7 +1173,6 @@ object Build {
           ++ (dir / "shared/src/test/require-jdk7" ** "*.scala").get
 
           ++ (dir / "js/src/test/scala" ** (("*.scala": FileFilter)
-            -- "ObjectTest.scala" // compile errors caused by #9588
             -- "StackTraceTest.scala" // would require `npm install source-map-support`
             -- "UnionTypeTest.scala" // requires the Scala 2 macro defined in Typechecking*.scala
             )).get


### PR DESCRIPTION
The issue preventing that test from compiling in the past was fixed, although we don't know when or by what.