### PR TITLE
Scala.js: Mangle test names when generating JUnit bootstrappers.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
@@ -223,7 +223,7 @@ class JUnitBootstrappers extends MiniPhase {
 
     DefDef(sym, {
       val metadata = for (test <- tests) yield {
-        val name = Literal(Constant(test.name.toString))
+        val name = Literal(Constant(test.name.mangledString))
         val ignored = Literal(Constant(test.hasAnnotation(junitdefn.IgnoreAnnotClass)))
         val testAnnot = test.getAnnotation(junitdefn.TestAnnotClass).get
 
@@ -266,7 +266,7 @@ class JUnitBootstrappers extends MiniPhase {
           val tp = junitdefn.NoSuchMethodExceptionType
           Throw(resolveConstructor(tp, nameParamRef :: Nil))
         } { (test, next) =>
-          If(Literal(Constant(test.name.toString)).select(defn.Any_equals).appliedTo(nameParamRef),
+          If(Literal(Constant(test.name.mangledString)).select(defn.Any_equals).appliedTo(nameParamRef),
             genTestInvocation(testClass, test, ref(castInstanceSym)),
             next)
         }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1183,18 +1183,6 @@ object Build {
           ++ (dir / "js/src/test/scala-new-collections" ** "*.scala").get
         )
       },
-
-      // A second blacklist for tests that compile and link, but do not pass at run-time.
-      // Putting them here instead of above makes sure that we do not regress on compilation+linking.
-      Test / testOptions += Tests.Filter { name =>
-        !Set[String](
-          // Not investigated so far
-          "org.scalajs.testsuite.junit.JUnitAbstractClassTestCheck",
-          "org.scalajs.testsuite.junit.JUnitNamesTestCheck",
-          "org.scalajs.testsuite.junit.JUnitSubClassTestCheck",
-          "org.scalajs.testsuite.junit.MultiCompilationSecondUnitTestCheck",
-        ).contains(name)
-      }
     )
 
   lazy val sjsCompilerTests = project.in(file("sjs-compiler-tests")).


### PR DESCRIPTION
This fixes the last remaining JUnit-related tests, which we therefore enable.