### PR TITLE
Fix #10900: Avoid loop for F-bounds in checkCanEqual

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -929,6 +929,8 @@ trait Implicits:
           apply(t.widen)
         case t: RefinedType =>
           apply(t.parent)
+        case t: LazyRef =>
+          t
         case _ =>
           if (variance > 0) mapOver(t) else t
       }

--- a/tests/pos/i10900.scala
+++ b/tests/pos/i10900.scala
@@ -1,0 +1,3 @@
+import scala.collection.IterableOps
+def foo[CC[A] <: IterableOps[A, CC, CC[A]], A](collection: CC[A]) =
+  collection == collection

--- a/tests/pos/i10900.scala
+++ b/tests/pos/i10900.scala
@@ -1,3 +1,23 @@
 import scala.collection.IterableOps
 def foo[CC[A] <: IterableOps[A, CC, CC[A]], A](collection: CC[A]) =
   collection == collection
+
+object Test1 {
+  import scala.collection.IterableOps
+  implicit class RichCollection[CC[A] <: IterableOps[A, CC, CC[A]], A](val collection: CC[A]) {
+    def awm(update: CC[A] => CC[A]): CC[A] = {
+      val newCollection = update(collection)
+      if (newCollection == collection) collection else newCollection.awm(update)
+    }
+  }
+}
+
+object Test2 {
+  import scala.collection.IterableOps
+  implicit class RichCollection[CC[A] <: IterableOps[A, CC, CC[A]], A](val collection: CC[A]) {
+    def awm(update: CC[A] => CC[A]): CC[A] = update(collection) match {
+      case `collection` => collection
+      case updated      => updated.awm(update)
+    }
+  }
+}


### PR DESCRIPTION
Fix #10900: Avoid loop for F-bounds in checkCanEqual