### PR TITLE
Fix CLA check for first-time contributors

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,3 +6,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: ./project/scripts/check-cla.sh
+      env:
+        AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/project/scripts/check-cla.sh
+++ b/project/scripts/check-cla.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eux
 
-AUTHOR=$GITHUB_ACTOR
 echo "Pull request submitted by $AUTHOR";
 signed=$(curl -s https://www.lightbend.com/contribute/cla/scala/check/$AUTHOR | jq -r ".signed");
 if [ "$signed" = "true" ] ; then


### PR DESCRIPTION
Now that Github Actions requires maintainer approval for workflow runs on PRs from first-time contributors, the CLA check is performed on the wrong user id (workflow approver rather than PR author).

A recent example of this is PR #12718, seen here: https://github.com/lampepfl/dotty/runs/2764331890?check_suite_focus=true#step:3:4
