### PR TITLE
Scala 3.X documentation snapshots

### DIFF
--- a/project/scripts/genDocs
+++ b/project/scripts/genDocs
@@ -19,7 +19,7 @@ mkdir -pv "$PREVIOUS_SNAPSHOTS_DIR"
 git remote add doc-remote "https://github.com/lampepfl/dotty-website.git"
 git fetch doc-remote gh-pages
 git checkout gh-pages
-(cp -vr 0.*/ "$PREVIOUS_SNAPSHOTS_DIR"; true)  # Don't fail if no `0.*` found to copy
+(cp -vr 3.*/ "$PREVIOUS_SNAPSHOTS_DIR"; true)  # Don't fail if no `3.*` found to copy
 git checkout "$GIT_HEAD"
 
 ### Generate the current snapshot of the website ###

--- a/project/scripts/genDocs
+++ b/project/scripts/genDocs
@@ -19,7 +19,7 @@ mkdir -pv "$PREVIOUS_SNAPSHOTS_DIR"
 git remote add doc-remote "https://github.com/lampepfl/dotty-website.git"
 git fetch doc-remote gh-pages
 git checkout gh-pages
-(cp -vr 3.*/ "$PREVIOUS_SNAPSHOTS_DIR"; true)  # Don't fail if no `3.*` found to copy
+(cp -vr [03].*/ "$PREVIOUS_SNAPSHOTS_DIR"; true)  # Don't fail if no `3.*` found to copy
 git checkout "$GIT_HEAD"
 
 ### Generate the current snapshot of the website ###


### PR DESCRIPTION
https://github.com/lampepfl/dotty-website/tree/gh-pages contains only previous versions for the 0.X Dotty versions.
This means that no previous version is maintained for the 3.X series, including 3.0.0.

This PR aims at fixing this issue as well as creating a stable URL for the api documentation of Scala 3.0.0