### PR TITLE
Fix Tuple.toList return type

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -44,6 +44,7 @@ i5720.scala
 # Tuples
 toexproftuple.scala
 i7580.scala
+i12721.scala
 
 # Nullability
 nullable.scala

--- a/compiler/test/dotc/run-test-pickling.blacklist
+++ b/compiler/test/dotc/run-test-pickling.blacklist
@@ -22,6 +22,7 @@ tuple-zip.scala
 tuples1.scala
 tuples1a.scala
 tuples1b.scala
+toList.scala
 typeCheckErrors.scala
 typeclass-derivation-doc-example.scala
 typeclass-derivation1.scala

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -12,9 +12,8 @@ sealed trait Tuple extends Product {
     runtime.Tuples.toArray(this)
 
   /** Create a copy this tuple as a List */
-  inline def toList: List[Union[this.type]] =
-    this.productIterator.toList
-      .asInstanceOf[List[Union[this.type]]]
+  inline def toList[This >: this.type <: Tuple]: List[Union[This]] =
+    this.productIterator.toList.asInstanceOf[List[Union[This]]]
 
   /** Create a copy this tuple as an IArray */
   inline def toIArray: IArray[Object] =

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -11,9 +11,15 @@ sealed trait Tuple extends Product {
   inline def toArray: Array[Object] =
     runtime.Tuples.toArray(this)
 
+  // NOTE: Replaced by `toList` extension method in the `Tuple` object.
+  //       Kept this version of the method as `private[scala]` to be
+  //       able to unpickle older TASTy files.
+  // TODO: When we can break TASTy compat, replace this method with one that has the following signature
+  //       `inline def toList[This >: this.type <: Tuple]: List[Union[This]]`
+  //       and remove the extension method in the `Tuple` object.
   /** Create a copy this tuple as a List */
-  inline def toList[This >: this.type <: Tuple]: List[Union[This]] =
-    this.productIterator.toList.asInstanceOf[List[Union[This]]]
+  private[scala] inline def toList: List[Union[this.type]] =
+    this.productIterator.toList.asInstanceOf[List[Union[this.type]]]
 
   /** Create a copy this tuple as an IArray */
   inline def toIArray: IArray[Object] =
@@ -231,6 +237,13 @@ object Tuple {
 
   def fromProductTyped[P <: Product](p: P)(using m: scala.deriving.Mirror.ProductOf[P]): m.MirroredElemTypes =
     runtime.Tuples.fromProduct(p).asInstanceOf[m.MirroredElemTypes]
+
+  // TODO: When we can break TASTy compat, move this method to `Tuple` class and use the following signature
+  //       `inline def toList[This >: this.type <: Tuple]: List[Union[This]]`
+  /** Create a copy this tuple as a List */
+  extension [This <: Tuple](inline tuple: This)
+    inline def toList: List[Union[This]] =
+      tuple.productIterator.toList.asInstanceOf[List[Union[This]]]
 }
 
 /** A tuple of 0 elements */

--- a/tests/pos/i12721.scala
+++ b/tests/pos/i12721.scala
@@ -1,0 +1,7 @@
+def bar(t: Any): Int = 1
+def foo(t: AnyRef): Unit =
+  (??? : Tuple).toList.map(bar)
+  (??? : EmptyTuple).toList.map(bar)
+  (??? : NonEmptyTuple).toList.map(bar)
+  (??? : *:[?, ?]).toList.map(bar)
+  (??? : (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)).toList.map(bar)


### PR DESCRIPTION
This method failed for any subtype of `Tuple`.
It only worked for `Tuple` and `TupleN` as these define their own `toList`.

Fixes #12721