### PR TITLE
Interactive: fix `contextOfPath` for Template

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -293,8 +293,10 @@ object Interactive {
             // in subsequent parameter sections
           localCtx
         case tree: MemberDef =>
-          assert(tree.symbol.exists)
-          outer.localContext(tree, tree.symbol)
+          if (tree.symbol.exists)
+            outer.localContext(tree, tree.symbol)
+          else
+            outer
         case tree @ Block(stats, expr) =>
           val localCtx = outer.fresh.setNewScope
           stats.foreach {
@@ -310,7 +312,7 @@ object Interactive {
           }
           localCtx
         case tree @ Template(constr, parents, self, _) =>
-          if ((constr :: self :: parents).contains(nested)) ctx
+          if ((constr :: self :: parents).contains(nested)) outer
           else contextOfStat(tree.body, nested, tree.symbol, outer.inClassContext(self.symbol))
         case _ =>
           outer

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -994,4 +994,33 @@ class CompletionTest {
             ("annotation", Module, "scala.annotation")
           )
         )
+  @Test def completeTemplateConstrArgType: Unit = {
+    val expected = Set(
+      ("Future", Class, "scala.concurrent.Future"),
+      ("Future", Module, "scala.concurrent.Future")
+    )
+    code"""import scala.concurrent.Future
+          |class Foo(x: Fut${m1})""".withSource
+      .completion(m1, expected) 
+  }
+
+  @Test def completeTemplateParents: Unit = {
+    val expected = Set(
+      ("Future", Class, "scala.concurrent.Future"),
+      ("Future", Module, "scala.concurrent.Future")
+    )
+    code"""import scala.concurrent.Future
+          |class Foo extends Futu${m1}""".withSource
+      .completion(m1, expected) 
+  }
+
+  @Test def completeTemplateSelfType: Unit = {
+    val expected = Set(
+      ("Future", Class, "scala.concurrent.Future"),
+      ("Future", Module, "scala.concurrent.Future")
+    )
+    code"""import scala.concurrent.Future
+          |class Foo[A]{ self: Futu${m1} => }""".withSource
+      .completion(m1, expected) 
+  }
 }


### PR DESCRIPTION
Without this fix, in case if input `path: List[Tree]` starts from `Template.constr` tree `contextOfPath` ignores parent trees and returns non-completed `Context` value.