### PR TITLE
Fix regression in provablyDisjoint

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2530,7 +2530,9 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     }.apply(true, tp)
 
     (tp1.dealias, tp2.dealias) match {
-      case (tp1: TypeRef, tp2: TypeRef) if tp1.symbol == defn.SingletonClass || tp2.symbol == defn.SingletonClass =>
+      case (tp1: TypeRef, _) if tp1.symbol == defn.SingletonClass =>
+        false
+      case (_, tp2: TypeRef) if tp2.symbol == defn.SingletonClass =>
         false
       case (tp1: ConstantType, tp2: ConstantType) =>
         tp1 != tp2

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2614,10 +2614,10 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         provablyDisjoint(tp1, gadtBounds(tp2.symbol).hi) || provablyDisjoint(tp1, tp2.superType)
       case (tp1: TermRef, tp2: TermRef) if isEnumValueOrModule(tp1) && isEnumValueOrModule(tp2) =>
         tp1.termSymbol != tp2.termSymbol
-      case (tp1: TermRef, _) if isEnumValue(tp1) =>
-        false
-      case (_, tp2: TermRef) if isEnumValue(tp2) =>
-        false
+      case (tp1: TermRef, tp2: TypeRef) if isEnumValue(tp1) =>
+        fullyInstantiated(tp2) && !tp1.classSymbols.exists(_.derivesFrom(tp2.symbol))
+      case (tp1: TypeRef, tp2: TermRef) if isEnumValue(tp2) =>
+        fullyInstantiated(tp1) && !tp2.classSymbols.exists(_.derivesFrom(tp1.symbol))
       case (tp1: Type, tp2: Type) if defn.isTupleType(tp1) =>
         provablyDisjoint(tp1.toNestedPairs, tp2)
       case (tp1: Type, tp2: Type) if defn.isTupleType(tp2) =>

--- a/tests/neg/12549.scala
+++ b/tests/neg/12549.scala
@@ -1,0 +1,18 @@
+enum Bool {
+  case True
+  case False
+}
+
+import Bool.*
+
+type Not[B <: Bool] = B match {
+  case True.type => False.type
+  case False.type => True.type
+  case _ => "unreachable"
+}
+
+def foo[B <: Bool & Singleton]: Unit = {
+  implicitly[Not[B] =:= "unreachable"] // error
+
+  ()
+}


### PR DESCRIPTION
#12549 introduced a regression in provablyDisjoint. The problem comes from the following case:

```scala
case (tp1: TermRef, tp2: TypeRef) if isEnumValueOrModule(tp1)
  && !tp1.classSymbols.exists(_.derivesFrom(tp2.classSymbol)) =>
    true
```

The `!tp1.classSymbols.exists(...)` is not sufficient, for instance if tp2 is unbounded type parameter that code can wrongly conclude that a `TermRef` doesn't belong to that type.