### PR TITLE
Fix #12739: Handle type alias in capturing wildcards

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -503,7 +503,7 @@ object Inferencing {
     *  $i is a skolem of type `scala.internal.TypeBox`, and `CAP` is its
     *  type member. See the documentation of `TypeBox` for a rationale why we do this.
     */
-  def captureWildcards(tp: Type)(using Context): Type = tp match {
+  def captureWildcards(tp: Type)(using Context): Type = tp.dealias match {
     case tp @ AppliedType(tycon, args) if tp.hasWildcardArg =>
       tycon.typeParams match {
         case tparams @ ((_: Symbol) :: _) =>

--- a/tests/pos/i12739.scala
+++ b/tests/pos/i12739.scala
@@ -1,0 +1,16 @@
+object O {
+
+  class CA[A](var x: A)
+  type C = CA[_]
+
+  val c: C = ???
+  def f[A](r: CA[A]): A = r.x
+
+  def g(): CA[_] = CA("hello")
+
+  f(g())
+  f(c)
+  f(c.asInstanceOf[CA[_]])
+  f(c.asInstanceOf[C])
+  f(c.asInstanceOf[c.type])
+}


### PR DESCRIPTION
Fix #12739: Handle type alias in capturing wildcards