### PR TITLE
Use `==` for instance tests against string constants

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -963,8 +963,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
     /** `tree.isInstanceOf[tp]`, with special treatment of singleton types */
     def isInstance(tp: Type)(using Context): Tree = tp.dealias match {
+      case ConstantType(c) if c.tag == StringTag =>
+        singleton(tp).equal(tree)
       case tp: SingletonType =>
-        if (tp.widen.derivesFrom(defn.ObjectClass))
+        if tp.widen.derivesFrom(defn.ObjectClass) then
           tree.ensureConforms(defn.ObjectType).select(defn.Object_eq).appliedTo(singleton(tp))
         else
           singleton(tp).equal(tree)

--- a/tests/run/i12796/A_1.scala
+++ b/tests/run/i12796/A_1.scala
@@ -1,0 +1,4 @@
+object A:
+  type Timeframe = "1m" | "2m" | "1H"
+
+  def test(input: String) = input.isInstanceOf[Timeframe]

--- a/tests/run/i12796/Test_2.scala
+++ b/tests/run/i12796/Test_2.scala
@@ -1,0 +1,3 @@
+@main def Test =
+  val x = "1"
+  assert(A.test(x + "m"))

--- a/tests/run/i6996.check
+++ b/tests/run/i6996.check
@@ -1,3 +1,3 @@
 an `a`
-false
-not `a`
+true
+an `a`


### PR DESCRIPTION
We used `eq` before, as for other objetc singletons. But this means
we are subject to the vagaries of string hashing.

Fixes #12796
Fixes #6996