### PR TITLE
Fix typo in syntax-3.1.md

### DIFF
--- a/docs/docs/internals/syntax-3.1.md
+++ b/docs/docs/internals/syntax-3.1.md
@@ -96,7 +96,7 @@ erased    extends   false     final     finally   for       given     if
 implied   import    lazy      match     new       null      object    package
 private   protected override  return    super     sealed    then      throw
 trait     true      try       type      val       var       while     yield
-:         =         <-        =>        <:        :>        #         @
+:         =         <-        =>        <:        >:        #         @
 ```
 
 ### Soft keywords


### PR DESCRIPTION
The supertype symbol was ':>' and it was changed to '>:' .

https://github.com/lampepfl/dotty/pull/12687