### PR TITLE
Fix TyperState assertion failures

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -526,6 +526,10 @@ object Contexts {
     final def withOwner(owner: Symbol): Context =
       if (owner ne this.owner) fresh.setOwner(owner) else this
 
+    final def withUncommittedTyperState: Context =
+      val ts = typerState.uncommittedAncestor
+      if ts ne typerState then fresh.setTyperState(ts) else this
+
     final def withProperty[T](key: Key[T], value: Option[T]): Context =
       if (property(key) == value) this
       else value match {

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -140,6 +140,7 @@ class TyperState() {
     Stats.record("typerState.commit")
     assert(isCommittable, s"$this is not committable")
     assert(!isCommitted, s"$this is already committed")
+    reporter.flush()
     setCommittable(false)
     val targetState = ctx.typerState
     assert(!targetState.isCommitted, s"Attempt to commit $this into already committed $targetState")
@@ -152,7 +153,6 @@ class TyperState() {
       else
         targetState.mergeConstraintWith(this)
     targetState.gc()
-    reporter.flush()
     isCommitted = true
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -138,9 +138,11 @@ class TyperState() {
    */
   def commit()(using Context): Unit = {
     Stats.record("typerState.commit")
-    assert(isCommittable)
+    assert(isCommittable, s"$this is not committable")
+    assert(!isCommitted, s"$this is already committed")
     setCommittable(false)
     val targetState = ctx.typerState
+    assert(!targetState.isCommitted, s"Attempt to commit $this into already committed $targetState")
     if constraint ne targetState.constraint then
       Stats.record("typerState.commit.new constraint")
       constr.println(i"committing $this to $targetState, fromConstr = $constraint, toConstr = ${targetState.constraint}")

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -388,8 +388,8 @@ object ProtoTypes {
       if state.typedArgs.size == args.length then state.typedArgs
       else
         val passedTyperState = ctx.typerState
-        inContext(protoCtx) {
-          val protoTyperState = protoCtx.typerState
+        inContext(protoCtx.withUncommittedTyperState) {
+          val protoTyperState = ctx.typerState
           val oldConstraint = protoTyperState.constraint
           val args1 = args.mapWithIndexConserve((arg, idx) =>
             cacheTypedArg(arg, arg => typer.typed(norm(arg, idx)), force = false))

--- a/tests/neg/i12736a.scala
+++ b/tests/neg/i12736a.scala
@@ -1,0 +1,6 @@
+object Test {
+  def apply[S](r: Any): Any = r
+
+  def test =
+    (x: Int) => Test(doesntexist, x) // error
+}

--- a/tests/neg/i12736b.scala
+++ b/tests/neg/i12736b.scala
@@ -1,0 +1,6 @@
+object Test {
+  def apply[S](r: Any)(using DoesntExist): Any = r // error
+
+  def test(o: Option[Any]) =
+    o.map(x => Test(doesntExist, x)) // error
+}


### PR DESCRIPTION
I nominate this PR for a backport to 3.0.1 since it fixes a regression introduced in 3.0.1-RC1 by #12519: that PR added some assertions which are now failing, this PR does not remove the assertions but fixes the underlying issues.