### PR TITLE
Update document for DottyTypeStealer

### DIFF
--- a/compiler/test/dotty/tools/DottyTypeStealer.scala
+++ b/compiler/test/dotty/tools/DottyTypeStealer.scala
@@ -7,6 +7,12 @@ import dotc.core.Contexts.Context
 import dotc.core.Decorators._
 import dotc.core.Types.Type
 
+@main def steal() = {
+  val s = DottyTypeStealer.stealType("class O { type X }", "O#X")
+  val t = s._2(0)
+  println(t)
+}
+
 object DottyTypeStealer extends DottyTest {
   def stealType(source: String, typeStrings: String*): (Context, List[Type]) = {
     val dummyName = "x_x_x"

--- a/docs/docs/contributing/workflow.md
+++ b/docs/docs/contributing/workflow.md
@@ -39,25 +39,23 @@ can be enabled through the `dotty.tools.dotc.config.Printers` object. Change any
 
 ## Inspecting Trees with Type Stealer ##
 
-There is no power mode for the REPL yet, but you can inspect types with the
-type stealer:
+You can inspect types with the type stealer, open `compiler/test/dotty/tools/DottyTypeStealer.scala` and you'll see:
+
+```scala
+@main def steal() = {
+  val s = DottyTypeStealer.stealType("class O { type X }", "O#X")
+  val t = s._2(0)
+  println(t)
+}
+```
 
 ```bash
 $ sbt
-> repl
-scala> import dotty.tools.DottyTypeStealer.*; import dotty.tools.dotc.core.*; import Contexts.*,Types.*
+> scala3-compiler-bootstrapped/Test/runMain dotty.tools.steal
+TypeRef(TypeRef(ThisType(TypeRef(NoPrefix,module class <empty>)),class O),type X)
 ```
 
-Now, you can define types and access their representation. For example:
-
-```scala
-scala> val s = stealType("class O { type X }", "O#X")
-scala> implicit val ctx: Context = s._1
-scala> val t = s._2(0)
-t: dotty.tools.dotc.core.Types.Type = TypeRef(TypeRef(ThisType(TypeRef(NoPrefix,<empty>)),O),X)
-scala> val u = t.asInstanceOf[TypeRef].underlying
-u: dotty.tools.dotc.core.Types.Type = TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,scala)),Nothing), TypeRef(ThisType(TypeRef(NoPrefix,scala)),Any))
-```
+You can inspect other value types by editing the arguments of `stealType`.
 
 ## Pretty-printing ##
 Many objects in the scalac compiler implement a `Showable` trait (e.g. `Tree`,

--- a/docs/docs/internals/type-system.md
+++ b/docs/docs/internals/type-system.md
@@ -23,23 +23,24 @@ Type -+- ProxyType --+- NamedType ----+--- TypeRef
       |              |                +--- ThisType
       |              |                +--- SuperType
       |              |                +--- ConstantType
-      |              |                +--- MethodParam
+      |              |                +--- TermParamRef
       |              |                +----RecThis
       |              |                +--- SkolemType
-      |              +- PolyParam
+      |              +- TypeParamRef
       |              +- RefinedOrRecType -+-- RefinedType
       |              |                   -+-- RecType
-      |              +- HKApply
+      |              +- AppliedType
       |              +- TypeBounds
       |              +- ExprType
       |              +- AnnotatedType
       |              +- TypeVar
-      |              +- PolyType
+      |              +- HKTypeLambda
+      |              +- MatchType
       |
       +- GroundType -+- AndType
                      +- OrType
-                     +- MethodType -----+- ImplicitMethodType
-                     |                  +- JavaMethodType
+                     +- MethodOrPoly ---+-- PolyType
+                     |                  +-- MethodType
                      +- ClassInfo
                      |
                      +- NoType


### PR DESCRIPTION
See: https://github.com/lampepfl/dotty/issues/12830

And copied Type diagram from `Types.scala` to `docs/docs/internals/type-system.md`.