### PR TITLE
TreeUnpickler: fix cycle involving param accessor

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -885,7 +885,12 @@ class TreeUnpickler(reader: TastyReader,
       }
       goto(end)
       setSpan(start, tree)
-      if (!sym.isType) // Only terms might have leaky aliases, see the documentation of `checkNoPrivateLeaks`
+
+      // Dealias any non-accessible type alias in the type of `sym`. This can be
+      // skipped for types (see `checkNoPrivateLeaks` for why) as well as for
+      // param accessors since they can't refer to an inaccesible type member of
+      // the class.
+      if !sym.isType && !sym.is(ParamAccessor) then
         sym.info = ta.avoidPrivateLeaks(sym)
 
       if (ctx.settings.YreadComments.value) {

--- a/tests/pos/i12834.scala
+++ b/tests/pos/i12834.scala
@@ -1,0 +1,2 @@
+class A(val ref: Option[B])
+class B extends A(None)


### PR DESCRIPTION
When unpickling a template like `A` in i12834.scala, the first thing we
do is to unpickle its class parameters, here that's `ref`. While
unpickling `ref` we run `avoidPrivateLeaks` on it which forces its info
and requires unpickling `B` which refers to `A.<init>` which leads to a
crash because we haven't entered `<init>` in `A` yet. We can avoid this
cycle by simply not running `avoidPrivateLeaks` on param accessors, this
should be safe since a primary constructor parameter cannot refer to a
type member of the class.

Fixes #12834.

<hr>

I've nominated this PR for backporting to 3.0.1 even though it's not a regression from 3.0.0 since having a broken `publishLocal` is a pretty big issue.