### PR TITLE
When checking tp1 <:< tycon2[args2], widen tp1 to reveal application

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1003,7 +1003,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       /** True if `tp1` and `tp2` have compatible type constructors and their
        *  corresponding arguments are subtypes relative to their variance (see `isSubArgs`).
        */
-      def isMatchingApply(tp1: Type): Boolean = tp1 match {
+      def isMatchingApply(tp1: Type): Boolean = tp1.widen match {
         case tp1 @ AppliedType(tycon1, args1) =>
           // We intentionally do not automatically dealias `tycon1` or `tycon2` here.
           // `TypeApplications#appliedTo` already takes care of dealiasing type

--- a/tests/pos/i11499.scala
+++ b/tests/pos/i11499.scala
@@ -1,0 +1,11 @@
+trait Functor[F[_]]
+
+object data {
+
+  type OptionT[F[_], A] = F[Option[A]]
+
+  def fold[F[_], A, B](value: OptionT[F, A])(f: Functor[F]): F[B] = ???
+
+  def cata[F[_], A, B](value: OptionT[F, A])(f: Functor[F]): F[B] =
+    fold(value)(f) // error
+}


### PR DESCRIPTION
Fixes #11499 (see the discussion there for details on what happened in
the test case before this change).