### PR TITLE
be more explicit when unpickling names

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -3,7 +3,7 @@ package core
 package tasty
 
 import dotty.tools.tasty.{TastyFormat, TastyBuffer, TastyReader, TastyHeaderUnpickler}
-import TastyFormat.NameTags._
+import TastyFormat.NameTags._, TastyFormat.nameTagToString
 import TastyBuffer.NameRef
 
 import scala.collection.mutable
@@ -79,8 +79,10 @@ class TastyUnpickler(reader: TastyReader) {
         val original = readName()
         val target = readName()
         readSignedRest(original, target)
-      case _ =>
+      case SUPERACCESSOR | INLINEACCESSOR | BODYRETAINER | OBJECTCLASS =>
         simpleNameKindOfTag(tag)(readName())
+      case _ =>
+        throw MatchError(s"unknown name tag ${nameTagToString(tag)}")
     }
     assert(currentAddr == end, s"bad name $result $start $currentAddr $end")
     result

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -356,8 +356,7 @@ class TreePickler(pickler: TastyPickler) {
   def pickleParam(tree: Tree)(using Context): Unit = {
     registerTreeAddr(tree)
     tree match {
-      case tree: ValDef => pickleDef(PARAM, tree, tree.tpt)
-      case tree: DefDef => pickleDef(PARAM, tree, tree.tpt, tree.rhs)
+      case tree: ValDef  => pickleDef(PARAM, tree, tree.tpt)
       case tree: TypeDef => pickleDef(TYPEPARAM, tree, tree.rhs)
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -873,15 +873,9 @@ class TreeUnpickler(reader: TastyReader,
           }
         case PARAM =>
           val tpt = readTpt()(using localCtx)
-          if (nothingButMods(end)) {
-            sym.info = tpt.tpe
-            ValDef(tpt)
-          }
-          else {
-            sym.info = ExprType(tpt.tpe)
-            pickling.println(i"reading param alias $name -> $currentAddr")
-            DefDef(Nil, tpt)
-          }
+          assert(nothingButMods(end))
+          sym.info = tpt.tpe
+          ValDef(tpt)
       }
       goto(end)
       setSpan(start, tree)

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -70,7 +70,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   BOUNDED               type_Term                                  -- type bound
 
   TypeParam     = TYPEPARAM      Length NameRef type_Term Modifier*                -- modifiers name bounds
-  TermParam     = PARAM          Length NameRef type_Term rhs_Term? Modifier*      -- modifiers name : type (= rhs_Term)?. `rhsTerm` is present in the case of an aliased class parameter
+  TermParam     = PARAM          Length NameRef type_Term Modifier*                -- modifiers name : type.
                   EMPTYCLAUSE                                                      -- an empty parameter clause ()
                   SPLITCLAUSE                                                      -- splits two non-empty parameter clauses of the same kind
   Param         = TypeParam


### PR DESCRIPTION
also assert there is no rhs for `PARAM` tags:
since #8428 all `PARAM` are ValDef with no rhs.
This is a tasty compatible change as the
major version has bumped since then.