### PR TITLE
Fix CI job test_windows_full

### DIFF
--- a/tests/pos/i11556.scala
+++ b/tests/pos/i11556.scala
@@ -10,9 +10,9 @@ type Query[-I, +O] = Traverser[Path[I], Path[O]]
 def nodesQ(using g: Graph): Query[Nothing, g.Node] = ???
 def outsQ(using g: Graph): Query[g.Node, g.Node] = ???
 
-object graph extends Graph
-import graph._
-given graph.type = graph
+object graphObj extends Graph
+import graphObj._
+given graphObj.type = graphObj
 
 object Issue11556:
   val q1: Query[Nothing, Node] = nodesQ ~> outsQ


### PR DESCRIPTION
The problem is well explained by the warning one got when compiling
i11556.scala:
```scala
5 |class Graph { class Node }
  |      ^
  |      class Graph differs only in case from object graph. Such classes will overwrite one another on case-insensitive filesystems.
```