### PR TITLE
Scaladoc: Fix emphasis rule in hljs config

### DIFF
--- a/scaladoc/resources/dotty_res/scripts/hljs-scala3.js
+++ b/scaladoc/resources/dotty_res/scripts/hljs-scala3.js
@@ -229,7 +229,7 @@ function highlightDotty(hljs) {
       {
         className: 'emphasis',
         variants: [
-          {begin: /\*(?![\*\s/])/, end: /\*/},
+          {begin: /\*(?!([\*\s/])|([^\*]*\*[\*/]))/, end: /\*/},
           {begin: /_/, end: /_/}
         ],
       },


### PR DESCRIPTION
closes #12868 

I've figured out that:

- hljs enters comment parsing mode on `/**`
- hljs finds `*` so it enters emphasis mode
- hljs looks for `*` to exit emphasis mode and it finds `*` in `*/`
- hljs takes `*` from `*/` so it can't exit comment and takes next line as comment

So my solution is to check in begin condition of emphasis mode if the next `*` char is not followed by `/` (marks comment end) and `*` (potentially starts bold mode)
