### PR TITLE
Properly handle self-types in reflection member lookup

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/SyntheticSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/SyntheticSupport.scala
@@ -74,7 +74,13 @@ object SyntheticsSupport:
     import dotty.tools.dotc
     given ctx: dotc.core.Contexts.Context = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
     val sym = rsym.asInstanceOf[dotc.core.Symbols.Symbol]
-    sym.typeRef.appliedTo(sym.typeParams.map(_.typeRef)).allMembers.iterator.map(_.symbol)
+    // `lookupPrefix` is private in `QuotesImpl#SymbolMethods`
+    val lookupPrefix =
+      if sym.isClass then
+        sym.thisType
+      else
+        sym.namedType
+    lookupPrefix.allMembers.iterator.map(_.symbol)
       .collect {
          case sym if
           (!sym.is(dotc.core.Flags.ModuleVal) || sym.is(dotc.core.Flags.Given)) &&

--- a/tests/run-macros/self.check
+++ b/tests/run-macros/self.check
@@ -1,0 +1,3 @@
+ExprType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),Int))
+MethodType(List(x), List(TypeRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),Predef),String)), TypeRef(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,module class <root>)),module class <empty>)),B),X))
+MethodType(List(x), List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),Int)), TypeRef(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,module class <root>)),module class <empty>)),B),X))

--- a/tests/run-macros/self/Macro_1.scala
+++ b/tests/run-macros/self/Macro_1.scala
@@ -1,0 +1,35 @@
+import scala.quoted.*
+
+trait A {
+  type X
+}
+trait B { self: A =>
+  def foo(x: Int): X
+  def foo(x: String): X
+}
+
+object Obj {
+  def foo: Int = 1
+}
+
+object Macros {
+
+  inline def test(): String = ${ testImpl }
+
+  private def testImpl(using Quotes) : Expr[String] = {
+    import quotes.reflect.*
+    val bTpe = TypeRepr.of[B]
+    val bSym = bTpe.classSymbol.get
+    val bMethSyms = bSym.methodMember("foo") // Used to throw a MissingType exception
+    val bMethTpes = bMethSyms.map(bTpe.memberType)
+
+    // Make sure we didn't break member lookup on terms
+    val objTpe = TypeRepr.of[Obj.type]
+    val objSym = objTpe.termSymbol
+    val objMethSyms = objSym.methodMember("foo")
+    val objMethTpes = objMethSyms.map(objTpe.memberType)
+
+    Expr((objMethTpes ++ bMethTpes).map(_.toString).sorted.mkString("\n"))
+  }
+
+}

--- a/tests/run-macros/self/Test_2.scala
+++ b/tests/run-macros/self/Test_2.scala
@@ -1,0 +1,8 @@
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    println(Macros.test())
+  }
+
+}


### PR DESCRIPTION
The type on which we lookup things needs to be the this-type of the
class, otherwise it will not include members that only appear in the
self-type, since these members can appear in the types of members of the
current class, this could lead to a MissingType exception being thrown.

Fixes #12081.

PS: as the documentation of `allMembers` mention, it's an expensive method to call and it would be better to call `memberDenots` with a custom filter, but that's a bigger refactoring than I have time to tackle right now.