### PR TITLE
Fix #12729: Don't encode <init> and <clinit> only.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -342,8 +342,7 @@ object Names {
 
     override def encode: SimpleName = {
       val dontEncode =
-        length >= 3 &&
-        head == '<' && last == '>' && isIdentifierStart(apply(1))
+        this == StdNames.nme.CONSTRUCTOR || this == StdNames.nme.STATIC_CONSTRUCTOR
       if (dontEncode) this else NameTransformer.encode(this)
     }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -978,6 +978,10 @@ object Parsers {
     def ident(): TermName =
       if (isIdent) {
         val name = in.name
+        if name == nme.CONSTRUCTOR || name == nme.STATIC_CONSTRUCTOR then
+          report.error(
+            i"""Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden""",
+            in.sourcePos())
         in.nextToken()
         name
       }

--- a/tests/neg/i12729.scala
+++ b/tests/neg/i12729.scala
@@ -1,0 +1,7 @@
+class Test(i: Int):
+  val `<init>` = "init" // error: Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden
+  val `<clinit>` = "clinit" // error: Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden
+  class `<init>`: // error: Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden
+    def `<init>`(in: String) = ??? // error: Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden
+  class `<clinit>`: // error: Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden
+    def `<clinit>`(in: String) = ??? // error: Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden

--- a/tests/run/i12729.scala
+++ b/tests/run/i12729.scala
@@ -1,0 +1,3 @@
+object Test:
+  val `<x>` = "hello!"
+  def main(args: Array[String]): Unit = println(`<x>`)


### PR DESCRIPTION
In addition, reject `<init>` and `<clinit>` in the parser, so that
users don't write them in source code.
fixes #12729