### PR TITLE
Add Automatic-Module-Names to MANIFEST.MF files of projects with suffix_3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -751,9 +751,18 @@ object Build {
   def dottyCompilerSettings(implicit mode: Mode): sbt.Def.SettingsDefinition =
     if (mode == NonBootstrapped) nonBootstrapedDottyCompilerSettings else bootstrapedDottyCompilerSettings
 
-  lazy val `scala3-compiler` = project.in(file("compiler")).asDottyCompiler(NonBootstrapped)
-  lazy val `scala3-compiler-bootstrapped` = project.in(file("compiler")).asDottyCompiler(Bootstrapped)
-
+  lazy val `scala3-compiler` = project.in(file("compiler")).
+    asDottyCompiler(NonBootstrapped).
+    settings(
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
+    )
+  lazy val `scala3-compiler-bootstrapped` = project.in(file("compiler")).
+    asDottyCompiler(Bootstrapped).
+    settings(
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
+    )
   def dottyCompiler(implicit mode: Mode): Project = mode match {
     case NonBootstrapped => `scala3-compiler`
     case Bootstrapped => `scala3-compiler-bootstrapped`
@@ -767,8 +776,18 @@ object Build {
     ),
   )
 
-  lazy val `scala3-library` = project.in(file("library")).asDottyLibrary(NonBootstrapped)
-  lazy val `scala3-library-bootstrapped`: Project = project.in(file("library")).asDottyLibrary(Bootstrapped)
+  lazy val `scala3-library` = project.in(file("library")).
+    asDottyLibrary(NonBootstrapped).
+    settings(
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
+    )
+  lazy val `scala3-library-bootstrapped`: Project = project.in(file("library")).
+    asDottyLibrary(Bootstrapped).
+    settings(
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
+    )
 
   def dottyLibrary(implicit mode: Mode): Project = mode match {
     case NonBootstrapped => `scala3-library`
@@ -792,6 +811,8 @@ object Build {
         ("org.scala-js" %% "scalajs-library" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
       Compile / unmanagedSourceDirectories ++=
         (`scala3-library-bootstrapped` / Compile / unmanagedSourceDirectories).value,
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}"),
 
       // Configure the source maps to point to GitHub for releases
       scalacOptions ++= {
@@ -813,9 +834,24 @@ object Build {
     scalacOptions += "-source:3.0-migration"
   )
 
-  lazy val `tasty-core` = project.in(file("tasty")).asTastyCore(NonBootstrapped)
-  lazy val `tasty-core-bootstrapped`: Project = project.in(file("tasty")).asTastyCore(Bootstrapped)
-  lazy val `tasty-core-scala2`: Project = project.in(file("tasty")).asTastyCoreScala2
+  lazy val `tasty-core` = project.in(file("tasty")).
+    asTastyCore(NonBootstrapped).
+    settings(
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
+    )
+  lazy val `tasty-core-bootstrapped`: Project = project.in(file("tasty")).
+    asTastyCore(Bootstrapped).
+    settings(
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
+    )
+  lazy val `tasty-core-scala2`: Project = project.in(file("tasty")).
+    asTastyCoreScala2.
+    settings(
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
+    )
 
   def tastyCore(implicit mode: Mode): Project = mode match {
     case NonBootstrapped => `tasty-core`
@@ -829,7 +865,9 @@ object Build {
     // but we always need it to be present on the JVM classpath at runtime.
     dependsOn(dottyCompiler(Bootstrapped) % "provided; compile->runtime; test->test").
     settings(
-      javaOptions := (`scala3-compiler-bootstrapped` / javaOptions).value
+      javaOptions := (`scala3-compiler-bootstrapped` / javaOptions).value,
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
     )
 
   lazy val `scala3-tasty-inspector` = project.in(file("tasty-inspector")).
@@ -839,7 +877,9 @@ object Build {
     // but we always need it to be present on the JVM classpath at runtime.
     dependsOn(dottyCompiler(Bootstrapped) % "provided; compile->runtime; test->test").
     settings(
-      javaOptions := (`scala3-compiler-bootstrapped` / javaOptions).value
+      javaOptions := (`scala3-compiler-bootstrapped` / javaOptions).value,
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}")
     )
 
   /** Scala library compiled by dotty using the latest published sources of the library */
@@ -999,6 +1039,8 @@ object Build {
       // Work around https://github.com/eclipse/lsp4j/issues/295
       dependencyOverrides += "org.eclipse.xtend" % "org.eclipse.xtend.lib" % "2.16.0",
       javaOptions := (`scala3-compiler-bootstrapped` / javaOptions).value,
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}"),
 
       run := Def.inputTaskDyn {
         val inputArgs = spaceDelimited("<arg>").parsed
@@ -1302,6 +1344,8 @@ object Build {
       Compile / mainClass := Some("dotty.tools.scaladoc.Main"),
       Compile / buildInfoKeys := Seq[BuildInfoKey](version),
       Compile / buildInfoPackage := "dotty.tools.scaladoc",
+      Compile / packageBin / packageOptions +=
+        Package.ManifestAttributes("Automatic-Module-Name" -> s"$dottyOrganization-${name.value}"),
       BuildInfoPlugin.buildInfoScopedSettings(Compile),
       BuildInfoPlugin.buildInfoDefaultSettings,
 


### PR DESCRIPTION
The issue is described in https://github.com/lampepfl/dotty/issues/12899

In this PR I decided to add `Automatic-Module-Name` values only to projects with the suffix _3, that is:
1. scala3-compiler_3
2. scala3-library_3
3. scala3-library-sjs1_3
4. scala3-language-server_3
5. scala3-staging_3
6. scala3-tasty-inspector_3
7. scaladoc_3
8. tasty-core_3
and for consistency also tasty-core-scala2. The values are derived from dottyOrganization + the project name.