### PR TITLE
Detect provisional superclasses and recompute in Typer

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -66,7 +66,7 @@ class CompilationUnit protected (val source: SourceFile) {
   def isSuspendable: Boolean = true
 
   /** Suspends the compilation unit by thowing a SuspendException
-   *  and recoring the suspended compilation unit
+   *  and recording the suspended compilation unit
    */
   def suspend()(using Context): Nothing =
     assert(isSuspendable)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -887,6 +887,7 @@ class Definitions {
   @tu lazy val BodyAnnot: ClassSymbol = requiredClass("scala.annotation.internal.Body")
   @tu lazy val ChildAnnot: ClassSymbol = requiredClass("scala.annotation.internal.Child")
   @tu lazy val ContextResultCountAnnot: ClassSymbol = requiredClass("scala.annotation.internal.ContextResultCount")
+  @tu lazy val ProvisionalSuperClassAnnot: ClassSymbol = requiredClass("scala.annotation.internal.ProvisionalSuperClass")
   @tu lazy val DeprecatedAnnot: ClassSymbol = requiredClass("scala.deprecated")
   @tu lazy val ImplicitAmbiguousAnnot: ClassSymbol = requiredClass("scala.annotation.implicitAmbiguous")
   @tu lazy val ImplicitNotFoundAnnot: ClassSymbol = requiredClass("scala.annotation.implicitNotFound")

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -359,6 +359,10 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
           if (sym.isClass)
             VarianceChecker.check(tree)
             annotateExperimental(sym)
+            tree.rhs match
+              case impl: Template =>
+                for parent <- impl.parents do
+                  Checking.checkTraitInheritance(parent.tpe.classSymbol, sym.asClass, parent.srcPos)
             // Add SourceFile annotation to top-level classes
             if sym.owner.is(Package)
                && ctx.compilationUnit.source.exists

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -191,6 +191,30 @@ object Checking {
       report.errorOrMigrationWarning(em"$tp is not a legal $what\nsince it${rstatus.msg}", pos)
   }
 
+  /** Given a parent `parent` of a class `cls`, if `parent` is a trait check that
+   *  the superclass of `cls` derived from the superclass of `parent`.
+   *
+   *  An exception is made if `cls` extends `Any`, and `parent` is `java.io.Serializable`
+   *  or `java.lang.Comparable`. These two classes are treated by Scala as universal
+   *  traits. E.g. the following is OK:
+   *
+   *      ... extends Any with java.io.Serializable
+   *
+   *  The standard library relies on this idiom.
+   */
+  def checkTraitInheritance(parent: Symbol, cls: ClassSymbol, pos: SrcPos)(using Context): Unit =
+    parent match {
+      case parent: ClassSymbol if parent.is(Trait) =>
+        val psuper = parent.superClass
+        val csuper = cls.superClass
+        val ok = csuper.derivesFrom(psuper) ||
+          parent.is(JavaDefined) && csuper == defn.AnyClass &&
+          (parent == defn.JavaSerializableClass || parent == defn.ComparableClass)
+        if (!ok)
+          report.error(em"illegal trait inheritance: super$csuper does not derive from $parent's super$psuper", pos)
+      case _ =>
+    }
+
   /** A type map which checks that the only cycles in a type are F-bounds
    *  and that protects all F-bounded references by LazyRefs.
    */

--- a/library/src/scala/annotation/internal/ProvisionalSuperClass.scala
+++ b/library/src/scala/annotation/internal/ProvisionalSuperClass.scala
@@ -1,0 +1,6 @@
+package scala.annotation
+package internal
+
+/** An annotation to record a provisional super class */
+class ProvisionalSuperClass extends StaticAnnotation
+

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -18,6 +18,7 @@ object MiMaFilters {
     exclude[MissingClassProblem]("scala.annotation.experimental"),
     exclude[MissingClassProblem]("scala.annotation.internal.ErasedParam"),
     exclude[MissingClassProblem]("scala.annotation.internal.ErasedParam"),
+    exclude[MissingClassProblem]("scala.annotation.internal.ProvisionalSuperClass"),
     exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes.valueOrAbort"),
     exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#reportModule.errorAndAbort"),
     exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.fieldMember"),

--- a/tests/neg/extend-matchable.scala
+++ b/tests/neg/extend-matchable.scala
@@ -12,9 +12,8 @@ class E1 extends AnyRef, M // OK
 class F1 extends Any, M // error: Any does not have a constructor
 
 class C2 extends M0 // OK inferred base type is AnyRef
-class D2(x: Int) extends AnyVal, M0 // error: illegal trait inheritance
 class E2 extends AnyRef, M0 // OK
-class F2 extends Any, M0 // error: Any does not have a constructor // error: illegal trait inheritance
+class F2 extends Any, M0 // error: Any does not have a constructor
 
 
 

--- a/tests/neg/i1501.scala
+++ b/tests/neg/i1501.scala
@@ -16,13 +16,3 @@ object Test {
     println(new C().foo)
   }
 }
-
-object Test2 {
-  class A
-  class SubA(x: Int) extends A
-  trait TA extends A
-  trait TSubA extends SubA(2) // error: trait TSubA may not call constructor of class SubA
-
-
-  class Foo extends TA with TSubA // error: missing argument for parameter x of constructor SubA:
-}

--- a/tests/neg/i1501a.scala
+++ b/tests/neg/i1501a.scala
@@ -1,0 +1,10 @@
+
+object Test2 {
+  class A
+  class SubA(x: Int) extends A
+  trait TA extends A
+  trait TSubA extends SubA(2) // error: trait TSubA may not call constructor of class SubA
+
+
+  class Foo extends TA with TSubA // error: missing argument for parameter x of constructor SubA:
+}

--- a/tests/neg/i1653.scala
+++ b/tests/neg/i1653.scala
@@ -1,3 +1,3 @@
 trait Foo {
-  def foo() = new Unit with Foo  // error: cannot extend final class Unit  // error: illegal trait inheritance
+  def foo() = new Unit with Foo  // error: cannot extend final class Unit
 }

--- a/tests/neg/i5005.scala
+++ b/tests/neg/i5005.scala
@@ -3,4 +3,4 @@ case class i0 (i0: i1) extends AnyVal // error
 trait i1 extends i0   // error
 
 trait F[x] extends AnyVal    // error
-case class G[x](a: F[x]) extends F[x] // error // error
+case class G[x](a: F[x]) extends F[x] // error

--- a/tests/pos/i12722.scala
+++ b/tests/pos/i12722.scala
@@ -1,0 +1,8 @@
+trait JsAny extends AnyRef
+class JsObject extends JsAny
+
+trait HTMLAttributes[T] extends JsObject
+trait Component[P] extends JsObject
+trait IPersonaSharedProps extends HTMLAttributes[PersonaCoinBase]
+trait PersonaCoinBase extends Component[IPersonaCoinProps]
+trait IPersonaCoinProps extends IPersonaSharedProps


### PR DESCRIPTION
Ensuring that the first parent of a class or trait is a class is done in completion.
But at that point some necessary info might not be computed yet, since not all base classes 
of parent classes are guaranteed to be known at that point. We cannot move the transform
to regular typing since that breaks too many assumptions.
Instead we detect the problematic case in Namer and recompute the superclass in Typer.

Fixes #12722