### PR TITLE
Map opaque types in arguments of inlined calls to proxies

### DIFF
--- a/tests/run/i12914.check
+++ b/tests/run/i12914.check
@@ -1,0 +1,8 @@
+ASD
+asd
+ASD
+asd
+ASD
+asd
+aSdaSdaSd
+aSdaSdaSd

--- a/tests/run/i12914.scala
+++ b/tests/run/i12914.scala
@@ -1,0 +1,27 @@
+
+class opq:
+  opaque type Str = java.lang.String
+  object Str:
+    def apply(s: String): Str = s
+  inline def lower(s: Str): String = s.toLowerCase
+  extension (s: Str)
+    transparent inline def upper: String = s.toUpperCase
+  inline def concat(xs: List[Str]): Str = String(xs.flatten.toArray)
+  transparent inline def concat2(xs: List[Str]): Str = String(xs.flatten.toArray)
+
+
+@main def Test =
+  val opq = new opq()
+  import opq.*
+  val a: Str = Str("aSd")
+  println(a.upper)
+  println(opq.lower(a))
+  def b: Str = Str("aSd")
+  println(b.upper)
+  println(opq.lower(b))
+  def c(): Str = Str("aSd")
+  println(c().upper)
+  println(opq.lower(c()))
+  println(opq.concat(List(a, b, c())))
+  println(opq.concat2(List(a, b, c())))
+


### PR DESCRIPTION
An argument of an inlined call might have a type that refers to opaque
types in the inlined method's scope. In that case, we need to cast those
arguments to types where the opaque references are replaced by proxies,
so that the opaque aliases are visible when accessing the argument.

Fixes #12914