### PR TITLE
Widen unions before finding members

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2049,7 +2049,10 @@ object SymDenotations {
 
     override final def findMember(name: Name, pre: Type, required: FlagSet, excluded: FlagSet)(using Context): Denotation =
       val raw = if excluded.is(Private) then nonPrivateMembersNamed(name) else membersNamed(name)
-      raw.filterWithFlags(required, excluded).asSeenFrom(pre).toDenot(pre)
+      val pre1 = pre match
+        case pre: OrType => pre.widenUnion
+        case _ => pre
+      raw.filterWithFlags(required, excluded).asSeenFrom(pre1).toDenot(pre1)
 
     final def findMemberNoShadowingBasedOnFlags(name: Name, pre: Type,
         required: FlagSet = EmptyFlags, excluded: FlagSet = EmptyFlags)(using Context): Denotation =

--- a/tests/pos/i12909.scala
+++ b/tests/pos/i12909.scala
@@ -1,0 +1,42 @@
+package example
+
+final case class Writer[W, A](run: (W, A)) {
+  def map[B](f: A => B): Writer[W, B] = ???
+
+  def flatMap[B](f: A => Writer[W, B]): Writer[W, B] = ???
+}
+
+object Main {
+  implicit class WriterOps[A](a: A) {
+    def set[W](w: W): Writer[W, A] = ???
+  }
+
+  def x1[A]: Writer[Vector[String], Option[A]] = ???
+
+  val failure = for {
+    a1 <- {
+      Option(1) match {
+        case Some(x) =>
+          x1[Boolean]
+        case _ =>
+          Option.empty[Boolean].set(Vector.empty[String])
+      }
+    }
+    a2 <- x1[String]
+  } yield ()
+
+  val success = for {
+    a1 <- {
+      val temp = Option(1) match {
+        case Some(x) =>
+          x1[Boolean]
+        case _ =>
+          Option.empty[Boolean].set(Vector.empty[String])
+      }
+      // why ???
+      temp
+    }
+    a2 <- x1[String]
+  } yield ()
+
+}


### PR DESCRIPTION
If a prefix in a findMember is an OrType, widen it to its join before
computing the selection denotation. This mimics what is done if the
prefix is pulled out into a temporary variable.

Fixes #12909