### PR TITLE
Revert `derivedNames` test to previous form

### DIFF
--- a/tests/generic-java-signatures/derivedNames.scala
+++ b/tests/generic-java-signatures/derivedNames.scala
@@ -4,12 +4,10 @@ object Test {
   def main(args: Array[String]): Unit = {
     val objectB = classOf[Foo[Any]].getClasses
     val returnType = objectB(1).getDeclaredMethod("m").getGenericReturnType.asInstanceOf[ParameterizedType]
-    val out1 = "Test$Foo.Test$Foo$A<Test.Test$Foo<T1>.B$>" // Windows and OSX
-    val out2 = "Test$Foo$A<Test$Foo<T1>$B$>"               // Linux and sometimes Windows
+    val out1 = "Test$Foo.Test$Foo$A<Test.Test$Foo<T1>.B$>" // Windows
+    val out2 = "Test$Foo$A<Test$Foo<T1>$B$>"               // Linux, OSX and sometimes Windows
     if (scala.util.Properties.isWin)
       assert(returnType.toString == out1 || returnType.toString == out2)
-    else if (scala.util.Properties.isMac)
-      assert(returnType.toString == out1, s"$returnType != $out1")
     else
       assert(returnType.toString == out2)
   }


### PR DESCRIPTION
The previous change (https://github.com/lampepfl/dotty/commit/fea5ccf6897fabe8e5e9b7ec1560c020a93564fc) broke the test on macs with updated jdk
Fixes #12917