### PR TITLE
Closes #11201 Incorrectly rendered signatures for parameterless methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -253,7 +253,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   protected def paramsText(lam: LambdaType): Text = {
     def paramText(name: Name, tp: Type) =
-      toText(name) ~ lambdaHash(lam) ~ toTextRHS(tp)
+      toText(name) ~ lambdaHash(lam) ~ toTextRHS(tp, isParameter = true)
     Text(lam.paramNames.lazyZip(lam.paramInfos).map(paramText), ", ")
   }
 
@@ -371,7 +371,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   end decomposeLambdas
 
   /** String representation of a definition's type following its name */
-  protected def toTextRHS(tp: Type): Text = controlled {
+  protected def toTextRHS(tp: Type, isParameter: Boolean = false): Text = controlled {
     homogenize(tp) match {
       case tp: TypeBounds =>
         val (tparamStr, rhs) = decomposeLambdas(tp)
@@ -401,7 +401,8 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case mt: MethodType =>
         toTextGlobal(mt)
       case tp: ExprType =>
-        ": => " ~ toTextGlobal(tp.widenExpr)
+        // parameterless methods require special treatment, see #11201
+        (if (isParameter) ": => " else ": ") ~ toTextGlobal(tp.widenExpr)
       case tp =>
         ": " ~ toTextGlobal(tp)
     }

--- a/tests/neg-scalajs/jsconstructorof-error-in-prepjsinterop.check
+++ b/tests/neg-scalajs/jsconstructorof-error-in-prepjsinterop.check
@@ -13,7 +13,7 @@
 -- Error: tests/neg-scalajs/jsconstructorof-error-in-prepjsinterop.scala:17:27 -----------------------------------------
 17 |  val d = js.constructorOf[NativeJSClass { def bar: Int }] // error
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                           NativeJSClass{bar: => Int} is not a class type
+   |                           NativeJSClass{bar: Int} is not a class type
 -- Error: tests/neg-scalajs/jsconstructorof-error-in-prepjsinterop.scala:19:27 -----------------------------------------
 19 |  val e = js.constructorOf[JSTrait] // error
    |                           ^^^^^^^
@@ -29,7 +29,7 @@
 -- Error: tests/neg-scalajs/jsconstructorof-error-in-prepjsinterop.scala:23:27 -----------------------------------------
 23 |  val h = js.constructorOf[JSClass { def bar: Int }] // error
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                           JSClass{bar: => Int} is not a class type
+   |                           JSClass{bar: Int} is not a class type
 -- Error: tests/neg-scalajs/jsconstructorof-error-in-prepjsinterop.scala:25:42 -----------------------------------------
 25 |  def foo[A <: js.Any] = js.constructorOf[A] // error
    |                                          ^

--- a/tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.check
+++ b/tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.check
@@ -13,7 +13,7 @@
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.scala:17:59 ----------------------------------------
 17 |  val d = js.constructorTag[NativeJSClass { def bar: Int }] // error
    |                                                           ^
-   |                                                           NativeJSClass{bar: => Int} is not a class type
+   |                                                           NativeJSClass{bar: Int} is not a class type
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.scala:19:36 ----------------------------------------
 19 |  val e = js.constructorTag[JSTrait] // error
    |                                    ^
@@ -29,7 +29,7 @@
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.scala:23:53 ----------------------------------------
 23 |  val h = js.constructorTag[JSClass { def bar: Int }] // error
    |                                                     ^
-   |                                                     JSClass{bar: => Int} is not a class type
+   |                                                     JSClass{bar: Int} is not a class type
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.scala:25:45 ----------------------------------------
 25 |  def foo[A <: js.Any] = js.constructorTag[A] // error
    |                                             ^

--- a/tests/neg/abstract-givens.check
+++ b/tests/neg/abstract-givens.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/abstract-givens.scala:11:8 -------------------------------------------------------------------------
 11 |  given s[T](using T): Seq[T] with // error
    |        ^
-   |instance cannot be created, since def iterator: => Iterator[A] in trait IterableOnce in package scala.collection is not defined 
+   |instance cannot be created, since def iterator: Iterator[A] in trait IterableOnce in package scala.collection is not defined 
 -- [E164] Declaration Error: tests/neg/abstract-givens.scala:8:8 -------------------------------------------------------
 8 |  given y(using Int): String = summon[Int].toString * 22 // error
   |        ^

--- a/tests/neg/doubleDefinition.check
+++ b/tests/neg/doubleDefinition.check
@@ -20,25 +20,25 @@
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test4 at line 25 and
-   |	    def foo: => Int in class Test4 at line 26
+   |	    def foo: Int in class Test4 at line 26
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:31:4 ----------------------------------------------------------
 31 |	val foo = 1 // error
    |	    ^
    |	    Double definition:
-   |	    def foo: => Int in class Test4b at line 30 and
+   |	    def foo: Int in class Test4b at line 30 and
    |	    val foo: Int in class Test4b at line 31
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:36:4 ----------------------------------------------------------
 36 |	var foo = 1 // error
    |	    ^
    |	    Double definition:
-   |	    def foo: => Int in class Test4c at line 35 and
+   |	    def foo: Int in class Test4c at line 35 and
    |	    var foo: Int in class Test4c at line 36
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:41:4 ----------------------------------------------------------
 41 |	def foo = 2 // error
    |	    ^
    |	    Double definition:
    |	    var foo: Int in class Test4d at line 40 and
-   |	    def foo: => Int in class Test4d at line 41
+   |	    def foo: Int in class Test4d at line 41
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:55:4 ----------------------------------------------------------
 55 |	def foo(x: List[B]): Function1[B, B] = ??? // error: same jvm signature
    |	    ^
@@ -61,70 +61,70 @@
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test8 at line 66 and
-   |	    def foo: => Int in class Test8 at line 67
+   |	    def foo: Int in class Test8 at line 67
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:72:4 ----------------------------------------------------------
 72 |	val foo = 1 // error
    |	    ^
    |	    Double definition:
-   |	    def foo: => Int in class Test8b at line 71 and
+   |	    def foo: Int in class Test8b at line 71 and
    |	    val foo: Int in class Test8b at line 72
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:77:4 ----------------------------------------------------------
 77 |	var foo = 1 // error
    |	    ^
    |	    Double definition:
-   |	    def foo: => Int in class Test8c at line 76 and
+   |	    def foo: Int in class Test8c at line 76 and
    |	    var foo: Int in class Test8c at line 77
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:82:4 ----------------------------------------------------------
 82 |	def foo = 2 // error
    |	    ^
    |	    Double definition:
    |	    var foo: Int in class Test8d at line 81 and
-   |	    def foo: => Int in class Test8d at line 82
+   |	    def foo: Int in class Test8d at line 82
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:88:4 ----------------------------------------------------------
 88 |	def foo: String // error
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test9 at line 87 and
-   |	    def foo: => String in class Test9 at line 88
+   |	    def foo: String in class Test9 at line 88
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:92:4 ----------------------------------------------------------
 92 |	def foo: Int // error
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test10 at line 91 and
-   |	    def foo: => Int in class Test10 at line 92
+   |	    def foo: Int in class Test10 at line 92
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:96:4 ----------------------------------------------------------
 96 |	def foo: String // error
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test11 at line 95 and
-   |	    def foo: => String in class Test11 at line 96
+   |	    def foo: String in class Test11 at line 96
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:100:4 ---------------------------------------------------------
 100 |	def foo: Int // error
     |	    ^
     |	    Double definition:
     |	    val foo: Int in class Test12 at line 99 and
-    |	    def foo: => Int in class Test12 at line 100
+    |	    def foo: Int in class Test12 at line 100
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:104:4 ---------------------------------------------------------
 104 |	def foo: String // error
     |	    ^
     |	    Double definition:
     |	    var foo: Int in class Test13 at line 103 and
-    |	    def foo: => String in class Test13 at line 104
+    |	    def foo: String in class Test13 at line 104
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:108:4 ---------------------------------------------------------
 108 |	def foo: Int // error
     |	    ^
     |	    Double definition:
     |	    var foo: Int in class Test14 at line 107 and
-    |	    def foo: => Int in class Test14 at line 108
+    |	    def foo: Int in class Test14 at line 108
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:112:4 ---------------------------------------------------------
 112 |	def foo: String // error
     |	    ^
     |	    Double definition:
     |	    var foo: Int in class Test15 at line 111 and
-    |	    def foo: => String in class Test15 at line 112
+    |	    def foo: String in class Test15 at line 112
 -- [E120] Naming Error: tests/neg/doubleDefinition.scala:116:4 ---------------------------------------------------------
 116 |	def foo: Int // error
     |	    ^
     |	    Double definition:
     |	    var foo: Int in class Test16 at line 115 and
-    |	    def foo: => Int in class Test16 at line 116
+    |	    def foo: Int in class Test16 at line 116

--- a/tests/neg/exports.check
+++ b/tests/neg/exports.check
@@ -16,8 +16,8 @@
 23 |    export printUnit.{stat => _, _} // error: double definition
    |                                 ^
    |                                 Double definition:
-   |                                 def status: => List[String] in class Copier at line 28 and
-   |                                 final def status: => List[String] in class Copier at line 23
+   |                                 def status: List[String] in class Copier at line 28 and
+   |                                 final def status: List[String] in class Copier at line 23
    |                                 have the same type after erasure.
    |
    |                                 Consider adding a @targetName annotation to one of the conflicting definitions
@@ -26,8 +26,8 @@
 24 |    export scanUnit._               // error: double definition
    |                    ^
    |                    Double definition:
-   |                    final def status: => List[String] in class Copier at line 23 and
-   |                    final def status: => List[String] in class Copier at line 24
+   |                    final def status: List[String] in class Copier at line 23 and
+   |                    final def status: List[String] in class Copier at line 24
    |                    have the same type after erasure.
    |
    |                    Consider adding a @targetName annotation to one of the conflicting definitions
@@ -36,8 +36,8 @@
 26 |    export printUnit.status         // error: double definition
    |                     ^
    |                     Double definition:
-   |                     final def status: => List[String] in class Copier at line 24 and
-   |                     final def status: => List[String] in class Copier at line 26
+   |                     final def status: List[String] in class Copier at line 24 and
+   |                     final def status: List[String] in class Copier at line 26
    |                     have the same type after erasure.
    |
    |                     Consider adding a @targetName annotation to one of the conflicting definitions
@@ -57,4 +57,4 @@
    |               ^
    |               Double definition:
    |               val bar: Bar in class Baz at line 45 and
-   |               final def bar: => (Baz.this.bar.bar : => (Baz.this.bar.baz.bar : Bar)) in class Baz at line 46
+   |               final def bar: (Baz.this.bar.bar : => (Baz.this.bar.baz.bar : Bar)) in class Baz at line 46

--- a/tests/neg/i9329.check
+++ b/tests/neg/i9329.check
@@ -1,5 +1,5 @@
 -- Error: tests/neg/i9329.scala:8:6 ------------------------------------------------------------------------------------
 8 |class GrandSon extends Son // error
   |      ^
-  |class GrandSon needs to be abstract, since def name: => String in trait Parent is not defined 
-  |(The class implements abstract override def name: => String in trait Son but that definition still needs an implementation)
+  |class GrandSon needs to be abstract, since def name: String in trait Parent is not defined 
+  |(The class implements abstract override def name: String in trait Son but that definition still needs an implementation)


### PR DESCRIPTION
- Handle special case in PlainPrinter
- Adjust testcase check files for correct formatting

fixes #11201 