### PR TITLE
Rewrite to no-indent keeps end comment

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -537,15 +537,13 @@ object Parsers {
     def inBrackets[T](body: => T): T = enclosed(LBRACKET, body)
 
     def inBracesOrIndented[T](body: => T, rewriteWithColon: Boolean = false): T =
-      if (in.token == INDENT) {
-        val rewriteToBraces =
-          in.rewriteNoIndent &&
-          !testChars(in.lastOffset - 3, " =>") // braces are always optional after `=>` so none should be inserted
-        if (rewriteToBraces) indentedToBraces(body)
+      if in.token == INDENT then
+        val rewriteToBraces = in.rewriteNoIndent
+          && !testChars(in.lastOffset - 3, " =>") // braces are always optional after `=>` so none should be inserted
+        if rewriteToBraces then indentedToBraces(body)
         else enclosed(INDENT, body)
-      }
       else
-        if (in.rewriteToIndent) bracesToIndented(body, rewriteWithColon)
+        if in.rewriteToIndent then bracesToIndented(body, rewriteWithColon)
         else inBraces(body)
 
     def inDefScopeBraces[T](body: => T, rewriteWithColon: Boolean = false): T =
@@ -635,26 +633,18 @@ object Parsers {
       else idx
 
     /** Parse indentation region `body` and rewrite it to be in braces instead */
-    def indentedToBraces[T](body: => T): T = {
-      val enclRegion = in.currentRegion.enclosing
-      def indentWidth = enclRegion.indentWidth
+    def indentedToBraces[T](body: => T): T =
+      val enclRegion   = in.currentRegion.enclosing          // capture on entry
+      def indentWidth  = enclRegion.indentWidth
       val followsColon = testChar(in.lastOffset - 1, ':')
-      val startOpening =
-        if (followsColon)
-          if (testChar(in.lastOffset - 2, ' ')) in.lastOffset - 2
-          else in.lastOffset - 1
-        else in.lastOffset
-      val endOpening = in.lastOffset
-
-      val t = enclosed(INDENT, body)
 
       /** Is `expr` a tree that lacks a final `else`? Put such trees in `{...}` to make
        *  sure we don't accidentally merge them with a following `else`.
        */
       def isPartialIf(expr: Tree): Boolean = expr match {
         case If(_, _, EmptyTree) => true
-        case If(_, _, e) => isPartialIf(e)
-        case _ => false
+        case If(_, _, e)         => isPartialIf(e)
+        case _                   => false
       }
 
       /** Is `expr` a (possibly curried) function that has a multi-statement block
@@ -662,41 +652,44 @@ object Parsers {
        *  a `=>` in braces.
        */
       def isBlockFunction[T](expr: T): Boolean = expr match {
-        case Function(_, body) => isBlockFunction(body)
+        case Function(_, body)  => isBlockFunction(body)
         case Block(stats, expr) => stats.nonEmpty || isBlockFunction(expr)
-        case _ => false
+        case _                  => false
       }
 
       /** Start of first line after in.lastOffset that does not have a comment
        *  at indent width greater than the indent width of the closing brace.
        */
       def closingOffset(lineStart: Offset): Offset =
-        if (in.lineOffset >= 0 && lineStart >= in.lineOffset) in.lineOffset
-        else {
-          val candidate = source.nextLine(lineStart)
+        if in.lineOffset >= 0 && lineStart >= in.lineOffset then in.lineOffset
+        else
+          val candidate = source.nextLine(lineStart)   // unused
           val commentStart = skipBlanks(lineStart)
-          if (testChar(commentStart, '/') && indentWidth < in.indentWidth(commentStart))
-            closingOffset(source.nextLine(lineStart))
-          else
-            lineStart
-        }
+          if testChar(commentStart, '/') && indentWidth < in.indentWidth(commentStart)
+          then closingOffset(source.nextLine(lineStart))
+          else lineStart
 
       def needsBraces(t: Any): Boolean = t match {
         case Match(EmptyTree, _) => true
-        case Block(stats, expr) =>
-          stats.nonEmpty || needsBraces(expr)
-        case expr: Tree =>
-          followsColon ||
-          isPartialIf(expr) && in.token == ELSE ||
-          isBlockFunction(expr)
-        case _ => true
+        case Block(stats, expr)  => stats.nonEmpty || needsBraces(expr)
+        case expr: Tree          => followsColon
+                                 || isPartialIf(expr) && in.token == ELSE
+                                 || isBlockFunction(expr)
+        case _                   => true
       }
-      if (needsBraces(t)) {
+      // begin indentedToBraces
+      val startOpening =
+        if followsColon then
+          if testChar(in.lastOffset - 2, ' ') then in.lastOffset - 2
+          else in.lastOffset - 1
+        else in.lastOffset
+      val endOpening = in.lastOffset
+      val t = enclosed(INDENT, body)
+      if needsBraces(t) then
         patch(source, Span(startOpening, endOpening), " {")
         patch(source, Span(closingOffset(source.nextLine(in.lastOffset))), indentWidth.toPrefix ++ "}\n")
-      }
       t
-    }
+    end indentedToBraces
 
     /** The region to eliminate when replacing an opening `(` or `{` that ends a line.
      *  The `(` or `{` is at in.offset.
@@ -1304,12 +1297,11 @@ object Parsers {
         case _: (ForYield | ForDo) => in.token == FOR
         case _ => false
 
-      def matchesAndSetEnd(last: T): Boolean = {
+      def matchesAndSetEnd(last: T): Boolean =
         val didMatch = matches(last)
         if didMatch then
           updateSpanOfLast(last)
         didMatch
-      }
 
       if in.token == END then
         val start = in.skipToken()

--- a/compiler/src/dotty/tools/dotc/util/Spans.scala
+++ b/compiler/src/dotty/tools/dotc/util/Spans.scala
@@ -85,6 +85,7 @@ object Spans {
       || containsInner(this, that.end)
       || containsInner(that, this.start)
       || containsInner(that, this.end)
+      || this.start == that.start && this.end == that.end   // exact match in one point
       )
     }
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -72,7 +72,8 @@ class CompilationTests {
       compileFile("tests/rewrites/rewrites3x.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
       compileFile("tests/rewrites/i8982.scala", defaultOptions.and("-indent", "-rewrite")),
       compileFile("tests/rewrites/i9632.scala", defaultOptions.and("-indent", "-rewrite")),
-      compileFile("tests/rewrites/i11895.scala", defaultOptions.and("-indent", "-rewrite"))
+      compileFile("tests/rewrites/i11895.scala", defaultOptions.and("-indent", "-rewrite")),
+      compileFile("tests/rewrites/i12340.scala", unindentOptions.and("-rewrite")),
     ).checkRewrites()
   }
 

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -978,7 +978,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
           target.copy(dir = copyToDir(outDir, dir))
       }
 
-      val test = new RewriteTest(copiedTargets, checkFileMap, times, threadLimit, shouldFail || shouldSuppressOutput).executeTestSuite()
+      new RewriteTest(copiedTargets, checkFileMap, times, threadLimit, shouldFail || shouldSuppressOutput).executeTestSuite()
       this
     }
 

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -60,6 +60,7 @@ object TestConfiguration {
 
   val commonOptions = Array("-indent", "-language:postfixOps") ++ checkOptions ++ noCheckOptions ++ yCheckOptions
   val defaultOptions = TestFlags(basicClasspath, commonOptions)
+  val unindentOptions = TestFlags(basicClasspath, Array("-no-indent") ++ checkOptions ++ noCheckOptions ++ yCheckOptions)
   val withCompilerOptions =
     defaultOptions.withClasspath(withCompilerClasspath).withRunClasspath(withCompilerClasspath)
   lazy val withStagingOptions =

--- a/tests/rewrites/i12340.check
+++ b/tests/rewrites/i12340.check
@@ -1,0 +1,17 @@
+
+class C {
+  def f = 42
+} // end C
+
+def f(i: Int) = {
+  if i < 42 then
+    println(i)
+  end if
+  i
+} // end f
+
+def g(i: Int) =
+  if i < 42 then
+    println(i)
+  end if
+end g

--- a/tests/rewrites/i12340.scala
+++ b/tests/rewrites/i12340.scala
@@ -1,0 +1,17 @@
+
+class C:
+  def f = 42
+end C
+
+def f(i: Int) =
+  if i < 42 then
+    println(i)
+  end if
+  i
+end f
+
+def g(i: Int) =
+  if i < 42 then
+    println(i)
+  end if
+end g


### PR DESCRIPTION
Preserve end marker as end comment, since if it was worth having an end marker, it's worth commenting.
```
class C:
  def f = 42
end C
```
is rewritten to
```
class C {
  def f = 42
} // end C
```

