### PR TITLE
Refine condition for eliding return in pattern matching

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -928,7 +928,7 @@ object PatternMatcher {
               default
           }
         case ResultPlan(tree) =>
-          if (tree.tpe <:< defn.NothingType) tree // For example MatchError
+          if (tree.symbol == defn.throwMethod) tree // For example MatchError
           else Return(tree, ref(resultLabel))
       }
     }

--- a/tests/run/i12976.scala
+++ b/tests/run/i12976.scala
@@ -1,0 +1,39 @@
+
+case class A(s: String)
+
+class B {
+  def b1[X](str: String): String = str
+
+  def b2[X](str: String): X = null.asInstanceOf[X]
+}
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    val a = A("aaa")
+    val b = new B
+
+    // no error
+    a match {
+      case A(s) =>
+        b.b1(s)
+    }
+
+    // no error if add explicit type param
+    a match {
+      case A(s) =>
+        b.b2[Boolean](s)
+    }
+
+    // scala.MatchError: A(aaa)
+    try
+      a match {
+        case A(s) =>
+          b.b2(s)
+      }
+      assert(false)
+    catch case ex: NullPointerException =>
+      () // OK
+  }
+
+}


### PR DESCRIPTION
Reverting to the first version of #5082.

Fixes #12976