### PR TITLE
Refine overriding pairs in RefChecks

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1021,7 +1021,7 @@ object Denotations {
      *  erasure (see i8615b, i9109b), Erasure takes care of adding any necessary
      *  bridge to make this work at runtime.
      */
-    def matchesLoosely(other: SingleDenotation, alwaysCompareParams: Boolean = false)(using Context): Boolean =
+    def matchesLoosely(other: SingleDenotation, alwaysCompareTypes: Boolean = false)(using Context): Boolean =
       if isType then true
       else
         val thisLanguage = SourceLanguage(symbol)
@@ -1031,7 +1031,7 @@ object Denotations {
         val otherSig = other.signature(commonLanguage)
         sig.matchDegree(otherSig) match
           case FullMatch =>
-            !alwaysCompareParams || info.matches(other.info)
+            !alwaysCompareTypes || info.matches(other.info)
           case MethodNotAMethodMatch =>
             !ctx.erasedTypes && {
               // A Scala zero-parameter method and a Scala non-method always match.

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1021,7 +1021,7 @@ object Denotations {
      *  erasure (see i8615b, i9109b), Erasure takes care of adding any necessary
      *  bridge to make this work at runtime.
      */
-    def matchesLoosely(other: SingleDenotation)(using Context): Boolean =
+    def matchesLoosely(other: SingleDenotation, alwaysCompareParams: Boolean = false)(using Context): Boolean =
       if isType then true
       else
         val thisLanguage = SourceLanguage(symbol)
@@ -1031,7 +1031,7 @@ object Denotations {
         val otherSig = other.signature(commonLanguage)
         sig.matchDegree(otherSig) match
           case FullMatch =>
-            true
+            !alwaysCompareParams || info.matches(other.info)
           case MethodNotAMethodMatch =>
             !ctx.erasedTypes && {
               // A Scala zero-parameter method and a Scala non-method always match.

--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -36,7 +36,7 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
       !sym.isOneOf(MethodOrModule) || super.exclude(sym)
   }
 
-  //val site = root.thisType
+  val site = root.thisType
 
   private var toBeRemoved = immutable.Set[Symbol]()
   private val bridges = mutable.ListBuffer[Tree]()
@@ -77,7 +77,13 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
                       |clashes with definition of the member itself; both have erased type ${info(member)(using elimErasedCtx)}."""",
                   bridgePosFor(member))
     }
-    else if (!bridgeExists)
+    else if !inContext(preErasureCtx)(site.memberInfo(member).matches(site.memberInfo(other))) then
+      // Neither symbol signatures nor pre-erasure types seen from root match; this means
+      // according to Scala 2 semantics there is no override.
+      // A bridge might introduce a classcast exception.
+      // Example where this was observed: run/i12828a.scala and MapView in stdlib213
+      report.log(i"suppress bridge in $root for ${member} in ${member.owner} and ${other.showLocated} since member infos ${site.memberInfo(member)} and ${site.memberInfo(other)} do not match")
+    else if !bridgeExists then
       addBridge(member, other)
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -1,8 +1,9 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package transform
 
 import core._
-import Flags._, Symbols._, Contexts._, Scopes._, Decorators._
+import Flags._, Symbols._, Contexts._, Scopes._, Decorators._, Types.Type
 import collection.mutable
 import collection.immutable.BitSet
 import scala.annotation.tailrec
@@ -35,9 +36,9 @@ object OverridingPairs {
      */
     protected def parents: Array[Symbol] = base.info.parents.toArray.map(_.typeSymbol)
 
-    /** Does `sym1` match `sym2` so that it qualifies as overriding.
-     *  Types always match. Term symbols match if their membertypes
-     *  relative to <base>.this do
+    /** Does `sym1` match `sym2` so that it qualifies as overriding when both symbols are
+     *  seen as members of `self`? Types always match. Term symbols match if their membertypes
+     *  relative to `self` do.
      */
     protected def matches(sym1: Symbol, sym2: Symbol): Boolean =
       sym1.isType || sym1.asSeenFrom(self).matches(sym2.asSeenFrom(self))
@@ -85,11 +86,22 @@ object OverridingPairs {
         then bits += i
       subParents(bc) = bits
 
-    private def hasCommonParentAsSubclass(cls1: Symbol, cls2: Symbol): Boolean =
-      (subParents(cls1) intersect subParents(cls2)).nonEmpty
+    /** Is the override of `sym1` and `sym2` already handled when checking
+     *  a parent of `self`?
+     */
+    private def isHandledByParent(sym1: Symbol, sym2: Symbol): Boolean =
+      val commonParents = subParents(sym1.owner).intersect(subParents(sym2.owner))
+      commonParents.nonEmpty
+      && commonParents.exists(i => canBeHandledByParent(sym1, sym2, parents(i).thisType))
+
+    /** Can pair `sym1`/`sym2` be handled by parent `parentType` which is a common subtype
+     *  of both symbol's owners? Assumed to be true by default, but overridden in RefChecks.
+     */
+    protected def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parentType: Type): Boolean =
+      true
 
     /** The scope entries that have already been visited as overridden
-     *  (maybe excluded because of hasCommonParentAsSubclass).
+     *  (maybe excluded because of already handled by a parent).
      *  These will not appear as overriding
      */
     private val visited = util.HashSet[Symbol]()
@@ -134,28 +146,22 @@ object OverridingPairs {
      *    overridden = overridden member of the pair, provided hasNext is true
      */
     @tailrec final def next(): Unit =
-      if (nextEntry ne null) {
+      if nextEntry != null then
         nextEntry = decls.lookupNextEntry(nextEntry)
-        if (nextEntry ne null)
-          try {
+        if nextEntry != null then
+          try
             overridden = nextEntry.sym
-            if (overriding.owner != overridden.owner && matches(overriding, overridden)) {
+            if overriding.owner != overridden.owner && matches(overriding, overridden) then
               visited += overridden
-              if (!hasCommonParentAsSubclass(overriding.owner, overridden.owner)) return
-            }
-          }
-          catch {
-            case ex: TypeError =>
-              // See neg/i1750a for an example where a cyclic error can arise.
-              // The root cause in this example is an illegal "override" of an inner trait
-              report.error(ex, base.srcPos)
-          }
-        else {
+              if !isHandledByParent(overriding, overridden) then return
+          catch case ex: TypeError =>
+            // See neg/i1750a for an example where a cyclic error can arise.
+            // The root cause in this example is an illegal "override" of an inner trait
+            report.error(ex, base.srcPos)
+        else
           curEntry = curEntry.prev
           nextOverriding()
-        }
         next()
-      }
 
     nextOverriding()
     next()

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -98,16 +98,7 @@ object OverridingPairs {
      *  of both symbol's owners? Assumed to be true by default, but overridden in RefChecks.
      */
     protected def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parent: Symbol): Boolean =
-      val owner1 = sym1.owner
-      val owner2 = sym2.owner
-      def precedesIn(bcs: List[ClassSymbol]): Boolean = (bcs: @unchecked) match
-        case bc :: bcs1 =>
-          if owner1 eq bc then true
-          else if owner2 eq bc then false
-          else precedesIn(bcs1)
-        case _ =>
-          false
-      precedesIn(parent.asClass.baseClasses)
+      true
 
     /** The scope entries that have already been visited as overridden
      *  (maybe excluded because of already handled by a parent).

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -514,9 +514,10 @@ object RefChecks {
 
       // We can exclude pairs safely from checking only of they also matched in
       // the parent class. See neg/i12828.scala for an example where this matters.
-      override def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parentType: Type): Boolean =
-        considerMatching(sym1, sym2, parentType)
-         .showing(i"already handled ${sym1.showLocated}: ${sym1.asSeenFrom(parentType).signature}, ${sym2.showLocated}: ${sym2.asSeenFrom(parentType).signature} = $result", refcheck)
+      override def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parent: Symbol): Boolean =
+        considerMatching(sym1, sym2, parent.thisType)
+         .showing(i"already handled ${sym1.showLocated}: ${sym1.asSeenFrom(parent.thisType).signature}, ${sym2.showLocated}: ${sym2.asSeenFrom(parent.thisType).signature} = $result", refcheck)
+        && super.canBeHandledByParent(sym1, sym2, parent)
     end opc
 
     while opc.hasNext do

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -324,7 +324,7 @@ object RefChecks {
             (if (member.owner == clazz) member else clazz).srcPos))
 
       /** Do types of term members `member` and `other` as seen from `self` match?
-       *  If not we treat them as not a real override and don't issue certain
+       *  If not we treat them as not a real override and don't issue override
        *  error messages. Also, bridges are not generated in this case.
        *  Type members are always assumed to match.
        */
@@ -595,7 +595,7 @@ object RefChecks {
         clazz.nonPrivateMembersNamed(mbr.name)
           .filterWithPredicate(
             impl => isConcrete(impl.symbol)
-              && mbrDenot.matchesLoosely(impl, alwaysCompareParams = true))
+              && mbrDenot.matchesLoosely(impl, alwaysCompareTypes = true))
           .exists
 
       /** The term symbols in this class and its baseclasses that are

--- a/tests/neg/OpaqueEscape.scala
+++ b/tests/neg/OpaqueEscape.scala
@@ -7,7 +7,7 @@ def unwrap(i:Wrapped):Int
   def wrap(i:Int):Wrapped
 }
 class Escaper extends EscaperBase{  // error: needs to be abstract
-  override def unwrap(i:Int):Int = i // error overriding method unwrap
+  override def unwrap(i:Int):Int = i // was error overriding method unwrap, now OK
   override def wrap(i:Int):Int = i  // error overriding method wrap
 }
 val e = new Escaper:EscaperBase

--- a/tests/neg/i11828.check
+++ b/tests/neg/i11828.check
@@ -1,5 +1,5 @@
 -- Error: tests/neg/i12828.scala:7:7 -----------------------------------------------------------------------------------
-7 |object Baz extends Bar[Int] // error: not implemented
+7 |object Baz extends Bar[Int] // error overriding foo: incompatible type
   |       ^
   |       object creation impossible, since def foo(x: A): Unit in trait Foo is not defined 
   |       (Note that

--- a/tests/neg/i12828.check
+++ b/tests/neg/i12828.check
@@ -1,0 +1,7 @@
+-- [E163] Declaration Error: tests/neg/i12828.scala:7:7 ----------------------------------------------------------------
+7 |object Baz extends Bar[Int] // error overriding foo: incompatible type
+  |       ^
+  |       error overriding method foo in trait Foo of type (x: Int): Unit;
+  |         method foo in trait Bar of type (x: Int & String): Unit has incompatible type
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i12828.scala
+++ b/tests/neg/i12828.scala
@@ -1,0 +1,9 @@
+trait Foo[A]:
+  def foo(x: A): Unit
+
+trait Bar[A] extends Foo[A]:
+  def foo(x: A & String): Unit = println(x.toUpperCase)
+
+object Baz extends Bar[Int] // error overriding foo: incompatible type
+
+@main def run() = Baz.foo(42)

--- a/tests/neg/i12828.scala
+++ b/tests/neg/i12828.scala
@@ -4,6 +4,6 @@ trait Foo[A]:
 trait Bar[A] extends Foo[A]:
   def foo(x: A & String): Unit = println(x.toUpperCase)
 
-object Baz extends Bar[Int] // error overriding foo: incompatible type
+object Baz extends Bar[Int] // error: not implemented
 
 @main def run() = Baz.foo(42)

--- a/tests/neg/i12828c.scala
+++ b/tests/neg/i12828c.scala
@@ -1,0 +1,12 @@
+abstract class Foo[A] {
+  def foo(x: A): Unit
+}
+abstract class Bar[A] extends Foo[A] {
+  def foo(x: A with String): Unit = println(x.toUpperCase)
+}
+object Baz extends Bar[Int] // error overriding foo: incompatible type
+                            // Scala 2 gives: object creation impossible. Missing implementation for `foo`
+
+object Test {
+  def main(args: Array[String]) = Baz.foo(42)
+}

--- a/tests/neg/i12828c.scala
+++ b/tests/neg/i12828c.scala
@@ -4,7 +4,7 @@ abstract class Foo[A] {
 abstract class Bar[A] extends Foo[A] {
   def foo(x: A with String): Unit = println(x.toUpperCase)
 }
-object Baz extends Bar[Int] // error overriding foo: incompatible type
+object Baz extends Bar[Int] // error: not implemented (same as Scala 2)
                             // Scala 2 gives: object creation impossible. Missing implementation for `foo`
 
 object Test {

--- a/tests/neg/i12828d.scala
+++ b/tests/neg/i12828d.scala
@@ -1,0 +1,18 @@
+trait A[X] {
+  def foo(x: X): Unit =
+    println("A.foo")
+}
+trait B[X] extends A[X] {
+  def foo(x: Int): Unit =
+    println("B.foo")
+}
+object C extends B[Int] // error: conflicting members
+                        // Scala 2: same
+
+object Test {
+  def main(args: Array[String]) = {
+    C.foo(1)
+    val a: A[Int] = C
+    a.foo(1)
+  }
+}

--- a/tests/neg/i5094.scala
+++ b/tests/neg/i5094.scala
@@ -9,7 +9,7 @@ trait SOIO extends IO {
 }
 trait SOSO extends SOIO with SO
 abstract class AS extends SO
-class L extends AS with SOSO
+class L extends AS with SOSO // error: cannot override final member
 object Test {
   def main(args: Array[String]): Unit = {
     new L

--- a/tests/neg/i7597.scala
+++ b/tests/neg/i7597.scala
@@ -6,8 +6,8 @@ object Test extends App {
     def apply(x: A): B
   }
 
-  class C[S <: String] extends Fn[String, Int] {
-    def apply(s: S): Int = 0 // error
+  class C[S <: String] extends Fn[String, Int] { // error
+    def apply(s: S): Int = 0
   }
 
   foo("")

--- a/tests/neg/varargs-annot-2.scala
+++ b/tests/neg/varargs-annot-2.scala
@@ -1,0 +1,9 @@
+import annotation.varargs
+
+trait C {
+  @varargs def v(i: Int*) = ()
+}
+
+class D extends C { // error: name clash between defined and inherited member
+  def v(i: Array[Int]) = ()
+}

--- a/tests/neg/varargs-annot.scala
+++ b/tests/neg/varargs-annot.scala
@@ -17,7 +17,7 @@ object Test {
 
   class D extends C {
     override def v(i: Int*) = () // error
-    def v(i: Array[Int]) = () // error
+    def v(i: Array[Int]) = () // ok, reported when used alone (see varargs-annot-2.scala)
   }
 
   @varargs def nov(a: Int) = 0 // error: A method without repeated parameters cannot be annotated with @varargs

--- a/tests/run/i12828a.scala
+++ b/tests/run/i12828a.scala
@@ -1,0 +1,12 @@
+trait Foo[A] {
+  def foo(x: A): Unit = ()
+}
+trait Bar[A] extends Foo[A] {
+  def foo(x: A with String): Unit = println(x.toUpperCase)
+}
+object Baz extends Bar[Int] // was: error: Baz inherits conflicting members, now like Scala 2
+                            // Scala 2 compiles and runs
+
+object Test {
+  def main(args: Array[String]) = Baz.foo(42)
+}

--- a/tests/run/i12828b.scala
+++ b/tests/run/i12828b.scala
@@ -1,0 +1,12 @@
+class Foo[A] {
+  def foo(x: A): Unit = ()
+}
+class Bar[A] extends Foo[A] {
+  def foo(x: A with String): Unit = println(x.toUpperCase)
+}
+object Baz extends Bar[Int] // was error: Baz inherits conflicting members, now like Scalac
+                            // Scala 2 compiles and runs
+
+object Test {
+  def main(args: Array[String]) = Baz.foo(42)
+}


### PR DESCRIPTION
We now exclude a pair of overriding / overridden symbols that
have a common subclass parent of the base class only under the
additional condition that their signatures also match when seen
as members of the parent class.

#12828 shows a case where this matters:
```scala
trait Foo[A]:
  def foo(x: A): Unit

trait Bar[A] extends Foo[A]:
  def foo(x: A & String): Unit = println(x.toUpperCase)

object Baz extends Bar[Int] // error overriding foo: incompatible type

@main def run() = Baz.foo(42)
```
When checking `Baz`, there is a common subclass parent (namely `Bar`),
but the signatures of the two `foo` definitions as seen from `Bar` are
different, so we cannot assume that the pair has already been checked.

Fixes #12828