### PR TITLE
Scaladoc: Fix snippets in documentation

### DIFF
--- a/docs/docs/reference/other-new-features/control-syntax.md
+++ b/docs/docs/reference/other-new-features/control-syntax.md
@@ -8,6 +8,16 @@ Scala 3 has a new "quiet" syntax for control expressions that does not rely on
 enclosing the condition in parentheses, and also allows to drop parentheses or braces
 around the generators of a `for`-expression. Examples:
 ```scala
+//{
+import java.io.IOException
+type T
+var x: Int
+var xs: List[Int]
+var ys: List[Int]
+var body: T
+var handle: T
+def f(x: Int): Int = ???
+//}
 if x < 0 then
   "negative"
 else if x == 0 then

--- a/docs/docs/reference/other-new-features/creator-applications.md
+++ b/docs/docs/reference/other-new-features/creator-applications.md
@@ -9,24 +9,26 @@ function application, without needing to write `new`.
 
 Scala 3 generalizes this scheme to all concrete classes. Example:
 
-```scala
-class StringBuilder(s: String):
+```scala sc-name:Base.scala
+class MyStringBuilder(s: String):
   def this() = this("")
+```
 
-StringBuilder("abc")  // old: new StringBuilder("abc")
-StringBuilder()       // old: new StringBuilder()
+```scala sc-compile-with:Base.scala
+MyStringBuilder("abc")  // old: new MyStringBuilder("abc")
+MyStringBuilder()       // old: new MyStringBuilder()
 ```
 
 This works since a companion object with two `apply` methods
 is generated together with the class. The object looks like this:
 
-```scala
-object StringBuilder:
-  inline def apply(s: String): StringBuilder = new StringBuilder(s)
-  inline def apply(): StringBuilder = new StringBuilder()
+```scala sc-compile-with:Base.scala
+object MyStringBuilder:
+  inline def apply(s: String): MyStringBuilder = new MyStringBuilder(s)
+  inline def apply(): MyStringBuilder = new MyStringBuilder()
 ```
 
-The synthetic object `StringBuilder` and its `apply` methods are called _constructor proxies_.
+The synthetic object `MyStringBuilder` and its `apply` methods are called _constructor proxies_.
 Constructor proxies are generated even for Java classes and classes coming from Scala 2.
 The precise rules are as follows:
 

--- a/docs/docs/reference/other-new-features/explicit-nulls.md
+++ b/docs/docs/reference/other-new-features/explicit-nulls.md
@@ -22,6 +22,9 @@ val x: String | Null = null // ok
 A nullable type could have null value during runtime; hence, it is not safe to select a member without checking its nullity.
 
 ```scala
+//{
+val x: String | Null
+//}
 x.trim // error: trim is not member of String | Null
 ```
 
@@ -123,7 +126,7 @@ We illustrate the rules with following examples:
 - The first two rules are easy: we nullify reference types but not value types.
 
   ```java
-  class C {
+  abstract class C {
     String s;
     int x;
   }
@@ -132,7 +135,7 @@ We illustrate the rules with following examples:
   ==>
 
   ```scala
-  class C:
+  abstract class C:
     val s: String | Null
     val x: Int
   ```
@@ -145,30 +148,33 @@ We illustrate the rules with following examples:
 
   ==>
 
-  ```scala
-  class C[T] { def foo(): T | Null }
+  ```scala sc-name:C.scala
+  class C[T] { def foo(): T | Null = null }
   ```
 
   Notice this is rule is sometimes too conservative, as witnessed by
 
-  ```scala
+  ```scala sc:fail sc-compile-with:C.scala
   class InScala:
-    val c: C[Bool] = ???  // C as above
-    val b: Bool = c.foo() // no longer typechecks, since foo now returns Bool | Null
+    val c: C[Boolean] = ???  // C as above
+    val b: Boolean = c.foo() // no longer typechecks, since foo now returns Bool | Null
   ```
 
 - We can reduce the number of redundant nullable types we need to add. Consider
 
   ```java
-  class Box<T> { T get(); }
-  class BoxFactory<T> { Box<T> makeBox(); }
+  abstract class Box<T> { T get(); }
+  abstract class BoxFactory<T> { Box<T> makeBox(); }
   ```
 
   ==>
 
-  ```scala
-  class Box[T] { def get(): T | Null }
-  class BoxFactory[T] { def makeBox(): Box[T] | Null }
+  ```scala sc-name:Box.scala
+  abstract class Box[T] { def get(): T | Null }
+  ```
+
+  ```scala sc-compile-with:Box.scala
+  abstract class BoxFactory[T] { def makeBox(): Box[T] | Null }
   ```
 
   Suppose we have a `BoxFactory[String]`. Notice that calling `makeBox()` on it returns a
@@ -184,7 +190,7 @@ We illustrate the rules with following examples:
 - We will append `Null` to the type arguments if the generic class is defined in Scala.
 
   ```java
-  class BoxFactory<T> {
+  abstract class BoxFactory<T> {
     Box<T> makeBox(); // Box is Scala-defined
     List<Box<List<T>>> makeCrazyBoxes(); // List is Java-defined
   }
@@ -192,8 +198,8 @@ We illustrate the rules with following examples:
 
   ==>
 
-  ```scala
-  class BoxFactory[T]:
+  ```scala sc-compile-with:Box.scala
+  abstract class BoxFactory[T]:
     def makeBox(): Box[T | Null] | Null
     def makeCrazyBoxes(): java.util.List[Box[java.util.List[T] | Null]] | Null
   ```
@@ -221,10 +227,13 @@ We illustrate the rules with following examples:
   ==>
 
   ```scala
+  //{
+  def getNewName(): String = ???
+  //}
   class Constants:
-    val NAME: String("name") = "name"
-    val AGE: Int(0) = 0
-    val CHAR: Char('a') = 'a'
+    val NAME: String = "name"
+    val AGE: Int = 0
+    val CHAR: Char = 'a'
 
     val NAME_GENERATED: String | Null = getNewName()
   ```
@@ -242,8 +251,8 @@ We illustrate the rules with following examples:
 
   ==>
 
-  ```scala
-  class C:
+  ```scala sc-compile-with:Box.scala
+  abstract class C:
     val name: String
     def getNames(prefix: String | Null): java.util.List[String] // we still need to nullify the paramter types
     def getBoxedName(): Box[String | Null] // we don't append `Null` to the outmost level, but we still need to nullify inside
@@ -252,7 +261,7 @@ We illustrate the rules with following examples:
   The annotation must be from the list below to be recognized as `NotNull` by the compiler.
   Check `Definitions.scala` for an updated list.
 
-  ```scala
+  ```scala sc:nocompile
   // A list of annotations that are commonly used to indicate
   // that a field/method argument or return type is not null.
   // These annotations are used by the nullification logic in
@@ -283,11 +292,17 @@ Suppose we have Java method `String f(String x)`, we can override this method in
 
 ```scala
 def f(x: String | Null): String | Null
+```
 
+```scala
 def f(x: String): String | Null
+```
 
+```scala
 def f(x: String | Null): String
+```
 
+```scala
 def f(x: String): String
 ```
 
@@ -304,7 +319,7 @@ Example:
 
 ```scala
 val s: String | Null = ???
-if s != null then
+if s != null then ???
   // s: String
 
 // s: String | Null
@@ -316,9 +331,12 @@ assert(s != null)
 A similar inference can be made for the `else` case if the test is `p == null`
 
 ```scala
+val s: String | Null = ???
 if s == null then
+  ???
   // s: String | Null
 else
+  ???
   // s: String
 ```
 
@@ -332,13 +350,16 @@ We also support logical operators (`&&`, `||`, and `!`):
 val s: String | Null = ???
 val s2: String | Null = ???
 if s != null && s2 != null then
+  ???
   // s: String
   // s2: String
 
 if s == null || s2 == null then
+  ???
   // s: String | Null
   // s2: String | Null
 else
+  ???
   // s: String
   // s2: String
 ```
@@ -351,11 +372,14 @@ We also support type specialization _within_ the condition, taking into account 
 val s: String | Null = ???
 
 if s != null && s.length > 0 then // s: String in `s.length > 0`
+  ???
   // s: String
 
 if s == null || s.length > 0 then // s: String in `s.length > 0`
+  ???
   // s: String | Null
 else
+  ???
   // s: String
 ```
 
@@ -442,6 +466,7 @@ We don't support:
   val s: String | Null = ???
   val s2: String | Null = ???
   if s != null && s == s2 then
+    ???
     // s:  String inferred
     // s2: String not inferred
   ```

--- a/docs/docs/reference/other-new-features/export.md
+++ b/docs/docs/reference/other-new-features/export.md
@@ -6,7 +6,7 @@ movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/export.
 
 An export clause defines aliases for selected members of an object. Example:
 
-```scala
+```scala sc-name:Model.scala
 class BitMap
 class InkJet
 
@@ -31,7 +31,7 @@ class Copier:
 
 The two `export` clauses define the following _export aliases_ in class `Copier`:
 
-```scala
+```scala sc:nocompile
 final def scan(): BitMap            = scanUnit.scan()
 final def print(bits: BitMap): Unit = printUnit.print(bits)
 final type PrinterType              = printUnit.PrinterType
@@ -39,14 +39,14 @@ final type PrinterType              = printUnit.PrinterType
 
 They can be accessed inside `Copier` as well as from outside:
 
-```scala
+```scala sc-compile-with:Model.scala
 val copier = new Copier
 copier.print(copier.scan())
 ```
 
 An export clause has the same format as an import clause. Its general form is:
 
-```scala
+```scala sc:nocompile
 export path . { sel_1, ..., sel_n }
 ```
 
@@ -86,9 +86,9 @@ referring to private values in the qualifier path
 are marked by the compiler as "stable" and their result types are the singleton types of the aliased definitions. This means that they can be used as parts of stable identifier paths, even though they are technically methods. For instance, the following is OK:
 ```scala
 class C { type T }
-object O { val c: C = ... }
+object O { val c: C = ??? }
 export O.c
-def f: c.T = ...
+def f: c.T = ???
 ```
 
 
@@ -98,7 +98,7 @@ def f: c.T = ...
  1. If an export clause contains a wildcard or given selector, it is forbidden for its qualifier path to refer to a package. This is because it is not yet known how to safely track wildcard dependencies to a package for the purposes of incremental compilation.
 
  1. Simple renaming exports like
-    ```scala
+    ```scala sc:nocompile
     export status as stat
     ```
     are not supported yet. They would run afoul of the restriction that the
@@ -142,16 +142,19 @@ ImportSelectors   ::=  NamedSelector [‘,’ ImportSelectors]
 Export clauses raise questions about the order of elaboration during type checking.
 Consider the following example:
 
-```scala
-class B { val c: Int }
+```scala sc-name:Base.scala
+class B { val c: Int = ??? }
 object a { val b = new B }
+```
+
+```scala sc-compile-with:Base.scala
 export a.*
 export b.*
 ```
 
 Is the `export b.*` clause legal? If yes, what does it export? Is it equivalent to `export a.b.*`? What about if we swap the last two clauses?
 
-```
+```scala sc:fail sc-compile-with:Base.scala
 export b.*
 export a.*
 ```

--- a/docs/docs/reference/other-new-features/indentation-experimental.md
+++ b/docs/docs/reference/other-new-features/indentation-experimental.md
@@ -18,6 +18,9 @@ This variant is more contentious and less stable than the rest of the significan
 
 Similar to what is done for classes and objects, a `:` that follows a function reference at the end of a line means braces can be omitted for function arguments. Example:
 ```scala
+import language.experimental.fewerBraces
+def times(i: Int)(fn: => Unit) = (0 to i).foreach(x => fn)
+
 times(10):
   println("ah")
   println("ha")
@@ -26,24 +29,37 @@ times(10):
 The colon can also follow an infix operator:
 
 ```scala
-credentials ++ :
-  val file = Path.userHome / ".credentials"
-  if file.exists
-  then Seq(Credentials(file))
+import language.experimental.fewerBraces
+//{
+val numbers: Seq[Int]
+val n: Int
+//}
+
+numbers ++ :
+  if n > 0
+  then Seq(n)
   else Seq()
 ```
 
 Function calls that take multiple argument lists can also be handled this way:
 
 ```scala
+import language.experimental.fewerBraces
+//{
+import java.io.File
+import io.Source
+val files: Map[String, File]
+val fileName: String
+//}
+
 val firstLine = files.get(fileName).fold:
-    val fileNames = files.values
+    val fileNames = files.keys
     s"""no file named $fileName found among
-      |${values.mkString(\n)}""".stripMargin
+      |${fileNames.mkString("\n")}""".stripMargin
   :
     f =>
-      val lines = f.iterator.map(_.readLine)
-      lines.mkString("\n)
+      val lines = Source.fromFile(f).getLines()
+      lines.mkString("\n")
 ```
 
 
@@ -51,10 +67,15 @@ val firstLine = files.get(fileName).fold:
 
 Braces can also be omitted around multiple line function value arguments:
 ```scala
+import language.experimental.fewerBraces
+//{
+val elems: Seq[Int]
+//}
+
 val xs = elems.map x =>
   val y = x - 1
   y * y
-xs.foldLeft (x, y) =>
+xs.foldLeft(0) (x, y) =>
   x + y
 ```
 Braces can be omitted if the lambda starts with a parameter list and `=>` or `=>?` at the end of one line and it has an indented body on the following lines.
@@ -73,10 +94,14 @@ IndentedArgument ::=  indent (CaseClauses | Block) outdent
 Note that a lambda argument must have the `=>` at the end of a line for braces
 to be optional. For instance, the following would also be incorrect:
 
-```scala
+```scala sc-name:Base.scala
+val xs: Seq[Int]
+```
+
+```scala sc:fail sc-compile-with:Base.scala
   xs.map x => x + 1   // error: braces or parentheses are required
 ```
 The lambda has to be enclosed in braces or parentheses:
-```scala
+```scala sc-compile-with:Base.scala
   xs.map(x => x + 1)  // ok
 ```

--- a/docs/docs/reference/other-new-features/kind-polymorphism.md
+++ b/docs/docs/reference/other-new-features/kind-polymorphism.md
@@ -17,12 +17,15 @@ value that works for parameters of any kind. This is now possible through a form
 Kind polymorphism relies on the special type `scala.AnyKind` that can be used as an upper bound of a type.
 
 ```scala
-def f[T <: AnyKind] = ...
+def f[T <: AnyKind] = ???
 ```
 
 The actual type arguments of `f` can then be types of arbitrary kinds. So the following would all be legal:
 
 ```scala
+//{
+def f[T <: AnyKind] = ???
+//}
 f[Int]
 f[List]
 f[Map]

--- a/docs/docs/reference/other-new-features/matchable.md
+++ b/docs/docs/reference/other-new-features/matchable.md
@@ -20,7 +20,7 @@ The `IArray` type offers extension methods for `length` and `apply`, but not for
 However, there is a potential hole due to pattern matching. Consider:
 
 ```scala
-val imm: IArray[Int] = ...
+val imm: IArray[Int]
 imm match
   case a: Array[Int] => a(0) = 1
 ```
@@ -31,6 +31,7 @@ The test will succeed at runtime since `IArray`s _are_ represented as
 __Aside:__ One could also achieve the same by casting:
 
 ```scala
+val imm: IArray[Int]
 imm.asInstanceOf[Array[Int]](0) = 1
 ```
 
@@ -40,6 +41,7 @@ Note also that the problem is not tied to opaque types as match selectors. The f
 type `T` as match selector leads to the same problem:
 
 ```scala
+val imm: IArray[Int]
 def f[T](x: T) = x match
   case a: Array[Int] => a(0) = 0
 f(imm)
@@ -75,7 +77,7 @@ extended by both `AnyVal` and `AnyRef`. Since `Matchable` is a supertype of ever
 
 Here is the hierarchy of top-level classes and traits with their defined methods:
 
-```scala
+```scala sc:nocompile
 abstract class Any:
   def getClass
   def isInstanceOf
@@ -118,7 +120,7 @@ is guaranteed to succeed at run-time since `Any` and `Matchable` both erase to
 
 For instance, consider the definitions
 
-```scala
+```scala sc-name:Meter.scala
 opaque type Meter = Double
 def Meter(x: Double) = x
 
@@ -128,14 +130,14 @@ def Second(x: Double) = x
 
 Here, universal `equals` will return true for
 
-```scala
-  Meter(10).equals(Second(10))
+```scala sc-compile-with:Meter.scala
+Meter(10).equals(Second(10))
 ```
 
 even though this is clearly false mathematically. With [multiversal equality](../contextual/multiversal-equality.md) one can mitigate that problem somewhat by turning
 
-```scala
-  Meter(10) == Second(10)
+```scala sc-compile-with:Meter.scala
+Meter(10) == Second(10)
 ```
 
 into a type error.

--- a/docs/docs/reference/other-new-features/named-typeargs-spec.md
+++ b/docs/docs/reference/other-new-features/named-typeargs-spec.md
@@ -16,7 +16,7 @@ NamedTypeArg      ::=  id ‘=’ Type
 
 Note in particular that named arguments cannot be passed to type constructors:
 
-``` scala
+``` scala sc:fail
 class C[T]
 
 val x: C[T = Int] = // error

--- a/docs/docs/reference/other-new-features/named-typeargs.md
+++ b/docs/docs/reference/other-new-features/named-typeargs.md
@@ -8,6 +8,10 @@ title: "Named Type Arguments"
 Type arguments of methods can now be specified by name as well as by position. Example:
 
 ``` scala
+//{
+import scala.language.experimental.namedTypeArguments
+// Currently, to use this feature you need to use experimental import
+//}
 def construct[Elem, Coll[_]](xs: Elem*): Coll[Elem] = ???
 
 val xs1 = construct[Coll = List, Elem = Int](1, 2, 3)

--- a/docs/docs/reference/other-new-features/opaques-details.md
+++ b/docs/docs/reference/other-new-features/opaques-details.md
@@ -21,6 +21,11 @@ at the top-level. They cannot be defined in local blocks.
 The general form of a (monomorphic) opaque type alias is
 
 ```scala
+//{
+type L
+type U
+type R >: L <: U
+//}
 opaque type T >: L <: U = R
 ```
 
@@ -29,11 +34,18 @@ where the lower bound `L` and the upper bound `U` may be missing, in which case 
 Inside the scope of the alias definition, the alias is transparent: `T` is treated
 as a normal alias of `R`. Outside its scope, the alias is treated as the abstract type
 ```scala
+//{
+type L
+type U
+//}
 type T >: L <: U
 ```
 A special case arises if the opaque type alias is defined in an object. Example:
 
 ```scala
+//{
+type R
+//}
 object o:
   opaque type T = R
 ```
@@ -56,11 +68,18 @@ def id(x: o.T): o.T = x
 Opaque type aliases can have a single type parameter list. The following aliases
 are well-formed
 ```scala
+//{
+type T
+//}
 opaque type F[T] = (T, T)
 opaque type G = [T] =>> List[T]
 ```
 but the following are not:
-```scala
+```scala sc:fail
+//{
+type T
+type U
+//}
 opaque type BadF[T] = [U] =>> (T, U)
 opaque type BadG = [T] =>> [U] => (T, U)
 ```
@@ -74,7 +93,7 @@ defined on the underlying type. For instance,
 ```scala
   opaque type T = Int
 
-  ...
+  // ...
   val x: T
   val y: T
   x == y    // uses Int equality for the comparison.
@@ -96,7 +115,7 @@ object obj:
 def z: String = x   // error: found: A, required: String
 ```
 This behavior becomes clear if one recalls that top-level definitions are placed in their own synthetic object. For instance, the code in `test1.scala` would expand to
-```scala
+```scala sc:fail
 object test1$package:
   opaque type A = String
   val x: A = "abc"

--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -6,7 +6,7 @@ movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/opaques
 
 Opaque types aliases provide type abstraction without any overhead. Example:
 
-```scala
+```scala sc-name:MyMath.scala
 object MyMath:
 
   opaque type Logarithm = Double
@@ -41,7 +41,7 @@ The public API of `Logarithm` consists of the `apply` and `safe` methods defined
 They convert from `Double`s to `Logarithm` values. Moreover, an operation `toDouble` that converts the other way, and operations `+` and `*` are defined as extension methods on `Logarithm` values.
 The following operations would be valid because they use functionality implemented in the `MyMath` object.
 
-```scala
+```scala sc-compile-with:MyMath.scala
 import MyMath.Logarithm
 
 val l = Logarithm(1.0)
@@ -52,7 +52,10 @@ val l4 = l + l2
 
 But the following operations would lead to type errors:
 
-```scala
+```scala sc:fail sc-compile-with:MyMath.scala
+import MyMath.Logarithm
+
+val l = Logarithm(1.0)
 val d: Double = l       // error: found: Logarithm, required: Double
 val l2: Logarithm = 1.0 // error: found: Double, required: Logarithm
 l * 2                   // error: found: Int(2), required: Logarithm
@@ -63,7 +66,7 @@ l / l2                  // error: `/` is not a member of Logarithm
 
 Opaque type aliases can also come with bounds. Example:
 
-```scala
+```scala sc-name:Access.scala
 object Access:
 
   opaque type Permissions = Int
@@ -110,7 +113,7 @@ All three opaque type aliases have the same underlying representation type `Int`
 it known outside the `Access` object that `Permission` is a subtype of the other
 two types.  Hence, the following usage scenario type-checks.
 
-```scala
+```scala sc-compile-with:Access.scala
 object User:
   import Access.*
 
@@ -139,7 +142,7 @@ since `Permissions` and `PermissionChoice` are different, unrelated types outsid
 While typically, opaque types are used together with objects to hide implementation details of a module, they can also be used with classes.
 
 For example, we can redefine the above example of Logarithms as a class.
-```scala
+```scala sc-name:Logarithms.scala
 class Logarithms:
 
   opaque type Logarithm = Double
@@ -153,7 +156,7 @@ class Logarithms:
 ```
 
 Opaque type members of different instances are treated as different:
-```scala
+```scala sc:fail sc-compile-with:Logarithms.scala
 val l1 = new Logarithms
 val l2 = new Logarithms
 val x = l1(1.5)

--- a/docs/docs/reference/other-new-features/open-classes.md
+++ b/docs/docs/reference/other-new-features/open-classes.md
@@ -7,8 +7,6 @@ movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/open-cl
 An `open` modifier on a class signals that the class is planned for extensions. Example:
 ```scala
 // File Writer.scala
-package p
-
 open class Writer[T]:
 
   /** Sends to stdout, can be overridden */
@@ -19,10 +17,11 @@ open class Writer[T]:
 end Writer
 
 // File EncryptedWriter.scala
-package p
+trait Encrypter[T]:
+  def encrypt(t: T): T
 
-class EncryptedWriter[T: Encryptable] extends Writer[T]:
-  override def send(x: T) = super.send(encrypt(x))
+class EncryptedWriter[T: Encrypter] extends Writer[T]:
+  override def send(x: T) = super.send(summon[Encrypter[T]].encrypt(x))
 ```
 An open class typically comes with some documentation that describes
 the internal calling patterns between methods of the class as well as hooks that can be overridden. We call this the _extension contract_ of the class. It is different from the _external contract_ between a class and its users.

--- a/docs/docs/reference/other-new-features/parameter-untupling-spec.md
+++ b/docs/docs/reference/other-new-features/parameter-untupling-spec.md
@@ -5,24 +5,23 @@ movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/paramet
 ---
 
 ## Motivation
-
 Say you have a list of pairs
 
-```scala
+```scala sc-name:Base.scala
 val xs: List[(Int, Int)]
 ```
 
 and you want to map `xs` to a list of `Int`s so that each pair of numbers is mapped to their sum.
 Previously, the best way to do this was with a pattern-matching decomposition:
 
-```scala
+```scala sc-compile-with:Base.scala
 xs.map {
   case (x, y) => x + y
 }
 ```
 While correct, this is inconvenient. Instead, we propose to write it the following way:
 
-```scala
+```scala sc-compile-with:Base.scala
 xs.map {
   (x, y) => x + y
 }
@@ -30,7 +29,7 @@ xs.map {
 
 or, equivalently:
 
-```scala
+```scala sc-compile-with:Base.scala
 xs.map(_ + _)
 ```
 
@@ -60,18 +59,18 @@ Parameter untupling composes with eta-expansion. That is, an n-ary function gene
 
 If the function
 
-```scala
+```scala sc:nocompile
 (p1, ..., pn) => e
 ```
 
 is feasible for parameter untupling with the expected type `TupleN[T1, ..., Tn] => Te`, then continue to type check the following adapted function
 
 ```scala
-(x: TupleN[T1, ..., Tn]) =>
+def func[T1, T2 /*, Tn*/] = (x: Tuple2[T1, T2 /*, Tn*/]) =>
   def p1: T1 = x._1
-  ...
-  def pn: Tn = x._n
-  e
+  def p2: T2 = x._2
+  // def pn: Tn = x._n
+  ???
 ```
 
 with the same expected type.

--- a/docs/docs/reference/other-new-features/parameter-untupling.md
+++ b/docs/docs/reference/other-new-features/parameter-untupling.md
@@ -6,14 +6,14 @@ movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/paramet
 
 Say you have a list of pairs
 
-```scala
+```scala sc-name:Base.scala
 val xs: List[(Int, Int)]
 ```
 
 and you want to map `xs` to a list of `Int`s so that each pair of numbers is mapped to
 their sum. Previously, the best way to do this was with a pattern-matching decomposition:
 
-```scala
+```scala sc-compile-with:Base.scala
 xs map {
   case (x, y) => x + y
 }
@@ -22,7 +22,7 @@ xs map {
 While correct, this is also inconvenient and confusing, since the `case`
 suggests that the pattern match could fail. As a shorter and clearer alternative Scala 3 now allows
 
-```scala
+```scala sc-compile-with:Base.scala
 xs.map {
   (x, y) => x + y
 }
@@ -30,7 +30,7 @@ xs.map {
 
 or, equivalently:
 
-```scala
+```scala sc-compile-with:Base.scala
 xs.map(_ + _)
 ```
 

--- a/docs/docs/reference/other-new-features/safe-initialization.md
+++ b/docs/docs/reference/other-new-features/safe-initialization.md
@@ -26,7 +26,7 @@ class RemoteFile(url: String) extends AbstractFile:
 
 The checker will report:
 
-``` scala
+```scala sc:nocompile
 -- Warning: tests/init/neg/AbstractFile.scala:7:4 ------------------------------
 7 |	val localFile: String = s"${url.##}.tmp"  // error: usage of `localFile` before it's initialized
   |	    ^
@@ -49,7 +49,7 @@ object Trees:
 
 The checker will report:
 
-``` scala
+``` scala sc:nocompile
 -- Warning: tests/init/neg/trees.scala:5:14 ------------------------------------
 5 |  private var counter = 0  // error
   |              ^
@@ -76,7 +76,7 @@ class Child extends Parent:
 
 The checker reports:
 
-``` scala
+``` scala sc:nocompile
 -- Warning: tests/init/neg/features-high-order.scala:7:6 -----------------------
 7 |  val b = "hello"           // error
   |      ^
@@ -114,6 +114,9 @@ are initialized at the end of the primary constructor, except for the language
 feature below:
 
 ``` scala
+//{
+type T
+//}
 var x: T = _
 ```
 
@@ -141,11 +144,19 @@ field points to an initialized object may not later point to an
 object under initialization. As an example, the following code will be rejected:
 
 ``` scala
+//{
+class Context:
+  var reporter: Reporter = null
+  // ...
+class File(s: String):
+  def write(s: String) = ???
+  // ...
+//}
 trait Reporter:
   def report(msg: String): Unit
 
 class FileReporter(ctx: Context) extends Reporter:
-  ctx.typer.reporter = this                // ctx now reaches an uninitialized object
+  ctx.reporter = this                // ctx now reaches an uninitialized object
   val file: File = new File("report.txt")
   def report(msg: String) = file.write(msg)
 ```

--- a/docs/docs/reference/other-new-features/trait-parameters.md
+++ b/docs/docs/reference/other-new-features/trait-parameters.md
@@ -6,7 +6,7 @@ movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/trait-p
 
 Scala 3 allows traits to have parameters, just like classes have parameters.
 
-```scala
+```scala sc-name:Greeting.scala
 trait Greeting(val name: String):
   def msg = s"How are you, $name"
 
@@ -20,7 +20,7 @@ One potential issue with trait parameters is how to prevent
 ambiguities. For instance, you might try to extend `Greeting` twice,
 with different parameters.
 
-```scala
+```scala sc:fail sc-compile-with:Greeting.scala
 class D extends C, Greeting("Bill") // error: parameter passed twice
 ```
 
@@ -35,21 +35,21 @@ because it violates the second rule of the following for trait parameters:
 
 Here's a trait extending the parameterized trait `Greeting`.
 
-```scala
+```scala sc-compile-with:Greeting.scala sc-name:FormalGreeting.scala
 trait FormalGreeting extends Greeting:
   override def msg = s"How do you do, $name"
 ```
 As is required, no arguments are passed to `Greeting`. However, this poses an issue
 when defining a class that extends `FormalGreeting`:
 
-```scala
+```scala sc:fail sc-compile-with:FormalGreeting.scala
 class E extends FormalGreeting // error: missing arguments for `Greeting`.
 ```
 
 The correct way to write `E` is to extend both `Greeting` and
 `FormalGreeting` (in either order):
 
-```scala
+```scala sc-compile-with:FormalGreeting.scala
 class E extends Greeting("Bob"), FormalGreeting
 ```
 
@@ -75,7 +75,7 @@ class F(using iname: ImpliedName) extends ImpliedFormalGreeting
 ```
 
 The definition of `F` in the last line is implicitly expanded to
-```scala
+```scala sc:nocompile
 class F(using iname: ImpliedName) extends
   Object,
   ImpliedGreeting(using iname),

--- a/docs/docs/reference/other-new-features/transparent-traits.md
+++ b/docs/docs/reference/other-new-features/transparent-traits.md
@@ -12,6 +12,9 @@ Traits are used in two roles:
 Some traits are used primarily in the first role, and we usually do not want to see them in inferred types. An example is the `Product` trait that the compiler adds as a mixin trait to every case class or case object. In Scala 2, this parent trait sometimes makes inferred types more complicated than they should be. Example:
 
 ```scala
+//{
+val condition: Boolean
+//}
 trait Kind
 case object Var extends Kind
 case object Val extends Kind
@@ -28,6 +31,9 @@ Here, the inferred type of `x` is `Set[Kind & Product & Serializable]` whereas o
 Scala 3 allows one to mark a mixin trait as `transparent`, which means that it can be suppressed in type inference. Here's an example that follows the lines of the code above, but now with a new transparent trait `S` instead of `Product`:
 
 ```scala
+//{
+val condition: Boolean
+//}
 transparent trait S
 trait Kind
 object Var extends Kind, S

--- a/docs/docs/reference/other-new-features/type-test.md
+++ b/docs/docs/reference/other-new-features/type-test.md
@@ -10,6 +10,11 @@ When pattern matching there are two situations where a runtime type test must be
 The first case is an explicit type test using the ascription pattern notation.
 
 ```scala
+//{
+type X
+type Y <: X
+val x: X
+//}
 (x: X) match
   case y: Y =>
 ```
@@ -17,11 +22,16 @@ The first case is an explicit type test using the ascription pattern notation.
 The second case is when an extractor takes an argument that is not a subtype of the scrutinee type.
 
 ```scala
+//{
+type X
+type Y <: X
+val x: X
+//}
 (x: X) match
   case y @ Y(n) =>
 
 object Y:
-  def unapply(x: Y): Some[Int] = ...
+  def unapply(x: Y): Some[Int] = ???
 ```
 
 In both cases, a class test will be performed at runtime.
@@ -29,7 +39,7 @@ But when the type test is on an abstract type (type parameter or type member), t
 
 A `TypeTest` can be provided to make this test possible.
 
-```scala
+```scala sc:nocompile
 package scala.reflect
 
 trait TypeTest[-S, T]:
@@ -40,7 +50,12 @@ It provides an extractor that returns its argument typed as a `T` if the argumen
 It can be used to encode a type test.
 
 ```scala
-def f[X, Y](x: X)(using tt: TypeTest[X, Y]): Option[Y] = x match
+import scala.reflect.TypeTest
+
+type Y
+object Y:
+  def unapply(x: Y): Some[Int] = ???
+def f[X](x: X)(using tt: TypeTest[X, Y]): Option[Y] = x match
   case tt(x @ Y(1)) => Some(x)
   case tt(x) => Some(x)
   case _ => None
@@ -51,7 +66,12 @@ This means that `x: Y` is transformed to `tt(x)` and `x @ Y(_)` to `tt(x @ Y(_))
 The previous code is equivalent to
 
 ```scala
-def f[X, Y](x: X)(using TypeTest[X, Y]): Option[Y] = x match
+import scala.reflect.TypeTest
+
+type Y
+object Y:
+  def unapply(x: Y): Some[Int] = ???
+def f[X](x: X)(using TypeTest[X, Y]): Option[Y] = x match
   case x @ Y(1) => Some(x)
   case x: Y => Some(x)
   case _ => None
@@ -60,10 +80,15 @@ def f[X, Y](x: X)(using TypeTest[X, Y]): Option[Y] = x match
 We could create a type test at call site where the type test can be performed with runtime class tests directly as follows
 
 ```scala
+import scala.reflect.TypeTest
+
+def f[X, Y](x: X)(using TypeTest[X, Y]): Option[Y] = x match
+  case x: Y => Some(x)
+  case _ => None
 val tt: TypeTest[Any, String] =
   new TypeTest[Any, String]:
     def unapply(s: Any): Option[s.type & String] = s match
-      case s: String => Some(s)
+      case s: (String & s.type) => Some(s)
       case _ => None
 
 f[AnyRef, String]("acb")(using tt)
@@ -72,9 +97,15 @@ f[AnyRef, String]("acb")(using tt)
 The compiler will synthesize a new instance of a type test if none is found in scope as:
 
 ```scala
+//{
+type A
+type B
+//}
+import scala.reflect.TypeTest
+
 new TypeTest[A, B]:
   def unapply(s: A): Option[s.type & B] = s match
-    case s: B => Some(s)
+    case s: (B & s.type) => Some(s)
     case _ => None
 ```
 
@@ -83,7 +114,7 @@ If the type tests cannot be done there will be an unchecked warning that will be
 The most common `TypeTest` instances are the ones that take any parameters (i.e. `TypeTest[Any, T]`).
 To make it possible to use such instances directly in context bounds we provide the alias
 
-```scala
+```scala sc:nocompile
 package scala.reflect
 
 type Typeable[T] = TypeTest[Any, T]
@@ -92,6 +123,8 @@ type Typeable[T] = TypeTest[Any, T]
 This alias can be used as
 
 ```scala
+import scala.reflect.Typeable
+
 def f[T: Typeable]: Boolean =
   "abc" match
     case x: T => true
@@ -112,9 +145,13 @@ Using `ClassTag` instances was unsound since classtags can check only the class 
 ## Example
 
 Given the following abstract definition of Peano numbers that provides two given instances of types `TypeTest[Nat, Zero]` and `TypeTest[Nat, Succ]`
+together with an implementation of Peano numbers based on type `Int`
+it is possible to write the following program
 
 ```scala
 import scala.reflect.*
+
+// Abstraction
 
 trait Peano:
   type Nat
@@ -132,11 +169,9 @@ trait Peano:
 
   given typeTestOfZero: TypeTest[Nat, Zero]
   given typeTestOfSucc: TypeTest[Nat, Succ]
-```
 
-together with an implementation of Peano numbers based on type `Int`
+// Implementation based on type Int
 
-```scala
 object PeanoInt extends Peano:
   type Nat  = Int
   type Zero = Int
@@ -157,12 +192,10 @@ object PeanoInt extends Peano:
   def typeTestOfSucc: TypeTest[Nat, Succ] = new:
     def unapply(x: Nat): Option[x.type & Succ] =
       if x > 0 then Some(x) else None
-```
 
-it is possible to write the following program
+// Program
 
-```scala
-@main def test =
+def test =
   import PeanoInt.*
 
   def divOpt(m: Nat, n: Nat): Option[(Nat, Nat)] =

--- a/docs/docs/usage/cbt-projects.md
+++ b/docs/docs/usage/cbt-projects.md
@@ -9,7 +9,7 @@ incremental compilation is not supported), we recommend [using Dotty with sbt](s
 cbt comes with built-in Dotty support. Follow the
 [cbt tutorial](https://github.com/cvogt/cbt/), then simply extend `Dotty` in the Build class.
 
-```scala
+```scala sc:nocompile
 // build/build.scala
 import cbt.*
 class Build(val context: Context) extends Dotty {

--- a/docs/docs/usage/getting-started.md
+++ b/docs/docs/usage/getting-started.md
@@ -79,7 +79,7 @@ brew upgrade dotty
 ### Scala 3 for Scripting
 If you have followed the steps in "Standalone Installation" section and have the `scala` executable on your `PATH`, you can run `*.scala` files as scripts. Given a source named Test.scala:
 
-```scala
+```scala sc:nocompile
 @main def Test(name: String): Unit =
   println(s"Hello ${name}!")
 ```

--- a/docs/docs/usage/language-versions.md
+++ b/docs/docs/usage/language-versions.md
@@ -24,11 +24,10 @@ There are two ways to specify a language version.
  - With a `-source` command line setting, e.g. `-source 3.0-migration`.
  - With a `scala.language` import at the top of a source file, e.g:
 
-```scala
-package p
+```scala sc:nocompile
 import scala.language.`future-migration`
 
-class C { ... }
+class C { /*...*/ }
 ```
 
 Language imports supersede command-line settings in the source files where they are specified. Only one language import specifying a source version is allowed in a source file, and it must come before any definitions in that file.

--- a/docs/docs/usage/scaladoc/scaladocDocstrings.md
+++ b/docs/docs/usage/scaladoc/scaladocDocstrings.md
@@ -25,7 +25,7 @@ Scaladoc comments go before the items they pertain to in a special comment block
   * Even on empty paragraph-break lines.
   *
   * Note that the * on each line is aligned
-  * with the second * in /** so that the
+  * with the second * in /\** so that the
   * left margin is on the same column on the
   * first line and on subsequent ones.
   *
@@ -83,7 +83,7 @@ These tags are well-suited to larger types or packages, with many members. They 
 
 These tags are not enabled by default! You must pass the -groups flag to Scaladoc in order to turn them on. Typically the sbt for this will look something like:
 
-```scala
+```scala sc:nocompile
 Compile / doc / scalacOptions ++= Seq(
   "-groups"
 )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1371,7 +1371,8 @@ object Build {
               "-comment-syntax", "wiki",
               s"-source-links:docs=github://lampepfl/dotty/master#docs",
               "-doc-root-content", docRootFile.toString,
-              "-Ydocument-synthetic-types"
+              "-Ydocument-synthetic-types",
+              s"-snippet-compiler:docs/docs/usage=compile,docs/docs/release-notes=nocompile,docs/docs/reference/other-new-features=compile"
             ) ++ (if (justAPI) Nil else Seq("-siteroot", "docs", "-Yapi-subdirectory")))
 
         if (dottyJars.isEmpty) Def.task { streams.value.log.error("Dotty lib wasn't found") }


### PR DESCRIPTION
Fixed snippets in "Other new features" section