### PR TITLE
Fix -Ydebug-tree-with-id

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -36,7 +36,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
       ids.put(this, ownId)
       if ownId == debugId then
         println(s"Debug tree (id=$debugId) creation \n$this\n")
-        Reporter.displayPrompt(Console.in, new PrintWriter(Console.err, true))
+        Thread.dumpStack()
 
   allocateId()
 


### PR DESCRIPTION
Simplify -Ydebug-tree-with-id logic.
Currently it doesn't work for unknown reason
so this simplified logic should be more reliable.