### PR TITLE
fix #12949: export synthetic given co-defined with class

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -711,6 +711,17 @@ object SymDenotations {
          }
       )
 
+    /** Do this symbol and `cls` represent a pair of a given or implicit method and
+     *  its associated class that were defined by a single definition?
+     *  This can mean one of two things:
+     *   - the method and class are defined in a structural given instance, or
+     *   - the class is an implicit class and the method is its implicit conversion.
+ 	   */
+    final def isCoDefinedGiven(cls: Symbol)(using Context): Boolean =
+      isAllOf(Method | Synthetic)
+      && isOneOf(GivenOrImplicit)
+      && name == cls.name.toTermName && owner == cls.owner
+
     /** Is this a denotation of a stable term (or an arbitrary type)?
       * Terms are stable if they are idempotent (as in TreeInfo.Idempotent): that is, they always return the same value,
       * if any.

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1627,7 +1627,7 @@ trait Applications extends Compatibility {
     /** Widen the result type of synthetic given methods from the implementation class to the
      *  type that's implemented. Example
      *
-     *      given I[X] as T { ... }
+     *      given I[X]: T with { ... }
      *
      *  This desugars to
      *
@@ -1648,8 +1648,8 @@ trait Applications extends Compatibility {
         mt.derivedLambdaType(mt.paramNames, mt.paramInfos, widenGiven(mt.resultType, alt))
       case pt: PolyType =>
         pt.derivedLambdaType(pt.paramNames, pt.paramInfos, widenGiven(pt.resultType, alt))
-      case _ =>
-        if (alt.symbol.isAllOf(SyntheticGivenMethod)) tp.widenToParents
+      case rt =>
+        if alt.symbol.isCoDefinedGiven(rt.typeSymbol) then tp.widenToParents
         else tp
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -847,7 +847,8 @@ trait Checking {
 
     sym.info.stripPoly match {
       case mt @ MethodType(_ :: Nil)
-      if !mt.isImplicitMethod && !sym.is(Synthetic) => // it's an old-styleconversion
+      if !mt.isImplicitMethod && !sym.isCoDefinedGiven(mt.finalResultType.typeSymbol) =>
+        // it's an old-style conversion
         check()
       case _ =>
     }

--- a/tests/pos/i12949.scala
+++ b/tests/pos/i12949.scala
@@ -1,0 +1,19 @@
+object Catch22:
+  trait TC[V]
+  object TC:
+    export Hodor.TC.given
+
+object Hodor:
+  object TC:
+    import Catch22.TC
+    given fromString[V <: String]: TC[V] = ???
+    transparent inline given fromDouble[V <: Double]: TC[V] =
+      new TC[V]:
+        type Out = Double
+    given fromInt[V <: Int]: TC[V] with
+      type Out = Int
+
+object Test:
+  summon[Catch22.TC["hi"]] //works
+  summon[Catch22.TC[7.7]] //works
+  summon[Catch22.TC[1]] //error


### PR DESCRIPTION
An alternative to #12979 that does not introduce new flags