### PR TITLE
Crash when calling Compiler.newRun() without a docCtx

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1781,7 +1781,7 @@ class Definitions {
   }
 
   def addSyntheticSymbolsComments(using Context): Unit =
-    def add(sym: Symbol, doc: String) = ctx.docCtx.get.addDocstring(sym, Some(Comment(NoSpan, doc)))
+    def add(sym: Symbol, doc: String) = ctx.docCtx.foreach(_.addDocstring(sym, Some(Comment(NoSpan, doc))))
 
     add(AnyClass,
     """/** Class `Any` is the root of the Scala class hierarchy.  Every class in a Scala


### PR DESCRIPTION
Changes based on suggestion in the issue:
- https://github.com/lampepfl/dotty/issues/12998#issuecomment-873270695

And the implementation currently seen here:
https://github.com/lampepfl/dotty/blob/79fae194b80e136a243e7c7f949268166d169e1e/compiler/src/dotty/tools/dotc/typer/Namer.scala#L449