### PR TITLE
Add missing case for finding default getters

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -210,6 +210,7 @@ object Applications {
         case Select(receiver, _) => receiver
         case mr => mr.tpe.normalizedPrefix match {
           case mr: TermRef => ref(mr)
+          case mr: ThisType => singleton(mr)
           case mr =>
             if testOnly then
               // In this case it is safe to skolemize now; we will produce a stable prefix for the actual call.

--- a/tests/pos/i12897/A.scala
+++ b/tests/pos/i12897/A.scala
@@ -1,0 +1,5 @@
+
+package TestFoo
+extension (text : String) def foo(defaultArg : Boolean = true) : String = ""
+
+//def foo(text : String) (defaultArg : Boolean = true) : String = ""

--- a/tests/pos/i12897/B.scala
+++ b/tests/pos/i12897/B.scala
@@ -1,0 +1,4 @@
+
+package TestFoo
+
+val f = "123".foo() //error


### PR DESCRIPTION
There are two modes for finding default getters. They depend on whether
the receiver is defined or not. If the receiver is not defined we search
the enclosing scopes instead. This fails if the method and the call are in different
toplevel files, since the scopes of the two are not enclosing. But that should
not matter since for toplevel definitions we do have a defined receiver, namely
the synthetic enclosing object. Only for extension methods it happened that
that object was referred to via a This reference instead of a TermRef. This is
allowed in general but fell through a missing case in this instance.

Fixes #12897