### PR TITLE
Fix ordering propagation during parameter unification in constraint solver

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -197,6 +197,7 @@ trait ConstraintHandling {
   private def unify(p1: TypeParamRef, p2: TypeParamRef)(using Context): Boolean = {
     constr.println(s"unifying $p1 $p2")
     assert(constraint.isLess(p1, p2))
+    constraint = constraint.addLess(p2, p1)
     val down = constraint.exclusiveLower(p2, p1)
     val up = constraint.exclusiveUpper(p1, p2)
     constraint = constraint.unify(p1, p2)

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -353,8 +353,15 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     else {
       assert(contains(param1), i"$param1")
       assert(contains(param2), i"$param2")
-      val newUpper = param2 :: exclusiveUpper(param2, param1)
-      val newLower = param1 :: exclusiveLower(param1, param2)
+      // Is `order` called during parameter unification?
+      val unifying = isLess(param2, param1)
+      val newUpper = param2 :: exclusiveUpper(param2, param1).filterNot(_ eq param1)
+      val newLower =
+        if unifying then
+          // Do not add bounds for param1 since it will be unified to param2 soon.
+          exclusiveLower(param1, param2).filterNot(_ eq param2)
+        else
+          param1 :: exclusiveLower(param1, param2).filterNot(_ eq param2)
       val current1 = newLower.foldLeft(current)(upperLens.map(this, _, _, newUpper ::: _))
       val current2 = newUpper.foldLeft(current1)(lowerLens.map(this, _, _, newLower ::: _))
       current2

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -355,13 +355,25 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
       assert(contains(param2), i"$param2")
       // Is `order` called during parameter unification?
       val unifying = isLess(param2, param1)
-      val newUpper = param2 :: exclusiveUpper(param2, param1).filterNot(_ eq param1)
-      val newLower =
+      val newUpper = {
+        val up = exclusiveUpper(param2, param1)
+        if unifying then
+          // Since param2 <:< param1 already holds now, filter out param1 to avoid adding
+          //   duplicated orderings.
+          param2 :: up.filterNot(_ eq param1)
+        else
+          param2 :: up
+      }
+      val newLower = {
+        val lower = exclusiveLower(param1, param2)
         if unifying then
           // Do not add bounds for param1 since it will be unified to param2 soon.
-          exclusiveLower(param1, param2).filterNot(_ eq param2)
+          // And, similarly filter out param2 from lowerly-ordered parameters
+          //   to avoid duplicated orderings.
+          lower.filterNot(_ eq param2)
         else
-          param1 :: exclusiveLower(param1, param2).filterNot(_ eq param2)
+          param1 :: lower
+      }
       val current1 = newLower.foldLeft(current)(upperLens.map(this, _, _, newUpper ::: _))
       val current2 = newUpper.foldLeft(current1)(lowerLens.map(this, _, _, newLower ::: _))
       current2

--- a/tests/pos/gadt-param-unification.scala
+++ b/tests/pos/gadt-param-unification.scala
@@ -1,0 +1,6 @@
+trait Expr[T]
+final class Lit[T] extends Expr[T]
+
+def foo[X, T1 >: X, T2](m: Expr[T2]): T2 = m match {
+  case _: Lit[T1] => ??? : X
+}


### PR DESCRIPTION
Before this PR, parameter orderings will not be properly propagated when unifying type parameters.

The following example illustrate this problem.
```scala
trait Expr[T]
final class Lit[T] extends Expr[T]

def foo[X, T1 >: X, T2](m: Expr[T2]): T2 = m match {
  case _: Lit[T1] => ??? : X
}
```

GADT logic in the compiler will unify `T1` to `T2` when we match `Expr[T2]` against `Lit[T1]`. During the process, the ordering `X <:< T2` (derived from `X <:< T1` and `T1 <:< T2`) will not be propagated. The resulting constraint will be in an inconsistent state where part of the orderings are not propagated. This problem will make `isLess(X, T2)` return `false` (since the ordering `X <:< T2` is not propagated), thus preventing the above code example from compiling.

This PR fixes the problem by calling `OrderingConstraint.addLess` when unifying type parameters to propagate the orderings, and tweaking the logic of `OrderingConstraint.order` to properly consider the parameter unification case.