### PR TITLE
Fix #13046: `override` is a valid identifier in Java, not a keyword

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaTokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaTokens.scala
@@ -10,7 +10,7 @@ object JavaTokens extends TokensCommon {
 
   final val javaOnlyKeywords: TokenSet = tokenRange(INSTANCEOF, ASSERT)
   final val sharedKeywords: BitSet = BitSet( IF, FOR, ELSE, THIS, NULL, NEW, SUPER, ABSTRACT, FINAL, PRIVATE, PROTECTED,
-    OVERRIDE, EXTENDS, TRUE, FALSE, CLASS, IMPORT, PACKAGE, DO, THROW, TRY, CATCH, FINALLY, WHILE, RETURN )
+    EXTENDS, TRUE, FALSE, CLASS, IMPORT, PACKAGE, DO, THROW, TRY, CATCH, FINALLY, WHILE, RETURN )
   final val primTypes: TokenSet = tokenRange(VOID, DOUBLE)
   final val keywords: BitSet = sharedKeywords | javaOnlyKeywords | primTypes
 

--- a/tests/pos/i13046/A.java
+++ b/tests/pos/i13046/A.java
@@ -1,0 +1,3 @@
+interface A {
+    public boolean override();
+}

--- a/tests/pos/i13046/B.scala
+++ b/tests/pos/i13046/B.scala
@@ -1,0 +1,3 @@
+class B extends A {
+  override def `override`: Boolean = true
+}


### PR DESCRIPTION
https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.9

Fixes #13046 