### PR TITLE
CI: honor [skip test_windows_fast] request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,10 +127,6 @@ jobs:
          || (
            github.event_name == 'pull_request'
            && !contains(github.event.pull_request.body, '[skip ci]')
-         )
-         || (
-           github.event_name == 'pull_request'
-           && !contains(github.event.pull_request.body, '[skip ci]')
            && !contains(github.event.pull_request.body, '[skip test_windows_fast]')
          )"
 


### PR DESCRIPTION
Previously, test_windows_fast would run even when [skip test_windows_fast] was requested.