### PR TITLE
set TimeZone for version number

### DIFF
--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -3,7 +3,7 @@ import org.eclipse.jgit.lib.{Constants, ObjectId, Ref, Repository}
 import org.eclipse.jgit.revwalk.{RevCommit, RevWalk}
 
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.{Date, TimeZone}
 
 object VersionUtil {
 
@@ -38,6 +38,7 @@ object VersionUtil {
   def gitHash: String = git.headCommitSha.substring(0, 7)
   def commitDate: String = {
     val format = new SimpleDateFormat("yyyyMMdd")
+    format.setTimeZone(TimeZone.getTimeZone("UTC"))
     format.format(git.headCommitDate)
   }
 }


### PR DESCRIPTION
for reproducible builds

```
Welcome to Scala 2.13.6 (OpenJDK 64-Bit Server VM, Java 1.8.0_292).
Type in expressions for evaluation. Or try :help.

scala> import java.text.SimpleDateFormat
import java.text.SimpleDateFormat

scala> import java.util.{Date, TimeZone}
import java.util.{Date, TimeZone}

scala> def date(zone: String) = {
     |   val format = new SimpleDateFormat("yyyyMMdd")
     |   format.setTimeZone(TimeZone.getTimeZone(zone))
     |   format.format(new Date(1626043918000L))
     | }
def date(zone: String): String

scala> date("JST")
val res0: String = 20210712

scala> date("UTC")
val res1: String = 20210711
```