### PR TITLE
Avoid auto-tupling in unapply unless a tuple is expected

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1360,7 +1360,7 @@ trait Applications extends Compatibility {
         for (argType <- argTypes) assert(!isBounds(argType), unapplyApp.tpe.show)
         val bunchedArgs = argTypes match {
           case argType :: Nil =>
-            if (args.lengthCompare(1) > 0 && Feature.autoTuplingEnabled) untpd.Tuple(args) :: Nil
+            if (args.lengthCompare(1) > 0 && Feature.autoTuplingEnabled && defn.isTupleType(argType)) untpd.Tuple(args) :: Nil
             else args
           case _ => args
         }

--- a/tests/neg/i10757.check
+++ b/tests/neg/i10757.check
@@ -1,0 +1,6 @@
+-- [E107] Syntax Error: tests/neg/i10757.scala:4:10 --------------------------------------------------------------------
+4 |  case Var(name, _) => name: String // error
+  |       ^^^^^^^^^^^^
+  |       Wrong number of argument patterns for Var; expected: (String)
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i10757.scala
+++ b/tests/neg/i10757.scala
@@ -1,0 +1,4 @@
+case class Var(name: String)
+
+@main def f = Var("a") match
+  case Var(name, _) => name: String // error


### PR DESCRIPTION
Fixes #10757