### PR TITLE
Fix for constraining dependent parameter references

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4417,6 +4417,8 @@ object Types {
 
   private final class RecThisImpl(binder: RecType) extends RecThis(binder)
 
+  // @sharable private var skid: Int = 0
+
   // ----- Skolem types -----------------------------------------------
 
   /** A skolem type reference with underlying type `info`.
@@ -4433,6 +4435,10 @@ object Types {
     override def equals(that: Any): Boolean = this.eq(that.asInstanceOf[AnyRef])
 
     def withName(name: Name): this.type = { myRepr = name; this }
+
+    //skid += 1
+    //val id = skid
+    //assert(id != 10)
 
     private var myRepr: Name = null
     def repr(using Context): Name = {

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -350,7 +350,10 @@ trait TypeAssigner {
           else {
             // Make sure arguments don't contain the type `pt` itself.
             // make a copy of the argument if that's the case.
-            // See pos/i6682a.scala for a test case where this matters.
+            // This is done to compensate for the fact that normally every
+            // reference to a polytype would have to be a fresh copy of that type,
+            // but we want to avoid that because it would increase compilation cost.
+            // See pos/i6682a.scala for a test case where the defensive copying matters.
             val ensureFresh = new TypeMap:
               def apply(tp: Type) = mapOver(
                 if tp eq pt then pt.newLikeThis(pt.paramNames, pt.paramInfos, pt.resType)

--- a/tests/pos/i12803.scala
+++ b/tests/pos/i12803.scala
@@ -1,0 +1,12 @@
+trait X {
+  type Y
+}
+
+trait E[A]
+
+trait Test {
+  val x: X
+  def wrap(x: X): E[x.Y] = ???
+  def run[I](i: E[I]): Unit = ???
+  run(wrap(x))
+}


### PR DESCRIPTION
We were too fast skolemizing the argument type as lower bound for a dependent parameter.
We need to do that only if the argument is unstable.

Fixing this revealed another problem in i6882a.scala, where we now got
confused by instantiating a poly type to a polymorphic function type
that contained the same polytype again. We avaoid that now by creating
a fresh copy of the polytype.

Fixes #12803