### PR TITLE
Refine "can be handled by parent" condition when generting bridges

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -34,6 +34,9 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
 
     override def exclude(sym: Symbol) =
       !sym.isOneOf(MethodOrModule) || super.exclude(sym)
+
+    override def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parent: Symbol): Boolean =
+      OverridingPairs.isOverridingPair(sym1, sym2, parent.thisType)
   }
 
   val site = root.thisType

--- a/tests/run/i1240.scala
+++ b/tests/run/i1240.scala
@@ -19,7 +19,9 @@ object Test {
       // In Java, this gives an error like this:
       // methods foo(A) from C[D] and foo(String) from C[D] are inherited with the same signature
       // But the analogous example with `b1` compiles OK in Java.
-    assert(b2.foo(new D) == "T foo")
+    assert(b2.foo(new D) == "D foo")
+      // Here we get "D foo" since a bridge method for foo(x: D) was inserted
+      // in the anonymous class of b2.
   }
 }
 

--- a/tests/run/i13087.scala
+++ b/tests/run/i13087.scala
@@ -1,0 +1,38 @@
+import scala.collection.mutable.Builder
+
+class DDD[S,T,A]
+
+trait NN[S, T, A, K[_], +D <: DDD[Set[S],T,K[A]]]
+class NNN[S, T, K[_], A] extends NN[S, T, A, K, DDD[Set[S],T,K[A]]]
+
+object NN {
+  def newBuilder[S, T, A, K[_]]:
+      NNbuilder[S, T, K, A, DDD[Set[S],T,K[A]], NN[S,T,A,K,?], Unit] =
+    new NNNbuilder[S, T, K, A]
+}
+
+// Remove the type parameter E, hardcoding in E := Unit, and the issue
+// goes away.
+trait NNbuilder
+  [S, T, K[_], A, +D <: DDD[Set[S],T,K[A]], +N <: NN[S,T,A,K,D], E]
+    extends Builder[Unit, N] {
+  def clear(): Unit = throw new UnsupportedOperationException()
+  final def addOne(builder: E): this.type = this
+}
+
+// Unfold this class defn, and the issue goes away
+abstract class AbstractNNNbuilder
+  [S, T, K[_], A, +D <: DDD[Set[S],T,K[A]], +N <: NN[S,T,A,K,D], E]
+    extends NNbuilder[S,T,K,A,D,N,E]
+
+class NNNbuilder[S, T, K[_], A] extends AbstractNNNbuilder[
+  S, T, K, A, DDD[Set[S], T, K[A]], NNN[S, T, K, A], Unit
+] {
+  override def result(): NNN[S, T, K, A] = new NNN[S, T, K, A]
+}
+
+@main def Test: Unit = {
+  val builder = NN.newBuilder[String, Char, Int, Set]
+  builder += ()
+  builder.result()
+}

--- a/tests/run/i13087a.scala
+++ b/tests/run/i13087a.scala
@@ -1,0 +1,17 @@
+trait SimpleTrait[T] {
+  def myMethod(t: T): Int
+  def doIt(t: T): Unit = {
+    myMethod(t) // java.lang.AbstractMethodError: Method BadClass.myMethod(Ljava/lang/Object;)I is abstract
+ }
+}
+
+abstract class SimpleClass[T] extends SimpleTrait[T] {
+  def myMethod(t: String): Int = 5
+}
+
+class BadClass extends SimpleClass[String]
+
+object Test {
+  def main(args: Array[String]): Unit =
+    (new BadClass).doIt("foobar")
+}


### PR DESCRIPTION
Fixes #13087

Reverses the outcome in i1240.scala.