### PR TITLE
Remove extended experimental checking

### DIFF
--- a/tests/pos/i13091.scala
+++ b/tests/pos/i13091.scala
@@ -1,0 +1,3 @@
+import annotation.experimental
+@experimental trait Foo
+val foo = new (Foo @experimental) {}


### PR DESCRIPTION
This PR makes @experimental behave analogously to @deprecated: if you refer
to something that's experimental then the compiler version must be a snapshot
release. I don't see a reason for more extensive rules. They are likely more
damaging than helpful, as i13091 shows.

Fixes #13091