### PR TITLE
Mark website content as outdated.

### DIFF
--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -2,6 +2,11 @@
 layout: base
 ---
 <div id="content-wrapper">
+    {% if page.movedTo %}
+    <aside class="warning">
+      The content of this page is outdated. Click <a href="{{ page.movedTo }}">here</a> to find the up to date version of this page.
+    </aside>
+    {% endif %}
     {{ content }}
 </div>
 <script>

--- a/docs/css/dottydoc.css
+++ b/docs/css/dottydoc.css
@@ -193,8 +193,8 @@ aside {
 }
 
 aside.warning {
-  border-left: 3px solid #d62c2c;
-  background-color: #ffe4e4;
+  border-left: 3px solid var(--red500);
+  background-color: var(--aside-warning-bg);
 }
 
 aside.notice {

--- a/docs/docs/reference/changed-features/compiler-plugins.md
+++ b/docs/docs/reference/changed-features/compiler-plugins.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Changes in Compiler Plugins"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/compiler-plugins.html
 ---
 
 Compiler plugins are supported by Dotty (and Scala 3) since 0.9. There are two notable changes

--- a/docs/docs/reference/changed-features/eta-expansion-spec.md
+++ b/docs/docs/reference/changed-features/eta-expansion-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Automatic Eta Expansion - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/eta-expansion-spec.html
 ---
 
 ## Motivation

--- a/docs/docs/reference/changed-features/eta-expansion.md
+++ b/docs/docs/reference/changed-features/eta-expansion.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Automatic Eta Expansion"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/eta-expansion.html
 ---
 
 The conversion of _methods_ into _functions_ has been improved and happens automatically for methods with one or more parameters.

--- a/docs/docs/reference/changed-features/implicit-conversions-spec.md
+++ b/docs/docs/reference/changed-features/implicit-conversions-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Implicit Conversions - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/implicit-conversions-spec.html
 ---
 
 ## Implementation

--- a/docs/docs/reference/changed-features/implicit-conversions.md
+++ b/docs/docs/reference/changed-features/implicit-conversions.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Implicit Conversions"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/implicit-conversions.html
 ---
 
 An _implicit conversion_, also called _view_, is a conversion that

--- a/docs/docs/reference/changed-features/implicit-resolution.md
+++ b/docs/docs/reference/changed-features/implicit-resolution.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Changes in Implicit Resolution"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/implicit-resolution.html
 ---
 This section describes changes to the implicit resolution that apply both to the new `given`s and to the old-style `implicit`s in Scala 3.
 Implicit resolution uses a new algorithm which caches implicit results

--- a/docs/docs/reference/changed-features/imports.md
+++ b/docs/docs/reference/changed-features/imports.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Imports"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/imports.html
 ---
 
 The syntax of wildcard and renaming imports (and exports) has changed.

--- a/docs/docs/reference/changed-features/interpolation-escapes.md
+++ b/docs/docs/reference/changed-features/interpolation-escapes.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Escapes in interpolations"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/interpolation-escapes.html
 ---
 
 In Scala 2 there is no straightforward way to represent a single quote character `"` in a single quoted interpolation. A `\` character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether the `"` should be escaped or used as a terminator.

--- a/docs/docs/reference/changed-features/lazy-vals-init.md
+++ b/docs/docs/reference/changed-features/lazy-vals-init.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: Lazy Vals initialization
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/lazy-vals-init.html
 ---
 
 Scala 3 implements [Version 6](https://docs.scala-lang.org/sips/improved-lazy-val-initialization.html#version-6---no-synchronization-on-this-and-concurrent-initialization-of-fields)

--- a/docs/docs/reference/changed-features/main-functions.md
+++ b/docs/docs/reference/changed-features/main-functions.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Main Methods"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/main-functions.html
 ---
 
 Scala 3 offers a new way to define programs that can be invoked from the command line:

--- a/docs/docs/reference/changed-features/match-syntax.md
+++ b/docs/docs/reference/changed-features/match-syntax.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Match Expressions"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/match-syntax.html
 ---
 
 The syntactical precedence of match expressions has been changed.

--- a/docs/docs/reference/changed-features/numeric-literals.md
+++ b/docs/docs/reference/changed-features/numeric-literals.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Numeric Literals"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/numeric-literals.html
 ---
 
 **Note**: This feature is not yet part of the Scala 3 language definition. It can be made available by a language import:

--- a/docs/docs/reference/changed-features/operators.md
+++ b/docs/docs/reference/changed-features/operators.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Rules for Operators"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/operators.html
 ---
 
 The rules for infix operators have changed in some parts:

--- a/docs/docs/reference/changed-features/overload-resolution.md
+++ b/docs/docs/reference/changed-features/overload-resolution.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Changes in Overload Resolution"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/overload-resolution.html
 ---
 
 Overload resolution in Scala 3 improves on Scala 2 in two ways.

--- a/docs/docs/reference/changed-features/pattern-bindings.md
+++ b/docs/docs/reference/changed-features/pattern-bindings.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Pattern Bindings"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/pattern-bindings.html
 ---
 
 In Scala 2, pattern bindings in `val` definitions and `for` expressions are

--- a/docs/docs/reference/changed-features/pattern-matching.md
+++ b/docs/docs/reference/changed-features/pattern-matching.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Option-less pattern matching"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/pattern-matching.html
 ---
 
 The implementation of pattern matching in Scala 3 was greatly simplified compared to Scala 2. From a user perspective, this means that Scala 3 generated patterns are a *lot* easier to debug, as variables all show up in debug modes and positions are correctly preserved.

--- a/docs/docs/reference/changed-features/structural-types-spec.md
+++ b/docs/docs/reference/changed-features/structural-types-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Programmatic Structural Types - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/structural-types-spec.html
 ---
 
 ## Syntax

--- a/docs/docs/reference/changed-features/structural-types.md
+++ b/docs/docs/reference/changed-features/structural-types.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Programmatic Structural Types"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/structural-types.html
 ---
 
 ## Motivation

--- a/docs/docs/reference/changed-features/type-checking.md
+++ b/docs/docs/reference/changed-features/type-checking.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Changes in Type Checking"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/type-checking.html
 ---
 
 *** **TO BE FILLED IN** ***

--- a/docs/docs/reference/changed-features/type-inference.md
+++ b/docs/docs/reference/changed-features/type-inference.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Changes in Type Inference"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/type-inference.html
 ---
 
 For more information, see the two presentations

--- a/docs/docs/reference/changed-features/vararg-splices.md
+++ b/docs/docs/reference/changed-features/vararg-splices.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Vararg Splices"
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/vararg-splices.html
 ---
 
 The syntax of vararg splices in patterns and function arguments has changed. The new syntax uses a postfix `*`,  analogously to how a vararg parameter is declared.

--- a/docs/docs/reference/changed-features/wildcards.md
+++ b/docs/docs/reference/changed-features/wildcards.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: Wildcard Arguments in Types
+movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/wildcards.html
 ---
 
 The syntax of wildcard arguments in types has changed from `_` to `?`. Example:

--- a/docs/docs/reference/contextual/by-name-context-parameters.md
+++ b/docs/docs/reference/contextual/by-name-context-parameters.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "By-Name Context Parameters"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/by-name-context-parameters.html
 ---
 
 Context parameters can be declared by-name to avoid a divergent inferred expansion. Example:

--- a/docs/docs/reference/contextual/context-bounds.md
+++ b/docs/docs/reference/contextual/context-bounds.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Context Bounds"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/context-bounds.html
 ---
 
 A context bound is a shorthand for expressing the common pattern of a context parameter that depends on a type parameter. Using a context bound, the `maximum` function of the last section can be written like this:

--- a/docs/docs/reference/contextual/context-functions-spec.md
+++ b/docs/docs/reference/contextual/context-functions-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Context Functions - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/context-functions-spec.html
 ---
 
 ## Syntax

--- a/docs/docs/reference/contextual/context-functions.md
+++ b/docs/docs/reference/contextual/context-functions.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Context Functions"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/context-functions.html
 ---
 
 _Context functions_ are functions with (only) context parameters.

--- a/docs/docs/reference/contextual/conversions.md
+++ b/docs/docs/reference/contextual/conversions.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Implicit Conversions"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/conversions.html
 ---
 
 Implicit conversions are defined by given instances of the `scala.Conversion` class.

--- a/docs/docs/reference/contextual/derivation-macro.md
+++ b/docs/docs/reference/contextual/derivation-macro.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "How to write a type class `derived` method using macros"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/derivation-macro.html
 ---
 
 In the main [derivation](./derivation.md) documentation page, we explained the

--- a/docs/docs/reference/contextual/derivation.md
+++ b/docs/docs/reference/contextual/derivation.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Type Class Derivation"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/derivation.html
 ---
 
 Type class derivation is a way to automatically generate given instances for type classes which satisfy some simple

--- a/docs/docs/reference/contextual/extension-methods.md
+++ b/docs/docs/reference/contextual/extension-methods.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Extension Methods"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html
 ---
 
 Extension methods allow one to add methods to a type after the type is defined. Example:

--- a/docs/docs/reference/contextual/given-imports.md
+++ b/docs/docs/reference/contextual/given-imports.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Importing Givens"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/given-imports.html
 ---
 
 A special form of import wildcard selector is used to import given instances. Example:

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Given Instances"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/givens.html
 ---
 
 Given instances (or, simply, "givens") define "canonical" values of certain types

--- a/docs/docs/reference/contextual/motivation.md
+++ b/docs/docs/reference/contextual/motivation.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Overview"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual.html
 ---
 
 ### Critique of the Status Quo

--- a/docs/docs/reference/contextual/multiversal-equality.md
+++ b/docs/docs/reference/contextual/multiversal-equality.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Multiversal Equality"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/multiversal-equality.html
 ---
 
 Previously, Scala had universal equality: Two values of any types

--- a/docs/docs/reference/contextual/relationship-implicits.md
+++ b/docs/docs/reference/contextual/relationship-implicits.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Relationship with Scala 2 Implicits"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/relationship-implicits.html
 ---
 
 Many, but not all, of the new contextual abstraction features in Scala 3 can be mapped to Scala 2's implicits. This page gives a rundown on the relationships between new and old features.

--- a/docs/docs/reference/contextual/right-associative-extension-methods.md
+++ b/docs/docs/reference/contextual/right-associative-extension-methods.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Right-Associative Extension Methods: Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/right-associative-extension-methods.html
 ---
 
 The most general form of leading parameters of an extension method is as follows:

--- a/docs/docs/reference/contextual/type-classes.md
+++ b/docs/docs/reference/contextual/type-classes.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Implementing Type classes"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/type-classes.html
 ---
 
 A _type class_ is an abstract, parameterized type that lets you add new behavior to any closed data type without using sub-typing. This can be useful in multiple use-cases, for example:

--- a/docs/docs/reference/contextual/using-clauses.md
+++ b/docs/docs/reference/contextual/using-clauses.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Using Clauses"
+movedTo: https://docs.scala-lang.org/scala3/reference/contextual/using-clauses.html
 ---
 
 Functional programming tends to express most dependencies as simple function parameterization.

--- a/docs/docs/reference/dropped-features/auto-apply.md
+++ b/docs/docs/reference/dropped-features/auto-apply.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Auto-Application"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/auto-apply.html
 ---
 
 Previously an empty argument list `()` was implicitly inserted when

--- a/docs/docs/reference/dropped-features/class-shadowing-spec.md
+++ b/docs/docs/reference/dropped-features/class-shadowing-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Class Shadowing - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/class-shadowing-spec.html
 ---
 
 Spec diff: in section [5.1.4 Overriding](https://www.scala-lang.org/files/archive/spec/2.13/05-classes-and-objects.html#Overriding), add *M' must not be a class*.

--- a/docs/docs/reference/dropped-features/class-shadowing.md
+++ b/docs/docs/reference/dropped-features/class-shadowing.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Class Shadowing"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/class-shadowing.html
 ---
 
 Scala 2 so far allowed patterns like this:

--- a/docs/docs/reference/dropped-features/delayed-init.md
+++ b/docs/docs/reference/dropped-features/delayed-init.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
-title: "Dropped: Delayedinit"
+title: "Dropped: DelayedInit"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/delayed-init.html
 ---
 
 The special handling of the `DelayedInit` trait is no longer supported.

--- a/docs/docs/reference/dropped-features/do-while.md
+++ b/docs/docs/reference/dropped-features/do-while.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Do-While"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/do-while.html
 ---
 
 The syntax construct

--- a/docs/docs/reference/dropped-features/early-initializers.md
+++ b/docs/docs/reference/dropped-features/early-initializers.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Early Initializers"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/early-initializers.html
 ---
 
 Early initializers of the form

--- a/docs/docs/reference/dropped-features/existential-types.md
+++ b/docs/docs/reference/dropped-features/existential-types.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Existential Types"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/existential-types.html
 ---
 
 Existential types using `forSome` (as in

--- a/docs/docs/reference/dropped-features/limit22.md
+++ b/docs/docs/reference/dropped-features/limit22.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Limit 22"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/limit22.html
 ---
 
 The limits of 22 for the maximal number of parameters of function types and the

--- a/docs/docs/reference/dropped-features/macros.md
+++ b/docs/docs/reference/dropped-features/macros.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Scala 2 Macros"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/macros.html
 ---
 
 The previous, experimental macro system has been dropped.

--- a/docs/docs/reference/dropped-features/nonlocal-returns.md
+++ b/docs/docs/reference/dropped-features/nonlocal-returns.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Deprecated: Nonlocal Returns"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html
 ---
 
 Returning from nested anonymous functions has been deprecated.

--- a/docs/docs/reference/dropped-features/package-objects.md
+++ b/docs/docs/reference/dropped-features/package-objects.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Package Objects"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/package-objects.html
 ---
 
 Package objects

--- a/docs/docs/reference/dropped-features/procedure-syntax.md
+++ b/docs/docs/reference/dropped-features/procedure-syntax.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Procedure Syntax"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/procedure-syntax.html
 ---
 
 Procedure syntax

--- a/docs/docs/reference/dropped-features/symlits.md
+++ b/docs/docs/reference/dropped-features/symlits.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Symbol Literals"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/symlits.html
 ---
 
 Symbol literals are no longer supported.

--- a/docs/docs/reference/dropped-features/this-qualifier.md
+++ b/docs/docs/reference/dropped-features/this-qualifier.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: private[this] and protected[this]"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
 ---
 
 The `private[this]` and `protected[this]` access modifiers are deprecated and will be phased out.

--- a/docs/docs/reference/dropped-features/type-projection.md
+++ b/docs/docs/reference/dropped-features/type-projection.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: General Type Projection"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/type-projection.html
 ---
 
 Scala so far allowed general type projection `T#A` where `T` is an arbitrary type

--- a/docs/docs/reference/dropped-features/weak-conformance-spec.md
+++ b/docs/docs/reference/dropped-features/weak-conformance-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Weak Conformance - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/weak-conformance-spec.html
 ---
 
 To simplify the underlying type theory, Scala 3 drops the notion of

--- a/docs/docs/reference/dropped-features/weak-conformance.md
+++ b/docs/docs/reference/dropped-features/weak-conformance.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Weak Conformance"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/weak-conformance.html
 ---
 
 In some situations, Scala used a _weak conformance_ relation when

--- a/docs/docs/reference/dropped-features/wildcard-init.md
+++ b/docs/docs/reference/dropped-features/wildcard-init.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: Wildcard Initializer"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/wildcard-init.html
 ---
 
 The syntax

--- a/docs/docs/reference/dropped-features/xml.md
+++ b/docs/docs/reference/dropped-features/xml.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dropped: XML Literals"
+movedTo: https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html
 ---
 
 XML Literals are still supported, but will be dropped in the near future, to

--- a/docs/docs/reference/enums/adts.md
+++ b/docs/docs/reference/enums/adts.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Algebraic Data Types"
+movedTo: https://docs.scala-lang.org/scala3/reference/enums/adts.html
 ---
 
 The [`enum` concept](./enums.md) is general enough to also support algebraic data

--- a/docs/docs/reference/enums/desugarEnums.md
+++ b/docs/docs/reference/enums/desugarEnums.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Translation of Enums and ADTs"
+movedTo: https://docs.scala-lang.org/scala3/reference/enums/desugarEnums.html
 ---
 
 The compiler expands enums and their cases to code that only uses

--- a/docs/docs/reference/enums/enums.md
+++ b/docs/docs/reference/enums/enums.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Enumerations"
+movedTo: https://docs.scala-lang.org/scala3/reference/enums/enums.html
 ---
 
 An enumeration is used to define a type consisting of a set of named values.

--- a/docs/docs/reference/metaprogramming/compiletime-ops.md
+++ b/docs/docs/reference/metaprogramming/compiletime-ops.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Compile-time operations"
+movedTo: https://docs.scala-lang.org/scala3/reference/metaprogramming/compiletime-ops.html
 ---
 
 ## The `scala.compiletime` Package

--- a/docs/docs/reference/metaprogramming/inline.md
+++ b/docs/docs/reference/metaprogramming/inline.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: Inline
+movedTo: https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html
 ---
 
 ## Inline Definitions

--- a/docs/docs/reference/metaprogramming/macros-spec.md
+++ b/docs/docs/reference/metaprogramming/macros-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Macros Spec"
+movedTo: https://docs.scala-lang.org/scala3/reference/metaprogramming/macros-spec.html
 ---
 
 ## Implementation

--- a/docs/docs/reference/metaprogramming/macros.md
+++ b/docs/docs/reference/metaprogramming/macros.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Macros"
+movedTo: https://docs.scala-lang.org/scala3/reference/metaprogramming/macros.html
 ---
 
 > When developing macros enable `-Xcheck-macros` scalac option flag to have extra runtime checks.

--- a/docs/docs/reference/metaprogramming/reflection.md
+++ b/docs/docs/reference/metaprogramming/reflection.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Reflection"
+movedTo: https://docs.scala-lang.org/scala3/reference/metaprogramming/reflection.html
 ---
 
 Reflection enables inspection and construction of Typed Abstract Syntax Trees

--- a/docs/docs/reference/metaprogramming/staging.md
+++ b/docs/docs/reference/metaprogramming/staging.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Runtime Multi-Stage Programming"
+movedTo: https://docs.scala-lang.org/scala3/reference/metaprogramming/staging.html
 ---
 
 The framework expresses at the same time compile-time metaprogramming and

--- a/docs/docs/reference/metaprogramming/tasty-inspect.md
+++ b/docs/docs/reference/metaprogramming/tasty-inspect.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "TASTy Inspection"
+movedTo: https://docs.scala-lang.org/scala3/reference/metaprogramming/tasty-inspect.html
 ---
 
 ```scala

--- a/docs/docs/reference/metaprogramming/toc.md
+++ b/docs/docs/reference/metaprogramming/toc.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Overview"
+movedTo: https://docs.scala-lang.org/scala3/reference/metaprogramming.html
 ---
 
 The following pages introduce the redesign of metaprogramming in Scala. They

--- a/docs/docs/reference/new-types/dependent-function-types-spec.md
+++ b/docs/docs/reference/new-types/dependent-function-types-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dependent Function Types - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/dependent-function-types-spec.html
 ---
 
 Initial implementation in [PR #3464](https://github.com/lampepfl/dotty/pull/3464).

--- a/docs/docs/reference/new-types/dependent-function-types.md
+++ b/docs/docs/reference/new-types/dependent-function-types.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Dependent Function Types"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/dependent-function-types.html
 ---
 
 A dependent function type is a function type whose result depends

--- a/docs/docs/reference/new-types/intersection-types-spec.md
+++ b/docs/docs/reference/new-types/intersection-types-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Intersection Types - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/intersection-types-spec.html
 ---
 
 ## Syntax

--- a/docs/docs/reference/new-types/intersection-types.md
+++ b/docs/docs/reference/new-types/intersection-types.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Intersection Types"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/intersection-types.html
 ---
 
 Used on types, the `&` operator creates an intersection type.

--- a/docs/docs/reference/new-types/match-types.md
+++ b/docs/docs/reference/new-types/match-types.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Match Types"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/match-types.html
 ---
 
 A match type reduces to one of its right-hand sides, depending on the type of

--- a/docs/docs/reference/new-types/polymorphic-function-types.md
+++ b/docs/docs/reference/new-types/polymorphic-function-types.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Polymorphic Function Types"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/polymorphic-function-types.html
 ---
 
 A polymorphic function type is a function type which accepts type parameters.

--- a/docs/docs/reference/new-types/type-lambdas-spec.md
+++ b/docs/docs/reference/new-types/type-lambdas-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Type Lambdas - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/type-lambdas-spec.html
 ---
 
 ## Syntax

--- a/docs/docs/reference/new-types/type-lambdas.md
+++ b/docs/docs/reference/new-types/type-lambdas.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Type Lambdas"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/type-lambdas.html
 ---
 
 A _type lambda_ lets one express a higher-kinded type directly, without

--- a/docs/docs/reference/new-types/union-types-spec.md
+++ b/docs/docs/reference/new-types/union-types-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Union Types - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/union-types-spec.html
 ---
 
 ## Syntax

--- a/docs/docs/reference/new-types/union-types.md
+++ b/docs/docs/reference/new-types/union-types.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Union Types"
+movedTo: https://docs.scala-lang.org/scala3/reference/new-types/union-types.html
 ---
 
 A union type `A | B` has as values all values of type `A` and also all values of type `B`.

--- a/docs/docs/reference/other-new-features/control-syntax.md
+++ b/docs/docs/reference/other-new-features/control-syntax.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: New Control Syntax
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/control-syntax.html
 ---
 
 Scala 3 has a new "quiet" syntax for control expressions that does not rely on

--- a/docs/docs/reference/other-new-features/creator-applications.md
+++ b/docs/docs/reference/other-new-features/creator-applications.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Universal Apply Methods"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/creator-applications.html
 ---
 
 Scala case classes generate apply methods, so that values of case classes can be created using simple

--- a/docs/docs/reference/other-new-features/explicit-nulls.md
+++ b/docs/docs/reference/other-new-features/explicit-nulls.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Explicit Nulls"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/explicit-nulls.html
 ---
 
 Explicit nulls is an opt-in feature that modifies the Scala type system, which makes reference types

--- a/docs/docs/reference/other-new-features/export.md
+++ b/docs/docs/reference/other-new-features/export.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Export Clauses"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/export.html
 ---
 
 An export clause defines aliases for selected members of an object. Example:

--- a/docs/docs/reference/other-new-features/indentation.md
+++ b/docs/docs/reference/other-new-features/indentation.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Optional Braces"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html
 ---
 
 Scala 3 enforces some rules on indentation and allows some occurrences of braces `{...}` to be optional:

--- a/docs/docs/reference/other-new-features/kind-polymorphism.md
+++ b/docs/docs/reference/other-new-features/kind-polymorphism.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Kind Polymorphism"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/kind-polymorphism.html
 ---
 
 Normally type parameters in Scala are partitioned into _kinds_. First-level types are types of values. Higher-kinded types are type constructors

--- a/docs/docs/reference/other-new-features/matchable.md
+++ b/docs/docs/reference/other-new-features/matchable.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "The Matchable Trait"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/matchable.html
 ---
 
 A new trait `Matchable` controls the ability to pattern match.

--- a/docs/docs/reference/other-new-features/opaques-details.md
+++ b/docs/docs/reference/other-new-features/opaques-details.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Opaque Type Aliases: More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/opaques-details.html
 ---
 
 ### Syntax

--- a/docs/docs/reference/other-new-features/opaques.md
+++ b/docs/docs/reference/other-new-features/opaques.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Opaque Type Aliases"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/opaques.html
 ---
 
 Opaque types aliases provide type abstraction without any overhead. Example:

--- a/docs/docs/reference/other-new-features/open-classes.md
+++ b/docs/docs/reference/other-new-features/open-classes.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Open Classes"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/open-classes.html
 ---
 
 An `open` modifier on a class signals that the class is planned for extensions. Example:

--- a/docs/docs/reference/other-new-features/parameter-untupling-spec.md
+++ b/docs/docs/reference/other-new-features/parameter-untupling-spec.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Parameter Untupling - More Details"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/parameter-untupling-spec.html
 ---
 
 ## Motivation

--- a/docs/docs/reference/other-new-features/parameter-untupling.md
+++ b/docs/docs/reference/other-new-features/parameter-untupling.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Parameter Untupling"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/parameter-untupling.html
 ---
 
 Say you have a list of pairs

--- a/docs/docs/reference/other-new-features/safe-initialization.md
+++ b/docs/docs/reference/other-new-features/safe-initialization.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Safe Initialization"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/safe-initialization.html
 ---
 
 Scala 3 implements experimental safe initialization check, which can be enabled by the compiler option `-Ysafe-init`.

--- a/docs/docs/reference/other-new-features/targetName.md
+++ b/docs/docs/reference/other-new-features/targetName.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "The @targetName annotation"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/targetName.html
 ---
 
 A `@targetName` annotation on a definition defines an alternate name for the implementation of that definition. Example:

--- a/docs/docs/reference/other-new-features/threadUnsafe-annotation.md
+++ b/docs/docs/reference/other-new-features/threadUnsafe-annotation.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "The @threadUnsafe annotation"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/threadUnsafe-annotation.html
 ---
 
 A new annotation `@threadUnsafe` can be used on a field which defines

--- a/docs/docs/reference/other-new-features/trait-parameters.md
+++ b/docs/docs/reference/other-new-features/trait-parameters.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Trait Parameters"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/trait-parameters.html
 ---
 
 Scala 3 allows traits to have parameters, just like classes have parameters.

--- a/docs/docs/reference/other-new-features/transparent-traits.md
+++ b/docs/docs/reference/other-new-features/transparent-traits.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Transparent Traits"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/transparent-traits.html
 ---
 
 Traits are used in two roles:

--- a/docs/docs/reference/other-new-features/type-test.md
+++ b/docs/docs/reference/other-new-features/type-test.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "TypeTest"
+movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/type-test.html
 ---
 
 ## TypeTest

--- a/docs/docs/reference/overview.md
+++ b/docs/docs/reference/overview.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Overview"
+movedTo: https://docs.scala-lang.org/scala3/reference/overview.html
 ---
 Scala 3 implements many language changes and improvements over Scala 2.
 In this reference, we discuss design decisions and present important differences compared to Scala 2.

--- a/docs/docs/reference/syntax.md
+++ b/docs/docs/reference/syntax.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Scala 3 Syntax Summary"
+movedTo: https://docs.scala-lang.org/scala3/reference/syntax.html
 ---
 
 The following description of Scala tokens uses literal characters `‘c’` when

--- a/docs/docs/resources/talks.md
+++ b/docs/docs/resources/talks.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: Talks
+movedTo: https://docs.scala-lang.org/scala3/talks.html
 ---
 
 Talks on Dotty

--- a/docs/docs/usage/getting-started.md
+++ b/docs/docs/usage/getting-started.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: Getting Started: Users
+movedTo: https://docs.scala-lang.org/scala3/getting-started.html
 ---
 
 ## Trying out Dotty

--- a/docs/docs/usage/ide-support.md
+++ b/docs/docs/usage/ide-support.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "IDE support for Scala 3"
+movedTo: https://docs.scala-lang.org/scala3/getting-started.html
 ---
 
 IDE support for Scala 3 is available in IDEs based on [Scala Metals](https://scalameta.org/metals/)

--- a/docs/docs/usage/language-versions.md
+++ b/docs/docs/usage/language-versions.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Language Versions"
+movedTo: https://docs.scala-lang.org/scala3/reference/language-versions.html
 ---
 
 The default Scala language version currently supported by the Dotty compiler is `3.0`. There are also other language versions that can be specified instead:

--- a/docs/docs/usage/worksheet-mode.md
+++ b/docs/docs/usage/worksheet-mode.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Worksheet mode with Dotty IDE"
+movedTo: https://docs.scala-lang.org/scala3/book/tools-worksheets.html
 ---
 
 A worksheet is a Scala file that is evaluated on save, and the result of each

--- a/scaladoc/resources/dotty_res/styles/colors.css
+++ b/scaladoc/resources/dotty_res/styles/colors.css
@@ -28,10 +28,10 @@
   --blue900: hsl(200, 72%, 8%);
 
   /* Red */
-  --red500: hsl(1 , 60% , 92%);
-  --red500: hsl(1 , 64% , 84%);
-  --red500: hsl(1 , 66% , 72%);
-  --red500: hsl(1 , 66% , 64%);
+  --red100: hsl(1 , 60%, 92%);
+  --red200: hsl(1 , 64%, 84%);
+  --red300: hsl(1 , 66%, 72%);
+  --red400: hsl(1 , 66% , 64%);
   --red500: hsl(1 , 71% , 52%);
   --red600: hsl(1 , 71% , 40%);
   --red700: hsl(1 , 72% , 32%);
@@ -82,6 +82,8 @@
   --selected-bg: var(--blue200);
 
   --shadow: var(--black);
+
+  --aside-warning-bg: var(--red100);
 }
 
   /* Dark Mode */
@@ -130,4 +132,6 @@
   --tab-default: var(--grey300);
 
   --shadow: var(--white);
+
+  --aside-warning-bg: var(--red800);
 }


### PR DESCRIPTION
The Scala 3 documentation is now hosted at https://docs.scala-lang.org.

There are still two issues:
- scaladoc emits links that look like `href="" https: docs.scala-lang.org scala3 reference overview.html""` (instead of `href="https://docs.scala-lang.org/scala3/reference/overview.html"`), I’m not sure where the problem comes from :thinking: 
- the dark theme does not play well with the “aside.warning” CSS rule.

Can someone experienced with scaladoc help with these issue?