### PR TITLE
Deskolemise patterns to suppress exhaustivity warnings

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -354,11 +354,8 @@ class SpaceEngine(using Context) extends SpaceLogic {
     case pat: Ident if isBackquoted(pat) =>
       Typ(pat.tpe, decomposed = false)
 
-    case Ident(nme.WILDCARD) =>
-      Typ(erase(pat.tpe.stripAnnots, isValue = true), decomposed = false)
-
     case Ident(_) | Select(_, _) =>
-      Typ(erase(pat.tpe.stripAnnots, isValue = true), decomposed = false)
+      Typ(erase(pat.tpe.stripAnnots.widenSkolem, isValue = true), decomposed = false)
 
     case Alternative(trees) =>
       Or(trees.map(project(_)))

--- a/tests/patmat/i13110.scala
+++ b/tests/patmat/i13110.scala
@@ -1,0 +1,12 @@
+object Test {
+  sealed trait Base
+  class Blub extends Base
+  object Blub {
+    def unapply(blub: Blub): Some[(Int, blub.type)] =
+      Some(1 -> blub)
+  }
+
+  (null: Base) match {
+    case Blub(i, x) => println(i)
+  }
+}


### PR DESCRIPTION
Ideally I'd want to not be destructive with this widen, but it seems to
already being done on the other side: in `signature` where the
components of the unapply result type are obtained the call to:

    mt.instantiate(scrutineeTp :: Nil).finalResultType

removes the more precise `blub.type` that was present in the signature.

So now, by widening the pattern the spaces cancel each other out,
thus the match is deemed exhaustive.

Fixes #13110