### PR TITLE
Analyze end markers when looking ahead

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -612,6 +612,7 @@ object Scanners {
       prev.copyFrom(this)
       lastOffset = lastCharOffset
       fetchToken()
+      if token == END && !isEndMarker then token = IDENTIFIER
     }
 
     def reset() = {

--- a/tests/pos/i13134.scala
+++ b/tests/pos/i13134.scala
@@ -1,0 +1,10 @@
+def test =
+  {
+    val end = 0
+    assert(~end == -1) //Not found: ~
+  }
+
+  {
+    val end = false
+    assert(!end) // postfix operator `end` needs to be enabled
+  }              // by making the implicit value scala.language.postfixOps visible.


### PR DESCRIPTION
Lookahead also has to replace and end marker with a normal identifier.

Fixes #13134