### PR TITLE
Avoid crash by relaxing TyperState assertion

### DIFF
--- a/tests/neg/i13101.scala
+++ b/tests/neg/i13101.scala
@@ -1,0 +1,24 @@
+trait Vehicle
+trait Car extends Vehicle
+
+trait Encoder[A]
+object Encoder {
+  implicit val encodeVehicle: Encoder[Vehicle] = ???
+  implicit val encodeCar: Encoder[Car] = ???
+}
+
+trait Route
+trait Printer
+trait Marshaller[-A]  // must be contravariant
+
+object Test {
+  implicit def marshaller[A: Encoder](implicit p: Printer = ???): Marshaller[A] = ???
+    // the `Printer` implicit arg seems to be necessary, either with default value, or no implicit in scope
+
+  def foo[A](v: A)(implicit m: Marshaller[A]): Route = ???
+
+  val route: Route = identity {
+    val f: (Car => Route) => Route = ???  // ok if s/Car/Vehicle/
+    f(vehicle => foo(vehicle)) // error: ambiguous implicit
+  }
+}


### PR DESCRIPTION
Flushing a reporter might force error messages (in particular when a
StoreReporter is flushed into a non-StoreReporter), and the TyperState
of the context captured in an error message might already be committed
at this point. In ea6449fbd4b62ee6033bb2d156ff3eb685dbb9d1 I tried to
deal with this by flushing before committing but that's not sufficient
since the reporter we're flushing might contain error messages from a
more deeply nested TyperState. So this commit just relaxes the assertion
(ideally we would also check that only TyperStates created in a
committed TyperState can be committed in one, but keeping track of that
would require an extra field in TyperState).

Fixes #13101.

<hr>

I nominate this PR for backporting since it fixes a regression with respect to 3.0.0