### PR TITLE
call deleteOnExit() after creating temporary scripting compile directory

### DIFF
--- a/compiler/src/dotty/tools/scripting/ScriptingDriver.scala
+++ b/compiler/src/dotty/tools/scripting/ScriptingDriver.scala
@@ -19,6 +19,7 @@ import sys.process._
 class ScriptingDriver(compilerArgs: Array[String], scriptFile: File, scriptArgs: Array[String]) extends Driver:
   def compileAndRun(pack:(Path, Seq[Path], String) => Boolean = null): Unit =
     val outDir = Files.createTempDirectory("scala3-scripting")
+    outDir.toFile.deleteOnExit()
     setup(compilerArgs :+ scriptFile.getAbsolutePath, initCtx.fresh) match
       case Some((toCompile, rootCtx)) =>
         given Context = rootCtx.fresh.setSetting(rootCtx.settings.outputDir,


### PR DESCRIPTION
The current implementation doesn't clean up after a script compilation run, resulting over time in numerous debris directories.
Examples:
```sh
/tmp/scala3-scripting7373413734569065715
/tmp/scala3-scripting6548539148718234542
/tmp/scala3-scripting2225018551136019262
/tmp/scala3-scripting8793089142957194557
/tmp/scala3-scripting9160983434545311523
/tmp/scala3-scripting3659889510603809660
/tmp/scala3-scripting4315852469284034054
/tmp/scala3-scripting2148698146036257887
```
