### PR TITLE
get some compiler code to compile on JDK 17

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/WrappedProperties.scala
+++ b/compiler/src/dotty/tools/dotc/config/WrappedProperties.scala
@@ -2,8 +2,6 @@ package dotty.tools
 package dotc
 package config
 
-import java.security.AccessControlException
-
 /** For placing a wrapper function around property functions.
  *  Motivated by places like google app engine throwing exceptions
  *  on property lookups.
@@ -29,6 +27,14 @@ trait WrappedProperties extends PropertiesTrait {
 
 object WrappedProperties {
   object AccessControl extends WrappedProperties {
-    def wrap[T](body: => T): Option[T] = try Some(body) catch { case _: AccessControlException => None }
+    def wrap[T](body: => T): Option[T] =
+      try Some(body)
+      catch {
+        // the actual exception we are concerned with is AccessControlException,
+        // but that's deprecated on JDK 17, so catching its superclass is a convenient
+        // way to avoid a deprecation warning
+        case _: SecurityException =>
+          None
+      }
   }
 }


### PR DESCRIPTION
with this change, `Test/compile` works on JDK 17. would be nice to add it to CI at some point in the not-too-distant future to prevent backsliding

the likeliest scenario where it matters is if we get a new or casual contributor who's on 17 already