### PR TITLE
Remove color from scala.compiletime.codeOf

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -379,7 +379,8 @@ object Inliner {
 
     /** Expand call to scala.compiletime.codeOf */
     def codeOf(arg: Tree, pos: SrcPos)(using Context): Tree =
-      Literal(Constant(arg.show)).withSpan(pos.span)
+      val ctx1 = ctx.fresh.setSetting(ctx.settings.color, "never")
+      Literal(Constant(arg.show(using ctx1))).withSpan(pos.span)
   }
 
   extension (tp: Type) {

--- a/compiler/test-resources/repl/i13181
+++ b/compiler/test-resources/repl/i13181
@@ -1,0 +1,2 @@
+scala> scala.compiletime.codeOf(1+2)
+val res0: String = 1.+(2)

--- a/tests/run/i13181.scala
+++ b/tests/run/i13181.scala
@@ -1,0 +1,1 @@
+@main def Test = assert(scala.compiletime.codeOf(1+2) == "1.+(2)")


### PR DESCRIPTION
We printed by mistake in color when the color flag was set.
This was an unintetional change that happend when intinifying this operation.

Fixes #13181