### PR TITLE
Make body of quotes inlinable

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -66,8 +66,11 @@ trait QuotesAndSplices {
         typedTypeApply(untpd.TypeApply(untpd.ref(defn.QuotedTypeModule_of.termRef), tree.quoted :: Nil), pt)(using quoteContext).select(nme.apply).appliedTo(qctx)
       else
         typedApply(untpd.Apply(untpd.ref(defn.QuotedRuntime_exprQuote.termRef), tree.quoted), pt)(using pushQuotes(qctx)).select(nme.apply).appliedTo(qctx)
-    tree1.withSpan(tree.span)
+    makeInlineable(tree1.withSpan(tree.span))
   }
+
+  private def makeInlineable(tree: Tree)(using Context): Tree =
+    ctx.compilationUnit.inlineAccessors.makeInlineable(tree)
 
   /** Translate `${ t: Expr[T] }` into expression `t.splice` while tracking the quotation level in the context */
   def typedSplice(tree: untpd.Splice, pt: Type)(using Context): Tree = {

--- a/tests/neg-macros/i7068-c.scala
+++ b/tests/neg-macros/i7068-c.scala
@@ -2,7 +2,7 @@ def species(using quoted.Quotes) = '{
   case object Bar // error
   case class FooT() // error
   ${
-    case object Baz // ok
+    case object Baz // error
     ???
   }
   FooT()

--- a/tests/pos-macros/i12948/Macros_1.scala
+++ b/tests/pos-macros/i12948/Macros_1.scala
@@ -1,0 +1,9 @@
+package mylib
+import scala.quoted.*
+
+object Main:
+  protected def foo: Unit = {}
+  inline def fooCaller: Unit = foo
+  inline def fooCallerM: Unit = ${ fooMacro }
+  def fooMacro(using Quotes): Expr[Unit] =
+    '{ foo }

--- a/tests/pos-macros/i12948/Test_2.scala
+++ b/tests/pos-macros/i12948/Test_2.scala
@@ -1,0 +1,5 @@
+import mylib.Main
+
+object Test:
+  Main.fooCaller
+  Main.fooCallerM

--- a/tests/pos-macros/i12948b.scala
+++ b/tests/pos-macros/i12948b.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+package foo {
+  trait Bar:
+    def bar(using Quotes) = '{ Baz }
+
+  private[foo] object Baz
+}

--- a/tests/pos-macros/i12948b.scala
+++ b/tests/pos-macros/i12948b.scala
@@ -1,8 +1,0 @@
-import scala.quoted.*
-
-package foo {
-  trait Bar:
-    def bar(using Quotes) = '{ Baz }
-
-  private[foo] object Baz
-}

--- a/tests/pos-macros/i8208/Macros_1.scala
+++ b/tests/pos-macros/i8208/Macros_1.scala
@@ -1,0 +1,22 @@
+package playground
+
+import scala.quoted._
+
+object X {
+
+  inline def power(n: Int, x: Double): Double =
+    ${ powerImpl('n, 'x) }
+
+  private def powerImpl(nExpr: Expr[Int], xExpr: Expr[Double])(using Quotes): Expr[Double] =
+    nExpr match {
+      case Expr(n1) => '{ 42.0 }
+      case _ => '{ dynamicPower($nExpr, $xExpr) }
+    }
+
+  private def dynamicPower(n: Int, x: Double): Double = {
+    println(s"dynamic: $n^$x")
+    if (n == 0) 1.0
+    else if (n % 2 == 0) dynamicPower(n / 2, x * x)
+    else x * dynamicPower(n - 1, x)
+  }
+}

--- a/tests/pos-macros/i8208/Test_2.scala
+++ b/tests/pos-macros/i8208/Test_2.scala
@@ -1,0 +1,2 @@
+import playground.X
+def test(x: Int) = X.power(x, 2)


### PR DESCRIPTION
This adds inline accessors for private/protected members if needed as we do with inline defs.

Fixes #8208
Fixes #12948