### PR TITLE
REPL: display the compiler + Java version on startup

### DIFF
--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -28,7 +28,7 @@ final class JLineTerminal extends java.io.Closeable {
   private def blue(str: String)(using Context) =
     if (ctx.settings.color.value != "never") Console.BLUE + str + Console.RESET
     else str
-  private def prompt(using Context)        = blue("scala> ")
+  private def prompt(using Context)        = blue("\nscala> ")
   private def newLinePrompt(using Context) = blue("     | ")
 
   /** Blockingly read line from `System.in`

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets
 
 import dotty.tools.dotc.ast.Trees._
 import dotty.tools.dotc.ast.{tpd, untpd}
+import dotty.tools.dotc.config.Properties.{javaVersion, javaVmName, simpleVersionString}
 import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Phases.{unfusedPhases, typerPhase}
 import dotty.tools.dotc.core.Denotations.Denotation
@@ -124,6 +125,10 @@ class ReplDriver(settings: Array[String],
   final def runUntilQuit(initialState: State = initialState): State = {
     val terminal = new JLineTerminal
 
+    out.println(
+      s"""Welcome to Scala $simpleVersionString ($javaVersion, Java $javaVmName).
+         |Type in expressions for evaluation. Or try :help.""".stripMargin)
+
     /** Blockingly read a line, getting back a parse result */
     def readLine(state: State): ParseResult = {
       val completer: Completer = { (_, line, candidates) =>
@@ -208,7 +213,7 @@ class ReplDriver(settings: Array[String],
   }
 
   private def interpret(res: ParseResult)(implicit state: State): State = {
-    val newState = res match {
+    res match {
       case parsed: Parsed if parsed.trees.nonEmpty =>
         compile(parsed, state)
 
@@ -224,11 +229,6 @@ class ReplDriver(settings: Array[String],
 
       case _ => // new line, empty tree
         state
-    }
-    inContext(newState.context) {
-      if (!ctx.settings.XreplDisableDisplay.value)
-        out.println()
-      newState
     }
   }
 

--- a/compiler/test/dotty/tools/repl/LoadTests.scala
+++ b/compiler/test/dotty/tools/repl/LoadTests.scala
@@ -16,12 +16,9 @@ class LoadTests extends ReplTest {
                  |""".stripMargin,
     defs    = """|Hello, World!
                  |def helloWorld: String
-                 |
-                 |
                  |""".stripMargin,
     runCode = "helloWorld",
     output  = """|val res0: String = Hello, World!
-                 |
                  |""".stripMargin
   )
 
@@ -29,12 +26,9 @@ class LoadTests extends ReplTest {
     file    = """|@main def helloWorld = println("Hello, World!")
                  |""".stripMargin,
     defs    = """|def helloWorld: Unit
-                 |
-                 |
                  |""".stripMargin,
     runCode = "helloWorld",
     output  = """|Hello, World!
-                 |
                  |""".stripMargin
   )
 
@@ -44,13 +38,10 @@ class LoadTests extends ReplTest {
                  |""".stripMargin,
     defs    = """|def helloWorld: Unit
                  |def helloTo(name: String): Unit
-                 |
-                 |
                  |""".stripMargin,
     runCode = """helloWorld; helloTo("Scala")""",
     output  = """|Hello, World!
                  |Hello, Scala!
-                 |
                  |""".stripMargin
   )
 

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -218,7 +218,7 @@ class ReplCompilerTests extends ReplTest {
       run("""val r = raw"\d+".r""")
     } andThen { implicit state =>
       run("""val r() = "abc"""")
-      assertEquals("scala.MatchError: abc (of class java.lang.String)", storedOutput().linesIterator.drop(2).next())
+      assertEquals("scala.MatchError: abc (of class java.lang.String)", storedOutput().linesIterator.drop(1).next())
     }
   @Test def `i10214 must show MatchError on literal type` = fromInitialState { implicit state =>
     run("val (x: 1) = 2")

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -74,10 +74,6 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
       inputRes.foldLeft(initialState) { (state, input) =>
         val (out, nstate) = evaluate(state, input)
         out.linesIterator.foreach(buf.append)
-
-        assert(out.endsWith("\n"),
-               s"Expected output of $input to end with newline")
-
         nstate
       }
       buf.toList.flatMap(filterEmpties)


### PR DESCRIPTION
before:

```
scala>                                                                                                                  
```

after:

```
Welcome to Scala 3.0.3-RC1-bin-SNAPSHOT-nonbootstrapped-git-2b1b622 (1.8.0_292, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                      
scala> 
```

which brings 3 in line with Scala 2:

```
Welcome to Scala 2.13.6 (OpenJDK 64-Bit Server VM, Java 1.8.0_292).
Type in expressions for evaluation. Or try :help.

scala> 
```
