### PR TITLE
REPL: emit parse warnings by reusing the reporter

### DIFF
--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -7,7 +7,7 @@ import dotc.core.Contexts._
 import dotc.core.StdNames.str
 import dotc.parsing.Parsers.Parser
 import dotc.parsing.Tokens
-import dotc.reporting.Diagnostic
+import dotc.reporting.{Diagnostic, StoreReporter}
 import dotc.util.SourceFile
 
 import scala.annotation.internal.sharable
@@ -16,7 +16,7 @@ import scala.annotation.internal.sharable
 sealed trait ParseResult
 
 /** An error free parsing resulting in a list of untyped trees */
-case class Parsed(source: SourceFile, trees: List[untpd.Tree]) extends ParseResult
+case class Parsed(source: SourceFile, trees: List[untpd.Tree], reporter: StoreReporter) extends ParseResult
 
 /** A parsing result containing syntax `errors` */
 case class SyntaxErrors(sourceCode: String,
@@ -154,7 +154,7 @@ object ParseResult {
               reporter.removeBufferedMessages,
               stats)
           else
-            Parsed(source, stats)
+            Parsed(source, stats, reporter)
         }
     }
   }

--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -237,7 +237,7 @@ class ReplCompiler extends Compiler {
       }
 
       ParseResult(sourceFile)(state) match {
-        case Parsed(_, trees) =>
+        case Parsed(_, trees, _) =>
           wrap(trees).result
         case SyntaxErrors(_, reported, trees) =>
           if (errorsAllowed) wrap(trees).result

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -18,7 +18,7 @@ import dotty.tools.dotc.core.StdNames._
 import dotty.tools.dotc.core.Symbols.{Symbol, defn}
 import dotty.tools.dotc.interactive.Completion
 import dotty.tools.dotc.printing.SyntaxHighlighting
-import dotty.tools.dotc.reporting.MessageRendering
+import dotty.tools.dotc.reporting.{MessageRendering, StoreReporter}
 import dotty.tools.dotc.reporting.{Message, Diagnostic}
 import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.{SourceFile, SourcePosition}
@@ -174,8 +174,8 @@ class ReplDriver(settings: Array[String],
     }
   }
 
-  private def newRun(state: State) = {
-    val run = compiler.newRun(rootCtx.fresh.setReporter(newStoreReporter), state)
+  private def newRun(state: State, reporter: StoreReporter = newStoreReporter) = {
+    val run = compiler.newRun(rootCtx.fresh.setReporter(reporter), state)
     state.copy(context = run.runContext)
   }
 
@@ -243,7 +243,7 @@ class ReplDriver(settings: Array[String],
       unfusedPhases(using ctx).collectFirst { case phase: CollectTopLevelImports => phase.imports }.get
 
     implicit val state = {
-      val state0 = newRun(istate)
+      val state0 = newRun(istate, parsed.reporter)
       state0.copy(context = state0.context.withSource(parsed.source))
     }
     compiler

--- a/compiler/test-resources/pending/repl/i13208.scala
+++ b/compiler/test-resources/pending/repl/i13208.scala
@@ -1,0 +1,11 @@
+// scalac: -source:future -deprecation
+scala> type M[X] = X match { case Int => String case _ => Int }
+-- Deprecation Warning:
+1 | type M[X] = X match { case Int => String case _ => Int }
+  |                                               ^
+  |        `_` is deprecated for wildcard arguments of types: use `?` instead
+scala> type N[X] = X match { case List[_] => Int }
+-- Deprecation Warning:
+1 | type N[X] = X match { case List[_] => Int }
+  |                                 ^
+  |        `_` is deprecated for wildcard arguments of types: use `?` instead

--- a/compiler/test-resources/repl/i13208.default.scala
+++ b/compiler/test-resources/repl/i13208.default.scala
@@ -1,0 +1,7 @@
+scala> try 1
+-- Warning:
+1 | try 1
+  | ^^^^^
+  | A try without catch or finally is equivalent to putting
+  | its body in a block; no exceptions are handled.
+val res0: Int = 1

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -95,7 +95,7 @@ class ReplCompilerTests extends ReplTest {
       """|sealed trait T1
          |case class X() extends T1
          |case class Y() extends T1
-         | case object O extends T1
+         |case object O extends T1
          """.stripMargin
     }
 


### PR DESCRIPTION
The original report requires the -deprecation and -source:future flags,
for which there is seems to be no support in repl.ScriptedTests.  So
switched to a non-deprecation syntax warning, that isn't guarded by
-source.

I might come back and add "pragma" support to the REPL scripts so I can
move the test out of pending.

Co-authored-by: Seth Tisue <seth@tisue.net>

Fixes #13208