### PR TITLE
Fix #12178: Add regression test

### DIFF
--- a/tests/pos/i12178.scala
+++ b/tests/pos/i12178.scala
@@ -20,5 +20,5 @@ extension[TLabel <: Singleton & String, TValue] (labelTagged: LabelTagged[TLabel
 @main def hello(): Unit = {
   val foo: LabelTagged["foo", Int] = LabelTagged("foo", 10)
   println(label(foo))  // OK
-  //println(foo.label)   // not OK
+  println(foo.label)   // was error, now OK
 }


### PR DESCRIPTION
Closes #12178.  Fixed by #12846.

A regression test using a normal method rather than an extension method (as in the issue) was previously added by #12206.