### PR TITLE
Employ frozen_<:< instead of <:< within EtaExpansion extractor logic

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -53,7 +53,7 @@ object TypeApplications {
       || {
         val paramRefs = tparams.map(_.paramRef)
         tp.typeParams.corresponds(tparams) { (param1, param2) =>
-          param2.paramInfo <:< param1.paramInfo.substParams(tp, paramRefs)
+          param2.paramInfo frozen_<:< param1.paramInfo.substParams(tp, paramRefs)
         }
       }
 


### PR DESCRIPTION
See discussion https://github.com/lampepfl/dotty/discussions/13205