### PR TITLE
Fix #13141 remove spurious coercion of `*` to a _type_ identifier (was already a valid identifier)

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1609,8 +1609,6 @@ object Parsers {
       else if isIdent(nme.?) then
         val start = in.skipToken()
         typeBounds().withSpan(Span(start, in.lastOffset, start))
-      else if isIdent(nme.*) && !ctx.settings.YkindProjector.isDefault then
-        typeIdent()
       else
         def singletonArgs(t: Tree): Tree =
           if in.token == LPAREN && in.featureEnabled(Feature.dependent)

--- a/tests/neg-custom-args/kind-projector-underscores.check
+++ b/tests/neg-custom-args/kind-projector-underscores.check
@@ -14,6 +14,10 @@ longer explanation available when compiling with `-explain`
    |        =, >:, or <: expected, but '_' found
 
 longer explanation available when compiling with `-explain`
+-- Error: tests/neg-custom-args/kind-projector-underscores.scala:14:51 -------------------------------------------------
+14 |class BacktickUnderscoreIsNotFine extends Foo[List[`_`]] // error wildcard invalid as backquoted identifier
+   |                                                   ^
+   |                                                   wildcard invalid as backquoted identifier
 -- Error: tests/neg-custom-args/kind-projector-underscores.scala:5:23 --------------------------------------------------
 5 |class Bar1 extends Foo[Either[_, _]] // error
   |                       ^^^^^^^^^^^^

--- a/tests/neg-custom-args/kind-projector-underscores.scala
+++ b/tests/neg-custom-args/kind-projector-underscores.scala
@@ -10,3 +10,5 @@ object Test {
   type -_ = Int // error -_ not allowed as a type def name without backticks
   type +_ = Int // error +_ not allowed as a type def name without backticks
 }
+
+class BacktickUnderscoreIsNotFine extends Foo[List[`_`]] // error wildcard invalid as backquoted identifier

--- a/tests/pos-special/kind-projector.scala
+++ b/tests/pos-special/kind-projector.scala
@@ -41,3 +41,20 @@ class VarianceAnnotationIsActuallyIgnored6 extends FooPlus[λ[`-x` => Either[Int
 class VarianceAnnotationIsActuallyIgnored7 extends QuxPlus[λ[(`-x`, `-y`) => Either[y, x]]]
 class VarianceAnnotationIsActuallyIgnored8 extends FooPlus[BazPlus[Int => -*, -*, Int]]
 class VarianceAnnotationIsActuallyIgnored9 extends Foo[λ[`-x` => BazPlus[x => -*, Int, x]]]
+
+class BackticksAreFine1 extends FooPlus[Either[Int, `-*`]]
+class BackticksAreFine2 extends FooPlus[Either[`-*`, Int]]
+class BackticksAreFine3 extends FooMinus[`+*` => Int]
+class BackticksAreFine4 extends FooPlus[Int => `-*`]
+class BackticksAreFine5 extends FooPlus[(Int, `-*`, Int)]
+class BackticksAreFine6 extends FooPlus[BazPlus[Int => `-*`, `-*`, Int]]
+class BackticksAreFine7 extends Foo[λ[`-x` => BazPlus[x => `-*`, Int, x]]]
+class BackticksAreFine8 extends Foo[λ[`x` => BazPlus[x => `*`, Int, x]]]
+
+// https://github.com/lampepfl/dotty/issues/13141
+// i13141
+object A {
+  class X { type Blah = Int }
+  val * = new X
+  val a: *.Blah = 2
+}


### PR DESCRIPTION
Add test case; add a new test case for backticks handling (not related to the bug above)

fixes #13141