### PR TITLE
Fix reachability of non-reducing match type children

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -427,10 +427,7 @@ object Types {
     def isMatch(using Context): Boolean = stripped match {
       case _: MatchType => true
       case tp: HKTypeLambda => tp.resType.isMatch
-      case tp: AppliedType =>
-        tp.tycon match
-          case tycon: TypeRef => tycon.info.isInstanceOf[MatchAlias]
-          case _ => false
+      case tp: AppliedType => tp.isMatchAlias
       case _ => false
     }
 

--- a/tests/patmat/i13189.scala
+++ b/tests/patmat/i13189.scala
@@ -1,0 +1,89 @@
+// original report
+def foo(opt: Option[Tuple.Tail[NonEmptyTuple]]): Unit =
+  opt match
+    case None => ???
+    case Some(a) => ???
+
+
+// again with a mini-Tuple with the extra NonEmptyTupExtra parent, to test transitivity
+object WithExtraParent:
+  sealed trait Tup
+
+  object Tup {
+    type Tail[X <: NonEmptyTup] <: Tup = X match {
+      case _ **: xs => xs
+    }
+  }
+
+  object EmptyTup extends Tup
+
+  sealed trait NonEmptyTup extends Tup
+  sealed trait NonEmptyTupExtra extends NonEmptyTup
+  sealed abstract class **:[+H, +T <: Tup] extends NonEmptyTupExtra
+
+  object **: {
+    def unapply[H, T <: Tup](x: H **: T): (H, T) = null
+  }
+
+  def foo(opt: Option[Tup.Tail[NonEmptyTup]]): Unit =
+    opt match
+      case None => ???
+      case Some(a) => ???
+end WithExtraParent
+
+
+// again with a non-abstract parent
+object WithNonAbstractParent:
+  sealed trait Tup
+
+  object Tup {
+    type Tail[X <: NonEmptyTup] <: Tup = X match {
+      case _ **: xs => xs
+    }
+  }
+
+  object EmptyTup extends Tup
+
+  sealed class NonEmptyTup extends Tup
+  sealed class **:[+H, +T <: Tup] extends NonEmptyTup
+
+  object **: {
+    def unapply[H, T <: Tup](x: H **: T): (H, T) = null
+  }
+
+  def foo(opt: Option[Tup.Tail[NonEmptyTup]]): Unit =
+    opt match
+      case None => ???
+      case Some(a) => ???
+end WithNonAbstractParent
+
+
+// again with multiple children, but an exhaustive match
+object WithExhaustiveMatch:
+  sealed trait Tup
+
+  object Tup {
+    type Tail[X <: NonEmptyTup] <: Tup = X match {
+      case _ **: xs => xs
+      case _ *+: xs => xs
+    }
+  }
+
+  object EmptyTup extends Tup
+
+  sealed trait NonEmptyTup extends Tup
+  sealed abstract class **:[+H, +T <: Tup] extends NonEmptyTup
+  sealed abstract class *+:[+H, +T <: Tup] extends NonEmptyTup
+
+  object **: {
+    def unapply[H, T <: Tup](x: H **: T): (H, T) = null
+  }
+  object *+: {
+    def unapply[H, T <: Tup](x: H *+: T): (H, T) = null
+  }
+
+  def foo(opt: Option[Tup.Tail[NonEmptyTup]]): Unit =
+    opt match
+      case None => ???
+      case Some(a) => ???
+end WithExhaustiveMatch


### PR DESCRIPTION
The reduction of a match type gets "stuck" when a case doesn't match but
is also not provably disjoint from it.  In these situations the match
type reduction returns NoType, which means that in `A <:< B` if B
reduces to NoType, then false will be returned.

In the reachability/Space logic subtype checks are used to refine the
candidate children of the scrutinee type so that impossible children
aren't marked as missing and possible cases aren't marked as
unreachable.  To achieve that there is already some type mapping that
runs before subtyping to approximate the parent.

We extend that parent approximating logic so that non-reducing match
types in the parent don't result in all the candidate children being
rejected.

The motivating case is NonEmptyTuple, its single-child `*:`, and the
`Tuple.Tail` match type.  In `Tuple.Tail[NonEmptyTuple]`, `case _ *: xs =>`
won't match because NonEmptyTuple isn't a subtype of `*:` but it's
also not provably disjoint from it (indeed it's `*:` parent)!  So the
reduction gets stuck, leading to NoType, leading to not a subtype.

I had initially looked to fix this for single-child abstract sealed
types, but that would still cause false positives in legitimate
multi-child sealed types and an exhaustive match type (see
WithExhaustiveMatch in patmat/i13189.scala).  Also it's less scary to
change the subtyping wrapping logic rather than the actually match
type's reduction/matching logic.

In a way the problem is that subtyping checks is too boolean: the
candidate rejection wants to drop children that are definitely not
subtypes, but the match type reduction is too conservative by returning
NoType as soon as the obvious case isn't met.  What subtyping should say
there is ¯\_(ツ)_/¯