### PR TITLE
Community build: use `dotty-staging` forks for jackson-module-scala, scala-java8-compat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -209,7 +209,7 @@
 	url = https://github.com/dotty-staging/libretto.git
 [submodule "community-build/community-projects/jackson-module-scala"]
 	path = community-build/community-projects/jackson-module-scala
-	url = https://github.com/FasterXML/jackson-module-scala.git
+	url = https://github.com/dotty-staging/jackson-module-scala.git
 [submodule "community-build/community-projects/scala-java8-compat"]
 	path = community-build/community-projects/scala-java8-compat
-	url = https://github.com/scala/scala-java8-compat.git
+	url = https://github.com/dotty-staging/scala-java8-compat.git


### PR DESCRIPTION
`jackson-module-scala` and `scala-java-compat` were inadvertently added to the community build using the upstream repository URLs.