### PR TITLE
Fix #9675: Type _ in MT patterns with correct kind

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1872,8 +1872,7 @@ class Typer extends Namer
             arg match {
               case untpd.WildcardTypeBoundsTree()
               if tparam.paramInfo.isLambdaSub &&
-                 tpt1.tpe.typeParamSymbols.nonEmpty &&
-                 !ctx.mode.is(Mode.Pattern) =>
+                 tpt1.tpe.typeParamSymbols.nonEmpty =>
                 // An unbounded `_` automatically adapts to type parameter bounds. This means:
                 // If we have wildcard application C[?], where `C` is a class replace
                 // with C[? >: L <: H] where `L` and `H` are the bounds of the corresponding

--- a/tests/pos/9675.scala
+++ b/tests/pos/9675.scala
@@ -1,0 +1,18 @@
+import scala.compiletime.ops.int.S
+
+sealed trait TList
+sealed trait TNil extends TList
+sealed trait ++:[H[_], T <: TList] extends TList
+
+type IndexOf[H[_], T <: TList] <: Int = T match
+  case H ++: _ => 0
+  case _ ++: t => S[IndexOf[H, t]]
+
+// compiles fine
+val a = summon[ValueOf[IndexOf[List, List ++: Option ++: TNil]]].value
+
+// causes an error
+val b = summon[ValueOf[IndexOf[List, Option ++: List ++: TNil]]].value
+
+object T extends App:
+  println(a)


### PR DESCRIPTION
I'm not sure why this condition in typer was there, but it resulted in an ill kinded program for the added test case. More precisely, the `_` in `case _ ++: t` used to have kind `*` instead of being higher-kinded, and removing that condition fixes that.