### PR TITLE
Add CanEqual typeclass instance for Seq to match Nil case

### DIFF
--- a/library/src/scala/CanEqual.scala
+++ b/library/src/scala/CanEqual.scala
@@ -26,10 +26,12 @@ object CanEqual {
   given canEqualNumber: CanEqual[Number, Number] = derived
   given canEqualString: CanEqual[String, String] = derived
 
-  // The next five definitions can go into the companion objects of their corresponding
+  // The next 6 definitions can go into the companion objects of their corresponding
   // classes. For now they are here in order not to have to touch the
   // source code of these classes
-  given canEqualSeq[T, U](using eq: CanEqual[T, U]): CanEqual[Seq[T], Seq[U]] = derived
+  given canEqualSeqs[T, U](using eq: CanEqual[T, U]): CanEqual[Seq[T], Seq[U]] = derived
+  given canEqualSeq[T](using eq: CanEqual[T, T]): CanEqual[Seq[T], Seq[T]] = derived // for `case Nil` in pattern matching
+
   given canEqualSet[T, U](using eq: CanEqual[T, U]): CanEqual[Set[T], Set[U]] = derived
 
   given canEqualOptions[T, U](using eq: CanEqual[T, U]): CanEqual[Option[T], Option[U]] = derived

--- a/tests/neg/derive-eq.scala
+++ b/tests/neg/derive-eq.scala
@@ -20,10 +20,10 @@ object Test extends App {
   val y: Triple[List[Two], One, Two] = ???
   val z: Triple[One, List[Two], One] = ???
   x == y // OK
+  y == x // OK
   x == x // OK
   y == y // OK
 
-  y == x // error
   x == z // error
   z == y // error
 }

--- a/tests/neg/equality1.scala
+++ b/tests/neg/equality1.scala
@@ -117,4 +117,19 @@ object equality1 {
   (1, "a") == (1, "a", true)  // error: cannot compare
   (1, "a", true, 't', 10L) == (1, "a", 1.5D, 't', 10L) // error: cannot compare
 
+
+  val ns1 = List(1, 2, 3, 4, 5)
+  val ns2 = List(1, 2, 3, 4, 5)
+  ns1 == ns2
+
+  val ss = List("1", "2", "3", "4", "5")
+  ns1 == ss // error: cannot compare
+
+  ns1 match {
+    case n :: ns =>
+      println(s"head: $n, tail: ${ns.mkString("[", ",", "]")}")
+    case Nil =>
+      println("empty")
+  }
+
 }


### PR DESCRIPTION
## Add `CanEqual` instance for `Seq` to match `Nil` case.
This PR solves the similar issue as what #12419 solves, but it's for pattern matching on `List`.
With `-language:strictEquality` compiler option or `import scala.language.strictEquality`, the following case doesn't compile
```scala
List(1, 2, 3, 4, 5) match {
  case n :: ns =>
    println(s"head: $n, tail: ${ns.mkString("[", ",", "]")}")
  case Nil =>
    println("empty")
}
```
with this compile-time error
```
    case Nil =>
         ^^^
Values of types object scala.collection.immutable.Nil and List[Int] cannot be compared with == or !=.
I found:

    CanEqual.canEqualSeq[Nothing, Int](/* missing */summon[CanEqual[Nothing, Int]])

But no implicit values were found that match type CanEqual[Nothing, Int].
```
This PR solves it.