### PR TITLE
Allow IntSetting's to be set with a colon

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -130,7 +130,8 @@ object Settings:
             val output = if (isJar) JarArchive.create(path) else new PlainDirectory(path)
             update(output, args)
           }
-        case (IntTag, arg2 :: args2) =>
+        case (IntTag, _) =>
+          val arg2 :: args2 = if (argRest == "") args else argRest :: args
           try {
             val x = arg2.toInt
             choices match {

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -165,6 +165,18 @@ class SettingsTests {
       assertEquals(expectedErrors, summary.errors)
     }
 
+  @Test def `Allow IntSetting's to be set with a colon`: Unit =
+    object Settings extends SettingGroup:
+      val foo = IntSetting("-foo", "foo", 80)
+    import Settings._
+
+    val args = List("-foo:100")
+    val summary = processArguments(args, processAll = true)
+    assertTrue(s"Setting args errors:\n  ${summary.errors.take(5).mkString("\n  ")}", summary.errors.isEmpty)
+    withProcessedArgs(summary) {
+      assertEquals(100, foo.value)
+    }
+
   private def withProcessedArgs(summary: ArgsSummary)(f: SettingsState ?=> Unit) = f(using summary.sstate)
 
   extension [T](setting: Setting[T])


### PR DESCRIPTION
For example "-pagewidth:100" instead of the two arg "-pagewidth 100".