### PR TITLE
Tweak -Xprint output

### DIFF
--- a/tests/printing/i620.check
+++ b/tests/printing/i620.check
@@ -1,4 +1,4 @@
-result of tests/printing/i620.scala after typer:
+[[syntax trees at end of                     typer]] // tests/printing/i620.scala
 package O {
   package O.A {
     class D() extends Object() {
@@ -30,3 +30,4 @@ package O {
     }
   }
 }
+


### PR DESCRIPTION
Most importantly, move "unchanged since $phase" to be on the same line
as the lead-in.  And then I copied over the lead-in from Scala 2,
because I like it.  It doesn't look as nice because MegaPhases don't
have their own trim name, but it starts nicely:

    [[syntax trees at end of                     typer]] // a.scala
    package <empty> {
      class C() extends Object() {
        def foo: Int = 1
      }
    }

    [[syntax trees at end of          inlinedPositions]] // a.scala: unchanged since typer
    [[syntax trees at end of                 posttyper]] // a.scala
    package <empty> {
      @scala.annotation.internal.SourceFile("a.scala") class C() extends Object() {
        def foo: Int = 1
      }
    }

    [[syntax trees at end of                   pickler]] // a.scala: unchanged since posttyper
    [[syntax trees at end of                  inlining]] // a.scala: unchanged since posttyper
    [[syntax trees at end of              postInlining]] // a.scala: unchanged since posttyper
    [[syntax trees at end of                   staging]] // a.scala: unchanged since posttyper
    [[syntax trees at end of              pickleQuotes]] // a.scala: unchanged since posttyper
    [[syntax trees at end of MegaPhase{firstTransform, checkReentrant, elimPackagePrefixes, cookComments, checkStatic, betaReduce, inlineVals, expandSAMs}]] // a.scala: unchanged since posttyper
    [[syntax trees at end of MegaPhase{elimRepeated, protectedAccessors, extmethods, uncacheGivenAliases, byNameClosures, hoistSuperArgs, specializeApplyMethods, refchecks, tryCatchPatterns, patternMatcher}]] // a.scala: unchanged since posttyper
    [[syntax trees at end of MegaPhase{elimOpaque, explicitOuter, explicitSelf, elimByName, stringInterpolatorOpt}]] // a.scala: unchanged since posttyper
    [[syntax trees at end of MegaPhase{pruneErasedDefs, uninitializedDefs, inlinePatterns, vcInlineMethods, seqLiterals, intercepted, getters, specializeFunctions, liftTry, collectNullableFields, elimOuterSelect, resolveSuper, functionXXLForwarders, paramForwarding, genericTuples, letOverApply, arrayConstructors}]] // a.scala: unchanged since posttyper