### PR TITLE
Decouple -print-tasty from compiler

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -35,8 +35,8 @@ object TastyPrinter:
       println(showContents(bytes, noColor))
       println()
       printLastLine = true
-    for arg <- args if arg != "-print-tasty" do
-      if arg == "-print-tasty" || arg == "-color:never" then () // skip
+    for arg <- args do
+      if arg == "-color:never" then () // skip
       else if arg.startsWith("-") then println(s"bad option '$arg' was ignored")
       else if arg.endsWith(".tasty") then {
         val path = Paths.get(arg)

--- a/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
@@ -40,12 +40,8 @@ class DecompilationPrinter extends Phase {
 
   private def printToOutput(out: PrintStream)(using Context): Unit = {
     val unit = ctx.compilationUnit
-    if (ctx.settings.printTasty.value)
-      println(TastyPrinter.show(unit.pickled.head._2()))
-    else {
-      val unitFile = unit.source.toString.replace("\\", "/").replace(".class", ".tasty")
-      out.println(s"/** Decompiled from $unitFile */")
-      out.println(QuotesImpl.showDecompiledTree(unit.tpdTree))
-    }
+    val unitFile = unit.source.toString.replace("\\", "/").replace(".class", ".tasty")
+    out.println(s"/** Decompiled from $unitFile */")
+    out.println(QuotesImpl.showDecompiledTree(unit.tpdTree))
   }
 }

--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -174,7 +174,7 @@ object PickledQuotes {
       positionWarnings.foreach(report.warning(_))
 
     val pickled = pickler.assembleParts()
-    quotePickling.println(s"**** pickled quote\n${TastyPrinter.show(pickled)}")
+    quotePickling.println(s"**** pickled quote\n${TastyPrinter.showContents(pickled, ctx.settings.color.value == "never")}")
     pickled
   }
 
@@ -195,7 +195,7 @@ object PickledQuotes {
           case pickled: String => TastyString.unpickle(pickled)
           case pickled: List[String] => TastyString.unpickle(pickled)
 
-        quotePickling.println(s"**** unpickling quote from TASTY\n${TastyPrinter.show(bytes)}")
+        quotePickling.println(s"**** unpickling quote from TASTY\n${TastyPrinter.showContents(bytes, ctx.settings.color.value == "never")}")
 
         val mode = if (isType) UnpickleMode.TypeTree else UnpickleMode.Term
         val unpickler = new DottyUnpickler(bytes, mode)

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -91,7 +91,7 @@ class Pickler extends Phase {
           if pickling ne noPrinter then
             pickling.synchronized {
               println(i"**** pickled info of $cls")
-              println(TastyPrinter.show(pickled))
+              println(TastyPrinter.showContents(pickled, ctx.settings.color.value == "never"))
             }
           pickled
         }(using ExecutionContext.global)

--- a/dist/bin/common
+++ b/dist/bin/common
@@ -200,6 +200,7 @@ default_java_opts="-Xmx768m -Xms768m"
 
 CompilerMain=dotty.tools.dotc.Main
 DecompilerMain=dotty.tools.dotc.decompiler.Main
+TastyPrinterMain=dotty.tools.dotc.core.tasty.TastyPrinter
 ReplMain=dotty.tools.repl.Main
 ScriptingMain=dotty.tools.scripting.Main
 

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -45,7 +45,7 @@ case "$1" in
                while [[ $# -gt 0 ]]; do addScript "$1" && shift ; done ;;
      -compile) PROG_NAME="$CompilerMain" && shift ;;
    -decompile) PROG_NAME="$DecompilerMain" && shift ;;
- -print-tasty) PROG_NAME="$DecompilerMain" && addScala "-print-tasty" && shift ;;
+ -print-tasty) PROG_NAME="$TastyPrinterMain" && shift ;;
          -run) PROG_NAME="$ReplMain" && shift ;;
       -colors) colors=true && shift ;;
    -no-colors) unset colors && shift ;;

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -640,7 +640,7 @@ object Build {
         val printTasty = args0.contains("-print-tasty")
         val debugFromTasty = args0.contains("-Ythrough-tasty")
         val args = args0.filter(arg => arg != "-repl" && arg != "-decompile" &&
-            arg != "-with-compiler" && arg != "-Ythrough-tasty")
+            arg != "-with-compiler" && arg != "-Ythrough-tasty" && arg != "-print-tasty")
 
         val main =
           if (decompile) "dotty.tools.dotc.decompiler.Main"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -643,13 +643,14 @@ object Build {
             arg != "-with-compiler" && arg != "-Ythrough-tasty")
 
         val main =
-          if (decompile || printTasty) "dotty.tools.dotc.decompiler.Main"
+          if (decompile) "dotty.tools.dotc.decompiler.Main"
+          else if (printTasty) "dotty.tools.dotc.core.tasty.TastyPrinter"
           else if (debugFromTasty) "dotty.tools.dotc.fromtasty.Debug"
           else "dotty.tools.dotc.Main"
 
         var extraClasspath = Seq(scalaLib, dottyLib)
 
-        if ((decompile || printTasty) && !args.contains("-classpath"))
+        if (decompile && !args.contains("-classpath"))
           extraClasspath ++= Seq(".")
 
         if (args0.contains("-with-compiler")) {
@@ -664,7 +665,7 @@ object Build {
           extraClasspath ++= Seq(dottyCompiler, dottyInterfaces, asm, dottyStaging, dottyTastyInspector, tastyCore)
         }
 
-        val fullArgs = main :: insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
+        val fullArgs = main :: (if (printTasty) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator)))
 
         (Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))
       }.evaluated,

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -23,10 +23,16 @@ clear_out "$OUT"
 "$SBT" ";scalac $SOURCE ; scala $MAIN" > "$tmp"
 grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
+echo "testing sbt scalac -print-tasty"
+clear_out "$OUT"
+"$SBT" ";scalac $SOURCE -d $OUT ;scalac -print-tasty -color:never $TASTY" > "$tmp"
+grep -qe "0: ASTs" "$tmp"
+grep -qe "0: tests/pos/HelloWorld.scala" "$tmp"
+
 echo "testing that paths SourceFile annotations are relativized"
 clear_out "$OUT"
 "$SBT" "scalac -d $OUT/out.jar -sourceroot tests/pos $(pwd)/tests/pos/i10430/lib.scala $(pwd)/tests/pos/i10430/app.scala"
-"$SBT" "scalac -decompile -print-tasty -color:never $OUT/out.jar" > "$tmp"
+"$SBT" "scalac -print-tasty -color:never $OUT/out.jar" > "$tmp"
 cat "$tmp" # for debugging
 grep -q ": i10430/lib.scala" "$tmp"
 grep -q ": i10430/app.scala" "$tmp"
@@ -82,3 +88,5 @@ clear_out "$OUT"
 #     fi
 #   fi
 # done 3<"$tmp1" 4<"./tests/vulpix-tests/meta/sbt-output.check"
+
+echo "cmdTests successful"


### PR DESCRIPTION
To print the contents of a tasty file we only need the bytes of the file.
The current architecture forced us to load the context and have a wroking classpath.
When debugging, we sometimes need to see the contents of a tasty file witouth having the full classpath available.

* Use `dotty.tools.dotc.core.TastyPrinter.main` as new entry point
* Decouple `-decompile` from `-print-tasty`
* Only require .tasty file to be able to print its contents
* Keep the same CLI commands and flags