### PR TITLE
Fix MatchError when printing match types from macros

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
@@ -232,6 +232,8 @@ object Extractors {
         this += "TypeBounds(" += lo += ", " += hi += ")"
       case NoPrefix() =>
         this += "NoPrefix()"
+      case MatchCase(pat, rhs) =>
+        this += "MatchCase(" += pat += ", " += rhs += ")"
     }
 
     def visitSignature(sig: Signature): this.type = {

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1224,6 +1224,12 @@ object SourceCode {
         this += " <: "
         printType(hi)
 
+      case MatchCase(pat, rhs) =>
+        this += "case "
+        printType(pat)
+        this += " => "
+        printType(rhs)
+
       case _ =>
         throw new MatchError(tpe.show(using Printer.TypeReprStructure))
     }

--- a/tests/run-macros/type-show/Macro_1.scala
+++ b/tests/run-macros/type-show/Macro_1.scala
@@ -1,7 +1,13 @@
 import scala.quoted.*
 
 object TypeToolbox {
-  inline def show[A]: String = ${ showImpl[A] }
-  private def showImpl[A: Type](using Quotes) : Expr[String] =
+  inline def show[A <: AnyKind]: String = ${ showImpl[A] }
+  private def showImpl[A <: AnyKind: Type](using Quotes) : Expr[String] =
     Expr(Type.show[A])
+
+  inline def showStructure[A <: AnyKind]: String = ${ showStructureImpl[A] }
+  private def showStructureImpl[A <: AnyKind](using q: Quotes, a: Type[A]) : Expr[String] = {
+    import q.reflect._
+    Expr(TypeRepr.of[A].show(using Printer.TypeReprStructure))
+  }
 }

--- a/tests/run-macros/type-show/Test_2.scala
+++ b/tests/run-macros/type-show/Test_2.scala
@@ -8,6 +8,11 @@ object Test {
     assert(show[Int] == "scala.Int")
     assert(show[Int => Int] == "scala.Function1[scala.Int, scala.Int]")
     assert(show[(Int, String)] == "scala.Tuple2[scala.Int, scala.Predef.String]")
+    assert(show[[X] =>> X match { case Int => Int }] ==
+      """[X >: scala.Nothing <: scala.Any] => X match  {
+        |  case scala.Int => scala.Int
+        |}""".stripMargin)
+    assert(showStructure[[X] =>> X match { case Int => Int }] == """TypeLambda(List(X), List(TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Nothing"), TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Any"))), MatchType(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Any"), ParamRef(binder, 0), List(MatchCase(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int"), TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")))))""")
 
     // TODO: more complex types:
     //  - implicit function types


### PR DESCRIPTION
Currently, type printing logic in `Extractors` and `SourceCode` lack a case for `MatchCase`. This means that attempting to print a match type (or any tree which contains a `TypeTree` with a match type) from a macro results in a `MatchError` being thrown. You can see this happen by running the included tests without the included fixes.

Adds cases for `MatchCase` to prevent this error.