### PR TITLE
Fetch Inkuire at scaladoc build instead of documentation generation

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -54,10 +54,8 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
 
   val onlyRenderedResources: Seq[Resource] =
     List(
-      ("https://github.com/VirtusLab/Inkuire/releases/download/1.0.0-M2/inkuire.js", "scripts/inkuire.js"),
-    ).map { case (url, path) =>
-      Resource.URLToCopy(url, path)
-    } ++
+      "scripts/inkuire.js"
+    ).map(dottyRes) ++
     List(
       "scripts/inkuire-worker.js"
     ).map(dottyRes)


### PR DESCRIPTION
closes #13272 

sbt doesn't provide an API for downloading files from internet so I need to use scala.sys.process. However, the process didn't timeout if the machine was offline so I wrapped that in Future and await result for 20s. I think it's enough considering the file size is 1mb.