### PR TITLE
[Backport] Avoid crash by relaxing TyperState assertion 

### DIFF
--- a/tests/neg/i13101.scala
+++ b/tests/neg/i13101.scala
@@ -1,0 +1,24 @@
+trait Vehicle
+trait Car extends Vehicle
+
+trait Encoder[A]
+object Encoder {
+  implicit val encodeVehicle: Encoder[Vehicle] = ???
+  implicit val encodeCar: Encoder[Car] = ???
+}
+
+trait Route
+trait Printer
+trait Marshaller[-A]  // must be contravariant
+
+object Test {
+  implicit def marshaller[A: Encoder](implicit p: Printer = ???): Marshaller[A] = ???
+    // the `Printer` implicit arg seems to be necessary, either with default value, or no implicit in scope
+
+  def foo[A](v: A)(implicit m: Marshaller[A]): Route = ???
+
+  val route: Route = identity {
+    val f: (Car => Route) => Route = ???  // ok if s/Car/Vehicle/
+    f(vehicle => foo(vehicle)) // error: ambiguous implicit
+  }
+}


### PR DESCRIPTION
This backports https://github.com/lampepfl/dotty/pull/13150 which fixes a regression introduced in 3.0.1.