### PR TITLE
Remove unnecessary type from UnApply

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -197,9 +197,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def Alternative(trees: List[Tree])(using Context): Alternative =
     ta.assignType(untpd.Alternative(trees), trees)
 
-  def UnApply(fun: Tree, implicits: List[Tree], patterns: List[Tree], proto: Type)(using Context): UnApply = {
+  def UnApply(fun: Tree, implicits: List[Tree], patterns: List[Tree])(using Context): UnApply = {
     assert(fun.isInstanceOf[RefTree] || fun.isInstanceOf[GenericApply])
-    ta.assignType(untpd.UnApply(fun, implicits, patterns), proto)
+    ta.assignType(untpd.UnApply(fun, implicits, patterns), defn.NothingType)
   }
 
   def ValDef(sym: TermSymbol, rhs: LazyTree = EmptyTree)(using Context): ValDef =

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -538,7 +538,8 @@ class TreePickler(pickler: TastyPickler) {
               writeByte(IMPLICITarg)
               pickleTree(implicitArg)
             }
-            pickleType(tree.tpe)
+            // TODO write a dummy type that takes less space?
+            pickleType(tree.tpe) // IGNORED // TODO remove when we can break TASTy compat.
             patterns.foreach(pickleTree)
           }
         case tree: ValDef =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1248,9 +1248,9 @@ class TreeUnpickler(reader: TastyReader,
                   readByte()
                   readTerm()
                 }
-              val patType = readType()
+              val patType = readType() // IGNORED // TODO remove when we can break TASTy compat.
               val argPats = until(end)(readTerm())
-              UnApply(fn, implicitArgs, argPats, patType)
+              UnApply(fn, implicitArgs, argPats)
             case REFINEDtpt =>
               val refineCls = symAtAddr.getOrElse(start,
                 newRefinedClassSymbol(coordAt(start))).asClass

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -1175,7 +1175,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
       case UNAPPLYtree =>
         val fun = readTreeRef()
         val args = until(end, () => readTreeRef())
-        UnApply(fun, Nil, args, defn.AnyType) // !!! this is wrong in general
+        UnApply(fun, Nil, args)
 
       case ARRAYVALUEtree =>
         val elemtpt = readTreeRef()

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1454,7 +1454,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object Unapply extends UnapplyModule:
       def apply(fun: Term, implicits: List[Term], patterns: List[Tree]): Unapply =
-        withDefaultPos(tpd.UnApply(fun, implicits, patterns, dotc.core.Symbols.defn.NothingType))
+        withDefaultPos(tpd.UnApply(fun, implicits, patterns))
       def copy(original: Tree)(fun: Term, implicits: List[Term], patterns: List[Tree]): Unapply =
         withDefaultPos(tpd.cpy.UnApply(original)(fun, implicits, patterns))
       def unapply(x: Unapply): (Term, List[Term], List[Tree]) =


### PR DESCRIPTION
This type is never used, it is just a placeholder to make the tree typed.
It is the `Typed` tree around the `UnApply` that holds the type information.