### PR TITLE
Give Closure trees the span of the underlying function

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1339,7 +1339,9 @@ object desugar {
       DefDef(nme.ANON_FUN, params :: Nil, if (tpt == null) TypeTree() else tpt, body)
         .withSpan(span)
         .withMods(synthetic | Artifact),
-      Closure(Nil, Ident(nme.ANON_FUN), if (isContextual) ContextualEmptyTree else EmptyTree))
+      Closure(Nil, Ident(nme.ANON_FUN), if (isContextual) ContextualEmptyTree else EmptyTree)
+        .withSpan(span)
+    )
 
   /** If `nparams` == 1, expand partial function
    *

--- a/tests/neg/i7746.scala
+++ b/tests/neg/i7746.scala
@@ -1,3 +1,3 @@
 class A {
-    def foo = (x : Int, y => x) => () // error // error
+    def foo = (x : Int, y => x) => () // error: not a gel formal parameter
 }

--- a/tests/neg/i9299.scala
+++ b/tests/neg/i9299.scala
@@ -1,4 +1,4 @@
-type F <: F = 1 match { // error
-  case _ => foo.foo // error // error
+type F <: F = 1 match { // error: Recursion limit exceeded.
+  case _ => foo.foo // error: Recursion limit exceeded.
 }
 def foo(a: Int): Unit = ???


### PR DESCRIPTION
Improves error location and avoids some redundant follow-on errors.
