### PR TITLE
Stabilize `scala.quoted.Type.valueOfTuple`

### DIFF
--- a/library/src/scala/quoted/Type.scala
+++ b/library/src/scala/quoted/Type.scala
@@ -50,7 +50,6 @@ object Type:
    *  ```
    *  @syntax markdown
    */
-  @experimental
   def valueOfTuple[T <: Tuple](using Type[T])(using Quotes): Option[T] =
     valueOfTuple(quotes.reflect.TypeRepr.of[T]).asInstanceOf[Option[T]]
 


### PR DESCRIPTION
#### Release note template
> * Stabilized `Type.valueOfTuple` in the `quoted` API.