### PR TITLE
update export.md: clarify how extensions are exported

### DIFF
--- a/docs/docs/reference/other-new-features/export.md
+++ b/docs/docs/reference/other-new-features/export.md
@@ -74,7 +74,7 @@ A member is _eligible_ if all of the following holds:
 It is a compile-time error if a simple or renaming selector does not identify any eligible members.
 
 Type members are aliased by type definitions, and term members are aliased by method definitions. Export aliases copy the type and value parameters of the members they refer to.
-Export aliases are always `final`. Aliases of given instances are again defined as givens (and aliases of old-style implicits are `implicit`). Aliases of inline methods or values are again defined `inline`. There are no other modifiers that can be given to an alias. This has the following consequences for overriding:
+Export aliases are always `final`. Aliases of given instances are again defined as givens (and aliases of old-style implicits are `implicit`). Aliases of extensions are again defined as extensions. Aliases of inline methods or values are again defined `inline`. There are no other modifiers that can be given to an alias. This has the following consequences for overriding:
 
  - Export aliases cannot be overridden, since they are final.
  - Export aliases cannot override concrete members in base classes, since they are


### PR DESCRIPTION
Docs mention how types, terms, and givens are exported, but mention nothing about extensions.

```scala
object Members {
  extension (s: String) {
    def ext1: String = ???
    def ext2(p: Int) = ???
  }
}

object Usage {
  export Members.*
}
```

produces
```scala
scalac: package <empty> {
  final lazy module val Members: Members = new Members()
  final module class Members() extends Object() { this: Members.type =>
    extension (s: String) def ext1: String = ???
    extension (s: String) def ext2(p: Int): Nothing = ???
  }
  final lazy module val Usage: Usage = new Usage()
  final module class Usage() extends Object() { this: Usage.type =>
    export Members.*
    extension (s: String) final def ext1: String = Members.ext1(s)
    extension (s: String) final def ext2(p: Int): Nothing = Members.ext2(s)(p)
  }
}
```