### PR TITLE
Remove anomalies and gaps in handling annotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -113,11 +113,11 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case _ => 0
   }
 
-  /** The (last) list of arguments of an application */
-  def arguments(tree: Tree): List[Tree] = unsplice(tree) match {
-    case Apply(_, args) => args
-    case TypeApply(fn, _) => arguments(fn)
-    case Block(_, expr) => arguments(expr)
+  /** All term arguments of an application in a single flattened list */
+  def allArguments(tree: Tree): List[Tree] = unsplice(tree) match {
+    case Apply(fn, args) => allArguments(fn) ::: args
+    case TypeApply(fn, _) => allArguments(fn)
+    case Block(_, expr) => allArguments(expr)
     case _ => Nil
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -67,6 +67,19 @@ object Annotations {
         else if diff.exists then derivedAnnotation(tm.mapOver(tree))
         else this
 
+    /** Does this annotation refer to a parameter of `tl`?
+     *  Overridden in ConcreteAnnotation
+     */
+    def refersToParamOf(tl: TermLambda)(using Context): Boolean =
+      val args = arguments
+      if args.isEmpty then false
+      else tree.existsSubTree {
+        case id: Ident => id.tpe match
+          case TermParamRef(tl1, _) => tl eq tl1
+          case _ => false
+        case _ => false
+      }
+
     /** A string representation of the annotation. Overridden in BodyAnnotation.
      */
     def toText(printer: Printer): Text = printer.annotText(this)

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -48,7 +48,7 @@ object Annotations {
     /** The tree evaluation has finished. */
     def isEvaluated: Boolean = true
 
-    /** Normally, map type map over all tree nodes of this annotation, but can
+    /** Normally, type map over all tree nodes of this annotation, but can
      *  be overridden. Returns EmptyAnnotation if type type map produces a range
      *  type, since ranges cannot be types of trees.
      */
@@ -67,9 +67,7 @@ object Annotations {
         else if diff.exists then derivedAnnotation(tm.mapOver(tree))
         else this
 
-    /** Does this annotation refer to a parameter of `tl`?
-     *  Overridden in ConcreteAnnotation
-     */
+    /** Does this annotation refer to a parameter of `tl`? */
     def refersToParamOf(tl: TermLambda)(using Context): Boolean =
       val args = arguments
       if args.isEmpty then false

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -162,9 +162,13 @@ object TypeOps:
         // with Nulls (which have no base classes). Under -Yexplicit-nulls, we take
         // corrective steps, so no widening is wanted.
         simplify(l, theMap) | simplify(r, theMap)
-      case AnnotatedType(parent, annot)
-      if annot.symbol == defn.UncheckedVarianceAnnot && !ctx.mode.is(Mode.Type) && !theMap.isInstanceOf[SimplifyKeepUnchecked] =>
-        simplify(parent, theMap)
+      case tp @ AnnotatedType(parent, annot) =>
+        val parent1 = simplify(parent, theMap)
+        if annot.symbol == defn.UncheckedVarianceAnnot
+            && !ctx.mode.is(Mode.Type)
+            && !theMap.isInstanceOf[SimplifyKeepUnchecked]
+        then parent1
+        else tp.derivedAnnotatedType(parent1, annot)
       case _: MatchType =>
         val normed = tp.tryNormalize
         if (normed.exists) normed else mapOver

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3604,6 +3604,9 @@ object Types {
           case tp: AppliedType => tp.fold(status, compute(_, _, theAcc))
           case tp: TypeVar if !tp.isInstantiated => combine(status, Provisional)
           case tp: TermParamRef if tp.binder eq thisLambdaType => TrueDeps
+          case AnnotatedType(parent, ann) =>
+            if ann.refersToParamOf(thisLambdaType) then TrueDeps
+            else compute(status, parent, theAcc)
           case _: ThisType | _: BoundType | NoPrefix => status
           case _ =>
             (if theAcc != null then theAcc else DepAcc()).foldOver(status, tp)
@@ -3656,8 +3659,10 @@ object Types {
       if (isResultDependent) {
         val dropDependencies = new ApproximatingTypeMap {
           def apply(tp: Type) = tp match {
-            case tp @ TermParamRef(thisLambdaType, _) =>
+            case tp @ TermParamRef(`thisLambdaType`, _) =>
               range(defn.NothingType, atVariance(1)(apply(tp.underlying)))
+            case AnnotatedType(parent, ann) if ann.refersToParamOf(thisLambdaType) =>
+              mapOver(parent)
             case _ => mapOver(tp)
           }
         }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5380,6 +5380,8 @@ object Types {
       variance = saved
       derivedLambdaType(tp)(ptypes1, this(restpe))
 
+    def isRange(tp: Type): Boolean = tp.isInstanceOf[Range]
+
     /** Map this function over given type */
     def mapOver(tp: Type): Type = {
       record(s"TypeMap mapOver ${getClass}")
@@ -5423,8 +5425,9 @@ object Types {
 
         case tp @ AnnotatedType(underlying, annot) =>
           val underlying1 = this(underlying)
-          if (underlying1 eq underlying) tp
-          else derivedAnnotatedType(tp, underlying1, mapOver(annot))
+          val annot1 = annot.mapWith(this)
+          if annot1 eq EmptyAnnotation then underlying1
+          else derivedAnnotatedType(tp, underlying1, annot1)
 
         case _: ThisType
           | _: BoundType
@@ -5496,9 +5499,6 @@ object Types {
       else newScopeWith(elems1: _*)
     }
 
-    def mapOver(annot: Annotation): Annotation =
-      annot.derivedAnnotation(mapOver(annot.tree))
-
     def mapOver(tree: Tree): Tree = treeTypeMap(tree)
 
     /** Can be overridden. By default, only the prefix is mapped. */
@@ -5544,8 +5544,6 @@ object Types {
       else Range(lower(lo), upper(hi))
 
     protected def emptyRange = range(defn.NothingType, defn.AnyType)
-
-    protected def isRange(tp: Type): Boolean = tp.isInstanceOf[Range]
 
     protected def lower(tp: Type): Type = tp match {
       case tp: Range => tp.lo

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -539,7 +539,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
     case _ => literalText(String.valueOf(const.value))
   }
 
-  def toText(annot: Annotation): Text = s"@${annot.symbol.name}" // for now
+  /** Usual target for `Annotation#toText`, overridden in RefinedPrinter */
+  def annotText(annot: Annotation): Text = s"@${annot.symbol.name}"
+
+  def toText(annot: Annotation): Text = annot.toText(this)
 
   def toText(param: LambdaParam): Text =
     varianceSign(param.paramVariance)
@@ -570,7 +573,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         Text()
 
     nodeName ~ "(" ~ elems ~ tpSuffix ~ ")" ~ (Str(tree.sourcePos.toString) provided printDebug)
-  }.close // todo: override in refined printer
+  }.close
 
   def toText(pos: SourcePosition): Text =
     if (!pos.exists) "<no position>"

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -119,6 +119,9 @@ abstract class Printer {
   /** A description of sym's location */
   def extendedLocationText(sym: Symbol): Text
 
+  /** Textual description of regular annotation in terms of its tree */
+  def annotText(annot: Annotation): Text
+
   /** Textual representation of denotation */
   def toText(denot: Denotation): Text
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -974,7 +974,11 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         val explicitArgs = args.filterNot(_.symbol.name.is(DefaultGetterName))
         recur(fn) ~ "(" ~ toTextGlobal(explicitArgs, ", ") ~ ")"
       case TypeApply(fn, args) => recur(fn) ~ "[" ~ toTextGlobal(args, ", ") ~ "]"
-      case _ => s"@${sym.orElse(tree.symbol).name}"
+      case Select(qual, nme.CONSTRUCTOR) => recur(qual)
+      case New(tpt) => recur(tpt)
+      case _ =>
+        val annotSym = sym.orElse(tree.symbol.enclosingClass)
+        s"@${if annotSym.exists then annotSym.name.toString else t.show}"
     recur(tree)
 
   protected def modText(mods: untpd.Modifiers, sym: Symbol, kw: String, isType: Boolean): Text = { // DD

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -607,7 +607,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case tree: Template =>
         toTextTemplate(tree)
       case Annotated(arg, annot) =>
-        toTextLocal(arg) ~~ toText(annot)
+        toTextLocal(arg) ~~ annotText(annot.symbol.enclosingClass, annot)
       case EmptyTree =>
         "<empty>"
       case TypedSplice(t) =>

--- a/tests/neg/annot-printing.check
+++ b/tests/neg/annot-printing.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/annot-printing.scala:5:46 -----------------------------------------------------
+5 |def x: Int @nowarn @main @Foo @Bar("hello") = "abc" // error
+  |                                              ^^^^^
+  |                                              Found:    ("abc" : String)
+  |                                              Required: Int @nowarn() @main @Foo @Bar("hello")
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/annot-printing.scala
+++ b/tests/neg/annot-printing.scala
@@ -1,0 +1,6 @@
+import scala.annotation.*
+class Foo() extends Annotation
+class Bar(s: String) extends Annotation
+
+def x: Int @nowarn @main @Foo @Bar("hello") = "abc" // error
+

--- a/tests/pos/dependent-annot.scala
+++ b/tests/pos/dependent-annot.scala
@@ -1,0 +1,7 @@
+class C
+class ann(x: Any*) extends annotation.Annotation
+
+def f(y: C, z: C) =
+  def g(): C @ann(y, z) = ???
+  val ac: ((x: C) => Array[String @ann(x)]) = ???
+  val dc = ac(g())

--- a/tests/printing/annot-printing.check
+++ b/tests/printing/annot-printing.check
@@ -1,0 +1,22 @@
+[[syntax trees at end of                     typer]] // tests/printing/annot-printing.scala
+package <empty> {
+  import scala.annotation.*
+  class Foo() extends annotation.Annotation() {}
+  class Bar(s: String) extends annotation.Annotation() {
+    private[this] val s: String
+  }
+  class Xyz(i: Int) extends annotation.Annotation() {
+    private[this] val i: Int
+  }
+  final lazy module val Xyz: Xyz = new Xyz()
+  final module class Xyz() extends AnyRef() { this: Xyz.type =>
+    def $lessinit$greater$default$1: Int @uncheckedVariance = 23
+  }
+  final lazy module val annot-printing$package: annot-printing$package = 
+    new annot-printing$package()
+  final module class annot-printing$package() extends Object() { 
+    this: annot-printing$package.type =>
+    def x: Int @nowarn() @main @Xyz() @Foo @Bar("hello") = ???
+  }
+}
+

--- a/tests/printing/annot-printing.scala
+++ b/tests/printing/annot-printing.scala
@@ -1,0 +1,7 @@
+import scala.annotation.*
+
+class Foo() extends Annotation
+class Bar(s: String) extends Annotation
+class Xyz(i: Int = 23) extends Annotation
+
+def x: Int @nowarn @main @Xyz() @Foo @Bar("hello") = ???

--- a/tests/printing/dependent-annot.check
+++ b/tests/printing/dependent-annot.check
@@ -1,0 +1,25 @@
+[[syntax trees at end of                     typer]] // tests/printing/dependent-annot.scala
+package <empty> {
+  class C() extends Object() {}
+  class ann(x: Seq[Any] @Repeated) extends annotation.Annotation() {
+    private[this] val x: Seq[Any] @Repeated
+  }
+  final lazy module val dependent-annot$package: dependent-annot$package = 
+    new dependent-annot$package()
+  final module class dependent-annot$package() extends Object() { 
+    this: dependent-annot$package.type =>
+    def f(y: C, z: C): Unit = 
+      {
+        def g(): C @ann([y,z : Any]*) = ???
+        val ac: 
+          (C => Array[String]) 
+            {
+              def apply(x: C): Array[String @ann([x : Any]*)]
+            }
+         = ???
+        val dc: Array[String] = ac.apply(g())
+        ()
+      }
+  }
+}
+

--- a/tests/printing/dependent-annot.scala
+++ b/tests/printing/dependent-annot.scala
@@ -1,0 +1,7 @@
+class C
+class ann(x: Any*) extends annotation.Annotation
+
+def f(y: C, z: C) =
+  def g(): C @ann(y, z) = ???
+  val ac: ((x: C) => Array[String @ann(x)]) = ???
+  val dc = ac(g())

--- a/tests/printing/untyped/annot-printing.check
+++ b/tests/printing/untyped/annot-printing.check
@@ -1,0 +1,9 @@
+[[syntax trees at end of                    parser]] // tests/printing/untyped/annot-printing.scala
+package <empty> {
+  import scala.annotation.*
+  class Foo() extends Annotation {}
+  class Bar(private[this] val s: String) extends Annotation {}
+  class Xyz(private[this] val i: Int = 23) extends Annotation {}
+  def x: Int @nowarn @main @Xyz @Foo @Bar("hello") = ???
+}
+

--- a/tests/printing/untyped/annot-printing.scala
+++ b/tests/printing/untyped/annot-printing.scala
@@ -1,0 +1,7 @@
+import scala.annotation.*
+
+class Foo() extends Annotation
+class Bar(s: String) extends Annotation
+class Xyz(i: Int = 23) extends Annotation
+
+def x: Int @nowarn @main @Xyz() @Foo @Bar("hello") = ???

--- a/tests/printing/untyped/dependent-annot.check
+++ b/tests/printing/untyped/dependent-annot.check
@@ -1,0 +1,13 @@
+[[syntax trees at end of                    parser]] // tests/printing/untyped/dependent-annot.scala
+package <empty> {
+  class C {}
+  class ann(private[this] val x: Any *) extends annotation.Annotation {}
+  def f(y: C, z: C) = 
+    {
+      def g(): C @ann(y, z) = ???
+      val ac: ((x: C) => Array[String @ann(x)]) = ???
+      val dc = ac(g())
+      <empty>
+    }
+}
+

--- a/tests/printing/untyped/dependent-annot.scala
+++ b/tests/printing/untyped/dependent-annot.scala
@@ -1,0 +1,7 @@
+class C
+class ann(x: Any*) extends annotation.Annotation
+
+def f(y: C, z: C) =
+  def g(): C @ann(y, z) = ???
+  val ac: ((x: C) => Array[String @ann(x)]) = ???
+  val dc = ac(g())


### PR DESCRIPTION
Three main fixes, with one commit for each:

 - Fix printing of annotations. Previously arguments were sometimes printed sometimes omitted.
 - Fix TypeMaps over annotated types
 - Fix dependent functions where the dependency goes through an annotation
 