### PR TITLE
wildApprox: also approximate FunProto arguments

### DIFF
--- a/tests/neg/i13340.scala
+++ b/tests/neg/i13340.scala
@@ -1,0 +1,3 @@
+case class Field(name: String, subQuery: Option[Query] = None)
+case class Query(fields: Seq[Field])
+val x = Query(Seq(Field("a", subQuery=Some(Query(Seq(Field("b")), Nil)))), Nil) // error


### PR DESCRIPTION
Previously, `wildApprox` delegated FunProto handling to
`TypeMap#mapOver` which only maps the result type of the FunProto, but
the result of `wildApprox` can be passed to
`ImplicitRunInfo#computeIScope` which will end up calling
`FunProto#typedArgs`. This caused two problems:
- It forced us to use a `provisional` flag in `computeIScope` to account
  for uninstantiated type variables that might show up in the result of
  typedArgs.
- It lead to an assertion failure (in i13340.scala) because it turns out
  that `typedArgs` doesn't always respect the pre-conditions of
  `mergeConstraintWith` (see added NOTE).

By approximating FunProto arguments in wildApprox we can drop the
`provisional` flag and avoid the issue with `typedArgs` (though we might
need to actually fix `typedArgs` one day if the same issue shows up in
other circumstances).

Fixes #13340.