### PR TITLE
Try to extract name when backtick is missing

### DIFF
--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -118,6 +118,7 @@ final class JLineTerminal extends java.io.Closeable {
       def currentToken: TokenData /* | Null */ = {
         val source = SourceFile.virtual("<completions>", input)
         val scanner = new Scanner(source)(using ctx.fresh.setReporter(Reporter.NoReporter))
+        var lastBacktickErrorStart: Option[Int] = None
         while (scanner.token != EOF) {
           val start = scanner.offset
           val token = scanner.token
@@ -126,7 +127,13 @@ final class JLineTerminal extends java.io.Closeable {
 
           val isCurrentToken = cursor >= start && cursor <= end
           if (isCurrentToken)
-            return TokenData(token, start, end)
+            return TokenData(token, lastBacktickErrorStart.getOrElse(start), end)
+
+          // we need to enclose the last backtick, which unclosed produces ERROR token
+          if (token == ERROR && input(start) == '`')
+            lastBacktickErrorStart = Some(start)
+          else
+            lastBacktickErrorStart = None
         }
         null
       }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -138,4 +138,8 @@ class TabcompleteTests extends ReplTest {
       tabComplete("import quoted.* ; def fooImpl(using Quotes): Expr[Int] = { import quotes.reflect.* ; TypeRepr.of[Int].s"))
   }
 
+  @Test def wrongAnyMember: Unit =  fromInitialState { implicit s =>
+    assertEquals(List("`scalaUtilChainingOps`", "`synchronized`"), tabComplete("import scala.util.chaining.`s"))
+    assertEquals(List("`scalaUtilChainingOps`"), tabComplete("import scala.util.chaining.`sc"))
+  }
 }

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -887,4 +887,38 @@ class CompletionTest {
           )
         )
   }
+
+  @Test def wrongAnyMember: Unit = {
+    code"""|import scala.util.chaining.`sc${m1}
+           |""".withSource
+      .completion(m1, Set(("`scalaUtilChainingOps`",Method,"[A](a: A): scala.util.ChainingOps[A]")))
+  }
+
+  @Test def importBackticked: Unit = {
+    code"""|object O{
+           | val `extends` = ""
+           |}
+           |import O.`extends`${m1}
+           |""".withSource
+      .completion(m1, Set(("extends",Field,"String")))
+  }
+
+  @Test def importBacktickedUnclosed: Unit = {
+    code"""|object O{
+           | val `extends` = ""
+           |}
+           |import O.`extends${m1}
+           |""".withSource
+      .completion(m1, Set(("`extends`",Field,"String")))
+  }
+
+
+  @Test def importBacktickedUnclosedSpace: Unit = {
+  code"""|object O{
+         | val `extends ` = ""
+         |}
+         |import O.`extends ${m1}
+         |""".withSource
+    .completion(m1, Set(("`extends `",Field,"String")))
+  }
 }


### PR DESCRIPTION
Previously, completion prefix would show up as an empty string if we had an unclosed backtick. Now, we try to extract the prefix from the file contents in that case.

An alternative approach would be to tranfer somehow the name string  in `nme.Error`, but I didn't see anything like that done before, so not sure how to properly address that.

Fixes https://github.com/lampepfl/dotty/issues/12514

@odersky is there a sensible way to fix this in the parser? Should we just fallback to using the name after the backtick with a reduced span?