### PR TITLE
Print the type parameter bounds of higher kinded types

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -348,15 +348,17 @@ class PlainPrinter(_ctx: Context) extends Printer {
     case None => "?"
   }
 
-  protected def decomposeLambdas(bounds: TypeBounds): (String, TypeBounds) =
-    def decompose(tp: Type) = tp.stripTypeVar match
+  protected def decomposeLambdas(bounds: TypeBounds): (Text, TypeBounds) =
+    def decompose(tp: Type): (Text, Type) = tp.stripTypeVar match
       case lam: HKTypeLambda =>
         val names =
           if lam.isDeclaredVarianceLambda then
             lam.paramNames.lazyZip(lam.declaredVariances).map((name, v) =>
               varianceSign(v) + name)
-          else lam.paramNames
-        (names.mkString("[", ", ", "]"), lam.resType)
+          else lam.paramNames.map(_.toString)
+        val infos = lam.paramInfos.map(toText)
+        val tparams = names.zip(infos).map(_ ~ _)
+        ("[" ~ Text(tparams, ",") ~ "]", lam.resType)
       case _ =>
         ("", tp)
     bounds match

--- a/tests/neg-custom-args/i11637.check
+++ b/tests/neg-custom-args/i11637.check
@@ -1,7 +1,7 @@
 -- [E057] Type Mismatch Error: tests/neg-custom-args/i11637.scala:11:33 ------------------------------------------------
 11 |  var h = new HKT3_1[FunctorImpl]();  // error // error
    |                                 ^
-   |                 Type argument test2.FunctorImpl does not conform to upper bound [Generic2[T] <: Set[T]] =>> Any
+   |       Type argument test2.FunctorImpl does not conform to upper bound [Generic2[T <: String] <: Set[T]] =>> Any
 
 Explanation
 ===========
@@ -9,13 +9,13 @@ Explanation
 I tried to show that
   test2.FunctorImpl
 conforms to
-  [Generic2[T] <: Set[T]] =>> Any
+  [Generic2[T <: String] <: Set[T]] =>> Any
 but the comparison trace ended with `false`:
           
-  ==> test2.FunctorImpl  <:  [Generic2[T] <: Set[T]] =>> Any
-    ==> test2.FunctorImpl  <:  [Generic2[T] <: Set[T]] =>> Any (recurring)
-      ==> type bounds [[T] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]]
-        ==> type bounds [[T] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] (recurring)
+  ==> test2.FunctorImpl  <:  [Generic2[T <: String] <: Set[T]] =>> Any
+    ==> test2.FunctorImpl  <:  [Generic2[T <: String] <: Set[T]] =>> Any (recurring)
+      ==> type bounds [[T <: String] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]]
+        ==> type bounds [[T <: String] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] (recurring)
           ==> [T <: String] =>> Set[T]  <:  Iterable
             ==> [T <: String] =>> Set[T]  <:  Iterable (recurring)
               ==> type bounds []  <:  type bounds [ <: String]
@@ -30,17 +30,17 @@ but the comparison trace ended with `false`:
               <== type bounds []  <:  type bounds [ <: String] = false
             <== [T <: String] =>> Set[T]  <:  Iterable (recurring) = false
           <== [T <: String] =>> Set[T]  <:  Iterable = false
-        <== type bounds [[T] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] (recurring) = false
-      <== type bounds [[T] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] = false
-    <== test2.FunctorImpl  <:  [Generic2[T] <: Set[T]] =>> Any (recurring) = false
-  <== test2.FunctorImpl  <:  [Generic2[T] <: Set[T]] =>> Any = false
+        <== type bounds [[T <: String] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] (recurring) = false
+      <== type bounds [[T <: String] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] = false
+    <== test2.FunctorImpl  <:  [Generic2[T <: String] <: Set[T]] =>> Any (recurring) = false
+  <== test2.FunctorImpl  <:  [Generic2[T <: String] <: Set[T]] =>> Any = false
 
 The tests were made under the empty constraint
 
 -- [E057] Type Mismatch Error: tests/neg-custom-args/i11637.scala:11:21 ------------------------------------------------
 11 |  var h = new HKT3_1[FunctorImpl]();  // error // error
    |                     ^
-   |                 Type argument test2.FunctorImpl does not conform to upper bound [Generic2[T] <: Set[T]] =>> Any
+   |       Type argument test2.FunctorImpl does not conform to upper bound [Generic2[T <: String] <: Set[T]] =>> Any
 
 Explanation
 ===========
@@ -48,13 +48,13 @@ Explanation
 I tried to show that
   test2.FunctorImpl
 conforms to
-  [Generic2[T] <: Set[T]] =>> Any
+  [Generic2[T <: String] <: Set[T]] =>> Any
 but the comparison trace ended with `false`:
           
-  ==> test2.FunctorImpl  <:  [Generic2[T] <: Set[T]] =>> Any
-    ==> test2.FunctorImpl  <:  [Generic2[T] <: Set[T]] =>> Any (recurring)
-      ==> type bounds [[T] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]]
-        ==> type bounds [[T] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] (recurring)
+  ==> test2.FunctorImpl  <:  [Generic2[T <: String] <: Set[T]] =>> Any
+    ==> test2.FunctorImpl  <:  [Generic2[T <: String] <: Set[T]] =>> Any (recurring)
+      ==> type bounds [[T <: String] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]]
+        ==> type bounds [[T <: String] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] (recurring)
           ==> [T <: String] =>> Set[T]  <:  Iterable
             ==> [T <: String] =>> Set[T]  <:  Iterable (recurring)
               ==> type bounds []  <:  type bounds [ <: String]
@@ -69,9 +69,9 @@ but the comparison trace ended with `false`:
               <== type bounds []  <:  type bounds [ <: String] = false
             <== [T <: String] =>> Set[T]  <:  Iterable (recurring) = false
           <== [T <: String] =>> Set[T]  <:  Iterable = false
-        <== type bounds [[T] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] (recurring) = false
-      <== type bounds [[T] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] = false
-    <== test2.FunctorImpl  <:  [Generic2[T] <: Set[T]] =>> Any (recurring) = false
-  <== test2.FunctorImpl  <:  [Generic2[T] <: Set[T]] =>> Any = false
+        <== type bounds [[T <: String] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] (recurring) = false
+      <== type bounds [[T <: String] <: Set[T]]  <:  type bounds [[T] <: Iterable[T]] = false
+    <== test2.FunctorImpl  <:  [Generic2[T <: String] <: Set[T]] =>> Any (recurring) = false
+  <== test2.FunctorImpl  <:  [Generic2[T <: String] <: Set[T]] =>> Any = false
 
 The tests were made under the empty constraint

--- a/tests/printing/i13306.check
+++ b/tests/printing/i13306.check
@@ -1,0 +1,14 @@
+[[syntax trees at end of                     typer]] // tests/printing/i13306.scala
+package example {
+  class MyClass() extends Object() {}
+  class MembersContainer() extends Object() {
+    type MyType[T >: Nothing <: example.MyClass] = Comparable[T]
+  }
+  final lazy module val Exports: example.Exports = new example.Exports()
+  final module class Exports() extends Object() { this: example.Exports.type =>
+    val instance: example.MembersContainer = new example.MembersContainer()
+    export example.Exports.instance.*
+    final type MyType[T <: example.MyClass] = Comparable[T]
+  }
+}
+

--- a/tests/printing/i13306.scala
+++ b/tests/printing/i13306.scala
@@ -1,0 +1,12 @@
+package example
+
+class MyClass
+
+class MembersContainer {
+  type MyType[T <: MyClass] = Comparable[T]
+}
+
+object Exports {
+  val instance = new MembersContainer
+  export instance.*
+}


### PR DESCRIPTION
Fix #13306 

When the exported type is a higher-kinded type, we print the bounds of its type parameters.

Co-authored by @bishabosha 
Co-authored by @mlachkar 