### PR TITLE
Fix #13310: Parse empty Java compilation units as EmptyTree

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -1013,7 +1013,9 @@ object JavaParsers {
       }
       val unit = atSpan(start) { PackageDef(pkg, buf.toList) }
       accept(EOF)
-      unit
+      unit match
+        case PackageDef(Ident(nme.EMPTY_PACKAGE), Nil) => EmptyTree
+        case _ => unit
     }
   }
 

--- a/tests/pos/i13310.java
+++ b/tests/pos/i13310.java
@@ -1,0 +1,2 @@
+// The entire contents of this file is intentionally commented out
+// public class i13310 {}


### PR DESCRIPTION
Before this commit, an empty Java compilation unit (one without a package declaration or any top level declarations) was parsed as
`PackageDef(Ident(<empty>),List())` which resulted in position not set errors.

With this commit, an empty Java compilation unit is parsed as `EmptyTree`. This is consistent with the parsing of empty Scala compilation units.

Fixes #13310