### PR TITLE
Adding fix point evaluation in initialization checker

### DIFF
--- a/tests/init/neg/enum-desugared.check
+++ b/tests/init/neg/enum-desugared.check
@@ -13,6 +13,6 @@
    |           Cannot prove that the value is fully-initialized. May only use initialized value as method arguments.
    |
    |           The unsafe promotion may cause the following problem:
-   |           Calling the external method method ordinal may cause initialization errors. Calling trace:
+   |           Calling the external method method name may cause initialization errors. Calling trace:
    |            -> Array(this.LazyErrorId, this.NoExplanationID) // error // error	[ enum-desugared.scala:17 ]
-   |             -> def errorNumber: Int = this.ordinal() - 2	[ enum-desugared.scala:8 ]
+   |             -> override def productPrefix: String = this.name()	[ enum-desugared.scala:29 ]

--- a/tests/init/neg/inner-loop.scala
+++ b/tests/init/neg/inner-loop.scala
@@ -1,6 +1,6 @@
 class Outer { outer =>
   class Inner extends Outer {
-    val x = 5 + outer.n    // error
+    val x = 5 + outer.n
   }
   val inner = new Inner
   val n = 6               // error

--- a/tests/init/neg/local-warm4.check
+++ b/tests/init/neg/local-warm4.check
@@ -6,6 +6,5 @@
    |           -> class A(x: Int) extends Foo(x) {	[ local-warm4.scala:6 ]
    |            -> val b = new B(y)	[ local-warm4.scala:10 ]
    |               -> class B(x: Int) extends A(x) {	[ local-warm4.scala:13 ]
-   |                 -> class A(x: Int) extends Foo(x) {	[ local-warm4.scala:6 ]
-   |                  -> increment()	[ local-warm4.scala:9 ]
-   |                   -> updateA()	[ local-warm4.scala:21 ]
+   |                -> if y < 10 then increment()	[ local-warm4.scala:23 ]
+   |                 -> updateA()	[ local-warm4.scala:21 ]

--- a/tests/init/neg/unsound1.check
+++ b/tests/init/neg/unsound1.check
@@ -1,0 +1,4 @@
+-- Error: tests/init/neg/unsound1.scala:2:35 ---------------------------------------------------------------------------
+2 |  if (m > 0) println(foo(m - 1).a2.n) // error
+  |                     ^^^^^^^^^^^^^^^
+  |                     Access field A.this.foo(A.this.m.-(1)).a2.n on a value with an unknown initialization status.

--- a/tests/init/neg/unsound1.scala
+++ b/tests/init/neg/unsound1.scala
@@ -1,0 +1,11 @@
+class A(m: Int) {
+  if (m > 0) println(foo(m - 1).a2.n) // error
+  def foo(n: Int): B =
+    if (n % 2 == 0)
+      new B(new A(n - 1), foo(n - 1).a1)
+    else
+      new B(this, new A(n - 1))
+  var n: Int = 10
+}
+
+class B(val a1: A, val a2: A)

--- a/tests/init/neg/unsound2.check
+++ b/tests/init/neg/unsound2.check
@@ -1,0 +1,6 @@
+-- Error: tests/init/neg/unsound2.scala:5:26 ---------------------------------------------------------------------------
+5 |        def getN: Int = a.n // error
+  |                        ^^^
+  | Access field B.this.a.n on a value with an unknown initialization status. Calling trace:
+  |  -> println(foo(x).getB)	[ unsound2.scala:8 ]
+  |   -> def foo(y: Int): B = if (y > 10) then B(bar(y - 1), foo(y - 1).getN) else B(bar(y), 10)	[ unsound2.scala:2 ]

--- a/tests/init/neg/unsound2.scala
+++ b/tests/init/neg/unsound2.scala
@@ -1,0 +1,10 @@
+case class A(x: Int) {
+    def foo(y: Int): B = if (y > 10) then B(bar(y - 1), foo(y - 1).getN) else B(bar(y), 10)
+    def bar(y: Int): A = if (y > 10) then A(y - 1) else this
+    class B(a: A, b: Int) {
+        def getN: Int = a.n // error
+        def getB: Int = b
+    }
+    println(foo(x).getB)
+    val n: Int = 10
+}

--- a/tests/init/neg/unsound3.check
+++ b/tests/init/neg/unsound3.check
@@ -1,0 +1,5 @@
+-- Error: tests/init/neg/unsound3.scala:10:38 --------------------------------------------------------------------------
+10 |        if (x < 12) then foo().getC().b else newB // error
+   |                         ^^^^^^^^^^^^^^
+   |             Access field C.this.foo().getC().b on a value with an unknown initialization status. Calling trace:
+   |              -> val b = foo()	[ unsound3.scala:12 ]

--- a/tests/init/neg/unsound3.scala
+++ b/tests/init/neg/unsound3.scala
@@ -1,0 +1,13 @@
+class B(c: C) {
+    def getC() = c
+}
+
+class C {
+    var x = 10
+    def foo(): B = {
+        x += 1
+        val newB = new B(this)
+        if (x < 12) then foo().getC().b else newB // error
+    }
+    val b = foo()
+}

--- a/tests/init/neg/unsound4.check
+++ b/tests/init/neg/unsound4.check
@@ -1,0 +1,6 @@
+-- Error: tests/init/neg/unsound4.scala:3:8 ----------------------------------------------------------------------------
+3 |    val aAgain = foo(5) // error
+  |        ^
+  |        Access non-initialized value aAgain. Calling trace:
+  |         -> val aAgain = foo(5) // error	[ unsound4.scala:3 ]
+  |          -> def foo(x: Int): A = if (x < 5) then this else foo(x - 1).aAgain	[ unsound4.scala:2 ]

--- a/tests/init/neg/unsound4.scala
+++ b/tests/init/neg/unsound4.scala
@@ -1,0 +1,4 @@
+class A {
+    def foo(x: Int): A = if (x < 5) then this else foo(x - 1).aAgain
+    val aAgain = foo(5) // error
+}


### PR DESCRIPTION
This PR adds the fix point evaluation in the initialization checker to ensure soundness using a two-cache approach. It also includes tests with have initialization error that are not detected in the current checker.