### PR TITLE
Fix #13221: Set JavaStatic on Module fields of module classes in JSCodeGen.

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -139,6 +139,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
         // See `tests/run/given-var.scala`
         //
 
+        // !!! Part of this logic is duplicated in JSCodeGen.genCompilationUnit
         claszSymbol.info.decls.foreach { f =>
           if f.isField && !f.name.is(LazyBitMapName) then
             f.setFlag(JavaStatic)

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -39,6 +39,11 @@ class RegressionTestScala3 {
   @Test def defaultAccessorBridgesIssue12572(): Unit = {
     new MyPromiseIssue12572[Int](5)
   }
+
+  @Test def desugarIdentCrashIssue13221(): Unit = {
+    assertEquals(1, X_Issue13221.I.i)
+    assertEquals(1, X_Issue13221.blah)
+  }
 }
 
 object RegressionTestScala3 {
@@ -75,6 +80,17 @@ object RegressionTestScala3 {
         onRejected: js.UndefOr[js.Function1[scala.Any, S | js.Thenable[S]]] = js.undefined): js.Promise[S] = {
       ???
     }
+  }
+
+  object X_Issue13221 extends Y_Issue13221 {
+    object I {
+      def i = 1
+    }
+  }
+
+  abstract class Y_Issue13221 { self: X_Issue13221.type =>
+    import I._
+    def blah = i
   }
 }
 


### PR DESCRIPTION
This replicates what the JVM back-end does, to some extent, and is necessary for `desugarIdent` not to crash in obscure cases.

We also remove an unnecessary call to `desugarIdent`.