### PR TITLE
Allow experimental language imports in experimental scopes

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -97,9 +97,9 @@ object Feature:
     else
       false
 
-  def checkExperimentalFeature(which: String, srcPos: SrcPos)(using Context) =
+  def checkExperimentalFeature(which: String, srcPos: SrcPos, note: => String = "")(using Context) =
     if !isExperimentalEnabled then
-      report.error(i"Experimental $which may only be used with a nightly or snapshot version of the compiler", srcPos)
+      report.error(i"Experimental $which may only be used with a nightly or snapshot version of the compiler$note", srcPos)
 
   def checkExperimentalDef(sym: Symbol, srcPos: SrcPos)(using Context) =
     if !isExperimentalEnabled then

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3114,10 +3114,6 @@ object Parsers {
       languageImport(tree) match
         case Some(prefix) =>
           in.languageImportContext = in.languageImportContext.importContext(imp, NoSymbol)
-          if prefix == nme.experimental
-             && selectors.exists(sel => Feature.experimental(sel.name) != Feature.scala2macros)
-          then
-            Feature.checkExperimentalFeature("features", imp.srcPos)
           for
             case ImportSelector(id @ Ident(imported), EmptyTree, _) <- selectors
             if allSourceVersionNames.contains(imported)

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -13,7 +13,6 @@ import Decorators._
 import Symbols._, SymUtils._, NameOps._
 import ContextFunctionResults.annotateContextResults
 import config.Printers.typr
-import config.Feature
 import reporting._
 
 object PostTyper {
@@ -449,30 +448,9 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
           throw ex
       }
 
-    /** In addition to normal processing, check that experimental language
-     *  imports are done only in experimental scopes, or in scopes where
-     *  all statements are @experimental definitions.
-     */
     override def transformStats(trees: List[Tree], exprOwner: Symbol)(using Context): List[Tree] =
-
-      def onlyExperimentalDefs = trees.forall {
-        case _: Import | EmptyTree => true
-        case stat: MemberDef => stat.symbol.isExperimental
-        case _ => false
-      }
-
-      def checkExperimentalImports =
-        for case imp @ Import(qual, selectors) <- trees do
-          languageImport(qual) match
-            case Some(nme.experimental)
-            if !ctx.owner.isInExperimentalScope && !onlyExperimentalDefs
-               && selectors.exists(sel => Feature.experimental(sel.name) != Feature.scala2macros) =>
-              Feature.checkExperimentalFeature("features", imp.srcPos)
-            case _ =>
-
       try super.transformStats(trees, exprOwner)
-      finally checkExperimentalImports
-    end transformStats
+      finally Checking.checkExperimentalImports(trees)
 
     /** Transforms the rhs tree into a its default tree if it is in an `erased` val/def.
      *  Performed to shrink the tree that is known to be erased later.

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -727,7 +727,7 @@ object Checking {
   def checkExperimentalImports(trees: List[Tree])(using Context): Unit =
     def onlyExperimentalDefs = trees.forall {
       case _: Import | EmptyTree => true
-      case stat: MemberDef => stat.symbol.isExperimental
+      case stat: MemberDef => stat.symbol.isExperimental || stat.symbol.is(Synthetic)
       case _ => false
     }
     for case imp @ Import(qual, selectors) <- trees do

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -178,7 +178,7 @@ class CompilationTests {
       compileFile("tests/neg-custom-args/matchable.scala", defaultOptions.and("-Xfatal-warnings", "-source", "future")),
       compileFile("tests/neg-custom-args/i7314.scala", defaultOptions.and("-Xfatal-warnings", "-source", "future")),
       compileFile("tests/neg-custom-args/feature-shadowing.scala", defaultOptions.and("-Xfatal-warnings", "-feature")),
-      compileDir("tests/neg-custom-args/hidden-type-errors",  defaultOptions.and("-explain")),
+      compileDir("tests/neg-custom-args/hidden-type-errors", defaultOptions.and("-explain")),
     ).checkExpectedErrors()
   }
 

--- a/tests/neg-custom-args/no-experimental/experimental-erased.scala
+++ b/tests/neg-custom-args/no-experimental/experimental-erased.scala
@@ -1,0 +1,7 @@
+import language.experimental.erasedDefinitions // error
+import annotation.experimental
+
+@experimental
+erased class CanThrow[-E <: Exception]
+
+def other = 1

--- a/tests/neg-custom-args/no-experimental/experimental.scala
+++ b/tests/neg-custom-args/no-experimental/experimental.scala
@@ -26,9 +26,3 @@ class Test2 {
 class Test6 {
   import scala.language.experimental  // ok
 }
-
-class Test7 {
-  import scala.language.experimental
-  import experimental.genericNumberLiterals // error: no aliases can be used to refer to a language import
-  val x: BigInt = 13232202002020202020202   // error
-}

--- a/tests/pos/experimental-erased-2.scala
+++ b/tests/pos/experimental-erased-2.scala
@@ -1,0 +1,10 @@
+import language.experimental.erasedDefinitions
+import annotation.experimental
+
+@experimental object Test:
+
+  erased class CanThrow[-E <: Exception]
+
+  def other = 1
+
+

--- a/tests/pos/experimental-erased.scala
+++ b/tests/pos/experimental-erased.scala
@@ -2,5 +2,14 @@ import language.experimental.erasedDefinitions
 import annotation.experimental
 
 @experimental
-erased class CanThrow[-E <: Exception]
+erased class CanThrow[-E <: Exception](val i: Int = 0)
+
+@experimental
+object Foo
+
+@experimental
+def bar = 1
+
+
+
 

--- a/tests/pos/experimental-erased.scala
+++ b/tests/pos/experimental-erased.scala
@@ -1,0 +1,6 @@
+import language.experimental.erasedDefinitions
+import annotation.experimental
+
+@experimental
+erased class CanThrow[-E <: Exception]
+


### PR DESCRIPTION
An experimental language import is permitted if the enclosing
scope is an experimental scope, or if all non-synthetic statements in that
scope are @experimental definitions.

Fixes #13392
Alternative to #13394 
