### PR TITLE
Don't crash when calling gc() on a committed TyperState

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -162,6 +162,7 @@ class TyperState() {
         targetState.mergeConstraintWith(this)
     targetState.gc()
     isCommitted = true
+    ownedVars = SimpleIdentitySet.empty
   }
 
   /** Ensure that this constraint does not associate different TypeVars for the

--- a/tests/neg/i13407.scala
+++ b/tests/neg/i13407.scala
@@ -1,0 +1,19 @@
+import scala.quoted.Type
+
+trait Tensor[S <: Tuple] {
+  def sum[Axis <: Shape: Type](axis: Axis): Tensor[S] = { // error
+    Tensor.mk
+  }
+}
+
+object Tensor {
+  def mk[S <: Tuple]: Tensor[S] = new Tensor {}
+}
+
+object Foo {
+  val t1: Tensor[("batch", "len", "embed")] = Tensor.mk
+   def foo(x: Any) = {
+
+  }
+  foo(foo(t1.sum("len"))) // error
+}


### PR DESCRIPTION
An already-committed TyperState might be committed into when errors are
flushed (cf #12827, #13150) and `commit()` calls `gc()`. This operation
could crash before this commit because we attempted to instantiate type
variables no longer owned by the TyperState. We fix this by clearing
`ownedVars` when committing a TyperState (because after committing it no
longer owns any type variable).

Fixes #13407.