### PR TITLE
Update reference compiler to 3.1.0-RC1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -63,9 +63,9 @@ object DottyJSPlugin extends AutoPlugin {
 }
 
 object Build {
-  val referenceVersion = "3.1.0-RC1-bin-20210823-dd7a07a-NIGHTLY"
+  val referenceVersion = "3.1.0-RC1"
 
-  val baseVersion = "3.1.0-RC1"
+  val baseVersion = "3.1.0-RC2"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.


### PR DESCRIPTION
and set base version to 3.1.0-RC2

Note: We need an RC2 because we need to compile 3.1.0 with a stable compiler, 3.1.0-RC1 was build with a nightly compiler.