### PR TITLE
Bump tasty to 28.3-1

### DIFF
--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -285,7 +285,7 @@ object TastyFormat {
    *  compatibility, but remains backwards compatible, with all
    *  preceeding `MinorVersion`.
    */
-  final val MinorVersion: Int = 2
+  final val MinorVersion: Int = 3
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing


### PR DESCRIPTION
On `release-3.1.0` tasty version was by mistake set to `28.2-1`. This sets the tasty version on the master to newer than in `3.1.0-RC1`.