### PR TITLE
Build: increase timeout for downloading inkuire.js from GitHub

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1334,7 +1334,7 @@ object Build {
         val downloadProcess = (new java.net.URL(inkuireLink) #> inkuireDestinationFile).run()
         val result: Future[Int] = Future(blocking(downloadProcess.exitValue()))
         val res = try {
-          Await.result(result, duration.Duration(20, "sec"))
+          Await.result(result, duration.Duration(60, "sec"))
         } catch {
           case _: TimeoutException =>
             downloadProcess.destroy()


### PR DESCRIPTION
I have seen this timeout on more than one occasion in CI.

Maybe we actually need retry?

```
Thu, 02 Sep 2021 16:42:00 GMT Error:  Failed to fetch inkuire.js from https://github.com/VirtusLab/Inkuire/releases/download/1.0.0-M2/inkuire.js: Download timeout
Thu, 02 Sep 2021 16:42:00 GMT Error:  (scaladoc / Compile / managedResources) Failed to fetch inkuire.js from https://github.com/VirtusLab/Inkuire/releases/download/1.0.0-M2/inkuire.js: Download timeout
Thu, 02 Sep 2021 16:42:00 GMT Error:  Total time: 226 s (03:46), completed Sep 2, 2021 6:42:00 PM
Thu, 02 Sep 2021 16:42:00 GMT Error: Process completed with exit code 1.
```