### PR TITLE
Revert "Bump tasty to 28.3-1"

### DIFF
--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -285,7 +285,7 @@ object TastyFormat {
    *  compatibility, but remains backwards compatible, with all
    *  preceeding `MinorVersion`.
    */
-  final val MinorVersion: Int = 3
+  final val MinorVersion: Int = 2
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing


### PR DESCRIPTION
Reverts lampepfl/dotty#13451

according to https://github.com/lampepfl/dotty/pull/13452#issuecomment-912080419 we will go back to `28.2-1`