### PR TITLE
REPL: Use the state context when building a new run

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -181,7 +181,7 @@ class ReplDriver(settings: Array[String],
   }
 
   private def newRun(state: State, reporter: StoreReporter = newStoreReporter) = {
-    val run = compiler.newRun(rootCtx.fresh.setReporter(reporter), state)
+    val run = compiler.newRun(state.context.fresh.setReporter(reporter), state)
     state.copy(context = run.runContext)
   }
 


### PR DESCRIPTION
This ensures that settings present in the state's context aren't lost by
using the root context instead.

Testing which tests fails from this.