### PR TITLE
Add retry logic to inkuire fetch

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1326,21 +1326,38 @@ object Build {
       Compile / resourceGenerators += Def.task {
         import _root_.scala.sys.process._
         import _root_.scala.concurrent._
+        import _root_.scala.concurrent.duration.Duration
         import ExecutionContext.Implicits.global
         val inkuireVersion = "1.0.0-M2"
         val inkuireLink = s"https://github.com/VirtusLab/Inkuire/releases/download/$inkuireVersion/inkuire.js"
         val inkuireDestinationFile = (Compile / resourceManaged).value / "dotty_res" / "scripts" / "inkuire.js"
         sbt.IO.touch(inkuireDestinationFile)
-        val downloadProcess = (new java.net.URL(inkuireLink) #> inkuireDestinationFile).run()
-        val result: Future[Int] = Future(blocking(downloadProcess.exitValue()))
-        val res = try {
-          Await.result(result, duration.Duration(60, "sec"))
-        } catch {
-          case _: TimeoutException =>
-            downloadProcess.destroy()
-            throw new MessageOnlyException(s"Failed to fetch inkuire.js from $inkuireLink: Download timeout")
+
+        def tryFetch(retries: Int, timeout: Duration): Unit = {
+          val downloadProcess = (new java.net.URL(inkuireLink) #> inkuireDestinationFile).run()
+          val result: Future[Int] = Future(blocking(downloadProcess.exitValue()))
+          try {
+            Await.result(result, timeout) match {
+              case 0 =>
+              case res if retries > 0 =>
+                println(s"Failed to fetch inkuire.js from $inkuireLink: Error code $res. $retries retries left")
+                tryFetch(retries - 1, timeout)
+              case res => throw new MessageOnlyException(s"Failed to fetch inkuire.js from $inkuireLink: Error code $res")
+            }
+          } catch {
+            case e: TimeoutException =>
+              downloadProcess.destroy()
+              if (retries > 0) {
+                println(s"Failed to fetch inkuire.js from $inkuireLink: Download timeout. $retries retries left")
+                tryFetch(retries - 1, timeout)
+              }
+              else {
+                throw new MessageOnlyException(s"Failed to fetch inkuire.js from $inkuireLink: Download timeout")
+              }
+          }
         }
-        if(res != 0) throw new MessageOnlyException(s"Failed to fetch inkuire.js from $inkuireLink: Error code $res")
+
+        tryFetch(5, Duration(60, "s"))
         Seq(inkuireDestinationFile)
       }.taskValue,
       libraryDependencies ++= Dependencies.flexmarkDeps ++ Seq(


### PR DESCRIPTION
Even after increasing timeout limit, inkuire fetch is still flaky. This PR adds retry logic to stabilize the process