### PR TITLE
Do not remove accessors to early

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -56,9 +56,6 @@ class CompilationUnit protected (val source: SourceFile) {
    */
   var needsQuotePickling: Boolean = false
 
-  /** A structure containing a temporary map for generating inline accessors */
-  val inlineAccessors: InlineAccessors = new InlineAccessors
-
   var suspended: Boolean = false
   var suspendedAtInliningPhase: Boolean = false
 

--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -31,12 +31,9 @@ abstract class AccessProxies {
    */
   protected def passReceiverAsArg(accessorName: Name)(using Context): Boolean = false
 
-  /** The accessor definitions that need to be added to class `cls`
-   *  As a side-effect, this method removes entries from the `accessedBy` map.
-   *  So a second call of the same method will yield the empty list.
-   */
+  /** The accessor definitions that need to be added to class `cls` */
   private def accessorDefs(cls: Symbol)(using Context): Iterator[DefDef] =
-    for (accessor <- cls.info.decls.iterator; accessed <- accessedBy.remove(accessor).toOption) yield
+    for accessor <- cls.info.decls.iterator; accessed <- accessedBy.get(accessor) yield
       DefDef(accessor.asTerm, prefss => {
         def numTypeParams = accessed.info match {
           case info: PolyType => info.paramNames.length

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -15,6 +15,7 @@ import SymUtils._
 import NameKinds._
 import dotty.tools.dotc.ast.tpd
 import typer.Implicits.SearchFailureType
+import typer.PrepareInlineable
 
 import scala.collection.mutable
 import dotty.tools.dotc.core.Annotations._

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -70,7 +70,7 @@ trait QuotesAndSplices {
   }
 
   private def makeInlineable(tree: Tree)(using Context): Tree =
-    ctx.compilationUnit.inlineAccessors.makeInlineable(tree)
+    PrepareInlineable.makeInlineable(tree)
 
   /** Translate `${ t: Expr[T] }` into expression `t.splice` while tracking the quotation level in the context */
   def typedSplice(tree: untpd.Splice, pt: Type)(using Context): Tree = {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2461,7 +2461,7 @@ class Typer extends Namer
       // 4. Polymorphic type defs override nothing.
 
   protected def addAccessorDefs(cls: Symbol, body: List[Tree])(using Context): List[Tree] =
-    ctx.compilationUnit.inlineAccessors.addAccessorDefs(cls, body)
+    PrepareInlineable.addAccessorDefs(cls, body)
 
   /** If this is a real class, make sure its first parent is a
    *  constructor call. Cannot simply use a type. Overridden in ReTyper.

--- a/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
@@ -81,7 +81,8 @@ class TyperPhase(addRootImports: Boolean = true) extends Phase {
   override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
     val unitContexts =
       for unit <- units yield
-        val newCtx = ctx.fresh.setPhase(this.start).setCompilationUnit(unit)
+        val newCtx0 = ctx.fresh.setPhase(this.start).setCompilationUnit(unit)
+        val newCtx = PrepareInlineable.initContext(newCtx0)
         report.inform(s"typing ${unit.source}")
         if (addRootImports)
           newCtx.withRootImports

--- a/tests/pos/i13476.scala
+++ b/tests/pos/i13476.scala
@@ -1,0 +1,7 @@
+private object Foo:
+  inline def d(arg : Int): Unit = {}
+  transparent inline def haha() : Unit = {}
+
+export Foo.*
+
+@main def main : Unit = haha()


### PR DESCRIPTION
Accessors that are added to packages were removed to early from `accessedBy`.
This resulted in a new symbol beeing entered for the same accessor.

Fixes #13476