### PR TITLE
Don't count constructors in allMembers

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6093,7 +6093,7 @@ object Types {
   }
 
   object takeAllFilter extends NameFilter {
-    def apply(pre: Type, name: Name)(using Context): Boolean = true
+    def apply(pre: Type, name: Name)(using Context): Boolean = name != nme.CONSTRUCTOR
     def isStable = true
   }
 


### PR DESCRIPTION
This caused a crash for Metals with the following stacktrace

```
Caused by: dotty.tools.dotc.core.TypeError: Toplevel definition <init> is defined in
  /Users/odersky/workspace/dotty/compiler/target/scala-3.1.0-RC1/classes/dotty/tools/dotc/util/LinearMap$package.class
and also in
  /Users/odersky/workspace/dotty/compiler/target/scala-3.1.0-RC1/classes/dotty/tools/dotc/util/LinearSet$package.class
One of these files should be removed from the classpath.
	at dotty.tools.dotc.core.SymDenotations$PackageClassDenotation.dropStale$1(SymDenotations.scala:2439)
	at dotty.tools.dotc.core.SymDenotations$PackageClassDenotation.recur$1(SymDenotations.scala:2403)
	at dotty.tools.dotc.core.SymDenotations$PackageClassDenotation.computeMembersNamed(SymDenotations.scala:2459)
	at dotty.tools.dotc.core.SymDenotations$ClassDenotation.membersNamed(SymDenotations.scala:2012)
	at dotty.tools.dotc.core.SymDenotations$ClassDenotation.findMember(SymDenotations.scala:2063)
	at dotty.tools.dotc.core.Types$Type.go$1(Types.scala:683)
	at dotty.tools.dotc.core.Types$Type.goThis$1(Types.scala:807)
	at dotty.tools.dotc.core.Types$Type.go$1(Types.scala:700)
	at dotty.tools.dotc.core.Types$Type.findMember(Types.scala:870)
	at dotty.tools.dotc.core.Types$Type.memberBasedOnFlags(Types.scala:666)
	at dotty.tools.dotc.core.Types$Type.member(Types.scala:650)
	at dotty.tools.dotc.core.Types$Type.allMembers$$anonfun$1(Types.scala:1011)
```
The problem arises when calling allMembers on a package with multiple package objects. These
will all have a constructor, and the constructors fail the dropStale test. There is not really
a good way to pick one constructor over another, so it's better to drop constructors in allMembers.