### PR TITLE
Fix specifity comparison for extensions in polymorphic givens

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -526,9 +526,11 @@ object Contexts {
     final def withOwner(owner: Symbol): Context =
       if (owner ne this.owner) fresh.setOwner(owner) else this
 
+    final def withTyperState(typerState: TyperState): Context =
+      if typerState ne this.typerState then fresh.setTyperState(typerState) else this
+
     final def withUncommittedTyperState: Context =
-      val ts = typerState.uncommittedAncestor
-      if ts ne typerState then fresh.setTyperState(ts) else this
+      withTyperState(typerState.uncommittedAncestor)
 
     final def withProperty[T](key: Key[T], value: Option[T]): Context =
       if (property(key) == value) this
@@ -599,8 +601,8 @@ object Contexts {
       this.scope = newScope
       this
     def setTyperState(typerState: TyperState): this.type = { this.typerState = typerState; this }
-    def setNewTyperState(): this.type = setTyperState(typerState.fresh().setCommittable(true))
-    def setExploreTyperState(): this.type = setTyperState(typerState.fresh().setCommittable(false))
+    def setNewTyperState(): this.type = setTyperState(typerState.fresh(committable = true))
+    def setExploreTyperState(): this.type = setTyperState(typerState.fresh(committable = false))
     def setReporter(reporter: Reporter): this.type = setTyperState(typerState.fresh().setReporter(reporter))
     def setTyper(typer: Typer): this.type = { this.scope = typer.scope; setTypeAssigner(typer) }
     def setGadt(gadt: GadtConstraint): this.type =

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -192,7 +192,7 @@ class TyperState() {
 
     val comparingCtx = ctx.withTyperState(this)
 
-    comparing(typeComparer =>
+    inContext(comparingCtx)(comparing(typeComparer =>
       val other = that.constraint
       val res = other.domainLambdas.forall(tl =>
         // Integrate the type lambdas from `other`
@@ -219,7 +219,7 @@ class TyperState() {
           )
         )
       assert(res || ctx.reporter.errorsReported, i"cannot merge $constraint with $other.")
-    )(using comparingCtx)
+    ))
 
     for tl <- constraint.domainLambdas do
       if constraint.isRemovable(tl) then constraint = constraint.remove(tl)

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -103,11 +103,12 @@ class TyperState() {
     this
 
   /** A fresh typer state with the same constraint as this one. */
-  def fresh(reporter: Reporter = StoreReporter(this.reporter)): TyperState =
+  def fresh(reporter: Reporter = StoreReporter(this.reporter),
+      committable: Boolean = this.isCommittable): TyperState =
     util.Stats.record("TyperState.fresh")
     TyperState().init(this, this.constraint)
       .setReporter(reporter)
-      .setCommittable(this.isCommittable)
+      .setCommittable(committable)
 
   /** The uninstantiated variables */
   def uninstVars: collection.Seq[TypeVar] = constraint.uninstVars
@@ -189,9 +190,7 @@ class TyperState() {
   def mergeConstraintWith(that: TyperState)(using Context): Unit =
     that.ensureNotConflicting(constraint)
 
-    val comparingCtx =
-      if ctx.typerState == this then ctx
-      else ctx.fresh.setTyperState(this)
+    val comparingCtx = ctx.withTyperState(this)
 
     comparing(typeComparer =>
       val other = that.constraint

--- a/tests/neg/extension-specificity2.scala
+++ b/tests/neg/extension-specificity2.scala
@@ -1,0 +1,10 @@
+trait Bla1[A]:
+  extension (x: A) def foo(y: A): Int
+trait Bla2[A]:
+  extension (x: A) def foo(y: A): Int
+
+def test =
+  given bla1[T <: Int]: Bla1[T] = ???
+  given bla2[S <: Int]: Bla2[S] = ???
+
+  1.foo(2) // error: never extension is more specific than the other

--- a/tests/run/extension-specificity2.scala
+++ b/tests/run/extension-specificity2.scala
@@ -1,0 +1,37 @@
+trait Foo[F[_]]:
+  extension [A](fa: F[A])
+    def foo[B](fb: F[B]): Int
+
+def test1 =
+  // Simplified from https://github.com/typelevel/spotted-leopards/issues/2
+  given listFoo: Foo[List] with
+    extension [A](fa: List[A])
+      def foo[B](fb: List[B]): Int = 1
+
+  given functionFoo[T]: Foo[[A] =>> T => A] with
+    extension [A](fa: T => A)
+      def foo[B](fb: T => B): Int = 2
+
+  val x = List(1, 2).foo(List(3, 4))
+  assert(x == 1, x)
+
+def test2 =
+  // This test case would fail if we used `wildApprox` on the method types
+  // instead of using the correct typer state.
+  trait Bar1[A]:
+    extension (x: A => A) def bar(y: A): Int
+  trait Bar2:
+    extension (x: Int => 1) def bar(y: Int): Int
+
+  given bla1[T]: Bar1[T] with
+    extension (x: T => T) def bar(y: T): Int = 1
+  given bla2: Bar2 with
+    extension (x: Int => 1) def bar(y: Int): Int = 2
+
+  val f: Int => 1 = x => 1
+  val x = f.bar(1)
+  assert(x == 2, x)
+
+@main def Test =
+  test1
+  test2


### PR DESCRIPTION
When we compare polymorphic methods for specificity, we replace their
type parameters by type variables constrained in the current
context (see isAsSpecific), but for extension methods in polymorphic
givens, the comparison was done with a constraint set that does not
include the type parameters of the givens, this lead to ambiguity errors
as experienced in
https://github.com/typelevel/spotted-leopards/issues/2.

We fix this by ensuring the TyperState we use for the comparison
contains any additional constraint specific to the TyperState of either
alternative. This required generalizing TyperState#mergeConstraintWith
to handle `this` not being committable (because in that case `this` does
not need to take ownership of the type variables owned by `that`,
therefore `that` itself is allowed to be committable).