### PR TITLE
Fix crash on uninstantiated field access

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3876,6 +3876,8 @@ object Types {
                   x.declaredVariance == y.declaredVariance))
         && {
           val bs1 = new BinderPairs(this, that, bs)
+          // `paramInfos` and `resType` might still be uninstantiated at this point
+          paramInfos != null && resType != null &&
           paramInfos.equalElements(that.paramInfos, bs1) &&
           resType.equals(that.resType, bs1)
         }

--- a/tests/neg/i13513.scala
+++ b/tests/neg/i13513.scala
@@ -1,0 +1,5 @@
+final case class TwoTypes[F, A](value: A)
+class Minimal {
+  def x[C[_]]: C[Int] = ???
+  x[TwoTypes].value // error:  Type argument TwoTypes does not conform to upper bound [_] =>> Any
+}


### PR DESCRIPTION
The uninstantiated access in the test case happens because the closure
passed to the HKTypeLambda constructor to construct the result type by
`HKTypeLambda.newLikeThis` calls `subst` which eventually calls
`HKTypeLambda#equals`, I don't see a way to prevent that at the source,
so make equality checking robust to uninstantatied fields.

Fixes #13513.