### PR TITLE
[Backport] Set typer phase after InteractiveDriver.run

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -167,6 +167,7 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
       cleanup(t)
       myOpenedTrees(uri) = topLevelTrees(t, source)
       myCompilationUnits(uri) = unit
+      myCtx = myCtx.fresh.setPhase(myInitCtx.base.typerPhase)
 
       reporter.removeBufferedMessages
     }

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -19,7 +19,7 @@ import scala.io.Codec
 import dotc._
 import ast.{Trees, tpd, untpd}
 import core._, core.Decorators._
-import Comments._, Constants._, Contexts._, Flags._, Names._, NameOps._, Symbols._, SymDenotations._, Trees._, Types._, Periods._
+import Comments._, Constants._, Contexts._, Flags._, Names._, NameOps._, Symbols._, SymDenotations._, Trees._, Types._
 import classpath.ClassPathEntries
 import reporting._
 import typer.Typer
@@ -307,7 +307,7 @@ class DottyLanguageServer extends LanguageServer
     val pos = sourcePosition(driver, uri, params.getPosition)
     val items = driver.compilationUnits.get(uri) match {
       case Some(unit) =>
-        val freshCtx = ctx.fresh.setPeriod(Period(ctx.runId, ctx.base.typerPhase.id)).setCompilationUnit(unit)
+        val freshCtx = ctx.fresh.setCompilationUnit(unit)
         Completion.completions(pos)(using freshCtx)._2
       case None => Nil
     }

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -857,4 +857,20 @@ class CompletionTest {
         |}""".withSource
       .completion(m1, Set(("show",Method, "(using x$2: x$1.reflect.Printer[x$1.reflect.Tree]): String")))
   }
+
+  @Test def concatMethodWithImplicits: Unit = {
+    code"""|object A {
+           |  Array.concat${m1}
+           |}""".withSource
+      .completion(
+          m1,
+          Set(
+            (
+              "concat",
+              Method,
+              "[T](xss: Array[T]*)(implicit evidence$11: scala.reflect.ClassTag[T]): Array[T]"
+            )
+          )
+        )
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/lampepfl/dotty/issues/13467
Backport of #13530, so we can have it in 3.1.0-RC2.