### PR TITLE
Freeze the static site

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1419,7 +1419,8 @@ object Build {
               "https://scala-lang.org/api/versions.json",
               "-Ydocument-synthetic-types",
               s"-snippet-compiler:${dottyLibRoot}/scala/quoted=compile"
-            ) ++ (if (justAPI) Nil else Seq("-siteroot", "docs", "-Yapi-subdirectory")))
+            )
+          )
 
         if (dottyJars.isEmpty) Def.task { streams.value.log.error("Dotty lib wasn't found") }
         else if (justAPI) generateDocTask

--- a/project/scripts/genDocs
+++ b/project/scripts/genDocs
@@ -19,7 +19,7 @@ mkdir -pv "$PREVIOUS_SNAPSHOTS_DIR"
 git remote add doc-remote "https://github.com/lampepfl/dotty-website.git"
 git fetch doc-remote gh-pages
 git checkout gh-pages
-(cp -vr [03].*/ "$PREVIOUS_SNAPSHOTS_DIR"; true)  # Don't fail if no `3.*` found to copy
+(cp -vr 0.*/ 3.*/ docs/ blog/ index.html "$PREVIOUS_SNAPSHOTS_DIR"; true)  # Don't fail if no `3.*` found to copy
 git checkout "$GIT_HEAD"
 
 ### Generate the current snapshot of the website ###
@@ -34,5 +34,5 @@ if [ ! -d "$SITE_OUT_DIR" ]; then
 fi
 
 ### Move previous versions' snapshots to _site ###
-mv -v "$PREVIOUS_SNAPSHOTS_DIR"/* "$SITE_OUT_DIR"
+mv -vf "$PREVIOUS_SNAPSHOTS_DIR"/* "$SITE_OUT_DIR"
 rm -rf "$PREVIOUS_SNAPSHOTS_DIR"


### PR DESCRIPTION
Stops generating static site from the sources and copies them between versions. Note that this is just a temporary fix for dotty.epfl.ch, before we get full integration of preprocessing these files for docs.scala-lang