### PR TITLE
Add SkolemType in metaprogramming

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2216,6 +2216,18 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def unapply(x: NoPrefix): true = true
     end NoPrefix
 
+    type SkolemType = dotc.core.Types.SkolemType
+
+    object SkolemTypeTypeTest extends TypeTest[TypeRepr, SkolemType]:
+      def unapply(x: TypeRepr): Option[SkolemType & x.type] = x match
+        case tpe: (Types.SkolemType & x.type) => Some(tpe)
+        case _ => None
+    end SkolemTypeTypeTest
+
+    object SkolemType extends SkolemTypeModule:
+      def unapply(x : SkolemType) : Some[TypeRepr] = Some(x.info)
+    end SkolemType
+
     type Constant = dotc.core.Constants.Constant
 
     object Constant extends ConstantModule

--- a/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/Extractors.scala
@@ -240,6 +240,8 @@ object Extractors {
         this += "NoPrefix()"
       case MatchCase(pat, rhs) =>
         this += "MatchCase(" += pat += ", " += rhs += ")"
+      case SkolemType(info) =>
+        this += "SkolemType(" += info += ")"
     }
 
     def visitSignature(sig: Signature): this.type = {

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1234,6 +1234,11 @@ object SourceCode {
         this += " => "
         printType(rhs)
 
+      case SkolemType(info) =>
+        this += "$skolem["
+        printType(info)
+        this += "]"
+
       case _ =>
         throw new MatchError(tpe.show(using Printer.TypeReprStructure))
     }

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3163,6 +3163,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def unapply(x: NoPrefix): true
     }
 
+    // ----- SkolemType -----------------------------------------------
+
+    /** SkolemType for a type selection */
+    type SkolemType <: TypeRepr
+
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `SkolemType` */
+    given SkolemTypeTypeTest: TypeTest[TypeRepr, SkolemType]
+
+    /** Module object of `type SkolemType`  */
+    val SkolemType: SkolemTypeModule
+
+    /** Methods of the module object `val SkolemType` */
+    trait SkolemTypeModule { this: SkolemType.type =>
+      def unapply(x: SkolemType): Some[TypeRepr]
+    }
+
     ///////////////
     // CONSTANTS //
     ///////////////


### PR DESCRIPTION
I ran into an error that somehow got a `SkolemType` during type-dependent metaprogramming. 
Because it was not handled, I got a match type error during `.show`. 
Therefore I added `SkolemType`, similarly to the other types.
A few questions:
1. Should a public API to access a `SkolemType` be available, or should we just handle the `.show` use-case?
2. For `.show` I chose to print it as `$skolem[info]`. Is there a better alternate suggestion?
