### PR TITLE
Fix SAM conversion involving ()-insertion and overloading

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -652,7 +652,8 @@ trait Applications extends Compatibility {
 
         def SAMargOK =
           defn.isFunctionType(argtpe1) && formal.match
-            case SAMType(sam) => argtpe <:< sam.toFunctionType(isJava = formal.classSymbol.is(JavaDefined))
+            case SAMType(sam) => argtpe <:< sam.toFunctionType(
+              isJava = formal.classSymbol.is(JavaDefined), unitToWildcard = true)
             case _ => false
 
         isCompatible(argtpe, formal)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3728,7 +3728,7 @@ class Typer extends Namer
         if defn.isFunctionType(wtp) && !defn.isFunctionType(pt) =>
           pt match {
             case SAMType(sam)
-            if wtp <:< sam.toFunctionType(isJava = pt.classSymbol.is(JavaDefined)) =>
+            if wtp <:< sam.toFunctionType(isJava = pt.classSymbol.is(JavaDefined), unitToWildcard = true) =>
               // was ... && isFullyDefined(pt, ForceDegree.flipBottom)
               // but this prevents case blocks from implementing polymorphic partial functions,
               // since we do not know the result parameter a priori. Have to wait until the

--- a/tests/pos/i13549.scala
+++ b/tests/pos/i13549.scala
@@ -1,0 +1,11 @@
+@FunctionalInterface
+trait Executable {
+  def execute(): Unit
+}
+
+object Test {
+  def assertThrows(executable: Executable, message: String): Unit = ???
+  def assertThrows(executable: Executable, foo: Int): Unit = ???
+
+  assertThrows(() => 3, "This is a message")
+}


### PR DESCRIPTION
Without overloading, a function literal `() => 3` whose expected type is
a Unit-returning SAM gets typed as `() => { 3; () }` as expected, but
with overloading we first type the function literal without an expected
type and then compare it against the formal parameter type.

This commit makes this check succeed by replacing a result type of
`Unit` by `WildcardType` so we end up comparing
`() => Int <:< () => ?` instead of `() => Int <:< () => Unit`.

Fixes #13549.