### PR TITLE
Prioritize ambiguous errors in extension method search

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3150,7 +3150,10 @@ class Typer extends Namer
       if !app.isEmpty && !nestedCtx.reporter.hasErrors then
         nestedCtx.typerState.commit()
         return app
-      for err <- nestedCtx.reporter.allErrors.take(1) do
+      val errs = nestedCtx.reporter.allErrors
+      val remembered = // report AmbiguousReferences as priority, otherwise last error
+        (errs.filter(_.msg.isInstanceOf[AmbiguousReference]) ++ errs).take(1)
+      for err <- remembered do
         rememberSearchFailure(qual,
           SearchFailure(app.withType(FailedExtension(app, selectionProto, err.msg))))
     catch case ex: TypeError => nestedFailure(ex)

--- a/tests/neg/i13558.check
+++ b/tests/neg/i13558.check
@@ -1,0 +1,22 @@
+-- [E008] Not Found Error: tests/neg/i13558.scala:23:14 ----------------------------------------------------------------
+23 |    println(a.id) // error
+   |            ^^^^
+   |            value id is not a member of testcode.A.
+   |            An extension method was tried, but could not be fully constructed:
+   |
+   |                testcode.ExtensionA.id(a)    failed with
+   |
+   |                    Reference to id is ambiguous,
+   |                    it is both imported by import testcode.ExtensionB._
+   |                    and imported subsequently by import testcode.ExtensionA._
+-- [E008] Not Found Error: tests/neg/i13558.scala:29:14 ----------------------------------------------------------------
+29 |    println(a.id) // error
+   |            ^^^^
+   |            value id is not a member of testcode.A.
+   |            An extension method was tried, but could not be fully constructed:
+   |
+   |                testcode.ExtensionB.id(a)    failed with
+   |
+   |                    Reference to id is ambiguous,
+   |                    it is both imported by import testcode.ExtensionA._
+   |                    and imported subsequently by import testcode.ExtensionB._

--- a/tests/neg/i13558.scala
+++ b/tests/neg/i13558.scala
@@ -1,0 +1,31 @@
+package testcode
+
+class A
+
+class B
+
+object ExtensionA {
+  extension (self: A) {
+    def id = "A"
+  }
+}
+object ExtensionB {
+  extension (self: B) {
+    def id = "B"
+  }
+}
+
+object Main {
+  def main1(args: Array[String]): Unit = {
+    import ExtensionB._
+    import ExtensionA._
+    val a = A()
+    println(a.id) // error
+  }
+  def main2(args: Array[String]): Unit = {
+    import ExtensionA._
+    import ExtensionB._
+    val a = A()
+    println(a.id) // error
+  }
+}


### PR DESCRIPTION
When an extension method search fails with an ambiguity, report the ambiguous message instead
of a message pertaining to the (arbitrary) surviving alternative.

Fixes #13558 