### PR TITLE
Fix #13197: Deskolemize lifted named arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1208,6 +1208,7 @@ object Types {
         if tp.isOverloaded then tp else tp.underlying.widen
       case tp: SingletonType => tp.underlying.widen
       case tp: ExprType => tp.resultType.widen
+      case tp: AndType => tp.derivedAndType(tp.tp1.widen, tp.tp2.widen)
       case tp =>
         val tp1 = tp.stripped
         if tp1 eq tp then tp

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -48,7 +48,7 @@ abstract class Lifter {
     else {
       val name = UniqueName.fresh(prefix)
       // don't instantiate here, as the type params could be further constrained, see tests/pos/pickleinf.scala
-      var liftedType = expr.tpe.widen
+      var liftedType = expr.tpe.widen.deskolemized
       if (liftedFlags.is(Method)) liftedType = ExprType(liftedType)
       val lifted = newSymbol(ctx.owner, name, liftedFlags | Synthetic, liftedType, coord = spanCoord(expr.span))
       defs += liftedDef(lifted, expr)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1704,15 +1704,6 @@ class Namer { typer: Typer =>
     // it would be erased to BoxedUnit.
     def dealiasIfUnit(tp: Type) = if (tp.isRef(defn.UnitClass)) defn.UnitType else tp
 
-    // Approximate a type `tp` with a type that does not contain skolem types.
-    val deskolemize = new ApproximatingTypeMap {
-      def apply(tp: Type) = /*trace(i"deskolemize($tp) at $variance", show = true)*/
-        tp match {
-          case tp: SkolemType => range(defn.NothingType, atVariance(1)(apply(tp.info)))
-          case _ => mapOver(tp)
-        }
-    }
-
     def cookedRhsType = dealiasIfUnit(rhsType).deskolemized
     def lhsType = fullyDefinedType(cookedRhsType, "right-hand side", mdef.span)
     //if (sym.name.toString == "y") println(i"rhs = $rhsType, cooked = $cookedRhsType")

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1713,7 +1713,7 @@ class Namer { typer: Typer =>
         }
     }
 
-    def cookedRhsType = deskolemize(dealiasIfUnit(rhsType))
+    def cookedRhsType = dealiasIfUnit(rhsType).deskolemized
     def lhsType = fullyDefinedType(cookedRhsType, "right-hand side", mdef.span)
     //if (sym.name.toString == "y") println(i"rhs = $rhsType, cooked = $cookedRhsType")
     if (inherited.exists)

--- a/tests/explicit-nulls/pos/i13197.scala
+++ b/tests/explicit-nulls/pos/i13197.scala
@@ -1,0 +1,7 @@
+trait Bar:
+  def b: String | Null
+
+class Foo(a: String = "", b: String)
+
+object Foo:
+  def foo(bar: Bar) = Foo(b = bar.b.nn)

--- a/tests/pos/i13197.scala
+++ b/tests/pos/i13197.scala
@@ -6,7 +6,7 @@ extension [T](x: T | String) inline def forceString: x.type & String =
 trait Bar:
   def b: String | Int
 
-class Foo(a: String = "", b: Any)
+class Foo(a: String = "", b: String)
 
 object Foo:
   def foo(bar: Bar) = Foo(b = bar.b.forceString)

--- a/tests/pos/i13197.scala
+++ b/tests/pos/i13197.scala
@@ -1,0 +1,12 @@
+// this test is similar to explicit-nulls/pos/i13197.scala, but without explicit nulls
+
+extension [T](x: T | String) inline def forceString: x.type & String =
+  x.asInstanceOf
+
+trait Bar:
+  def b: String | Int
+
+class Foo(a: String = "", b: Any)
+
+object Foo:
+  def foo(bar: Bar) = Foo(b = bar.b.forceString)


### PR DESCRIPTION
Fix #13197 

The lift named arguments contain skolem types, which causes checker in inliner to fail.

```scala
def foo(bar: Bar): Foo = {
  val b$1: (?1 : String | Int) & String = forceString[Int](bar.b)
  val a$1: String @uncheckedVariance = Foo.$lessinit$greater$default$1
  new Foo(a$1, b = b$1)
}
```

We add `deskolemized` to fix this issue.