### PR TITLE
Ignore StaleSymbol exceptions when testing whether dependencies shoul…

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -349,6 +349,7 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
       sym.isAnonymousFunction ||
       sym.isAnonymousClass
     catch case ex: StaleSymbol =>
+      // can happen for constructor proxies. Test case is pos-macros/i13532.
       true
 
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -243,7 +243,7 @@ class ExtractSemanticDB extends Phase:
                 for alt <- tree.expr.tpe.member(imported).alternatives do
                   registerUseGuarded(None, alt.symbol, sel.imported.span, tree.source)
                   try
-                    if (alt.symbol.companionClass.isDefinedInCurrentRun)
+                    if (alt.symbol.companionClass.exists)
                       registerUseGuarded(None, alt.symbol.companionClass, sel.imported.span, tree.source)
                   catch case ex: StaleSymbol =>
                     // can happen for constructor proxies. Test case is pos-macros/i13532.

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -691,7 +691,8 @@ class Namer { typer: Typer =>
               for moduleSym <- companionVals do
                 if moduleSym.is(Module) && !moduleSym.isDefinedInCurrentRun then
                   val companion =
-                    if needsConstructorProxies(classSym) then classConstructorCompanion(classSym.asClass)
+                    if needsConstructorProxies(classSym) then
+                      classConstructorCompanion(classSym.asClass)
                     else newModuleSymbol(
                       ctx.owner, moduleName, EmptyFlags, EmptyFlags, (_, _) => NoType)
                   enterSymbol(companion)

--- a/tests/pos/i13532/Bar.scala
+++ b/tests/pos/i13532/Bar.scala
@@ -1,0 +1,7 @@
+package testcode
+
+import testcode.Foo
+
+class Bar(f: Foo) {
+	TestMacro.call()
+}

--- a/tests/pos/i13532/Foo.scala
+++ b/tests/pos/i13532/Foo.scala
@@ -1,0 +1,5 @@
+package testcode
+
+class Foo {
+	TestMacro.call()
+}

--- a/tests/pos/i13532/TestMacro.scala
+++ b/tests/pos/i13532/TestMacro.scala
@@ -1,0 +1,8 @@
+package testcode
+
+import scala.quoted.Quotes
+
+object TestMacro {
+    private def impl()(using Quotes) = '{ 123 }
+    inline def call(): Int = ${ impl() }
+}


### PR DESCRIPTION
…d be ignored

Fixes #13532

A question is whether the catch should be in `ignoreDependency` in the SBT dependency
extractor or in `isAbsent` itself. I put it in `ignoreDependency` for now in order
not to hide possible stale symbol errors since isAbsent is called quite often.