### PR TITLE
Don't reduce inline matches, when a guard cannot be checked at compile time

### DIFF
--- a/tests/neg/i13570.check
+++ b/tests/neg/i13570.check
@@ -1,0 +1,9 @@
+-- Error: tests/neg/i13570.scala:8:5 -----------------------------------------------------------------------------------
+8 |  jim(Seq(1,2)) // error
+  |  ^^^^^^^^^^^^^
+  |  cannot reduce inline match with
+  |   scrutinee:  seq$proxy1 : (seq$proxy1 : Seq[Int])
+  |   patterns :  case s @ _:Seq[Int] if s.isEmpty
+  |               case s @ _:Seq[Int]
+  |               case _
+  | This location contains code that was inlined from i13570.scala:3

--- a/tests/neg/i13570.scala
+++ b/tests/neg/i13570.scala
@@ -1,0 +1,8 @@
+object Test:
+  inline def jim(seq: Seq[Int]) =
+    inline seq match
+      case s: Seq[Int] if s.isEmpty => println("seq is empty")
+      case s: Seq[Int] => println("seq is not empty")
+      case _ => println("somthing hinky happened")
+
+  jim(Seq(1,2)) // error


### PR DESCRIPTION
fixes #13570