### PR TITLE
Fix missing SymbolOccurrence for aliased symbol

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -320,7 +320,7 @@ class ExtractSemanticDB extends Phase:
         generated += occ
 
     private def registerUseGuarded(qualSym: Option[Symbol], sym: Symbol, span: Span, treeSource: SourceFile)(using Context) =
-      if !excludeUse(qualSym, sym) && namePresentInSource(sym, span, treeSource) then
+      if !excludeUse(qualSym, sym) && !span.isZeroExtent then
         registerUse(sym, span, treeSource)
 
     private def registerUse(sym: Symbol, span: Span, treeSource: SourceFile)(using Context): Unit =

--- a/tests/semanticdb/expect/Givens.expect.scala
+++ b/tests/semanticdb/expect/Givens.expect.scala
@@ -4,11 +4,11 @@ package b
 object Givens/*<-a::b::Givens.*/:
 
   extension [A/*<-a::b::Givens.sayHello().[A]*/](any/*<-a::b::Givens.sayHello().(any)*/: A/*->a::b::Givens.sayHello().[A]*/)
-    def sayHello/*<-a::b::Givens.sayHello().*/ = s"Hello, I am $any/*->a::b::Givens.sayHello().(any)*/"
+    def sayHello/*<-a::b::Givens.sayHello().*/ = s"Hello, I am $any/*->a::b::Givens.sayHello().(any)*/"/*->scala::StringContext#s().*/
 
   extension [B/*<-a::b::Givens.sayGoodbye().[B]*//*<-a::b::Givens.saySoLong().[B]*/](any/*<-a::b::Givens.sayGoodbye().(any)*//*<-a::b::Givens.saySoLong().(any)*/: B/*->a::b::Givens.sayGoodbye().[B]*//*->a::b::Givens.saySoLong().[B]*/)
-    def sayGoodbye/*<-a::b::Givens.sayGoodbye().*/ = s"Goodbye, from $any/*->a::b::Givens.sayGoodbye().(any)*/"
-    def saySoLong/*<-a::b::Givens.saySoLong().*/ = s"So Long, from $any/*->a::b::Givens.saySoLong().(any)*/"
+    def sayGoodbye/*<-a::b::Givens.sayGoodbye().*/ = s"Goodbye, from $any/*->a::b::Givens.sayGoodbye().(any)*/"/*->scala::StringContext#s().*/
+    def saySoLong/*<-a::b::Givens.saySoLong().*/ = s"So Long, from $any/*->a::b::Givens.saySoLong().(any)*/"/*->scala::StringContext#s().*/
 
   val hello1/*<-a::b::Givens.hello1.*/ = 1.sayHello/*->a::b::Givens.sayHello().*/
   val goodbye1/*<-a::b::Givens.goodbye1.*/ = 1.sayGoodbye/*->a::b::Givens.sayGoodbye().*/

--- a/tests/semanticdb/expect/ImplicitConversion.expect.scala
+++ b/tests/semanticdb/expect/ImplicitConversion.expect.scala
@@ -21,10 +21,10 @@ class ImplicitConversion/*<-example::ImplicitConversion#*/ {
   val x/*<-example::ImplicitConversion#x.*/: Int/*->scala::Int#*/ = message/*->example::ImplicitConversion#message.*/
 
   // interpolators
-  s"Hello $message/*->example::ImplicitConversion#message.*/ $number/*->example::ImplicitConversion#number.*/"
+  s"Hello $message/*->example::ImplicitConversion#message.*/ $number/*->example::ImplicitConversion#number.*/"/*->scala::StringContext#s().*/
   s"""Hello
      |$message/*->example::ImplicitConversion#message.*/
-     |$number/*->example::ImplicitConversion#number.*/""".stripMargin/*->scala::collection::StringOps#stripMargin(+1).*/
+     |$number/*->example::ImplicitConversion#number.*/"""/*->scala::StringContext#s().*/.stripMargin/*->scala::collection::StringOps#stripMargin(+1).*/
 
   val a/*<-example::ImplicitConversion#a.*/: Int/*->scala::Int#*/ = char/*->example::ImplicitConversion#char.*/
   val b/*<-example::ImplicitConversion#b.*/: Long/*->scala::Long#*/ = char/*->example::ImplicitConversion#char.*/

--- a/tests/semanticdb/expect/Imports.expect.scala
+++ b/tests/semanticdb/expect/Imports.expect.scala
@@ -1,1 +1,4 @@
 import scala.util.control.NonFatal/*->scala::util::control::NonFatal.*/
+import scala.collection.immutable.{HashMap/*->scala::collection::immutable::HashMap.*//*->scala::collection::immutable::HashMap#*/ as HM}
+
+val m/*<-_empty_::Imports$package.m.*/: HM/*->scala::collection::immutable::HashMap#*/[Int/*->scala::Int#*/, Int/*->scala::Int#*/] = HM/*->scala::collection::immutable::HashMap.*/[Int/*->scala::Int#*/, Int/*->scala::Int#*/]()

--- a/tests/semanticdb/expect/Imports.scala
+++ b/tests/semanticdb/expect/Imports.scala
@@ -1,1 +1,4 @@
 import scala.util.control.NonFatal
+import scala.collection.immutable.{HashMap as HM}
+
+val m: HM[Int, Int] = HM[Int, Int]()

--- a/tests/semanticdb/expect/Synthetic.expect.scala
+++ b/tests/semanticdb/expect/Synthetic.expect.scala
@@ -30,7 +30,7 @@ class Synthetic/*<-example::Synthetic#*/ {
     null.asInstanceOf/*->scala::Any#asInstanceOf().*/[Int/*->scala::Int#*/ => Int/*->scala::Int#*/](2)
   }
 
-  class J/*<-example::Synthetic#J#*/[T/*<-example::Synthetic#J#[T]*//*<-example::Synthetic#J#evidence$1.*/: Manifest/*->scala::Predef.Manifest#*/] { val arr/*<-example::Synthetic#J#arr.*/ = Array/*->scala::Array.*/.empty/*->scala::Array.empty().*/[T/*->example::Synthetic#J#[T]*/]/*->example::Synthetic#J#evidence$1.*/ }
+  class J/*<-example::Synthetic#J#*/[T/*<-example::Synthetic#J#[T]*//*<-example::Synthetic#J#evidence$1.*/: Manifest/*->scala::Predef.Manifest#*/] { val arr/*<-example::Synthetic#J#arr.*/ = Array/*->scala::Array.*/.empty/*->scala::Array.empty().*/[T/*->example::Synthetic#J#[T]*/] }
 
   class F/*<-example::Synthetic#F#*/
   implicit val ordering/*<-example::Synthetic#ordering.*/: Ordering/*->scala::package.Ordering#*/[F/*->example::Synthetic#F#*/] = ???/*->scala::Predef.`???`().*/

--- a/tests/semanticdb/expect/Vals.expect.scala
+++ b/tests/semanticdb/expect/Vals.expect.scala
@@ -47,5 +47,5 @@ object ValUsages/*<-example::ValUsages.*/ {
   println/*->scala::Predef.println(+1).*/(v/*->example::ValUsages.v.*/.xzm/*->example::Vals#xzm.*/)
   v/*->example::ValUsages.v.*/.yfm/*->example::Vals#`yfm_=`().*/ = v/*->example::ValUsages.v.*/.xfm/*->example::Vals#xfm.*/ +/*->scala::Int#`+`(+4).*/ v/*->example::ValUsages.v.*/.yfm/*->example::Vals#yfm().*/
   v/*->example::ValUsages.v.*/.yim/*->example::Vals#`yim_=`().*/ = v/*->example::ValUsages.v.*/.xim/*->example::Vals#xim.*/ +/*->scala::Int#`+`(+4).*/ v/*->example::ValUsages.v.*/.yim/*->example::Vals#yim().*/
-  v/*->example::ValUsages.v.*/.explicitSetter = 25
+  v/*->example::ValUsages.v.*/.explicitSetter/*->example::Vals#`explicitSetter_=`().*/ = 25
 }

--- a/tests/semanticdb/expect/toplevel.expect.scala
+++ b/tests/semanticdb/expect/toplevel.expect.scala
@@ -5,4 +5,4 @@ def combine/*<-_empty_::toplevel$package.combine(+2).*/ = 0
 def foo/*<-_empty_::toplevel$package.foo().*/ = "foo"
 @main/*->scala::main#*/ def MyProgram/*<-_empty_::toplevel$package.MyProgram().*/(times/*<-_empty_::toplevel$package.MyProgram().(times)*/: Int/*->scala::Int#*/): Unit/*->scala::Unit#*/ = (1 to/*->scala::runtime::RichInt#to().*/ times/*->_empty_::toplevel$package.MyProgram().(times)*/) foreach/*->scala::collection::immutable::Range#foreach().*/ (_ => println/*->scala::Predef.println(+1).*/("hello"))
 @main/*->scala::main#*/ def readInts/*<-_empty_::toplevel$package.readInts().*/(ints/*<-_empty_::toplevel$package.readInts().(ints)*/: Int/*->scala::Int#*/*): Unit/*->scala::Unit#*/ = println/*->scala::Predef.println(+1).*/(ints/*->_empty_::toplevel$package.readInts().(ints)*/.mkString/*->scala::collection::IterableOnceOps#mkString(+1).*/(","))
-def fooRef/*<-_empty_::toplevel$package.fooRef().*/ = toplevel$package.foo/*->_empty_::toplevel$package.foo().*/
+def fooRef/*<-_empty_::toplevel$package.fooRef().*/ = toplevel$package/*->_empty_::toplevel$package.*/.foo/*->_empty_::toplevel$package.foo().*/

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -1408,7 +1408,7 @@ Uri => Givens.scala
 Text => empty
 Language => Scala
 Symbols => 29 entries
-Occurrences => 62 entries
+Occurrences => 65 entries
 
 Symbols:
 a/b/Givens. => final object Givens extends Object { self: Givens.type => +12 decls }
@@ -1450,6 +1450,7 @@ Occurrences:
 [5:21..5:22): A -> a/b/Givens.sayHello().[A]
 [6:8..6:16): sayHello <- a/b/Givens.sayHello().
 [6:34..6:37): any -> a/b/Givens.sayHello().(any)
+[6:37..6:38): " -> scala/StringContext#s().
 [8:13..8:14): B <- a/b/Givens.sayGoodbye().[B]
 [8:13..8:14): B <- a/b/Givens.saySoLong().[B]
 [8:16..8:19): any <- a/b/Givens.sayGoodbye().(any)
@@ -1458,8 +1459,10 @@ Occurrences:
 [8:21..8:22): B -> a/b/Givens.saySoLong().[B]
 [9:8..9:18): sayGoodbye <- a/b/Givens.sayGoodbye().
 [9:38..9:41): any -> a/b/Givens.sayGoodbye().(any)
+[9:41..9:42): " -> scala/StringContext#s().
 [10:8..10:17): saySoLong <- a/b/Givens.saySoLong().
 [10:37..10:40): any -> a/b/Givens.saySoLong().(any)
+[10:40..10:41): " -> scala/StringContext#s().
 [12:6..12:12): hello1 <- a/b/Givens.hello1.
 [12:17..12:25): sayHello -> a/b/Givens.sayHello().
 [13:6..13:14): goodbye1 <- a/b/Givens.goodbye1.
@@ -1514,7 +1517,7 @@ Uri => ImplicitConversion.scala
 Text => empty
 Language => Scala
 Symbols => 23 entries
-Occurrences => 48 entries
+Occurrences => 50 entries
 Synthetics => 6 entries
 
 Symbols:
@@ -1567,8 +1570,10 @@ Occurrences:
 [20:15..20:22): message -> example/ImplicitConversion#message.
 [23:11..23:18): message -> example/ImplicitConversion#message.
 [23:20..23:26): number -> example/ImplicitConversion#number.
+[23:26..23:27): " -> scala/StringContext#s().
 [25:7..25:14): message -> example/ImplicitConversion#message.
 [26:7..26:13): number -> example/ImplicitConversion#number.
+[26:15..26:16): " -> scala/StringContext#s().
 [26:17..26:28): stripMargin -> scala/collection/StringOps#stripMargin(+1).
 [28:6..28:7): a <- example/ImplicitConversion#a.
 [28:9..28:12): Int -> scala/Int#
@@ -1610,16 +1615,30 @@ Schema => SemanticDB v4
 Uri => Imports.scala
 Text => empty
 Language => Scala
-Symbols => 0 entries
-Occurrences => 4 entries
+Symbols => 2 entries
+Occurrences => 16 entries
 
 Symbols:
+_empty_/Imports$package. => final package object _empty_ extends Object { self: _empty_.type => +2 decls }
+_empty_/Imports$package.m. => val method m HashMap[Int, Int]
 
 Occurrences:
 [0:7..0:12): scala -> scala/
 [0:13..0:17): util -> scala/util/
 [0:18..0:25): control -> scala/util/control/
 [0:26..0:34): NonFatal -> scala/util/control/NonFatal.
+[1:7..1:12): scala -> scala/
+[1:13..1:23): collection -> scala/collection/
+[1:24..1:33): immutable -> scala/collection/immutable/
+[1:35..1:42): HashMap -> scala/collection/immutable/HashMap.
+[1:35..1:42): HashMap -> scala/collection/immutable/HashMap#
+[3:4..3:5): m <- _empty_/Imports$package.m.
+[3:7..3:9): HM -> scala/collection/immutable/HashMap#
+[3:10..3:13): Int -> scala/Int#
+[3:15..3:18): Int -> scala/Int#
+[3:22..3:24): HM -> scala/collection/immutable/HashMap.
+[3:25..3:28): Int -> scala/Int#
+[3:30..3:33): Int -> scala/Int#
 
 expect/InstrumentTyper.scala
 ----------------------------
@@ -2964,7 +2983,7 @@ Uri => Synthetic.scala
 Text => empty
 Language => Scala
 Symbols => 52 entries
-Occurrences => 133 entries
+Occurrences => 132 entries
 Synthetics => 21 entries
 
 Symbols:
@@ -3093,7 +3112,6 @@ Occurrences:
 [32:35..32:40): Array -> scala/Array.
 [32:41..32:46): empty -> scala/Array.empty().
 [32:47..32:48): T -> example/Synthetic#J#[T]
-[32:49..32:49): -> example/Synthetic#J#evidence$1.
 [34:8..34:9): F <- example/Synthetic#F#
 [35:15..35:23): ordering <- example/Synthetic#ordering.
 [35:25..35:33): Ordering -> scala/package.Ordering#
@@ -3311,7 +3329,7 @@ Uri => Vals.scala
 Text => empty
 Language => Scala
 Symbols => 42 entries
-Occurrences => 127 entries
+Occurrences => 128 entries
 
 Symbols:
 example/ValUsages. => final object ValUsages extends Object { self: ValUsages.type => +2 decls }
@@ -3485,6 +3503,7 @@ Occurrences:
 [48:18..48:19): v -> example/ValUsages.v.
 [48:20..48:23): yim -> example/Vals#yim().
 [49:2..49:3): v -> example/ValUsages.v.
+[49:3..49:18): .explicitSetter -> example/Vals#`explicitSetter_=`().
 
 expect/Vararg.scala
 -------------------
@@ -4609,7 +4628,7 @@ Uri => toplevel.scala
 Text => empty
 Language => Scala
 Symbols => 18 entries
-Occurrences => 42 entries
+Occurrences => 43 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -4674,6 +4693,7 @@ Occurrences:
 [6:47..6:51): ints -> _empty_/toplevel$package.readInts().(ints)
 [6:52..6:60): mkString -> scala/collection/IterableOnceOps#mkString(+1).
 [7:4..7:10): fooRef <- _empty_/toplevel$package.fooRef().
+[7:13..7:29): toplevel$package -> _empty_/toplevel$package.
 [7:30..7:33): foo -> _empty_/toplevel$package.foo().
 
 Synthetics:


### PR DESCRIPTION
fix https://github.com/lampepfl/dotty/issues/13556

Previously, we included symbols iff its name present in the source by `namePresentInSource` https://github.com/lampepfl/dotty/pull/12885/commits/fef5be020c9e7c02446772140910b9e6a03aeaa8
However, if symbols are aliased by, for example, renamed imports, there's a difference between the name of symbol and the name in source, even though they are the same symbol.

```scala
import scala.collection.immutable.{HashMap as HM}

// namePresentInSource for `HM` will be false,
// because the symbol name is `HashMap` whereas the name in the source is `HM`
val s: HM[Int, Int] = ...
```

We really need to exclude the symbols that never appear in the source and the gap between symbol name and name in the source should be acceptable. Therefore, this commit tries to exclude a symbol using `isZeroExtent` instead of `namePresentInSource` Actually, the diff looks fine.