### PR TITLE
Fix couple links in experimental features overview

### DIFF
--- a/docs/docs/reference/experimental/overview.md
+++ b/docs/docs/reference/experimental/overview.md
@@ -11,8 +11,8 @@ They are enabled by importing the feature or using the `-language` compiler flag
 
 * [`erasedDefinitions`](./erased-defs.md): Enable support for `erased` modifier.
 * `fewerBraces`: Enable support for using indentation for arguments.
-* [`genericNumberLiterals`](../numeric-literals.md): Enable support for generic number literals.
-* [`namedTypeArguments`](../named-typeargs.md): Enable support for named type arguments
+* [`genericNumberLiterals`](./numeric-literals.md): Enable support for generic number literals.
+* [`namedTypeArguments`](./named-typeargs.md): Enable support for named type arguments
 
 ### Experimental language imports
 


### PR DESCRIPTION
The links went to `docs/docs/reference/foo.md` instead of `docs/docs/reference/experimental/foo.md`.