### PR TITLE
fix 13618 - undo windows wildcard classpath globbing

### DIFF
--- a/compiler/src/dotty/tools/MainGenericRunner.scala
+++ b/compiler/src/dotty/tools/MainGenericRunner.scala
@@ -105,7 +105,7 @@ object MainGenericRunner {
     case "-run" :: fqName :: tail =>
       process(tail, settings.withExecuteMode(ExecuteMode.Run).withTargetToRun(fqName))
     case ("-cp" | "-classpath" | "--class-path") :: cp :: tail =>
-      val globdir = cp.replaceAll("[\\/][^\\/]*$", "") // slash/backslash agnostic
+      val globdir = cp.replaceAll("[\\\\/][^\\\\/]*$", "") // slash/backslash agnostic
       val (tailargs, cpstr) = if globdir.nonEmpty && classpathSeparator != ";" || cp.contains(classpathSeparator) then
         (tail, cp)
       else
@@ -204,16 +204,15 @@ object MainGenericRunner {
         val targetScript = Paths.get(settings.targetScript).toFile
         val targetJar = settings.targetScript.replaceAll("[.][^\\/]*$", "")+".jar"
         val precompiledJar = Paths.get(targetJar).toFile
-        def mainClass = Jar(targetJar).mainClass.getOrElse("") // throws exception if file not found
-        val jarIsValid = precompiledJar.isFile && mainClass.nonEmpty && precompiledJar.lastModified >= targetScript.lastModified
+        val mainClass = if !precompiledJar.isFile then "" else Jar(targetJar).mainClass.getOrElse("")
+        val jarIsValid = mainClass.nonEmpty && precompiledJar.lastModified >= targetScript.lastModified
         if jarIsValid then
           // precompiledJar exists, is newer than targetScript, and manifest defines a mainClass
           sys.props("script.path") = targetScript.toPath.toAbsolutePath.normalize.toString
           val scalaClasspath = ClasspathFromClassloader(Thread.currentThread().getContextClassLoader).split(classpathSeparator)
           val newClasspath = (settings.classPath.flatMap(_.split(classpathSeparator).filter(_.nonEmpty)) ++ removeCompiler(scalaClasspath) :+ ".").map(File(_).toURI.toURL)
-          val mc = mainClass
-          if mc.nonEmpty then
-            ObjectRunner.runAndCatch(newClasspath :+ File(targetJar).toURI.toURL, mc, settings.scriptArgs)
+          if mainClass.nonEmpty then
+            ObjectRunner.runAndCatch(newClasspath :+ File(targetJar).toURI.toURL, mainClass, settings.scriptArgs)
           else
             Some(IllegalArgumentException(s"No main class defined in manifest in jar: $precompiledJar"))
         else

--- a/compiler/src/dotty/tools/MainGenericRunner.scala
+++ b/compiler/src/dotty/tools/MainGenericRunner.scala
@@ -106,14 +106,14 @@ object MainGenericRunner {
       process(tail, settings.withExecuteMode(ExecuteMode.Run).withTargetToRun(fqName))
     case ("-cp" | "-classpath" | "--class-path") :: cp :: tail =>
       val globdir = cp.replaceAll("[\\\\/][^\\\\/]*$", "") // slash/backslash agnostic
-      val (tailargs, cpstr) = if globdir.nonEmpty && classpathSeparator != ";" || cp.contains(classpathSeparator) then
-        (tail, cp)
-      else
-        // combine globbed classpath entries into a classpath
+      val (tailargs, cpstr) = if globdir.nonEmpty && !cp.contains(classpathSeparator) then
+        // globdir is wildcard directory for globbed jar files, reconstruct the intended classpath
         val jarfiles = cp :: tail
         val cpfiles = jarfiles.takeWhile( f => f.startsWith(globdir) && ((f.toLowerCase.endsWith(".jar") || f.endsWith(".zip"))) )
         val tailargs = jarfiles.drop(cpfiles.size)
         (tailargs, cpfiles.mkString(classpathSeparator))
+      else
+        (tail, cp)
         
       process(tailargs, settings.copy(classPath = settings.classPath ++ cpstr.split(classpathSeparator).filter(_.nonEmpty)))
 

--- a/compiler/src/dotty/tools/MainGenericRunner.scala
+++ b/compiler/src/dotty/tools/MainGenericRunner.scala
@@ -106,7 +106,7 @@ object MainGenericRunner {
       process(tail, settings.withExecuteMode(ExecuteMode.Run).withTargetToRun(fqName))
     case ("-cp" | "-classpath" | "--class-path") :: cp :: tail =>
       val cpEntries = cp.split(classpathSeparator).toList
-      val singleEntryClasspath: Boolean = cpEntries.nonEmpty && cpEntries.drop(1).isEmpty
+      val singleEntryClasspath: Boolean = cpEntries.take(2).size == 1
       val globdir: String = if singleEntryClasspath then cp.replaceAll("[\\\\/][^\\\\/]*$", "") else "" // slash/backslash agnostic
       def validGlobbedJar(s: String): Boolean = s.startsWith(globdir) && ((s.toLowerCase.endsWith(".jar") || s.toLowerCase.endsWith(".zip")))
       val (tailargs, newEntries) = if singleEntryClasspath && validGlobbedJar(cpEntries.head) then
@@ -243,22 +243,4 @@ object MainGenericRunner {
     e.foreach(_.printStackTrace())
     !isFailure
   }
-
-  def display(settings: Settings)= Seq(
-    s"verbose: ${settings.verbose}",
-    s"classPath: ${settings.classPath.mkString("\n  ","\n  ","")}",
-    s"executeMode: ${settings.executeMode}",
-    s"exitCode: ${settings.exitCode}",
-    s"javaArgs: ${settings.javaArgs}",
-    s"scalaArgs: ${settings.scalaArgs}",
-    s"residualArgs: ${settings.residualArgs}",
-    s"possibleEntryPaths: ${settings.possibleEntryPaths}",
-    s"scriptArgs: ${settings.scriptArgs}",
-    s"targetScript: ${settings.targetScript}",
-    s"targetToRun: ${settings.targetToRun}",
-    s"save: ${settings.save}",
-    s"modeShouldBePossibleRun: ${settings.modeShouldBePossibleRun}",
-    s"modeShouldBeRun: ${settings.modeShouldBeRun}",
-    s"compiler: ${settings.compiler}",
-  )
 }

--- a/compiler/test-resources/scripting/unglobClasspath.sc
+++ b/compiler/test-resources/scripting/unglobClasspath.sc
@@ -1,0 +1,8 @@
+#!bin/scala -classpath 'dist/target/pack/lib/*'
+
+// won't compile unless the hashbang line sets classpath
+import org.jline.terminal.Terminal
+
+def main(args: Array[String]) =
+  val cp = sys.props("java.class.path")
+  printf("unglobbed classpath: %s\n", cp)

--- a/compiler/test/dotty/tools/scripting/BashScriptsTests.scala
+++ b/compiler/test/dotty/tools/scripting/BashScriptsTests.scala
@@ -97,11 +97,13 @@ class BashScriptsTests:
     printf("===> verify SCALA_OPTS='@argsfile' is properly handled by `dist/bin/scala`\n")
     val envPairs = List(("SCALA_OPTS", s"@$argsfile"))
     val (validTest, exitCode, stdout, stderr) = bashCommand(scriptFile.absPath, envPairs)
+    printf("stdout: %s\n", stdout.mkString("\n","\n",""))
     if validTest then
-      val expected = s"${workingDirectory.toString}"
-      val List(line1: String, line2: String) = stdout.take(2)
-      printf("line1 [%s]\n", line1)
-      val valid = line2.dropWhile( _ != ' ').trim.startsWith(expected)
+      val expected = s"${workingDirectory.norm}"
+      val output = stdout.find( _.trim.startsWith("cwd") ).getOrElse("").dropWhile(_!=' ').trim
+      printf("output  [%s]\n", output)
+      printf("expected[%s]\n", expected)
+      val valid = output.startsWith(expected)
       if valid then printf(s"\n===> success: classpath begins with %s, as reported by [%s]\n", workingDirectory, scriptFile.getName)
       assert(valid, s"script ${scriptFile.absPath} did not report valid java.class.path first entry")
 

--- a/compiler/test/dotty/tools/scripting/ClasspathTests.scala
+++ b/compiler/test/dotty/tools/scripting/ClasspathTests.scala
@@ -50,10 +50,12 @@ class ClasspathTests:
       val hashbangClasspathJars = scriptCp.split(psep).map { _.getName }.sorted.distinct
       val packlibJars = listJars(s"$scriptCwd/$packLibDir").sorted.distinct
      
+      printf("%d jar files in dist/target/pack/lib\n", packlibJars.size)
+      printf("%d test script jars in classpath\n", hashbangClasspathJars.size)
+
       // verify that the classpath set in the hashbang line is effective
       if hashbangClasspathJars.size != packlibJars.size then
-        printf("%d test script jars in classpath\n", hashbangClasspathJars.size)
-        printf("%d jar files in dist/target/pack/lib\n", packlibJars.size)
+        printf("hashbangClasspathJars: %s\n", hashbangClasspathJars.mkString("\n ", "\n ", ""))
 
       assert(hashbangClasspathJars.size == packlibJars.size)
   }

--- a/compiler/test/dotty/tools/scripting/ScriptingTests.scala
+++ b/compiler/test/dotty/tools/scripting/ScriptingTests.scala
@@ -19,7 +19,7 @@ class ScriptingTests:
     f.getAbsolutePath.replace('\\', '/')
 
   // classpath tests managed by scripting.ClasspathTests.scala
-  def testFiles = scripts("/scripting").filter { ! _.getName.startsWith("classpath") }
+  def testFiles = scripts("/scripting").filter { ! _.getName.toLowerCase.contains("classpath") }
 
   def script2jar(scriptFile: File) = 
     val jarName = s"${scriptFile.getName.dropExtension}.jar"


### PR DESCRIPTION
@BarkingBad 
This is the fix referred to in #13618, and discussed at the tail end of #13562.

The error output generated by the compiler by this problem can be simulated before this fix by the following command line (notice that there are no quotes around the wildcard classpath entry):

```scala
bin/scala -classpath dist/target/pack/lib/* compiler/test-resources/scripting/unglobClasspath.sc >test.out 2>&1
```

To verify the fix, a new test is added to [ClasspathTests](https://github.com/lampepfl/dotty/blob/5455902d9e4d6b8ca712e4c62e9771640029927d/compiler/test/dotty/tools/scripting/ClasspathTests.scala).