### PR TITLE
Fix variable handling in super calls

### DIFF
--- a/tests/neg/i11045.scala
+++ b/tests/neg/i11045.scala
@@ -1,5 +1,0 @@
-abstract class Foo(x: Any)
-class Boom(var x: Unit, y: Unit) extends Foo((x: Int) => x) // error: super constructor cannot be passed a self reference
-@main def Test =
-  Boom((), ())
-

--- a/tests/run/i11045.scala
+++ b/tests/run/i11045.scala
@@ -1,0 +1,5 @@
+abstract class Foo(x: Any)
+class Boom(var x: Unit, y: Unit) extends Foo((x: Int) => x) // was error: super constructor cannot be passed a self reference
+@main def Test =
+  Boom((), ())
+

--- a/tests/run/i13630.check
+++ b/tests/run/i13630.check
@@ -1,0 +1,1 @@
+it worked

--- a/tests/run/i13630.scala
+++ b/tests/run/i13630.scala
@@ -1,0 +1,9 @@
+class ClassWithLambda(sup: () => Long)
+class ClassWithVar(var msg: String) extends ClassWithLambda(() => 1)
+
+object Test:
+  val _ = new ClassWithVar("foo")
+
+  def main(args: Array[String]): Unit = {
+    println("it worked")
+  }


### PR DESCRIPTION
Accesses to var parameters in super calls need to refer to the constructor
parameter, not the getter.

Fixes #13630