### PR TITLE
Allow using clauses to introduce Scala-2 conversions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1041,9 +1041,13 @@ trait Implicits:
           adapt(generated, pt.widenExpr, locked)
         else {
           def untpdGenerated = untpd.TypedSplice(generated)
+          def producesConversion(info: Type): Boolean = info match
+            case info: PolyType => producesConversion(info.resType)
+            case info: MethodType if info.isImplicitMethod => producesConversion(info.resType)
+            case _ => info.derivesFrom(defn.ConversionClass)
           def tryConversion(using Context) = {
             val untpdConv =
-              if (ref.symbol.is(Given))
+              if ref.symbol.is(Given) && producesConversion(ref.symbol.info) then
                 untpd.Select(
                   untpd.TypedSplice(
                     adapt(generated,

--- a/tests/pos/i12955.scala
+++ b/tests/pos/i12955.scala
@@ -1,0 +1,2 @@
+def test[A, B](using c: A <:< B) =
+  val b: B = ??? : A


### PR DESCRIPTION
Notably, `(using A <:< B)` should introduce an implicit conversion.
Previously that did not work since we tried to elaborate the context
parameter as a `scala.Conversion`.