### PR TITLE
Remember compared polytypes

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -45,7 +45,7 @@ class CommunityBuildTestB:
   @Test def fs2 = projects.fs2.run()
   @Test def munit = projects.munit.run()
   @Test def munitCatsEffect = projects.munitCatsEffect.run()
-  // @Test def perspective = projects.perspective.run()
+  @Test def perspective = projects.perspective.run()
   @Test def scalacheckEffect = projects.scalacheckEffect.run()
   @Test def scodec = projects.scodec.run()
   @Test def scodecBits = projects.scodecBits.run()

--- a/tests/pos/i13660.scala
+++ b/tests/pos/i13660.scala
@@ -1,0 +1,15 @@
+type Const[A] = [_] =>> A
+type FunctionK[A[_], B[_]] = [Z] => A[Z] => B[Z]
+
+type #~>#:[T, R] = FunctionK[Const[T], Const[R]]
+
+object FunctionK:
+  def liftConst[A, B](f: A => B): /*FunctionK[Const[A], Const[B]]*/ A #~>#: B =
+    [Z1] => (a: A) => f(a)
+
+trait FoldableK[F[_[_], _]]:
+
+  def foldMapK1[A[_], C, B](fa: F[A, C])(f: FunctionK[A, Const[B]]): B
+
+  def toListK[A, C](fa: F[Const[A], C]): List[A] =
+    foldMapK1(fa)(FunctionK.liftConst(List(_: A)))

--- a/tests/pos/i7888.scala
+++ b/tests/pos/i7888.scala
@@ -1,0 +1,8 @@
+def usingSeq[B](f: [A] => Seq[A] => B): B = {
+  f(Nil)
+}
+def crash() = {
+  usingSeq { [A] => (a: Seq[A]) =>
+    a
+  }
+}


### PR DESCRIPTION
Remember comparisons of PolyTypes in `comparedTypeLambdas`. This means that parameters
of such types will not be added to the constraint as parts of bounds. We already do the same for
HkTypeLambdas but for some reason we forgot to do it for PolyTypes, which are the other kind of type 
lambdas.

Fixes #13660
Fixes #7888

Allows perspective to be re-enabled in CB