### PR TITLE
Don't lose paramSyms when unpickling from Scala 2

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -847,6 +847,12 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         val maker = MethodType.companion(
           isImplicit = tag == IMPLICITMETHODtpe || params.nonEmpty && params.head.is(Implicit))
         val result = maker.fromSymbols(params, restpe)
+        result.resType match
+          case restpe1: MethodType if restpe1 ne restpe =>
+            val prevResParams = paramsOfMethodType.remove(restpe)
+            if prevResParams != null then
+              paramsOfMethodType.put(restpe1, prevResParams)
+          case _ =>
         if params.nonEmpty then paramsOfMethodType.put(result, params)
         result
       case POLYtpe =>

--- a/sbt-test/compilerReporter/simple/project/Reporter.scala
+++ b/sbt-test/compilerReporter/simple/project/Reporter.scala
@@ -24,7 +24,7 @@ object Reporter {
 
   lazy val checkSettings = Seq(
     Compile / compile / compilerReporter := reporter,
-    check := (compile in Compile).failure.map(_ => {
+    check := (Compile / compile).failure.map(_ => {
       val problems = reporter.problems
       println(problems.toList)
       assert(problems.size == 1)

--- a/sbt-test/scala2-compat/i13238/app/App.scala
+++ b/sbt-test/scala2-compat/i13238/app/App.scala
@@ -1,0 +1,5 @@
+package app
+
+import lib.*
+
+def boom(foo: Foo) = foo.foo(foo) // error: no implicit argument of type lib.Bar was found for parameter bar of method foo in class Foo

--- a/sbt-test/scala2-compat/i13238/build.sbt
+++ b/sbt-test/scala2-compat/i13238/build.sbt
@@ -1,0 +1,14 @@
+val scala3Version = sys.props("plugin.scalaVersion")
+val scala2Version = sys.props("plugin.scala2Version")
+
+lazy val lib = project.in(file("lib"))
+  .settings(
+    scalaVersion := scala2Version
+  )
+
+lazy val app = project.in(file("app"))
+  .dependsOn(lib)
+  .settings(Reporter.checkSettings)
+  .settings(
+    scalaVersion := scala3Version
+  )

--- a/sbt-test/scala2-compat/i13238/lib/Lib.scala
+++ b/sbt-test/scala2-compat/i13238/lib/Lib.scala
@@ -1,0 +1,6 @@
+package lib
+
+trait Bar
+class Foo {
+  def foo(out: Foo)(implicit bar: Bar): out.type = out
+}

--- a/sbt-test/scala2-compat/i13238/project/Reporter.scala
+++ b/sbt-test/scala2-compat/i13238/project/Reporter.scala
@@ -5,7 +5,7 @@ import KeyRanks.DTask
 object Reporter {
   import xsbti.{Reporter, Problem, Position, Severity}
 
-  lazy val check = TaskKey[Unit]("check", "make sure compilation info are forwared to sbt")
+  lazy val check = TaskKey[Unit]("check", "Check compilation output")
 
   // compilerReporter is marked private in sbt
   lazy val compilerReporter = TaskKey[xsbti.Reporter]("compilerReporter", "Experimental hook to listen (or send) compilation failure messages.", DTask)
@@ -25,18 +25,9 @@ object Reporter {
   lazy val checkSettings = Seq(
     Compile / compile / compilerReporter := reporter,
     check := (Compile / compile).failure.map(_ => {
-      println(reporter.problems.toList)
-      assert(reporter.problems.length == 1)
-      val problem = reporter.problems.head
-      // Check that all methods on position can ba called without crashing
-      val pos = problem.position
-      println(pos.sourceFile)
-      println(pos.sourcePath)
-      println(pos.line)
-      println(pos.lineContent)
-      println(pos.offset)
-      println(pos.pointer)
-      println(pos.pointerSpace)
+      val problems = reporter.problems
+      assert(problems.size == 1, problems.size)
+      assert(problems.head.position.line.get() == 5, problems.head.position.line)
     }).value
   )
 }

--- a/sbt-test/scala2-compat/i13238/test
+++ b/sbt-test/scala2-compat/i13238/test
@@ -1,0 +1,2 @@
+> lib/compile
+> app/check


### PR DESCRIPTION
We could lose them for curried methods since the nested method type was copied
in case there was a depencency on a parameter of the first method type.

Fixes #13238