### PR TITLE
relax requirements for recognizing valid scala hashbang lines - fix for #13670

### DIFF
--- a/compiler/src/dotty/tools/MainGenericRunner.scala
+++ b/compiler/src/dotty/tools/MainGenericRunner.scala
@@ -146,7 +146,8 @@ object MainGenericRunner {
       process(tail, settings.withScalaArgs(o))
     case arg :: tail =>
       val line = Try(Source.fromFile(arg).getLines.toList).toOption.flatMap(_.headOption)
-      if arg.endsWith(".scala") || arg.endsWith(".sc") || (line.nonEmpty && raw"#!.*scala".r.matches(line.get)) then
+      lazy val hasScalaHashbang = { val s = line.getOrElse("") ; s.startsWith("#!") && s.contains("scala") }
+      if arg.endsWith(".scala") || arg.endsWith(".sc") || hasScalaHashbang then
         settings
           .withExecuteMode(ExecuteMode.Script)
           .withTargetScript(arg)


### PR DESCRIPTION
This PR changes the current strict requirement that a hashbang line MUST end with "scala" in order to be recognized as a valid scala script.

The problem will only manifested if the script filename extension is neither `.scala` nor `.sc`, and the hashbang line has characters following "scala".

For example, if the hashbang line also provides a -classpath argument following "scala", the script name is not recognized as a valid script, and the REPL is entered.

Example:
A valid scala script named `finder` with these contents:
```scala
#!/usr/bin/env scala -classpath "/opt/lib/find.jar"
import foo.bar
def main(args: Array[String]): Unit =
  bar.finder(args)
```
Rather than executing the script, the current behavior is to enter the REPL.

The proposed fix is to consider a file to be a valid scala script if the first line of the file has these features:

1. the line starts with "#!"
2. the line contains the string "scala"

Although a workaround is to rename the file (e.g., to `finder.sc` rather than `finder`), this is restricive, because it prevents scala scripts from from shadowing command line tools written in other languages.

This regression was introduced after `scala3-3.0.2`.