### PR TITLE
Fix broken lookups

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/DocRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/DocRenderer.scala
@@ -66,7 +66,7 @@ class DocRender(signatureRenderer: SignatureRenderer)(using DocContext):
     case Superscript(text) => span(cls:="superscript")(renderElement(text))  // TODO implement style
     case Subscript(text) => span(cls:="subscript")(renderElement(text))  // TODO implement style
     case Link(target, body) =>
-      renderLink(target, default => body.fold[TagArg](text(default))(renderElement))
+      renderLink(target, default => body.fold[TagArg](default)(renderElement))
     case Text(text) => raw(text)
     case Summary(text) => renderElement(text)
     case HtmlTag(content) => raw(content)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
@@ -193,7 +193,7 @@ trait MemberLookup {
           case Some(sym) =>
             val externalOwner: Option[reflect.Symbol] =
               if owner eq sym.owner then None
-              else if owner.flags.is(Flags.Module) then Some(owner.moduleClass)
+              else if owner.flags.is(Flags.Module) && !owner.flags.is(Flags.Package) then Some(owner.moduleClass)
               else if owner.isClassDef then Some(owner)
               else None
             Some(sym -> externalOwner)


### PR DESCRIPTION
This PR fixes:
- double escaping in links resulting in wrong presentation, e. g: `scala.<:<`
- wrong lookups for some links, e. g. `[[ <.< ]]`