### PR TITLE
Do not perform completion on higher kinded trees

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -114,11 +114,12 @@ object Completion {
     val completions = path match {
         // Ignore synthetic select from `This` because in code it was `Ident`
         // See example in dotty.tools.languageserver.CompletionTest.syntheticThis
-        case Select(qual @ This(_), _) :: _ if qual.span.isSynthetic => completer.scopeCompletions
-        case Select(qual, _) :: _                                    => completer.selectionCompletions(qual)
-        case Import(expr, _) :: _                                    => completer.directMemberCompletions(expr)
-        case (_: untpd.ImportSelector) :: Import(expr, _) :: _       => completer.directMemberCompletions(expr)
-        case _                                                       => completer.scopeCompletions
+        case Select(qual @ This(_), _) :: _ if qual.span.isSynthetic   => completer.scopeCompletions
+        case Select(qual, _) :: _           if !qual.tpe.hasSimpleKind => Map.empty
+        case Select(qual, _) :: _                                      => completer.selectionCompletions(qual)
+        case Import(expr, _) :: _                                      => completer.directMemberCompletions(expr)
+        case (_: untpd.ImportSelector) :: Import(expr, _) :: _         => completer.directMemberCompletions(expr)
+        case _                                                         => completer.scopeCompletions
       }
 
     val describedCompletions = describeCompletions(completions)

--- a/compiler/test/dotty/tools/dotc/interactive/CustomCompletionTests.scala
+++ b/compiler/test/dotty/tools/dotc/interactive/CustomCompletionTests.scala
@@ -169,3 +169,21 @@ class CustomCompletionTests extends DottyTest:
 
       assert(offset == prefix.length)
       assert(labels.contains("scala.Function2"))
+
+   @Test def i12465_hkt(): Unit =
+      val prefix = "???.asInstanceOf[scala.collection.Seq]"
+      val input = prefix + "."
+
+      val (offset, completions0) = completions(input)
+      val labels = completions0.map(_.label)
+
+      assert(labels.isEmpty)
+
+   @Test def i12465_hkt_alias(): Unit =
+      val prefix = "???.asInstanceOf[Seq]"
+      val input = prefix + "."
+
+      val (offset, completions0) = completions(input)
+      val labels = completions0.map(_.label)
+
+      assert(labels.isEmpty)


### PR DESCRIPTION
This solution was developed during the 6th issue spree in the collaboration of @ghostbuster91 @KacperFKorban and Mark T. Kennedy.

We followed suggestion from @anatoliykmetyuk that invalid trees as `???.asInstanceOf[Seq]` which would result in compilation error when submitted in repl shouldn't provide any completions.

Proposed solution behaves consistently both for `???.asInstanceOf[Seq]` and `???.asInstanceOf[scala.collection.Seq]` giving zero completions.

This closes #12465


 
