### PR TITLE
Fix encoding of setters on anonymous classes with structural types

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3894,6 +3894,9 @@ object Parsers {
       val stats = new ListBuffer[Tree]
       def checkLegal(tree: Tree): List[Tree] =
         val problem = tree match
+          case tree: ValDef if tree.mods.is(Mutable) =>
+            i"""refinement cannot be a mutable var.
+               |You can use an explicit getter ${tree.name} and setter ${tree.name}_= instead"""
           case tree: MemberDef if !(tree.mods.flags & ModifierFlags).isEmpty =>
             i"refinement cannot be ${(tree.mods.flags & ModifierFlags).flagStrings().mkString("`", "`, `", "`")}"
           case tree: DefDef if tree.termParamss.nestedExists(!_.rhs.isEmpty) =>

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -186,7 +186,7 @@ trait Dynamic {
       val base =
         untpd.Apply(
           untpd.TypedSplice(selectable.select(selectorName)).withSpan(fun.span),
-          (Literal(Constant(name.toString)) :: Nil).map(untpd.TypedSplice(_)))
+          (Literal(Constant(name.encode.toString)) :: Nil).map(untpd.TypedSplice(_)))
 
       val scall =
         if (vargss.isEmpty) base

--- a/tests/neg/i13703.check
+++ b/tests/neg/i13703.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg/i13703.scala:3:17 ----------------------------------------------------------------------------------
+3 |val f: Foo { var i: Int } = new Foo { var i: Int = 0 } // error
+  |             ^^^^^^^^^^
+  |             refinement cannot be a mutable var.
+  |             You can use an explicit getter i and setter i_= instead

--- a/tests/neg/i13703.scala
+++ b/tests/neg/i13703.scala
@@ -1,0 +1,5 @@
+trait Foo extends reflect.Selectable
+
+val f: Foo { var i: Int } = new Foo { var i: Int = 0 } // error
+
+val f2: Foo { val i: Int; def i_=(x: Int): Unit } = new Foo { var i: Int = 0 } // OK

--- a/tests/run/i13703.scala
+++ b/tests/run/i13703.scala
@@ -1,0 +1,5 @@
+trait Foo extends reflect.Selectable
+
+@main def Test: Unit =
+  val f = new Foo { var i: Int = 0 }
+  f.i = 1


### PR DESCRIPTION
Also improve error message when a `var` appears in a refinement.

Fixes #13703