### PR TITLE
Handle Java varargs `T...` where `T` is a class parameter

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -376,18 +376,18 @@ class Definitions {
    *       <T> void meth8(T... args) {}
    *
    *       // B.scala
-   *       meth7(1) // OK
-   *       meth8(1) // OK
+   *       meth7(1) // OK (creates a reference array)
+   *       meth8(1) // OK (creates a primitive array and copies it into a reference array at Erasure)
    *       val ai = Array[Int](1)
-   *       meth7(ai: _*) // OK (will copy the array)
-   *       meth8(ai: _*) // OK (will copy the array)
+   *       meth7(ai: _*) // OK (will copy the array at Erasure)
+   *       meth8(ai: _*) // OK (will copy the array at Erasure)
    *
    *     Java repeated arguments are erased to arrays, so it would be safe to treat
    *     them in the same way: add an `& Object` to the parameter type to disallow
    *     passing primitives, but that would be very inconvenient as it is common to
    *     want to pass a primitive to an Object repeated argument (e.g.
    *     `String.format("foo: %d", 1)`). So instead we type them _without_ adding the
-   *     `& Object` and let `ElimRepeated` take care of doing any necessary adaptation
+   *     `& Object` and let `ElimRepeated` and `Erasure` take care of doing any necessary adaptation
    *     (note that adapting a primitive array to a reference array requires
    *     copying the whole array, so this transformation only preserves semantics
    *     if the callee does not try to mutate the varargs array which is a reasonable

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -299,7 +299,8 @@ object Types {
       loop(this)
     }
 
-    def isFromJavaObject(using Context): Boolean = typeSymbol eq defn.FromJavaObjectSymbol
+    def isFromJavaObject(using Context): Boolean =
+      isRef(defn.ObjectClass) && (typeSymbol eq defn.FromJavaObjectSymbol)
 
     def containsFromJavaObject(using Context): Boolean = this match
       case tp: OrType => tp.tp1.containsFromJavaObject || tp.tp2.containsFromJavaObject

--- a/tests/run/java-varargs-3/A.java
+++ b/tests/run/java-varargs-3/A.java
@@ -1,0 +1,14 @@
+class A<S> {
+  public void gen(S... args) {
+  }
+
+  public <T extends S> void gen2(S... args) {
+  }
+}
+class B<S extends java.io.Serializable> {
+  public void gen(S... args) {
+  }
+
+  public <T extends S> void gen2(S... args) {
+  }
+}

--- a/tests/run/java-varargs-3/Test.scala
+++ b/tests/run/java-varargs-3/Test.scala
@@ -1,0 +1,19 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val ai = new A[Int]
+    ai.gen(1)
+    ai.gen2(1)
+    ai.gen(Array(1)*)
+    ai.gen2(Array(1)*)
+    ai.gen(Seq(1)*)
+    ai.gen2(Seq(1)*)
+
+    val b = new B[String]
+    b.gen("")
+    b.gen2("")
+    b.gen(Array("")*)
+    b.gen2(Array("")*)
+    b.gen(Seq("")*)
+    b.gen2(Seq("")*)
+  }
+}


### PR DESCRIPTION
Previously, ElimRepeated correctly handled Java varargs of the
form `Object...` and `T...` where `T` is a method parameter, in both
cases we erased them to `Array[? <: Object]` in the denotation
transformer and handled any adaptation in the tree transformer of
ElimRepeated.

Unfortunately, the denotation transformer logic failed to account for
class type parameters, and fixing it introduced issues in override
checking (RefChecks happens after ElimRepeated). So this commit gives up
and delay the adaptation of primitive arrays into reference arrays until
Erasure. This is less efficient in some situations but is closer to what
Scala 2 does so hopefully means we won't run into more pitfalls.

Fixes #13645.