### PR TITLE
Avoid cycle with top-level export and trait

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2542,6 +2542,10 @@ class Typer extends Namer
     pid1 match
       case pid1: RefTree if pkg.is(Package) =>
         inContext(ctx.packageContext(tree, pkg)) {
+          // If it exists, complete the class containing the top-level definitions
+          // before typing any statement in the package to avoid cycles as in i13669.scala
+          val topLevelClassName = desugar.packageObjectName(ctx.source).moduleClassName
+          pkg.moduleClass.info.decls.lookup(topLevelClassName).ensureCompleted()
           var stats1 = typedStats(tree.stats, pkg.moduleClass)._1
           if (!ctx.isAfterTyper)
             stats1 = stats1 ++ typedBlockStats(MainProxies.mainProxies(stats1))._1

--- a/tests/pos/i13669.scala
+++ b/tests/pos/i13669.scala
@@ -1,0 +1,6 @@
+trait MyExtensions:
+  extension (lhs: Int) def bash: Unit = {}
+object MyExtensions extends MyExtensions
+
+export MyExtensions.*
+val fails = 1.bash


### PR DESCRIPTION
Previously, the following lead to a cycle (typing the extension method
requires typing its `Int` parameter, which forces completion of the
package object containing the top-level definition, which forces
completion of the extension method via the export clause):

```scala
trait MyExtensions:
  extension (lhs: Int) def bash: Unit = {}
object MyExtensions extends MyExtensions

export MyExtensions.*
val fails = 1.bash
```

But curiously enough, simply defining `object MyExtensions` before
`trait MyExtensions` was enough to work around the issue. This happened
because typing the module val of the object forces the package object,
this in turns forces the extension method but because of the way
class completers work, this doesn't lead to a cycle.

Based on this experiment, this commit simply always forces the package
object before typing any definition in the package, so we don't run into
a cycle no matter the order in which definitions appear.