### PR TITLE
Fix error message when "import given" is missing

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -876,7 +876,8 @@ trait Implicits:
     def ignoredInstanceNormalImport = arg.tpe match
       case fail: SearchFailureType =>
         if (fail.expectedType eq pt) || isFullyDefined(fail.expectedType, ForceDegree.none) then
-          inferImplicit(fail.expectedType, fail.argument, arg.span) match {
+          inferImplicit(fail.expectedType, fail.argument, arg.span)(
+            using findHiddenImplicitsCtx(ctx)) match {
             case s: SearchSuccess => Some(s)
             case f: SearchFailure =>
               f.reason match {

--- a/tests/neg/hidden.check
+++ b/tests/neg/hidden.check
@@ -1,0 +1,6 @@
+-- Error: tests/neg/hidden.scala:6:13 ----------------------------------------------------------------------------------
+6 |  summon[Int] // error
+  |             ^
+  |    no implicit argument of type Int was found for parameter x of method summon in object Predef
+  |
+  |    Note: given instance given_Int in object A was not considered because it was not imported with `import given`.


### PR DESCRIPTION
`findHiddenImplicitsCtx` is necessary for the error message to contain
the line:

> Note: given instance given_Int in object A was not considered because
>  it was not imported with `import given`.

But it looks like we accidentally stopped using it in
1760da388e1ab491dc533f326e49dd12aa0e45eb, this commit restores the
previous behavior.