### PR TITLE
Fix erased context function types, 2nd attempt

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1358,6 +1358,8 @@ class Definitions {
    *    - FunctionN for 22 > N >= 0 remains as FunctionN
    *    - ContextFunctionN for N > 22 becomes FunctionXXL
    *    - ContextFunctionN for N <= 22 becomes FunctionN
+   *    - ErasedFunctionN becomes Function0
+   *    - ImplicitErasedFunctionN becomes Function0
    *    - anything else becomes a NoType
    */
   def functionTypeErasure(cls: Symbol): Type =

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1353,39 +1353,19 @@ class Definitions {
   def isBoxedUnitClass(cls: Symbol): Boolean =
     cls.isClass && (cls.owner eq ScalaRuntimePackageClass) && cls.name == tpnme.BoxedUnit
 
-  /** Returns the erased class of the function class `cls`
-   *    - FunctionN for N > 22 becomes FunctionXXL
-   *    - FunctionN for 22 > N >= 0 remains as FunctionN
-   *    - ContextFunctionN for N > 22 becomes FunctionXXL
-   *    - ContextFunctionN for N <= 22 becomes FunctionN
-   *    - ErasedFunctionN becomes Function0
-   *    - ImplicitErasedFunctionN becomes Function0
-   *    - anything else becomes a NoSymbol
-   */
-  def erasedFunctionClass(cls: Symbol): Symbol = {
-    val arity = scalaClassName(cls).functionArity
-    if (cls.name.isErasedFunction) FunctionClass(0)
-    else if (arity > 22) FunctionXXLClass
-    else if (arity >= 0) FunctionClass(arity)
-    else NoSymbol
-  }
-
   /** Returns the erased type of the function class `cls`
    *    - FunctionN for N > 22 becomes FunctionXXL
    *    - FunctionN for 22 > N >= 0 remains as FunctionN
    *    - ContextFunctionN for N > 22 becomes FunctionXXL
    *    - ContextFunctionN for N <= 22 becomes FunctionN
-   *    - ErasedFunctionN becomes Function0
-   *    - ImplicitErasedFunctionN becomes Function0
    *    - anything else becomes a NoType
    */
-  def erasedFunctionType(cls: Symbol): Type = {
+  def functionTypeErasure(cls: Symbol): Type =
     val arity = scalaClassName(cls).functionArity
-    if (cls.name.isErasedFunction) FunctionType(0)
-    else if (arity > 22) FunctionXXLClass.typeRef
-    else if (arity >= 0) FunctionType(arity)
+    if cls.name.isErasedFunction then FunctionType(0)
+    else if arity > 22 then FunctionXXLClass.typeRef
+    else if arity >= 0 then FunctionType(arity)
     else NoType
-  }
 
   val predefClassNames: Set[Name] =
     Set("Predef$", "DeprecatedPredef", "LowPriorityImplicits").map(_.toTypeName.unmangleClassName)

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -365,7 +365,7 @@ object NameKinds {
   val ExtMethName: SuffixNameKind = new SuffixNameKind(EXTMETH, "$extension")
   val ParamAccessorName: SuffixNameKind = new SuffixNameKind(PARAMACC, "$accessor")
   val ModuleClassName: SuffixNameKind = new SuffixNameKind(OBJECTCLASS, "$", optInfoString = "ModuleClass")
-  val ImplMethName: SuffixNameKind = new SuffixNameKind(IMPLMETH, "$")
+  val DirectMethName: SuffixNameKind = new SuffixNameKind(DIRECT, "$direct")
   val AdaptedClosureName: SuffixNameKind = new SuffixNameKind(ADAPTEDCLOSURE, "$adapted") { override def definesNewName = true }
   val SyntheticSetterName: SuffixNameKind = new SuffixNameKind(SETTER, "_$eq")
 

--- a/compiler/src/dotty/tools/dotc/core/NameTags.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameTags.scala
@@ -24,8 +24,9 @@ object NameTags extends TastyFormat.NameTags {
 
   final val ADAPTEDCLOSURE = 31 // Used in Erasure to adapt closures over primitive types.
 
-  final val IMPLMETH = 32       // Used to define methods in implementation classes
-                                // (can probably be removed).
+  final val DIRECT = 32         // Used to define implementations of methods with
+                                // erased context function results that can override some
+                                // other method.
 
   final val PARAMACC = 33       // Used for a private parameter alias
 
@@ -48,7 +49,7 @@ object NameTags extends TastyFormat.NameTags {
     case INITIALIZER => "INITIALIZER"
     case FIELD => "FIELD"
     case EXTMETH => "EXTMETH"
-    case IMPLMETH => "IMPLMETH"
+    case DIRECT => "DIRECT"
     case PARAMACC => "PARAMACC"
     case ADAPTEDCLOSURE => "ADAPTEDCLOSURE"
     case OBJECTCLASS => "OBJECTCLASS"

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -712,6 +712,10 @@ object Symbols {
       coord: Coord = NoCoord)(using Context): TermSymbol =
     newSymbol(cls, nme.CONSTRUCTOR, flags | Method, MethodType(paramNames, paramTypes, cls.typeRef), privateWithin, coord)
 
+  /** Create an anonymous function symbol */
+  def newAnonFun(owner: Symbol, info: Type, coord: Coord = NoCoord)(using Context): TermSymbol =
+    newSymbol(owner, nme.ANON_FUN, Synthetic | Method, info, coord = coord)
+
   /** Create an empty default constructor symbol for given class `cls`. */
   def newDefaultConstructor(cls: ClassSymbol)(using Context): TermSymbol =
     newConstructor(cls, EmptyFlags, Nil, Nil)

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -581,7 +581,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
       val sym = tp.symbol
       if (!sym.isClass) this(tp.translucentSuperType)
       else if (semiEraseVCs && isDerivedValueClass(sym)) eraseDerivedValueClass(tp)
-      else if (defn.isSyntheticFunctionClass(sym)) defn.erasedFunctionType(sym)
+      else if (defn.isSyntheticFunctionClass(sym)) defn.functionTypeErasure(sym)
       else eraseNormalClassRef(tp)
     case tp: AppliedType =>
       val tycon = tp.tycon
@@ -791,7 +791,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
           if (erasedVCRef.exists) return sigName(erasedVCRef)
         }
         if (defn.isSyntheticFunctionClass(sym))
-          sigName(defn.erasedFunctionType(sym))
+          sigName(defn.functionTypeErasure(sym))
         else
           val cls = normalizeClass(sym.asClass)
           val fullName =

--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -51,7 +51,10 @@ abstract class AccessProxies {
               forwardedArgss.nonEmpty && forwardedArgss.head.nonEmpty) // defensive conditions
             accessRef.becomes(forwardedArgss.head.head)
           else
-            accessRef.appliedToTypeTrees(forwardedTpts).appliedToArgss(forwardedArgss)
+            accessRef
+              .appliedToTypeTrees(forwardedTpts)
+              .appliedToArgss(forwardedArgss)
+              .etaExpandCFT(using ctx.withOwner(accessor))
         rhs.withSpan(accessed.span)
       })
 

--- a/compiler/src/dotty/tools/dotc/transform/ByNameClosures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ByNameClosures.scala
@@ -30,11 +30,9 @@ class ByNameClosures extends TransformByNameApply with IdentityDenotTransformer 
     // ExpanSAMs applied to partial functions creates methods that need
     // to be fully defined before converting. Test case is pos/i9391.scala.
 
-  override def mkByNameClosure(arg: Tree, argType: Type)(using Context): Tree = {
-    val meth = newSymbol(
-      ctx.owner, nme.ANON_FUN, Synthetic | Method, MethodType(Nil, Nil, argType))
+  override def mkByNameClosure(arg: Tree, argType: Type)(using Context): Tree =
+    val meth = newAnonFun(ctx.owner, MethodType(Nil, argType))
     Closure(meth, _ => arg.changeOwnerAfter(ctx.owner, meth, thisPhase)).withSpan(arg.span)
-  }
 }
 
 object ByNameClosures {

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -57,6 +57,7 @@ class Erasure extends Phase with DenotTransformer {
             case _                              => false
           }
         }
+
       def erasedName =
         if ref.is(Flags.Method)
             && contextResultsAreErased(ref.symbol)
@@ -383,8 +384,8 @@ object Erasure {
       case _: FunProto | AnyFunctionProto => tree
       case _ => tree.tpe.widen match
         case mt: MethodType if tree.isTerm =>
-          if mt.paramInfos.isEmpty then adaptToType(tree.appliedToNone, pt)
-          else etaExpand(tree, mt, pt)
+          assert(mt.paramInfos.isEmpty)
+          adaptToType(tree.appliedToNone, pt)
         case tpw =>
           if (pt.isInstanceOf[ProtoType] || tree.tpe <:< pt)
             tree
@@ -533,61 +534,6 @@ object Erasure {
       else
         tree
     end adaptClosure
-
-    /** Eta expand given `tree` that has the given method type `mt`, so that
-     *  it conforms to erased result type `pt`.
-     *  To do this correctly, we have to look at the tree's original pre-erasure
-     *  type and figure out which context function types in its result are
-     *  not yet instantiated.
-     */
-    def etaExpand(tree: Tree, mt: MethodType, pt: Type)(using Context): Tree =
-      report.log(i"eta expanding $tree")
-      val defs = new mutable.ListBuffer[Tree]
-      val tree1 = LiftErased.liftApp(defs, tree)
-      val xmt = if tree.isInstanceOf[Apply] then mt else expandedMethodType(mt, tree)
-      val targetLength = xmt.paramInfos.length
-      val origOwner = ctx.owner
-
-      // The original type from which closures should be constructed
-      val origType = contextFunctionResultTypeCovering(tree.symbol, targetLength)
-
-      def abstracted(args: List[Tree], tp: Type, pt: Type)(using Context): Tree =
-        if args.length < targetLength then
-          try
-            val defn.ContextFunctionType(argTpes, resTpe, isErased) = tp: @unchecked
-            if isErased then abstracted(args, resTpe, pt)
-            else
-              val anonFun = newSymbol(
-                ctx.owner, nme.ANON_FUN, Flags.Synthetic | Flags.Method,
-                MethodType(argTpes, resTpe), coord = tree.span.endPos)
-              anonFun.info = transformInfo(anonFun, anonFun.info)
-              def lambdaBody(refss: List[List[Tree]]) =
-                val refs :: Nil = refss: @unchecked
-                val expandedRefs = refs.map(_.withSpan(tree.span.endPos)) match
-                  case (bunchedParam @ Ident(nme.ALLARGS)) :: Nil =>
-                    argTpes.indices.toList.map(n =>
-                      bunchedParam
-                        .select(nme.primitive.arrayApply)
-                        .appliedTo(Literal(Constant(n))))
-                  case refs1 => refs1
-                abstracted(args ::: expandedRefs, resTpe, anonFun.info.finalResultType)(
-                  using ctx.withOwner(anonFun))
-
-              val unadapted = Closure(anonFun, lambdaBody)
-              cpy.Block(unadapted)(unadapted.stats, adaptClosure(unadapted.expr.asInstanceOf[Closure]))
-          catch case ex: MatchError =>
-            println(i"error while abstracting tree = $tree | mt = $mt | args = $args%, % | tp = $tp | pt = $pt")
-            throw ex
-        else
-          assert(args.length == targetLength, i"wrong # args tree = $tree | args = $args%, % | mt = $mt | tree type = ${tree.tpe}")
-          val app = untpd.cpy.Apply(tree1)(tree1, args)
-          assert(ctx.typer.isInstanceOf[Erasure.Typer])
-          ctx.typer.typed(app, pt)
-            .changeOwnerAfter(origOwner, ctx.owner, erasurePhase.asInstanceOf[Erasure])
-
-      seq(defs.toList, abstracted(Nil, origType, pt))
-    end etaExpand
-
   end Boxing
 
   class Typer(erasurePhase: DenotTransformer) extends typer.ReTyper with NoChecking {

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -12,7 +12,7 @@ import core.Types._
 import core.Names._
 import core.StdNames._
 import core.NameOps._
-import core.NameKinds.{AdaptedClosureName, BodyRetainerName, ImplMethName}
+import core.NameKinds.{AdaptedClosureName, BodyRetainerName, DirectMethName}
 import core.Scopes.newScopeWith
 import core.Decorators._
 import core.Constants._
@@ -63,10 +63,10 @@ class Erasure extends Phase with DenotTransformer {
             && contextResultsAreErased(ref.symbol)
             && (ref.owner.is(Flags.Trait) || ref.symbol.allOverriddenSymbols.hasNext)
         then
-          // Add a `$` to prevent this method from having the same signature
+          // Add a `$direct` to prevent this method from having the same signature
           // as a method it overrides. We need a bridge between the
           // two methods, so they are not allowed to already override after erasure.
-          ImplMethName(ref.targetName.asTermName)
+          DirectMethName(ref.targetName.asTermName)
         else
           ref.targetName
 

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -12,7 +12,7 @@ import core.Types._
 import core.Names._
 import core.StdNames._
 import core.NameOps._
-import core.NameKinds.{AdaptedClosureName, BodyRetainerName}
+import core.NameKinds.{AdaptedClosureName, BodyRetainerName, ImplMethName}
 import core.Scopes.newScopeWith
 import core.Decorators._
 import core.Constants._
@@ -57,6 +57,17 @@ class Erasure extends Phase with DenotTransformer {
             case _                              => false
           }
         }
+      def erasedName =
+        if ref.is(Flags.Method)
+            && contextResultsAreErased(ref.symbol)
+            && (ref.owner.is(Flags.Trait) || ref.symbol.allOverriddenSymbols.hasNext)
+        then
+          // Add a `$` to prevent this method from having the same signature
+          // as a method it overrides. We need a bridge between the
+          // two methods, so they are not allowed to already override after erasure.
+          ImplMethName(ref.targetName.asTermName)
+        else
+          ref.targetName
 
       assert(ctx.phase == this, s"transforming $ref at ${ctx.phase}")
       if (ref.symbol eq defn.ObjectClass) {
@@ -80,7 +91,7 @@ class Erasure extends Phase with DenotTransformer {
         val oldOwner = ref.owner
         val newOwner = if oldOwner == defn.AnyClass then defn.ObjectClass else oldOwner
         val oldName = ref.name
-        val newName = ref.targetName
+        val newName = erasedName
         val oldInfo = ref.info
         var newInfo = transformInfo(oldSymbol, oldInfo)
         val oldFlags = ref.flags
@@ -391,7 +402,6 @@ object Erasure {
           else
             cast(tree, pt)
     end adaptToType
-
 
     /** The following code:
      *
@@ -714,7 +724,7 @@ object Erasure {
             assert(sym.isConstructor, s"${sym.showLocated}")
             defn.specialErasure(owner)
           else if defn.isSyntheticFunctionClass(owner) then
-            defn.erasedFunctionClass(owner)
+            defn.functionTypeErasure(owner).typeSymbol
           else
             owner
 

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -274,10 +274,10 @@ object GenericSignatures {
               jsig(erasedUnderlying, toplevel, primitiveOK)
           }
           else if (defn.isSyntheticFunctionClass(sym)) {
-            val erasedSym = defn.erasedFunctionClass(sym)
+            val erasedSym = defn.functionTypeErasure(sym).typeSymbol
             classSig(erasedSym, pre, if (erasedSym.typeParams.isEmpty) Nil else args)
           }
-          else if (sym.isClass)
+          else if sym.isClass then
             classSig(sym, pre, args)
           else
             jsig(erasure(tp), toplevel, primitiveOK)

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -70,7 +70,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
               ref(defn.NoneModule))
           }
           val tpe = MethodType(List(nme.s))(_ => List(tp1), mth => defn.OptionClass.typeRef.appliedTo(mth.newParamRef(0) & tp2))
-          val meth = newSymbol(ctx.owner, nme.ANON_FUN, Synthetic | Method, tpe, coord = span)
+          val meth = newAnonFun(ctx.owner, tpe, coord = span)
           val typeTestType = defn.TypeTestClass.typeRef.appliedTo(List(tp1, tp2))
           Closure(meth, tss => body(tss.head).changeOwner(ctx.owner, meth), targetType = typeTestType).withSpan(span)
       case _ =>

--- a/compiler/src/scala/quoted/runtime/impl/QuoteMatcher.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuoteMatcher.scala
@@ -212,7 +212,7 @@ object QuoteMatcher {
           }
           val argTypes = args.map(x => x.tpe.widenTermRefExpr)
           val methTpe = MethodType(names)(_ => argTypes, _ => pattern.tpe)
-          val meth = newSymbol(ctx.owner, nme.ANON_FUN, Synthetic | Method, methTpe)
+          val meth = newAnonFun(ctx.owner, methTpe)
           def bodyFn(lambdaArgss: List[List[Tree]]): Tree = {
             val argsMap = args.map(_.symbol).zip(lambdaArgss.head).toMap
             val body = new TreeMap {

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -385,7 +385,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
               case t => t
             }
             val closureTpe = Types.MethodType(mtpe.paramNames, mtpe.paramInfos, closureResType)
-            val closureMethod = dotc.core.Symbols.newSymbol(owner, nme.ANON_FUN, Synthetic | Method, closureTpe)
+            val closureMethod = dotc.core.Symbols.newAnonFun(owner, closureTpe)
             tpd.Closure(closureMethod, tss => new tpd.TreeOps(self).appliedToTermArgs(tss.head).etaExpand(closureMethod))
           case _ => self
         }
@@ -793,7 +793,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object Lambda extends LambdaModule:
       def apply(owner: Symbol, tpe: MethodType, rhsFn: (Symbol, List[Tree]) => Tree): Block =
-        val meth = dotc.core.Symbols.newSymbol(owner, nme.ANON_FUN, Synthetic | Method, tpe)
+        val meth = dotc.core.Symbols.newAnonFun(owner, tpe)
         withDefaultPos(tpd.Closure(meth, tss => xCheckMacroedOwners(xCheckMacroValidExpr(rhsFn(meth, tss.head.map(withDefaultPos))), meth)))
 
       def unapply(tree: Block): Option[(List[ValDef], Term)] = tree match {

--- a/tests/run/i13691.scala
+++ b/tests/run/i13691.scala
@@ -1,0 +1,53 @@
+import language.experimental.erasedDefinitions
+
+erased class CanThrow[-E <: Exception]
+erased class Foo
+class Bar
+
+object unsafeExceptions:
+  given canThrowAny: CanThrow[Exception] = null
+
+object test1:
+  trait Decoder[+T]:
+    def apply(): T
+
+  def deco: Decoder[CanThrow[Exception] ?=> Int] = new Decoder[CanThrow[Exception] ?=> Int]:
+    def apply(): CanThrow[Exception] ?=> Int = 1
+
+object test2:
+  trait Decoder[+T]:
+    def apply(): T
+
+  def deco: Decoder[(CanThrow[Exception], Foo) ?=> Int] = new Decoder[(CanThrow[Exception], Foo) ?=> Int]:
+    def apply(): (CanThrow[Exception], Foo) ?=> Int = 1
+
+object test3:
+  trait Decoder[+T]:
+    def apply(): T
+
+  def deco: Decoder[CanThrow[Exception] ?=> Foo ?=> Int] = new Decoder[CanThrow[Exception] ?=> Foo ?=> Int]:
+    def apply(): CanThrow[Exception] ?=> Foo ?=> Int = 1
+
+object test4:
+  trait Decoder[+T]:
+    def apply(): T
+
+  def deco: Decoder[CanThrow[Exception] ?=> Bar ?=> Int] = new Decoder[CanThrow[Exception] ?=> Bar ?=> Int]:
+    def apply(): CanThrow[Exception] ?=> Bar ?=> Int = 1
+
+object test5:
+  trait Decoder[+T]:
+    def apply(): T
+
+  def deco: Decoder[Bar ?=> CanThrow[Exception] ?=> Int] = new Decoder[Bar ?=> CanThrow[Exception] ?=> Int]:
+    def apply(): Bar ?=> CanThrow[Exception] ?=> Int = 1
+
+@main def Test(): Unit =
+  import unsafeExceptions.canThrowAny
+  given Foo = ???
+  given Bar = Bar()
+  test1.deco.apply().apply
+  test2.deco.apply().apply
+  test3.deco.apply().apply
+  test4.deco.apply().apply
+  test5.deco.apply().apply

--- a/tests/run/i13961a.scala
+++ b/tests/run/i13961a.scala
@@ -1,0 +1,11 @@
+import language.experimental.saferExceptions
+
+trait Decoder[+T]:
+  def apply(): T
+
+given Decoder[Int throws Exception] = new Decoder[Int throws Exception]:
+  def apply(): Int throws Exception = 1
+
+@main def Test(): Unit =
+  import unsafeExceptions.canThrowAny
+  summon[Decoder[Int throws Exception]]()


### PR DESCRIPTION
1. Name mangle methods with erased context results

Add a `$` to the name of a method that has erased context results and that
may override some other method. This is to prevent the two methods from having
the same names and parameters in their erased signatures. We need a bridge between the
two methods, so they are not allowed to already override after erasure.

2. Change the logic of eta expansion at erasure to take erased functions into account.
