### PR TITLE
Remove unnecessary call to constrainResult

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -891,15 +891,6 @@ trait Applications extends Compatibility {
         then originalProto.tupledDual
         else originalProto
 
-      // If some of the application's arguments are function literals without explicitly declared
-      // parameter types, relate the normalized result type of the application with the
-      // expected type through `constrainResult`. This can add more constraints which
-      // help sharpen the inferred parameter types for the argument function literal(s).
-      // This tweak is needed to make i1378 compile.
-      if (tree.args.exists(untpd.isFunctionWithUnknownParamType(_)))
-        if (!constrainResult(tree.symbol, fun1.tpe.widen, proto.derivedFunProto(resultType = pt)))
-          typr.println(i"result failure for $tree with type ${fun1.tpe.widen}, expected = $pt")
-
       /** Type application where arguments come from prototype, and no implicits are inserted */
       def simpleApply(fun1: Tree, proto: FunProto)(using Context): Tree =
         methPart(fun1).tpe match {


### PR DESCRIPTION
This was originally added in #1395 to make the following compile:

    (1, x => 2): (Int, Int => Int)

But reverting this change doesn't break anything anymore: the other call
to `constrainResult` in `Application#init` is enough to propagate the
constraint needed to type lambda. The strange thing is that this call
already existed before #1395, I don't know why it wasn't enough back then.