### PR TITLE
Can mark var implementation as override

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -466,8 +466,7 @@ object RefChecks {
           overrideError("needs `override` modifier")
       else if (other.is(AbsOverride) && other.isIncompleteIn(clazz) && !member.is(AbsOverride))
         overrideError("needs `abstract override` modifiers")
-      else if (member.is(Override) && other.is(Accessor) &&
-        other.accessedFieldOrGetter.is(Mutable, butNot = Lazy))
+      else if member.is(Override) && other.is(Accessor, butNot = Deferred) && other.accessedFieldOrGetter.is(Mutable, butNot = Lazy) then
         overrideError("cannot override a mutable variable")
       else if (member.isAnyOverride &&
         !(member.owner.thisType.baseClasses exists (_ isSubClass other.owner)) &&

--- a/tests/pos/i13019.scala
+++ b/tests/pos/i13019.scala
@@ -1,0 +1,13 @@
+
+trait Ok1 { var i: Int }
+class Ok1C extends Ok1 { var i: Int = 1 }
+
+trait Ok2 {
+  def i: Int
+  def i_=(v: Int): Unit
+}
+class Ok2C extends Ok2 { override var i: Int = 1 }
+
+// was: variable i of type Int cannot override a mutable variable
+trait NotOk {var i: Int}
+class NotOkC extends NotOk { override var i: Int = 1 }


### PR DESCRIPTION
Implementation of an abstract var declaration can be marked override.

Fixes #13019