### PR TITLE
Reject @throws annotation where before class keywords(squash commit)

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -281,6 +281,9 @@ object SymUtils:
     def isDeprecated(using Context): Boolean =
       self.hasAnnotation(defn.DeprecatedAnnot)
 
+    def hasThrowsAnnot(using Context): Boolean =
+      self.hasAnnotation(defn.ThrowsAnnot)
+
     /** Is symbol assumed or declared as an infix symbol? */
     def isDeclaredInfix(using Context): Boolean =
       self.is(Infix)

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1025,6 +1025,14 @@ object RefChecks {
           report.error(i"private $sym cannot override ${other.showLocated}", sym.srcPos)
   end checkNoPrivateOverrides
 
+  /** Check if throws annotation is defined. */
+  def checkNoThrows(tree: Tree)(using Context): Unit = {
+    val symbol = tree.symbol
+    if (symbol.hasThrowsAnnot) {
+      report.error("`@throws` only allowed for methods and constructors", tree.srcPos)
+    }
+  }
+
   /** Check that unary method definition do not receive parameters.
    *  They can only receive inferred parameters such as type parameters and implicit parameters.
    */
@@ -1254,6 +1262,7 @@ class RefChecks extends MiniPhase { thisPhase =>
   override def transformValDef(tree: ValDef)(using Context): ValDef = {
     checkNoPrivateOverrides(tree)
     checkDeprecatedOvers(tree)
+    checkNoThrows(tree) // Don't allow throws-annotation on val and var definitions
     checkExperimentalAnnots(tree.symbol)
     checkExperimentalSignature(tree.symbol, tree)
     val sym = tree.symbol
@@ -1345,6 +1354,7 @@ class RefChecks extends MiniPhase { thisPhase =>
 
   override def transformTypeDef(tree: TypeDef)(using Context): TypeDef = {
     checkExperimentalAnnots(tree.symbol)
+    checkNoThrows(tree) // Don't allow throws-annotation on classes, objects, traits, and type aliases
     tree
   }
 }

--- a/tests/neg/i11634.scala
+++ b/tests/neg/i11634.scala
@@ -1,0 +1,36 @@
+class ClassThrowsA[T] @throws(classOf[Exception])(someList: List[T]) { // OK, throws applied to the primary constructor
+  throw new IllegalArgumentException("Boom!")
+}
+
+class ClassThrowsB[T] @throws[Exception]()(someList: List[T]) { // OK, modern version
+  throw new IllegalArgumentException("Boom!")
+}
+
+@throws[Exception] class ClassNoThrows[T](someList: List[T]) { // error
+  throw new IllegalArgumentException("Boom!")
+}
+
+@throws[Exception] object ObjectNoThrows { // error
+  throw new UnsupportedOperationException("Boom!")
+}
+
+@throws[Exception] trait TraitNoThrows { // error
+  throw new UnsupportedOperationException("Boom!")
+}
+
+@throws[Exception] type AliasNoThrows = Unit // error
+
+object OuterObj {
+  // might be useful to annotate accessors of lazy vals
+  @throws[Exception] object InnerObj { // error
+    throw new UnsupportedOperationException("Boom!")
+  }
+}
+
+trait Various {
+  def f[A <: AnyRef](a: A): AnyRef = a: AnyRef @throws[Exception] // there is no check where clearly wrong place
+
+  def g(): Unit = (): @throws[Exception] // no check
+
+  def n(i: Int) = i match { case 42 => 27: @throws[Exception] } // no check
+}


### PR DESCRIPTION
Fixes #11634.  
#11635 did not make its own branch, so we will issue a new PR.  