### PR TITLE
provide scala.home setting for scripts - fix for #13758

### DIFF
--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -31,7 +31,7 @@ source "$PROG_HOME/bin/common"
 # exec here would prevent onExit from being called, leaving terminal in unusable state
 compilerJavaClasspathArgs
 [ -z "${ConEmuPID-}" -o -n "${cygwin-}" ] && export MSYSTEM= PWD= # workaround for #12405
-eval "\"$JAVACMD\"" "-classpath \"$jvm_cp_args\"" "dotty.tools.MainGenericRunner" "-classpath \"$jvm_cp_args\"" "$@"
+eval "\"$JAVACMD\"" "-Dscala.home=$PROG_HOME" "-classpath \"$jvm_cp_args\"" "dotty.tools.MainGenericRunner" "-classpath \"$jvm_cp_args\"" "$@"
 scala_exit_status=$?
 
 


### PR DESCRIPTION
Set the "scala.home" system property when launching scripts.