### PR TITLE
Use `IArray.map` in the `Tuple.fromIArray`

### DIFF
--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -228,18 +228,17 @@ object Tuple {
       case xs: Array[Object] => xs
       case xs => xs.map(_.asInstanceOf[Object])
     }
-    runtime.Tuples.fromArray(xs2).asInstanceOf[Tuple]
+    runtime.Tuples.fromArray(xs2)
   }
 
   /** Convert an immutable array into a tuple of unknown arity and types */
   def fromIArray[T](xs: IArray[T]): Tuple = {
     val xs2: IArray[Object] = xs match {
       case xs: IArray[Object] @unchecked => xs
-      case xs =>
-        // TODO support IArray.map
-        xs.asInstanceOf[Array[T]].map(_.asInstanceOf[Object]).asInstanceOf[IArray[Object]]
+      case _ =>
+        xs.map(_.asInstanceOf[Object])
     }
-    runtime.Tuples.fromIArray(xs2).asInstanceOf[Tuple]
+    runtime.Tuples.fromIArray(xs2)
   }
 
   /** Convert a Product into a tuple of unknown arity and types */


### PR DESCRIPTION
This PR fixes one `todo` and removes two unnecessary `asInstanceOf` in the `Tuple`.