### PR TITLE
Fix init checker on secondary constructor parameter access

### DIFF
--- a/tests/init/pos/second-ctor-fields.scala
+++ b/tests/init/pos/second-ctor-fields.scala
@@ -1,0 +1,17 @@
+
+class A(b: B) {
+  def this(b: B, m: Int) = {
+    this(b)
+    def foo = m // resolved to parameter `m`
+    class C { foo } // resolved to parameter `m`, as hidden field of `A`
+    new C
+  }
+}
+
+class D(b: B) extends A(b, 10) {
+  val n = 10
+}
+
+class B {
+  val a = new D(this)
+}


### PR DESCRIPTION
Insert the parameters of the secondary constructor into the
`Objekt` of `thisV`, so that they can be looked up when it is
referenced.

An example is provided as a test file.

Upon calling a secondary constructor, we add the
parameters into the cache as if they were fields of
the constructed object (similar to a primary constructor).

Due to the actual fields referenced being resolved to
fully qualified names (but references to parameters are not),
we also change the `accessLocal` logic to look at the
object cache first, if we are in a Constructor context.
