### PR TITLE
Remove Type#hasNonWildcard{LowerBound, UpperBound}

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4615,20 +4615,6 @@ object Types {
     /** For uninstantiated type variables: Is the upper bound different from Any? */
     def hasUpperBound(using Context): Boolean = !currentEntry.hiBound.isRef(defn.AnyClass)
 
-    /** For uninstantiated type variables: Is the lower bound different from Nothing and
-     *  does it not contain wildcard types?
-     */
-    def hasNonWildcardLowerBound(using Context): Boolean =
-      val lo = currentEntry.loBound
-      !lo.isExactlyNothing && !lo.containsWildcardTypes
-
-    /** For uninstantiated type variables: Is the upper bound different from Any and
-     *  does it not contain wildcard types?
-     */
-    def hasNonWildcardUpperBound(using Context): Boolean =
-      val hi = currentEntry.hiBound
-      !hi.isRef(defn.AnyClass) && !hi.containsWildcardTypes
-
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar
      */

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -179,9 +179,9 @@ object Inferencing {
         && {
           val direction = instDirection(tvar.origin)
           if minimizeSelected then
-            if direction <= 0 && tvar.hasNonWildcardLowerBound then
+            if direction <= 0 && tvar.hasLowerBound then
               instantiate(tvar, fromBelow = true)
-            else if direction >= 0 && tvar.hasNonWildcardUpperBound then
+            else if direction >= 0 && tvar.hasUpperBound then
               instantiate(tvar, fromBelow = false)
             // else hold off instantiating unbounded unconstrained variable
           else if direction != 0 then


### PR DESCRIPTION
These are no longer needed since we stopped storing wildcards in
constraints (see dropWildcards in ConstraintHandling#addOneBound).