### PR TITLE
Consider minTargetVersion as always supported

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -24,7 +24,7 @@ object ScalaSettings:
       val jdkVersion = JDK9Reflectors.runtimeVersionMajor(JDK9Reflectors.runtimeVersion()).intValue()
       val maxVersion = Math.min(jdkVersion, maxTargetVersion)
       (minTargetVersion to maxVersion).toList.map(_.toString)
-    else List()
+    else List(minTargetVersion).map(_.toString)
 
   def defaultClasspath: String = sys.env.getOrElse("CLASSPATH", ".")
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -64,6 +64,7 @@ class CompilationTests {
       compileFile("tests/pos-custom-args/help.scala", defaultOptions.and("-help", "-V", "-W", "-X", "-Y")),
       compileFile("tests/pos-custom-args/i10383.scala", defaultOptions.and("-source", "future", "-deprecation", "-Xfatal-warnings")),
       compileFile("tests/pos-custom-args/i13044.scala", defaultOptions.and("-Xmax-inlines:33")),
+      compileFile("tests/pos-custom-args/jdk-8-app.scala", defaultOptions.and("-release:8")),
     ).checkCompile()
   }
 
@@ -184,6 +185,7 @@ class CompilationTests {
       compileDir("tests/neg-custom-args/hidden-type-errors", defaultOptions.and("-explain")),
       compileFile("tests/neg-custom-args/i13026.scala", defaultOptions.and("-print-lines")),
       compileFile("tests/neg-custom-args/i13838.scala", defaultOptions.and("-Ximplicit-search-limit", "1000")),
+      compileFile("tests/neg-custom-args/jdk-9-app.scala", defaultOptions.and("-release:8")),
     ).checkExpectedErrors()
   }
 

--- a/tests/neg-custom-args/jdk-9-app.check
+++ b/tests/neg-custom-args/jdk-9-app.check
@@ -1,0 +1,6 @@
+-- [E006] Not Found Error: tests/neg-custom-args/jdk-9-app.scala:4:10 --------------------------------------------------
+4 |  println(ProcessHandle.current().pid()) // error: not found
+  |          ^^^^^^^^^^^^^
+  |          Not found: ProcessHandle
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/jdk-9-app.scala
+++ b/tests/neg-custom-args/jdk-9-app.scala
@@ -1,0 +1,5 @@
+import java.lang.ProcessHandle
+
+object Jdk9App extends App {
+  println(ProcessHandle.current().pid()) // error: not found
+}

--- a/tests/pos-custom-args/jdk-8-app.scala
+++ b/tests/pos-custom-args/jdk-8-app.scala
@@ -1,0 +1,5 @@
+import java.time.LocalDate
+
+object Jdk8App extends App {
+  println(LocalDate.now())
+}


### PR DESCRIPTION
Fixes #13810 

[test_java8]

Allows to use consistent scalac options running with JDK 1.8 and higher if targeting Java8 bytecode level.

Don't know if there are more places to check for more code changes required.