### PR TITLE
Resurrect proposed Fix #13553: add `Symbol#tpe` method

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2480,6 +2480,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
         def name: String = self.denot.name.toString
         def fullName: String = self.denot.fullName.toString
+        def tpe: TypeRepr = self.denot.info
         def pos: Option[Position] =
           if self.exists then Some(self.sourcePos) else None
 

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3585,6 +3585,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** The full name of this symbol up to the root package */
         def fullName: String
 
+        /** The type of this symbol */
+        def tpe: TypeRepr
+
         /** The position of this symbol */
         def pos: Option[Position]
 


### PR DESCRIPTION
by @cchantep 
This seems to have been erroneously submitted as a feature request and then closed https://github.com/lampepfl/dotty-feature-requests/issues/247
I suspect that simply exposing `def tpe: TypeRepr = self.denot.info` is sufficient to fix the bulk of the issue, so I'm reopening it as a PR.