### PR TITLE
Fix #13026: No longer print VBAR and padding in the middle of the message

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Texts.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Texts.scala
@@ -106,11 +106,13 @@ object Texts {
       case Str(s, lines) =>
         if (numberWidth != 0) {
           val ln = lines.show
-          val pad = (numberWidth - ln.length - 1)
-          assert(pad >= 0)
-          sb.append(" " * pad)
-          sb.append(ln)
-          sb.append("|")
+          if (ln.nonEmpty) {
+            val pad = (numberWidth - ln.length - 1)
+            assert(pad >= 0)
+            sb.append(" " * pad)
+            sb.append(ln)
+            sb.append("|")
+          }
         }
         sb.append(s)
       case _ =>

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -182,6 +182,7 @@ class CompilationTests {
       compileFile("tests/neg-custom-args/i7314.scala", defaultOptions.and("-Xfatal-warnings", "-source", "future")),
       compileFile("tests/neg-custom-args/feature-shadowing.scala", defaultOptions.and("-Xfatal-warnings", "-feature")),
       compileDir("tests/neg-custom-args/hidden-type-errors", defaultOptions.and("-explain")),
+      compileFile("tests/neg-custom-args/i13026.scala", defaultOptions.and("-print-lines")),
     ).checkExpectedErrors()
   }
 

--- a/tests/neg-custom-args/i13026.check
+++ b/tests/neg-custom-args/i13026.check
@@ -1,0 +1,18 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/i13026.scala:1:13 -------------------------------------------------
+1 |val x: Int = "not an int" // error
+  |             ^^^^^^^^^^^^
+  |             Found:    ("not an int" : String)
+  |             Required: Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/i13026.scala:2:13 -------------------------------------------------
+2 |val y: Int = "not an int" // error
+  |             ^^^^^^^^^^^^
+  |             Found:    ("not an int" : String)
+  |             Required: Int
+
+longer explanation available when compiling with `-explain`
+-- [E008] Not Found Error: tests/neg-custom-args/i13026.scala:3:20 -----------------------------------------------------
+3 |def foo(x: Any) = x.foo // error
+  |                  ^^^^^
+  |                  value foo is not a member of Any

--- a/tests/neg-custom-args/i13026.scala
+++ b/tests/neg-custom-args/i13026.scala
@@ -1,0 +1,3 @@
+val x: Int = "not an int" // error
+val y: Int = "not an int" // error
+def foo(x: Any) = x.foo // error


### PR DESCRIPTION
VBARs and paddings were added even in the middle of the message when they should be added only at the beginning of a line.

Co-authored-by: Tom Grigg <tomegrigg@gmail.com>

Fixes #13026 