### PR TITLE
solves dotc assertion error on (non-sensical?) parameter type. #13769

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -442,6 +442,9 @@ object Parsers {
     def convertToParam(tree: Tree, mods: Modifiers, expected: String = "formal parameter"): ValDef = tree match {
       case id @ Ident(name) =>
         makeParameter(name.asTermName, TypeTree(), mods, isBackquoted = isBackquoted(id)).withSpan(tree.span)
+      case Typed(_, tpt: TypeBoundsTree) =>
+        syntaxError(s"not a legal $expected", tree.span)
+        makeParameter(nme.ERROR, tree, mods)
       case Typed(id @ Ident(name), tpt) =>
         makeParameter(name.asTermName, tpt, mods, isBackquoted = isBackquoted(id)).withSpan(tree.span)
       case Typed(Splice(Ident(name)), tpt) =>

--- a/tests/neg/i13769.check
+++ b/tests/neg/i13769.check
@@ -1,0 +1,10 @@
+-- Error: tests/neg/i13769.scala:2:18 ----------------------------------------------------------------------------------
+2 |val te = tup.map((x: _ <: Int) => List(x)) // error // error
+  |                  ^^^^^^^^^^^
+  |                  not a legal formal parameter
+-- [E006] Not Found Error: tests/neg/i13769.scala:2:39 -----------------------------------------------------------------
+2 |val te = tup.map((x: _ <: Int) => List(x)) // error // error
+  |                                       ^
+  |                                       Not found: x
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg/i13769.scala
+++ b/tests/neg/i13769.scala
@@ -1,0 +1,2 @@
+val tup = (1, "s")
+val te = tup.map((x: _ <: Int) => List(x)) // error // error


### PR DESCRIPTION
Solves issue 13769
https://github.com/lampepfl/dotty/issues/13769

The change was to introduce an additional check to  `convertToParam()` in Parsers.scala to trigger a parsing error for the invalid code: 
```
val tup = (1, "s")
val te = tup.map((x: _ <: Singleton) => List(x))
```
instead of generating a later type related error.


Done in the context of the Scala spree 26.10.2021 together with:  Kackper Korban, Andrzej Ratajczak and Jiri Dutkevic.

