### PR TITLE
Fix missing code-completion on standalone annotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3472,7 +3472,11 @@ object Parsers {
           givenDef(start, mods, atSpan(in.skipToken()) { Mod.Given() })
         case _ =>
           syntaxErrorOrIncomplete(ExpectedStartOfTopLevelDefinition())
-          EmptyTree
+          mods.annotations match {
+            case head :: Nil => head
+            case Nil => EmptyTree
+            case all => Block(all, errorTermTree)
+          }
       }
 
     /** ClassDef ::= id ClassConstr TemplateOpt

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -137,4 +137,5 @@ class TabcompleteTests extends ReplTest {
     assertEquals(List("select", "show", "simplified", "substituteTypes"),
       tabComplete("import quoted.* ; def fooImpl(using Quotes): Expr[Int] = { import quotes.reflect.* ; TypeRepr.of[Int].s"))
   }
+
 }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -138,4 +138,8 @@ class TabcompleteTests extends ReplTest {
       tabComplete("import quoted.* ; def fooImpl(using Quotes): Expr[Int] = { import quotes.reflect.* ; TypeRepr.of[Int].s"))
   }
 
+  @Test def i13624 = fromInitialState { implicit s =>
+    assertEquals(List("implicitNotFound"), tabComplete("@annotation.implicitNot"))
+    assertEquals(List("main"), tabComplete("@annotation.implicitNotFound @mai"))
+  }
 }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -137,9 +137,4 @@ class TabcompleteTests extends ReplTest {
     assertEquals(List("select", "show", "simplified", "substituteTypes"),
       tabComplete("import quoted.* ; def fooImpl(using Quotes): Expr[Int] = { import quotes.reflect.* ; TypeRepr.of[Int].s"))
   }
-
-  @Test def i13624 = fromInitialState { implicit s =>
-    assertEquals(List("implicitNotFound"), tabComplete("@annotation.implicitNot"))
-    assertEquals(List("main"), tabComplete("@annotation.implicitNotFound @mai"))
-  }
 }

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -946,4 +946,21 @@ class CompletionTest {
           ("MyAnnotation", Module, "Foo.MyAnnotation")
         )
       )
+
+  @Test def i13624_annotation : Unit =
+    code"""@annotation.implicitNot${m1}
+          |@annotation.implicitNotFound @mai${m2}"""
+          .withSource
+          .completion(m1,
+            Set(
+              ("implicitNotFound", Class, "scala.annotation.implicitNotFound"),
+              ("implicitNotFound", Module, "scala.annotation.implicitNotFound")
+            )
+          )
+          .completion(m2,
+            Set(
+              ("main", Class, "scala.main"),
+              ("main", Module, "main")
+            )
+          )
 }


### PR DESCRIPTION
This PR adds missing code completion for standalone annotations.

In a REPL session:
```
@annotation.implicitNot
```

The annotations themselves are a part of `Modifiers` object which is not a tree but rather a bag of different modifiers. 
The root cause of the issue was that parser was returning an empty tree which can't have (AFAIK) any modifiers attached.
We solved that, by returning annotations tree from the `Modifiers` object instead of an empty tree.


Relates to #13624

The work on this PR was powered by 7th edition of issue-spree :tada: 

Co-authored-by: @spavikevik
Co-authored-by: @tgodzik
Co-authored-by: @anatoliykmetyuk 