### PR TITLE
Fix error summary printed twice

### DIFF
--- a/sbt-bridge/src/dotty/tools/xsbt/CompilerBridgeDriver.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/CompilerBridgeDriver.java
@@ -91,9 +91,9 @@ public class CompilerBridgeDriver extends Driver {
           callback.problem(problem.category(), problem.position(), problem.message(), problem.severity(),
             true);
         }
+      } else {  
+        delegate.printSummary();
       }
-
-      delegate.printSummary();
 
       if (delegate.hasErrors()) {
         log.debug(() -> "Compilation failed");


### PR DESCRIPTION
Fix https://github.com/sbt/sbt/issues/6687

`printSummary` is already called in `Driver.finish`:
https://github.com/lampepfl/dotty/blob/29f03741b9668c5052ec2b9502d061b7ecd614df/compiler/src/dotty/tools/dotc/Driver.scala#L53

Should this be backported somewhere?