### PR TITLE
Add `scala.language.{3.1, 3.1-migration}`

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -148,17 +148,33 @@ object language:
   @compileTimeOnly("`3.0` can only be used at compile time in import statements")
   object `3.0`
 
-/* This can be added when we go to 3.1
   /** Set source version to 3.1-migration.
     *
     * @see [[https://scalacenter.github.io/scala-3-migration-guide/docs/scala-3-migration-mode]]
     */
+  @compileTimeOnly("`3.1-migration` can only be used at compile time in import statements")
   object `3.1-migration`
 
   /** Set source version to 3.1
     *
     * @see [[https://scalacenter.github.io/scala-3-migration-guide/docs/scala-3-migration-mode]]
     */
+  @compileTimeOnly("`3.1` can only be used at compile time in import statements")
   object `3.1`
+
+/* This can be added when we go to 3.2
+  /** Set source version to 3.2-migration.
+    *
+    * @see [[https://scalacenter.github.io/scala-3-migration-guide/docs/scala-3-migration-mode]]
+    */
+  @compileTimeOnly("`3.2-migration` can only be used at compile time in import statements")
+  object `3.2-migration`
+
+  /** Set source version to 3.2
+    *
+    * @see [[https://scalacenter.github.io/scala-3-migration-guide/docs/scala-3-migration-mode]]
+    */
+  @compileTimeOnly("`3.2` can only be used at compile time in import statements")
+  object `3.2`
 */
 end language

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -5,6 +5,14 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 object MiMaFilters {
   val Library: Seq[ProblemFilter] = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Tuples.init"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Tuples.last")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Tuples.last"),
+
+    // Should have been added in 3.1.0
+    // These are only allowed on imports and therefore should not be present in binaries emitted before
+    // this addition of these members and therefore should not cause any conflicts.
+    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.1-migration"),
+    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.1"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E1$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E1$minusmigration$"),
   )
 }

--- a/tests/pos/source-import-3-0-migration.scala
+++ b/tests/pos/source-import-3-0-migration.scala
@@ -1,0 +1,1 @@
+import language.`3.0-migration`

--- a/tests/pos/source-import-3-0.scala
+++ b/tests/pos/source-import-3-0.scala
@@ -1,0 +1,1 @@
+import language.`3.0`

--- a/tests/pos/source-import-3-1-migration.scala
+++ b/tests/pos/source-import-3-1-migration.scala
@@ -1,0 +1,1 @@
+import language.`3.1-migration`

--- a/tests/pos/source-import-3-1.scala
+++ b/tests/pos/source-import-3-1.scala
@@ -1,0 +1,1 @@
+import language.`3.1`


### PR DESCRIPTION
Backport #13797 to `3.1.1`

Fixes #13773
