### PR TITLE
Add missing position when expanding `error`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -367,9 +367,9 @@ object Inliner {
         lit(error.pos.column),
         if kind == ErrorKind.Parser then parserErrorKind else typerErrorKind)
 
-    private def packErrors(errors: List[(ErrorKind, Error)])(using Context): Tree =
+    private def packErrors(errors: List[(ErrorKind, Error)], pos: SrcPos)(using Context): Tree =
       val individualErrors: List[Tree] = errors.map(packError)
-      val errorTpt = ref(defn.CompiletimeTesting_ErrorClass)
+      val errorTpt = ref(defn.CompiletimeTesting_ErrorClass).withSpan(pos.span)
       mkList(individualErrors, errorTpt)
 
     /** Expand call to scala.compiletime.testing.typeChecks */
@@ -380,7 +380,7 @@ object Inliner {
     /** Expand call to scala.compiletime.testing.typeCheckErrors */
     def typeCheckErrors(tree: Tree)(using Context): Tree =
       val errors = compileForErrors(tree)
-      packErrors(errors)
+      packErrors(errors, tree)
 
     /** Expand call to scala.compiletime.codeOf */
     def codeOf(arg: Tree, pos: SrcPos)(using Context): Tree =

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -17,6 +17,7 @@ i7740a.scala
 i7740b.scala
 i6507b.scala
 i12299a.scala
+i13871.scala
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/tests/pos/i13871.scala
+++ b/tests/pos/i13871.scala
@@ -1,0 +1,10 @@
+import scala.compiletime.{error, codeOf}
+import scala.compiletime.testing.*
+
+inline def testError(inline typeName: Any): String = error("Got error " + codeOf(typeName))
+
+transparent inline def compileErrors(inline code: String): List[Error] = typeCheckErrors(code)
+
+def test =
+  typeCheckErrors("""testError("string")""")
+  compileErrors("""testError("string")""")


### PR DESCRIPTION
Closes #13871. This issue was already fixed but failed `-Ycheck` due to
the missing position.