### PR TITLE
Refine treatment of TypeBounds in patterns

### DIFF
--- a/tests/neg-custom-args/fatal-warnings/i13820.scala
+++ b/tests/neg-custom-args/fatal-warnings/i13820.scala
@@ -1,0 +1,5 @@
+trait Expr { type T }
+
+def foo[A](e: Expr { type T = A }) = e match
+  case e1: Expr { type T <: Int } => // error: type test cannot be checked at runtime
+    val i: Int = ??? : e1.T

--- a/tests/pos/i13820.scala
+++ b/tests/pos/i13820.scala
@@ -1,0 +1,5 @@
+trait Expr { type T }
+
+def foo[A](e: Expr { type T = A }) = e match
+  case e1: Expr { type T <: Int } =>
+    val i: Int = ??? : e1.T


### PR DESCRIPTION
Only map type bounds to pattern-bound symbols at the toplevel of a pattern, or
when they appear as type arguments. Do not map them in refinements.

Fixes #13820