### PR TITLE
Try to instantiate type variables in tryInsertImplicitOnQualifier

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -81,6 +81,12 @@ object Typer {
    */
   private val InsertedApply = new Property.Key[Unit]
 
+  /** An attachment on a result of an implicit conversion or extension method
+   *  that was added by tryInsertImplicitOnQualifier. Needed to prevent infinite
+   *  expansions in error cases (e.g. in fuzzy/i9293.scala).
+   */
+  private val InsertedImplicitOnQualifier = new Property.Key[Unit]
+
   /** An attachment on a tree `t` occurring as part of a `t()` where
    *  the `()` was dropped by the Typer.
    */
@@ -3130,21 +3136,30 @@ class Typer extends Namer
   }
 
   /** If this tree is a select node `qual.name` (possibly applied to type variables)
-   *  that does not conform to `pt`, try to insert an implicit conversion `c` around
-   *  `qual` so that `c(qual).name` conforms to `pt`.
+   *  that does not conform to `pt`, try two mitigations:
+   *   1. Instantiate any TypeVars in the widened type of `tree` with their lower bounds.
+   *   2. Try to insert an implicit conversion `c` around `qual` so that
+   *   `c(qual).name` conforms to `pt`.
    */
   def tryInsertImplicitOnQualifier(tree: Tree, pt: Type, locked: TypeVars)(using Context): Option[Tree] = trace(i"try insert impl on qualifier $tree $pt") {
     tree match
       case tree @ Select(qual, name) if name != nme.CONSTRUCTOR =>
-        val selProto = SelectionProto(name, pt, NoViewsAllowed, privateOK = false)
-        if selProto.isMatchedBy(qual.tpe) then None
+        if couldInstantiateTypeVar(qual.tpe.widen, applied = true)
+        then
+          Some(adapt(tree, pt, locked))
         else
-          tryEither {
-            val tree1 = tryExtensionOrConversion(tree, pt, pt, qual, locked, NoViewsAllowed, inSelect = false)
-            if tree1.isEmpty then None
-            else Some(adapt(tree1, pt, locked))
-          } { (_, _) => None
-          }
+          val selProto = SelectionProto(name, pt, NoViewsAllowed, privateOK = false)
+          if selProto.isMatchedBy(qual.tpe) || tree.hasAttachment(InsertedImplicitOnQualifier) then
+            None
+          else
+            tryEither {
+              val tree1 = tryExtensionOrConversion(tree, pt, pt, qual, locked, NoViewsAllowed, inSelect = false)
+              if tree1.isEmpty then None
+              else
+                tree1.putAttachment(InsertedImplicitOnQualifier, ())
+                Some(adapt(tree1, pt, locked))
+            } { (_, _) => None
+            }
       case TypeApply(fn, args) if args.forall(_.isInstanceOf[untpd.InferredTypeTree]) =>
         tryInsertImplicitOnQualifier(fn, pt, locked)
       case _ => None

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -67,6 +67,10 @@ i8182.scala
 # local lifted value in annotation argument has different position after pickling
 i2797a
 
+# Late instantiation of type variable in tryInsertImplicitOnQualifier
+# allows to simplify a type that was already computed
+i13842.scala
+
 # GADT cast applied to singleton type difference
 i4176-gadt.scala
 

--- a/tests/pos/i13842.scala
+++ b/tests/pos/i13842.scala
@@ -1,0 +1,14 @@
+class Parent { class E }
+
+object ChildA extends Parent
+
+object ChildB extends Parent
+
+class Printer[C <: Parent](val child: C):
+  def print22(e: child.E): String = ""
+
+def test =
+  Printer(ChildA).print22(new ChildA.E) // does not work
+
+  //Printer[ChildA.type](ChildA).print22(new ChildA.E) // works
+  //val p = Printer(ChildA); p.print22(new ChildA.E) // works


### PR DESCRIPTION
Fixes #13842

What happened in #13842 was that we were not hitting this case in
`tryWiden`, which is a method in ApproximatingTypeMap that tries
to dealias or widen before propagating a Range outwards:

```scala
          case info: SingletonType =>
            // if H#x: y.type, then for any x in L..H, x.type =:= y.type,
            // hence we can replace with y.type under all variances
            reapply(info)
```
The actual info here was a TypeVar with a singleton type as lower bound. Instantiating
the TypeVar produces a SingletonType and the case applies.

We cannot really instantiate TypeVars here since this is very low-level code. For instance
we might be in a state where the instantiation is provisional and the TyperState is thrown
away. But AsSeenFrom results are cached so we'd have the wrong type in the caches.

What we do instead is add an additional case in `tryInsertImplicitOnQualifier` which is the
last resort when an application fails. Here, if we can instantiate some type variables in the
qualifier, we try again.