### PR TITLE
Automate releases to SDKMAN

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,10 +8,6 @@ jobs:
     container:
       image: lampepfl/dotty:2021-03-22
       options: --cpu-shares 4096
-      volumes:
-        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
-        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
-        - ${{ github.workspace }}/../../cache/general:/root/.cache
 
     env:
       SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }} 
@@ -21,14 +17,8 @@ jobs:
       - name: Reset existing repo
         run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
 
-      - name: Checkout cleanup script
-        uses: actions/checkout@v2
-
       - name: Cleanup
         run: .github/workflows/cleanup.sh
-
-      - name: Git Checkout
-        uses: actions/checkout@v2
 
       - name: Publish to SDKMAN
         run: .github/workflows/scripts/publish-sdkman.sh

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,34 @@
+name: Releases
+on:
+  workflow_dispatch:
+
+jobs:
+  publish_release:
+    runs-on: [self-hosted, Linux]
+    container:
+      image: lampepfl/dotty:2021-03-22
+      options: --cpu-shares 4096
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
+
+    env:
+      SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }} 
+      SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
+      
+    steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
+      - name: Checkout cleanup script
+        uses: actions/checkout@v2
+
+      - name: Cleanup
+        run: .github/workflows/cleanup.sh
+
+      - name: Git Checkout
+        uses: actions/checkout@v2
+
+      - name: Publish to SDKMAN
+        run: .github/workflows/scripts/publish-sdkman.sh

--- a/.github/workflows/scripts/publish-sdkman.sh
+++ b/.github/workflows/scripts/publish-sdkman.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# This is script for publishing scala on SDKMAN.
+# Script resolves the latest stable version of scala and then send REST request to SDKMAN Vendor API.
+# It's releasing and announcing the release of scala on SDKMAN.
+#
+# Requirement:
+#   - the latest stable version of scala should be available in github atrifacts
+
 set -eu
 
 # latest stable dotty version 
@@ -12,7 +20,8 @@ if ! curl --output /dev/null --silent --head --fail "$DOTTY_URL"; then
 fi
 
 # Release a new Candidate Version
-curl -X POST \
+curl --silent --show-error --fail \
+          -X POST \
           -H "Consumer-Key: $SDKMAN_KEY" \
           -H "Consumer-Token: $SDKMAN_TOKEN" \
           -H "Content-Type: application/json" \
@@ -20,8 +29,10 @@ curl -X POST \
           -d '{"candidate": "scala", "version": "'"$DOTTY_VERSION"'", "url": "'"$DOTTY_URL"'"}' \
           https://vendors.sdkman.io/release
 
+
 # Set DOTTY_VERSION as Default for Candidate
-curl -X PUT \
+curl --silent --show-error --fail \
+    -X PUT \
     -H "Consumer-Key: $SDKMAN_KEY" \
     -H "Consumer-Token: $SDKMAN_TOKEN" \
     -H "Content-Type: application/json" \

--- a/.github/workflows/scripts/publish-sdkman.sh
+++ b/.github/workflows/scripts/publish-sdkman.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eu
+
+# latest stable dotty version 
+DOTTY_VERSION=$(curl -s https://api.github.com/repos/lampepfl/dotty/releases/latest  | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+DOTTY_URL="https://github.com/lampepfl/dotty/releases/download/$DOTTY_VERSION/scala3-$DOTTY_VERSION.zip"
+
+# checking if dotty version is available 
+if ! curl --output /dev/null --silent --head --fail "$DOTTY_URL"; then
+  echo "URL not exists: $DOTTY_URL"
+  exit 1
+fi
+
+# Release a new Candidate Version
+curl -X POST \
+          -H "Consumer-Key: $SDKMAN_KEY" \
+          -H "Consumer-Token: $SDKMAN_TOKEN" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "scala", "version": "'"$DOTTY_VERSION"'", "url": "'"$DOTTY_URL"'"}' \
+          https://vendors.sdkman.io/release
+
+# Set DOTTY_VERSION as Default for Candidate
+curl -X PUT \
+    -H "Consumer-Key: $SDKMAN_KEY" \
+    -H "Consumer-Token: $SDKMAN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"candidate": "scala", "version": "'"$DOTTY_VERSION"'"}' \
+    https://vendors.sdkman.io/default

--- a/.github/workflows/scripts/publish-sdkman.sh
+++ b/.github/workflows/scripts/publish-sdkman.sh
@@ -5,9 +5,9 @@
 # It's releasing and announcing the release of scala on SDKMAN.
 #
 # Requirement:
-#   - the latest stable version of scala should be available in github atrifacts
+#   - the latest stable version of scala should be available in github artifacts
 
-set -eu
+set -u
 
 # latest stable dotty version 
 DOTTY_VERSION=$(curl -s https://api.github.com/repos/lampepfl/dotty/releases/latest  | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
@@ -15,20 +15,24 @@ DOTTY_URL="https://github.com/lampepfl/dotty/releases/download/$DOTTY_VERSION/sc
 
 # checking if dotty version is available 
 if ! curl --output /dev/null --silent --head --fail "$DOTTY_URL"; then
-  echo "URL not exists: $DOTTY_URL"
+  echo "URL doesn't exist: $DOTTY_URL"
   exit 1
 fi
 
 # Release a new Candidate Version
 curl --silent --show-error --fail \
-          -X POST \
-          -H "Consumer-Key: $SDKMAN_KEY" \
-          -H "Consumer-Token: $SDKMAN_TOKEN" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "scala", "version": "'"$DOTTY_VERSION"'", "url": "'"$DOTTY_URL"'"}' \
-          https://vendors.sdkman.io/release
+    -X POST \
+    -H "Consumer-Key: $SDKMAN_KEY" \
+    -H "Consumer-Token: $SDKMAN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"candidate": "scala", "version": "'"$DOTTY_VERSION"'", "url": "'"$DOTTY_URL"'"}' \
+    https://vendors.sdkman.io/release
 
+if [[ $? -ne 0 ]]; then
+  echo "Fail sending POST request to releasing scala on SDKMAN."
+  exit 1
+fi
 
 # Set DOTTY_VERSION as Default for Candidate
 curl --silent --show-error --fail \
@@ -39,3 +43,8 @@ curl --silent --show-error --fail \
     -H "Accept: application/json" \
     -d '{"candidate": "scala", "version": "'"$DOTTY_VERSION"'"}' \
     https://vendors.sdkman.io/default
+
+if [[ $? -ne 0 ]]; then
+  echo "Fail sending PUT request to announcing the release of scala on SDKMAN."
+  exit 1
+fi

--- a/docs/docs/contributing/checklist.sh
+++ b/docs/docs/contributing/checklist.sh
@@ -48,6 +48,7 @@ LIST='- [ ] Publish artifacts to Maven via CI
   - [ ] Publish Blog Post on dotty.epfl.ch
   - [ ] Make an announcement thread on https://contributors.scala-lang.org
   - [ ] Tweet the announcement blog post on https://twitter.com/scala_lang
+  - [ ] Run workflow releases CI to publish scala on SDKMAN - https://github.com/lampepfl/dotty/actions/workflows/releases.yml
 
 [Instructions on how to release](https://dotty.epfl.ch/docs/contributing/release.html)'
 


### PR DESCRIPTION
Based on discussion in [#782](https://github.com/scala/scala-dev/issues/782#issuecomment-915845429) I added new workflow `Releases` to automate releases to SDKMAN. This flow have to be trigger manually after official scala release.

It's no trigger automatically due to issues observed at [scala-steward-org/scala-steward#1104.](https://github.com/scala-steward-org/scala-steward/issues/1104).

Thanks @julienrf for adding two secrets `SDKMAN_KEY` and `SDKMAN_TOKEN` in the dotty repository.