### PR TITLE
Infer type of `Selectable` type arguments

### DIFF
--- a/tests/pos/i13891.scala
+++ b/tests/pos/i13891.scala
@@ -1,0 +1,23 @@
+trait TC[A] {
+  def cast(any: Any): A
+}
+object TC {
+  given TC[Int] with {
+    override def cast(any: Any): Int = any.asInstanceOf[Int]
+  }
+  given TC[String] with {
+    override def cast(any: Any): String = any.asInstanceOf[String]
+  }
+}
+
+class DiscordRecord(private val map: Map[String, Any]) extends Selectable {
+  def selectDynamic[A](name: String)(using decoder: TC[A]): A =
+    decoder.cast(map(name))
+}
+
+type Test = DiscordRecord {
+  val foo: Int
+}
+
+val t: Test = ???
+def test = t.foo


### PR DESCRIPTION
Use the refined result type to infer type parameters of `selectDynamic` or `applyDynamic`.

Fixes #13891