### PR TITLE
Scaladoc: Add source position for errors from doc-root-content file

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
@@ -88,6 +88,11 @@ abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
     if repr == null then null.asInstanceOf[qctx.reflect.Symbol] else repr.sym
   private given qctx.type = qctx
 
+  lazy val srcPos = if owner == qctx.reflect.defn.RootClass then {
+    val sourceFile = dctx.args.rootDocPath.map(p => dotty.tools.dotc.util.SourceFile(dotty.tools.io.AbstractFile.getFile(p), scala.io.Codec.UTF8))
+    sourceFile.fold(dotty.tools.dotc.util.NoSourcePosition)(sf => dotty.tools.dotc.util.SourcePosition(sf, dotty.tools.dotc.util.Spans.NoSpan))
+  } else owner.pos.get.asInstanceOf[dotty.tools.dotc.util.SrcPos]
+
   object SymOpsWithLinkCache extends SymOpsWithLinkCache
   export SymOpsWithLinkCache._
   import SymOps._
@@ -96,8 +101,7 @@ abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
     if SchemeUri.matches(queryStr) then DocLink.ToURL(queryStr)
     else QueryParser(queryStr).tryReadQuery() match
       case Left(err) =>
-        // TODO convert owner.pos to get to the comment, add stack trace
-        report.warning(s"Unable to parse query `$queryStr`: ${err.getMessage}")
+        report.warning(s"Unable to parse query `$queryStr`: ${err.getMessage}", srcPos)
         val msg = s"Unable to parse query: ${err.getMessage}"
         DocLink.UnresolvedDRI(queryStr, msg)
       case Right(query) =>
@@ -112,7 +116,8 @@ abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
             val msg = s"$txt: $queryStr"
 
             if (!summon[DocContext].args.noLinkWarnings) then
-              report.warning(msg, owner.pos.get.asInstanceOf[dotty.tools.dotc.util.SrcPos])
+
+              report.warning(msg, srcPos)
 
             DocLink.UnresolvedDRI(queryStr, txt)
 


### PR DESCRIPTION
closes #13874 