### PR TITLE
Scaladoc: Fix double implicit modifier

### DIFF
--- a/scaladoc-testcases/src/tests/classModifiers.scala
+++ b/scaladoc-testcases/src/tests/classModifiers.scala
@@ -11,3 +11,5 @@ sealed case class D(c: String)
 final case class E(c: String)
 
 open class F
+
+implicit class Foo(i: Int)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
@@ -100,7 +100,7 @@ object SymOps:
         Flags.Case -> Modifier.Case,
       ).collect {
         case (flag, mod) if sym.flags.is(flag) => mod
-      } ++ Seq(Modifier.Implicit).filter(_ => sym.isImplicitClass)
+      }
 
     def isHiddenByVisibility(using dctx: DocContext): Boolean =
       import VisibilityScope._


### PR DESCRIPTION
closes #13869 

It seems that compiler now adds Implicit flag to both desugarized method and class. (Before only method was implicit)