### PR TITLE
Fix messages leaking via suspended messages

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -103,7 +103,7 @@ class TyperState() {
     this
 
   /** A fresh typer state with the same constraint as this one. */
-  def fresh(reporter: Reporter = StoreReporter(this.reporter),
+  def fresh(reporter: Reporter = StoreReporter(this.reporter, fromTyperState = true),
       committable: Boolean = this.isCommittable): TyperState =
     util.Stats.record("TyperState.fresh")
     TyperState().init(this, this.constraint)

--- a/compiler/src/dotty/tools/dotc/reporting/ExploringReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ExploringReporter.scala
@@ -7,7 +7,7 @@ import core.Contexts.Context
 import Diagnostic._
 
 /** A re-usable Reporter used in Contexts#test */
-class ExploringReporter extends StoreReporter(null):
+class ExploringReporter extends StoreReporter(null, fromTyperState = false):
   infos = new mutable.ListBuffer[Diagnostic]
 
   override def hasUnreportedErrors: Boolean =

--- a/compiler/src/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/TestReporter.scala
@@ -6,7 +6,7 @@ import collection.mutable
 import Diagnostic._
 
 /** A re-usable Reporter used in Contexts#test */
-class TestingReporter extends StoreReporter(null):
+class TestingReporter extends StoreReporter(null, fromTyperState = false):
   infos = new mutable.ListBuffer[Diagnostic]
   override def hasUnreportedErrors: Boolean = infos.exists(_.isInstanceOf[Error])
   def reset(): Unit = infos.clear()


### PR DESCRIPTION
It isn't clear what StoreReporter's purpose is.  Is it simply a store of
all messages, or is it a store of "real" messages, i.e. messages that
aren't suppressed with `@nowarn` or -Wconf (i.e. configurable warnings)?
I believe StoreReporter is often used as a way to get programmatic
access to the real messages.

Typer, with its TyperState, uses StoreReporter as a more general buffer
while making typing attempts, such as when trying to apply an implicit
conversion.  But with configurable warnings, we don't know if a warning
is real or not until we've typed all the `@nowarn` annotation in the
code, which is why we suspend the messages, on Run.

So we add an override for TyperState, so that StoreReporter is used as
simply a buffer.  When it then unbuffers its messages in flush to the
parent context's reporter, it will run through the regular
"issueIfNotSuppressed" code (assuming it's not another store reporter).

[test_java8]