### PR TITLE
Don't lift try-catch statements that are already in local functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/LiftTry.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LiftTry.scala
@@ -44,6 +44,9 @@ class LiftTry extends MiniPhase with IdentityDenotTransformer { thisPhase =>
   override def prepareForApply(tree: Apply)(using Context): Context =
     liftingCtx(true)
 
+  override def prepareForDefDef(tree: DefDef)(using Context): Context =
+    liftingCtx(false)
+
   override def prepareForValDef(tree: ValDef)(using Context): Context =
     if !tree.symbol.exists
        || tree.symbol.isSelfSym

--- a/tests/pos/i13941.scala
+++ b/tests/pos/i13941.scala
@@ -1,0 +1,15 @@
+import scala.annotation.tailrec
+
+object A {
+  def b = Option("a").map { x =>
+    @tailrec
+    def loop(): Int = {
+      try
+        2
+      catch
+        case _: Throwable =>
+          loop()
+    }
+    x
+  }
+}


### PR DESCRIPTION
closes #13941

The problem in #13941 is that before tail recursion can be expanded the `try` is lifted to a local function, which in turn moves direct recursive calls.