### PR TITLE
move implementation of ordinal in enums to posttyper

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -179,13 +179,12 @@ object DesugarEnums {
    *   }
    */
   private def enumValueCreator(using Context) = {
-    val fieldMethods = if isJavaEnum then Nil else ordinalMeth(Ident(nme.ordinalDollar_)) :: Nil
     val creator = New(Template(
       constr = emptyConstructor,
       parents = enumClassRef :: scalaRuntimeDot(tpnme.EnumValue) :: Nil,
       derived = Nil,
       self = EmptyValDef,
-      body = fieldMethods
+      body = Nil
     ).withAttachment(ExtendsSingletonMirror, ()))
     DefDef(nme.DOLLAR_NEW,
         List(List(param(nme.ordinalDollar_, defn.IntType), param(nme.nameDollar, defn.StringType))),
@@ -270,8 +269,6 @@ object DesugarEnums {
   def param(name: TermName, typ: Type)(using Context): ValDef = param(name, TypeTree(typ))
   def param(name: TermName, tpt: Tree)(using Context): ValDef = ValDef(name, tpt, EmptyTree).withFlags(Param)
 
-  private def isJavaEnum(using Context): Boolean = enumClass.derivesFrom(defn.JavaEnumClass)
-
   def ordinalMeth(body: Tree)(using Context): DefDef =
     DefDef(nme.ordinal, Nil, TypeTree(defn.IntType), body).withAddedFlags(Synthetic)
 
@@ -290,10 +287,8 @@ object DesugarEnums {
       expandSimpleEnumCase(name, mods, definesLookups, span)
     else {
       val (tag, scaffolding) = nextOrdinal(name, CaseKind.Object, definesLookups)
-      val impl1 = cpy.Template(impl)(
-        parents = impl.parents :+ scalaRuntimeDot(tpnme.EnumValue),
-        body = if isJavaEnum then Nil else ordinalMethLit(tag) :: Nil
-      ).withAttachment(ExtendsSingletonMirror, ())
+      val impl1 = cpy.Template(impl)(parents = impl.parents :+ scalaRuntimeDot(tpnme.EnumValue), body = Nil)
+        .withAttachment(ExtendsSingletonMirror, ())
       val vdef = ValDef(name, TypeTree(), New(impl1)).withMods(mods.withAddedFlags(EnumValue, span))
       flatTree(vdef :: scaffolding).withSpan(span)
     }

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -733,6 +733,7 @@ class Definitions {
   @tu lazy val NoneModule: Symbol = requiredModule("scala.None")
 
   @tu lazy val EnumClass: ClassSymbol = requiredClass("scala.reflect.Enum")
+    @tu lazy val Enum_ordinal: Symbol = EnumClass.requiredMethod(nme.ordinal)
 
   @tu lazy val EnumValueSerializationProxyClass: ClassSymbol = requiredClass("scala.runtime.EnumValueSerializationProxy")
     @tu lazy val EnumValueSerializationProxyConstructor: TermSymbol =

--- a/tests/neg/enumsLabel-singleimpl.scala
+++ b/tests/neg/enumsLabel-singleimpl.scala
@@ -1,13 +1,13 @@
 enum Ordinalled {
 
-  case A // error: method ordinal of type => Int needs `override` modifier
+  case A
 
-  def ordinal: Int = -1
+  def ordinal: Int = -1 // error: the ordinal method of enum class Ordinalled can not be defined by the user
 
 }
 
 trait HasOrdinal { def ordinal: Int = 23 }
 
-enum MyEnum extends HasOrdinal {
-  case Foo // error: method ordinal of type => Int needs `override` modifier
+enum MyEnum extends HasOrdinal { // error: enum class MyEnum can not inherit the concrete ordinal method of trait HasOrdinal
+  case Foo
 }

--- a/tests/pos/i13554.scala
+++ b/tests/pos/i13554.scala
@@ -1,0 +1,6 @@
+object StatusCode:
+  class Matcher
+
+enum StatusCode(m: StatusCode.Matcher):
+  case InternalServerError extends StatusCode(???)
+

--- a/tests/pos/i13554a.scala
+++ b/tests/pos/i13554a.scala
@@ -1,0 +1,15 @@
+object StatusCode:
+  enum Matcher:
+    case ServerError extends Matcher
+  end Matcher
+end StatusCode
+
+enum StatusCode(code: Int, m: StatusCode.Matcher):
+  case InternalServerError extends StatusCode(500, StatusCode.Matcher.ServerError)
+end StatusCode
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println(StatusCode.InternalServerError)
+  }
+}


### PR DESCRIPTION
It was identified by @odersky that the cause of #13554 was forcing of the enum class in desugaring (in `isJavaEnum` method). `isJavaEnum` is only used to provide an implementation of `ordinal` for singleton cases, so the whole thing can be deferred until later.

also add a check that `ordinal` is not implemented by the user in the body of an enum class, or mixed in by a trait - this is necessary as `scala.deriving.Mirror.Sum` delegates to ordinal method on an enum.

Note- before this PR enum cases would declare `ordinal` methods without an override flag, so refchecks would issue an override-without-override-modifier error anyway if the user declared their own.

fixes #13554 