### PR TITLE
Tighten product match logic in irrefutable check

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -821,7 +821,7 @@ trait Checking {
             recur(pat1, pt)
           case UnApply(fn, _, pats) =>
             check(pat, pt) &&
-            (isIrrefutable(fn) || fail(pat, pt)) && {
+            (isIrrefutable(fn, pats.length) || fail(pat, pt)) && {
               val argPts = unapplyArgs(fn.tpe.widen.finalResultType, fn, pats, pat.srcPos)
               pats.corresponds(argPts)(recur)
             }

--- a/tests/patmat/i13737.check
+++ b/tests/patmat/i13737.check
@@ -1,0 +1,1 @@
+14: Pattern Match Exhaustivity: _: Success

--- a/tests/patmat/i13737.scala
+++ b/tests/patmat/i13737.scala
@@ -1,0 +1,15 @@
+sealed trait Result
+
+case class Success(result: String, next: Int) extends Result {
+  def isEmpty: Boolean = 10 % 2 == 1
+  def get: String = result
+}
+
+object Success {
+  def unapply(x: Success): Success = x
+}
+
+def main =
+  val res: Result = ???
+  res match // error
+    case Success(v) => v

--- a/tests/patmat/irrefutable.check
+++ b/tests/patmat/irrefutable.check
@@ -1,2 +1,2 @@
 22: Pattern Match Exhaustivity: _: A, _: B, C(_, _)
-65: Pattern Match Exhaustivity: ExM(_, _)
+65: Pattern Match Exhaustivity: _: M


### PR DESCRIPTION
This avoids accidentally considering refutable name-based extractors as
irrefutable because they also happen to be a Product.

With this change some tests no longer go through the Typ to Prod rewrite
that occurs in `minus(a, b)` when `a` is a Typ and `b` is a Prod,
leading to a Typ result.  This renders in the counter-example as a
generic value type rather than a product, which we see in the warning
text changes in the tests.