### PR TITLE
Complete when importing same symbol multiple times

### DIFF
--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -404,6 +404,19 @@ class CompletionTest {
       .completion(m1, Set())
   }
 
+  @Test def completeFromSameImportsForEqualNestingLevels: Unit = {
+    code"""object Foo {
+          |  def xxxx(i: Int): Int = i
+          |}
+          |object Test {
+          |  import Foo.xxxx
+          |  import Foo.xxxx
+          |  import Foo.xxxx
+          |  val x = xx$m1
+          |}""".withSource
+      .completion(m1, Set(("xxxx", Method, "(i: Int): Int")))
+  }
+
   @Test def preferLocalDefinitionToImportForEqualNestingLevels: Unit = {
     code"""object Foo {
           |  val xxxx = 1


### PR DESCRIPTION
This is related to https://github.com/lampepfl/dotty/issues/13623 - since it seems that Predef might be imported more than once, but this doesn't yet solve the issue.