### PR TITLE
Fixes and improvements to trace logging

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1370,13 +1370,6 @@ class Definitions {
     else if arity >= 0 then FunctionType(arity)
     else NoType
 
-  val predefClassNames: Set[Name] =
-    Set("Predef$", "DeprecatedPredef", "LowPriorityImplicits").map(_.toTypeName.unmangleClassName)
-
-  /** Is `cls` the predef module class, or a class inherited by Predef? */
-  def isPredefClass(cls: Symbol): Boolean =
-    (cls.owner eq ScalaPackageClass) && predefClassNames.contains(cls.name)
-
   private val JavaImportFns: List[RootRef] = List(
     RootRef(() => JavaLangPackageVal.termRef)
   )

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -36,7 +36,7 @@ object Formatting {
               case _ => ex.getMessage
             s"[cannot display due to $msg, raw string = ${arg.toString}]"
         }
-      case _ => arg.toString
+      case _ => String.valueOf(arg)
     }
 
     private def treatArg(arg: Any, suffix: String)(using Context): (Any, String) = arg match {

--- a/compiler/src/dotty/tools/dotc/reporting/trace.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/trace.scala
@@ -7,6 +7,12 @@ import config.Config
 import config.Printers
 import core.Mode
 
+/** Exposes the {{{ trace("question") { op } }}} syntax.
+ *
+ * Traced operations will print indented messages if enabled.
+ * Tracing depends on [[Config.tracingEnabled]] and [[dotty.tools.dotc.config.ScalaSettings.Ylog]].
+ * Tracing can be forced by replacing [[trace]] with [[trace.force]] or [[trace.log]] (see below).
+ */
 object trace extends TraceSyntax:
   inline def isEnabled = Config.tracingEnabled
   protected val isForced = false
@@ -14,6 +20,10 @@ object trace extends TraceSyntax:
   object force extends TraceSyntax:
     inline def isEnabled: true = true
     protected val isForced = true
+
+  object log extends TraceSyntax:
+    inline def isEnabled: true = true
+    protected val isForced = false
 end trace
 
 /** This module is carefully optimized to give zero overhead if Config.tracingEnabled
@@ -73,7 +83,7 @@ trait TraceSyntax:
       var logctx = ctx
       while logctx.reporter.isInstanceOf[StoreReporter] do logctx = logctx.outer
       def margin = ctx.base.indentTab * ctx.base.indent
-      def doLog(s: String) = if isForced then println(s) else report.log(s)
+      def doLog(s: String) = if isForced then println(s) else report.log(s)(using logctx)
       def finalize(msg: String) =
         if !finalized then
           ctx.base.indent -= 1


### PR DESCRIPTION
The String.valueOf is because I somehow ended up with a null.

Then I found some docs in the history of trace, as well as a mistake in
a commit revert: using the non-StoreReporter logctx!

I also added a "log" variant to "force", which is also default enabled
but doesn't force the output to the standard out, meaning I can
bootstrap the compiler without it taking forever to output all the trace
output it generates while bootstrapping the compiler, bottlenecking on
console IO)...

Also, remove some dead code in Definitions.