### PR TITLE
Fix Mirror.Product for type lambdas

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -829,4 +829,11 @@ object TypeOps:
   def nestedPairs(ts: List[Type])(using Context): Type =
     ts.foldRight(defn.EmptyTupleModule.termRef: Type)(defn.PairClass.typeRef.appliedTo(_, _))
 
+  class StripTypeVarsMap(using Context) extends TypeMap:
+    def apply(tp: Type) = mapOver(tp).stripTypeVar
+
+  /** Apply [[Type.stripTypeVar]] recursively. */
+  def stripTypeVars(tp: Type)(using Context): Type =
+    new StripTypeVarsMap().apply(tp)
+
 end TypeOps

--- a/tests/pos/i13859.scala
+++ b/tests/pos/i13859.scala
@@ -1,0 +1,31 @@
+import scala.deriving.*
+
+object Test:
+  type Kind1[C, O[_]] = C {
+    type MirroredType[X] = O[X]
+    type MirroredMonoType = O[Any]
+    type MirroredElemTypes[_] <: Tuple
+  }
+
+  type Kind2[C, O[_, _]] = C {
+    type MirroredType[X, Y] = O[X, Y]
+    type MirroredMonoType = O[Any, Any]
+    type MirroredElemTypes[_, _] <: Tuple
+  }
+
+  type Test[X] = (X, Boolean)
+  type Swap[X, Y] = (Y, X)
+
+  locally {
+    val x = summon[Kind1[Mirror.Product, Test]]
+    x: Mirror.Product {
+      type MirroredElemTypes[X] = (X, Boolean)
+    }
+  }
+
+  locally {
+    val x = summon[Kind2[Mirror.Product, Swap]]
+    x: Mirror.Product {
+      type MirroredElemTypes[X, Y] = (Y, X)
+    }
+  }


### PR DESCRIPTION
We don't need to guess how the type parameters should be substituted.
Instead we can use the result type directly to obtain the member type.
This exposed another issue - the mirrored type contained type variables.
To get rid of them we apply `Type.stripTypeVar` recursively.

Fixes #13859