### PR TITLE
Remove preprocessing markdowns from CD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -505,17 +505,6 @@ jobs:
           external_repository: lampepfl/dotty-website
           publish_branch: gh-pages
 
-      - name: Generate docs.scala-lang preprocessed files
-        run: |
-          ./project/scripts/genDocsScalaLang
-
-      - name: Deploy Website to docs.scala-lang
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          personal_token: ${{ env.DOCS_SCALALANG_BOT_TOKEN }}
-          publish_dir: docsScalaLang
-          external_repository: BarkingBad/docs.scala-lang
-          publish_branch: dev
 
   publish_release:
     runs-on: [self-hosted, Linux]


### PR DESCRIPTION
I've removed unused outputs of CD. Actually, I should clean some other things, but it was supposed to be in a follow up PR to #13954 https://github.com/lampepfl/dotty/pull/13954#discussion_r758227519
I didn't suppose I will accidentally break CD. Hopefully, the dotty-website has been published last night since this step is earlier and I see the page has changed.