### PR TITLE
Allow `import <ident>` to show completions

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -24,6 +24,7 @@ import dotty.tools.dotc.printing.Texts._
 import dotty.tools.dotc.util.{NameTransformer, NoSourcePosition, SourcePosition}
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 /**
  * One of the results of a completion query.
@@ -223,11 +224,11 @@ object Completion {
         // import java.lang.annotation
         //    is shadowed by
         // import scala.annotation
-        def isJavaLangAndScala =  denotss match
-          case List(first, second) =>
-            isScalaPackage(first) && isJavaLangPackage(second) ||
-            isScalaPackage(second) && isJavaLangPackage(first)
-          case _ => false
+        def isJavaLangAndScala =
+          try
+            denotss.forall(denots => isScalaPackage(denots) || isJavaLangPackage(denots))
+          catch
+            case NonFatal(_) => false
 
         denotss.find(!_.ctx.isImportContext) match {
           // most deeply nested member or local definition if not shadowed by an import

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -985,4 +985,13 @@ class CompletionTest {
               ("annotation", Module, "scala.annotation")
             )
           )
+
+  @Test def importAnnotationAfterImport : Unit =
+    code"""import java.lang.annotation; import annot${m1}"""
+        .withSource
+        .completion(m1,
+          Set(
+            ("annotation", Module, "scala.annotation")
+          )
+        )
 }

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -976,4 +976,13 @@ class CompletionTest {
               ("main", Module, "main")
             )
           )
+
+  @Test def i13623_annotation : Unit =
+    code"""import annot${m1}"""
+          .withSource
+          .completion(m1,
+            Set(
+              ("annotation", Module, "scala.annotation")
+            )
+          )
 }


### PR DESCRIPTION
Previously, there would be no completions after simple `import annot`. Now, we make sure that the completions mode is set correctly for that case.

Additionally, whenever both `java.lang` and `scala` imports conflict we choose scala one.

Connected to https://github.com/lampepfl/dotty/issues/13623

But it will not work with package objects yet. We should most likely open up a separate issue for that?