### PR TITLE
Avoid field/field clashes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -369,6 +369,7 @@ object NameKinds {
   val FieldName: SuffixNameKind = new SuffixNameKind(FIELD, "$$local") {
       override def mkString(underlying: TermName, info: ThisInfo) = underlying.toString
   }
+  val ExplicitFieldName: SuffixNameKind = new SuffixNameKind(EXPLICITFIELD, "$field")
   val ExtMethName: SuffixNameKind = new SuffixNameKind(EXTMETH, "$extension")
   val ParamAccessorName: SuffixNameKind = new SuffixNameKind(PARAMACC, "$accessor")
   val ModuleClassName: SuffixNameKind = new SuffixNameKind(OBJECTCLASS, "$", optInfoString = "ModuleClass")

--- a/compiler/src/dotty/tools/dotc/core/NameTags.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameTags.scala
@@ -37,6 +37,9 @@ object NameTags extends TastyFormat.NameTags {
   final val AVOIDLOWER = 36
   final val AVOIDBOTH = 37
 
+  inline val EXPLICITFIELD = 38  // An explicitly named field, introduce to avoid a clash
+                                 // with a regular field of the underlying name
+
   def nameTagToString(tag: Int): String = tag match {
     case UTF8 => "UTF8"
     case QUALIFIED => "QUALIFIED"

--- a/tests/run/i13862.scala
+++ b/tests/run/i13862.scala
@@ -1,0 +1,11 @@
+trait Foo(val num: Int)                 // a trait with a parameter stored in a val
+
+class Bar(num: Int) extends Foo(num):   // an extending class with a parameter of the same name
+  def bar = this.num                    // implicitly creates another num in Bar
+
+@main def Test = Bar(123)
+
+class Bar2(n: Int) extends Foo(n):   // an extending class with a parameter of the same name
+  private val num = n
+  def bar = this.num                    // implicitly creates another num in Bar
+


### PR DESCRIPTION
There needs to be a special alignment of planetary bodies to obtain two fields
that have different names for Dotty (one has a FieldName, the other a regular name),
but that still map to the same underlying name. This is now detected and resolved.

Fixes #13862