### PR TITLE
Make outer references Java-synthetic

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -343,6 +343,7 @@ trait BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
     def emitParamNames(jmethod: asm.MethodVisitor, params: List[Symbol]) =
       for param <- params do
         var access = asm.Opcodes.ACC_FINAL
+        if param.is(Artifact) then access |= asm.Opcodes.ACC_SYNTHETIC
         jmethod.visitParameter(param.name.mangledString, access)
 
     /*

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -929,7 +929,7 @@ object Erasure {
       if constr.isConstructor && needsOuterParam(constr.owner.asClass) then
         constr.info match
           case MethodTpe(outerName :: _, outerType :: _, _) =>
-            val outerSym = newSymbol(constr, outerName, Flags.Param, outerType)
+            val outerSym = newSymbol(constr, outerName, Flags.Param | Flags.SyntheticArtifact, outerType)
             ValDef(outerSym) :: Nil
           case _ =>
             // There's a possible race condition that a constructor was looked at

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -177,7 +177,7 @@ object ExplicitOuter {
           else prefix.widen)
     val info = if (flags.is(Method)) ExprType(target) else target
     atPhaseNoEarlier(explicitOuterPhase.next) { // outer accessors are entered at explicitOuter + 1, should not be defined before.
-      newSymbol(owner, name, Synthetic | flags, info, coord = cls.coord)
+      newSymbol(owner, name, SyntheticArtifact | flags, info, coord = cls.coord)
     }
   }
 

--- a/tests/pos/i14083.scala
+++ b/tests/pos/i14083.scala
@@ -1,0 +1,3 @@
+class Outer {
+  class Inner
+}

--- a/tests/pos/i14083.scala
+++ b/tests/pos/i14083.scala
@@ -1,3 +1,0 @@
-class Outer {
-  class Inner
-}

--- a/tests/run/i14083.scala
+++ b/tests/run/i14083.scala
@@ -2,6 +2,10 @@ class Outer {
   class Inner
 }
 @main def Test =
+  assert(classOf[Outer#Inner]
+    .getConstructors.head
+    .getParameters.head
+    .isSynthetic)
   assert(
     classOf[Outer#Inner]
       .getDeclaredFields

--- a/tests/run/i14083.scala
+++ b/tests/run/i14083.scala
@@ -1,0 +1,9 @@
+class Outer {
+  class Inner
+}
+@main def Test =
+  assert(
+    classOf[Outer#Inner]
+      .getDeclaredFields
+      .filter(_.getName == "$outer")
+      .exists(_.isSynthetic))


### PR DESCRIPTION
Fixes #14083

I verified manually that the puter accessors are now ACC_SYNTHETIC. If someone wants to add a bytecode test, this would be good. I don't know how to make one.