### PR TITLE
Add typed versions of Mirror.ProductOf#fromProduct

### DIFF
--- a/library/src/scala/deriving/Mirror.scala
+++ b/library/src/scala/deriving/Mirror.scala
@@ -49,4 +49,13 @@ object Mirror {
   type Of[T] = Mirror { type MirroredType = T; type MirroredMonoType = T ; type MirroredElemTypes <: Tuple }
   type ProductOf[T] = Mirror.Product { type MirroredType = T; type MirroredMonoType = T ; type MirroredElemTypes <: Tuple }
   type SumOf[T] = Mirror.Sum { type MirroredType = T; type MirroredMonoType = T; type MirroredElemTypes <: Tuple }
+
+  extension [T](p: ProductOf[T])
+    /** Create a new instance of type `T` with elements taken from product `a`. */
+    def fromProductTyped[A <: scala.Product](a: A)(using m: ProductOf[A], ev: p.MirroredElemTypes =:= m.MirroredElemTypes): T =
+      p.fromProduct(a)
+
+    /** Create a new instance of type `T` with elements taken from tuple `t`. */
+    def fromTuple(t: p.MirroredElemTypes): T =
+      p.fromProduct(t)
 }

--- a/library/src/scala/deriving/Mirror.scala
+++ b/library/src/scala/deriving/Mirror.scala
@@ -52,10 +52,12 @@ object Mirror {
 
   extension [T](p: ProductOf[T])
     /** Create a new instance of type `T` with elements taken from product `a`. */
+    @annotation.experimental
     def fromProductTyped[A <: scala.Product](a: A)(using m: ProductOf[A], ev: p.MirroredElemTypes =:= m.MirroredElemTypes): T =
       p.fromProduct(a)
 
     /** Create a new instance of type `T` with elements taken from tuple `t`. */
+    @annotation.experimental
     def fromTuple(t: p.MirroredElemTypes): T =
       p.fromProduct(t)
 }

--- a/library/src/scala/deriving/Mirror.scala
+++ b/library/src/scala/deriving/Mirror.scala
@@ -53,7 +53,7 @@ object Mirror {
   extension [T](p: ProductOf[T])
     /** Create a new instance of type `T` with elements taken from product `a`. */
     @annotation.experimental
-    def fromProductTyped[A <: scala.Product](a: A)(using m: ProductOf[A], ev: p.MirroredElemTypes =:= m.MirroredElemTypes): T =
+    def fromProductTyped[A <: scala.Product, Elems <: p.MirroredElemTypes](a: A)(using m: ProductOf[A] { type MirroredElemTypes = Elems }): T =
       p.fromProduct(a)
 
     /** Create a new instance of type `T` with elements taken from tuple `t`. */

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -17,6 +17,8 @@ object MiMaFilters {
     ProblemFilters.exclude[MissingClassProblem]("scala.compiletime.ops.long$"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#CompilationInfoModule.XmacroSettings"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#CompilationInfoModule.XmacroSettings"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.deriving.Mirror.fromProductTyped"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.deriving.Mirror.fromTuple"),
 
     // Private to the compiler - needed for forward binary compatibility
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.since")

--- a/tests/neg/deriving-from-product-typed.scala
+++ b/tests/neg/deriving-from-product-typed.scala
@@ -1,0 +1,10 @@
+import deriving.Mirror
+
+case class A(x: Int, y: String)
+case class B(a: Any, b: Any)
+object A:
+  def f = summon[Mirror.ProductOf[A]].fromProductTyped((1, 2)) // error
+  def g = summon[Mirror.ProductOf[A]].fromTuple((1, 2)) // error
+  def h = summon[Mirror.ProductOf[B]].fromProductTyped(A(1, ""))
+  def i = summon[Mirror.ProductOf[A]].fromProductTyped(B(1, "")) // error
+

--- a/tests/neg/deriving.scala
+++ b/tests/neg/deriving.scala
@@ -1,6 +1,6 @@
-import reflect.Generic
+import deriving.MirrorOf
 
-sealed trait A derives Generic // error: cannot take shape, it has anonymous or inaccessible subclasses
+sealed trait A
 
 object A {
   def f() = {
@@ -9,17 +9,28 @@ object A {
   }
 }
 
-sealed trait B derives Generic // error: cannot take shape, its subclass class D is not a case class
+def aMirror = summon[Mirror.Of[A]] // error: cannot take shape, it has anonymous or inaccessible subclasses
+
+sealed trait B
 
 class D(x: Int, y: String) extends B
 
+def bMirror = summon[Mirror.Of[B]] // error: cannot take shape, its subclass class D is not a case class
 
-class E derives Generic // error: cannot take shape, it is neither sealed nor a case class
+class E
+def eMirror = summon[Mirror.Of[E]] // error: cannot take shape, it is neither sealed nor a case class
 
-sealed trait F derives Generic // error: cannot take shape, it has anonymous or inaccessible subclasses
+sealed trait F
+def fMirror = summon[Mirror.Of[F]] // error: cannot take shape, it has anonymous or inaccessible subclasses
 
 object G {
   def f() = {
     case class H() extends F
   }
 }
+
+case class I(x: Int, y: String)
+object I:
+  def f = summon[deriving.Mirror.ProductOf[I]].fromProductTyped((1, 2)) // error
+  def g = summon[deriving.Mirror.ProductOf[I]].fromTuple((1, 2)) // error
+

--- a/tests/neg/deriving.scala
+++ b/tests/neg/deriving.scala
@@ -1,6 +1,6 @@
-import deriving.MirrorOf
+import reflect.Generic
 
-sealed trait A
+sealed trait A derives Generic // error: cannot take shape, it has anonymous or inaccessible subclasses
 
 object A {
   def f() = {
@@ -9,28 +9,17 @@ object A {
   }
 }
 
-def aMirror = summon[Mirror.Of[A]] // error: cannot take shape, it has anonymous or inaccessible subclasses
-
-sealed trait B
+sealed trait B derives Generic // error: cannot take shape, its subclass class D is not a case class
 
 class D(x: Int, y: String) extends B
 
-def bMirror = summon[Mirror.Of[B]] // error: cannot take shape, its subclass class D is not a case class
+class E derives Generic // error: cannot take shape, it is neither sealed nor a case class
 
-class E
-def eMirror = summon[Mirror.Of[E]] // error: cannot take shape, it is neither sealed nor a case class
-
-sealed trait F
-def fMirror = summon[Mirror.Of[F]] // error: cannot take shape, it has anonymous or inaccessible subclasses
+sealed trait F derives Generic // error: cannot take shape, it has anonymous or inaccessible subclasses
 
 object G {
   def f() = {
     case class H() extends F
   }
 }
-
-case class I(x: Int, y: String)
-object I:
-  def f = summon[deriving.Mirror.ProductOf[I]].fromProductTyped((1, 2)) // error
-  def g = summon[deriving.Mirror.ProductOf[I]].fromTuple((1, 2)) // error
 

--- a/tests/run/deriving-from-product-typed.scala
+++ b/tests/run/deriving-from-product-typed.scala
@@ -1,0 +1,11 @@
+case class A(x: Option[Int], y: Option[Any])
+case class B(x: Some[Int], y: Some[Boolean])
+
+object Test extends App:
+  import deriving.*
+
+  val ma = summon[Mirror.ProductOf[A]]
+
+  ma.fromProductTyped(B(Some(1), Some(true)))
+  ma.fromProductTyped((Some(1), Some(false)))
+

--- a/tests/run/deriving.scala
+++ b/tests/run/deriving.scala
@@ -13,6 +13,8 @@ object Test extends App {
   case class AA[X >: Null <: AnyRef](x: X, y: X, z: String)
 
   println(summon[Mirror.ProductOf[A]].fromProduct(A(1, 2)))
+  summon[Mirror.ProductOf[A]].fromProductTyped(A(1, 2))
+  summon[Mirror.ProductOf[A]].fromTuple((1, 2))
   assert(summon[Mirror.SumOf[T]].ordinal(A(1, 2)) == 0)
   assert(summon[Mirror.Sum { type MirroredType = T }].ordinal(B) == 1)
   summon[Mirror.Of[A]] match {


### PR DESCRIPTION
The existing `Mirror.ProductOf#fromProduct` method is defined for any `scala.Product` which can lead to some surprising runtime errors:

```scala
Welcome to Scala 3.1.2-RC1-bin-SNAPSHOT-nonbootstrapped-git-b636aa9 (17.0.1, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> case class Point(x: Int, y: Int, z: Int)
// defined case class Point

scala> summon[deriving.Mirror.ProductOf[Point]].fromProduct((1, 2))
java.lang.IndexOutOfBoundsException: 2 is out of bounds (min 0, max 1)
  at scala.Product2.productElement(Product2.scala:43)
  at scala.Product2.productElement$(Product2.scala:40)
  at scala.Tuple2.productElement(Tuple2.scala:24)
  at rs$line$1$Point$.fromProduct(rs$line$1:1)
  at rs$line$1$Point$.fromProduct(rs$line$1:1)
  ... 38 elided

scala> summon[deriving.Mirror.ProductOf[Point]].fromProduct((1, 2, 3.0))
java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.lang.Integer (java.lang.Double and java.lang.Integer are in module java.base of loader 'bootstrap')
  at scala.runtime.BoxesRunTime.unboxToInt(BoxesRunTime.java:99)
  at rs$line$1$Point$.fromProduct(rs$line$1:1)
  at rs$line$1$Point$.fromProduct(rs$line$1:1)
  ... 38 elided
```

This PR adds `fromTuple` and `fromProductTyped` extension methods to `Mirror.ProductOf[T]`, both which ensure the argument is well typed:

```scala
scala> summon[deriving.Mirror.ProductOf[Point]].fromTuple((1, 2))
-- [E007] Type Mismatch Error: -------------------------------------------------
1 |summon[deriving.Mirror.ProductOf[Point]].fromTuple((1, 2))
  |                                                   ^^^^^^
  |                                                 Found:    (Int, Int)
  |                                                 Required: (Int, Int, Int)

longer explanation available when compiling with `-explain`
1 error found

scala> summon[deriving.Mirror.ProductOf[Point]].fromTuple((1, 2, 3.0))
-- [E007] Type Mismatch Error: -------------------------------------------------
1 |summon[deriving.Mirror.ProductOf[Point]].fromTuple((1, 2, 3.0))
  |                                                          ^^^
  |                                                 Found:    (3.0d : Double)
  |                                                 Required: Int

longer explanation available when compiling with `-explain`
1 error found

scala> summon[deriving.Mirror.ProductOf[Point]].fromTuple((1, 2, 3))
val res2: Point = Point(1,2,3)
```