### PR TITLE
Fix reachability by retaining spaces of Prod params

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -212,14 +212,20 @@ trait SpaceLogic {
         if (isSubType(tp2, tp1)) b
         else if (canDecompose(tp1)) tryDecompose1(tp1)
         else if (isSubType(tp1, tp2)) a // problematic corner case: inheriting a case class
-        else intersectUnrelatedAtomicTypes(tp1, tp2)
+        else intersectUnrelatedAtomicTypes(tp1, tp2) match
+          case Typ(tp, _) => Prod(tp, fun, ss)
+          case sp         => sp
       case (Prod(tp1, fun, ss), Typ(tp2, _)) =>
         if (isSubType(tp1, tp2)) a
         else if (canDecompose(tp2)) tryDecompose2(tp2)
         else if (isSubType(tp2, tp1)) a  // problematic corner case: inheriting a case class
-        else intersectUnrelatedAtomicTypes(tp1, tp2)
+        else intersectUnrelatedAtomicTypes(tp1, tp2) match
+          case Typ(tp, _) => Prod(tp, fun, ss)
+          case sp         => sp
       case (Prod(tp1, fun1, ss1), Prod(tp2, fun2, ss2)) =>
-        if (!isSameUnapply(fun1, fun2)) intersectUnrelatedAtomicTypes(tp1, tp2)
+        if (!isSameUnapply(fun1, fun2)) intersectUnrelatedAtomicTypes(tp1, tp2) match
+          case Typ(tp, _) => Prod(tp, fun1, ss1)
+          case sp         => sp
         else if (ss1.zip(ss2).exists(p => simplify(intersect(p._1, p._2)) == Empty)) Empty
         else Prod(tp1, fun1, ss1.zip(ss2).map((intersect _).tupled))
     }

--- a/tests/patmat/i14102.min.scala
+++ b/tests/patmat/i14102.min.scala
@@ -1,0 +1,7 @@
+trait Foo[-X]
+case class Bar(n: Int) extends Foo[Nothing]
+
+def test[X](foo: Foo[X]) = foo match
+  case Bar(1) =>
+  case Bar(_) =>
+  case _      =>

--- a/tests/patmat/i14102.scala
+++ b/tests/patmat/i14102.scala
@@ -1,0 +1,8 @@
+trait T[-X]
+case class CC[-X](x: List[T[X]]) extends T[Nothing]
+case class Id[-X](x: String) extends T[X]
+
+def f[X](tree: T[X]) = tree match
+  case CC(Id("hi") :: Nil) => ???
+  case CC(refs) => ???
+  case _ => ???


### PR DESCRIPTION
When intersecting a product type space with a type space, if the two
types aren't related, we must retain the spaces of the parameters,
otherwise the intersection will represent a bigger space of values that
it should (leading to a false positive unreachability warning).

I actually think that the first condition, `isSubType(tp1, tp2)`, should
be true, because `Bar` is a subtype of `Foo[X]`, provided `X` is
instantiated to `Nothing`.  Maybe that's not isSubType but something
else (because we want forSome X, not forAll X).  But, either way, fixing
that the intersection doesn't overpromise (i.e. lie) is a good fix
anyways.
