### PR TITLE
Upgrade SBT to 1.5.7

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -140,7 +140,7 @@ final case class SbtCommunityProject(
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
     extraSbtArgs ++ sbtProps ++ List(
-      "-sbt-version", "1.5.6",
+      "-sbt-version", "1.5.7",
       "-Dsbt.supershell=false",
       s"-Ddotty.communitybuild.dir=$communitybuildDir",
       s"--addPluginSbtFile=$sbtPluginFilePath"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.5.7


### PR DESCRIPTION
Updates log4j 2 to 2.16.0, which disables JNDI lookup and fixes a denial of service vulnerability (CVE-2021-45046)

See https://github.com/sbt/sbt/releases/tag/v1.5.7