### PR TITLE
Fix `derivedPolyProto` to use the correct result type

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -582,7 +582,7 @@ object ProtoTypes {
     override def isMatchedBy(tp: Type, keepConstraint: Boolean)(using Context): Boolean =
       canInstantiate(tp) || tp.member(nme.apply).hasAltWith(d => canInstantiate(d.info))
 
-    def derivedPolyProto(targs: List[Tree], resultType: Type): PolyProto =
+    def derivedPolyProto(targs: List[Tree], resType: Type): PolyProto =
       if ((targs eq this.targs) && (resType eq this.resType)) this
       else PolyProto(targs, resType)
 

--- a/tests/neg/i14145.scala
+++ b/tests/neg/i14145.scala
@@ -1,0 +1,4 @@
+val l: List[Option[Int]] = List(None, Some(1), None)
+
+@main def m15 =
+  l.collectFirst(Some.unapply.unlift[Option[Int], Int]) // error


### PR DESCRIPTION
The method parameter was called `resultType` but inside the method we
use `resType` which is the result type of the existing PolyProto
instance, so TypeMaps never updated the result type of a PolyProto
before.

According to git blame, this typo was introduced when the class
parameter was renamed back in 2015 in
b5c3a28f1eabada74827e34743dc264e583f7479.

Fixes #14145.