### PR TITLE
Shorthand for curried function types

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -1,0 +1,328 @@
+package dotty.tools
+package dotc
+package cc
+
+import core._
+import Phases.*, DenotTransformers.*, SymDenotations.*
+import Contexts.*, Names.*, Flags.*, Symbols.*, Decorators.*
+import Types.*, StdNames.*
+import config.Printers.capt
+import ast.tpd
+import transform.Recheck.*
+
+class Setup(
+  preRecheckPhase: DenotTransformer,
+  thisPhase: DenotTransformer,
+  recheckDef: (tpd.ValOrDefDef, Symbol) => Context ?=> Unit)
+extends tpd.TreeTraverser:
+  import tpd.*
+
+  private def depFun(tycon: Type, argTypes: List[Type], resType: Type)(using Context): Type =
+    MethodType.companion(
+        isContextual = defn.isContextFunctionClass(tycon.classSymbol),
+        isErased = defn.isErasedFunctionClass(tycon.classSymbol)
+      )(argTypes, resType)
+      .toFunctionType(isJava = false, alwaysDependent = true)
+
+  private def box(tp: Type)(using Context): Type = tp match
+    case CapturingType(parent, refs, false) => CapturingType(parent, refs, true)
+    case _ => tp
+
+  private def setBoxed(tp: Type)(using Context) = tp match
+    case AnnotatedType(_, annot) if annot.symbol == defn.RetainsAnnot =>
+      annot.tree.setBoxedCapturing()
+    case _ =>
+
+  private def addBoxes(using Context) = new TypeTraverser:
+    def traverse(t: Type) =
+      t match
+        case AppliedType(tycon, args) if !defn.isNonRefinedFunction(t) =>
+          args.foreach(setBoxed)
+        case TypeBounds(lo, hi) =>
+          setBoxed(lo); setBoxed(hi)
+        case _ =>
+      traverseChildren(t)
+
+  /** Perform the following transformation steps everywhere in a type:
+    *  1. Drop retains annotations
+    *  2. Turn plain function types into dependent function types, so that
+    *     we can refer to their parameter in capture sets. Currently this is
+    *     only done at the toplevel, i.e. for function types that are not
+    *     themselves argument types of other function types. Without this restriction
+    *     boxmap-paper.scala fails. Need to figure out why.
+    *  3. Refine other class types C by adding capture set variables to their parameter getters
+    *     (see addCaptureRefinements)
+    *  4. Add capture set variables to all types that can be tracked
+    *
+    *  Polytype bounds are only cleaned using step 1, but not otherwise transformed.
+    */
+  private def mapInferred(using Context) = new TypeMap:
+
+    /** Drop @retains annotations everywhere */
+    object cleanup extends TypeMap:
+      def apply(t: Type) = t match
+        case AnnotatedType(parent, annot) if annot.symbol == defn.RetainsAnnot =>
+          apply(parent)
+        case _ =>
+          mapOver(t)
+
+    /** Refine a possibly applied class type C where the class has tracked parameters
+     *  x_1: T_1, ..., x_n: T_n to C { val x_1: CV_1 T_1, ..., val x_n: CV_n T_n }
+     *  where CV_1, ..., CV_n are fresh capture sets.
+     */
+    def addCaptureRefinements(tp: Type): Type = tp match
+      case _: TypeRef | _: AppliedType if tp.typeParams.isEmpty =>
+        tp.typeSymbol match
+          case cls: ClassSymbol if !defn.isFunctionClass(cls) =>
+            cls.paramGetters.foldLeft(tp) { (core, getter) =>
+              if getter.termRef.isTracked then
+                val getterType = tp.memberInfo(getter).strippedDealias
+                RefinedType(core, getter.name, CapturingType(getterType, CaptureSet.Var(), boxed = false))
+                  .showing(i"add capture refinement $tp --> $result", capt)
+              else
+                core
+            }
+          case _ => tp
+      case _ => tp
+
+    /** Should a capture set variable be added on type `tp`? */
+    def canHaveInferredCapture(tp: Type): Boolean =
+      tp.typeParams.isEmpty && tp.match
+        case tp: (TypeRef | AppliedType) =>
+          val sym = tp.typeSymbol
+          if sym.isClass then !sym.isValueClass && sym != defn.AnyClass
+          else canHaveInferredCapture(tp.superType.dealias)
+        case tp: (RefinedOrRecType | MatchType) =>
+          canHaveInferredCapture(tp.underlying)
+        case tp: AndType =>
+          canHaveInferredCapture(tp.tp1) && canHaveInferredCapture(tp.tp2)
+        case tp: OrType =>
+          canHaveInferredCapture(tp.tp1) || canHaveInferredCapture(tp.tp2)
+        case _ =>
+          false
+
+    /** Add a capture set variable to `tp` if necessary, or maybe pull out
+     *  an embedded capture set variables from a part of `tp`.
+     */
+    def addVar(tp: Type) = tp match
+      case tp @ RefinedType(parent @ CapturingType(parent1, refs, boxed), rname, rinfo) =>
+        CapturingType(tp.derivedRefinedType(parent1, rname, rinfo), refs, boxed)
+      case tp: RecType =>
+        tp.parent match
+          case CapturingType(parent1, refs, boxed) =>
+            CapturingType(tp.derivedRecType(parent1), refs, boxed)
+          case _ =>
+            tp // can return `tp` here since unlike RefinedTypes, RecTypes are never created
+                // by `mapInferred`. Hence if the underlying type admits capture variables
+                // a variable was already added, and the first case above would apply.
+      case AndType(CapturingType(parent1, refs1, boxed1), CapturingType(parent2, refs2, boxed2)) =>
+        assert(refs1.asVar.elems.isEmpty)
+        assert(refs2.asVar.elems.isEmpty)
+        assert(boxed1 == boxed2)
+        CapturingType(AndType(parent1, parent2), refs1, boxed1)
+      case tp @ OrType(CapturingType(parent1, refs1, boxed1), CapturingType(parent2, refs2, boxed2)) =>
+        assert(refs1.asVar.elems.isEmpty)
+        assert(refs2.asVar.elems.isEmpty)
+        assert(boxed1 == boxed2)
+        CapturingType(OrType(parent1, parent2, tp.isSoft), refs1, boxed1)
+      case tp @ OrType(CapturingType(parent1, refs1, boxed1), tp2) =>
+        CapturingType(OrType(parent1, tp2, tp.isSoft), refs1, boxed1)
+      case tp @ OrType(tp1, CapturingType(parent2, refs2, boxed2)) =>
+        CapturingType(OrType(tp1, parent2, tp.isSoft), refs2, boxed2)
+      case _ if canHaveInferredCapture(tp) =>
+        CapturingType(tp, CaptureSet.Var(), boxed = false)
+      case _ =>
+        tp
+
+    var isTopLevel = true
+
+    def mapNested(ts: List[Type]): List[Type] =
+      val saved = isTopLevel
+      isTopLevel = false
+      try ts.mapConserve(this) finally isTopLevel = saved
+
+    def apply(t: Type) =
+      val t1 = t match
+        case AnnotatedType(parent, annot) if annot.symbol == defn.RetainsAnnot =>
+          apply(parent)
+        case tp @ AppliedType(tycon, args) =>
+          val tycon1 = this(tycon)
+          if defn.isNonRefinedFunction(tp) then
+            val args1 = mapNested(args.init)
+            val res1 = this(args.last)
+            if isTopLevel then
+              depFun(tycon1, args1, res1)
+                .showing(i"add function refinement $tp --> $result", capt)
+            else
+              tp.derivedAppliedType(tycon1, args1 :+ res1)
+          else
+            tp.derivedAppliedType(tycon1, args.mapConserve(arg => box(this(arg))))
+        case tp @ RefinedType(core, rname, rinfo) if defn.isFunctionType(tp) =>
+          val rinfo1 = apply(rinfo)
+          if rinfo1 ne rinfo then rinfo1.toFunctionType(isJava = false, alwaysDependent = true)
+          else tp
+        case tp: MethodType =>
+          tp.derivedLambdaType(
+            paramInfos = mapNested(tp.paramInfos),
+            resType = this(tp.resType))
+        case tp: TypeLambda =>
+          // Don't recurse into parameter bounds, just cleanup any stray retains annotations
+          tp.derivedLambdaType(
+            paramInfos = tp.paramInfos.mapConserve(cleanup(_).bounds),
+            resType = this(tp.resType))
+        case _ =>
+          mapOver(t)
+      addVar(addCaptureRefinements(t1))
+  end mapInferred
+
+  private def expandAbbreviations(using Context) = new TypeMap:
+
+    def propagateMethodResult(tp: Type, outerCs: CaptureSet, deep: Boolean): Type = tp match
+      case tp: MethodType =>
+        if deep then
+          val tp1 = tp.derivedLambdaType(paramInfos = tp.paramInfos.mapConserve(this))
+          propagateMethodResult(tp1, outerCs, deep = false)
+        else
+          val localCs = CaptureSet(tp.paramRefs.filter(_.isTracked)*)
+          tp.derivedLambdaType(
+            resType = propagateEnclosing(tp.resType, CaptureSet.empty, outerCs ++ localCs))
+
+    def propagateDepFunctionResult(tp: Type, outerCs: CaptureSet, deep: Boolean): Type = tp match
+      case tp @ RefinedType(parent, nme.apply, rinfo: MethodType) =>
+        val rinfo1 = propagateMethodResult(rinfo, outerCs, deep)
+        if rinfo1 ne rinfo then rinfo1.toFunctionType(isJava = false, alwaysDependent = true)
+        else tp
+
+    def propagateEnclosing(tp: Type, currentCs: CaptureSet, outerCs: CaptureSet): Type = tp match
+      case tp @ AppliedType(tycon, args) if defn.isFunctionClass(tycon.typeSymbol) =>
+        val tycon1 = this(tycon)
+        val args1 = args.init.mapConserve(this)
+        val tp1 =
+          if args1.exists(!_.captureSet.isAlwaysEmpty) then
+            val propagated = propagateDepFunctionResult(
+              depFun(tycon, args1, args.last), currentCs ++ outerCs, deep = false)
+            propagated match
+              case RefinedType(_, _, mt: MethodType) =>
+                val following = mt.resType.captureSet.elems
+                if mt.paramRefs.exists(following.contains(_)) then propagated
+                else tp.derivedAppliedType(tycon1, args1 :+ mt.resType)
+          else
+            val resType1 = propagateEnclosing(
+              args.last, CaptureSet.empty, currentCs ++ outerCs)
+            tp.derivedAppliedType(tycon1, args1 :+ resType1)
+        tp1.capturing(outerCs)
+      case tp @ RefinedType(parent, nme.apply, rinfo: MethodType) if defn.isFunctionType(tp) =>
+        propagateDepFunctionResult(tp, currentCs ++ outerCs, deep = true)
+          .capturing(outerCs)
+      case _ =>
+        mapOver(tp)
+
+    def apply(tp: Type): Type = tp match
+      case CapturingType(parent, cs, boxed) =>
+        tp.derivedCapturingType(propagateEnclosing(parent, cs, CaptureSet.empty), cs)
+      case _ =>
+        propagateEnclosing(tp, CaptureSet.empty, CaptureSet.empty)
+  end expandAbbreviations
+
+  private def transformInferredType(tp: Type, boxed: Boolean)(using Context): Type =
+    val tp1 = mapInferred(tp)
+    if boxed then box(tp1) else tp1
+
+  private def transformExplicitType(tp: Type, boxed: Boolean)(using Context): Type =
+    addBoxes.traverse(tp)
+    if boxed then setBoxed(tp)
+    if ctx.settings.YccNoAbbrev.value then tp
+    else expandAbbreviations(tp)
+
+  // Substitute parameter symbols in `from` to paramRefs in corresponding
+  // method or poly types `to`. We use a single BiTypeMap to do everything.
+  private class SubstParams(from: List[List[Symbol]], to: List[LambdaType])(using Context)
+  extends DeepTypeMap, BiTypeMap:
+
+    def apply(t: Type): Type = t match
+      case t: NamedType =>
+        val sym = t.symbol
+        def outer(froms: List[List[Symbol]], tos: List[LambdaType]): Type =
+          def inner(from: List[Symbol], to: List[ParamRef]): Type =
+            if from.isEmpty then outer(froms.tail, tos.tail)
+            else if sym eq from.head then to.head
+            else inner(from.tail, to.tail)
+          if tos.isEmpty then t
+          else inner(froms.head, tos.head.paramRefs)
+        outer(from, to)
+      case _ =>
+        mapOver(t)
+
+    def inverse(t: Type): Type = t match
+      case t: ParamRef =>
+        def recur(from: List[LambdaType], to: List[List[Symbol]]): Type =
+          if from.isEmpty then t
+          else if t.binder eq from.head then to.head(t.paramNum).namedType
+          else recur(from.tail, to.tail)
+        recur(to, from)
+      case _ =>
+        mapOver(t)
+  end SubstParams
+
+  private def transformTT(tree: TypeTree, boxed: Boolean)(using Context) =
+    tree.rememberType(
+      if tree.isInstanceOf[InferredTypeTree]
+      then transformInferredType(tree.tpe, boxed)
+      else transformExplicitType(tree.tpe, boxed))
+
+  def traverse(tree: Tree)(using Context) =
+    tree match
+      case tree @ ValDef(_, tpt: TypeTree, _) if tree.symbol.is(Mutable) =>
+        transformTT(tpt, boxed = true)
+        traverse(tree.rhs)
+      case _ =>
+        traverseChildren(tree)
+    tree match
+      case tree: TypeTree =>
+        transformTT(tree, boxed = false)
+      case tree: ValOrDefDef =>
+        val sym = tree.symbol
+
+        // replace an existing symbol info with inferred types
+        def integrateRT(
+            info: Type,                     // symbol info to replace
+            psymss: List[List[Symbol]],     // the local (type and trem) parameter symbols corresponding to `info`
+            prevPsymss: List[List[Symbol]], // the local parameter symbols seen previously in reverse order
+            prevLambdas: List[LambdaType]   // the outer method and polytypes generated previously in reverse order
+          ): Type =
+          info match
+            case mt: MethodOrPoly =>
+              val psyms = psymss.head
+              mt.companion(mt.paramNames)(
+                mt1 =>
+                  if !psyms.exists(_.isUpdatedAfter(preRecheckPhase)) && !mt.isParamDependent && prevLambdas.isEmpty then
+                    mt.paramInfos
+                  else
+                    val subst = SubstParams(psyms :: prevPsymss, mt1 :: prevLambdas)
+                    psyms.map(psym => subst(psym.info).asInstanceOf[mt.PInfo]),
+                mt1 =>
+                  integrateRT(mt.resType, psymss.tail, psyms :: prevPsymss, mt1 :: prevLambdas)
+              )
+            case info: ExprType =>
+              info.derivedExprType(resType =
+                integrateRT(info.resType, psymss, prevPsymss, prevLambdas))
+            case _ =>
+              val restp = tree.tpt.knownType
+              if prevLambdas.isEmpty then restp
+              else SubstParams(prevPsymss, prevLambdas)(restp)
+
+        if tree.tpt.hasRememberedType && !sym.isConstructor then
+          val newInfo = integrateRT(sym.info, sym.paramSymss, Nil, Nil)
+            .showing(i"update info $sym: ${sym.info} --> $result", capt)
+          if newInfo ne sym.info then
+            val completer = new LazyType:
+              def complete(denot: SymDenotation)(using Context) =
+                denot.info = newInfo
+                recheckDef(tree, sym)
+            sym.updateInfoBetween(preRecheckPhase, thisPhase, completer)
+      case tree: Bind =>
+        val sym = tree.symbol
+        sym.updateInfoBetween(preRecheckPhase, thisPhase,
+          transformInferredType(sym.info, boxed = false))
+      case _ =>
+end Setup

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -314,6 +314,7 @@ private sealed trait YSettings:
   val Yrecheck: Setting[Boolean] = BooleanSetting("-Yrecheck", "Run type rechecks (test only)")
   val Ycc: Setting[Boolean] = BooleanSetting("-Ycc", "Check captured references")
   val YccDebug: Setting[Boolean] = BooleanSetting("-Ycc-debug", "Debug info for captured references")
+  val YccNoAbbrev: Setting[Boolean] = BooleanSetting("-Ycc-no-abbrev", "Used in conjunction with -Ycc, suppress type abbreviations")
 
   /** Area-specific debug output */
   val YexplainLowlevel: Setting[Boolean] = BooleanSetting("-Yexplain-lowlevel", "When explaining type errors, show types at a lower level.")

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -203,6 +203,7 @@ class TreePickler(pickler: TastyPickler) {
         writeByte(if (tpe.isType) TYPEREFdirect else TERMREFdirect)
         if !symRefs.contains(sym) && !sym.isPatternBound && !sym.hasAnnotation(defn.QuotedRuntimePatterns_patternTypeAnnot) then
             report.log(i"pickling reference to as yet undefined $tpe with symbol ${sym}", sym.srcPos)
+             // todo: find out why this happens for pos-customargs/captures/capt2
         pickleSymRef(sym)
       }
       else tpe.designator match {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -896,6 +896,10 @@ object Parsers {
 
     def followingIsCaptureSet(): Boolean =
       val lookahead = in.LookaheadScanner()
+      def followingIsTypeStart() =
+        lookahead.nextToken()
+        canStartInfixTypeTokens.contains(lookahead.token)
+        || lookahead.token == LBRACKET
       def recur(): Boolean =
         (lookahead.isIdent || lookahead.token == THIS) && {
           lookahead.nextToken()
@@ -903,14 +907,10 @@ object Parsers {
             lookahead.nextToken()
             recur()
           else
-            lookahead.token == RBRACE && {
-              lookahead.nextToken()
-              canStartInfixTypeTokens.contains(lookahead.token)
-              || lookahead.token == LBRACKET
-            }
+            lookahead.token == RBRACE && followingIsTypeStart()
         }
       lookahead.nextToken()
-      recur()
+      if lookahead.token == RBRACE then followingIsTypeStart() else recur()
 
   /* --------- OPERAND/OPERATOR STACK --------------------------------------- */
 
@@ -1486,7 +1486,9 @@ object Parsers {
           else { accept(TLARROW); typ() }
         }
         else if in.token == LBRACE && followingIsCaptureSet() then
-          val refs = inBraces { commaSeparated(captureRef) }
+          val refs = inBraces {
+            if in.token == RBRACE then Nil else commaSeparated(captureRef)
+          }
           val t = typ()
           CapturingTypeTree(refs, t)
         else if (in.token == INDENT) enclosed(INDENT, typ())

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1486,11 +1486,7 @@ object Parsers {
           else { accept(TLARROW); typ() }
         }
         else if in.token == LBRACE && followingIsCaptureSet() then
-          val refs = inBraces {
-            if in.token == RBRACE then Nil else commaSeparated(captureRef)
-          }
-          val t = typ()
-          CapturingTypeTree(refs, t)
+          CapturingTypeTree(captureSet(), typ())
         else if (in.token == INDENT) enclosed(INDENT, typ())
         else infixType()
 
@@ -1873,7 +1869,13 @@ object Parsers {
     def typeDependingOn(location: Location): Tree =
       if location.inParens then typ()
       else if location.inPattern then refinedType()
+      else if in.token == LBRACE && followingIsCaptureSet() then
+        CapturingTypeTree(captureSet(), infixType())
       else infixType()
+
+    def captureSet(): List[Tree] = inBraces {
+      if in.token == RBRACE then Nil else commaSeparated(captureRef)
+    }
 
 /* ----------- EXPRESSIONS ------------------------------------------------ */
 
@@ -1944,7 +1946,7 @@ object Parsers {
      *                      |  ‘inline’ InfixExpr MatchClause
      *  Bindings          ::=  `(' [Binding {`,' Binding}] `)'
      *  Binding           ::=  (id | `_') [`:' Type]
-     *  Ascription        ::=  `:' InfixType
+     *  Ascription        ::=  `:' [CaptureSet] InfixType
      *                      |  `:' Annotation {Annotation}
      *                      |  `:' `_' `*'
      *  Catches           ::=  ‘catch’ (Expr | ExprCaseClause)
@@ -3894,7 +3896,7 @@ object Parsers {
       stats.toList
     }
 
-    /** TemplateStatSeq  ::= [id [`:' Type] `=>'] TemplateStat {semi TemplateStat}
+    /** TemplateStatSeq  ::= [SelfType] TemplateStat {semi TemplateStat}
      *  TemplateStat     ::= Import
      *                     | Export
      *                     | Annotations Modifiers Def
@@ -3904,6 +3906,8 @@ object Parsers {
      *                     |
      *  EnumStat         ::= TemplateStat
      *                     | Annotations Modifiers EnumCase
+     *  SelfType         ::= id [‘:’ [CaptureSet] InfixType] ‘=>’
+     *                     | ‘this’ ‘:’ [CaptureSet] InfixType ‘=>’
      */
     def templateStatSeq(): (ValDef, List[Tree]) = checkNoEscapingPlaceholders {
       var self: ValDef = EmptyValDef

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -30,7 +30,7 @@ import config.Config
 import language.implicitConversions
 import dotty.tools.dotc.util.{NameTransformer, SourcePosition}
 import dotty.tools.dotc.ast.untpd.{MemberDef, Modifiers, PackageDef, RefTree, Template, TypeDef, ValOrDefDef}
-import cc.{EventuallyCapturingType, CaptureSet, toCaptureSet, IllegalCaptureRef}
+import cc.{CaptureSet, toCaptureSet, IllegalCaptureRef}
 
 class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 

--- a/compiler/src/dotty/tools/dotc/typer/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CheckCaptures.scala
@@ -5,26 +5,17 @@ package cc
 import core._
 import Phases.*, DenotTransformers.*, SymDenotations.*
 import Contexts.*, Names.*, Flags.*, Symbols.*, Decorators.*
-import Types._
-import Symbols._
-import StdNames._
-import Decorators._
+import Types.*, StdNames.*
 import config.Printers.{capt, recheckr}
 import ast.{tpd, untpd, Trees}
-import NameKinds.{DocArtifactName, OuterSelectName, DefaultGetterName}
-import Trees._
-import scala.util.control.NonFatal
-import typer.ErrorReporting._
-import typer.RefChecks
-import util.Spans.Span
+import Trees.*
+import typer.RefChecks.checkAllOverrides
 import util.{SimpleIdentitySet, EqHashMap, SrcPos}
-import util.Chars.*
-import transform.*
 import transform.SymUtils.*
+import transform.Recheck
+import Recheck.*
 import scala.collection.mutable
-import reporting._
-import dotty.tools.backend.jvm.DottyBackendInterface.symExtensions
-import CaptureSet.{CompareResult, withCaptureSetsExplained}
+import CaptureSet.withCaptureSetsExplained
 
 object CheckCaptures:
   import ast.tpd.*
@@ -108,179 +99,12 @@ class CheckCaptures extends Recheck:
           // ^^^ TODO: Can we avoid doing overrides checks twice?
           // We need to do them here since only at this phase CaptureTypes are relevant
           // But maybe we can then elide the check during the RefChecks phase if -Ycc is set?
-          RefChecks.checkAllOverrides(ctx.owner.asClass)
+          checkAllOverrides(ctx.owner.asClass)
         case _ =>
       traverseChildren(t)
 
   class CaptureChecker(ictx: Context) extends Rechecker(ictx):
     import ast.tpd.*
-
-    override def transformType(tp: Type, inferred: Boolean, boxed: Boolean)(using Context): Type =
-
-      def depFun(tycon: Type, argTypes: List[Type], resType: Type): Type =
-        MethodType.companion(
-            isContextual = defn.isContextFunctionClass(tycon.classSymbol),
-            isErased = defn.isErasedFunctionClass(tycon.classSymbol)
-          )(argTypes, resType)
-          .toFunctionType(isJava = false, alwaysDependent = true)
-
-      def box(tp: Type): Type = tp match
-        case CapturingType(parent, refs, false) => CapturingType(parent, refs, true)
-        case _ => tp
-
-      /** Perform the following transformation steps everywhere in a type:
-       *  1. Drop retains annotations
-       *  2. Turn plain function types into dependent function types, so that
-       *     we can refer to their parameter in capture sets. Currently this is
-       *     only done at the toplevel, i.e. for function types that are not
-       *     themselves argument types of other function types. Without this restriction
-       *     boxmap-paper.scala fails. Need to figure out why.
-       *  3. Refine other class types C by adding capture set variables to their parameter getters
-       *     (see addCaptureRefinements)
-       *  4. Add capture set variables to all types that can be tracked
-       *
-       *  Polytype bounds are only cleaned using step 1, but not otherwise transformed.
-       */
-      def mapInferred = new TypeMap:
-
-        /** Drop @retains annotations everywhere */
-        object cleanup extends TypeMap:
-          def apply(t: Type) = t match
-            case AnnotatedType(parent, annot) if annot.symbol == defn.RetainsAnnot =>
-              apply(parent)
-            case _ =>
-              mapOver(t)
-
-        /** Refine a possibly applied class type C where the class has tracked parameters
-         *  x_1: T_1, ..., x_n: T_n to C { val x_1: CV_1 T_1, ..., val x_n: CV_n T_n }
-         *  where CV_1, ..., CV_n are fresh capture sets.
-         */
-        def addCaptureRefinements(tp: Type): Type = tp match
-          case _: TypeRef | _: AppliedType if tp.typeParams.isEmpty =>
-            tp.typeSymbol match
-              case cls: ClassSymbol if !defn.isFunctionClass(cls) =>
-                cls.paramGetters.foldLeft(tp) { (core, getter) =>
-                  if getter.termRef.isTracked then
-                    val getterType = tp.memberInfo(getter).strippedDealias
-                    RefinedType(core, getter.name, CapturingType(getterType, CaptureSet.Var(), boxed = false))
-                      .showing(i"add capture refinement $tp --> $result", capt)
-                  else
-                    core
-                }
-              case _ => tp
-          case _ => tp
-
-        /** Should a capture set variable be added on type `tp`? */
-        def canHaveInferredCapture(tp: Type): Boolean =
-          tp.typeParams.isEmpty && tp.match
-            case tp: (TypeRef | AppliedType) =>
-              val sym = tp.typeSymbol
-              if sym.isClass then !sym.isValueClass && sym != defn.AnyClass
-              else canHaveInferredCapture(tp.superType.dealias)
-            case tp: (RefinedOrRecType | MatchType) =>
-              canHaveInferredCapture(tp.underlying)
-            case tp: AndType =>
-              canHaveInferredCapture(tp.tp1) && canHaveInferredCapture(tp.tp2)
-            case tp: OrType =>
-              canHaveInferredCapture(tp.tp1) || canHaveInferredCapture(tp.tp2)
-            case _ =>
-              false
-
-        /** Add a capture set variable to `tp` if necessary, or maybe pull out
-         *  an embedded capture set variables from a part of `tp`.
-         */
-        def addVar(tp: Type) = tp match
-          case tp @ RefinedType(parent @ CapturingType(parent1, refs, boxed), rname, rinfo) =>
-            CapturingType(tp.derivedRefinedType(parent1, rname, rinfo), refs, boxed)
-          case tp: RecType =>
-            tp.parent match
-              case CapturingType(parent1, refs, boxed) =>
-                CapturingType(tp.derivedRecType(parent1), refs, boxed)
-              case _ =>
-                tp // can return `tp` here since unlike RefinedTypes, RecTypes are never created
-                   // by `mapInferred`. Hence if the underlying type admits capture variables
-                   // a variable was already added, and the first case above would apply.
-          case AndType(CapturingType(parent1, refs1, boxed1), CapturingType(parent2, refs2, boxed2)) =>
-            assert(refs1.asVar.elems.isEmpty)
-            assert(refs2.asVar.elems.isEmpty)
-            assert(boxed1 == boxed2)
-            CapturingType(AndType(parent1, parent2), refs1, boxed1)
-          case tp @ OrType(CapturingType(parent1, refs1, boxed1), CapturingType(parent2, refs2, boxed2)) =>
-            assert(refs1.asVar.elems.isEmpty)
-            assert(refs2.asVar.elems.isEmpty)
-            assert(boxed1 == boxed2)
-            CapturingType(OrType(parent1, parent2, tp.isSoft), refs1, boxed1)
-          case tp @ OrType(CapturingType(parent1, refs1, boxed1), tp2) =>
-            CapturingType(OrType(parent1, tp2, tp.isSoft), refs1, boxed1)
-          case tp @ OrType(tp1, CapturingType(parent2, refs2, boxed2)) =>
-            CapturingType(OrType(tp1, parent2, tp.isSoft), refs2, boxed2)
-          case _ if canHaveInferredCapture(tp) =>
-            CapturingType(tp, CaptureSet.Var(), boxed = false)
-          case _ =>
-            tp
-
-        var isTopLevel = true
-
-        def mapNested(ts: List[Type]): List[Type] =
-          val saved = isTopLevel
-          isTopLevel = false
-          try ts.mapConserve(this) finally isTopLevel = saved
-
-        def apply(t: Type) =
-          val t1 = t match
-            case AnnotatedType(parent, annot) if annot.symbol == defn.RetainsAnnot =>
-              apply(parent)
-            case tp @ AppliedType(tycon, args) =>
-              val tycon1 = this(tycon)
-              if defn.isNonRefinedFunction(tp) then
-                val args1 = mapNested(args.init)
-                val res1 = this(args.last)
-                if isTopLevel then
-                  depFun(tycon1, args1, res1)
-                    .showing(i"add function refinement $tp --> $result", capt)
-                else
-                  tp.derivedAppliedType(tycon1, args1 :+ res1)
-              else
-                tp.derivedAppliedType(tycon1, args.mapConserve(arg => box(this(arg))))
-            case tp @ RefinedType(core, rname, rinfo) if defn.isFunctionType(tp) =>
-              apply(rinfo).toFunctionType(isJava = false, alwaysDependent = true)
-            case tp: MethodType =>
-              tp.derivedLambdaType(
-                paramInfos = mapNested(tp.paramInfos),
-                resType = this(tp.resType))
-            case tp: TypeLambda =>
-              // Don't recurse into parameter bounds, just cleanup any stray retains annotations
-              tp.derivedLambdaType(
-                paramInfos = tp.paramInfos.mapConserve(cleanup(_).bounds),
-                resType = this(tp.resType))
-            case _ =>
-              mapOver(t)
-          addVar(addCaptureRefinements(t1))
-      end mapInferred
-
-      if inferred then
-        val tp1 = mapInferred(tp)
-        if boxed then box(tp1) else tp1
-      else
-        def setBoxed(t: Type) = t match
-          case AnnotatedType(_, annot) if annot.symbol == defn.RetainsAnnot =>
-            annot.tree.setBoxedCapturing()
-          case _ =>
-
-        val addBoxes = new TypeTraverser:
-          def traverse(t: Type) =
-            t match
-              case AppliedType(tycon, args) if !defn.isNonRefinedFunction(t) =>
-                args.foreach(setBoxed)
-              case TypeBounds(lo, hi) =>
-                setBoxed(lo); setBoxed(hi)
-              case _ =>
-            traverseChildren(t)
-
-        if boxed then setBoxed(tp)
-        addBoxes.traverse(tp)
-        tp
-    end transformType
 
     private def interpolator(using Context) = new TypeTraverser:
       override def traverse(t: Type) =
@@ -299,8 +123,8 @@ class CheckCaptures extends Recheck:
 
     private def interpolateVarsIn(tpt: Tree)(using Context): Unit =
       if tpt.isInstanceOf[InferredTypeTree] then
-        interpolator.traverse(knownType(tpt))
-          .showing(i"solved vars in ${knownType(tpt)}", capt)
+        interpolator.traverse(tpt.knownType)
+          .showing(i"solved vars in ${tpt.knownType}", capt)
 
     private var curEnv: Env = Env(NoSymbol, CaptureSet.empty, false, null)
 
@@ -477,6 +301,8 @@ class CheckCaptures extends Recheck:
       res
 
     override def checkUnit(unit: CompilationUnit)(using Context): Unit =
+      Setup(preRecheckPhase, thisPhase, recheckDef)
+        .traverse(ctx.compilationUnit.tpdTree)
       withCaptureSetsExplained {
         super.checkUnit(unit)
         PostRefinerCheck.traverse(unit.tpdTree)
@@ -494,12 +320,12 @@ class CheckCaptures extends Recheck:
           val notAllowed = i" is not allowed to capture the $what capability $ref"
           def msg =
             if allArgs.isEmpty then
-              i"type of mutable variable ${knownType(tree)}$notAllowed"
+              i"type of mutable variable ${tree.knownType}$notAllowed"
             else tree match
               case tree: InferredTypeTree =>
-                i"""inferred type argument ${knownType(tree)}$notAllowed
+                i"""inferred type argument ${tree.knownType}$notAllowed
                     |
-                    |The inferred arguments are: [${allArgs.map(knownType)}%, %]"""
+                    |The inferred arguments are: [${allArgs.map(_.knownType)}%, %]"""
               case _ => s"type argument$notAllowed"
           report.error(msg, tree.srcPos)
 
@@ -509,7 +335,7 @@ class CheckCaptures extends Recheck:
           case LambdaTypeTree(_, restpt) =>
             checkNotGlobal(restpt, allArgs*)
           case _ =>
-            checkNotGlobal(tree, knownType(tree), allArgs*)
+            checkNotGlobal(tree, tree.knownType, allArgs*)
 
     def checkNotGlobalDeep(tree: Tree)(using Context): Unit =
       val checker = new TypeTraverser:
@@ -522,23 +348,23 @@ class CheckCaptures extends Recheck:
           case _ =>
             checkNotGlobal(tree, tp)
             traverseChildren(tp)
-      checker.traverse(knownType(tree))
+      checker.traverse(tree.knownType)
 
     object PostRefinerCheck extends TreeTraverser:
       def traverse(tree: Tree)(using Context) =
         tree match
           case _: InferredTypeTree =>
           case tree: TypeTree if !tree.span.isZeroExtent =>
-            knownType(tree).foreachPart(
+            tree.knownType.foreachPart(
               checkWellformedPost(_, tree.srcPos))
-            knownType(tree).foreachPart {
+            tree.knownType.foreachPart {
               case AnnotatedType(_, annot) =>
                 checkWellformedPost(annot.tree)
               case _ =>
             }
           case tree1 @ TypeApply(fn, args) if disallowGlobal =>
             for arg <- args do
-              //println(i"checking $arg in $tree: ${knownType(tree).captureSet}")
+              //println(i"checking $arg in $tree: ${tree.knownType.captureSet}")
               checkNotGlobal(arg, args*)
           case t: ValOrDefDef if t.tpt.isInstanceOf[InferredTypeTree] =>
             val sym = t.symbol
@@ -551,7 +377,7 @@ class CheckCaptures extends Recheck:
               || sym.owner.is(Trait)               // ... since we do OverridingPairs checking before capture inference
               || sym.allOverriddenSymbols.nonEmpty // ... since we do override checking before capture inference
             then
-              val inferred = knownType(t.tpt)
+              val inferred = t.tpt.knownType
               def checkPure(tp: Type) = tp match
                 case CapturingType(_, refs, _) if !refs.elems.isEmpty =>
                   val resultStr = if t.isInstanceOf[DefDef] then " result" else ""

--- a/tests/disabled/pos/lazylist.scala
+++ b/tests/disabled/pos/lazylist.scala
@@ -1,7 +1,7 @@
 package lazylists
 
 abstract class LazyList[+T]:
-  this: ({*} LazyList[T]) =>
+  this: {*} LazyList[T] =>
 
   def isEmpty: Boolean
   def head: T

--- a/tests/neg-custom-args/captures/class-contra.check
+++ b/tests/neg-custom-args/captures/class-contra.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/class-contra.scala:12:39 ---------------------------------
+12 |  def fun(x: K{val f: {a} T}) = x.setf(a) // error
+   |                                       ^
+   |                                       Found:    (a : {x, y} T)
+   |                                       Required: T
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/class-contra.scala
+++ b/tests/neg-custom-args/captures/class-contra.scala
@@ -1,0 +1,13 @@
+
+class C
+type Cap = {*} C
+
+class K(val f: {*} T):
+  def setf(x: {f} T) = ???
+
+class T
+
+def test(x: Cap, y: Cap) =
+  val a: {x, y} T = ???
+  def fun(x: K{val f: {a} T}) = x.setf(a) // error
+  ()

--- a/tests/neg-custom-args/captures/curried-simplified.check
+++ b/tests/neg-custom-args/captures/curried-simplified.check
@@ -1,0 +1,42 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:7:28 ----------------------------
+7 |  def y1: () -> () -> Int = x1  // error
+  |                            ^^
+  |                            Found:    {x} () -> {x} () -> Int
+  |                            Required: () -> () -> Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:9:28 ----------------------------
+9 |  def y2: () -> () => Int = x2 // error
+  |                            ^^
+  |                            Found:    {x} () -> () => Int
+  |                            Required: () -> () => Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:11:39 ---------------------------
+11 |  def y3: Cap -> Protect[Int -> Int] = x3 // error
+   |                                       ^^
+   |                                       Found:    (x$0: Cap) -> {x$0} Int -> Int
+   |                                       Required: Cap -> Protect[Int -> Int]
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:15:33 ---------------------------
+15 |  def y5: Cap -> {} Int -> Int = x5 // error
+   |                                 ^^
+   |                                 Found:    Cap -> {x} Int -> Int
+   |                                 Required: Cap -> {} Int -> Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:17:49 ---------------------------
+17 |  def y6: Cap -> {} Cap -> Protect[Int -> Int] = x6 // error
+   |                                                 ^^
+   |                                               Found:    (x$0: Cap) -> {x$0} (x$0: Cap) -> {x$0, x$0} Int -> Int
+   |                                               Required: Cap -> {} Cap -> Protect[Int -> Int]
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:19:49 ---------------------------
+19 |  def y7: Cap -> Protect[Cap -> {} Int -> Int] = x7 // error
+   |                                                 ^^
+   |                                                 Found:    (x$0: Cap) -> {x$0} (x: Cap) -> {x$0, x} Int -> Int
+   |                                                 Required: Cap -> Protect[Cap -> {} Int -> Int]
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/curried-simplified.scala
+++ b/tests/neg-custom-args/captures/curried-simplified.scala
@@ -1,0 +1,21 @@
+@annotation.capability class Cap
+
+type Protect[T] = T
+
+def test(x: Cap, y: Cap) =
+  def x1: {x} () -> () -> Int = ???
+  def y1: () -> () -> Int = x1  // error
+  def x2: {x} () -> () => Int = ???
+  def y2: () -> () => Int = x2 // error
+  def x3: Cap -> Int -> Int = ???
+  def y3: Cap -> Protect[Int -> Int] = x3 // error
+  def x4: Cap -> Protect[Int -> Int] = ???
+  def y4: Cap -> {} Int -> Int = x4 // ok
+  def x5: Cap -> {x} Int -> Int = ???
+  def y5: Cap -> {} Int -> Int = x5 // error
+  def x6: Cap -> Cap -> Int -> Int = ???
+  def y6: Cap -> {} Cap -> Protect[Int -> Int] = x6 // error
+  def x7: Cap -> (x: Cap) -> Int -> Int = ???
+  def y7: Cap -> Protect[Cap -> {} Int -> Int] = x7 // error
+
+

--- a/tests/pos-custom-args/captures/capt-depfun.scala
+++ b/tests/pos-custom-args/captures/capt-depfun.scala
@@ -3,6 +3,8 @@ type Cap = C @retains(*)
 
 type T = (x: Cap) -> String @retains(x)
 
+type ID[X] = X
+
 val aa: ((x: Cap) -> String @retains(x)) = (x: Cap) => ""
 
 def f(y: Cap, z: Cap): String @retains(*) =
@@ -12,7 +14,7 @@ def f(y: Cap, z: Cap): String @retains(*) =
   def g(): C @retains(y, z) = ???
   val d = a(g())
 
-  val ac: ((x: Cap) -> String @retains(x) -> String @retains(x)) = ???
+  val ac: ((x: Cap) -> ID[String @retains(x) -> String @retains(x)]) = ???
   val bc: (({y} String) -> {y} String) = ac(y)
   val dc: (String -> {y, z} String) = ac(g())
   c

--- a/tests/pos-custom-args/captures/classes.scala
+++ b/tests/pos-custom-args/captures/classes.scala
@@ -1,7 +1,7 @@
 class B
 type Cap = {*} B
 class C(val n: Cap):
-  this: ({n} C) =>
+  this: {n} C =>
   def foo(): {n} B = n
 
 
@@ -9,7 +9,7 @@ def test(x: Cap, y: Cap, z: Cap) =
   val c0 = C(x)
   val c1: {x} C {val n: {x} B} = c0
   val d = c1.foo()
-  d: ({x} B)
+  d: {x} B
 
   val c2 = if ??? then C(x) else C(y)
   val c2a = identity(c2)

--- a/tests/pos-custom-args/captures/iterators.scala
+++ b/tests/pos-custom-args/captures/iterators.scala
@@ -1,7 +1,7 @@
 package cctest
 
 abstract class Iterator[T]:
-  thisIterator: ({*} Iterator[T]) =>
+  thisIterator: {*} Iterator[T] =>
 
   def hasNext: Boolean
   def next: T

--- a/tests/pos-custom-args/captures/lazylists.scala
+++ b/tests/pos-custom-args/captures/lazylists.scala
@@ -2,7 +2,7 @@ class CC
 type Cap = {*} CC
 
 trait LazyList[+A]:
-  this: ({*} LazyList[A]) =>
+  this: {*} LazyList[A] =>
 
   def isEmpty: Boolean
   def head: A
@@ -16,12 +16,12 @@ object LazyNil extends LazyList[Nothing]:
 extension [A](xs: {*} LazyList[A])
   def map[B](f: A => B): {xs, f} LazyList[B] =
     final class Mapped extends LazyList[B]:
-      this: ({xs, f} Mapped) =>
+      this: {xs, f} Mapped =>
 
       def isEmpty = false
       def head: B = f(xs.head)
       def tail: {this} LazyList[B] = xs.tail.map(f)  // OK
-      def concat(other: {f} LazyList[A]): {this, f} LazyList[A] = ??? : ({xs, f} LazyList[A]) // OK
+      def concat(other: {f} LazyList[A]): {this, f} LazyList[A] = ??? : {xs, f} LazyList[A] // OK
     if xs.isEmpty then LazyNil
     else new Mapped
 
@@ -31,7 +31,7 @@ def test(cap1: Cap, cap2: Cap) =
 
   val xs =
     class Initial extends LazyList[String]:
-      this: ({cap1} Initial) =>
+      this: {cap1} Initial =>
 
       def isEmpty = false
       def head = f("")

--- a/tests/pos-custom-args/captures/lazylists1.scala
+++ b/tests/pos-custom-args/captures/lazylists1.scala
@@ -2,7 +2,7 @@ class CC
 type Cap = {*} CC
 
 trait LazyList[+A]:
-  this: ({*} LazyList[A]) =>
+  this: {*} LazyList[A] =>
 
   def isEmpty: Boolean
   def head: A
@@ -14,7 +14,7 @@ object LazyNil extends LazyList[Nothing]:
   def tail = ???
 
 final class LazyCons[+T](val x: T, val xs: Int => {*} LazyList[T]) extends LazyList[T]:
-  this: ({*} LazyList[T]) =>
+  this: {*} LazyList[T] =>
 
   def isEmpty = false
   def head = x


### PR DESCRIPTION
Propagate capture sets to the right in curried functions. Example:

    {x} A -> B -> C

is a shorthand for

    {x} A -> {x} B -> C

or:

    (x: {*} A) -> B -> C

is a shorthand for

    (x: {*} A) -> {x} B -> C

or:

    ({*} A) -> B -> C

is a shorthand for

    (x$0: {*} A) -> {x$0} B -> C

The idea is that in most cases a curried function does not compute between arrows, and in particular does not discard captures by computing. So if a curried function
captures a capability or takes a capability as a parameter, that capability is assumed to be also captured in any curried functions on the right. This convention can be overridden by putting curried functions on the right in type aliases, or by adding an explicit capture set (which can be empty). The propagation only works for explicit curried functions (so adding an indirection via a type alias stops it) and it also stops when an explicit capture set is given.
