### PR TITLE
Scaladoc: Update year in Scaladoc script test

### DIFF
--- a/project/scripts/cmdScaladocTests
+++ b/project/scripts/cmdScaladocTests
@@ -36,7 +36,7 @@ dist/target/pack/bin/scaladoc \
   "-skip-by-id:scala.runtime.MatchCase" \
   "-snippet-compiler:scaladoc-testcases/docs=compile" \
   -siteroot scaladoc-testcases/docs \
-  -project-footer "Copyright (c) 2002-2021, LAMP/EPFL" \
+  -project-footer "Copyright (c) 2002-2022, LAMP/EPFL" \
   -default-template static-site-main \
   -author -groups -revision master -project-version "${DOTTY_BOOTSTRAPPED_VERSION}" \
   out/bootstrap/scaladoc-testcases/scala-"${DOTTY_NONBOOTSTRAPPED_VERSION}"/classes > "$tmp" 2>&1 || echo "generated testcases project with scripts"


### PR DESCRIPTION
The New Year greeted us with a red CI :)