### PR TITLE
Disallow `inline given ... with ..`

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3619,6 +3619,8 @@ object Parsers {
             syntaxError(em"anonymous given cannot be abstract")
           DefDef(name, joinParams(tparams, vparamss), parents.head, EmptyTree)
         else
+          if mods.is(Inline) then
+            syntaxError(i"`inline given` cannot be implemented using a `with`")
           val tparams1 = tparams.map(tparam => tparam.withMods(tparam.mods | PrivateLocal))
           val vparamss1 = vparamss.map(_.map(vparam =>
             vparam.withMods(vparam.mods &~ Param | ParamAccessor | Protected)))

--- a/tests/neg/i14177a.scala
+++ b/tests/neg/i14177a.scala
@@ -1,0 +1,6 @@
+import scala.compiletime.*
+
+trait C[A]
+
+inline given [Tup <: Tuple]: C[Tup] with // error
+  val cs = summonAll[Tuple.Map[Tup, C]]

--- a/tests/neg/i14177b.scala
+++ b/tests/neg/i14177b.scala
@@ -1,0 +1,15 @@
+class T
+
+inline given fail1: T with // error
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+inline given fail2[X]: T with // error
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+inline given fail3(using DummyImplicit): T with // error
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+
+inline given ok1: T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+inline given ok2[X]: T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+inline given ok3(using DummyImplicit): T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]


### PR DESCRIPTION
Only allow `inline given ... = ...` as the desugaring of
`inline given ... with ..` is fundamentally incompatible with inline
definitions.