### PR TITLE
migrate gitter links to discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Dotty
 =====
 [![Dotty CI](https://github.com/lampepfl/dotty/workflows/Dotty/badge.svg?branch=master)](https://github.com/lampepfl/dotty/actions?query=branch%3Amaster)
-[![Join the chat at https://gitter.im/scala/scala](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scala/scala?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://discord.com/invite/scala](https://img.shields.io/discord/632150470000902164)](https://img.shields.io/discord/632150470000902164)
 
 * [Homepage](https://dotty.epfl.ch)
 * [Documentation](https://dotty.epfl.ch/docs)
@@ -18,7 +18,7 @@ Building a Local Distribution
 Code of Conduct
 ===============
 Dotty uses the [Scala Code of Conduct](https://www.scala-lang.org/conduct.html)
-for all communication and discussion. This includes both GitHub, Gitter chat and
+for all communication and discussion. This includes both GitHub, Discord and
 other more direct lines of communication such as email.
 
 How to Contribute

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -8,9 +8,3 @@ extraCSS:
 <div id="content-wrapper">
   {{ content }}
 </div>
-<script>
-  ((window.gitter = {}).chat = {}).options = {
-    room: 'scala/scala'
-  };
-</script>
-<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>

--- a/docs/css/dottydoc.css
+++ b/docs/css/dottydoc.css
@@ -211,21 +211,6 @@ aside.success {
   background-color: #ebfddd;
 }
 
-/* gitter chat */
-.gitter-open-chat-button {
-  background-color: grey;
-}
-.gitter-open-chat-button:focus, .gitter-open-chat-button:hover {
-  background-color: var(--primary);
-}
-.gitter-open-chat-button:focus {
-  box-shadow: 0 0 8px var(--primary);
-}
-.gitter-chat-embed {
-  top: 40px; /* 50px (navbar) - 10px (aside's margin) */
-  bottom: -10px;
-}
-
 /* media queries for bigger screens (dottydoc is mobile-first) */
 @media (min-width: 576px) {
   .byline .author {
@@ -250,20 +235,6 @@ aside.success {
   main.container {
     padding: 15px 45px;
   }
-}
-
-.gitter-open-chat-button {
-  writing-mode: vertical-lr;
-  text-orientation: upright;
-  right: 0px;
-  bottom: 100px;
-  padding: 0.5em 0.25em 0.5em 0.25em;
-  border-bottom-left-radius: .5em;
-  border-top-right-radius: 0em;
-}
-
-.gitter-open-chat-button.is-collapsed {
-  transform: translateX(120%);
 }
 
 header {

--- a/docs/css/frontpage.css
+++ b/docs/css/frontpage.css
@@ -119,12 +119,6 @@ pre, code {
   line-height: 1.75em;
 }
 
-/* gitter chat */
-.gitter-chat-embed {
-  top: 0;
-  bottom: 0;
-}
-
 aside {
   margin: 0;
   padding: 0;

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -329,7 +329,7 @@ object Build {
       "-project-logo", "docs/logo.svg",
       "-social-links:" +
         "github::https://github.com/lampepfl/dotty," +
-        "gitter::https://gitter.im/scala/scala," +
+        "discord::https://discord.com/invite/scala," +
         "twitter::https://twitter.com/scala_lang",
       // contains special definitions which are "transplanted" elsewhere
       // and which therefore confuse Scaladoc when accessed from this pkg

--- a/project/scripts/cmdScaladocTests
+++ b/project/scripts/cmdScaladocTests
@@ -30,7 +30,7 @@ dist/target/pack/bin/scaladoc \
   "-skip-by-regex:.+\.internal($|\..+)" \
   "-skip-by-regex:.+\.impl($|\..+)" \
   -project-logo docs/logo.svg \
-  -social-links:github::https://github.com/lampepfl/dotty,gitter::https://gitter.im/scala/scala,twitter::https://twitter.com/scala_lang \
+  -social-links:github::https://github.com/lampepfl/dotty,discord::https://discord.com/invite/scala,twitter::https://twitter.com/scala_lang \
   -Ygenerate-inkuire \
   "-skip-by-id:scala.runtime.stdLibPatches" \
   "-skip-by-id:scala.runtime.MatchCase" \


### PR DESCRIPTION
This follows up the announcement made on https://www.scala-lang.org/blog/2021/12/21/discord.html
that Discord is now the official Scala chat.