### PR TITLE
Fix Scala.JS source map URIs

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -828,7 +828,7 @@ object Build {
         if (isRelease) {
           val baseURI = (LocalRootProject / baseDirectory).value.toURI
           val dottyVersion = version.value
-          Seq(s"-scalajs-mapSourceURI:$baseURI->$dottyGithubRawUserContentUrl/v$dottyVersion/")
+          Seq(s"-scalajs-mapSourceURI:$baseURI->$dottyGithubRawUserContentUrl/$dottyVersion/")
         } else {
           Nil
         }


### PR DESCRIPTION
Dotty publishes release versions without a `v` in the tag, but the Scala.JS source map URI configuration is set with a `v` prefix. This causes incorrect source map URLs like: https://raw.githubusercontent.com/lampepfl/dotty/v3.1.0/library/src/scala/IArray.scala (this is in the current latest release JAR).

This commit fixes the source map URIs to no longer use the `v` prefix. Resulting in a URL like: https://raw.githubusercontent.com/lampepfl/dotty/3.1.0/library/src/scala/IArray.scala (for a next release)