### PR TITLE
Bump jackson version to 2.12.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
  *  to ensure the same version of the dependency is used in all projects
  */
 object Dependencies {
-  private val jacksonVersion = "2.9.8"
+  private val jacksonVersion = "2.12.1"
   val `jackson-databind` =
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   val `jackson-dataformat-yaml` =


### PR DESCRIPTION
Recently bumped liqp uses jackson dependencies in version 2.12.1. Due to that, most libraries from jackson has been bumped together with liqp but there are still few libs that stay in version 2.9.8.

closes #14235 