### PR TITLE
Homogenize generation of erased definitions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1765,8 +1765,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       untpd.ValDef(
           EvidenceParamName.fresh(),
           untpd.TypeTree(defn.CanThrowClass.typeRef.appliedTo(tp)),
-          untpd.ref(defn.Predef_undefined))
-        .withFlags(Given | Final | Lazy | Erased)
+          untpd.ref(defn.Compiletime_erasedValue))
+        .withFlags(Given | Final | Erased)
         .withSpan(expr.span)
     val caughtExceptions =
       if Feature.enabled(Feature.saferExceptions) then


### PR DESCRIPTION
The erased value generated by a `try` is now a reference to `erasedValue` like other generated erased expressions. We also remove the `Lazy` as it is semantically meaningless in an erased definition.