### PR TITLE
Allow erased definitions without implementation

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3615,7 +3615,7 @@ object Parsers {
           else
             DefDef(name, joinParams(tparams, vparamss), parents.head, subExpr())
         else if (isStatSep || isStatSeqEnd) && parentsIsType then
-          if name.isEmpty then
+          if name.isEmpty && !mods1.is(Erased) then
             syntaxError(em"anonymous given cannot be abstract")
           DefDef(name, joinParams(tparams, vparamss), parents.head, EmptyTree)
         else

--- a/docs/docs/reference/experimental/canthrow.md
+++ b/docs/docs/reference/experimental/canthrow.md
@@ -120,7 +120,7 @@ catch
 the compiler generates an accumulated capability of type `CanThrow[Ex1 | ... | Ex2]` that is available as a given in the scope of `body`. It does this by augmenting the `try` roughly as follows:
 ```scala
 try
-  erased given CanThrow[Ex1 | ... | ExN] = ???
+  erased given CanThrow[Ex1 | ... | ExN]
   body
 catch ...
 ```
@@ -194,7 +194,7 @@ Everything typechecks and works as expected. But wait - we have called `map` wit
 // compiler-generated code
 @main def test(xs: Double*) =
   try
-    erased given ctl: CanThrow[LimitExceeded] = ???
+    erased given ctl: CanThrow[LimitExceeded]
     println(xs.map(x => f(x)(using ctl)).sum)
   catch case ex: LimitExceeded => println("too large")
 ```

--- a/docs/docs/reference/experimental/erased-defs-spec.md
+++ b/docs/docs/reference/experimental/erased-defs-spec.md
@@ -15,8 +15,8 @@ TODO: complete
    * In a `class` or `trait` definition
 
     ```scala
-    erased val x = ...
-    erased def f = ...
+    erased val x: Int
+    erased def f: Int
 
     def g(erased x: Int) = ...
 

--- a/docs/docs/reference/experimental/erased-defs.md
+++ b/docs/docs/reference/experimental/erased-defs.md
@@ -79,7 +79,7 @@ with `erased`. These will also only be usable as arguments to `erased`
 parameters.
 
 ```scala
-erased val erasedEvidence: Ev = ...
+erased val erasedEvidence: Ev
 methodWithErasedEv(erasedEvidence)
 ```
 
@@ -93,8 +93,8 @@ erased.
 def methodWithErasedEv(erased ev: Ev): Int = ...
 
 def evidence1: Ev = ...
-erased def erasedEvidence2: Ev = ... // does not exist at runtime
-erased val erasedEvidence3: Ev = ... // does not exist at runtime
+erased def erasedEvidence2: Ev // does not exist at runtime
+erased val erasedEvidence3: Ev // does not exist at runtime
 
 // evidence1 is not evaluated and no value is passed to methodWithErasedEv
 methodWithErasedEv(evidence1)
@@ -137,7 +137,7 @@ class IsOn[S <: State]
 object IsOn:
   // will not exist at runtime, the compiler will only
   // require that this evidence exists at compile time
-  erased given IsOn[On] = new IsOn[On]
+  erased given IsOn[On]
 
 class Machine[S <: State] private ():
   // ev will disappear from both functions
@@ -216,11 +216,11 @@ The code above expands to
 ```scala
 erased class CanRead
 
-erased val x: CanRead = ...
+erased val x: CanRead
 val y: (erased CanRead) => Int = ...
 def f(erased x: CanRead) = ...
-erased def g(): CanRead = ...
-erased given CanRead = ...
+erased def g(): CanRead
+erased given CanRead
 ```
 After erasure, it is checked that no references to values of erased classes remain and that no instances of erased classes are created. So the following would be an error:
 ```scala

--- a/tests/invalid/neg/typelevel-erased-leak.scala
+++ b/tests/invalid/neg/typelevel-erased-leak.scala
@@ -1,6 +1,6 @@
 
 object typelevel {
-  erased def erasedValue[T]: T = ???
+  erased def erasedValue[T]: T
 }
 
 object Test {

--- a/tests/invalid/run/Tuple.scala
+++ b/tests/invalid/run/Tuple.scala
@@ -2,7 +2,7 @@ import annotation.showAsInfix
 
 // This version of Tuple requires full retyping of untyped trees on inlining
 object typelevel {
-  erased def erasedValue[T]: T = ???
+  erased def erasedValue[T]: T
   class Typed[T](val value: T) { type Type = T }
 }
 

--- a/tests/neg-custom-args/erased/erased-3.scala
+++ b/tests/neg-custom-args/erased/erased-3.scala
@@ -41,5 +41,5 @@ object Test {
     u() // OK
   }
 
-  erased def u(): Int = 42
+  erased def u(): Int
 }

--- a/tests/neg-custom-args/erased/erased-6.scala
+++ b/tests/neg-custom-args/erased/erased-6.scala
@@ -1,5 +1,5 @@
 object Test {
-  erased def foo: Foo = new Foo
+  erased def foo: Foo
   foo.x() // error
   foo.y // error
   foo.z // error

--- a/tests/neg-custom-args/erased/erased-implicit.scala
+++ b/tests/neg-custom-args/erased/erased-implicit.scala
@@ -4,6 +4,6 @@ object Test {
 
   def fun(implicit a: Double): Int = 42
 
-  erased implicit def doubleImplicit: Double = 42.0
+  erased implicit def doubleImplicit: Double
 
 }

--- a/tests/neg-custom-args/erased/erased-lazy-val.scala
+++ b/tests/neg-custom-args/erased/erased-lazy-val.scala
@@ -1,3 +1,3 @@
 object Test {
-  erased lazy val i: Int = 1 // error
+  erased lazy val i: Int // error
 }

--- a/tests/neg-custom-args/erased/erased-var.scala
+++ b/tests/neg-custom-args/erased/erased-var.scala
@@ -1,3 +1,4 @@
+import language.experimental.erasedDefinitions
 object Test {
-  erased var i: Int = 1 // error
+  erased var i: Int // error // error
 }

--- a/tests/neg-custom-args/inline-position/B_2.scala
+++ b/tests/neg-custom-args/inline-position/B_2.scala
@@ -1,5 +1,5 @@
 object B {
-  erased val y = Array('a')
+  erased val y: Array[Char]
 
   A.f(new String(y)) // error: value y is declared as erased but is in fact used
 }

--- a/tests/neg-custom-args/no-experimental/experimental-imports.scala
+++ b/tests/neg-custom-args/no-experimental/experimental-imports.scala
@@ -6,14 +6,14 @@ object Object1:
   import language.experimental.namedTypeArguments
   import language.experimental.genericNumberLiterals
   import language.experimental.erasedDefinitions
-  erased def f = 1
+  erased def f: Int
 
 object Object2:
   import language.experimental.fewerBraces // error
   import language.experimental.namedTypeArguments // error
   import language.experimental.genericNumberLiterals // error
   import language.experimental.erasedDefinitions
-  erased def f = 1
+  erased def f: Int
 
 @experimental
 object Class1:
@@ -21,14 +21,14 @@ object Class1:
   import language.experimental.namedTypeArguments
   import language.experimental.genericNumberLiterals
   import language.experimental.erasedDefinitions
-  erased def f = 1
+  erased def f: Int
 
 object Class2:
   import language.experimental.fewerBraces // error
   import language.experimental.namedTypeArguments // error
   import language.experimental.genericNumberLiterals // error
   import language.experimental.erasedDefinitions
-  erased def f = 1
+  erased def f: Int
 
 @experimental
 def fun1 =
@@ -36,11 +36,11 @@ def fun1 =
   import language.experimental.namedTypeArguments
   import language.experimental.genericNumberLiterals
   import language.experimental.erasedDefinitions
-  erased def f = 1
+  erased def f: Int
 
 def fun2 =
   import language.experimental.fewerBraces // error
   import language.experimental.namedTypeArguments // error
   import language.experimental.genericNumberLiterals // error
   import language.experimental.erasedDefinitions
-  erased def f = 1
+  erased def f: Int

--- a/tests/neg-custom-args/no-experimental/experimental.scala
+++ b/tests/neg-custom-args/no-experimental/experimental.scala
@@ -11,7 +11,7 @@ class Test1 {
   import scala.compiletime.erasedValue
   type UnivEq[A]
   object UnivEq:
-    erased def force[A]: UnivEq[A] = erasedValue
+    erased def force[A]: UnivEq[A]
     extension [A](erased proof: UnivEq[A])
       inline def univEq(a: A, b: A): Boolean =
         a == b

--- a/tests/neg-custom-args/no-experimental/experimentalErased.scala
+++ b/tests/neg-custom-args/no-experimental/experimentalErased.scala
@@ -7,14 +7,14 @@ erased class Foo
 erased class Bar // error
 
 @experimental
-erased def foo = 2
+erased def foo: Int
 
-erased def bar = 2 // error
+erased def bar: Int // error
 
 @experimental
-erased val foo2 = 2
+erased val foo2: Int
 
-erased val bar2 = 2 // error
+erased val bar2: Int // error
 
 @experimental
 def foo3(erased a: Int) = 2

--- a/tests/neg-custom-args/typeclass-derivation2.scala
+++ b/tests/neg-custom-args/typeclass-derivation2.scala
@@ -117,7 +117,7 @@ object TypeLevel {
   type Subtype[t] = Type[_, t]
   type Supertype[t] = Type[t, _]
   type Exactly[t] = Type[t, t]
-  erased def typeOf[T]: Type[T, T] = ???
+  erased def typeOf[T]: Type[T, T]
 }
 
 // An algebraic datatype

--- a/tests/neg-custom-args/typelevel-noeta.scala
+++ b/tests/neg-custom-args/typelevel-noeta.scala
@@ -12,7 +12,7 @@ object Test {
     case _: Char =>
   }
 
-  erased def test3(x: Int) = x + 1
+  erased def test3(x: Int): Int
 
   def f(g: Int => Int) = g(0)
 

--- a/tests/neg/safeThrowsStrawman.scala
+++ b/tests/neg/safeThrowsStrawman.scala
@@ -21,7 +21,7 @@ def bar: Int raises Exception =
 
 @main def Test =
   try
-    erased given CanThrow[Fail] = ???
+    erased given CanThrow[Fail]
     println(foo(true))
     println(foo(false))
     println(bar)        // error

--- a/tests/pos-custom-args/erased/i10848a.scala
+++ b/tests/pos-custom-args/erased/i10848a.scala
@@ -1,5 +1,5 @@
 class IsOn[T]
 type On
 object IsOn {
-  erased given IsOn[On] = new IsOn[On]
+  erased given IsOn[On]
 }

--- a/tests/pos-custom-args/erased/i10848b.scala
+++ b/tests/pos-custom-args/erased/i10848b.scala
@@ -1,4 +1,4 @@
 class Foo:
-  erased given Int = 1
+  erased given Int
   def foo(using erased x: Int): Unit = ()
   foo

--- a/tests/pos-custom-args/erased/i11896.scala
+++ b/tests/pos-custom-args/erased/i11896.scala
@@ -1,7 +1,7 @@
 import scala.language.experimental.erasedDefinitions
 
 type X
-erased def x: X = compiletime.erasedValue
+erased def x: X
 
 def foo(using erased X): Unit = ()
 

--- a/tests/pos-custom-args/i5938.scala
+++ b/tests/pos-custom-args/i5938.scala
@@ -12,7 +12,7 @@ inline def link[T] =
 
 class Foo
 object Foo {
-  erased implicit val barLink: Link[Foo, Bar.type] = null
+  erased implicit val barLink: Link[Foo, Bar.type]
 }
 
 implicit object Bar {

--- a/tests/pos-custom-args/i6009a.scala
+++ b/tests/pos-custom-args/i6009a.scala
@@ -1,6 +1,6 @@
 class Foo {
   def foo(f: (erased Int) => Int): Int = {
-    erased val ctx = 1
+    erased val ctx: Int
     f(ctx)
   }
 }

--- a/tests/pos-custom-args/i6009b.scala
+++ b/tests/pos-custom-args/i6009b.scala
@@ -1,6 +1,6 @@
 class Foo {
   def foo(f: (erased Int) => Int): Int = {
-    erased val ctx = 1
+    erased val ctx: Int
     f(ctx)
   }
 }

--- a/tests/pos-custom-args/inline-match-gadt.scala
+++ b/tests/pos-custom-args/inline-match-gadt.scala
@@ -1,6 +1,6 @@
 object `inline-match-gadt` {
   class Exactly[T]
-  erased def exactType[T]: Exactly[T] = ???
+  erased def exactType[T]: Exactly[T]
 
   inline def foo[T](t: T): T =
     inline exactType[T] match {

--- a/tests/pos-custom-args/matchtype.scala
+++ b/tests/pos-custom-args/matchtype.scala
@@ -11,21 +11,21 @@ object Test {
   }
 
   type T2 = Len[(1, 2, 3)]
-  erased val x: 3 = erasedValue[T2]
+  erased val x: 3
 
   type T1 = S[0]
 
-  erased val x2: 1 = erasedValue[T1]
+  erased val x2: 1
 
-  erased val y0: S[S[S[0]]] = erasedValue[T2]
-  erased val z0: T2 = erasedValue[S[S[S[0]]]]
+  erased val y0: S[S[S[0]]]
+  erased val z0: T2
 
   type Head[X <: Tuple] = X match {
     case (x1, _) => x1
   }
 
-  erased val y1: Int = erasedValue[Head[(Int, String)]]
-  erased val z1: Head[(Int, String)] = 22
+  erased val y1: Int
+  erased val z1: Head[(Int, String)]
 
   type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
     case Unit => Y
@@ -45,22 +45,22 @@ object Test {
     case (x *: xs, S[n1]) => Elem1[xs, n1]
   }
 
-  erased val x3: String = erasedValue[Elem[(String, Int), 0]]
-  erased val x4: Int = erasedValue[Elem1[(String, Int), 1]]
+  erased val x3: String
+  erased val x4: Int
 
-  erased val y2: Elem[(String, Int, Boolean), 0] = erasedValue[String]
-  erased val z2: String = erasedValue[Elem[(String, Int, Boolean), 0]]
-  erased val y3: Elem1[(String, Int, Boolean), 1] = erasedValue[Int]
-  erased val z3: Int = erasedValue[Elem1[(String, Int, Boolean), 1]]
-  erased val y4: Elem[(String, Int, Boolean), 2] = erasedValue[Boolean]
-  erased val z4: Boolean = erasedValue[Elem[(String, Int, Boolean), 2]]
+  erased val y2: Elem[(String, Int, Boolean), 0]
+  erased val z2: String
+  erased val y3: Elem1[(String, Int, Boolean), 1]
+  erased val z3: Int
+  erased val y4: Elem[(String, Int, Boolean), 2]
+  erased val z4: Boolean
 
-  erased val y5: Concat[Unit, (String, Int)] = erasedValue[(String, Int)]
-  erased val z5: (String, Int) = erasedValue[Concat[Unit, (String, Int)]]
-  erased val y6: Concat[(Boolean, Boolean), (String, Int)] = erasedValue[Boolean *: Boolean *: (String, Int)]
-  erased val z6: Boolean *: Boolean *: (String, Int) = erasedValue[Concat[(Boolean, Boolean), (String, Int)]]
-  erased val y7: (Boolean, Boolean, String, Int) = erasedValue[Concat[(Boolean, Boolean), String *: Int *: EmptyTuple]]
-  erased val z7: Concat[(Boolean, Boolean), String *: Int *: EmptyTuple] = erasedValue[(Boolean, Boolean, String, Int)]
+  erased val y5: Concat[Unit, (String, Int)]
+  erased val z5: (String, Int)
+  erased val y6: Concat[(Boolean, Boolean), (String, Int)]
+  erased val z6: Boolean *: Boolean *: (String, Int)
+  erased val y7: (Boolean, Boolean, String, Int)
+  erased val z7: Concat[(Boolean, Boolean), String *: Int *: EmptyTuple]
 
   def index[Xs <: NonEmptyTuple](xs: Xs, n: Int): Elem[Xs, n.type] = xs(n).asInstanceOf
 

--- a/tests/pos-custom-args/no-experimental/experimental-imports-top.scala
+++ b/tests/pos-custom-args/no-experimental/experimental-imports-top.scala
@@ -2,4 +2,4 @@ import language.experimental.erasedDefinitions
 import annotation.experimental
 
 @experimental
-erased def f = 1
+erased def f: Int

--- a/tests/pos-custom-args/phantom-Eq.scala
+++ b/tests/pos-custom-args/phantom-Eq.scala
@@ -20,12 +20,12 @@ object EqUtil {
   extension [T](x: T)
     def ===[U](y: U)(using erased PhantomEq[T, U]) = x.equals(y)
 
-  erased given eqString: PhantomEqEq[String] = ???
-  erased given eqInt: PhantomEqEq[Int]       = ???
-  erased given eqDouble: PhantomEqEq[Double] = ???
+  erased given eqString: PhantomEqEq[String]
+  erased given eqInt: PhantomEqEq[Int]
+  erased given eqDouble: PhantomEqEq[Double]
 
-  erased given eqByteNum: PhantomEq[Byte, Number] = ???
-  erased given eqNumByte: PhantomEq[Number, Byte] = ???
+  erased given eqByteNum: PhantomEq[Byte, Number]
+  erased given eqNumByte: PhantomEq[Number, Byte]
 
-  erased given eqSeq[T, U](using erased PhantomEq[T, U]): PhantomEq[Seq[T], Seq[U]] = ???
+  erased given eqSeq[T, U](using erased PhantomEq[T, U]): PhantomEq[Seq[T], Seq[U]]
 }

--- a/tests/pos-custom-args/phantom-Eq2/Phantom-Eq_1.scala
+++ b/tests/pos-custom-args/phantom-Eq2/Phantom-Eq_1.scala
@@ -8,11 +8,10 @@ object EqUtil {
   extension [T](x: T)
     def ===[U] (y: U) (using erased PhantomEq[T, U]) = x.equals(y)
 
-  erased given eqString: PhantomEqEq[String] = new PhantomEq[String, String]
-  erased given eqInt: PhantomEqEq[Int]       = new PhantomEq[Int, Int]
-  erased given eqDouble: PhantomEqEq[Double] = new PhantomEq[Double, Double]
-  erased given eqByteNum: PhantomEq[Byte, Number] = new PhantomEq[Byte, Number]
-  erased given eqNumByte: PhantomEq[Number, Byte] = new PhantomEq[Number, Byte]
-  erased given eqSeq[T, U] (using erased eq: PhantomEq[T, U]): PhantomEq[Seq[T], Seq[U]] =
-    new PhantomEq[Seq[T], Seq[U]]
+  erased given eqString: PhantomEqEq[String]
+  erased given eqInt: PhantomEqEq[Int]
+  erased given eqDouble: PhantomEqEq[Double]
+  erased given eqByteNum: PhantomEq[Byte, Number]
+  erased given eqNumByte: PhantomEq[Number, Byte]
+  erased given eqSeq[T, U] (using erased eq: PhantomEq[T, U]): PhantomEq[Seq[T], Seq[U]]
 }

--- a/tests/pos-custom-args/phantom-Evidence.scala
+++ b/tests/pos-custom-args/phantom-Evidence.scala
@@ -24,5 +24,5 @@ object WithNormalState {
 
 object Utils {
   type =::=[From, To]
-  erased given tpEquals[A]: A =::= A = ???
+  erased given tpEquals[A]: A =::= A
 }

--- a/tests/pos/erased-class-separate/A_1.scala
+++ b/tests/pos/erased-class-separate/A_1.scala
@@ -1,3 +1,2 @@
 import language.experimental.erasedDefinitions
 erased class A
-

--- a/tests/pos/erased-conforms.scala
+++ b/tests/pos/erased-conforms.scala
@@ -5,7 +5,7 @@ erased class <::<[-From, +To] extends ErasedTerm
 
 erased class =::=[From, To] extends (From <::< To)
 
-erased given [X]: (X =::= X) = scala.compiletime.erasedValue
+erased given [X]: (X =::= X)
 
 extension [From](x: From)
   inline def cast[To](using From <::< To): To = x.asInstanceOf[To] // Safe cast because we know `From <:< To`

--- a/tests/pos/experimentalErased.scala
+++ b/tests/pos/experimentalErased.scala
@@ -7,14 +7,14 @@ erased class Foo
 erased class Bar
 
 @experimental
-erased def foo = 2
+erased def foo: Int
 
-erased def bar = 2
+erased def bar: Int
 
 @experimental
-erased val foo2 = 2
+erased val foo2: Int
 
-erased val bar2 = 2
+erased val bar2: Int
 
 @experimental
 def foo3(erased a: Int) = 2

--- a/tests/pos/i11743.scala
+++ b/tests/pos/i11743.scala
@@ -1,8 +1,8 @@
 import language.experimental.erasedDefinitions
-import scala.compiletime.erasedValue
+
 type UnivEq[A]
 object UnivEq:
-  erased def force[A]: UnivEq[A] = erasedValue
+  erased def force[A]: UnivEq[A]
   extension [A](erased proof: UnivEq[A])
     inline def univEq(a: A, b: A): Boolean =
       a == b

--- a/tests/pos/i11864.scala
+++ b/tests/pos/i11864.scala
@@ -40,7 +40,7 @@ final class CallbackTo[+A] {
 object CallbackTo {
 
   type MapGuard[A] = { type Out = A }
-  erased given MapGuard[A]: MapGuard[A] = ???
+  erased given MapGuard[A]: MapGuard[A]
 
   def traverse[A, B](ta: List[A]): CallbackTo[List[B]] =
     val x: CallbackTo[List[A] => List[B]] = ???

--- a/tests/run-custom-args/companion-loading.scala
+++ b/tests/run-custom-args/companion-loading.scala
@@ -9,7 +9,7 @@ case class Foo(i: Int)
 object Foo {
   println(s"Foo companion")
 
-  erased implicit val barLink: Link[Foo, FooAssoc.type] = null
+  erased implicit val barLink: Link[Foo, FooAssoc.type]
 }
 
 implicit object FooAssoc extends Assoc[Foo] {

--- a/tests/run-custom-args/erased/erased-2.scala
+++ b/tests/run-custom-args/erased/erased-2.scala
@@ -2,7 +2,7 @@ object Test {
 
   def main(args: Array[String]): Unit = {
 
-    erased def !!! : Nothing = ???
+    erased def !!! : Nothing
 
     try {
       fun(!!!)

--- a/tests/run-custom-args/erased/erased-select-prefix.scala
+++ b/tests/run-custom-args/erased/erased-select-prefix.scala
@@ -27,9 +27,9 @@ object Test {
 
   def bar(erased i: Int): Unit = ()
 
-  erased def foo0: Int = 0
-  erased def foo1(): Int = 1
-  erased def foo2[T]: Int = 2
-  erased def foo3[T](): Int = 3
+  erased def foo0: Int
+  erased def foo1(): Int
+  erased def foo2[T]: Int
+  erased def foo3[T](): Int
 
 }

--- a/tests/run-custom-args/erased/i11996.scala
+++ b/tests/run-custom-args/erased/i11996.scala
@@ -1,8 +1,8 @@
 final class UnivEq[A]
 
 object UnivEq:
-  erased def force[A]: UnivEq[A] =
-    compiletime.erasedValue
+  object force:
+    erased given [A]: UnivEq[A]
 
 extension [A](a: A)
   inline def ==*[B >: A](b: B)(using erased UnivEq[B]): Boolean = a == b
@@ -12,7 +12,7 @@ case class I(i: Int)
 
 @main def Test = {
   def test[A](a: A, b: A): Unit = {
-    erased given UnivEq[A] = UnivEq.force[A]
+    import UnivEq.force.given
     println(a ==* a)
     println(a !=* b)
   }

--- a/tests/run-custom-args/typeclass-derivation2.scala
+++ b/tests/run-custom-args/typeclass-derivation2.scala
@@ -119,7 +119,7 @@ object TypeLevel {
   type Subtype[t] = Type[_, t]
   type Supertype[t] = Type[t, _]
   type Exactly[t] = Type[t, t]
-  erased def typeOf[T]: Type[T, T] = ???
+  erased def typeOf[T]: Type[T, T]
 }
 
 // An algebraic datatype

--- a/tests/run-custom-args/typeclass-derivation2c.scala
+++ b/tests/run-custom-args/typeclass-derivation2c.scala
@@ -24,12 +24,12 @@ object Deriving {
       /** The number of cases in the sum.
       *  Implemented by an inline method in concrete subclasses.
       */
-      erased def numberOfCases: Int = ???
+      erased def numberOfCases: Int
 
       /** The Generic representations of the sum's alternatives.
       *  Implemented by an inline method in concrete subclasses.
       */
-      erased def alternative(n: Int): Generic[_ <: T] = ???
+      erased def alternative(n: Int): Generic[_ <: T]
     }
 
     /** The Generic for a product type */

--- a/tests/run-custom-args/typelevel-defaultValue.scala
+++ b/tests/run-custom-args/typelevel-defaultValue.scala
@@ -1,6 +1,6 @@
 
 object compiletime {
-  erased def erasedValue[T]: T = ???
+  erased def erasedValue[T]: T
 }
 
 object Test extends App {


### PR DESCRIPTION
This is to avoid the need for a dummy implementation that is usually redundant and meaningless. To avoid this with a simple mechanism/rule that desugars abstract erased definitions into concrete ones.

Users will be able to write 
```scala
erased val x: T
erased def f: T
erased given (using X): T
```

The desugaring works for `val`/`def` as follows
```diff
- erased val f: T
+ erased val f: T = scala.compiletime.erasedValue
```
```diff
- erased def f: T
+ erased def f: T = scala.compiletime.erasedValue
```

This works well because of three properties of erased definitions
* An abstract erased definition is semantically equivalent to a non-abstract one. It is only their signature that influences their semantics.
* The implementation of an erased definition is only used to infer the type of the definition. Most of the time this is redundant.
* Most of the time the result type should be explicitly given