### PR TITLE
Disallow erased inline definitions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -541,6 +541,9 @@ object Checking {
     checkCombination(Abstract, Override)
     checkCombination(Private, Override)
     checkCombination(Lazy, Inline)
+    // The issue with `erased inline` is that the erased semantics get lost
+    // as the code is inlined and the reference is removed before the erased usage check.
+    checkCombination(Erased, Inline)
     checkNoConflict(Lazy, ParamAccessor, s"parameter may not be `lazy`")
   }
 

--- a/tests/pos-custom-args/erased/i7878.scala
+++ b/tests/pos-custom-args/erased/i7878.scala
@@ -2,7 +2,7 @@ object Boom {
   import scala.compiletime.*
   trait Fail[A <: Int, B <: Int]
 
-  erased transparent inline given fail[X <: Int, Y <: Int]: Fail[X, Y] = {
+  transparent inline given fail[X <: Int, Y <: Int]: Fail[X, Y] = {
      scala.compiletime.summonFrom {
        case t: Fail[X, y] if constValue[y] < constValue[Y] => ???
     }

--- a/tests/pos-custom-args/erasedInline.scala
+++ b/tests/pos-custom-args/erasedInline.scala
@@ -1,0 +1,4 @@
+import language.experimental.erasedDefinitions
+
+erased inline def f: Unit = () // error: illegal combination of modifiers: `erased` and `inline` for: method f
+inline def g: Unit = ()


### PR DESCRIPTION
The issue with the combination is that the `erased` semantics get lost as the code is inlined and the reference is removed. This implies that when we check for references to erased definitions we will not find it (exaclty as with inline alone).