### PR TITLE
fix 2 problems plus add workaround for #13760

### DIFF
--- a/compiler/src/dotty/tools/MainGenericRunner.scala
+++ b/compiler/src/dotty/tools/MainGenericRunner.scala
@@ -81,6 +81,9 @@ case class Settings(
   def withSave: Settings =
     this.copy(save = true)
 
+  def noSave: Settings =
+    this.copy(save = false)
+
   def withModeShouldBePossibleRun: Settings =
     this.copy(modeShouldBePossibleRun = true)
 
@@ -135,6 +138,8 @@ object MainGenericRunner {
       )
     case "-save" :: tail =>
       process(tail, settings.withSave)
+    case "-nosave" :: tail =>
+      process(tail, settings.noSave)
     case "-with-compiler" :: tail =>
       process(tail, settings.withCompiler)
     case (o @ javaOption(striped)) :: tail =>
@@ -207,18 +212,20 @@ object MainGenericRunner {
       case ExecuteMode.Script =>
         val targetScript = Paths.get(settings.targetScript).toFile
         val targetJar = settings.targetScript.replaceAll("[.][^\\/]*$", "")+".jar"
-        val precompiledJar = Paths.get(targetJar).toFile
+        val precompiledJar = File(targetJar)
         val mainClass = if !precompiledJar.isFile then "" else Jar(targetJar).mainClass.getOrElse("")
-        val jarIsValid = mainClass.nonEmpty && precompiledJar.lastModified >= targetScript.lastModified
+        val jarIsValid = mainClass.nonEmpty && precompiledJar.lastModified >= targetScript.lastModified && settings.save
         if jarIsValid then
           // precompiledJar exists, is newer than targetScript, and manifest defines a mainClass
           sys.props("script.path") = targetScript.toPath.toAbsolutePath.normalize.toString
           val scalaClasspath = ClasspathFromClassloader(Thread.currentThread().getContextClassLoader).split(classpathSeparator)
           val newClasspath = (settings.classPath.flatMap(_.split(classpathSeparator).filter(_.nonEmpty)) ++ removeCompiler(scalaClasspath) :+ ".").map(File(_).toURI.toURL)
-          if mainClass.nonEmpty then
+          val res = if mainClass.nonEmpty then
             ObjectRunner.runAndCatch(newClasspath :+ File(targetJar).toURI.toURL, mainClass, settings.scriptArgs)
           else
             Some(IllegalArgumentException(s"No main class defined in manifest in jar: $precompiledJar"))
+          errorFn("", res)
+
         else
           val properArgs =
             List("-classpath", settings.classPath.mkString(classpathSeparator)).filter(Function.const(settings.classPath.nonEmpty))

--- a/compiler/test-resources/scripting/sqlDateError.sc
+++ b/compiler/test-resources/scripting/sqlDateError.sc
@@ -1,0 +1,6 @@
+#!bin/scala -nosave
+
+def main(args: Array[String]): Unit = {
+  println(new java.sql.Date(100L))
+  System.err.println("SCALA_OPTS="+Option(System.getenv("SCALA_OPTS")).getOrElse(""))
+}

--- a/compiler/test/dotty/tools/scripting/BashScriptsTests.scala
+++ b/compiler/test/dotty/tools/scripting/BashScriptsTests.scala
@@ -188,3 +188,24 @@ class BashScriptsTests:
       if valid then printf(s"\n===> success: classpath begins with %s, as reported by [%s]\n", workingDirectory, scriptFile.getName)
       assert(valid, s"script ${scriptFile.absPath} did not report valid java.class.path first entry")
 
+  /*
+   * verify that individual scripts can override -save with -nosave (needed to address #13760).
+   */
+  @Test def sqlDateTest =
+    val scriptBase = "sqlDateError"
+    val scriptFile = testFiles.find(_.getName == s"$scriptBase.sc").get
+    val testJar = testFile(s"$scriptBase.jar") // jar should not be created when scriptFile runs
+    printf("===> verify '-save' is cancelled by '-nosave' in script hashbang.`\n")
+    val (validTest, exitCode, stdout, stderr) = bashCommand(s"SCALA_OPTS=-save ${scriptFile.absPath}")
+    printf("stdout: %s\n", stdout.mkString("\n","\n",""))
+    if verifyValid(validTest) then
+      // the script should print '1969-12-31' or '1970-01-01', depending on time zone
+      // stdout can be polluted with an ANSI color prefix, in some test environments
+      val valid = stdout.mkString("").matches(""".*\d{4}-\d{2}-\d{2}.*""")
+      if (!valid) then
+        stdout.foreach { printf("stdout[%s]\n", _) }
+        stderr.foreach { printf("stderr[%s]\n", _) }
+      if valid then printf(s"\n===> success: scripts can override -save via -nosave\n")
+      assert(valid, s"script ${scriptFile.absPath} reported unexpected value for java.sql.Date ${stdout.mkString("\n")}")
+      assert(!testJar.exists,s"unexpected, jar file [$testJar] was created")
+


### PR DESCRIPTION
replaces #14241

These changes fix 2 problems, and add a workaround for #13760.

- script exceptions are discarded by `MainGenericRunner`, when running from a compiled jar.
- when the `-save` option is not specified at runtime, execution should not be from a previously compiled jar

The `-save` behavior matches the expectation in `scala2`.

This PR displays all exceptions on the Console when running from a `jar` file.

_This PR executes from the `jar` only if the `-save` option is specified at runtime._   Problem scripts (i.e., with references to `java.sql.Date`) can now selectively disable the -save option. 

The -save` option change provides a workaround for the `ClassNotFound: java.sql.Date` problem, which affects jdk 9+.
```scala
`java.lang.ClassNotFoundException: java.sql.Date`
```
A new command line option `-nosave` is provided, for undoing a `-save` option on the command line (e.g., in`SCALA_OPTS`)  This provides a way for individual scripts to override the `-save` option.

Adding `-save` to `SCALA_OPTS` will typically reduce script startup time by a couple of seconds.  This PR provides per-script granularity for overriding the '-save' option.   Scripts that would otherwise throw an exception when running from a compiled jar may specify `-nosave` in the hashbang line.   This avoids having to remove the `-save` option from `SCALA_OPTS`.

The `-nosave` option can be added to the hashbang line, as in these two example hashbang lines:

The first version requires `/usr/bin/env` version `8.30` or later:
```sh
#!/usr/bin/env -S scala -nosave
```

This version uses the path to the scala wrapper:
```sh
#!/opt/scala3/bin/scala -nosave
```
