### PR TITLE
Scala 2.13.8 (was 2.13.6)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -99,8 +99,8 @@ object Build {
    *  scala-library.
    */
   def stdlibVersion(implicit mode: Mode): String = mode match {
-    case NonBootstrapped => "2.13.6"
-    case Bootstrapped => "2.13.6"
+    case NonBootstrapped => "2.13.8"
+    case Bootstrapped => "2.13.8"
   }
 
   val dottyOrganization = "org.scala-lang"

--- a/tests/neg/i8752.check
+++ b/tests/neg/i8752.check
@@ -8,4 +8,4 @@ longer explanation available when compiling with `-explain`
 -- Error: tests/neg/i8752.scala:3:39 -----------------------------------------------------------------------------------
 3 |trait Arround1[C <:[X]=>>IterableOps[X,C,C[X]] ] // error // error
   |                                       ^
-  |                                       Type argument C does not have the same kind as its bound [_]
+  |                                       Type argument C does not have the same kind as its bound [_$$1]


### PR DESCRIPTION
Not sure what the policy is — is this eligible for 3.1.1, or does it wait for 3.2?

Also not sure if 2.13.7 was skipped for a reason, or just nobody thought of it. Regardless, I've added opening a PR such as this one to the Scala 2 release steps, for next time.