### PR TITLE
Fix #7512: Normalize type arguments before instantiation 

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4171,7 +4171,7 @@ object Types {
           case MatchAlias(alias) =>
             trace(i"normalize $this", typr, show = true) {
               MatchTypeTrace.recurseWith(this) {
-                alias.applyIfParameterized(args).tryNormalize
+                alias.applyIfParameterized(args.map(_.normalized)).tryNormalize
               }
             }
           case _ =>

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -39,6 +39,7 @@ i9999.scala
 9757.scala
 9890.scala
 13491.scala
+7512.scala
 
 # Opaque type
 i5720.scala

--- a/tests/pos/7512.scala
+++ b/tests/pos/7512.scala
@@ -1,0 +1,24 @@
+import scala.compiletime.ops.int.S
+
+object InfiniteLoopMatchType {
+    def main(args: Array[String]): Unit = {
+        testProd(2, 10)
+    }
+
+    def testProd(a: Int, b: Int)(using ev: (a.type * b.type) =:= (b.type * a.type)) = true
+
+    type *[A <: Int, B <: Int] <: Int = A match {
+        case 0 => 0
+        case _ => MultiplyLoop[A, B, 0]
+    }
+
+    type MultiplyLoop[A <: Int, B <: Int, Acc <: Int] <: Int = A match {
+        case 0 => Acc
+        case S[aMinusOne] => MultiplyLoop[aMinusOne, B, B + Acc]
+    }
+
+    type +[A <: Int, B <: Int] <: Int = A match {
+        case 0 => B
+        case S[aMinusOne] => aMinusOne + S[B]
+    }
+}


### PR DESCRIPTION
This PR fixes a long-lasting issue with type normalization that led to unnecessary exponential compilation time. I recently wrote some match type benchmarks and managed to reproduce this issue in a more controlled environment, which lead to this PR.

To summarize the issue, which is hard to observe without looking at the compiler internal, here is a simple example that exercises the exponential behavior:

```scala
// GEQ[5, 1] compiles, because 5 is greater than 1
type GEQ[A, B] = A match {
  case B => true
  case _ => GEQ[A, B + 1]
}
```

The issue with this code is we try to normalize `B + 1` first too early, and then too late. We normalize type at creating, but at that point `B` is abstract and `B + 1` cannot be normalized. Then, we normalize during subtyping, but that's a bit late. Here are the queries that will be sent to type comparer for `GEQ[5, 1]`:

```
5 <: 1? no
5 <: 1+1? no
5 <: 1+1+1? no
5 <: 1+1+1+1? no
5 <: 1+1+1+1+1? yes
```

Which results in a quadratic number of additions being computer... The solution is to normalize types when doing substitution, so that each addition is computed once and for all at each set of the recursion.

Fixes #7512