### PR TITLE
Format compiler crash stack traces

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -271,7 +271,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
     /** This callback is executed once the compilation of this test source finished */
     private final def onComplete(testSource: TestSource, reportersOrCrash: Try[Seq[TestReporter]], logger: LoggedRunnable): Unit =
       reportersOrCrash match {
-        case TryFailure(exn) => onFailure(testSource, Nil, logger, Some(s"Fatal compiler crash when compiling: ${testSource.title}:\n${exn.getMessage}\n${exn.getStackTrace.mkString("\n")}"))
+        case TryFailure(exn) => onFailure(testSource, Nil, logger, Some(s"Fatal compiler crash when compiling: ${testSource.title}:\n${exn.getMessage}${exn.getStackTrace.map("\n\tat " + _).mkString}"))
         case TrySuccess(reporters) => maybeFailureMessage(testSource, reporters) match {
           case Some(msg) => onFailure(testSource, reporters, logger, Option(msg).filter(_.nonEmpty))
           case None => onSuccess(testSource, reporters, logger)


### PR DESCRIPTION
This allows them to be recognised, e.g. from IntelliJ.