### PR TITLE
Properly desugar `inline given .. with ..`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -809,7 +809,9 @@ object desugar {
             Nil
         }
       }
-      val classMods = if mods.is(Given) then mods &~ Inline | Synthetic else mods
+      if mods.isAllOf(Given | Inline | Transparent) then
+        report.error("inline non-alias given cannot be trasparent", cdef)
+      val classMods = if mods.is(Given) then mods &~ (Inline | Transparent) | Synthetic else mods
       cpy.TypeDef(cdef: TypeDef)(
         name = className,
         rhs = cpy.Template(impl)(constr, parents1, clsDerived, self1,

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -783,7 +783,7 @@ object desugar {
         DefDef(
           className.toTermName, joinParams(constrTparams, defParamss),
           classTypeRef, creatorExpr)
-          .withMods(companionMods | mods.flags.toTermFlags & GivenOrImplicit | Final)
+          .withMods(companionMods | mods.flags.toTermFlags & (GivenOrImplicit | Inline) | Final)
           .withSpan(cdef.span) :: Nil
       }
 
@@ -809,7 +809,7 @@ object desugar {
             Nil
         }
       }
-      val classMods = if mods.is(Given) then mods | Synthetic else mods
+      val classMods = if mods.is(Given) then mods &~ Inline | Synthetic else mods
       cpy.TypeDef(cdef: TypeDef)(
         name = className,
         rhs = cpy.Template(impl)(constr, parents1, clsDerived, self1,

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -810,7 +810,7 @@ object desugar {
         }
       }
       if mods.isAllOf(Given | Inline | Transparent) then
-        report.error("inline non-alias given cannot be trasparent", cdef)
+        report.error("inline given instances cannot be trasparent", cdef)
       val classMods = if mods.is(Given) then mods &~ (Inline | Transparent) | Synthetic else mods
       cpy.TypeDef(cdef: TypeDef)(
         name = className,

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3626,7 +3626,7 @@ object Parsers {
           val templ =
             if isStatSep || isStatSeqEnd then Template(constr, parents, Nil, EmptyValDef, Nil)
             else withTemplate(constr, parents)
-          if noParams then ModuleDef(name, templ)
+          if noParams && !mods.is(Inline) then ModuleDef(name, templ)
           else TypeDef(name.toTypeName, templ)
       end gdef
       finalizeDef(gdef, mods1, start)

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -114,6 +114,9 @@ inline given Show[Foo] with {
 ```
 Note that the inline methods within the given instances may be `transparent`.
 
+The inlining of given instances will not inline/duplicate the implementation of the given, it will just inline the instantiation of that instance.
+This is used to help dead code elimination of the given instances that are not used after inlining.
+
 
 ## Pattern-Bound Given Instances
 

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -100,6 +100,21 @@ transparent inline given mkAnnotations[A, T]: Annotations[A, T] = ${
 
 Since `mkAnnotations` is `transparent`, the type of an application is the type of its right-hand side, which can be a proper subtype of the declared result type `Annotations[A, T]`.
 
+Given instances can have the `inline` but not `transparent` modifiers as their type is already known from the signature.
+Example:
+
+```scala
+trait Show[T] {
+  inline def show(x: T): String
+}
+
+inline given Show[Foo] with {
+  /*transparent*/ inline def show(x: Foo): String = ${ ... }
+}
+```
+Note that the inline methods within the given instances may be `transparent`.
+
+
 ## Pattern-Bound Given Instances
 
 Given instances can also appear in patterns. Example:

--- a/docs/docs/reference/contextual/givens.md
+++ b/docs/docs/reference/contextual/givens.md
@@ -111,6 +111,10 @@ trait Show[T] {
 inline given Show[Foo] with {
   /*transparent*/ inline def show(x: Foo): String = ${ ... }
 }
+
+def app =
+  // inlines `show` method call and removes the call to `given Show[Foo]`
+  summon[Show[Foo]].show(foo)
 ```
 Note that the inline methods within the given instances may be `transparent`.
 

--- a/tests/neg/i14177a.scala
+++ b/tests/neg/i14177a.scala
@@ -1,0 +1,6 @@
+import scala.compiletime.*
+
+trait C[A]
+
+inline given [Tup <: Tuple]: C[Tup] with
+  val cs = summonAll[Tuple.Map[Tup, C]] // error cannot reduce inline match with

--- a/tests/neg/i14177c.scala
+++ b/tests/neg/i14177c.scala
@@ -1,0 +1,15 @@
+class T
+
+transparent inline given fail1: T with // error
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+transparent inline given fail2[X]: T with // error
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+transparent inline given fail3(using DummyImplicit): T with // error
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+
+transparent inline given ok1: T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+transparent inline given ok2[X]: T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+transparent inline given ok3(using DummyImplicit): T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]

--- a/tests/pos/i14177b.scala
+++ b/tests/pos/i14177b.scala
@@ -1,0 +1,15 @@
+class T
+
+inline given fail1: T with
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+inline given fail2[X]: T with
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+inline given fail3(using DummyImplicit): T with
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+
+inline given ok1: T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+inline given ok2[X]: T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]
+inline given ok3(using DummyImplicit): T = new T:
+  val cs = scala.compiletime.summonAll[EmptyTuple]

--- a/tests/pos/i14282.scala
+++ b/tests/pos/i14282.scala
@@ -1,0 +1,13 @@
+trait Foo[A] {
+  inline def foo(): Unit
+}
+
+inline given FooA[A]: Foo[A] with {
+  inline def foo(): Unit = println()
+}
+def test1 = FooA.foo()
+
+inline given FooInt: Foo[Int] with {
+  inline def foo(): Unit = println()
+}
+def test2 = FooInt.foo()


### PR DESCRIPTION
```scala
inline given Foo with { .. }
```

now becomes
```scala
inline given def given_Foo: given_Foo = new given_Foo
class given_Foo extends Foo with { ... }
```

There are no creation of `lazy vals` when we have `inline`.
We inline the `new givne_Foo` only, the class does not get inlined.
This is useful to remove the instatiation of the given instance when
the methods are inline themselfs.

Fixes #14282
Fixes #14177