### PR TITLE
Update wording of uninitialized value error to be grammatically correct

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -1042,7 +1042,7 @@ object Semantic {
 
   /** Utility definition used for better error-reporting of argument errors */
   case class ArgInfo(value: Value, source: Tree) {
-    def promote: Contextual[List[Error]] = value.promote("May only use initialized value as arguments", source)
+    def promote: Contextual[List[Error]] = value.promote("Only initialized values may be used as arguments", source)
   }
 
   /** Evaluate an expression with the given value for `this` in a given class `klass`

--- a/tests/init/neg/closureLeak.check
+++ b/tests/init/neg/closureLeak.check
@@ -1,7 +1,7 @@
 -- Error: tests/init/neg/closureLeak.scala:11:14 -----------------------------------------------------------------------
 11 |    l.foreach(a => a.addX(this)) // error
    |              ^^^^^^^^^^^^^^^^^
-   |              Cannot prove that the value is fully-initialized. May only use initialized value as arguments.
+   |             Cannot prove that the value is fully-initialized. Only initialized values may be used as arguments.
    |
-   |              The unsafe promotion may cause the following problem:
-   |              Cannot prove that the value is fully initialized. May only use initialized value as arguments.
+   |             The unsafe promotion may cause the following problem:
+   |             Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.

--- a/tests/init/neg/default-this.check
+++ b/tests/init/neg/default-this.check
@@ -1,5 +1,5 @@
 -- Error: tests/init/neg/default-this.scala:9:8 ------------------------------------------------------------------------
 9 |        compare() // error
   |        ^^^^^^^
-  |     Cannot prove that the value is fully initialized. May only use initialized value as arguments. Calling trace:
-  |      -> val result = updateThenCompare(5)	[ default-this.scala:11 ]
+  |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
+  | -> val result = updateThenCompare(5)	[ default-this.scala:11 ]

--- a/tests/init/neg/promotion-loop.check
+++ b/tests/init/neg/promotion-loop.check
@@ -1,7 +1,7 @@
 -- Error: tests/init/neg/promotion-loop.scala:16:10 --------------------------------------------------------------------
 16 |  println(b)      // error
    |          ^
-   |          Cannot prove that the value is fully-initialized. May only use initialized value as arguments.
+   |          Cannot prove that the value is fully-initialized. Only initialized values may be used as arguments.
    |
    |          The unsafe promotion may cause the following problem:
-   |          Cannot prove that the value is fully initialized. May only use initialized value as arguments.
+   |          Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.

--- a/tests/init/neg/t3273.check
+++ b/tests/init/neg/t3273.check
@@ -1,7 +1,7 @@
 -- Error: tests/init/neg/t3273.scala:4:42 ------------------------------------------------------------------------------
 4 |  val num1: LazyList[Int] = 1 #:: num1.map(_ + 1)                        // error
   |                                  ^^^^^^^^^^^^^^^
-  |             Cannot prove that the value is fully-initialized. May only use initialized value as arguments.
+  |             Cannot prove that the value is fully-initialized. Only initialized values may be used as arguments.
   |
   |             The unsafe promotion may cause the following problem:
   |             Access non-initialized value num1. Calling trace:
@@ -9,7 +9,7 @@
 -- Error: tests/init/neg/t3273.scala:5:61 ------------------------------------------------------------------------------
 5 |  val num2: LazyList[Int] = 1 #:: num2.iterator.map(_ + 1).to(LazyList)  // error
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |             Cannot prove that the value is fully-initialized. May only use initialized value as arguments.
+  |             Cannot prove that the value is fully-initialized. Only initialized values may be used as arguments.
   |
   |             The unsafe promotion may cause the following problem:
   |             Access non-initialized value num2. Calling trace:


### PR DESCRIPTION
Update wording of uninitialized value error to be grammatically correct.

Instead of "May only use initialized value as arguments." it now says "Only initialized values may be used as arguments."

In theory, this should improve readability of error messages such as:
```
[error] 238 |  final val VoidRef = PrimRef(NoType)
[error]     |                              ^^^^^^
[error]     |Cannot prove that the value is fully-initialized. May only use initialized value as arguments.
```

Signed the CLA - @Xavientois

Review by @liufengyun 