### PR TITLE
Parse unary operators as regular identifiers when followed by square brackets

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2217,6 +2217,7 @@ object Parsers {
     val prefixExpr: Location => Tree = location =>
       if isIdent && nme.raw.isUnary(in.name)
          && in.canStartExprTokens.contains(in.lookahead.token)
+          && in.lookahead.token != LBRACKET
       then
         val start = in.offset
         val op = termIdent()

--- a/tests/pos/unary-with-type-params.scala
+++ b/tests/pos/unary-with-type-params.scala
@@ -1,0 +1,5 @@
+object Test {
+  def +[T](x: T): String = "x"
+  +[Int](6): String // Parser can treat + as identifier in non-unary context
+  +(6): Int // Parser prioritizes + as unary when possible
+}


### PR DESCRIPTION
Currently, `+(6)` parses as a unary `+` on the expression `6` and `+[Int](6)` does not parse at all because `[Int](6)` is not the legal start of an expression. This PR makes `+[Int](y)` parse as regular apply by removing `[` from the set of tokens that can follow a unary operator. I believe this is safe because although `[` can begin an expression, it can only begin a typed lambda like `[T] => T => Int`, and a `+` could not parse as a unary operator on such an expression in any case. This also happens to be the behavior of Scalameta. I'm not sure which behavior is correct but I believe there is no reason to disallow this behavior. 