### PR TITLE
Semi-Fix scaladoc of extensions methods

### DIFF
--- a/scaladoc-testcases/src/tests/extensionParams.scala
+++ b/scaladoc-testcases/src/tests/extensionParams.scala
@@ -1,22 +1,44 @@
 package tests.extensionParams
 
 extension [A](thiz: A)
-  def toTuple2[B](that: B): (A, B) = thiz -> that
+  def toTuple2[B](that: B): (A, B) 
+  = thiz -> that
+extension [A](a: A)(using Int)
+  def f1[B](b: B): (A, B) 
+  = ???
 
 extension [A](a: A)(using Int)
-  def f[B](b: B): (A, B) = ???
+  def f2(b: A): (A, A) 
+  = ???
 
 extension [A](a: A)(using Int)
-  def ff(b: A): (A, A) = ???
-
-extension [A](a: A)(using Int)
-  def fff(using String)(b: A): (A, A) = ???
+  def f3(using String)(b: A): (A, A) 
+  = ???
 
 extension (a: Char)(using Int)
-  def ffff(using String)(b: Int): Unit = ???
+  def f4(using String)(b: Int): Unit 
+  = ???
 
 extension (a: Char)(using Int)
-  def fffff[B](using String)(b: B): Unit = ???
+  def f5[B](using String)(b: B): Unit 
+  = ???
 
 extension [A <: List[Char]](a: A)(using Int)
-  def ffffff[B](b: B): (A, B) = ???
+  def f6[B](b: B): (A, B) 
+  = ???
+
+extension [A <: List[Char]](using String)(using Unit)(a: A)(using Int)(using Number)
+  def f7[B, C](b: B)(c: C): (A, B) 
+  = ???
+
+extension [A <: List[Char]](using String)(using Unit)(a: A)(using Int)(using Number)
+  def f8(b: Any)(c: Any): Any 
+  = ???
+
+extension [A <: List[Char]](using String)(using Unit)(a: A)(using Int)(using Number)
+  def f9[B, C](using Int)(b: B)(c: C): (A, B) 
+  = ???
+
+extension [A <: List[Char]](using String)(using Unit)(a: A)(using Int)(using Number)
+  def f10(using Int)(b: Any)(c: Any): Any 
+  = ???

--- a/scaladoc/src/dotty/tools/scaladoc/api.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/api.scala
@@ -43,7 +43,7 @@ enum Modifier(val name: String, val prefix: Boolean):
   case Transparent extends Modifier("transparent", true)
   case Infix extends Modifier("infix", true)
 
-case class ExtensionTarget(name: String, typeParams: Seq[TypeParameter], argsLists: Seq[ParametersList], signature: Signature, dri: DRI, position: Long)
+case class ExtensionTarget(name: String, typeParams: Seq[TypeParameter], argsLists: Seq[TermParametersList], signature: Signature, dri: DRI, position: Long)
 case class ImplicitConversion(from: DRI, to: DRI)
 trait ImplicitConversionProvider { def conversion: Option[ImplicitConversion] }
 trait Classlike
@@ -51,14 +51,14 @@ trait Classlike
 enum Kind(val name: String):
   case RootPackage extends Kind("")
   case Package extends Kind("package")
-  case Class(typeParams: Seq[TypeParameter], argsLists: Seq[ParametersList])
+  case Class(typeParams: Seq[TypeParameter], argsLists: Seq[TermParametersList])
     extends Kind("class") with Classlike
   case Object extends Kind("object") with Classlike
-  case Trait(typeParams: Seq[TypeParameter], argsLists: Seq[ParametersList])
+  case Trait(typeParams: Seq[TypeParameter], argsLists: Seq[TermParametersList])
     extends Kind("trait") with Classlike
-  case Enum(typeParams: Seq[TypeParameter], argsLists: Seq[ParametersList]) extends Kind("enum") with Classlike
+  case Enum(typeParams: Seq[TypeParameter], argsLists: Seq[TermParametersList]) extends Kind("enum") with Classlike
   case EnumCase(kind: Object.type | Kind.Type | Val.type | Class) extends Kind("case")
-  case Def(typeParams: Seq[TypeParameter], argsLists: Seq[ParametersList])
+  case Def(params: Seq[TypeParametersList | TermParametersList]) // TODO: sc
     extends Kind("def")
   case Extension(on: ExtensionTarget, m: Kind.Def) extends Kind("def")
   case Constructor(base: Kind.Def) extends Kind("def")
@@ -94,12 +94,15 @@ object Annotation:
   case class LinkParameter(name: Option[String] = None, dri: DRI, value: String) extends AnnotationParameter
   case class UnresolvedParameter(name: Option[String] = None, unresolvedText: String) extends AnnotationParameter
 
-case class ParametersList(
-  parameters: Seq[Parameter],
+
+// type ParametersList = TermParametersList | TypeParametersList // TODO: sc
+
+case class TermParametersList(
+  parameters: Seq[TermParameter],
   modifiers: String
 )
 
-case class Parameter(
+case class TermParameter(
   annotations: Seq[Annotation],
   modifiers: String,
   name: Option[String],
@@ -107,6 +110,10 @@ case class Parameter(
   signature: Signature,
   isExtendedSymbol: Boolean = false,
   isGrouped: Boolean = false
+)
+
+case class TypeParametersList(
+  parameters: Seq[TypeParameter]
 )
 
 case class TypeParameter(

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -130,7 +130,10 @@ trait ClassLikeSupport:
       case dd: DefDef if isDocumentableExtension(dd.symbol) =>
         dd.symbol.extendedSymbol.map { extSym =>
           val memberInfo = unwrapMemberInfo(c, dd.symbol)
-          val typeParams = dd.symbol.extendedTypeParams.map(mkTypeArgument(_, memberInfo.genericTypes))
+          val typeParams = dd.symbol.extendedTypeParamList.map(mkTypeArgument(_, memberInfo.genericTypes))
+          //println(dd.name)
+          //println("MemberInfo:\n" + memberInfo.paramLists)
+          //println("extended...:\n" + dd.symbol.extendedTermParamLists)
           val termParams = dd.symbol.extendedTermParamLists.zipWithIndex.flatMap { case (paramList, index) =>
             memberInfo.paramLists(index) match
               case EvidenceOnlyParameterList => Nil
@@ -328,7 +331,7 @@ trait ClassLikeSupport:
     ): Member =
     val method = methodSymbol.tree.asInstanceOf[DefDef]
     val paramLists: List[TermParamClause] = methodSymbol.nonExtensionTermParamLists
-    val genericTypes: List[TypeDef] = if (methodSymbol.isClassConstructor) Nil else methodSymbol.nonExtensionLeadingTypeParams
+    val genericTypes: List[TypeDef] = if (methodSymbol.isClassConstructor) Nil else methodSymbol.nonExtensionTypeParamList
 
     val memberInfo = unwrapMemberInfo(c, methodSymbol)
 

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -45,7 +45,7 @@ trait ClassLikeSupport:
           .filter(s => s.exists && !s.isHiddenByVisibility)
           .map( _.tree.asInstanceOf[DefDef])
       constr.fold(Nil)(
-        _.termParamss.map(pList => ParametersList(pList.params.map(p => mkParameter(p, parameterModifier)), paramListModifier(pList.params)))
+        _.termParamss.map(pList => TermParametersList(pList.params.map(p => mkParameter(p, parameterModifier)), paramListModifier(pList.params)))
         )
 
     if classDef.symbol.flags.is(Flags.Module) then Kind.Object
@@ -138,7 +138,7 @@ trait ClassLikeSupport:
             memberInfo.paramLists(index) match
               case EvidenceOnlyParameterList => Nil
               case info: RegularParameterList =>
-                Seq(ParametersList(paramList.params.map(mkParameter(_, memberInfo = info)), paramListModifier(paramList.params)))
+                Seq(TermParametersList(paramList.params.map(mkParameter(_, memberInfo = info)), paramListModifier(paramList.params)))
           }
           val target = ExtensionTarget(
             extSym.symbol.normalizedName,
@@ -330,32 +330,62 @@ trait ClassLikeSupport:
       specificKind: (Kind.Def => Kind) = identity
     ): Member =
     val method = methodSymbol.tree.asInstanceOf[DefDef]
-    val paramLists: List[TermParamClause] = methodSymbol.nonExtensionTermParamLists
-    val genericTypes: List[TypeDef] = if (methodSymbol.isClassConstructor) Nil else methodSymbol.nonExtensionTypeParamList
+    val allParamss: List[ParamClause] = method.paramss
+    val nonExtensionParamss: List[ParamClause] = methodSymbol.nonExtensionParamLists
+    //val paramLists: List[TermParamClause] = methodSymbol.nonExtensionTermParamLists
+    //val genericTypes: List[TypeDef] = if (methodSymbol.isClassConstructor) Nil else methodSymbol.nonExtensionTypeParamList
 
     val memberInfo = unwrapMemberInfo(c, methodSymbol)
 
+    assert(allParamss.size == memberInfo.paramLists.size)
+
+    // assumes method is left-associative
+    // finds indices in memberInfo.paramLists corresponding to nonExtensionParamss
+    // probably not going to work, as they are related but not ==
+    val nonExtensionParamssWithIndices = allParamss.zipWithIndex.dropWhile(_._1 != nonExtensionParamss.head)
+
     val basicKind: Kind.Def = Kind.Def(
+      nonExtensionParamssWithIndices map ( (clause, i) => (clause, memberInfo.paramLists(i)) ) flatMap {
+        case (terms: TermParamClause, EvidenceOnlyParameterList)  => None
+        case (terms: TermParamClause, info: RegularParameterList) => 
+          Some( TermParametersList( 
+            terms.params.map(
+              mkParameter(_, paramPrefix, memberInfo = info)
+            ), 
+            paramListModifier(terms.params)
+          ))
+        case (types: TypeParamClause, info: TypeParameterList) => 
+          Some( TypeParametersList(
+            types.params.map(
+              mkTypeArgument(_, info, memberInfo.contextBounds)
+            ) 
+          ))
+        
+      }
+    )
+    /*
+    val basicKind: Kind.Def = Kind.Def( // TODO: sc
       genericTypes.map(mkTypeArgument(_, memberInfo.genericTypes, memberInfo.contextBounds)),
       paramLists.zipWithIndex.flatMap { (pList, index) =>
         memberInfo.paramLists(index) match
-          case EvidenceOnlyParameterList => Nil
-          case info: RegularParameterList =>
-            Seq(ParametersList(pList.params.map(
-              mkParameter(_, paramPrefix, memberInfo = info)), paramListModifier(pList.params)
-            ))
+          
       }
     )
+    */
+
+    val numberOfTermParams = paramss.zipWithIndex.findLast{case _: TermParamClause => true case _ => false}.map((_, i) => i+1).getOrElse(0)
+    val firstTermParams: Option[TermParamClause] = paramss.collectFirst{case tpc: TermParamClause => tpc }
+    val firstTermParamsCount = firstTermParams.map(_.params.size).getOrElse(0)
 
     val methodKind =
       if methodSymbol.isClassConstructor then Kind.Constructor(basicKind)
       else if methodSymbol.flags.is(Flags.Implicit) then extractImplicitConversion(method.returnTpt.tpe) match
-        case Some(conversion) if paramLists.size == 0 || (paramLists.size == 1 && paramLists.head.params.size == 0) =>
+        case Some(conversion) if numberOfTermParams == 0 || (numberOfTermParams == 1 && firstTermParamsCount == 0) =>
           Kind.Implicit(basicKind, Some(conversion))
-        case None if paramLists.size == 1 && paramLists(0).params.size == 1 =>
+        case None if numberOfTermParams == 1 && firstTermParamsCount == 1 =>
           Kind.Implicit(basicKind, Some(
             ImplicitConversion(
-              paramLists(0).params(0).tpt.tpe.typeSymbol.dri,
+              firstTermParams.get.params(0).tpt.tpe.typeSymbol.dri,
               method.returnTpt.tpe.typeSymbol.dri
             )
           ))
@@ -379,7 +409,7 @@ trait ClassLikeSupport:
       val inlinePrefix = if argument.symbol.flags.is(Flags.Inline) then "inline " else ""
       val nameIfNotSynthetic = Option.when(!argument.symbol.flags.is(Flags.Synthetic))(argument.symbol.normalizedName)
       val name = argument.symbol.normalizedName
-      Parameter(
+      TermParameter(
         argument.symbol.getAnnotations(),
         inlinePrefix + prefix(argument.symbol),
         nameIfNotSynthetic,
@@ -474,10 +504,11 @@ trait ClassLikeSupport:
 
   object EvidenceOnlyParameterList
   type RegularParameterList = Map[String, TypeRepr]
-  type ParameterList = RegularParameterList | EvidenceOnlyParameterList.type
+  type TermParameterList = RegularParameterList | EvidenceOnlyParameterList.type
+  type TypeParameterList = Map[String, TypeBounds]
+  type ParameterList = TypeParameterList | TermParameterList
 
   case class MemberInfo(
-    genericTypes: Map[String, TypeBounds],
     paramLists: List[ParameterList],
     res: TypeRepr,
     contextBounds: Map[String, DSignature] = Map.empty,
@@ -485,7 +516,6 @@ trait ClassLikeSupport:
 
 
   def unwrapMemberInfo(c: ClassDef, symbol: Symbol): MemberInfo =
-    val baseTypeRepr = memberInfo(c, symbol)
 
     def isSyntheticEvidence(name: String) =
       if !name.startsWith(NameKinds.EvidenceParamName.separator) then false else
@@ -498,12 +528,12 @@ trait ClassLikeSupport:
         // Documenting method slightly different then its definition is withing the 'undefiend behaviour'.
         symbol.paramSymss.flatten.find(_.name == name).exists(_.flags.is(Flags.Implicit))
 
-    def handlePolyType(polyType: PolyType): MemberInfo =
-      MemberInfo(polyType.paramNames.zip(polyType.paramBounds).toMap, List.empty, polyType.resType)
+    def handlePolyType(memberInfo: MemberInfo, polyType: PolyType): MemberInfo = 
+      MemberInfo(memberInfo.paramLists :+ polyType.paramNames.zip(polyType.paramBounds).toMap, polyType.resType, memberInfo.contextBounds) 
 
     def handleMethodType(memberInfo: MemberInfo, methodType: MethodType): MemberInfo =
       val rawParams = methodType.paramNames.zip(methodType.paramTypes).toMap
-      val (evidences, notEvidences) = rawParams.partition(e => isSyntheticEvidence(e._1))
+      val (evidences, notEvidences) = rawParams.partition(e => isSyntheticEvidence(e._1)) 
 
 
       def findParamRefs(t: TypeRepr): Seq[ParamRef] = t match
@@ -532,22 +562,23 @@ trait ClassLikeSupport:
 
       val newParams = notEvidences ++ paramsThatLookLikeContextBounds
 
-      val newLists: List[ParameterList] = if newParams.isEmpty   && contextBounds.nonEmpty
+      val newLists: List[TermParameterList] = if newParams.isEmpty   && contextBounds.nonEmpty
         then memberInfo.paramLists ++  Seq(EvidenceOnlyParameterList)
         else memberInfo.paramLists ++ Seq(newParams)
-
-      MemberInfo(memberInfo.genericTypes, newLists , methodType.resType, contextBounds.toMap)
+      
+      val baseTypeRepr: TypeRepr = memberInfo(c, symbol)
+      MemberInfo(newLists, methodType.resType, contextBounds.toMap)
 
     def handleByNameType(memberInfo: MemberInfo, byNameType: ByNameType): MemberInfo =
-      MemberInfo(memberInfo.genericTypes, memberInfo.paramLists, byNameType.underlying)
+      MemberInfo(memberInfo.paramLists, byNameType.underlying)
 
     def recursivelyCalculateMemberInfo(memberInfo: MemberInfo): MemberInfo = memberInfo.res match
-      case p: PolyType => recursivelyCalculateMemberInfo(handlePolyType(p))
+      case p: PolyType => recursivelyCalculateMemberInfo(handlePolyType(memberInfo, p))
       case m: MethodType => recursivelyCalculateMemberInfo(handleMethodType(memberInfo, m))
       case b: ByNameType => handleByNameType(memberInfo, b)
       case _ => memberInfo
 
-    recursivelyCalculateMemberInfo(MemberInfo(Map.empty, List.empty, baseTypeRepr))
+    recursivelyCalculateMemberInfo(MemberInfo(List.empty, baseTypeRepr))
 
   private def paramListModifier(parameters: Seq[ValDef]): String =
     if parameters.size > 0 then

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
@@ -200,26 +200,25 @@ object SymOps:
       //println(res._2.map(_.params.map(_.show)).mkString("NonExtensionPart:\n","\n","\n"))
       res
 
+    
     def extendedParamLists: List[reflect.ParamClause] =
       sym.splitExtensionParamLists._1
-
-    def extendedTypeParams: List[reflect.TypeDef] =
-      val typeParamss: List[reflect.TypeParamClause] = sym.extendedParamLists.collect{case types: reflect.TypeParamClause => types}
-      typeParamss.headOption.map(_.params).getOrElse(List()) // only one type param clause on LHS
-
-
     
     def extendedTermParamLists: List[reflect.TermParamClause] =
       sym.extendedParamLists.collect{case terms: reflect.TermParamClause => terms}
 
-    def nonExtensionTermParamLists: List[reflect.TermParamClause] =
-      sym.nonExtensionParamLists.collect{case terms: reflect.TermParamClause => terms}
+    def extendedTypeParamList: List[reflect.TypeDef] =
+      val typeParamss: List[reflect.TypeParamClause] = sym.extendedParamLists.collect{case types: reflect.TypeParamClause => types}
+      typeParamss.headOption.map(_.params).getOrElse(List()) // only one type param clause on LHS
+
 
     def nonExtensionParamLists: List[reflect.ParamClause] =
       sym.splitExtensionParamLists._2
 
-
-    def nonExtensionLeadingTypeParams: List[reflect.TypeDef] =
+    def nonExtensionTermParamLists: List[reflect.TermParamClause] =
+      sym.nonExtensionParamLists.collect{case terms: reflect.TermParamClause => terms}
+    
+    def nonExtensionTypeParamList: List[reflect.TypeDef] =
       val typeParamss: List[reflect.TypeParamClause] = sym.nonExtensionParamLists.collect{case types: reflect.TypeParamClause => types}
       typeParamss.headOption.map(_.params).getOrElse(List()) // only one type param clause on RHS
 

--- a/scaladoc/src/dotty/tools/scaladoc/transformers/ImplicitMembersExtensionTransformer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/transformers/ImplicitMembersExtensionTransformer.scala
@@ -29,7 +29,7 @@ class ImplicitMembersExtensionTransformer(using DocContext) extends(Module => Mo
         case m @ Member(_, _, _, Kind.Extension(ExtensionTarget(_, _, _, _, MyDri, _), _), Origin.RegularlyDefined) =>
           val kind = m.kind match
             case d: Kind.Def => d
-            case _ => Kind.Def(Nil, Nil)
+            case _ => Kind.Def(Nil)
 
           Seq(m.withOrigin(Origin.ExtensionFrom(source.name, source.dri)).withKind(kind))
         case m @ Member(_, _, _, conversionProvider: ImplicitConversionProvider, Origin.RegularlyDefined) =>

--- a/scaladoc/src/dotty/tools/scaladoc/translators/ScalaSignatureProvider.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/translators/ScalaSignatureProvider.scala
@@ -118,28 +118,25 @@ object ScalaSignatureProvider:
 
     parentsSignature(clazz, selfSignature)
 
-  private def extensionSignature(extension: Member, fun: Kind.Def, builder: SignatureBuilder): SignatureBuilder =
+  private def extensionSignature(extension: Member, fun: Kind.Def, builder: SignatureBuilder): SignatureBuilder = // TODO: sc
     val withSignature = builder
       .modifiersAndVisibility(extension, "def")
       .name(extension.name, extension.dri)
-      .generics(fun.typeParams)
-      .functionParameters(fun.argsLists)
+      .functionParameters2(fun.params)
 
       withSignature.plain(":").plain(" ").signature(extension.signature)
 
-  private def givenMethodSignature(method: Member, body: Kind.Def, builder: SignatureBuilder): SignatureBuilder = method.kind match
+  private def givenMethodSignature(method: Member, body: Kind.Def, builder: SignatureBuilder): SignatureBuilder = method.kind match // TODO: sc
     case Kind.Given(_, Some(instance), _) =>
       builder.keyword("given ")
         .name(method.name, method.dri)
-        .generics(body.typeParams)
-        .functionParameters(body.argsLists)
+        .functionParameters2(body.params)
         .plain(": ")
         .signature(instance)
     case _ =>
       builder.keyword("given ")
         .name(method.name, method.dri)
-        .generics(body.typeParams)
-        .functionParameters(body.argsLists)
+      .functionParameters2(body.params)
 
   private def givenValSignature(field: Member, builder: SignatureBuilder): SignatureBuilder = field.kind match
     case Kind.Given(_, Some(instance), _) =>
@@ -150,12 +147,12 @@ object ScalaSignatureProvider:
     case _ =>
       builder.keyword("given ").name(field.name, field.dri)
 
-  private def methodSignature(method: Member, cls: Kind.Def, builder: SignatureBuilder): SignatureBuilder =
+  private def methodSignature(method: Member, cls: Kind.Def, builder: SignatureBuilder): SignatureBuilder = // TODO: sc
     val bdr = builder
     .modifiersAndVisibility(method, "def")
     .name(method.name, method.dri)
-    .generics(cls.typeParams)
-    .functionParameters(cls.argsLists)
+    .functionParameters2(cls.params)
+
     if !method.kind.isInstanceOf[Kind.Constructor] then
       bdr.plain(": ").signature(method.signature)
     else bdr

--- a/scaladoc/src/dotty/tools/scaladoc/translators/ScalaSignatureUtils.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/translators/ScalaSignatureUtils.scala
@@ -44,7 +44,7 @@ trait SignatureBuilder extends ScalaSignatureUtils {
   def annotationsBlock(d: Member): SignatureBuilder =
     d.annotations.foldLeft(this){ (bdr, annotation) => bdr.buildAnnotation(annotation)}
 
-  def annotationsInline(d: Parameter): SignatureBuilder =
+  def annotationsInline(d: TermParameter): SignatureBuilder =
     d.annotations.foldLeft(this){ (bdr, annotation) => bdr.buildAnnotation(annotation) }
 
   def annotationsInline(t: TypeParameter): SignatureBuilder =
@@ -87,7 +87,7 @@ trait SignatureBuilder extends ScalaSignatureUtils {
     bdr.annotationsInline(e).keyword(e.variance).tpe(e.name, Some(e.dri)).signature(e.signature)
   }
 
-  def functionParameters(params: Seq[ParametersList]) =
+  def functionParameters(params: Seq[TermParametersList]) =
     if params.isEmpty then this.plain("")
     else if params.size == 1 && params(0).parameters == Nil then this.plain("()")
     else this.list(params, separator = List(Plain(""))) { (bld, pList) =>
@@ -98,7 +98,22 @@ trait SignatureBuilder extends ScalaSignatureUtils {
         name.signature(p.signature)
       }
     }
+  /* 
+  def functionParameter = 
+    (bdr: SignatureBuilder, param: TypeParametersList | TermParametersList) => param match {
+      case types: TypeParameterList => generics(ts)
+      case terms: TermParametersList => functionParameters(terms)
+    }  */
+
+  def functionParameters2(params: Seq[TypeParametersList | TermParametersList]) = params.foldLeft(this){ (bdr, params) => params match {
+      case types: TypeParametersList => bdr.generics(types.parameters)
+      case terms: TermParametersList => bdr.functionParameters(Seq(terms))
+    }} // TODO: sc
+    
+  
 }
+
+
 
 trait ScalaSignatureUtils:
   extension (tokens: Seq[String]) def toSignatureString(): String =

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -1,5 +1,7 @@
 package dotty.tools.scaladoc.signatures
 
+import java.security.Signature
+
 class GenericSignaftures extends SignatureTest("genericSignatures", Seq("class"))
 
 class ObjectSignatures extends SignatureTest("objectSignatures", Seq("object"))
@@ -21,6 +23,8 @@ class VisibilityTest extends SignatureTest("visibility", SignatureTest.all)
 class GenericMethodsTest extends SignatureTest("genericMethods", Seq("def"))
 
 class MethodsAndConstructors extends SignatureTest("methodsAndConstructors", Seq("def"))
+
+class ExtensionParams extends SignatureTest("extensionParams", SignatureTest.all)
 
 class TypesSignatures extends SignatureTest("typesSignatures", SignatureTest.all)
 


### PR DESCRIPTION
This changes the heuristic used by scaladoc to one I was not able to fault (smarter people might)
(à propos, the main idea behind the heuristic was @smarter's)

Note that it is not enough for tests to pass, as `unwrapMemberInfo` is also incorrect, but I do not have the time to fix it

The commits are neatly split and annotated, so it should be relatively easy to understand what I did

I left some commented `println`s, they highlight that the new heuristic works correctly, and how `unwrapMemberInfo` is incorrect, for example with `f1` from the rehabilitated test `extensionParams`:
file:
```scala
extension [A](a: A)(using Int)
  def f1[B](b: B): (A, B) 
```
cleaned up output:
```scala
f1
ExtensionPart:
List(type A)
List(val a: A)
List(val x$2: scala.Int)
NonExtensionPart:
List(type B)
List(val b: B)

f1
MemberInfo:
List(Map(b -> TypeParamRef(B)))
extended...:
List(List(ValDef(a,Ident(A),EmptyTree)), List(ValDef(x$2,Ident(Int),EmptyTree)))
```




