### PR TITLE
Scaladoc: Fix rendering dependent function types

### DIFF
--- a/scaladoc-testcases/src/tests/typesSignatures.scala
+++ b/scaladoc-testcases/src/tests/typesSignatures.scala
@@ -37,6 +37,8 @@ class Base
   type I = (Int, String, Int) => (String, Int)
 
   type J = (a: A) => a.type
+
+  type K = [A] => (a: A) => a.type
 }
 
 class Operators

--- a/scaladoc-testcases/src/tests/typesSignatures.scala
+++ b/scaladoc-testcases/src/tests/typesSignatures.scala
@@ -35,6 +35,8 @@ class Base
   type H = () => String
 
   type I = (Int, String, Int) => (String, Int)
+
+  type J = (a: A) => a.type
 }
 
 class Operators


### PR DESCRIPTION
A valid dependent function type, such as:
`type J = (a: A) => a.type`
is reported as:
`type J = A => A { def apply(a: A): a; }`