### PR TITLE
Avoid misleading error message

### DIFF
--- a/tests/neg/parent-refinement.check
+++ b/tests/neg/parent-refinement.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/parent-refinement.scala:5:2 ------------------------------------------------------------------------
+5 |  with Ordered[Year] { // error
+  |  ^^^^
+  |  end of toplevel definition expected but 'with' found

--- a/tests/neg/parent-refinement.scala
+++ b/tests/neg/parent-refinement.scala
@@ -1,0 +1,7 @@
+
+trait Id { type Value }
+case class Year(value: Int) extends AnyVal
+  with Id { type Value = Int }
+  with Ordered[Year] { // error
+
+}


### PR DESCRIPTION
The error message falsely referred to missing support for early definitions
in the example, but none were present.

Fixes #14326