### PR TITLE
Make exceptions trackable

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -454,7 +454,7 @@ object desugar {
 
     if mods.is(Trait) then
       for vparams <- originalVparamss; vparam <- vparams do
-        if vparam.tpt.isInstanceOf[ByNameTypeTree] then
+        if isByNameType(vparam.tpt) then
           report.error(em"implementation restriction: traits cannot have by name parameters", vparam.srcPos)
 
     // Annotations on class _type_ parameters are set on the derived parameters
@@ -558,9 +558,8 @@ object desugar {
       appliedTypeTree(tycon, targs)
     }
 
-    def isRepeated(tree: Tree): Boolean = tree match {
+    def isRepeated(tree: Tree): Boolean = stripByNameType(tree) match {
       case PostfixOp(_, Ident(tpnme.raw.STAR)) => true
-      case ByNameTypeTree(tree1) => isRepeated(tree1)
       case _ => false
     }
 
@@ -1732,8 +1731,13 @@ object desugar {
       case ext: ExtMethods =>
         Block(List(ext), Literal(Constant(())).withSpan(ext.span))
       case CapturingTypeTree(refs, parent) =>
-        val annot = New(scalaDot(tpnme.retains), List(refs))
-        Annotated(parent, annot)
+        def annotate(annotName: TypeName, tp: Tree) =
+          Annotated(tp, New(scalaDot(annotName), List(refs)))
+        parent match
+          case ByNameTypeTree(restpt) =>
+            cpy.ByNameTypeTree(parent)(annotate(tpnme.retainsByName, restpt))
+          case _ =>
+            annotate(tpnme.retains, parent)
     }
     desugared.withSpan(tree.span)
   }

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -172,8 +172,7 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
   }
 
   /** Is tpt a vararg type of the form T* or => T*? */
-  def isRepeatedParamType(tpt: Tree)(using Context): Boolean = tpt match {
-    case ByNameTypeTree(tpt1) => isRepeatedParamType(tpt1)
+  def isRepeatedParamType(tpt: Tree)(using Context): Boolean = stripByNameType(tpt) match {
     case tpt: TypeTree => tpt.typeOpt.isRepeatedParam
     case AppliedTypeTree(Select(_, tpnme.REPEATED_PARAM_CLASS), _) => true
     case _ => false
@@ -189,6 +188,16 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case NamedArg(_, arg) => isWildcardStarArg(arg)
     case arg => arg.typeOpt.widen.isRepeatedParam
   }
+
+  def isByNameType(tree: Tree)(using Context): Boolean =
+    stripByNameType(tree) ne tree
+
+  def stripByNameType(tree: Tree)(using Context): Tree = unsplice(tree) match
+    case ByNameTypeTree(t1) => t1
+    case untpd.CapturingTypeTree(_, parent) =>
+      val parent1 = stripByNameType(parent)
+      if parent1 eq parent then tree else parent1
+    case _ => tree
 
   /** All type and value parameter symbols of this DefDef */
   def allParamSyms(ddef: DefDef)(using Context): List[Symbol] =
@@ -389,6 +398,16 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
       case _ => None
     }
   }
+
+  object ImpureByNameTypeTree:
+    def apply(tp: ByNameTypeTree)(using Context): untpd.CapturingTypeTree =
+      untpd.CapturingTypeTree(
+        Ident(nme.CAPTURE_ROOT).withSpan(tp.span.startPos) :: Nil, tp)
+    def unapply(tp: Tree)(using Context): Option[ByNameTypeTree] = tp match
+      case untpd.CapturingTypeTree(id @ Ident(nme.CAPTURE_ROOT) :: Nil, bntp: ByNameTypeTree)
+      if id.span == bntp.span.startPos => Some(bntp)
+      case _ => None
+  end ImpureByNameTypeTree
 }
 
 trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -43,9 +43,9 @@ extension (tree: Tree)
 extension (tp: Type)
 
   def derivedCapturingType(parent: Type, refs: CaptureSet)(using Context): Type = tp match
-    case CapturingType(p, r, b) =>
+    case CapturingType(p, r, k) =>
       if (parent eq p) && (refs eq r) then tp
-      else CapturingType(parent, refs, b)
+      else CapturingType(parent, refs, k)
 
   /** If this is  type variable instantiated or upper bounded with a capturing type,
    *  the capture set associated with that type. Extended to and-or types and
@@ -54,7 +54,8 @@ extension (tp: Type)
    */
   def boxedCaptured(using Context): CaptureSet =
     def getBoxed(tp: Type): CaptureSet = tp match
-      case CapturingType(_, refs, boxed) => if boxed then refs else CaptureSet.empty
+      case CapturingType(_, refs, CapturingKind.Boxed) => refs
+      case CapturingType(_, _, _) => CaptureSet.empty
       case tp: TypeProxy => getBoxed(tp.superType)
       case tp: AndType => getBoxed(tp.tp1) ++ getBoxed(tp.tp2)
       case tp: OrType => getBoxed(tp.tp1) ** getBoxed(tp.tp2)

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -209,8 +209,9 @@ sealed abstract class CaptureSet extends Showable:
     ((NoType: Type) /: elems) ((tp, ref) =>
       if tp.exists then OrType(tp, ref, soft = false) else ref)
 
-  def toRegularAnnotation(using Context): Annotation  =
-    Annotation(CaptureAnnotation(this, boxed = false).tree)
+  def toRegularAnnotation(byName: Boolean)(using Context): Annotation =
+    val kind = if byName then CapturingKind.ByName else CapturingKind.Regular
+    Annotation(CaptureAnnotation(this, kind).tree)
 
   override def toText(printer: Printer): Text =
     Str("{") ~ Text(elems.toList.map(printer.toTextCaptureRef), ", ") ~ Str("}")

--- a/compiler/src/dotty/tools/dotc/cc/CapturingKind.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CapturingKind.scala
@@ -1,0 +1,9 @@
+package dotty.tools
+package dotc
+package cc
+
+/** Possible kinds of captures */
+enum CapturingKind:
+  case Regular     // normal capture
+  case Boxed       // capture under box
+  case ByName      // capture applies to enclosing by-name type (only possible before ElimByName)

--- a/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
@@ -29,7 +29,7 @@ end CapturingType
 
 /** An extractor for types that will be capturing types at phase CheckCaptures. Also
  *  included are types that indicate captures on enclosing call-by-name parameters
- *  before phase ElimByName
+ *  before phase ElimByName.
  */
 object EventuallyCapturingType:
 

--- a/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
@@ -5,26 +5,46 @@ package cc
 import core.*
 import Types.*, Symbols.*, Contexts.*
 
+/** A capturing type. This is internally represented as an annotated type with a `retains`
+ *  annotation, but the extractor will succeed only at phase CheckCaptures.
+ *  Annotated types with `@retainsByName` annotation can also be created that way, by
+ *  giving a `CapturingKind.ByName` as `kind` argument, but they are never extracted,
+ *  since they have already been converted to regular capturing types before CheckCaptures.
+ */
 object CapturingType:
 
-  def apply(parent: Type, refs: CaptureSet, boxed: Boolean)(using Context): Type =
+  def apply(parent: Type, refs: CaptureSet, kind: CapturingKind)(using Context): Type =
     if refs.isAlwaysEmpty then parent
-    else AnnotatedType(parent, CaptureAnnotation(refs, boxed))
+    else AnnotatedType(parent, CaptureAnnotation(refs, kind))
 
-  def unapply(tp: AnnotatedType)(using Context): Option[(Type, CaptureSet, Boolean)] =
-    if ctx.phase == Phases.checkCapturesPhase then EventuallyCapturingType.unapply(tp)
+  def unapply(tp: AnnotatedType)(using Context): Option[(Type, CaptureSet, CapturingKind)] =
+    if ctx.phase == Phases.checkCapturesPhase then
+      val r = EventuallyCapturingType.unapply(tp)
+      r match
+        case Some((_, _, CapturingKind.ByName)) => None
+        case _ => r
     else None
 
 end CapturingType
 
+/** An extractor for types that will be capturing types at phase CheckCaptures. Also
+ *  included are types that indicate captures on enclosing call-by-name parameters
+ *  before phase ElimByName
+ */
 object EventuallyCapturingType:
 
-  def unapply(tp: AnnotatedType)(using Context): Option[(Type, CaptureSet, Boolean)] =
-    if tp.annot.symbol == defn.RetainsAnnot then
+  def unapply(tp: AnnotatedType)(using Context): Option[(Type, CaptureSet, CapturingKind)] =
+    val sym = tp.annot.symbol
+    if sym == defn.RetainsAnnot || sym == defn.RetainsByNameAnnot then
       tp.annot match
-        case ann: CaptureAnnotation => Some((tp.parent, ann.refs, ann.boxed))
+        case ann: CaptureAnnotation =>
+          Some((tp.parent, ann.refs, ann.kind))
         case ann =>
-          try Some((tp.parent, ann.tree.toCaptureSet, ann.tree.isBoxedCapturing))
+          val kind =
+            if ann.tree.isBoxedCapturing then CapturingKind.Boxed
+            else if sym == defn.RetainsByNameAnnot then CapturingKind.ByName
+            else CapturingKind.Regular
+          try Some((tp.parent, ann.tree.toCaptureSet, kind))
           catch case ex: IllegalCaptureRef => None
     else None
 

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -25,7 +25,8 @@ extends tpd.TreeTraverser:
       .toFunctionType(isJava = false, alwaysDependent = true)
 
   private def box(tp: Type)(using Context): Type = tp match
-    case CapturingType(parent, refs, false) => CapturingType(parent, refs, true)
+    case CapturingType(parent, refs, CapturingKind.Regular) =>
+      CapturingType(parent, refs, CapturingKind.Boxed)
     case _ => tp
 
   private def setBoxed(tp: Type)(using Context) = tp match
@@ -77,7 +78,7 @@ extends tpd.TreeTraverser:
             cls.paramGetters.foldLeft(tp) { (core, getter) =>
               if getter.termRef.isTracked then
                 val getterType = tp.memberInfo(getter).strippedDealias
-                RefinedType(core, getter.name, CapturingType(getterType, CaptureSet.Var(), boxed = false))
+                RefinedType(core, getter.name, CapturingType(getterType, CaptureSet.Var(), CapturingKind.Regular))
                   .showing(i"add capture refinement $tp --> $result", capt)
               else
                 core
@@ -130,7 +131,7 @@ extends tpd.TreeTraverser:
       case tp @ OrType(tp1, CapturingType(parent2, refs2, boxed2)) =>
         CapturingType(OrType(tp1, parent2, tp.isSoft), refs2, boxed2)
       case _ if canHaveInferredCapture(tp) =>
-        CapturingType(tp, CaptureSet.Var(), boxed = false)
+        CapturingType(tp, CaptureSet.Var(), CapturingKind.Regular)
       case _ =>
         tp
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -923,6 +923,7 @@ class Definitions {
   @tu lazy val BooleanBeanPropertyAnnot: ClassSymbol = requiredClass("scala.beans.BooleanBeanProperty")
   @tu lazy val BodyAnnot: ClassSymbol = requiredClass("scala.annotation.internal.Body")
   @tu lazy val CapabilityAnnot: ClassSymbol = requiredClass("scala.annotation.capability")
+  @tu lazy val CaptureCheckedAnnot: ClassSymbol = requiredClass("scala.annotation.internal.CaptureChecked")
   @tu lazy val ChildAnnot: ClassSymbol = requiredClass("scala.annotation.internal.Child")
   @tu lazy val ContextResultCountAnnot: ClassSymbol = requiredClass("scala.annotation.internal.ContextResultCount")
   @tu lazy val ProvisionalSuperClassAnnot: ClassSymbol = requiredClass("scala.annotation.internal.ProvisionalSuperClass")

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -14,7 +14,7 @@ import typer.ImportInfo.RootRef
 import Comments.CommentsContext
 import Comments.Comment
 import util.Spans.NoSpan
-import cc.{CapturingType, CaptureSet}
+import cc.{CapturingType, CaptureSet, CapturingKind, EventuallyCapturingType}
 
 import scala.annotation.tailrec
 
@@ -117,9 +117,9 @@ class Definitions {
    *
    *  ErasedFunctionN and ErasedContextFunctionN erase to Function0.
    *
-   *  EffXYZFunctionN afollow this template:
+   *  ImpureXYZFunctionN follow this template:
    *
-   *      type EffXYZFunctionN[-T0,...,-T{N-1}, +R] = {*} XYZFunctionN[T0,...,T{N-1}, R]
+   *      type ImpureXYZFunctionN[-T0,...,-T{N-1}, +R] = {*} XYZFunctionN[T0,...,T{N-1}, R]
    */
   private def newFunctionNType(name: TypeName): Symbol = {
     val impure = name.startsWith("Impure")
@@ -135,7 +135,7 @@ class Definitions {
             HKTypeLambda(argParamNames :+ "R".toTypeName, argVariances :+ Covariant)(
               tl => List.fill(arity + 1)(TypeBounds.empty),
               tl => CapturingType(underlyingClass.typeRef.appliedTo(tl.paramRefs),
-                CaptureSet.universal, boxed = false)
+                CaptureSet.universal, CapturingKind.Regular)
             ))
         else
           val cls = denot.asClass.classSymbol
@@ -968,6 +968,7 @@ class Definitions {
   @tu lazy val VarargsAnnot: ClassSymbol = requiredClass("scala.annotation.varargs")
   @tu lazy val SinceAnnot: ClassSymbol = requiredClass("scala.annotation.since")
   @tu lazy val RetainsAnnot: ClassSymbol = requiredClass("scala.retains")
+  @tu lazy val RetainsByNameAnnot: ClassSymbol = requiredClass("scala.retainsByName")
 
   @tu lazy val JavaRepeatableAnnot: ClassSymbol = requiredClass("java.lang.annotation.Repeatable")
 
@@ -1101,9 +1102,16 @@ class Definitions {
     }
   }
 
+  /** Extractor for function types representing by-name parameters, of the form
+   *  `() ?=> T`.
+   *  Under -Ycc, this becomes `() ?-> T` or `{r1, ..., rN} () ?-> T`.
+   */
   object ByNameFunction:
-    def apply(tp: Type)(using Context): Type =
-      defn.ContextFunction0.typeRef.appliedTo(tp :: Nil)
+    def apply(tp: Type)(using Context): Type = tp match
+      case EventuallyCapturingType(tp1, refs, CapturingKind.ByName) =>
+        CapturingType(apply(tp1), refs, CapturingKind.Regular)
+      case _ =>
+        defn.ContextFunction0.typeRef.appliedTo(tp :: Nil)
     def unapply(tp: Type)(using Context): Option[Type] = tp match
       case tp @ AppliedType(tycon, arg :: Nil) if defn.isByNameFunctionClass(tycon.typeSymbol) =>
         Some(arg)

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -580,6 +580,7 @@ object StdNames {
     val reify : N               = "reify"
     val releaseFence : N        = "releaseFence"
     val retains: N              = "retains"
+    val retainsByName: N        = "retainsByName"
     val rootMirror : N          = "rootMirror"
     val run: N                  = "run"
     val runOrElse: N            = "runOrElse"

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -24,7 +24,7 @@ import typer.Applications.productSelectorTypes
 import reporting.trace
 import NullOpsDecorator._
 import annotation.constructorOnly
-import cc.{CapturingType, derivedCapturingType, CaptureSet, stripCapturing}
+import cc.{CapturingType, derivedCapturingType, CaptureSet, CapturingKind, stripCapturing}
 
 /** Provides methods to compare types.
  */
@@ -832,7 +832,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           tp1 match
             case tp1: CaptureRef if tp1.isTracked =>
               val stripped = tp1w.stripCapturing
-              tp1w = CapturingType(stripped, tp1.singletonCaptureSet, boxed = false)
+              tp1w = CapturingType(stripped, tp1.singletonCaptureSet, CapturingKind.Regular)
             case _ =>
           isSubType(tp1w, tp2, approx.addLow)
         }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -38,7 +38,7 @@ import scala.util.hashing.{ MurmurHash3 => hashing }
 import config.Printers.{core, typr, matchTypes}
 import reporting.{trace, Message}
 import java.lang.ref.WeakReference
-import cc.{CapturingType, CaptureSet, derivedCapturingType, retainedElems, isBoxedCapturing}
+import cc.{CapturingType, CaptureSet, derivedCapturingType, retainedElems, isBoxedCapturing, CapturingKind}
 import CaptureSet.CompareResult
 
 import scala.annotation.internal.sharable
@@ -1869,13 +1869,15 @@ object Types {
 
     def capturing(ref: CaptureRef)(using Context): Type =
       if captureSet.accountsFor(ref) then this
-      else CapturingType(this, ref.singletonCaptureSet, this.isBoxedCapturing)
+      else CapturingType(this, ref.singletonCaptureSet,
+        if this.isBoxedCapturing then CapturingKind.Boxed else CapturingKind.Regular)
 
     def capturing(cs: CaptureSet)(using Context): Type =
       if cs.isConst && cs.subCaptures(captureSet, frozen = true).isOK then this
       else this match
         case CapturingType(parent, cs1, boxed) => parent.capturing(cs1 ++ cs)
-        case _ => CapturingType(this, cs, this.isBoxedCapturing)
+        case _ => CapturingType(this, cs,
+          if this.isBoxedCapturing then CapturingKind.Boxed else CapturingKind.Regular)
 
     /** The set of distinct symbols referred to by this type, after all aliases are expanded */
     def coveringSet(using Context): Set[Symbol] =
@@ -3796,10 +3798,11 @@ object Types {
                   CapturingType(parent1, CaptureSet.universal, boxed))
             case AnnotatedType(parent, ann) if ann.refersToParamOf(thisLambdaType) =>
               val parent1 = mapOver(parent)
-              if ann.symbol == defn.RetainsAnnot then
+              if ann.symbol == defn.RetainsAnnot || ann.symbol == defn.RetainsByNameAnnot then
+                val byName = ann.symbol == defn.RetainsByNameAnnot
                 range(
-                  AnnotatedType(parent1, CaptureSet.empty.toRegularAnnotation),
-                  AnnotatedType(parent1, CaptureSet.universal.toRegularAnnotation))
+                  AnnotatedType(parent1, CaptureSet.empty.toRegularAnnotation(byName)),
+                  AnnotatedType(parent1, CaptureSet.universal.toRegularAnnotation(byName)))
               else
                 parent1
             case _ => mapOver(tp)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -31,6 +31,7 @@ import ast.{TreeTypeMap, Trees, tpd, untpd}
 import Trees._
 import Decorators._
 import transform.SymUtils._
+import cc.adaptFunctionType
 
 import dotty.tools.tasty.{TastyBuffer, TastyReader}
 import TastyBuffer._
@@ -86,6 +87,9 @@ class TreeUnpickler(reader: TastyReader,
 
   /** The root owner tree. See `OwnerTree` class definition. Set by `enterTopLevel`. */
   private var ownerTree: OwnerTree = _
+
+  /** Was unpickled class compiled with -Ycc? */
+  private var wasCaptureChecked: Boolean = false
 
   private def registerSym(addr: Addr, sym: Symbol) =
     symAtAddr(addr) = sym
@@ -357,7 +361,7 @@ class TreeUnpickler(reader: TastyReader,
                 // Note that the lambda "rt => ..." is not equivalent to a wildcard closure!
                 // Eta expansion of the latter puts readType() out of the expression.
             case APPLIEDtype =>
-              readType().appliedTo(until(end)(readType()))
+              postProcessFunction(readType().appliedTo(until(end)(readType())))
             case TYPEBOUNDS =>
               val lo = readType()
               if nothingButMods(end) then
@@ -469,6 +473,12 @@ class TreeUnpickler(reader: TastyReader,
 
     def readTermRef()(using Context): TermRef =
       readType().asInstanceOf[TermRef]
+
+    /** Under -Ycc, map all function types to impure function types,
+     *  unless the unpickled class was also compiled with -Ycc.
+     */
+    private def postProcessFunction(tp: Type)(using Context): Type =
+      if wasCaptureChecked then tp else tp.adaptFunctionType
 
 // ------ Reading definitions -----------------------------------------------------
 
@@ -605,6 +615,8 @@ class TreeUnpickler(reader: TastyReader,
       }
       registerSym(start, sym)
       if (isClass) {
+        if sym.owner.is(Package) && annots.exists(_.symbol == defn.CaptureCheckedAnnot) then
+          wasCaptureChecked = true
         sym.completer.withDecls(newScope)
         forkAt(templateStart).indexTemplateParams()(using localContext(sym))
       }
@@ -1265,7 +1277,7 @@ class TreeUnpickler(reader: TastyReader,
               val args = until(end)(readTpt())
               val tree = untpd.AppliedTypeTree(tycon, args)
               val ownType = ctx.typeAssigner.processAppliedType(tree, tycon.tpe.safeAppliedTo(args.tpes))
-              tree.withType(ownType)
+              tree.withType(postProcessFunction(ownType))
             case ANNOTATEDtpt =>
               Annotated(readTpt(), readTerm())
             case LAMBDAtpt =>

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -30,6 +30,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.annotation.switch
 import reporting._
+import cc.adaptFunctionType
 
 object Scala2Unpickler {
 
@@ -818,7 +819,9 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
           // special-case in erasure, see TypeErasure#eraseInfo.
           OrType(args(0), args(1), soft = false)
         }
-        else if (args.nonEmpty) tycon.safeAppliedTo(EtaExpandIfHK(sym.typeParams, args.map(translateTempPoly)))
+        else if args.nonEmpty then
+          tycon.safeAppliedTo(EtaExpandIfHK(sym.typeParams, args.map(translateTempPoly)))
+            .adaptFunctionType
         else if (sym.typeParams.nonEmpty) tycon.EtaExpand(sym.typeParams)
         else tycon
       case TYPEBOUNDStpe =>

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -421,7 +421,10 @@ object Parsers {
     /** Convert tree to formal parameter list
     */
     def convertToParams(tree: Tree): List[ValDef] =
-      val mods = if in.token == CTXARROW then Modifiers(Given) else EmptyModifiers
+      val mods =
+        if in.token == CTXARROW || in.isIdent(nme.PURECTXARROW)
+        then Modifiers(Given)
+        else EmptyModifiers
       tree match
         case Parens(t) =>
           convertToParam(t, mods) :: Nil
@@ -1446,7 +1449,7 @@ object Parsers {
                 funTypeArgsRest(t, funArgType)
             }
             accept(RPAREN)
-            if isValParamList || in.isArrow then
+            if isValParamList || in.isArrow || in.isPureArrow then
               functionRest(ts)
             else {
               val ts1 = ts.mapConserve { t =>

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1402,8 +1402,9 @@ object Parsers {
 
           val resultType = typ()
           if token == TLARROW then
-            for case ValDef(_, tpt: ByNameTypeTree, _) <- params do
-              syntaxError(em"parameter of type lambda may not be call-by-name", tpt.span)
+            for case ValDef(_, tpt, _) <- params do
+              if isByNameType(tpt) then
+                syntaxError(em"parameter of type lambda may not be call-by-name", tpt.span)
             TermLambdaTypeTree(params.asInstanceOf[List[ValDef]], resultType)
           else if imods.isOneOf(Given | Erased | Impure) then
             if imods.is(Given) && params.isEmpty then
@@ -1448,15 +1449,13 @@ object Parsers {
             if isValParamList || in.isArrow then
               functionRest(ts)
             else {
-              val ts1 =
-                for (t <- ts) yield
-                  t match {
-                    case t@ByNameTypeTree(t1) =>
-                      syntaxError(ByNameParameterNotSupported(t), t.span)
-                      t1
-                    case _ =>
-                      t
-                  }
+              val ts1 = ts.mapConserve { t =>
+                if isByNameType(t) then
+                  syntaxError(ByNameParameterNotSupported(t), t.span)
+                  stripByNameType(t)
+                else
+                  t
+              }
               val tuple = atSpan(start) { makeTupleOrParens(ts1) }
               infixTypeRest(
                 refinedTypeRest(
@@ -1793,17 +1792,48 @@ object Parsers {
       else commaSeparated(() => argType())
     }
 
-    /** FunArgType ::=  Type | `=>' Type
-     */
-    val funArgType: () => Tree = () =>
-      if (in.token == ARROW) atSpan(in.skipToken()) { ByNameTypeTree(typ()) }
-      else typ()
+    def paramTypeOf(core: () => Tree): Tree =
+      if in.token == ARROW || isIdent(nme.PUREARROW) then
+        val isImpure = in.token == ARROW
+        val tp = atSpan(in.skipToken()) { ByNameTypeTree(core()) }
+        if isImpure && ctx.settings.Ycc.value then ImpureByNameTypeTree(tp) else tp
+      else if in.token == LBRACE && followingIsCaptureSet() then
+        val start = in.offset
+        val cs = captureSet()
+        val endCsOffset = in.lastOffset
+        val startTpOffset = in.offset
+        val tp = paramTypeOf(core)
+        val tp1 = tp match
+          case ImpureByNameTypeTree(tp1) =>
+            syntaxError("explicit captureSet is superfluous for impure call-by-name type", start)
+            tp1
+          case CapturingTypeTree(_, tp1: ByNameTypeTree) =>
+            syntaxError("only one captureSet is allowed here", start)
+            tp1
+          case _: ByNameTypeTree if startTpOffset > endCsOffset =>
+            report.warning(
+              i"""Style: by-name `->` should immediately follow closing `}` of capture set
+                 |to avoid confusion with function type.
+                 |That is, `{c}-> T` instead of `{c} -> T`.""",
+              source.atSpan(Span(startTpOffset, startTpOffset)))
+            tp
+          case _ =>
+            tp
+        CapturingTypeTree(cs, tp1)
+      else
+        core()
 
-    /** ParamType ::= [`=>'] ParamValueType
+    /** FunArgType ::=  Type
+     *               |  `=>' Type
+     *               |  [CaptureSet] `->' Type
      */
-    def paramType(): Tree =
-      if (in.token == ARROW) atSpan(in.skipToken()) { ByNameTypeTree(paramValueType()) }
-      else paramValueType()
+    val funArgType: () => Tree = () => paramTypeOf(typ)
+
+    /** ParamType  ::=  ParamValueType
+     *               |  `=>' ParamValueType
+     *               |  [CaptureSet] `->' ParamValueType
+     */
+    def paramType(): Tree = paramTypeOf(paramValueType)
 
     /** ParamValueType ::= Type [`*']
      */
@@ -3071,6 +3101,7 @@ object Parsers {
           acceptColon()
           if (in.token == ARROW && ofClass && !mods.is(Local))
             syntaxError(VarValParametersMayNotBeCallByName(name, mods.is(Mutable)))
+              // needed?, it's checked later anyway
           val tpt = paramType()
           val default =
             if (in.token == EQUALS) { in.nextToken(); subExpr() }

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -93,6 +93,9 @@ object Scanners {
 
     def isArrow =
       token == ARROW || token == CTXARROW
+
+    def isPureArrow =
+      isIdent(nme.PUREARROW) || isIdent(nme.PURECTXARROW)
   }
 
   abstract class ScannerCommon(source: SourceFile)(using Context) extends CharArrayReader with TokenData {

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -554,7 +554,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
           (" <: " ~ toText(bound) provided !bound.isEmpty)
         }
       case ByNameTypeTree(tpt) =>
-        "=> " ~ toTextLocal(tpt)
+        (if ctx.settings.Ycc.value then "-> " else "=> ")
+        ~ toTextLocal(tpt)
       case TypeBoundsTree(lo, hi, alias) =>
         if (lo eq hi) && alias.isEmpty then optText(lo)(" = " ~ _)
         else optText(lo)(" >: " ~ _) ~ optText(hi)(" <: " ~ _) ~ optText(alias)(" = " ~ _)
@@ -719,7 +720,11 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         val argsText = toTextGlobal(args, ", ")
         prefix ~~ idx.toString ~~ "|" ~~ argsText ~~ postfix
       case CapturingTypeTree(refs, parent) =>
-        changePrec(GlobalPrec)("{" ~ Text(refs.map(toText), ", ") ~ "} " ~ toText(parent))
+        parent match
+          case ImpureByNameTypeTree(bntpt) =>
+            "=> " ~ toTextLocal(bntpt)
+          case _ =>
+            changePrec(GlobalPrec)("{" ~ Text(refs.map(toText), ", ") ~ "} " ~ toText(parent))
       case _ =>
         tree.fallbackToText(this)
     }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -666,7 +666,7 @@ import transform.SymUtils._
     }
   }
 
-  class ByNameParameterNotSupported(tpe: untpd.TypTree)(using Context)
+  class ByNameParameterNotSupported(tpe: untpd.Tree)(using Context)
   extends SyntaxMsg(ByNameParameterNotSupportedID) {
     def msg = em"By-name parameter type ${tpe} not allowed here."
 

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -370,13 +370,13 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
                 for parent <- impl.parents do
                   Checking.checkTraitInheritance(parent.tpe.classSymbol, sym.asClass, parent.srcPos)
             // Add SourceFile annotation to top-level classes
-            if sym.owner.is(Package)
-               && ctx.compilationUnit.source.exists
-               && sym != defn.SourceFileAnnot
-            then
-              val reference = ctx.settings.sourceroot.value
-              val relativePath = util.SourceFile.relativePath(ctx.compilationUnit.source, reference)
-              sym.addAnnotation(Annotation.makeSourceFile(relativePath))
+            if sym.owner.is(Package) then
+              if ctx.compilationUnit.source.exists && sym != defn.SourceFileAnnot then
+                val reference = ctx.settings.sourceroot.value
+                val relativePath = util.SourceFile.relativePath(ctx.compilationUnit.source, reference)
+                sym.addAnnotation(Annotation.makeSourceFile(relativePath))
+              if ctx.settings.Ycc.value && sym != defn.CaptureCheckedAnnot then
+                sym.addAnnotation(Annotation(defn.CaptureCheckedAnnot))
           else (tree.rhs, sym.info) match
             case (rhs: LambdaTypeTree, bounds: TypeBounds) =>
               VarianceChecker.checkLambda(rhs, bounds)

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -337,7 +337,9 @@ abstract class Recheck extends Phase, IdentityDenotTransformer:
 
     def recheckFinish(tpe: Type, tree: Tree, pt: Type)(using Context): Type =
       checkConforms(tpe, pt, tree)
-      if keepTypes then tree.rememberType(tpe)
+      if keepTypes
+        || tree.isInstanceOf[Try]  // type needs tp be checked for * escapes
+      then tree.rememberType(tpe)
       tpe
 
     def recheck(tree: Tree, pt: Type = WildcardType)(using Context): Type =
@@ -363,6 +365,7 @@ abstract class Recheck extends Phase, IdentityDenotTransformer:
           || expected.isRepeatedParam
              && actual <:< expected.translateFromRepeated(toArray = tree.tpe.isRef(defn.ArrayClass))
         if !isCompatible then
+          recheckr.println(i"conforms failed for ${tree}: $tpe vs $expected")
           err.typeMismatch(tree.withType(tpe), expected)
         else if debugSuccesses then
           tree match

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -126,13 +126,25 @@ object ErrorReporting {
     def typeMismatch(tree: Tree, pt: Type, implicitFailure: SearchFailureType = NoMatchingImplicits): Tree = {
       val normTp = normalize(tree.tpe, pt)
       val normPt = normalize(pt, pt)
+      
+      def contextFunctionCount(tp: Type): Int = tp.stripped match
+        case defn.ContextFunctionType(_, restp, _) => 1 + contextFunctionCount(restp)
+        case _ => 0
+      def strippedTpCount = contextFunctionCount(tree.tpe) - contextFunctionCount(normTp)
+      def strippedPtCount = contextFunctionCount(pt) - contextFunctionCount(normPt)
+      
       val (treeTp, expectedTp) =
-        if (normTp <:< normPt) (tree.tpe, pt) else (normTp, normPt)
-        // use normalized types if that also shows an error, original types otherwise
+        if normTp <:< normPt || strippedTpCount != strippedPtCount
+        then (tree.tpe, pt)
+        else (normTp, normPt)
+        // use normalized types if that also shows an error, and both sides stripped
+        // the same number of context functions. Use original types otherwise.
+        
       def missingElse = tree match
         case If(_, _, elsep @ Literal(Constant(()))) if elsep.span.isSynthetic =>
           "\nMaybe you are missing an else part for the conditional?"
         case _ => ""
+        
       errorTree(tree, TypeMismatch(treeTp, expectedTp, Some(tree), implicitFailure.whyNoConversion, missingElse))
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -125,13 +125,15 @@ object ErrorReporting {
 
     def typeMismatch(tree: Tree, pt: Type, implicitFailure: SearchFailureType = NoMatchingImplicits): Tree = {
       val normTp = normalize(tree.tpe, pt)
-      val treeTp = if (normTp <:< pt) tree.tpe else normTp
-        // use normalized type if that also shows an error, original type otherwise
+      val normPt = normalize(pt, pt)
+      val (treeTp, expectedTp) =
+        if (normTp <:< normPt) (tree.tpe, pt) else (normTp, normPt)
+        // use normalized types if that also shows an error, original types otherwise
       def missingElse = tree match
         case If(_, _, elsep @ Literal(Constant(()))) if elsep.span.isSynthetic =>
           "\nMaybe you are missing an else part for the conditional?"
         case _ => ""
-      errorTree(tree, TypeMismatch(treeTp, pt, Some(tree), implicitFailure.whyNoConversion, missingElse))
+      errorTree(tree, TypeMismatch(treeTp, expectedTp, Some(tree), implicitFailure.whyNoConversion, missingElse))
     }
 
     /** A subtype log explaining why `found` does not conform to `expected` */

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2306,7 +2306,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       //todo: make sure dependent method types do not depend on implicits or by-name params
   }
 
-  /** (1) Check that the signature of the class mamber does not return a repeated parameter type
+  /** (1) Check that the signature of the class member does not return a repeated parameter type
    *  (2) If info is an erased class, set erased flag of member
    */
   private def postProcessInfo(sym: Symbol)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2598,7 +2598,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       registerNowarn(annot1, tree)
     val arg1 = typed(tree.arg, pt)
     if (ctx.mode is Mode.Type) {
-      if annot1.symbol.maybeOwner == defn.RetainsAnnot then
+      val cls = annot1.symbol.maybeOwner
+      if cls == defn.RetainsAnnot || cls == defn.RetainsByNameAnnot then
         CheckCaptures.checkWellformed(annot1)
       if arg1.isType then
         assignType(cpy.Annotated(tree)(arg1, annot1), arg1, annot1)

--- a/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
+++ b/compiler/src/dotty/tools/dotc/util/SimpleIdentitySet.scala
@@ -36,6 +36,10 @@ abstract class SimpleIdentitySet[+Elem <: AnyRef] {
       ((SimpleIdentitySet.empty: SimpleIdentitySet[E]) /: this) { (s, x) =>
         if (that.contains(x)) s else s + x
       }
+
+  def == [E >: Elem <: AnyRef](that: SimpleIdentitySet[E]): Boolean =
+    this.size == that.size && forall(that.contains)
+
   override def toString: String = toList.mkString("{", ", ", "}")
 }
 

--- a/library/src-bootstrapped/scala/retainsByName.scala
+++ b/library/src-bootstrapped/scala/retainsByName.scala
@@ -1,0 +1,6 @@
+package scala
+
+/** An annotation that indicates capture of an enclosing by-name type
+ */
+class retainsByName(xs: Any*) extends annotation.StaticAnnotation
+

--- a/library/src/scala/CanThrow.scala
+++ b/library/src/scala/CanThrow.scala
@@ -1,12 +1,12 @@
 package scala
 import language.experimental.erasedDefinitions
-import annotation.{implicitNotFound, experimental}
+import annotation.{implicitNotFound, experimental, capability}
 
 /** A capability class that allows to throw exception `E`. When used with the
  *  experimental.saferExceptions feature, a `throw Ex()` expression will require
  *  a given of class `CanThrow[Ex]` to be available.
  */
-@experimental
+@experimental @capability
 @implicitNotFound("The capability to throw exception ${E} is missing.\nThe capability can be provided by one of the following:\n - Adding a using clause `(using CanThrow[${E}])` to the definition of the enclosing method\n - Adding `throws ${E}` clause after the result type of the enclosing method\n - Wrapping this piece of code with a `try` block that catches ${E}")
 erased class CanThrow[-E <: Exception]
 

--- a/library/src/scala/annotation/internal/CaptureChecked.scala
+++ b/library/src/scala/annotation/internal/CaptureChecked.scala
@@ -1,0 +1,8 @@
+package scala.annotation
+package internal
+
+/** A marker annotation on a toplevel class that indicates
+ *  that the class was checked under -Ycc
+ */
+class CaptureChecked extends StaticAnnotation
+

--- a/tests/neg-custom-args/captures/byname.check
+++ b/tests/neg-custom-args/captures/byname.check
@@ -1,0 +1,20 @@
+-- Warning: tests/neg-custom-args/captures/byname.scala:14:18 ----------------------------------------------------------
+14 |  def h(x: {cap1} -> I) = x // warning
+   |                  ^
+   |                  Style: by-name `->` should immediately follow closing `}` of capture set
+   |                  to avoid confusion with function type.
+   |                  That is, `{c}-> T` instead of `{c} -> T`.
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/byname.scala:7:5 -----------------------------------------
+7 |  h(f())  // error
+  |    ^^^
+  |    Found:    {cap2} (x$0: Int) -> Int
+  |    Required: Int -> Int
+
+longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/byname.scala:16:5 ----------------------------------------
+16 |  h(g()) // error
+   |    ^^^
+   |    Found:    {cap2} () ?-> I
+   |    Required: {cap1} () ?-> I
+
+longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/byname.scala
+++ b/tests/neg-custom-args/captures/byname.scala
@@ -6,4 +6,14 @@ def test(cap1: Cap, cap2: Cap) =
   def h(ff: => {cap2} Int -> Int) = ff
   h(f())  // error
 
+class I
+
+def test2(cap1: Cap, cap2: Cap): {cap1} I =
+  def f() = if cap1 == cap1 then I() else I()
+  def g() = if cap2 == cap2 then I() else I()
+  def h(x: {cap1} -> I) = x // warning
+  h(f()) // OK
+  h(g()) // error
+
+
 

--- a/tests/neg-custom-args/captures/lazylist.check
+++ b/tests/neg-custom-args/captures/lazylist.check
@@ -1,8 +1,8 @@
 -- [E163] Declaration Error: tests/neg-custom-args/captures/lazylist.scala:22:6 ----------------------------------------
 22 |  def tail: {*} LazyList[Nothing] = ???  // error overriding
    |      ^
-   |      error overriding method tail in class LazyList of type => lazylists.LazyList[Nothing];
-   |        method tail of type => {*} lazylists.LazyList[Nothing] has incompatible type
+   |      error overriding method tail in class LazyList of type -> lazylists.LazyList[Nothing];
+   |        method tail of type -> {*} lazylists.LazyList[Nothing] has incompatible type
 
 longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:35:29 -------------------------------------

--- a/tests/neg-custom-args/captures/lazylists2.check
+++ b/tests/neg-custom-args/captures/lazylists2.check
@@ -1,8 +1,8 @@
 -- [E163] Declaration Error: tests/neg-custom-args/captures/lazylists2.scala:50:10 -------------------------------------
 50 |      def tail: {xs, f} LazyList[B] = xs.tail.map(f) // error
    |          ^
-   |          error overriding method tail in trait LazyList of type => {Mapped.this} LazyList[B];
-   |            method tail of type => {xs, f} LazyList[B] has incompatible type
+   |          error overriding method tail in trait LazyList of type -> {Mapped.this} LazyList[B];
+   |            method tail of type -> {xs, f} LazyList[B] has incompatible type
 
 longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylists2.scala:18:4 ------------------------------------

--- a/tests/neg-custom-args/captures/real-try.check
+++ b/tests/neg-custom-args/captures/real-try.check
@@ -1,0 +1,8 @@
+-- Error: tests/neg-custom-args/captures/real-try.scala:10:2 -----------------------------------------------------------
+10 |  try  // error
+   |  ^
+   |  result type {*} () -> Unit is not allowed to capture the universal capability *.type
+11 |    () => foo(1)
+12 |  catch
+13 |    case _: Ex1 => ???
+14 |    case _: Ex2 => ???

--- a/tests/neg-custom-args/captures/real-try.scala
+++ b/tests/neg-custom-args/captures/real-try.scala
@@ -1,0 +1,14 @@
+import language.experimental.saferExceptions
+
+class Ex1 extends Exception("Ex1")
+class Ex2 extends Exception("Ex2")
+
+def foo(i: Int): (CanThrow[Ex1], CanThrow[Ex2]) ?-> Unit =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def test() =
+  try  // error
+    () => foo(1)
+  catch
+    case _: Ex1 => ???
+    case _: Ex2 => ???

--- a/tests/pos-custom-args/captures/byname.scala
+++ b/tests/pos-custom-args/captures/byname.scala
@@ -5,6 +5,6 @@ class I
 
 def test(cap1: Cap, cap2: Cap): {cap1} I =
   def f() = if cap1 == cap1 then I() else I()
-  def h(x: /*=>*/ {cap1} I) = x  // TODO: enable cbn
-  h(f())
+  def h(x: {cap1}-> I) = x
+  h(f()) // OK
 

--- a/tests/pos-custom-args/captures/capt-separate/Lib_1.scala
+++ b/tests/pos-custom-args/captures/capt-separate/Lib_1.scala
@@ -1,0 +1,6 @@
+object Lib:
+  extension [A](xs: Seq[A])
+    def mapp[B](f: A => B): Seq[B] =
+      xs.map(f.asInstanceOf[A -> B])
+
+

--- a/tests/pos-custom-args/captures/capt-separate/Test_2.scala
+++ b/tests/pos-custom-args/captures/capt-separate/Test_2.scala
@@ -1,0 +1,15 @@
+import language.experimental.saferExceptions
+import Lib.*
+
+class LimitExceeded extends Exception
+
+val limit = 10e9
+
+def f(x: Double): Double throws LimitExceeded =
+  if x < limit then x * x else throw LimitExceeded()
+
+@main def test(xs: Double*) =
+  try println(xs.mapp(f).sum)
+  catch case ex: LimitExceeded => println("too large")
+
+

--- a/tests/pos-custom-args/captures/i13816.scala
+++ b/tests/pos-custom-args/captures/i13816.scala
@@ -1,0 +1,63 @@
+import language.experimental.saferExceptions
+
+class Ex1 extends Exception("Ex1")
+class Ex2 extends Exception("Ex2")
+
+def foo0(i: Int): (CanThrow[Ex1], CanThrow[Ex2]) ?-> Unit =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def foo01(i: Int): CanThrow[Ex1] ?-> CanThrow[Ex2] ?-> Unit =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def foo1(i: Int): Unit throws Ex1 throws Ex2 =
+  if i > 0 then throw new Ex1 else throw new Ex1
+
+def foo2(i: Int): Unit throws Ex1 | Ex2 =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def foo3(i: Int): Unit throws (Ex1 | Ex2) =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def foo4(i: Int)(using CanThrow[Ex1], CanThrow[Ex2]): Unit =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def foo5(i: Int)(using CanThrow[Ex1])(using CanThrow[Ex2]): Unit =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def foo6(i: Int)(using CanThrow[Ex1 | Ex2]): Unit =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def foo7(i: Int)(using CanThrow[Ex1]): Unit throws Ex2 =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def foo8(i: Int)(using CanThrow[Ex2]): Unit throws Ex1 =
+  if i > 0 then throw new Ex1 else throw new Ex2
+
+def test(): Unit =
+  try
+    foo1(1)
+    foo2(1)
+    foo3(1)
+    foo4(1)
+    foo5(1)
+    foo6(1)
+    foo7(1)
+    foo8(1)
+  catch
+    case _: Ex1 =>
+    case _: Ex2 =>
+
+  try
+    try
+      foo1(1)
+      foo2(1)
+      foo3(1)
+      foo4(1)
+      foo5(1)
+      // foo6(1) // As explained in the docs this won't work until we find a way to aggregate capabilities
+      foo7(1)
+      foo8(1)
+    catch
+      case _: Ex1 =>
+  catch
+    case _: Ex2 =>

--- a/tests/pos-custom-args/captures/saferExceptions.scala
+++ b/tests/pos-custom-args/captures/saferExceptions.scala
@@ -1,0 +1,18 @@
+import language.experimental.saferExceptions
+
+class LimitExceeded extends Exception
+
+val limit = 10e9
+
+extension [A](xs: Seq[A])
+  def mapp[B](f: A => B): Seq[B] =
+    xs.map(f.asInstanceOf[A -> B])
+
+def f(x: Double): Double throws LimitExceeded =
+  if x < limit then x * x else throw LimitExceeded()
+
+@main def test(xs: Double*) =
+  try println(xs.mapp(f).sum + xs.map(f).sum)
+  catch case ex: LimitExceeded => println("too large")
+
+


### PR DESCRIPTION
Make CanBuildFrom a @capability class. This means exceptions are checked for captures, so that it's 
an error to throw a checked exception at a point where its handler has exited.

To be practical, collections and other parts of the standard library would have to be ported to the new typing discipline.

