### PR TITLE
`Ycheck` fail when `map`ping `Option` on `Tuple`

### DIFF
--- a/tests/pos/mapOnPair1.scala
+++ b/tests/pos/mapOnPair1.scala
@@ -1,0 +1,2 @@
+object mapOnPair1:
+    val p1: (Option[Int], Option[String]) = (1,"foo").map([T] => (x: T) => Option.apply[T](x))

--- a/tests/pos/mapOnPair2.scala
+++ b/tests/pos/mapOnPair2.scala
@@ -1,0 +1,2 @@
+object mapOnPair2:
+    val p2: (Option[Int], Option[String]) = (1,"foo").map[Option[_]]([T] => (x: T) => Option.apply[T](x))


### PR DESCRIPTION
Note that if you run:
`run tests/pos/mapOnPair1.scala`
it compiles fine, 
the error appears only when using `Ycheck`

(`run tests/pos/mapOnPair2.scala` always causes the issue)