### PR TITLE
fix ExpressionTest#verifyImports test compile error introduced in #14263

### DIFF
--- a/compiler/test/dotty/tools/scripting/ExpressionTest.scala
+++ b/compiler/test/dotty/tools/scripting/ExpressionTest.scala
@@ -25,9 +25,11 @@ class ExpressionTest:
     assert(result.contains(expected), s"expression [$expression] did not send [$expected] to stdout")
 
   @Test def verifyImports: Unit =
+
     val expressionLines = List(
       "import java.nio.file.Paths",
-      s"""println(Paths.get("\""."\"").toFile.listFiles.toList.filter(_.isDirectory).size)""",
+      "import dotty.tools.dotc.config.Properties.userDir",
+      s"""println(Paths.get(userDir).toFile.listFiles.toList.filter(_.isDirectory).size)""",
     )
     val expression = expressionLines.mkString(";")
     val success = testExpression(expression){ result =>
@@ -36,8 +38,7 @@ class ExpressionTest:
     assert(success)
 
   def getResult(expression: String): String =
-    val cmd = s"bin/scala -e $expression"
-    val (_, _, stdout, stderr) = bashCommand(s"""bin/scala -e '$expression'""")
+    val (_, _, stdout, stderr) = bashCommand(s"$scalaPath -e '$expression'")
     printf("stdout: %s\n", stdout.mkString("|"))
     printf("stderr: %s\n", stderr.mkString("\n","\n",""))
     stdout.filter(_.nonEmpty).mkString("")

--- a/compiler/test/dotty/tools/scripting/ExpressionTest.scala
+++ b/compiler/test/dotty/tools/scripting/ExpressionTest.scala
@@ -25,11 +25,10 @@ class ExpressionTest:
     assert(result.contains(expected), s"expression [$expression] did not send [$expected] to stdout")
 
   @Test def verifyImports: Unit =
-
     val expressionLines = List(
       "import java.nio.file.Paths",
-      "import dotty.tools.dotc.config.Properties.userDir",
-      s"""println(Paths.get(userDir).toFile.listFiles.toList.filter(_.isDirectory).size)""",
+      "import scala.util.Properties.userDir",
+      "println(Paths.get(userDir).toFile.listFiles.toList.filter(_.isDirectory).size)",
     )
     val expression = expressionLines.mkString(";")
     val success = testExpression(expression){ result =>
@@ -40,11 +39,18 @@ class ExpressionTest:
   def getResult(expression: String): String =
     val (_, _, stdout, stderr) = bashCommand(s"$scalaPath -e '$expression'")
     printf("stdout: %s\n", stdout.mkString("|"))
-    printf("stderr: %s\n", stderr.mkString("\n","\n",""))
+    printf("stderr: %s\n", stderr.mkString("\n", "\n", ""))
     stdout.filter(_.nonEmpty).mkString("")
     
-  def testExpression(expression: String)(check: (result: String) => Boolean): Boolean = {
+  def testExpression(expression: String)(check: (result: String) => Boolean): Boolean =
     val result = getResult(expression)
     check(result)
-  }
 
+object ExpressionTest:
+
+  def main(args: Array[String]): Unit =
+    val tests = new ExpressionTest
+    println("\n=== verifyCommandLineExpression ===")
+    tests.verifyCommandLineExpression
+    println("\n=== verifyImports ===")
+    tests.verifyImports

--- a/compiler/test/dotty/tools/scripting/ExpressionTest.scala
+++ b/compiler/test/dotty/tools/scripting/ExpressionTest.scala
@@ -27,13 +27,13 @@ class ExpressionTest:
   @Test def verifyImports: Unit =
     val expressionLines = List(
       "import java.nio.file.Paths",
-      """val cwd = Paths.get(""."")""",
-      """println(cwd.toFile.listFiles.toList.filter(_.isDirectory).size)""",
+      s"""println(Paths.get("\""."\"").toFile.listFiles.toList.filter(_.isDirectory).size)""",
     )
     val expression = expressionLines.mkString(";")
-    testExpression(expression){ result =>
+    val success = testExpression(expression){ result =>
       result.matches("[0-9]+") && result.toInt > 0
     }
+    assert(success)
 
   def getResult(expression: String): String =
     val cmd = s"bin/scala -e $expression"
@@ -42,7 +42,7 @@ class ExpressionTest:
     printf("stderr: %s\n", stderr.mkString("\n","\n",""))
     stdout.filter(_.nonEmpty).mkString("")
     
-  def testExpression(expression: String)(check: (result: String) => Boolean) = {
+  def testExpression(expression: String)(check: (result: String) => Boolean): Boolean = {
     val result = getResult(expression)
     check(result)
   }

--- a/compiler/test/dotty/tools/scripting/ScriptTestEnv.scala
+++ b/compiler/test/dotty/tools/scripting/ScriptTestEnv.scala
@@ -21,13 +21,14 @@ object ScriptTestEnv {
   def psep: String = sys.props("path.separator")
   def userDir: String = sys.props("user.dir").norm
   def testCwd = envOrElse("TEST_CWD", "").norm // optional working directory TEST_CWD
+  def verbose = envOrElse("VERBOSE", "").nonEmpty
 
   def whichJava: String = whichExe("java")
   def whichBash: String = whichExe("bash")
 
   lazy val workingDirectory: String = {
     val dirstr = if testCwd.nonEmpty then
-      printf("TEST_CWD set to [%s]\n", testCwd)
+      if verbose then printf("TEST_CWD set to [%s]\n", testCwd)
       testCwd
     else 
       userDir // userDir, if TEST_CWD not set
@@ -37,7 +38,7 @@ object ScriptTestEnv {
     if !test.isDirectory then
       printf("warning: not found below working directory: %s\n", test.norm)
 
-    printf("working directory is [%s]\n", dirstr)
+    if verbose then printf("working directory is [%s]\n", dirstr)
     dirstr
   }
 
@@ -106,7 +107,7 @@ object ScriptTestEnv {
       // a misconfigured environment (e.g., script is not executable) can prevent script execution
       val validTest = !stderr.exists(_.contains("Permission denied"))
       if ! validTest then
-        printf("\nunable to execute script, return value is %d\n", exitVal)
+        System.err.printf("\nunable to execute script, return value is %d\n", exitVal)
         stderr.foreach { System.err.printf("stderr [%s]\n", _) }
 
       (validTest, exitVal, stdout.reverse, stderr.reverse)
@@ -275,8 +276,7 @@ object ScriptTestEnv {
       ("MSYS", msyshome),
       ("SHELLOPTS", shellopts),
     ).filter { case (name, valu) => valu.nonEmpty }
-    for (k, v) <- pairs do
-      printf("%s : %s\n", k ,v)
+    if verbose then for (k, v) <- pairs do printf("%s : %s\n", k ,v)
     pairs
   }
 


### PR DESCRIPTION
The -e (eval) expression in [dotty.tools.scripting.ExpressionTest#verifyImports](https://github.com/philwalk/dotty/blob/c4494f9f6d1db23ca2ed8278a957c56c1c87a1b5/compiler/test/dotty/tools/scripting/ExpressionTest.scala) fails to compile, but the test passes anyway because of a missing assertion.

This PR corrects the expression so that it compiles, and it asserts that the expression must print an integer to `STDOUT`, so that the test will fail if the `-e <expression>` implementation fails.

The compile error is mentioned in #14332