### PR TITLE
Introduce hard ConstantTypes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Hashable.scala
+++ b/compiler/src/dotty/tools/dotc/core/Hashable.scala
@@ -108,6 +108,9 @@ trait Hashable {
   protected final def doHash(bs: Binders, x1: Any, tp2: Type, tps3: List[Type]): Int =
     finishHash(bs, hashing.mix(hashSeed, x1.hashCode), 1, tp2, tps3)
 
+  protected final def doHash(x1: Any, x2: Int): Int =
+    finishHash(hashing.mix(hashing.mix(hashSeed, x1.hashCode), x2), 1)
+
   protected final def doHash(x1: Int, x2: Int): Int =
     finishHash(hashing.mix(hashing.mix(hashSeed, x1), x2), 1)
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1230,7 +1230,7 @@ object Types {
      *  base type by applying one or more `underlying` dereferences.
      */
     final def widenSingleton(using Context): Type = stripped match {
-      case tp: SingletonType if !tp.isOverloaded => tp.underlying.widenSingleton
+      case tp: SingletonType if tp.isSoft && !tp.isOverloaded => tp.underlying.widenSingleton
       case _ => this
     }
 
@@ -2869,7 +2869,6 @@ object Types {
   final class CachedConstantType(value: Constant, override val isSoft: Boolean = true) extends ConstantType(value)
 
   object ConstantType {
-    var i = 0
     def apply(value: Constant, soft: Boolean = true)(using Context): ConstantType = {
       assertUnerased()
       unique(new CachedConstantType(value, soft))

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -438,7 +438,7 @@ class TreeUnpickler(reader: TastyReader,
         case BYNAMEtype =>
           ExprType(readType())
         case _ =>
-          ConstantType(readConstant(tag))
+          ConstantType(readConstant(tag), soft = false)
       }
 
       if (tag < firstLengthTreeTag) readSimpleType() else readLengthType()

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -935,7 +935,7 @@ trait Implicits:
             case TypeBounds(lo, hi) if lo.ne(hi) && !t.symbol.is(Opaque) => apply(hi)
             case _ => t
           }
-        case t: SingletonType =>
+        case t: SingletonType if t.isSoft =>
           apply(t.widen)
         case t: RefinedType =>
           apply(t.parent)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1879,7 +1879,12 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
   def typedSingletonTypeTree(tree: untpd.SingletonTypeTree)(using Context): SingletonTypeTree = {
     val ref1 = typedExpr(tree.ref)
     checkStable(ref1.tpe, tree.srcPos, "singleton type")
-    assignType(cpy.SingletonTypeTree(tree)(ref1), ref1)
+
+    val ref2 = ref1.tpe match
+      case ConstantType(c) => ref1.withType(ConstantType(c, soft = false))
+      case _ => ref1
+
+    assignType(cpy.SingletonTypeTree(tree)(ref2), ref2)
   }
 
   def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(using Context): TypTree = {

--- a/tests/pos/widen-singletons.scala
+++ b/tests/pos/widen-singletons.scala
@@ -1,0 +1,12 @@
+object Test:
+  def is2(x: 2) = true
+
+  def testValType() =
+    val x: 2 = 2
+    val v = x
+    is2(v)
+
+  def testDefReturnType() =
+    def f(): 2 = 2
+    val v = f()
+    is2(v)

--- a/tests/pos/widen-union.scala
+++ b/tests/pos/widen-union.scala
@@ -13,7 +13,6 @@ object Test2:
     || xs.corresponds(ys)(consistent(_, _))  // error, found: Any, required: Int | String
 
 object Test3:
-
   def g[X](x: X | String): Int = ???
   def y: Boolean | String = ???
   g[Boolean](y)
@@ -21,4 +20,23 @@ object Test3:
   g[Boolean](identity(y))
   g(identity(y))
 
+object TestSingletonsInUnions:
+  def is2Or3(a: 2 | 3) = true
 
+  def testValType() =
+    val x: 2 | 3 = 2
+    val v = x
+    is2Or3(v)
+
+  def testDefReturnType() =
+    def f(): 2 | 3 = 2
+    val v = f()
+    is2Or3(v)
+
+  def testSoftUnionInHardUnion() =
+    def isStringOr3(a: String | 3) = true
+
+    def f(x: String): x.type | 3 = 3
+    val b: Boolean = true
+    val v = f(if b then "a" else "b")
+    isStringOr3(v)


### PR DESCRIPTION
As other precise types, constant types are currently often widened away. For example:

```scala
val a: 3 = 3
val b /* : Int */ = a
```

For union types, there exists a concept of _softeness_: _hard_ unions are union types explicitly written by the user, while _soft_ unions are created by the compiler (for example as the result of a condition or a match). The former are not widened, while the later are:

```scala
val bool: Boolean = true
val str: String = "hello"
val int: Int = 42
val c /* : Matchable */ = if bool then str else int // Soft union String | Int widened to Matchable
val d: String | Int = if bool then str else int // Explicitly typed as hard union String | Int
val e /* : String | Int */ = d // Hard unions are not widened
```

This PR adds the same _softeness_ concept to constant types, such that constant types explicitly typed by the user are not widened:

```scala
val a: 3 = 3 // Now, this is a hard constant type
val b /* : 3 */ = a // Not widened
```

Previous attempt: https://github.com/lampepfl/dotty/pull/14347, which was only handling singletons inside hard unions.