### PR TITLE
Keep language imports around longer

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/MacroTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroTransform.scala
@@ -29,18 +29,10 @@ abstract class MacroTransform extends Phase {
    */
   protected def transformPhase(using Context): Phase = this
 
-  class Transformer extends TreeMap(cpy = cpyBetweenPhases) {
+  class Transformer extends TreeMapWithPreciseStatContexts(cpy = cpyBetweenPhases):
 
-    protected def localCtx(tree: Tree)(using Context): FreshContext = 
+    protected def localCtx(tree: Tree)(using Context): FreshContext =
       ctx.fresh.setTree(tree).setOwner(localOwner(tree))
-
-    override def transformStats(trees: List[Tree], exprOwner: Symbol)(using Context): List[Tree] = {
-      def transformStat(stat: Tree): Tree = stat match {
-        case _: Import | _: DefTree => transform(stat)
-        case _ => transform(stat)(using ctx.exprContext(stat, exprOwner))
-      }
-      flatten(trees.mapconserve(transformStat(_)))
-    }
 
     override def transform(tree: Tree)(using Context): Tree =
       try
@@ -67,5 +59,5 @@ abstract class MacroTransform extends Phase {
 
     def transformSelf(vd: ValDef)(using Context): ValDef =
       cpy.ValDef(vd)(tpt = transform(vd.tpt))
-  }
+  end Transformer
 }

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -433,43 +433,9 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
     transformTree(tree, start).asInstanceOf[T]
 
   def transformStats(trees: List[Tree], exprOwner: Symbol, start: Int)(using Context): List[Tree] =
-
-    def transformStat(stat: Tree)(using Context): Tree = stat match {
-      case _: Import | _: DefTree => transformTree(stat, start)
-      case Thicket(stats) => cpy.Thicket(stat)(stats.mapConserve(transformStat))
-      case _ => transformTree(stat, start)(using ctx.exprContext(stat, exprOwner))
-    }
-
-    def restContext(tree: Tree)(using Context): Context = tree match
-      case imp: Import => ctx.importContext(imp, imp.symbol)
-      case _ => ctx
-
-     // A slower implementation that avoids deep recursions and stack overflows
-    def transformSlow(trees: List[Tree])(using Context): List[Tree] =
-      var curCtx = ctx
-      flatten(trees.mapConserve { tree =>
-        val tree1 = transformStat(tree)(using curCtx)
-        curCtx = restContext(tree)(using curCtx)
-        tree1
-      })
-
-    def recur(trees: List[Tree], count: Int)(using Context): List[Tree] =
-      if count > MapRecursionLimit then
-        transformSlow(trees)
-      else trees match
-        case tree :: rest =>
-          val tree1 = transformStat(tree)
-          val rest1 = recur(rest, count + 1)(using restContext(tree))
-          if (tree1 eq tree) && (rest1 eq rest) then trees
-          else tree1 match
-            case Thicket(elems1) => elems1 ::: rest1
-            case _ => tree1 :: rest1
-        case nil => nil
-
     val nestedCtx = prepStats(trees, start)
-    val trees1 = recur(trees, 0)(using nestedCtx)
+    val trees1 = trees.mapStatements(exprOwner, transformTree(_, start))(using nestedCtx)
     goStats(trees1, start)(using nestedCtx)
-  end transformStats
 
   def transformUnit(tree: Tree)(using Context): Tree = {
     val nestedCtx = prepUnit(tree, 0)

--- a/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
@@ -14,6 +14,7 @@ import StdNames.nme
 import ast.tpd
 import SymUtils._
 import config.Feature
+import Decorators.*
 
 /** This phase makes all erased term members of classes private so that they cannot
  *  conflict with non-erased members. This is needed so that subsequent phases like
@@ -21,6 +22,7 @@ import config.Feature
  *  The phase also replaces all expressions that appear in an erased context by
  *  default values. This is necessary so that subsequent checking phases such
  *  as IsInstanceOfChecker don't give false negatives.
+ *  Finally, the phase drops (language-) imports.
  */
 class PruneErasedDefs extends MiniPhase with SymTransformer { thisTransform =>
   import tpd._
@@ -54,10 +56,18 @@ class PruneErasedDefs extends MiniPhase with SymTransformer { thisTransform =>
     checkErasedInExperimental(tree.symbol)
     tree
 
+  override def transformOther(tree: Tree)(using Context): Tree = tree match
+    case tree: Import => EmptyTree
+    case _ => tree
+
   def checkErasedInExperimental(sym: Symbol)(using Context): Unit =
     // Make an exception for Scala 2 experimental macros to allow dual Scala 2/3 macros under non experimental mode
     if sym.is(Erased, butNot = Macro) && sym != defn.Compiletime_erasedValue && !sym.isInExperimentalScope then
       Feature.checkExperimentalFeature("erased", sym.sourcePos)
+
+  override def checkPostCondition(tree: Tree)(using Context): Unit = tree match
+    case _: tpd.Import => assert(false, i"illegal tree: $tree")
+    case _ =>
 }
 
 object PruneErasedDefs {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2556,7 +2556,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 |The selector is not a member of an object or package.""")
     else typd(imp.expr, AnySelectionProto)
 
-  def typedImport(imp: untpd.Import, sym: Symbol)(using Context): Import =
+  def typedImport(imp: untpd.Import, sym: Symbol)(using Context): Tree =
     val expr1 = typedImportQualifier(imp, typedExpr(_, _)(using ctx.withOwner(sym)))
     checkLegalImportPath(expr1)
     val selectors1 = typedSelectors(imp.selectors)


### PR DESCRIPTION
Some phases might need to know what language imports are active. Concretely, under
explicit nulls, the exhaustivity checks for patterns need to know that. We therefore
keep language imports until phase PruneErasedDefs. Other imports are dropped in
FirstTransform, as before.

The handling of statements in MegaPhase was changed so that imports now are visible
in the context for transforming the following statements.

Update: Now, MacroTransform has the same changes, and in fact all of MegaPhase, MacroTransform and TreeMapWithImplicits use the same inline method for treating statement lists.

Fixes #14346