### PR TITLE
Tighten unary op syntax and untupling language

### DIFF
--- a/docs/_docs/reference/changed-features/operators.md
+++ b/docs/_docs/reference/changed-features/operators.md
@@ -169,7 +169,5 @@ neither of its occurrences is followed by a space and a token that can start an 
 
 ## Unary operators
 
-As a minor restriction, the first parameter list of a unary operator must not be explicit and empty.
+A unary operator must not have explicit parameter lists even if they are empty.
 A unary operator is a method named "unary_`op`" where `op` is one of `+`, `-`, `!`, or `~`.
-
-The reason for this restriction is that unary operator syntax does not support supplying an argument list, even if it is empty.

--- a/docs/_docs/reference/changed-features/operators.md
+++ b/docs/_docs/reference/changed-features/operators.md
@@ -6,9 +6,12 @@ movedTo: https://docs.scala-lang.org/scala3/reference/changed-features/operators
 
 The rules for infix operators have changed in some parts:
 
-First, an alphanumeric method can be used as an infix operator only if its definition carries an `infix` modifier. Second, it is recommended (but not enforced) to
-augment definitions of symbolic operators with [`@targetName` annotations](../other-new-features/targetName.md). Finally,
-a syntax change allows infix operators to be written on the left in a multi-line expression.
+First, an alphanumeric method can be used as an infix operator only if its definition carries an `infix` modifier.
+
+Second, it is recommended (but not enforced) to augment definitions of symbolic operators
+with [`@targetName` annotations](../other-new-features/targetName.md).
+
+Finally, a syntax change allows infix operators to be written on the left in a multi-line expression.
 
 ## The `infix` Modifier
 
@@ -163,3 +166,10 @@ Another example:
 
 This code is recognized as three different statements. `???` is syntactically a symbolic identifier, but
 neither of its occurrences is followed by a space and a token that can start an expression.
+
+## Unary operators
+
+As a minor restriction, the first parameter list of a unary operator must not be explicit and empty.
+A unary operator is a method named "unary_`op`" where `op` is one of `+`, `-`, `!`, or `~`.
+
+The reason for this restriction is that unary operator syntax does not support supplying an argument list, even if it is empty.

--- a/docs/_docs/reference/other-new-features/parameter-untupling.md
+++ b/docs/_docs/reference/other-new-features/parameter-untupling.md
@@ -39,9 +39,9 @@ def combine(i: Int, j: Int) = i + j
 xs.map(combine)
 ```
 
-Generally, a function value with `n > 1` parameters is converted to a
-pattern-matching closure using `case` if the expected type is a unary
-function type of the form `((T_1, ..., T_n)) => U`.
+Generally, a function value with `n > 1` parameters is wrapped in a
+function type of the form `((T_1, ..., T_n)) => U` if that is the expected type.
+The tuple parameter is decomposed and its elements are passed directly to the underlying function.
 
 More specifically, the adaptation is applied to the mismatching formal
 parameter list. In particular, the adaptation is not a conversion


### PR DESCRIPTION
Fixes #9241

Disallow unary ops with parens.

Follow up untupling spec where it is not pattern-matching like `.tupled`. It simply takes the params it knows to take.