### PR TITLE
Scaladoc: Unescaped special characters in Quotes documentation

### DIFF
--- a/scaladoc-testcases/src/tests/markdowncode.scala
+++ b/scaladoc-testcases/src/tests/markdowncode.scala
@@ -1,0 +1,5 @@
+package tests.markdowncode
+
+/** Some text `{ <statements: List[Statement]>; <expr: Term> }` */
+val aVal: Float
+  = 1.2f

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/DocRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/DocRenderer.scala
@@ -86,7 +86,7 @@ class DocRender(signatureRenderer: SignatureRenderer)(using DocContext):
     case Subscript(text) => span(cls:="subscript")(renderElement(text))  // TODO implement style
     case Link(target, body) =>
       renderLink(target, default => body.fold[TagArg](default)(renderElement))
-    case Text(text) => raw(text)
+    case Text(text) => raw(text.escapeReservedTokens)
     case Summary(text) => renderElement(text)
     case HtmlTag(content) => raw(content)
 

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -92,3 +92,5 @@ class FBoundedTypeParameters extends SignatureTest("fboundedTypeParameters", Sig
 class Exports extends SignatureTest("exports2", SignatureTest.all, sourceFiles = List("exports1", "exports2"))
 
 class ContextFunctions extends SignatureTest("contextfunctions", SignatureTest.all)
+
+class MarkdownCode extends SignatureTest("markdowncode", SignatureTest.all)


### PR DESCRIPTION
closes #13746

![image](https://user-images.githubusercontent.com/39772805/151550253-56884225-be58-49f5-bbf2-b7d81c76d3bb.png)

@pikinier20 could you check if HTML formatting doesn't break?
