### PR TITLE
Update protoquill to latest build

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -714,9 +714,10 @@ object projects:
 
   lazy val protoquill = SbtCommunityProject(
     project = "protoquill",
-    sbtTestCommand = "test",
+    extraSbtArgs  = List("-Dcommunity=true", "-DcommunityRemote=true", "-Dquill.macro.stdout=true"),
+    sbtTestCommand = "runCommunityBuild",
     sbtPublishCommand = "publishLocal",
-    dependencies = () => List(), // TODO add scalatest and pprint (see protoquill/build.sbt)
+    dependencies = () => List(scalatest),
     scalacOptions = List("-language:implicitConversions"), // disabled -Ysafe-init, due to bug in macro
   )
 


### PR DESCRIPTION
ProtoQuill community build is on a very, very old version, I would like to re-integrate with the latest code now since in my primary codebase I have replaced `EntityQuery.insert/update` with `insertValue` and `updateValue`. Also, this means that changes in https://github.com/dotty-staging/protoquill/commit/5ed25aac9440eb0fcca5d9cd828dc85728fee422 need to be undone. I hope this is alright.

I added compile and scalatest-driven testing of quill-sql and quill-sql-tests which is a minimum of what is needed to verify quill functionality. Also, I added Test/compile for quill-cassandra since this module uses macros in it's own unique ways. These settings are internally controlled by Quill's `runCommunityBuild` task. I want to keep it that way so that quill community builds can be run on a quill CI independently of community-build infrastructure.