### PR TITLE
refactor: improve output of -Xshow-phases

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/CollectSuperCalls.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CollectSuperCalls.scala
@@ -20,7 +20,9 @@ import dotty.tools.dotc.transform.MegaPhase.MiniPhase
 class CollectSuperCalls extends MiniPhase {
   import tpd._
 
-  def phaseName: String = "collectSuperCalls"
+  override def phaseName: String = CollectSuperCalls.name
+
+  override def description: String = CollectSuperCalls.description
 
   override def transformSelect(tree: Select)(using Context): Tree = {
     tree.qualifier match {
@@ -40,3 +42,7 @@ class CollectSuperCalls extends MiniPhase {
     }
   }
 }
+
+object CollectSuperCalls:
+  val name: String = "collectSuperCalls"
+  val description: String = "find classes that are called with super"

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -34,7 +34,10 @@ import StdNames._
 import dotty.tools.io._
 
 class GenBCode extends Phase {
-  def phaseName: String = GenBCode.name
+
+  override def phaseName: String = GenBCode.name
+
+  override def description: String = GenBCode.description
 
   private val superCallsMap = new MutableSymbolMap[Set[ClassSymbol]]
   def registerSuperCall(sym: Symbol, calls: ClassSymbol): Unit = {
@@ -106,6 +109,7 @@ class GenBCode extends Phase {
 
 object GenBCode {
   val name: String = "genBCode"
+  val description: String = "generate JVM bytecode"
 }
 
 class GenBCodePipeline(val int: DottyBackendInterface, val primitives: DottyPrimitives)(using Context) extends BCodeSyncAndTry {

--- a/compiler/src/dotty/tools/backend/sjs/GenSJSIR.scala
+++ b/compiler/src/dotty/tools/backend/sjs/GenSJSIR.scala
@@ -6,7 +6,10 @@ import Phases._
 
 /** Generates Scala.js IR files for the compilation unit. */
 class GenSJSIR extends Phase {
-  def phaseName: String = "genSJSIR"
+
+  override def phaseName: String = GenSJSIR.name
+
+  override def description: String = GenSJSIR.description
 
   override def isRunnable(using Context): Boolean =
     super.isRunnable && ctx.settings.scalajs.value
@@ -14,3 +17,7 @@ class GenSJSIR extends Phase {
   def run(using Context): Unit =
     new JSCodeGen().run()
 }
+
+object GenSJSIR:
+  val name: String = "genSJSIR"
+  val description: String = "generate .sjsir files for Scala.js"

--- a/compiler/src/dotty/tools/dotc/parsing/ParserPhase.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/ParserPhase.scala
@@ -15,6 +15,7 @@ import dotty.tools.unsupported
 class Parser extends Phase {
 
   override def phaseName: String = Parser.name
+  override def description: String = Parser.description
 
   // We run TreeChecker only after type checking
   override def isCheckable: Boolean = false
@@ -58,4 +59,5 @@ class Parser extends Phase {
 
 object Parser{
   val name: String = "parser"
+  val description: String = "scan and parse sources"
 }

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -43,7 +43,10 @@ import scala.util.chaining.*
  *  @see ExtractDependencies
  */
 class ExtractAPI extends Phase {
-  override def phaseName: String = "sbt-api"
+
+  override def phaseName: String = ExtractAPI.name
+
+  override def description: String = ExtractAPI.description
 
   override def isRunnable(using Context): Boolean = {
     def forceRun = ctx.settings.YdumpSbtInc.value || ctx.settings.YforceSbtPhases.value
@@ -86,6 +89,10 @@ class ExtractAPI extends Phase {
       mainClasses.foreach(ctx.sbtCallback.mainClass(sourceFile.file, _))
   }
 }
+
+object ExtractAPI:
+  val name: String = "sbt-api"
+  val description: String = "sends a representation of the API of classes to sbt"
 
 /** Extracts full (including private members) API representation out of Symbols and Types.
  *

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -49,7 +49,9 @@ import scala.collection.{Set, mutable}
 class ExtractDependencies extends Phase {
   import ExtractDependencies._
 
-  override def phaseName: String = "sbt-deps"
+  override def phaseName: String = ExtractDependencies.name
+
+  override def description: String = ExtractDependencies.description
 
   override def isRunnable(using Context): Boolean = {
     def forceRun = ctx.settings.YdumpSbtInc.value || ctx.settings.YforceSbtPhases.value
@@ -180,6 +182,9 @@ class ExtractDependencies extends Phase {
 }
 
 object ExtractDependencies {
+  val name: String = "sbt-deps"
+  val description: String = "sends information on classes' dependencies to sbt"
+
   def classNameAsString(sym: Symbol)(using Context): String =
     sym.fullName.stripModuleClassSuffix.toString
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -36,6 +36,8 @@ class ExtractSemanticDB extends Phase:
 
   override val phaseName: String = ExtractSemanticDB.name
 
+  override val description: String = ExtractSemanticDB.description
+
   override def isRunnable(using Context) =
     super.isRunnable && ctx.settings.Xsemanticdb.value
 
@@ -461,6 +463,7 @@ object ExtractSemanticDB:
   import java.nio.file.Paths
 
   val name: String = "extractSemanticDB"
+  val description: String = "extract info into .semanticdb files"
 
   def write(
     source: SourceFile,

--- a/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
@@ -21,7 +21,9 @@ import scala.reflect.ClassTag
 class ArrayApply extends MiniPhase {
   import tpd._
 
-  override def phaseName: String = "arrayApply"
+  override def phaseName: String = ArrayApply.name
+
+  override def description: String = ArrayApply.description
 
   override def transformApply(tree: tpd.Apply)(using Context): tpd.Tree =
     if isArrayModuleApply(tree.symbol) then
@@ -71,3 +73,7 @@ class ArrayApply extends MiniPhase {
     }
   }
 }
+
+object ArrayApply:
+  val name: String = "arrayApply"
+  val description: String = "optimize `scala.Array.apply`"

--- a/compiler/src/dotty/tools/dotc/transform/ArrayConstructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayConstructors.scala
@@ -22,7 +22,9 @@ import scala.collection.immutable.::
 class ArrayConstructors extends MiniPhase {
   import ast.tpd._
 
-  override def phaseName: String = "arrayConstructors"
+  override def phaseName: String = ArrayConstructors.name
+
+  override def description: String = ArrayConstructors.description
 
   override def transformApply(tree: tpd.Apply)(using Context): tpd.Tree = {
     def expand(elemType: Type, dims: List[Tree]) =
@@ -49,3 +51,7 @@ class ArrayConstructors extends MiniPhase {
     else tree
   }
 }
+
+object ArrayConstructors:
+  val name: String = "arrayConstructors"
+  val description: String = "intercept creation of (non-generic) arrays and intrinsify"

--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -33,7 +33,9 @@ import ast.TreeTypeMap
 class BetaReduce extends MiniPhase:
   import ast.tpd._
 
-  def phaseName: String = "betaReduce"
+  override def phaseName: String = BetaReduce.name
+
+  override def description: String = BetaReduce.description
 
   override def transformApply(app: Apply)(using Context): Tree = app.fun match
     case Select(fn, nme.apply) if defn.isFunctionType(fn.tpe) =>
@@ -46,6 +48,9 @@ class BetaReduce extends MiniPhase:
 
 object BetaReduce:
   import ast.tpd._
+
+  val name: String = "betaReduce"
+  val description: String = "reduce closure applications"
 
   /** Beta-reduces a call to `fn` with arguments `argSyms` or returns `tree` */
   def apply(original: Tree, fn: Tree, args: List[Tree])(using Context): Tree =

--- a/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CapturedVars.scala
@@ -22,8 +22,9 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer:
   thisPhase =>
   import ast.tpd._
 
-  /** the following two members override abstract members in Transform */
-  val phaseName: String = "capturedVars"
+  override def phaseName: String = CapturedVars.name
+
+  override def description: String = CapturedVars.description
 
   override def runsAfterGroupsOf: Set[String] = Set(LiftTry.name)
     // lifting tries changes what variables are considered to be captured
@@ -167,3 +168,7 @@ class CapturedVars extends MiniPhase with IdentityDenotTransformer:
       case _ =>
         tree
     recur(tree.lhs)
+
+object CapturedVars:
+  val name: String = "capturedVars"
+  val description: String = "represent vars captured by closures as heap objects"

--- a/compiler/src/dotty/tools/dotc/transform/CheckLoopingImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckLoopingImplicits.scala
@@ -12,6 +12,7 @@ import annotation.threadUnsafe
 
 object CheckLoopingImplicits:
   val name: String = "checkLoopingImplicits"
+  val description: String = "check that implicit defs do not call themselves in an infinite loop"
 
 /** Checks that implicit defs do not call themselves in an infinite loop */
 class CheckLoopingImplicits extends MiniPhase:
@@ -19,6 +20,8 @@ class CheckLoopingImplicits extends MiniPhase:
   import tpd._
 
   override def phaseName: String = CheckLoopingImplicits.name
+
+  override def description: String = CheckLoopingImplicits.description
 
   override def transformValDef(mdef: ValDef)(using Context): Tree = 
     transform(mdef)

--- a/compiler/src/dotty/tools/dotc/transform/CheckNoSuperThis.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckNoSuperThis.scala
@@ -12,6 +12,7 @@ import annotation.threadUnsafe
 
 object CheckNoSuperThis:
   val name: String = "checkNoSuperThis"
+  val description: String = "check that supercalls don't contain references to This"
 
 /** Checks that super and this calls do not pass `this` as (part of) an argument. */
 class CheckNoSuperThis extends MiniPhase:
@@ -19,6 +20,8 @@ class CheckNoSuperThis extends MiniPhase:
   import tpd._
 
   override def phaseName: String = CheckNoSuperThis.name
+
+  override def description: String = CheckNoSuperThis.description
 
   override def runsAfterGroupsOf: Set[String] = Set(Constructors.name)
 

--- a/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
@@ -29,7 +29,9 @@ import Decorators._
 class CheckReentrant extends MiniPhase {
   import ast.tpd._
 
-  override def phaseName: String = "checkReentrant"
+  override def phaseName: String = CheckReentrant.name
+
+  override def description: String = CheckReentrant.description
 
   private var shared: Set[Symbol] = Set()
   private var seen: Set[ClassSymbol] = Set()
@@ -84,3 +86,7 @@ class CheckReentrant extends MiniPhase {
     tree
   }
 }
+
+object CheckReentrant:
+  val name: String = "checkReentrant"
+  val description: String = "check no data races involving global vars"

--- a/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
@@ -29,6 +29,8 @@ class CheckStatic extends MiniPhase {
 
   override def phaseName: String = CheckStatic.name
 
+  override def description: String = CheckStatic.description
+
   override def transformTemplate(tree: tpd.Template)(using Context): tpd.Tree = {
     val defns = tree.body.collect{case t: ValOrDefDef => t}
     var hadNonStaticField = false
@@ -63,4 +65,5 @@ class CheckStatic extends MiniPhase {
 
 object CheckStatic {
   val name: String = "checkStatic"
+  val description: String = "check restrictions that apply to @static members"
 }

--- a/compiler/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
@@ -29,7 +29,10 @@ import dotty.tools.backend.jvm.GenBCode
  *   -Xmain-class
  */
 class CollectEntryPoints extends MiniPhase:
-  def phaseName: String = "Collect entry points"
+
+  override def phaseName: String = CollectEntryPoints.name
+
+  override def description: String = CollectEntryPoints.description
 
   override def isRunnable(using Context): Boolean =
     def forceRun = ctx.settings.XmainClass.isDefault && ctx.settings.outputDir.value.isInstanceOf[JarArchive]
@@ -52,3 +55,7 @@ class CollectEntryPoints extends MiniPhase:
       case _ =>
     }
   }
+
+object CollectEntryPoints:
+  val name: String = "Collect entry points"
+  val description: String = "collect all entry points and save them in the context"

--- a/compiler/src/dotty/tools/dotc/transform/CollectNullableFields.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CollectNullableFields.scala
@@ -13,6 +13,7 @@ import java.util.IdentityHashMap
 
 object CollectNullableFields {
   val name: String = "collectNullableFields"
+  val description: String = "collect fields that can be nulled out after use in lazy initialization"
 }
 
 /** Collect fields that can be nulled out after use in lazy initialization.
@@ -42,6 +43,8 @@ class CollectNullableFields extends MiniPhase {
   import tpd._
 
   override def phaseName: String = CollectNullableFields.name
+
+  override def description: String = CollectNullableFields.description
 
   /** Running after `ElimByName` to see by names as nullable types. */
   override def runsAfter: Set[String] = Set(ElimByName.name)

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -20,6 +20,7 @@ import annotation.threadUnsafe
 
 object CompleteJavaEnums {
   val name: String = "completeJavaEnums"
+  val description: String = "fill in constructors for Java enums"
 
   private val nameParamName: TermName = "_$name".toTermName
   private val ordinalParamName: TermName = "_$ordinal".toTermName
@@ -34,6 +35,8 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
   import ast.tpd._
 
   override def phaseName: String = CompleteJavaEnums.name
+
+  override def description: String = CompleteJavaEnums.description
 
   override def relaxedTypingInGroup: Boolean = true
     // Because it adds additional parameters to some constructors

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -21,6 +21,7 @@ import collection.mutable
 
 object Constructors {
   val name: String = "constructors"
+  val description: String = "collect initialization code in primary constructors"
 }
 
 /** This transform
@@ -33,6 +34,9 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
   import tpd._
 
   override def phaseName: String = Constructors.name
+
+  override def description: String = Constructors.description
+
   override def runsAfter: Set[String] = Set(HoistSuperArgs.name)
   override def runsAfterGroupsOf: Set[String] = Set(Memoize.name)
     // Memoized needs to be finished because we depend on the ownerchain after Memoize

--- a/compiler/src/dotty/tools/dotc/transform/CookComments.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CookComments.scala
@@ -6,7 +6,10 @@ import dotty.tools.dotc.core.ContextOps._
 import dotty.tools.dotc.typer.Docstrings
 
 class CookComments extends MegaPhase.MiniPhase {
-  override def phaseName: String = "cookComments"
+
+  override def phaseName: String = CookComments.name
+
+  override def description: String = CookComments.description
 
   override def transformTypeDef(tree: tpd.TypeDef)(using Context): tpd.Tree = {
     if (ctx.settings.YcookComments.value && tree.isClassDef) {
@@ -26,4 +29,6 @@ class CookComments extends MegaPhase.MiniPhase {
   }
 }
 
-
+object CookComments:
+  val name = "cookComments"
+  val description: String = "cook the comments: expand variables, doc, etc."

--- a/compiler/src/dotty/tools/dotc/transform/CountOuterAccesses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CountOuterAccesses.scala
@@ -15,6 +15,7 @@ import collection.mutable
 
 object CountOuterAccesses:
   val name: String = "countOuterAccesses"
+  val description: String = "identify outer accessors that can be dropped"
 
   /** Characterizes outer accessors and outer fields that can be dropped
    *  if there are no references to them from within the toplevel class
@@ -37,6 +38,8 @@ class CountOuterAccesses extends MiniPhase:
   import tpd._
 
   override def phaseName: String = CountOuterAccesses.name
+
+  override def description: String = CountOuterAccesses.description
 
   override def runsAfter: Set[String] = Set(LambdaLift.name)
     // LambdaLift can create outer paths. These need to be known in this phase.

--- a/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
@@ -18,6 +18,7 @@ import annotation.threadUnsafe
 
 object DropOuterAccessors:
   val name: String = "dropOuterAccessors"
+  val description: String = "drop unused outer accessors"
 
 /** Drops unused outer accessors of inner classes that are visible only in one
  *  toplevel class. For other classes, we can't tell whether an outer accessor
@@ -28,6 +29,8 @@ class DropOuterAccessors extends MiniPhase with IdentityDenotTransformer:
   import tpd._
 
   override def phaseName: String = DropOuterAccessors.name
+
+  override def description: String = DropOuterAccessors.description
 
   override def runsAfterGroupsOf: Set[String] = Set(CountOuterAccesses.name)
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimByName.scala
@@ -56,6 +56,8 @@ class ElimByName extends MiniPhase, InfoTransformer:
 
   override def phaseName: String = ElimByName.name
 
+  override def description: String = ElimByName.description
+
   override def runsAfterGroupsOf: Set[String] = Set(ExpandSAMs.name, ElimRepeated.name, RefChecks.name)
     // - ExpanSAMs applied to partial functions creates methods that need
     //   to be fully defined before converting. Test case is pos/i9391.scala.
@@ -158,3 +160,4 @@ class ElimByName extends MiniPhase, InfoTransformer:
 
 object ElimByName:
   val name: String = "elimByName"
+  val description: String = "map by-name parameters to functions"

--- a/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
@@ -13,6 +13,7 @@ import NameKinds.SuperAccessorName
 
 object ElimErasedValueType {
   val name: String = "elimErasedValueType"
+  val description: String = "expand erased value types to their underlying implmementation types"
 
   def elimEVT(tp: Type)(using Context): Type = tp match {
     case ErasedValueType(_, underlying) =>
@@ -39,6 +40,8 @@ class ElimErasedValueType extends MiniPhase with InfoTransformer { thisPhase =>
   import ElimErasedValueType.elimEVT
 
   override def phaseName: String = ElimErasedValueType.name
+
+  override def description: String = ElimErasedValueType.description
 
   override def runsAfter: Set[String] = Set(Erasure.name)
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimOpaque.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimOpaque.scala
@@ -18,6 +18,7 @@ import ast.Trees._
 
 object ElimOpaque {
   val name: String = "elimOpaque"
+  val description: String = "turn opaque into normal aliases"
 }
 
 /** Rewrites opaque type aliases to normal alias types */
@@ -26,6 +27,8 @@ class ElimOpaque extends MiniPhase with DenotTransformer {
   import ast.tpd._
 
   override def phaseName: String = ElimOpaque.name
+
+  override def description: String = ElimOpaque.description
 
   // Override checks need to take place before treating opaque types as aliases
   override def runsAfterGroupsOf: Set[String] = Set(typer.RefChecks.name)

--- a/compiler/src/dotty/tools/dotc/transform/ElimOuterSelect.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimOuterSelect.scala
@@ -13,7 +13,9 @@ import NameKinds.OuterSelectName
 class ElimOuterSelect extends MiniPhase {
   import ast.tpd._
 
-  override def phaseName: String = "elimOuterSelect"
+  override def phaseName: String = ElimOuterSelect.name
+
+  override def description: String = ElimOuterSelect.description
 
   override def runsAfterGroupsOf: Set[String] = Set(ExplicitOuter.name)
     // ExplicitOuter needs to have run to completion before so that all classes
@@ -30,3 +32,7 @@ class ElimOuterSelect extends MiniPhase {
       case _ => tree
     }
 }
+
+object ElimOuterSelect:
+  val name: String = "elimOuterSelect"
+  val description: String = "expand outer selections"

--- a/compiler/src/dotty/tools/dotc/transform/ElimPackagePrefixes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimPackagePrefixes.scala
@@ -12,7 +12,9 @@ import MegaPhase.MiniPhase
  */
 class ElimPackagePrefixes extends MiniPhase {
 
-  override def phaseName: String = "elimPackagePrefixes"
+  override def phaseName: String = ElimPackagePrefixes.name
+
+  override def description: String = ElimPackagePrefixes.description
 
   override def transformSelect(tree: Select)(using Context): Tree =
     if (isPackageClassRef(tree)) Ident(tree.tpe.asInstanceOf[TypeRef]) else tree
@@ -29,3 +31,7 @@ class ElimPackagePrefixes extends MiniPhase {
     case _ => false
   }
 }
+
+object ElimPackagePrefixes:
+  val name: String = "elimPackagePrefixes"
+  val description: String = "eliminate references to package prefixes in Select nodes"

--- a/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
@@ -24,6 +24,8 @@ class ElimPolyFunction extends MiniPhase with DenotTransformer {
 
   override def phaseName: String = ElimPolyFunction.name
 
+  override def description: String = ElimPolyFunction.description
+
   override def runsAfter = Set(Erasure.name)
 
   override def changesParents: Boolean = true // Replaces PolyFunction by FunctionN
@@ -63,6 +65,7 @@ class ElimPolyFunction extends MiniPhase with DenotTransformer {
 }
 
 object ElimPolyFunction {
-  val name = "elimPolyFunction"
+  val name: String = "elimPolyFunction"
+  val description: String = "rewrite PolyFunction subclasses to FunctionN subclasses"
 }
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -19,6 +19,7 @@ import NullOpsDecorator._
 
 object ElimRepeated {
   val name: String = "elimRepeated"
+  val description: String = "rewrite vararg parameters and arguments"
 }
 
 /** A transformer that eliminates repeated parameters (T*) from all types, replacing
@@ -29,6 +30,8 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
   import ast.tpd._
 
   override def phaseName: String = ElimRepeated.name
+
+  override def description: String = ElimRepeated.description
 
   override def changesMembers: Boolean = true // the phase adds vararg forwarders
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimStaticThis.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimStaticThis.scala
@@ -13,7 +13,10 @@ import dotty.tools.dotc.core.Types.{ThisType, TermRef}
  */
 class ElimStaticThis extends MiniPhase {
   import ast.tpd._
-  def phaseName: String = "elimStaticThis"
+
+  override def phaseName: String = ElimStaticThis.name
+
+  override def description: String = ElimStaticThis.description
 
   override def transformThis(tree: This)(using Context): Tree =
     if (!tree.symbol.is(Package) && ctx.owner.enclosingMethod.is(JavaStatic)) {
@@ -34,3 +37,7 @@ class ElimStaticThis extends MiniPhase {
       }
     else tree
 }
+
+object ElimStaticThis:
+  val name: String = "elimStaticThis"
+  val description: String = "replace This references to static objects by global identifiers"

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -42,6 +42,8 @@ class Erasure extends Phase with DenotTransformer {
 
   override def phaseName: String = Erasure.name
 
+  override def description: String = Erasure.description
+
   /** List of names of phases that should precede this phase */
   override def runsAfter: Set[String] = Set(InterceptedMethods.name, ElimRepeated.name)
 
@@ -203,6 +205,7 @@ object Erasure {
   import TypeTestsCasts._
 
   val name: String = "erasure"
+  val description: String = "rewrite types to JVM model"
 
   /** An attachment on Apply nodes indicating that multiple arguments
    *  are passed in a single array. This occurs only if the function

--- a/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
@@ -24,7 +24,9 @@ import ast.Trees.*
 class EtaReduce extends MiniPhase:
   import ast.tpd._
 
-  override def phaseName: String = "etaReduce"
+  override def phaseName: String = EtaReduce.name
+
+  override def description: String = EtaReduce.description
 
   override def transformBlock(tree: Block)(using Context): Tree = tree match
     case Block((meth : DefDef) :: Nil, closure: Closure)
@@ -42,3 +44,7 @@ class EtaReduce extends MiniPhase:
     case _ => tree
 
 end EtaReduce
+
+object EtaReduce:
+  val name: String = "etaReduce"
+  val description: String = "reduce eta expansions of pure paths"

--- a/compiler/src/dotty/tools/dotc/transform/ExpandPrivate.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandPrivate.scala
@@ -32,7 +32,9 @@ import ValueClasses._
 class ExpandPrivate extends MiniPhase with IdentityDenotTransformer { thisPhase =>
   import ast.tpd._
 
-  override def phaseName: String = "expandPrivate"
+  override def phaseName: String = ExpandPrivate.name
+
+  override def description: String = ExpandPrivate.description
 
   // This phase moves methods around (in infotransform) so it may need to make other methods public
   override def runsAfter: Set[String] = Set(MoveStatics.name)
@@ -111,3 +113,7 @@ class ExpandPrivate extends MiniPhase with IdentityDenotTransformer { thisPhase 
     tree
   }
 }
+
+object ExpandPrivate:
+  val name: String = "expandPrivate"
+  val description: String = "widen private definitions accessed from nested classes"

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -28,6 +28,7 @@ import dotty.tools.dotc.util.Spans.Span
  */
 object ExpandSAMs:
   val name: String = "expandSAMs"
+  val description: String = "expand SAM closures to anonymous classes"
 
   /** Is the SAMType `cls` also a SAM under the rules of the platform? */
   def isPlatformSam(cls: ClassSymbol)(using Context): Boolean =
@@ -42,6 +43,8 @@ class ExpandSAMs extends MiniPhase:
   import ast.tpd._
 
   override def phaseName: String = ExpandSAMs.name
+
+  override def description: String = ExpandSAMs.description
 
   override def transformBlock(tree: Block)(using Context): Tree = tree match {
     case Block(stats @ (fn: DefDef) :: Nil, Closure(_, fnRef, tpt)) if fnRef.symbol == fn.symbol =>

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -40,6 +40,8 @@ class ExplicitOuter extends MiniPhase with InfoTransformer { thisPhase =>
 
   override def phaseName: String = ExplicitOuter.name
 
+  override def description: String = ExplicitOuter.description
+
   override def runsAfter:         Set[String] = Set(HoistSuperArgs.name)
   override def runsAfterGroupsOf: Set[String] = Set(PatternMatcher.name)
 
@@ -125,6 +127,7 @@ object ExplicitOuter {
   import ast.tpd._
 
   val name: String = "explicitOuter"
+  val description: String = "add accessors to outer classes from nested ones"
 
   /** Ensure that class `cls` has outer accessors */
   def ensureOuterAccessors(cls: ClassSymbol)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
@@ -21,7 +21,9 @@ import Contexts._, Types._, MegaPhase._, ast.Trees._, Symbols._, Decorators._, F
 class ExplicitSelf extends MiniPhase {
   import ast.tpd._
 
-  override def phaseName: String = "explicitSelf"
+  override def phaseName: String = ExplicitSelf.name
+
+  override def description: String = ExplicitSelf.description
 
   private def needsCast(tree: RefTree, cls: ClassSymbol)(using Context) =
     !cls.is(Package) && cls.givenSelfType.exists && !cls.derivesFrom(tree.symbol.owner)
@@ -49,3 +51,7 @@ class ExplicitSelf extends MiniPhase {
     case _ => tree
   }
 }
+
+object ExplicitSelf:
+  val  name: String = "explicitSelf"
+  val description: String = "make references to non-trivial self types explicit as casts"

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -41,8 +41,9 @@ class ExtensionMethods extends MiniPhase with DenotTransformer with FullParamete
   import tpd._
   import ExtensionMethods._
 
-  /** the following two members override abstract members in Transform */
   override def phaseName: String = ExtensionMethods.name
+
+  override def description: String = ExtensionMethods.description
 
   override def runsAfter: Set[String] = Set(
     ElimRepeated.name,
@@ -174,6 +175,7 @@ class ExtensionMethods extends MiniPhase with DenotTransformer with FullParamete
 
 object ExtensionMethods {
   val name: String = "extmethods"
+  val description: String = "expand methods of value classes with extension methods"
 
   /** Name of the extension method that corresponds to given instance method `meth`. */
   def extensionName(imeth: Symbol)(using Context): TermName =

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -22,6 +22,7 @@ import TypeUtils.isErasedValueType
 
 object FirstTransform {
   val name: String = "firstTransform"
+  val description: String = "some transformations to put trees into a canonical form"
 }
 
 /** The first tree transform
@@ -39,6 +40,8 @@ class FirstTransform extends MiniPhase with InfoTransformer { thisPhase =>
   import ast.tpd._
 
   override def phaseName: String = FirstTransform.name
+
+  override def description: String = FirstTransform.description
 
   /** eliminate self symbol in ClassInfo */
   override def transformInfo(tp: Type, sym: Symbol)(using Context): Type = tp match {

--- a/compiler/src/dotty/tools/dotc/transform/Flatten.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Flatten.scala
@@ -14,7 +14,9 @@ import util.Store
 class Flatten extends MiniPhase with SymTransformer {
   import ast.tpd._
 
-  override def phaseName: String = "flatten"
+  override def phaseName: String = Flatten.name
+
+  override def description: String = Flatten.description
 
   // private[this] and protected[this] modifiers must be dropped
   // before classes are lifted. Getters drop these modifiers.
@@ -56,3 +58,7 @@ class Flatten extends MiniPhase with SymTransformer {
   override def transformTypeDef(tree: TypeDef)(using Context): Tree =
     liftIfNested(tree)
 }
+
+object Flatten:
+  val name: String = "flatten"
+  val description: String = "lift all inner classes to package scope"

--- a/compiler/src/dotty/tools/dotc/transform/ForwardDepChecks.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ForwardDepChecks.scala
@@ -15,6 +15,7 @@ object ForwardDepChecks:
   import tpd.*
 
   val name: String = "forwardDepChecks"
+  val description: String = "ensure no forward references to local vals"
 
   type LevelAndIndex = immutable.Map[Symbol, (LevelInfo, Int)]
 
@@ -57,6 +58,8 @@ class ForwardDepChecks extends MiniPhase:
   import tpd.*
 
   override def phaseName: String = ForwardDepChecks.name
+
+  override def description: String = ForwardDepChecks.description
 
   override def runsAfter: Set[String] = Set(ElimByName.name)
 

--- a/compiler/src/dotty/tools/dotc/transform/FunctionXXLForwarders.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FunctionXXLForwarders.scala
@@ -25,7 +25,9 @@ import Types._
 class FunctionXXLForwarders extends MiniPhase with IdentityDenotTransformer {
   import ast.tpd._
 
-  override def phaseName: String = "functionXXLForwarders"
+  override def phaseName: String = FunctionXXLForwarders.name
+
+  override def description: String = FunctionXXLForwarders.description
 
   override def transformTemplate(impl: Template)(using Context): Template = {
 
@@ -59,3 +61,6 @@ class FunctionXXLForwarders extends MiniPhase with IdentityDenotTransformer {
   }
 }
 
+object FunctionXXLForwarders:
+  val name: String = "functionXXLForwarders"
+  val description: String = "add forwarders for FunctionXXL apply methods"

--- a/compiler/src/dotty/tools/dotc/transform/Getters.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Getters.scala
@@ -62,6 +62,8 @@ class Getters extends MiniPhase with SymTransformer { thisPhase =>
 
   override def phaseName: String = Getters.name
 
+  override def description: String = Getters.description
+
   override def transformSym(d: SymDenotation)(using Context): SymDenotation = {
     def noGetterNeeded =
       d.isOneOf(NoGetterNeededFlags) ||
@@ -120,4 +122,5 @@ class Getters extends MiniPhase with SymTransformer { thisPhase =>
 
 object Getters {
   val name: String = "getters"
+  val description: String = "replace non-private vals and vars with getter defs"
 }

--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -16,6 +16,7 @@ import SymUtils._
 
 object HoistSuperArgs {
   val name: String = "hoistSuperArgs"
+  val description: String = "hoist complex arguments of supercalls to enclosing scope"
 }
 
 /** This phase hoists complex arguments of supercalls and this-calls out of the enclosing class.
@@ -43,7 +44,9 @@ object HoistSuperArgs {
 class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase =>
   import ast.tpd._
 
-  def phaseName: String = HoistSuperArgs.name
+  override def phaseName: String = HoistSuperArgs.name
+
+  override def description: String = HoistSuperArgs.description
 
   override def runsAfter: Set[String] = Set(ElimByName.name)
     // By name closures need to be introduced first in order to be hoisted out here.

--- a/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
@@ -29,7 +29,9 @@ import ast.TreeTypeMap
 class InlinePatterns extends MiniPhase:
   import ast.tpd._
 
-  def phaseName: String = "inlinePatterns"
+  override def phaseName: String = InlinePatterns.name
+
+  override def description: String = InlinePatterns.description
 
   // This phase needs to run after because it need to transform trees that are generated
   // by the pattern matcher but are still not visible in that group of phases.
@@ -59,3 +61,8 @@ class InlinePatterns extends MiniPhase:
           case List(ddef @ DefDef(`name`, _, _, _)) => BetaReduce(ddef, args)
           case _ => tree
       case _ => tree
+
+object InlinePatterns:
+  val name: String = "inlinePatterns"
+  val description: String = "remove placeholders of inlined patterns"
+

--- a/compiler/src/dotty/tools/dotc/transform/InlineVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InlineVals.scala
@@ -14,7 +14,9 @@ import dotty.tools.dotc.typer.Inliner
 class InlineVals extends MiniPhase:
   import ast.tpd._
 
-  def phaseName: String = "inlineVals"
+  override def phaseName: String = InlineVals.name
+
+  override def description: String = InlineVals.description
 
   override def checkPostCondition(tree: Tree)(using Context): Unit =
     if !ctx.erasedTypes then
@@ -51,3 +53,7 @@ class InlineVals extends MiniPhase:
           else
             report.error(em"inline value must contain a literal constant value.\n\nTo inline more complex types consider using `inline def`", rhs)
   }
+
+object InlineVals:
+  val name: String = "inlineVals"
+  val description: String = "check right hand-sides of an `inline val`s"

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -37,6 +37,8 @@ class Inlining extends MacroTransform {
 
   override def phaseName: String = Inlining.name
 
+  override def description: String = Inlining.description
+
   override def allowsImplicitSearch: Boolean = true
 
   override def run(using Context): Unit =
@@ -98,3 +100,4 @@ class Inlining extends MacroTransform {
 
 object Inlining:
   val name: String = "inlining"
+  val description: String = "inline and execute macros"

--- a/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
@@ -23,7 +23,9 @@ import Constants.Constant
 class Instrumentation extends MiniPhase { thisPhase =>
   import ast.tpd._
 
-  override def phaseName: String = "instrumentation"
+  override def phaseName: String = Instrumentation.name
+
+  override def description: String = Instrumentation.description
 
   override def isEnabled(using Context) =
     ctx.settings.Yinstrument.value
@@ -105,3 +107,7 @@ class Instrumentation extends MiniPhase { thisPhase =>
       tree
   }
 }
+
+object Instrumentation:
+  val name: String = "instrumentation"
+  val description: String = "count calls and allocations under -Yinstrument"

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -13,6 +13,7 @@ import dotty.tools.dotc.transform.MegaPhase.MiniPhase
 
 object InterceptedMethods {
   val name: String = "intercepted"
+  val description: String = "handling of `==`, `|=`, `getClass` methods"
 }
 
 /** Replace member references as follows:
@@ -26,6 +27,8 @@ class InterceptedMethods extends MiniPhase {
   import tpd._
 
   override def phaseName: String = InterceptedMethods.name
+
+  override def description: String = InterceptedMethods.description
 
   // this should be removed if we have guarantee that ## will get Apply node
   override def transformSelect(tree: tpd.Select)(using Context): Tree =

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -23,6 +23,7 @@ object LambdaLift:
   import ast.tpd._
 
   val name: String = "lambdaLift"
+  val description: String = "lifts out nested functions to class scope"
 
   /** The core lambda lift functionality. */
   class Lifter(thisPhase: MiniPhase & DenotTransformer)(using Context):
@@ -265,8 +266,9 @@ class LambdaLift extends MiniPhase with IdentityDenotTransformer { thisPhase =>
   import LambdaLift._
   import ast.tpd._
 
-  /** the following two members override abstract members in Transform */
-  val phaseName: String = LambdaLift.name
+  override def phaseName: String = LambdaLift.name
+
+  override def description: String = LambdaLift.description
 
   override def relaxedTypingInGroup: Boolean = true
     // Because it adds free vars as additional proxy parameters

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -30,6 +30,8 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
 
   override def phaseName: String = LazyVals.name
 
+  override def description: String = LazyVals.description
+
   /** List of names of phases that should have finished processing of tree
     * before this phase starts processing same tree */
   override def runsAfter: Set[String] = Set(Mixin.name, CollectNullableFields.name)
@@ -439,6 +441,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
 
 object LazyVals {
   val name: String = "lazyVals"
+  val description: String = "expand lazy vals"
 
   object lazyNme {
     import Names.TermName

--- a/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
@@ -15,7 +15,9 @@ import ast.Trees._
 class LetOverApply extends MiniPhase:
   import ast.tpd._
 
-  override def phaseName: String = "letOverApply"
+  override def phaseName: String = LetOverApply.name
+
+  override def description: String = LetOverApply.description
 
   override def transformApply(tree: Apply)(using Context): Tree =
     tree.fun match
@@ -30,3 +32,7 @@ class LetOverApply extends MiniPhase:
         tree
 
 end LetOverApply
+
+object LetOverApply:
+  val name: String = "letOverApply"
+  val description: String = "lift blocks from receivers of applications"

--- a/compiler/src/dotty/tools/dotc/transform/LiftTry.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LiftTry.scala
@@ -30,7 +30,9 @@ import util.Store
 class LiftTry extends MiniPhase with IdentityDenotTransformer { thisPhase =>
   import ast.tpd._
 
-  val phaseName: String = LiftTry.name
+  override def phaseName: String = LiftTry.name
+
+  override def description: String = LiftTry.description
 
   private var NeedLift: Store.Location[Boolean] = _
   private def needLift(using Context): Boolean = ctx.store(NeedLift)
@@ -83,3 +85,4 @@ class LiftTry extends MiniPhase with IdentityDenotTransformer { thisPhase =>
 }
 object LiftTry:
   val name = "liftTry"
+  val description: String = "Lifts try's that might be executed on non-empty expression stacks"

--- a/compiler/src/dotty/tools/dotc/transform/Memoize.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Memoize.scala
@@ -22,6 +22,7 @@ import util.Store
 
 object Memoize {
   val name: String = "memoize"
+  val description: String = "add private fields to getters and setters"
 
   private final class MyState {
     val classesThatNeedReleaseFence = new util.HashSet[Symbol]
@@ -48,6 +49,8 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
   import ast.tpd._
 
   override def phaseName: String = Memoize.name
+
+  override def description: String = Memoize.description
 
   private var MyState: Store.Location[MyState] = _
   private def myState(using Context): MyState = ctx.store(MyState)

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -22,6 +22,7 @@ import collection.mutable
 
 object Mixin {
   val name: String = "mixin"
+  val description: String = "expand trait fields and trait initializers"
 
   def traitSetterName(getter: TermSymbol)(using Context): TermName =
     getter.ensureNotPrivate.name
@@ -111,6 +112,8 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
   import ast.tpd._
 
   override def phaseName: String = Mixin.name
+
+  override def description: String = Mixin.description
 
   override def relaxedTypingInGroup: Boolean = true
     // Because it changes number of parameters in trait initializers

--- a/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
@@ -26,6 +26,8 @@ class MoveStatics extends MiniPhase with SymTransformer {
 
   override def phaseName: String = MoveStatics.name
 
+  override def description: String = MoveStatics.description
+
   def transformSym(sym: SymDenotation)(using Context): SymDenotation =
     if (sym.hasAnnotation(defn.ScalaStaticAnnot) && sym.owner.is(Flags.Module) && sym.owner.companionClass.exists &&
         (sym.is(Flags.Method) || !(sym.is(Flags.Mutable) && sym.owner.companionClass.is(Flags.Trait)))) {
@@ -88,4 +90,5 @@ class MoveStatics extends MiniPhase with SymTransformer {
 
 object MoveStatics {
   val name: String = "moveStatic"
+  val description: String = "move static methods from companion to the class itself"
 }

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -10,6 +10,10 @@ import config.SourceVersion._
 
 object NonLocalReturns {
   import ast.tpd._
+
+  val name: String = "nonLocalReturns"
+  val description: String = "expand non-local returns"
+
   def isNonLocalReturn(ret: Return)(using Context): Boolean =
     !ret.from.symbol.is(Label) && (ret.from.symbol != ctx.owner.enclosingMethod || ctx.owner.is(Lazy))
 }
@@ -17,7 +21,10 @@ object NonLocalReturns {
 /** Implement non-local returns using NonLocalReturnControl exceptions.
  */
 class NonLocalReturns extends MiniPhase {
-  override def phaseName: String = "nonLocalReturns"
+
+  override def phaseName: String = NonLocalReturns.name
+
+  override def description: String = NonLocalReturns.description
 
   import NonLocalReturns._
   import ast.tpd._

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -36,7 +36,9 @@ class ParamForwarding extends MiniPhase with IdentityDenotTransformer:
 
   private def thisPhase: ParamForwarding = this
 
-  val phaseName: String = "paramForwarding"
+  override def phaseName: String = ParamForwarding.name
+
+  override def description: String = ParamForwarding.description
 
   def transformIfParamAlias(mdef: ValOrDefDef)(using Context): Tree =
 
@@ -80,3 +82,7 @@ class ParamForwarding extends MiniPhase with IdentityDenotTransformer:
 
   override def transformDefDef(mdef: DefDef)(using Context): Tree =
     transformIfParamAlias(mdef)
+
+object ParamForwarding:
+  val name: String = "paramForwarding"
+  val description: String = "add forwarders for aliases of superclass parameters"

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -27,6 +27,9 @@ class PatternMatcher extends MiniPhase {
   import PatternMatcher._
 
   override def phaseName: String = PatternMatcher.name
+
+  override def description: String = PatternMatcher.description
+
   override def runsAfter: Set[String] = Set(ElimRepeated.name)
 
   override def transformMatch(tree: Match)(using Context): Tree =
@@ -53,6 +56,7 @@ object PatternMatcher {
   import ast.tpd._
 
   val name: String = "patternMatcher"
+  val description: String = "compile pattern matches"
 
   inline val selfCheck = false // debug option, if on we check that no case gets generated twice
 

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -73,6 +73,8 @@ class PickleQuotes extends MacroTransform {
 
   override def phaseName: String = PickleQuotes.name
 
+  override def description: String = PickleQuotes.description
+
   override def allowsImplicitSearch: Boolean = true
 
   override def checkPostCondition(tree: Tree)(using Context): Unit =
@@ -528,6 +530,7 @@ object PickleQuotes {
   import tpd._
 
   val name: String = "pickleQuotes"
+  val description: String = "turn quoted trees into explicit run-time data structures"
 
   def getLiteral(tree: tpd.Tree): Option[Literal] = tree match {
     case tree: Literal => Some(tree)

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -18,6 +18,7 @@ import scala.concurrent.duration.Duration
 
 object Pickler {
   val name: String = "pickler"
+  val description: String = "generates TASTy info"
 
   /** If set, perform jump target compacting, position and comment pickling,
    *  as well as final assembly in parallel with downstream phases; force
@@ -31,6 +32,8 @@ class Pickler extends Phase {
   import ast.tpd._
 
   override def phaseName: String = Pickler.name
+
+  override def description: String = Pickler.description
 
   // No need to repickle trees coming from TASTY
   override def isRunnable(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/transform/PostInlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostInlining.scala
@@ -13,6 +13,9 @@ class PostInlining extends MacroTransform, IdentityDenotTransformer:
   thisPhase =>
 
   override def phaseName: String = PostInlining.name
+
+  override def description: String = PostInlining.description
+
   override def changesMembers = true
 
   override def run(using Context): Unit =
@@ -32,3 +35,4 @@ class PostInlining extends MacroTransform, IdentityDenotTransformer:
 
 object PostInlining:
   val name: String = "postInlining"
+  val description: String = "add mirror support for inlined code"

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -17,6 +17,7 @@ import reporting._
 
 object PostTyper {
   val name: String = "posttyper"
+  val description: String = "additional checks and cleanups after type checking"
 }
 
 /** A macro transform that runs immediately after typer and that performs the following functions:
@@ -57,8 +58,9 @@ object PostTyper {
 class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase =>
   import tpd._
 
-  /** the following two members override abstract members in Transform */
   override def phaseName: String = PostTyper.name
+
+  override def description: String = PostTyper.description
 
   override def checkPostCondition(tree: tpd.Tree)(using Context): Unit = tree match {
     case tree: ValOrDefDef =>

--- a/compiler/src/dotty/tools/dotc/transform/ProtectedAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ProtectedAccessors.scala
@@ -18,6 +18,7 @@ import dotty.tools.dotc.util.Property
  */
 object ProtectedAccessors {
   val name: String = "protectedAccessors"
+  val description: String = "add accessors for protected members"
 
   /** Is the current context's owner inside the access boundary established by `sym`? */
   def insideBoundaryOf(sym: Symbol)(using Context): Boolean =
@@ -50,6 +51,8 @@ class ProtectedAccessors extends MiniPhase {
   import ast.tpd._
 
   override def phaseName: String = ProtectedAccessors.name
+
+  override def description: String = ProtectedAccessors.description
 
   private val AccessorsKey = new Property.Key[Accessors]
 

--- a/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
@@ -30,6 +30,8 @@ class PruneErasedDefs extends MiniPhase with SymTransformer { thisTransform =>
 
   override def phaseName: String = PruneErasedDefs.name
 
+  override def description: String = PruneErasedDefs.description
+
   override def changesMembers: Boolean = true   // makes erased members private
 
   override def runsAfterGroupsOf: Set[String] = Set(RefChecks.name, ExplicitOuter.name)
@@ -74,6 +76,7 @@ object PruneErasedDefs {
   import tpd._
 
   val name: String = "pruneErasedDefs"
+  val description: String = "drop erased definitions and simplify erased expressions"
 
   def trivialErasedTree(tree: Tree)(using Context): Tree =
     ref(defn.Compiletime_erasedValue).appliedToType(tree.tpe).withSpan(tree.span)

--- a/compiler/src/dotty/tools/dotc/transform/PureStats.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PureStats.scala
@@ -9,6 +9,7 @@ import Symbols._, StdNames._, Trees._
 
 object PureStats {
   val name: String = "pureStats"
+  val description: String = "remove pure statements in blocks"
 }
 
 /** Remove pure statements in blocks */
@@ -17,6 +18,8 @@ class PureStats extends MiniPhase {
   import tpd._
 
   override def phaseName: String = PureStats.name
+
+  override def description: String = PureStats.description
 
   override def runsAfter: Set[String] = Set(Erasure.name)
 

--- a/compiler/src/dotty/tools/dotc/transform/RepeatableAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/RepeatableAnnotations.scala
@@ -12,7 +12,10 @@ import Types._
 import Decorators._
 
 class RepeatableAnnotations extends MiniPhase:
-  override def phaseName = "repeatableAnnotations"
+
+  override def phaseName: String = RepeatableAnnotations.name
+
+  override def description: String = RepeatableAnnotations.description
 
   override def transformTypeDef(tree: TypeDef)(using Context): Tree = transformDef(tree)
   override def transformValDef(tree: ValDef)(using Context): Tree = transformDef(tree)
@@ -46,3 +49,7 @@ class RepeatableAnnotations extends MiniPhase:
             Nil
       case (_, anns) => anns
     }.toList
+
+object RepeatableAnnotations:
+  val name: String = "repeatableAnnotations"
+  val description: String = "aggregate repeatable annotations"

--- a/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
@@ -35,6 +35,8 @@ class ResolveSuper extends MiniPhase with IdentityDenotTransformer { thisPhase =
 
   override def phaseName: String = ResolveSuper.name
 
+  override def description: String = ResolveSuper.description
+
   override def runsAfter: Set[String] = Set(ElimByName.name, // verified empirically, need to figure out what the reason is.
                                PruneErasedDefs.name) // Erased decls make `isCurrent` work incorrectly
 
@@ -72,6 +74,7 @@ class ResolveSuper extends MiniPhase with IdentityDenotTransformer { thisPhase =
 
 object ResolveSuper {
   val name: String = "resolveSuper"
+  val description: String = "implement super accessors"
 
   /** Returns the symbol that is accessed by a super-accessor in a mixin composition.
    *

--- a/compiler/src/dotty/tools/dotc/transform/RestoreScopes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/RestoreScopes.scala
@@ -16,7 +16,10 @@ import StdNames._
  */
 class RestoreScopes extends MiniPhase with IdentityDenotTransformer { thisPhase =>
   import ast.tpd._
-  override def phaseName: String = "restoreScopes"
+
+  override def phaseName: String = RestoreScopes.name
+
+  override def description: String = RestoreScopes.description
 
   override def changesMembers: Boolean = true // the phase affects scopes, applying tree transformations of previous phases
 
@@ -50,3 +53,6 @@ class RestoreScopes extends MiniPhase with IdentityDenotTransformer { thisPhase 
   }
 }
 
+object RestoreScopes:
+  val name: String = "restoreScopes"
+  val description: String = "repair rendered invalid scopes"

--- a/compiler/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -46,7 +46,9 @@ import dotty.tools.dotc.transform.SymUtils._
 class SelectStatic extends MiniPhase with IdentityDenotTransformer {
   import ast.tpd._
 
-  override def phaseName: String = "selectStatic"
+  override def phaseName: String = SelectStatic.name
+
+  override def description: String = SelectStatic.description
 
   override def transformSelect(tree: tpd.Select)(using Context): tpd.Tree = {
     val sym = tree.symbol
@@ -94,3 +96,7 @@ class SelectStatic extends MiniPhase with IdentityDenotTransformer {
   override def transformClosure(tree: tpd.Closure)(using Context): tpd.Tree =
     normalize(tree)
 }
+
+object SelectStatic:
+  val name: String = "selectStatic"
+  val description: String = "get rid of selects that would be compiled into GetStatic"

--- a/compiler/src/dotty/tools/dotc/transform/SeqLiterals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SeqLiterals.scala
@@ -17,7 +17,10 @@ import Contexts._
 class SeqLiterals extends MiniPhase {
   import ast.tpd._
 
-  override def phaseName: String = "seqLiterals"
+  override def phaseName: String = SeqLiterals.name
+
+  override def description: String = SeqLiterals.description
+
   override def runsAfter: Set[String] = Set(PatternMatcher.name)
 
   override def checkPostCondition(tree: Tree)(using Context): Unit = tree match {
@@ -34,3 +37,8 @@ class SeqLiterals extends MiniPhase {
       wrapArray(arr, elemtp).withSpan(tree.span).ensureConforms(tree.tpe)
   }
 }
+
+object SeqLiterals:
+  val name: String = "seqLiterals"
+  val description: String = "express vararg arguments as arrays"
+

--- a/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
@@ -9,6 +9,9 @@ import dotty.tools.dotc.core.Phases.Phase
 class SetRootTree extends Phase {
 
   override val phaseName: String = SetRootTree.name
+
+  override val description: String = SetRootTree.description
+
   override def isRunnable(using Context) =
     super.isRunnable && ctx.settings.YretainTrees.value
 
@@ -43,4 +46,5 @@ class SetRootTree extends Phase {
 
 object SetRootTree {
   val name: String = "SetRootTree"
+  val description: String = "set the rootTreeOrProvider on class symbols"
 }

--- a/compiler/src/dotty/tools/dotc/transform/SpecializeApplyMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeApplyMethods.scala
@@ -20,7 +20,9 @@ import scala.collection.mutable
 class SpecializeApplyMethods extends MiniPhase with InfoTransformer {
   import ast.tpd._
 
-  val phaseName = "specializeApplyMethods"
+  override def phaseName: String = SpecializeApplyMethods.name
+
+  override def description: String = SpecializeApplyMethods.description
 
   override def isEnabled(using Context): Boolean =
     !ctx.settings.scalajs.value
@@ -116,3 +118,7 @@ class SpecializeApplyMethods extends MiniPhase with InfoTransformer {
       tree
   }
 }
+
+object SpecializeApplyMethods:
+  val name: String = "specializeApplyMethods"
+  val description: String = "adds specialized methods to FunctionN"

--- a/compiler/src/dotty/tools/dotc/transform/SpecializeFunctions.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeFunctions.scala
@@ -13,7 +13,11 @@ import scala.collection.mutable
  */
 class SpecializeFunctions extends MiniPhase {
   import ast.tpd._
-  val phaseName = "specializeFunctions"
+
+  override def phaseName: String = SpecializeFunctions.name
+
+  override def description: String = SpecializeFunctions.description
+
   override def runsAfter = Set(ElimByName.name)
 
   override def isEnabled(using Context): Boolean =
@@ -105,3 +109,7 @@ class SpecializeFunctions extends MiniPhase {
       p == defn.Function0 || p == defn.Function1 || p == defn.Function2
     }
 }
+
+object SpecializeFunctions:
+  val name: String = "specializeFunctions"
+  val description: String = "specialize Function{0,1,2} by replacing super with specialized super"

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -34,6 +34,8 @@ class Staging extends MacroTransform {
 
   override def phaseName: String = Staging.name
 
+  override def description: String = Staging.description
+
   override def runsAfter: Set[String] = Set(Inlining.name)
 
   override def allowsImplicitSearch: Boolean = true
@@ -85,4 +87,5 @@ class Staging extends MacroTransform {
 
 object Staging {
   val name: String = "staging"
+  val description: String = "check staging levels and heal staged types"
 }

--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -113,6 +113,8 @@ class TailRec extends MiniPhase {
 
   override def phaseName: String = TailRec.name
 
+  override def description: String = TailRec.description
+
   override def runsAfter: Set[String] = Set(Erasure.name) // tailrec assumes erased types
 
   override def transformDefDef(tree: DefDef)(using Context): Tree = {
@@ -444,4 +446,5 @@ class TailRec extends MiniPhase {
 
 object TailRec {
   val name: String = "tailrec"
+  val description: String = "rewrite tail recursion to loops"
 }

--- a/compiler/src/dotty/tools/dotc/transform/TransformWildcards.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TransformWildcards.scala
@@ -14,7 +14,9 @@ import ast.tpd
 class TransformWildcards extends MiniPhase with IdentityDenotTransformer {
   import tpd._
 
-  override def phaseName: String = "transformWildcards"
+  override def phaseName: String = TransformWildcards.name
+
+  override def description: String = TransformWildcards.description
 
   override def checkPostCondition(tree: Tree)(using Context): Unit =
     tree match {
@@ -26,3 +28,7 @@ class TransformWildcards extends MiniPhase with IdentityDenotTransformer {
     if (ctx.owner.isClass) tree
     else cpy.ValDef(tree)(rhs = tree.rhs.wildcardToDefault)
 }
+
+object TransformWildcards:
+  val name: String = "transformWildcards"
+  val description: String = "replace wildcards with default values"

--- a/compiler/src/dotty/tools/dotc/transform/TryCatchPatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TryCatchPatterns.scala
@@ -42,7 +42,9 @@ import dotty.tools.dotc.util.Spans.Span
 class TryCatchPatterns extends MiniPhase {
   import dotty.tools.dotc.ast.tpd._
 
-  def phaseName: String = "tryCatchPatterns"
+  override def phaseName: String = TryCatchPatterns.name
+
+  override def description: String = TryCatchPatterns.description
 
   override def runsAfter: Set[String] = Set(ElimRepeated.name)
 
@@ -98,3 +100,6 @@ class TryCatchPatterns extends MiniPhase {
     }
 }
 
+object TryCatchPatterns:
+  val name: String = "tryCatchPatterns"
+  val description: String = "compile cases in try/catch"

--- a/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
@@ -21,7 +21,9 @@ import scala.annotation.tailrec
 class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
   import tpd._
 
-  def phaseName: String = "genericTuples"
+  override def phaseName: String = TupleOptimizations.name
+
+  override def description: String = TupleOptimizations.description
 
   override def transformApply(tree: tpd.Apply)(using Context): tpd.Tree =
     if (!tree.symbol.exists || tree.symbol.owner != defn.RuntimeTuplesModuleClass) tree
@@ -218,3 +220,6 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
     (0 until size).map(i => tup.select(nme.selectorName(i))).toList
 }
 
+object TupleOptimizations:
+  val name: String = "genericTuples"
+  val description: String = "optimize generic operations on tuples"

--- a/compiler/src/dotty/tools/dotc/transform/UncacheGivenAliases.scala
+++ b/compiler/src/dotty/tools/dotc/transform/UncacheGivenAliases.scala
@@ -15,6 +15,7 @@ import ast.tpd
 
 object UncacheGivenAliases:
   val name: String = "uncacheGivenAliases"
+  val description: String = "avoid caching RHS of simple parameterless given aliases"
 
 /** This phase optimizes alias givens represented as lazy vals to be uncached
  *  if that does not change runtime behavior. A definition does not need to be
@@ -29,6 +30,8 @@ class UncacheGivenAliases extends MiniPhase with IdentityDenotTransformer:
   import tpd._
 
   override def phaseName: String = UncacheGivenAliases.name
+
+  override def description: String = UncacheGivenAliases.description
 
   private def needsCache(sym: Symbol, rhs: Tree)(using Context): Boolean = rhs.tpe match
     case rhsTpe @ TermRef(NoPrefix, _)

--- a/compiler/src/dotty/tools/dotc/transform/UninitializedDefs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/UninitializedDefs.scala
@@ -27,6 +27,8 @@ class UninitializedDefs extends MiniPhase:
 
   override def phaseName: String = UninitializedDefs.name
 
+  override def description: String = UninitializedDefs.description
+
   override def transformValDef(tree: ValDef)(using Context): Tree =
     if !hasUninitializedRHS(tree) then tree
     else cpy.ValDef(tree)(rhs = cpy.Ident(tree.rhs)(nme.WILDCARD).withType(tree.tpt.tpe))
@@ -46,4 +48,5 @@ end UninitializedDefs
 
 object UninitializedDefs:
   val name: String = "uninitializedDefs"
+  val description: String = "replaces `compiletime.uninitialized` by `_`"
 end UninitializedDefs

--- a/compiler/src/dotty/tools/dotc/transform/VCElideAllocations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/VCElideAllocations.scala
@@ -18,7 +18,9 @@ import TreeExtractors._, ValueClasses._
 class VCElideAllocations extends MiniPhase with IdentityDenotTransformer {
   import tpd._
 
-  override def phaseName: String = "vcElideAllocations"
+  override def phaseName: String = VCElideAllocations.name
+
+  override def description: String = VCElideAllocations.description
 
   override def runsAfter: Set[String] = Set(ElimErasedValueType.name)
 
@@ -47,3 +49,7 @@ class VCElideAllocations extends MiniPhase with IdentityDenotTransformer {
         tree
     }
 }
+
+object VCElideAllocations:
+  val name: String = "vcElideAllocations"
+  val description: String = "peep-hole optimization to eliminate unnecessary value class allocations"

--- a/compiler/src/dotty/tools/dotc/transform/VCInlineMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/VCInlineMethods.scala
@@ -42,7 +42,9 @@ import ExtensionMethods._, ValueClasses._
 class VCInlineMethods extends MiniPhase with IdentityDenotTransformer {
   import tpd._
 
-  override def phaseName: String = "vcInlineMethods"
+  override def phaseName: String = VCInlineMethods.name
+
+  override def description: String = VCInlineMethods.description
 
   override def runsAfter: Set[String] =
     Set(ExtensionMethods.name, PatternMatcher.name)
@@ -105,3 +107,7 @@ class VCInlineMethods extends MiniPhase with IdentityDenotTransformer {
   override def transformApply(tree: Apply)(using Context): Tree =
     rewireIfNeeded(tree)
 }
+
+object VCInlineMethods:
+  val name: String = "vcInlineMethods"
+  val description: String = "inlines calls to value class methods"

--- a/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala
+++ b/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala
@@ -14,7 +14,9 @@ import dotty.tools.dotc.util.SourceFile
 class YCheckPositions extends Phase {
   import tpd._
 
-  def phaseName: String = "inlinedPositions"
+  override def phaseName: String = YCheckPositions.name
+
+  override def description: String = YCheckPositions.description
 
   override def run(using Context): Unit = () // YCheck only
 
@@ -63,3 +65,6 @@ class YCheckPositions extends Phase {
 
 }
 
+object YCheckPositions:
+  val name: String = "inlinedPositions"
+  val description: String = "check inlined positions"

--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -22,7 +22,9 @@ import Semantic._
 
 class Checker extends Phase {
 
-  val phaseName = "initChecker"
+  override def phaseName: String = Checker.name
+
+  override def description: String = Checker.description
 
   override val runsAfter = Set(Pickler.name)
 
@@ -78,3 +80,7 @@ class Checker extends Phase {
     instantiable && cls.enclosingPackageClass != defn.StdLibPatchesPackage.moduleClass
   }
 }
+
+object Checker:
+  val name: String = "initChecker"
+  val description: String = "check initialization of objects"

--- a/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
@@ -24,7 +24,9 @@ import dotty.tools.dotc.typer.ConstFold
 class StringInterpolatorOpt extends MiniPhase {
   import tpd._
 
-  override def phaseName: String = "stringInterpolatorOpt"
+  override def phaseName: String = StringInterpolatorOpt.name
+
+  override def description: String = StringInterpolatorOpt.description
 
   override def checkPostCondition(tree: tpd.Tree)(using Context): Unit = {
     tree match {
@@ -178,3 +180,7 @@ class StringInterpolatorOpt extends MiniPhase {
   }
 
 }
+
+object StringInterpolatorOpt:
+  val name: String = "stringInterpolatorOpt"
+  val description: String = "optimize raw and s string interpolators"

--- a/compiler/src/dotty/tools/dotc/transform/sjs/AddLocalJSFakeNews.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/AddLocalJSFakeNews.scala
@@ -54,6 +54,8 @@ class AddLocalJSFakeNews extends MiniPhase { thisPhase =>
 
   override def phaseName: String = AddLocalJSFakeNews.name
 
+  override def description: String = AddLocalJSFakeNews.description
+
   override def isEnabled(using Context): Boolean =
     ctx.settings.scalajs.value
 
@@ -96,4 +98,5 @@ class AddLocalJSFakeNews extends MiniPhase { thisPhase =>
 
 object AddLocalJSFakeNews {
   val name: String = "addLocalJSFakeNews"
+  val description: String = "adds fake new invocations to local JS classes in calls to `createLocalJSClass`"
 }

--- a/compiler/src/dotty/tools/dotc/transform/sjs/ExplicitJSClasses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/ExplicitJSClasses.scala
@@ -239,6 +239,8 @@ class ExplicitJSClasses extends MiniPhase with InfoTransformer { thisPhase =>
 
   override def phaseName: String = ExplicitJSClasses.name
 
+  override def description: String = ExplicitJSClasses.description
+
   private var MyState: Store.Location[MyState] = _
   private def myState(using Context) = ctx.store(MyState)
 
@@ -720,6 +722,7 @@ class ExplicitJSClasses extends MiniPhase with InfoTransformer { thisPhase =>
 
 object ExplicitJSClasses {
   val name: String = "explicitJSClasses"
+  val description: String = "make all JS classes explicit"
 
   val LocalJSClassValueName: UniqueNameKind = new UniqueNameKind("$jsclass")
 

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
@@ -111,7 +111,9 @@ class JUnitBootstrappers extends MiniPhase {
   import JUnitBootstrappers._
   import ast.tpd._
 
-  def phaseName: String = "junitBootstrappers"
+  override def phaseName: String = JUnitBootstrappers.name
+
+  override def description: String = JUnitBootstrappers.description
 
   override def isEnabled(using Context): Boolean =
     super.isEnabled && ctx.settings.scalajs.value
@@ -312,6 +314,8 @@ class JUnitBootstrappers extends MiniPhase {
 }
 
 object JUnitBootstrappers {
+  val name: String = "junitBootstrappers"
+  val description: String = "generate JUnit-specific bootstrapper classes for Scala.js"
 
   private object junitNme {
     val beforeClass: TermName = termName("beforeClass")

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
@@ -64,6 +64,8 @@ class PrepJSInterop extends MacroTransform with IdentityDenotTransformer { thisP
 
   override def phaseName: String = PrepJSInterop.name
 
+  override def description: String = PrepJSInterop.description
+
   override def isEnabled(using Context): Boolean =
     ctx.settings.scalajs.value
 
@@ -993,6 +995,7 @@ class PrepJSInterop extends MacroTransform with IdentityDenotTransformer { thisP
 
 object PrepJSInterop {
   val name: String = "prepjsinterop"
+  val description: String = "additional checks and transformations for Scala.js"
 
   private final class OwnerKind private (private val baseKinds: Int) extends AnyVal {
     import OwnerKind._

--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -13,7 +13,9 @@ import ast.tpd
 class CrossVersionChecks extends MiniPhase:
   import tpd.*
 
-  def phaseName = "crossVersionChecks"
+  override def phaseName: String = CrossVersionChecks.name
+
+  override def description: String = CrossVersionChecks.description
 
   override def runsAfterGroupsOf: Set[String] = Set(FirstTransform.name)
     // We assume all type trees except TypeTree have been eliminated
@@ -208,3 +210,7 @@ class CrossVersionChecks extends MiniPhase:
   }
 
 end CrossVersionChecks
+
+object CrossVersionChecks:
+  val name: String = "crossVersionChecks"
+  val description: String = "check issues related to deprecated and experimental"

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -28,6 +28,7 @@ object RefChecks {
   import tpd._
 
   val name: String = "refchecks"
+  val description: String = "checks related to abstract members and overriding"
 
   private val defaultMethodFilter = new NameFilter {
     def apply(pre: Type, name: Name)(using Context): Boolean = name.is(DefaultGetterName)
@@ -1090,6 +1091,8 @@ class RefChecks extends MiniPhase { thisPhase =>
   import tpd._
 
   override def phaseName: String = RefChecks.name
+
+  override def description: String = RefChecks.description
 
   override def runsAfter: Set[String] = Set(ElimRepeated.name)
     // Needs to run after ElimRepeated for override checks involving varargs methods

--- a/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
@@ -26,7 +26,11 @@ import ast.Trees._
 class TyperPhase(addRootImports: Boolean = true) extends Phase {
 
   override def phaseName: String = TyperPhase.name
+
+  override def description: String = TyperPhase.description
+
   override def isTyper: Boolean = true
+
   import ast.tpd
 
   override def allowsImplicitSearch: Boolean = true
@@ -98,6 +102,7 @@ class TyperPhase(addRootImports: Boolean = true) extends Phase {
 
 object TyperPhase {
   val name: String = "typer"
+  val description: String = "type the trees"
 }
 
 @deprecated(message = "FrontEnd has been split into TyperPhase and Parser. Refer to one or the other.")


### PR DESCRIPTION
This change improves the usability and the display of the current
-Xshow-phases flag. Currently when this is used you just get a big
flattened list like so:

```
❯ scala3-compiler -Xshow-phases
parser
typer
inlinedPositions
sbt-deps
extractSemanticDB
posttyper
prepjsinterop
sbt-api
SetRootTree
pickler
inlining
postInlining
staging
pickleQuotes
{firstTransform, checkReentrant, elimPackagePrefixes, cookComments, checkStatic, checkLoopingImplicits, betaReduce, inlineVals, expandSAMs}
initChecker
{elimRepeated, protectedAccessors, extmethods, uncacheGivenAliases, byNameClosures, hoistSuperArgs, specializeApplyMethods, refchecks, tryCatchPatterns, patternMatcher}
{elimOpaque, explicitJSClasses, explicitOuter, explicitSelf, elimByName, stringInterpolatorOpt}
{pruneErasedDefs, uninitializedDefs, inlinePatterns, vcInlineMethods, seqLiterals, intercepted, getters, specializeFunctions, liftTry, collectNullableFields, elimOuterSelect, resolveSuper, functionXXLForwarders, paramForwarding, genericTuples, letOverApply, arrayConstructors}
erasure
{elimErasedValueType, pureStats, vcElideAllocations, arrayApply, addLocalJSFakeNews, elimPolyFunction, tailrec, completeJavaEnums, mixin, lazyVals, memoize, nonLocalReturns, capturedVars}
{constructors, instrumentation}
{lambdaLift, elimStaticThis, countOuterAccesses}
{dropOuterAccessors, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, junitBootstrappers, Collect entry points, collectSuperCalls, repeatableAnnotations}
genSJSIR
genBCode
```
This changes mimics the Scala 2 compiler and provides a more structured
output that also contains the description of the phase:

```
sbt:scala3> scala3/scalac -Xshow-phases

            phase name  description
            ----------  -----------
                parser  scan and parse sources
                 typer  type the trees
      inlinedPositions  check inlined positions
              sbt-deps  sends information on classes' dependencies to sbt
     extractSemanticDB  extract info into .semanticdb files
             posttyper  additional checks and cleanups after type checking
         prepjsinterop  additional checks and transformations for Scala.js
               sbt-api  sends a representation of the API of classes to sbt
           SetRootTree  set the rootTreeOrProvider on class symbols
               pickler  generates TASTy info
              inlining  inline and execute macros
          postInlining  add mirror support for inlined code
               staging  check staging levels and heal staged types
          pickleQuotes  turn quoted trees into explicit run-time data structures
      { firstTransform  some transformations to put trees into a canonical form
        checkReentrant  check no data races involving global vars
   elimPackagePrefixes  eliminate references to package prefixes in Select nodes
          cookComments  cook the comments: expand variables, doc, etc.
           checkStatic  check restrictions that apply to @static members
 checkLoopingImplicits  check that implicit defs do not call themselves in an infinite loop
            betaReduce  reduce closure applications
            inlineVals  check right hand-sides of an `inline val`s
            expandSAMs  expand SAM closures to anonymous classes
          elimRepeated  rewrite vararg parameters and arguments
             refchecks  checks related to abstract members and overriding }
           initChecker  check initialization of objects
  { crossVersionChecks  check issues related to deprecated and experimental
    protectedAccessors  add accessors for protected members
            extmethods  expand methods of value classes with extension methods
   uncacheGivenAliases  avoid caching RHS of simple parameterless given aliases
            elimByName  map by-name parameters to functions
        hoistSuperArgs  hoist complex arguments of supercalls to enclosing scope
      forwardDepChecks  ensure no forward references to local vals
 specializeApplyMethod  adds specialized methods to FunctionN
      tryCatchPatterns  compile cases in try/catch
        patternMatcher  compile pattern matches }
          { elimOpaque  turn opaque into normal aliases
     explicitJSClasses  make all JS classes explicit
         explicitOuter  add accessors to outer classes from nested ones
          explicitSelf  make references to non-trivial self types explicit as casts
 stringInterpolatorOpt  optimize raw and s string interpolators }
     { pruneErasedDefs  drop erased definitions and simplify erased expressions
     uninitializedDefs  replaces `compiletime.uninitialized` by `_`
        inlinePatterns  remove placeholders of inlined patterns
       vcInlineMethods  inlines calls to value class methods
           seqLiterals  express vararg arguments as arrays
           intercepted  handling of `==`, `|=`, `getClass` methods
               getters  replace non-private vals and vars with getter defs
   specializeFunctions  specialize Function{0,1,2} by replacing super with specialized super
               liftTry  Lifts try's that might be executed on non-empty expression stacks
 collectNullableFields  collect fields that can be nulled out after use in lazy initialization
       elimOuterSelect  expand outer selections
          resolveSuper  implement super accessors
 functionXXLForwarders  add forwarders for FunctionXXL apply methods
       paramForwarding  add forwarders for aliases of superclass parameters
         genericTuples  optimize generic operations on tuples
          letOverApply  lift blocks from receivers of applications
     arrayConstructors  intercept creation of (non-generic) arrays and intrinsify }
               erasure  rewrite types to JVM model
 { elimErasedValueType  expand erased value types to their underlying implmementation types
             pureStats  remove pure statements in blocks
    vcElideAllocations  peep-hole optimization to eliminate unnecessary value class allocations
             etaReduce  reduce eta expansions of pure paths
            arrayApply  optimize `scala.Array.apply`
    addLocalJSFakeNews  adds fake new invocations to local JS classes in calls to `createLocalJS
      elimPolyFunction  rewrite PolyFunction subclasses to FunctionN subclasses
               tailrec  rewrite tail recursion to loops
     completeJavaEnums  fill in constructors for Java enums
                 mixin  expand trait fields and trait initializers
              lazyVals  expand lazy vals
               memoize  add private fields to getters and setters
       nonLocalReturns  expand non-local returns
          capturedVars  represent vars captured by closures as heap objects }
        { constructors  collect initialization code in primary constructors
       instrumentation  count calls and allocations under -Yinstrument }
          { lambdaLift  lifts out nested functions to class scope
        elimStaticThis  replace This references to static objects by global identifiers
    countOuterAccesses  identify outer accessors that can be dropped }
  { dropOuterAccessors  drop unused outer accessors
      checkNoSuperThis  check that supercalls don't contain references to This
               flatten  lift all inner classes to package scope
    transformWildcards  replace wildcards with default values
            moveStatic  move static methods from companion to the class itself
         expandPrivate  widen private definitions accessed from nested classes
         restoreScopes  repair rendered invalid scopes
          selectStatic  get rid of selects that would be compiled into GetStatic
    junitBootstrappers  generate JUnit-specific bootstrapper classes for Scala.js
  Collect entry points  collect all entry points and save them in the context
     collectSuperCalls  find classes that are called with super
 repeatableAnnotations  aggregate repeatable annotations }
              genSJSIR  generate .sjsir files for Scala.js
              genBCode  generate JVM bytecode
```

The mini-phases are still grouped and indicated by the surrounding `{}`.

There are also some small changes in all the phase files to ensure they
are all done the same way with overriding the phaseName and the
description, both provided in a companion object. The descriptions
themselves were just pulled from the comments in the code.