### PR TITLE
Fix - after cleanup run checkout to back to repo directory

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Cleanup
         run: .github/workflows/cleanup.sh
 
+      - name: Git Checkout
+        uses: actions/checkout@v2
+
       - name: Publish to SDKMAN
         run: .github/workflows/scripts/publish-sdkman.sh


### PR DESCRIPTION
Running cleanup.sh script changes the current directory and then not back to repo directory. 

[CI fails](https://github.com/lampepfl/dotty/runs/5024790712?check_suite_focus=true) - because cleanup.sh change current directory. 