### PR TITLE
Keep softness when widening unions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3263,10 +3263,10 @@ object Types {
       if myUnionPeriod != ctx.period then
         myUnion =
           if isSoft then
-            TypeComparer.lub(tp1.widenUnionWithoutNull, tp2.widenUnionWithoutNull, canConstrain = true) match
+            TypeComparer.lub(tp1.widenUnionWithoutNull, tp2.widenUnionWithoutNull, canConstrain = true, isSoft = isSoft) match
               case union: OrType => union.join
               case res => res
-          else derivedOrType(tp1.widenUnionWithoutNull, tp2.widenUnionWithoutNull)
+          else derivedOrType(tp1.widenUnionWithoutNull, tp2.widenUnionWithoutNull, soft = isSoft)
         if !isProvisional then myUnionPeriod = ctx.period
       myUnion
 
@@ -3282,7 +3282,7 @@ object Types {
           else tp1.atoms | tp2.atoms
         val tp1w = tp1.widenSingletons
         val tp2w = tp2.widenSingletons
-        myWidened = if ((tp1 eq tp1w) && (tp2 eq tp2w)) this else tp1w | tp2w
+        myWidened = if ((tp1 eq tp1w) && (tp2 eq tp2w)) this else TypeComparer.lub(tp1w, tp2w, isSoft = isSoft)
         atomsRunId = ctx.runId
 
     override def atoms(using Context): Atoms =

--- a/tests/pos/widen-union.scala
+++ b/tests/pos/widen-union.scala
@@ -5,6 +5,11 @@ object Test1:
   val z: Int | String = y
 
 object Test2:
+  val x: 3 | "a" = 3
+  val y = x
+  val z: Int | String = y
+
+object Test3:
   type Sig = Int | String
   def consistent(x: Sig, y: Sig): Boolean = ???// x == y
 
@@ -12,7 +17,7 @@ object Test2:
        xs.corresponds(ys)(consistent)        // OK
     || xs.corresponds(ys)(consistent(_, _))  // error, found: Any, required: Int | String
 
-object Test3:
+object Test4:
 
   def g[X](x: X | String): Int = ???
   def y: Boolean | String = ???


### PR DESCRIPTION
_Hard_ unions are union types explicitly written by the user, while _soft_ unions are created by the compiler (for example as the result of a condition or a match). The former should not be widened, while the later should. Currently, this does not work if the union's operands are singletons because the union looses its "hardness" qualification. This PR fixes it.

Before:
```scala
val x: Int | String = 3
val y /* : Int | String */ = x
val x2: 3 | "a" = 3
val y2 /* : Matchable */ = x2
```

After:
```scala
val x: Int | String = 3
val y /* : Int | String */ = x
val x2: 3 | "a" = 3
val y2 /* --> : Int | String <-- */ = x2
```

#14347 and #14360 are linked but have a wider scope: avoiding to widen explicit singleton types altogether. But these are not conclusive yet.