### PR TITLE
Set context when reporting summonInline errors

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inliner.scala
@@ -849,13 +849,15 @@ class Inliner(call: tpd.Tree, rhsToInline: tpd.Tree)(using Context) {
         def searchImplicit(tpt: Tree) =
           val evTyper = new Typer(ctx.nestingLevel + 1)
           val evCtx = ctx.fresh.setTyper(evTyper)
-          val evidence = evTyper.inferImplicitArg(tpt.tpe, tpt.span)(using evCtx)
-          evidence.tpe match
-            case fail: Implicits.SearchFailureType =>
-              val msg = evTyper.missingArgMsg(evidence, tpt.tpe, "")
-              errorTree(call, em"$msg")
-            case _ =>
-              evidence
+          inContext(evCtx) {
+            val evidence = evTyper.inferImplicitArg(tpt.tpe, tpt.span)
+            evidence.tpe match
+              case fail: Implicits.SearchFailureType =>
+                val msg = evTyper.missingArgMsg(evidence, tpt.tpe, "")
+                errorTree(call, em"$msg")
+              case _ =>
+                evidence
+          }
         return searchImplicit(callTypeArgs.head)
       }
 

--- a/tests/neg-macros/i13406/Qux_1.scala
+++ b/tests/neg-macros/i13406/Qux_1.scala
@@ -1,0 +1,4 @@
+// Qux_1.scala
+sealed trait Qux[T] // anonymous mirror because no companion
+object QuxImpl:
+  case class Foo[A](a: A) extends Qux[A]

--- a/tests/neg-macros/i13406/Test_2.scala
+++ b/tests/neg-macros/i13406/Test_2.scala
@@ -1,0 +1,8 @@
+// Test_2.scala
+trait Bar
+
+inline given derivedReducible(using scala.deriving.Mirror.SumOf[Qux[_]]): Bar =
+  scala.compiletime.summonInline[Bar]
+  ???
+
+def test = derivedReducible // error


### PR DESCRIPTION
Set proper context when reporting summonInline errors - and puts everything in inContext block, so this won't happen in the future.