### PR TITLE
Fix #14319: Use correct stat context when transforming Block

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeMapWithImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeMapWithImplicits.scala
@@ -48,13 +48,7 @@ class TreeMapWithImplicits extends tpd.TreeMapWithPreciseStatContexts {
   override def transform(tree: Tree)(using Context): Tree = {
     try tree match {
       case Block(stats, expr) =>
-        inContext(nestedScopeCtx(stats)) {
-          if stats.exists(_.isInstanceOf[Import]) then
-            // need to transform stats and expr together to account for import visibility
-            val stats1 = transformStats(stats :+ expr, ctx.owner)
-            cpy.Block(tree)(stats1.init, stats1.last)
-          else super.transform(tree)
-        }
+        super.transform(tree)(using nestedScopeCtx(stats))
       case tree: DefDef =>
         inContext(localCtx(tree)) {
           cpy.DefDef(tree)(

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1195,6 +1195,13 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    *    - imports are reflected in the contexts of subsequent statements
    */
   class TreeMapWithPreciseStatContexts(cpy: TreeCopier = tpd.cpy) extends TreeMap(cpy):
+    override def transform(tree: Tree)(using Context): Tree = tree match
+      case Block(stats, expr) =>
+        val stats1 = transformStats(stats :+ expr, ctx.owner)
+        cpy.Block(tree)(stats1.init, stats1.last)
+      case _ =>
+        super.transform(tree)
+
     override def transformStats(trees: List[Tree], exprOwner: Symbol)(using Context): List[Tree] =
       trees.mapStatements(exprOwner, transform(_))
 

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -296,9 +296,8 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
         }
       case tree: Block =>
         inContext(prepBlock(tree, start)(using outerCtx)) {
-          val stats = transformStats(tree.stats, ctx.owner, start)
-          val expr = transformTree(tree.expr, start)
-          goBlock(cpy.Block(tree)(stats, expr), start)
+          val stats1 = transformStats(tree.stats :+ tree.expr, ctx.owner, start)
+          goBlock(cpy.Block(tree)(stats1.init, stats1.last), start)
         }
       case tree: TypeApply =>
         inContext(prepTypeApply(tree, start)(using outerCtx)) {

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -296,8 +296,9 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
         }
       case tree: Block =>
         inContext(prepBlock(tree, start)(using outerCtx)) {
-          val stats1 = transformStats(tree.stats :+ tree.expr, ctx.owner, start)
-          goBlock(cpy.Block(tree)(stats1.init, stats1.last), start)
+          val stats = transformStats(tree.stats, ctx.owner, start)
+          val expr = transformTree(tree.expr, start)
+          goBlock(cpy.Block(tree)(stats, expr), start)
         }
       case tree: TypeApply =>
         inContext(prepTypeApply(tree, start)(using outerCtx)) {

--- a/tests/explicit-nulls/pos/unsafe-chain.scala
+++ b/tests/explicit-nulls/pos/unsafe-chain.scala
@@ -1,0 +1,10 @@
+import java.nio.file.FileSystems
+import java.util.ArrayList
+
+def directorySeparator: String =
+  import scala.language.unsafeNulls
+  FileSystems.getDefault().getSeparator()
+
+def getFirstOfFirst(xs: ArrayList[ArrayList[ArrayList[String]]]): String =
+  import scala.language.unsafeNulls
+  xs.get(0).get(0).get(0)


### PR DESCRIPTION
Fix #14319

When transforming a Block, the last expression should have import information from statements above.