### PR TITLE
Kotlin interop: Find nested class if InnerClass entry is missing

### DIFF
--- a/tests/run/i12086/Test_1.java
+++ b/tests/run/i12086/Test_1.java
@@ -1,0 +1,11 @@
+class C$D { public int i() { return 1; } }
+class C$E { public int i() { return 1; } }
+class C$F$G { public int i() { return 1; } }
+
+// Test1 has a reference to C$D, which is a top-level class in this case,
+// so there's no INNERCLASS attribute in Test1
+class Test_1 {
+  static C$D mD(C$D cd) { return cd; }
+  static C$E mE(C$E ce) { return ce; }
+  static C$F$G mG(C$F$G cg ) { return cg; }
+}

--- a/tests/run/i12086/Test_2.java
+++ b/tests/run/i12086/Test_2.java
@@ -1,0 +1,12 @@
+class C {
+  class D { public int i() { return 2; } }
+  static class E { public int i() { return 2; } }
+  static class F { static class G { public int i() { return 2; } } }
+}
+
+// Test2 has an INNERCLASS attribute for C$D
+class Test_2 {
+  public static int acceptD(C.D cd) { return cd.i(); }
+  public static int acceptE(C.E ce) { return ce.i(); }
+  public static int acceptG(C.F.G cg ) { return cg.i(); }
+}

--- a/tests/run/i12086/Test_3.scala
+++ b/tests/run/i12086/Test_3.scala
@@ -1,0 +1,8 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new C
+    assert(Test_2.acceptD(Test_1.mD(new c.D)) == 2)
+    assert(Test_2.acceptE(Test_1.mE(new C.E)) == 2)
+    assert(Test_2.acceptG(Test_1.mG(new C.F.G)) == 2)
+  }
+}


### PR DESCRIPTION
This is a port of https://github.com/scala/scala/pull/5822 which works
around a bug in Kotlin (https://youtrack.jetbrains.com/issue/KT-27936).

Fixes #12086.

Co-Authored-By: Lukas Rytz <lukas.rytz@gmail.com>
Co-Authored-By: Brandon Barker <beb82@cornell.edu>