### PR TITLE
Scaladoc: Make member filtering case-insensitive

### DIFF
--- a/scaladoc/resources/dotty_res/scripts/components/DocumentableList.js
+++ b/scaladoc/resources/dotty_res/scripts/components/DocumentableList.js
@@ -139,7 +139,9 @@ class List {
       : includesInputValue()
 
     function includesInputValue() {
-      return elementData.name.includes(filter.value) || elementData.description.includes(filter.value);
+      const lcValue = filter.value.toLowerCase()
+      return elementData.name.toLowerCase().includes(lcValue) 
+          || elementData.description.toLowerCase().includes(lcValue);
     }
 
     function areFiltersFromElementSelected() {

--- a/scaladoc/resources/dotty_res/scripts/components/Filter.js
+++ b/scaladoc/resources/dotty_res/scripts/components/Filter.js
@@ -75,12 +75,14 @@ class Filter {
   * @returns { Filters }
   */
   _generateFiltersOnTyping(value) {
+    const lcValue = value.toLowerCase()
+
     const elementsDatasets = this.elementsRefs
       .filter(element => {
-        const name = getElementTextContent(getElementNameRef(element));
-        const description = getElementTextContent(getElementDescription(element));
+        const lcName = getElementTextContent(getElementNameRef(element)).toLowerCase();
+        const lcDescription = getElementTextContent(getElementDescription(element)).toLowerCase();
 
-        return name.includes(value) || description.includes(value);
+        return lcName.includes(lcValue) || lcDescription.includes(lcValue);
       })
       .map(element => this._getDatasetWithKeywordData(element.dataset))
 


### PR DESCRIPTION
Both the members themselves, as well as filtering tags based on those members were taken into account. Not sure how this can be tested, other than manually.

Closes #14421