### PR TITLE
Fix #11008: Support generic tuples as a valid unapply result

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -346,9 +346,6 @@ object PatternMatcher {
                 .map(ref(unappResult).select(_))
               matchArgsPlan(selectors, args, onSuccess)
             }
-            else if unappResult.info <:< defn.NonEmptyTupleTypeRef then
-              val components = (0 until foldApplyTupleType(unappResult.denot.info).length).toList.map(tupleApp(_, ref(unappResult)))
-              matchArgsPlan(components, args, onSuccess)
             else if (isUnapplySeq && isProductSeqMatch(unapp.tpe.widen, args.length, unapp.srcPos)) {
               val arity = productArity(unapp.tpe.widen, unapp.srcPos)
               unapplyProductSeqPlan(unappResult, args, arity)
@@ -356,6 +353,9 @@ object PatternMatcher {
             else if (isUnapplySeq && unapplySeqTypeElemTp(unapp.tpe.widen.finalResultType).exists) {
               unapplySeqPlan(unappResult, args)
             }
+            else if unappResult.info <:< defn.NonEmptyTupleTypeRef then
+              val components = (0 until foldApplyTupleType(unappResult.denot.info).length).toList.map(tupleApp(_, ref(unappResult)))
+              matchArgsPlan(components, args, onSuccess)
             else {
               assert(isGetMatch(unapp.tpe))
               val argsPlan = {

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -173,6 +173,7 @@ object Applications {
       val elemTp = unapplySeqTypeElemTp(tp)
       if (elemTp.exists) args.map(Function.const(elemTp))
       else if (isProductSeqMatch(tp, args.length, pos)) productSeqSelectors(tp, args.length, pos)
+      else if tp.derivesFrom(defn.NonEmptyTupleClass) then foldApplyTupleType(tp)
       else fallback
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -193,9 +193,21 @@ object Applications {
         productSelectorTypes(unapplyResult, pos)
           // this will cause a "wrong number of arguments in pattern" error later on,
           // which is better than the message in `fail`.
+      else if unapplyResult.derivesFrom(defn.NonEmptyTupleClass) then
+        foldApplyTupleType(unapplyResult)
       else fail
     }
   }
+
+  def foldApplyTupleType(tp: Type)(using Context): List[Type] =
+    object tupleFold extends TypeAccumulator[List[Type]]:
+      override def apply(accum: List[Type], t: Type): List[Type] =
+        t match
+          case AppliedType(tycon, x :: x2 :: Nil) if tycon.typeSymbol == defn.PairClass =>
+            apply(x :: accum, x2)
+          case x => foldOver(accum, x)
+    end tupleFold
+    tupleFold(Nil, tp).reverse
 
   def wrapDefs(defs: mutable.ListBuffer[Tree], tree: Tree)(using Context): Tree =
     if (defs != null && defs.nonEmpty) tpd.Block(defs.toList, tree) else tree

--- a/tests/run/i11008.check
+++ b/tests/run/i11008.check
@@ -1,0 +1,2 @@
+hello
+hello and 10

--- a/tests/run/i11008.scala
+++ b/tests/run/i11008.scala
@@ -1,0 +1,13 @@
+object A:
+  def unapply(s: String): String *: EmptyTuple = Tuple1(s)
+
+object B:
+  def unapply(s:String): String *: Int *: EmptyTuple = Tuple2(s, 10)
+
+@main def Test =
+  "hello" match
+    case A(x) =>
+      println(x)
+  "hello" match
+    case B(x, y) =>
+      println(s"$x and $y")

--- a/tests/run/i11008b.check
+++ b/tests/run/i11008b.check
@@ -1,0 +1,1 @@
+Many 3 characters List(f, o, o)

--- a/tests/run/i11008b.scala
+++ b/tests/run/i11008b.scala
@@ -1,0 +1,7 @@
+object Foo:
+  def unapplySeq(x: String): Int *: Seq[String] *: EmptyTuple = (x.length, x.toList.map(_.toString))
+
+@main def Test =
+  "foo" match
+    case Foo(1, c) => println("One character " + c)
+    case Foo(x, xs*) => println(s"Many $x characters $xs")


### PR DESCRIPTION
On top #14296.

Done during the Issue Spree of 8th February together with @dwijnand and @prolativ 