### PR TITLE
Revert eager use of escape in interpolator

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1253,7 +1253,7 @@ object Scanners {
               nextChar()
             }
           }
-          val alt = if oct == LF then raw"\n" else f"\\u$oct%04x"
+          val alt = if oct == LF then raw"\n" else f"${"\\"}u$oct%04x"
           error(s"octal escape literals are unsupported: use $alt instead", start)
           putChar(oct.toChar)
         }

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -542,7 +542,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
     case '"' => "\\\""
     case '\'' => "\\\'"
     case '\\' => "\\\\"
-    case _ => if ch.isControl then f"\\u${ch.toInt}%04x" else String.valueOf(ch)
+    case _ => if ch.isControl then f"${"\\"}u${ch.toInt}%04x" else String.valueOf(ch)
   }
 
   def toText(const: Constant): Text = const.tag match {

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1423,7 +1423,7 @@ object SourceCode {
       case '"' => "\\\""
       case '\'' => "\\\'"
       case '\\' => "\\\\"
-      case _ => if ch.isControl then f"\\u${ch.toInt}%04x" else String.valueOf(ch)
+      case _ => if ch.isControl then f"${"\\"}u${ch.toInt}%04x" else String.valueOf(ch)
     }
 
     private def escapedString(str: String): String = str flatMap escapedChar


### PR DESCRIPTION
[test_non_bootstrapped]

Partially revert https://github.com/lampepfl/dotty/pull/13367/commits/07d809fc12639ddc7030c4f94ed348a3a4f39665 for unbootstrapped testing.