### PR TITLE
Make singleton operations covariant

### DIFF
--- a/library/src/scala/compiletime/ops/any.scala
+++ b/library/src/scala/compiletime/ops/any.scala
@@ -42,7 +42,7 @@ object any:
    * @syntax markdown
    */
   @experimental
-  type IsConst[+X] <: Boolean
+  type IsConst[X] <: Boolean
 
   /** String conversion of a constant singleton type.
    *  ```scala

--- a/library/src/scala/compiletime/ops/any.scala
+++ b/library/src/scala/compiletime/ops/any.scala
@@ -12,7 +12,7 @@ object any:
    * ```
    * @syntax markdown
    */
-  type ==[X, Y] <: Boolean
+  type ==[+X, +Y] <: Boolean
 
   /** Inequality comparison of two singleton types.
    * ```scala
@@ -22,7 +22,7 @@ object any:
    * ```
    * @syntax markdown
    */
-  type !=[X, Y] <: Boolean
+  type !=[+X, +Y] <: Boolean
 
   /** Tests if a type is a constant.
    * ```scala
@@ -42,7 +42,7 @@ object any:
    * @syntax markdown
    */
   @experimental
-  type IsConst[X] <: Boolean
+  type IsConst[+X] <: Boolean
 
   /** String conversion of a constant singleton type.
    *  ```scala
@@ -52,4 +52,4 @@ object any:
    *  @syntax markdown
    */
   @experimental
-  type ToString[X] <: String
+  type ToString[+X] <: String

--- a/library/src/scala/compiletime/ops/boolean.scala
+++ b/library/src/scala/compiletime/ops/boolean.scala
@@ -10,7 +10,7 @@ object boolean:
    *  ```
    *  @syntax markdown
    */
-  type ![X <: Boolean] <: Boolean
+  type ![+X <: Boolean] <: Boolean
 
   /** Exclusive disjunction of two `Boolean` singleton types.
    *  ```scala
@@ -19,7 +19,7 @@ object boolean:
    *  ```
    *  @syntax markdown
    */
-  type ^[X <: Boolean, Y <: Boolean] <: Boolean
+  type ^[+X <: Boolean, +Y <: Boolean] <: Boolean
 
   /** Conjunction of two `Boolean` singleton types.
    *  ```scala
@@ -28,7 +28,7 @@ object boolean:
    *  ```
    *  @syntax markdown
    */
-  type &&[X <: Boolean, Y <: Boolean] <: Boolean
+  type &&[+X <: Boolean, +Y <: Boolean] <: Boolean
 
   /** Disjunction of two `Boolean` singleton types.
    *  ```scala
@@ -37,4 +37,4 @@ object boolean:
    *  ```
    *  @syntax markdown
    */
-  type ||[X <: Boolean, Y <: Boolean] <: Boolean
+  type ||[+X <: Boolean, +Y <: Boolean] <: Boolean

--- a/library/src/scala/compiletime/ops/double.scala
+++ b/library/src/scala/compiletime/ops/double.scala
@@ -11,7 +11,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: Double, Y <: Double] <: Double
+  type +[+X <: Double, +Y <: Double] <: Double
 
   /** Subtraction of two `Double` singleton types.
    *  ```scala
@@ -19,7 +19,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type -[X <: Double, Y <: Double] <: Double
+  type -[+X <: Double, +Y <: Double] <: Double
 
   /** Multiplication of two `Double` singleton types.
    *  ```scala
@@ -27,7 +27,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type *[X <: Double, Y <: Double] <: Double
+  type *[+X <: Double, +Y <: Double] <: Double
 
   /** Integer division of two `Double` singleton types.
    *  ```scala
@@ -35,7 +35,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type /[X <: Double, Y <: Double] <: Double
+  type /[+X <: Double, +Y <: Double] <: Double
 
   /** Remainder of the division of `X` by `Y`.
    *  ```scala
@@ -43,7 +43,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type %[X <: Double, Y <: Double] <: Double
+  type %[+X <: Double, +Y <: Double] <: Double
 
   /** Less-than comparison of two `Double` singleton types.
    *  ```scala
@@ -52,7 +52,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type <[X <: Double, Y <: Double] <: Boolean
+  type <[+X <: Double, +Y <: Double] <: Boolean
 
   /** Greater-than comparison of two `Double` singleton types.
    *  ```scala
@@ -61,7 +61,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type >[X <: Double, Y <: Double] <: Boolean
+  type >[+X <: Double, +Y <: Double] <: Boolean
 
   /** Greater-or-equal comparison of two `Double` singleton types.
    *  ```scala
@@ -70,7 +70,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type >=[X <: Double, Y <: Double] <: Boolean
+  type >=[+X <: Double, +Y <: Double] <: Boolean
 
   /** Less-or-equal comparison of two `Double` singleton types.
    *  ```scala
@@ -79,7 +79,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type <=[X <: Double, Y <: Double] <: Boolean
+  type <=[+X <: Double, +Y <: Double] <: Boolean
 
   /** Absolute value of an `Double` singleton type.
    *  ```scala
@@ -87,7 +87,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type Abs[X <: Double] <: Double
+  type Abs[+X <: Double] <: Double
 
   /** Negation of an `Double` singleton type.
    *  ```scala
@@ -96,7 +96,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type Negate[X <: Double] <: Double
+  type Negate[+X <: Double] <: Double
 
   /** Minimum of two `Double` singleton types.
    *  ```scala
@@ -104,7 +104,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type Min[X <: Double, Y <: Double] <: Double
+  type Min[+X <: Double, +Y <: Double] <: Double
 
   /** Maximum of two `Double` singleton types.
    *  ```scala
@@ -112,7 +112,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type Max[X <: Double, Y <: Double] <: Double
+  type Max[+X <: Double, +Y <: Double] <: Double
 
   /** Int conversion of a `Double` singleton type.
    *  ```scala
@@ -120,7 +120,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type ToInt[X <: Double] <: Int
+  type ToInt[+X <: Double] <: Int
 
   /** Long conversion of a `Double` singleton type.
    *  ```scala
@@ -128,7 +128,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type ToLong[X <: Double] <: Long
+  type ToLong[+X <: Double] <: Long
 
   /** Float conversion of a `Double` singleton type.
    *  ```scala
@@ -136,4 +136,4 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type ToFloat[X <: Double] <: Float
+  type ToFloat[+X <: Double] <: Float

--- a/library/src/scala/compiletime/ops/float.scala
+++ b/library/src/scala/compiletime/ops/float.scala
@@ -11,7 +11,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: Float, Y <: Float] <: Float
+  type +[+X <: Float, +Y <: Float] <: Float
 
   /** Subtraction of two `Float` singleton types.
    *  ```scala
@@ -19,7 +19,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type -[X <: Float, Y <: Float] <: Float
+  type -[+X <: Float, +Y <: Float] <: Float
 
   /** Multiplication of two `Float` singleton types.
    *  ```scala
@@ -27,7 +27,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type *[X <: Float, Y <: Float] <: Float
+  type *[+X <: Float, +Y <: Float] <: Float
 
   /** Integer division of two `Float` singleton types.
    *  ```scala
@@ -35,7 +35,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type /[X <: Float, Y <: Float] <: Float
+  type /[+X <: Float, +Y <: Float] <: Float
 
   /** Remainder of the division of `X` by `Y`.
    *  ```scala
@@ -43,7 +43,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type %[X <: Float, Y <: Float] <: Float
+  type %[+X <: Float, +Y <: Float] <: Float
 
   /** Less-than comparison of two `Float` singleton types.
    *  ```scala
@@ -52,7 +52,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type <[X <: Float, Y <: Float] <: Boolean
+  type <[+X <: Float, +Y <: Float] <: Boolean
 
   /** Greater-than comparison of two `Float` singleton types.
    *  ```scala
@@ -61,7 +61,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type >[X <: Float, Y <: Float] <: Boolean
+  type >[+X <: Float, +Y <: Float] <: Boolean
 
   /** Greater-or-equal comparison of two `Float` singleton types.
    *  ```scala
@@ -70,7 +70,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type >=[X <: Float, Y <: Float] <: Boolean
+  type >=[+X <: Float, +Y <: Float] <: Boolean
 
   /** Less-or-equal comparison of two `Float` singleton types.
    *  ```scala
@@ -79,7 +79,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type <=[X <: Float, Y <: Float] <: Boolean
+  type <=[+X <: Float, +Y <: Float] <: Boolean
 
   /** Absolute value of an `Float` singleton type.
    *  ```scala
@@ -87,7 +87,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type Abs[X <: Float] <: Float
+  type Abs[+X <: Float] <: Float
 
   /** Negation of an `Float` singleton type.
    *  ```scala
@@ -96,7 +96,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type Negate[X <: Float] <: Float
+  type Negate[+X <: Float] <: Float
 
   /** Minimum of two `Float` singleton types.
    *  ```scala
@@ -104,7 +104,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type Min[X <: Float, Y <: Float] <: Float
+  type Min[+X <: Float, +Y <: Float] <: Float
 
   /** Maximum of two `Float` singleton types.
    *  ```scala
@@ -112,7 +112,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type Max[X <: Float, Y <: Float] <: Float
+  type Max[+X <: Float, +Y <: Float] <: Float
 
   /** Int conversion of a `Float` singleton type.
    *  ```scala
@@ -120,7 +120,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type ToInt[X <: Float] <: Int
+  type ToInt[+X <: Float] <: Int
 
   /** Long conversion of a `Float` singleton type.
    *  ```scala
@@ -128,7 +128,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type ToLong[X <: Float] <: Long
+  type ToLong[+X <: Float] <: Long
 
   /** Double conversion of a `Float` singleton type.
    *  ```scala
@@ -136,4 +136,4 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type ToDouble[X <: Float] <: Double
+  type ToDouble[+X <: Float] <: Double

--- a/library/src/scala/compiletime/ops/int.scala
+++ b/library/src/scala/compiletime/ops/int.scala
@@ -17,7 +17,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type S[N <: Int] <: Int
+  type S[+N <: Int] <: Int
 
   /** Addition of two `Int` singleton types.
    *  ```scala
@@ -25,7 +25,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: Int, Y <: Int] <: Int
+  type +[+X <: Int, +Y <: Int] <: Int
 
   /** Subtraction of two `Int` singleton types.
    *  ```scala
@@ -33,7 +33,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type -[X <: Int, Y <: Int] <: Int
+  type -[+X <: Int, +Y <: Int] <: Int
 
   /** Multiplication of two `Int` singleton types.
    *  ```scala
@@ -41,7 +41,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type *[X <: Int, Y <: Int] <: Int
+  type *[+X <: Int, +Y <: Int] <: Int
 
   /** Integer division of two `Int` singleton types.
    *  ```scala
@@ -49,7 +49,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type /[X <: Int, Y <: Int] <: Int
+  type /[+X <: Int, +Y <: Int] <: Int
 
   /** Remainder of the division of `X` by `Y`.
    *  ```scala
@@ -57,7 +57,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type %[X <: Int, Y <: Int] <: Int
+  type %[+X <: Int, +Y <: Int] <: Int
 
   /** Binary left shift of `X` by `Y`.
    *  ```scala
@@ -65,7 +65,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type <<[X <: Int, Y <: Int] <: Int
+  type <<[+X <: Int, +Y <: Int] <: Int
 
   /** Binary right shift of `X` by `Y`.
    *  ```scala
@@ -73,7 +73,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type >>[X <: Int, Y <: Int] <: Int
+  type >>[+X <: Int, +Y <: Int] <: Int
 
   /** Binary right shift of `X` by `Y`, filling the left with zeros.
    *  ```scala
@@ -81,7 +81,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type >>>[X <: Int, Y <: Int] <: Int
+  type >>>[+X <: Int, +Y <: Int] <: Int
 
   /** Bitwise xor of `X` and `Y`.
    *  ```scala
@@ -89,7 +89,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type ^[X <: Int, Y <: Int] <: Int
+  type ^[+X <: Int, +Y <: Int] <: Int
 
   /** Less-than comparison of two `Int` singleton types.
    *  ```scala
@@ -98,7 +98,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type <[X <: Int, Y <: Int] <: Boolean
+  type <[+X <: Int, +Y <: Int] <: Boolean
 
   /** Greater-than comparison of two `Int` singleton types.
    *  ```scala
@@ -107,7 +107,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type >[X <: Int, Y <: Int] <: Boolean
+  type >[+X <: Int, +Y <: Int] <: Boolean
 
   /** Greater-or-equal comparison of two `Int` singleton types.
    *  ```scala
@@ -116,7 +116,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type >=[X <: Int, Y <: Int] <: Boolean
+  type >=[+X <: Int, +Y <: Int] <: Boolean
 
   /** Less-or-equal comparison of two `Int` singleton types.
    *  ```scala
@@ -125,7 +125,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type <=[X <: Int, Y <: Int] <: Boolean
+  type <=[+X <: Int, +Y <: Int] <: Boolean
 
   /** Bitwise and of `X` and `Y`.
    *  ```scala
@@ -134,7 +134,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type BitwiseAnd[X <: Int, Y <: Int] <: Int
+  type BitwiseAnd[+X <: Int, +Y <: Int] <: Int
 
   /** Bitwise or of `X` and `Y`.
    *  ```scala
@@ -142,7 +142,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type BitwiseOr[X <: Int, Y <: Int] <: Int
+  type BitwiseOr[+X <: Int, +Y <: Int] <: Int
 
   /** Absolute value of an `Int` singleton type.
    *  ```scala
@@ -150,7 +150,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type Abs[X <: Int] <: Int
+  type Abs[+X <: Int] <: Int
 
   /** Negation of an `Int` singleton type.
    *  ```scala
@@ -159,7 +159,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type Negate[X <: Int] <: Int
+  type Negate[+X <: Int] <: Int
 
   /** Minimum of two `Int` singleton types.
    *  ```scala
@@ -167,7 +167,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type Min[X <: Int, Y <: Int] <: Int
+  type Min[+X <: Int, +Y <: Int] <: Int
 
   /** Maximum of two `Int` singleton types.
    *  ```scala
@@ -175,7 +175,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type Max[X <: Int, Y <: Int] <: Int
+  type Max[+X <: Int, +Y <: Int] <: Int
 
   /** String conversion of an `Int` singleton type.
    *  ```scala
@@ -184,7 +184,7 @@ object int:
    *  @syntax markdown
    */
   //@deprecated("Use compiletime.ops.any.ToString instead.","3.2.0") // uncomment when reaching 3.2.0
-  type ToString[X <: Int] <: String
+  type ToString[+X <: Int] <: String
 
   /** Long conversion of an `Int` singleton type.
    *  ```scala
@@ -193,7 +193,7 @@ object int:
    *  @syntax markdown
    */
   @experimental
-  type ToLong[X <: Int] <: Long
+  type ToLong[+X <: Int] <: Long
 
   /** Float conversion of an `Int` singleton type.
    *  ```scala
@@ -202,7 +202,7 @@ object int:
    *  @syntax markdown
    */
   @experimental
-  type ToFloat[X <: Int] <: Float
+  type ToFloat[+X <: Int] <: Float
 
   /** Double conversion of an `Int` singleton type.
    *  ```scala
@@ -211,7 +211,7 @@ object int:
    *  @syntax markdown
    */
   @experimental
-  type ToDouble[X <: Int] <: Double
+  type ToDouble[+X <: Int] <: Double
 
   /** Number of zero bits preceding the highest-order ("leftmost")
    * one-bit in the two's complement binary representation of the specified `Int` singleton type.
@@ -226,4 +226,4 @@ object int:
    *  @syntax markdown
    */
   @experimental
-  type NumberOfLeadingZeros[X <: Int] <: Int
+  type NumberOfLeadingZeros[+X <: Int] <: Int

--- a/library/src/scala/compiletime/ops/long.scala
+++ b/library/src/scala/compiletime/ops/long.scala
@@ -18,7 +18,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type S[N <: Long] <: Long
+  type S[+N <: Long] <: Long
 
   /** Addition of two `Long` singleton types.
    *  ```scala
@@ -26,7 +26,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: Long, Y <: Long] <: Long
+  type +[+X <: Long, +Y <: Long] <: Long
 
   /** Subtraction of two `Long` singleton types.
    *  ```scala
@@ -34,7 +34,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type -[X <: Long, Y <: Long] <: Long
+  type -[+X <: Long, +Y <: Long] <: Long
 
   /** Multiplication of two `Long` singleton types.
    *  ```scala
@@ -42,7 +42,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type *[X <: Long, Y <: Long] <: Long
+  type *[+X <: Long, +Y <: Long] <: Long
 
   /** Integer division of two `Long` singleton types.
    *  ```scala
@@ -50,7 +50,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type /[X <: Long, Y <: Long] <: Long
+  type /[+X <: Long, +Y <: Long] <: Long
 
   /** Remainder of the division of `X` by `Y`.
    *  ```scala
@@ -58,7 +58,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type %[X <: Long, Y <: Long] <: Long
+  type %[+X <: Long, +Y <: Long] <: Long
 
   /** Binary left shift of `X` by `Y`.
    *  ```scala
@@ -66,7 +66,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type <<[X <: Long, Y <: Long] <: Long
+  type <<[+X <: Long, +Y <: Long] <: Long
 
   /** Binary right shift of `X` by `Y`.
    *  ```scala
@@ -74,7 +74,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type >>[X <: Long, Y <: Long] <: Long
+  type >>[+X <: Long, +Y <: Long] <: Long
 
   /** Binary right shift of `X` by `Y`, filling the left with zeros.
    *  ```scala
@@ -82,7 +82,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type >>>[X <: Long, Y <: Long] <: Long
+  type >>>[+X <: Long, +Y <: Long] <: Long
 
   /** Bitwise xor of `X` and `Y`.
    *  ```scala
@@ -90,7 +90,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type ^[X <: Long, Y <: Long] <: Long
+  type ^[+X <: Long, +Y <: Long] <: Long
 
   /** Less-than comparison of two `Long` singleton types.
    *  ```scala
@@ -99,7 +99,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type <[X <: Long, Y <: Long] <: Boolean
+  type <[+X <: Long, +Y <: Long] <: Boolean
 
   /** Greater-than comparison of two `Long` singleton types.
    *  ```scala
@@ -108,7 +108,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type >[X <: Long, Y <: Long] <: Boolean
+  type >[+X <: Long, +Y <: Long] <: Boolean
 
   /** Greater-or-equal comparison of two `Long` singleton types.
    *  ```scala
@@ -117,7 +117,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type >=[X <: Long, Y <: Long] <: Boolean
+  type >=[+X <: Long, +Y <: Long] <: Boolean
 
   /** Less-or-equal comparison of two `Long` singleton types.
    *  ```scala
@@ -126,7 +126,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type <=[X <: Long, Y <: Long] <: Boolean
+  type <=[+X <: Long, +Y <: Long] <: Boolean
 
   /** Bitwise and of `X` and `Y`.
    *  ```scala
@@ -135,7 +135,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type BitwiseAnd[X <: Long, Y <: Long] <: Long
+  type BitwiseAnd[+X <: Long, +Y <: Long] <: Long
 
   /** Bitwise or of `X` and `Y`.
    *  ```scala
@@ -143,7 +143,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type BitwiseOr[X <: Long, Y <: Long] <: Long
+  type BitwiseOr[+X <: Long, +Y <: Long] <: Long
 
   /** Absolute value of an `Long` singleton type.
    *  ```scala
@@ -151,7 +151,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type Abs[X <: Long] <: Long
+  type Abs[+X <: Long] <: Long
 
   /** Negation of an `Long` singleton type.
    *  ```scala
@@ -160,7 +160,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type Negate[X <: Long] <: Long
+  type Negate[+X <: Long] <: Long
 
   /** Minimum of two `Long` singleton types.
    *  ```scala
@@ -168,7 +168,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type Min[X <: Long, Y <: Long] <: Long
+  type Min[+X <: Long, +Y <: Long] <: Long
 
   /** Maximum of two `Long` singleton types.
    *  ```scala
@@ -176,7 +176,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type Max[X <: Long, Y <: Long] <: Long
+  type Max[+X <: Long, +Y <: Long] <: Long
 
   /** Number of zero bits preceding the highest-order ("leftmost")
    * one-bit in the two's complement binary representation of the specified `Long` singleton type.
@@ -190,7 +190,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type NumberOfLeadingZeros[X <: Long] <: Int
+  type NumberOfLeadingZeros[+X <: Long] <: Int
 
   /** Int conversion of a `Long` singleton type.
    *  ```scala
@@ -198,7 +198,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type ToInt[X <: Long] <: Int
+  type ToInt[+X <: Long] <: Int
 
   /** Float conversion of a `Long` singleton type.
    *  ```scala
@@ -206,7 +206,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type ToFloat[X <: Long] <: Float
+  type ToFloat[+X <: Long] <: Float
 
   /** Double conversion of a `Long` singleton type.
    *  ```scala
@@ -214,4 +214,4 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type ToDouble[X <: Long] <: Double
+  type ToDouble[+X <: Long] <: Double

--- a/library/src/scala/compiletime/ops/string.scala
+++ b/library/src/scala/compiletime/ops/string.scala
@@ -10,7 +10,7 @@ object string:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: String, Y <: String] <: String
+  type +[+X <: String, +Y <: String] <: String
 
   /** Length of a `String` singleton type.
    *  ```scala
@@ -19,7 +19,7 @@ object string:
    *  @syntax markdown
    */
   @experimental
-  type Length[X <: String] <: Int
+  type Length[+X <: String] <: Int
 
   /** Substring of a `String` singleton type, with a singleton type
    * begin inclusive index `IBeg`, and a singleton type exclusive end index `IEnd`.
@@ -32,7 +32,7 @@ object string:
    *  @syntax markdown
    */
   @experimental
-  type Substring[S <: String, IBeg <: Int, IEnd <: Int] <: String
+  type Substring[+S <: String, +IBeg <: Int, +IEnd <: Int] <: String
 
   /** Tests if this `String` singleton type matches the given
    * regular expression `String` singleton type.
@@ -42,4 +42,4 @@ object string:
    *  @syntax markdown
    */
   @experimental
-  type Matches[S <: String, Regex <: String] <: Boolean
+  type Matches[+S <: String, +Regex <: String] <: Boolean

--- a/tests/neg/singleton-ops-int.scala
+++ b/tests/neg/singleton-ops-int.scala
@@ -116,4 +116,12 @@ object Test {
 
   val t83: ToDouble[1] = 1.0
   val t84: ToDouble[2] = 2 // error
+
+  // Singleton operations are covariant.
+  type Plus2[X <: Int] = X + 2
+  val x: Int = 5
+  val xPlus2: Plus2[x.type] = (x + 2).asInstanceOf
+  summon[xPlus2.type + 1 <:< Plus2[x.type] + 1]
+  def mult(x: Int, y: Int): x.type * y.type = (x * y).asInstanceOf
+  val y: x.type * x.type * x.type = mult(mult(x, x), x)
 }


### PR DESCRIPTION
Currently, this does not compile:

```scala
def mult(x: Int, y: Int): x.type * y.type = (x * y).asInstanceOf
val y: x.type * x.type * x.type = mult(mult(x, x), x)
|                                 ^^^^^^^^^^^^^^^^^^^
|Found:    (?1 : (Test.x : Int) * (Test.x : Int)) * (Test.x : Int)
|Required: (Test.x : Int) * (Test.x : Int) * (Test.x : Int)
because (x: X) * Y is not a subtype of X * Y.
```

because `(x: X) * Y` is not a subtype of `X * Y`.

Making the compiletime operation types covariant in their arguments would enable this.
