### PR TITLE
Scaladoc: Add member position IDs to anchors in searchbar

### DIFF
--- a/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
+++ b/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
@@ -6,6 +6,8 @@ import org.scalajs.dom.html.Input
 import scala.scalajs.js.timers._
 import scala.concurrent.duration._
 
+import java.net.URI
+
 class SearchbarComponent(engine: SearchbarEngine, inkuireEngine: InkuireJSSearchEngine, parser: QueryParser):
   val resultsChunkSize = 100
   extension (p: PageEntry)
@@ -55,7 +57,12 @@ class SearchbarComponent(engine: SearchbarEngine, inkuireEngine: InkuireJSSearch
       icon.classList.add(m.entryType.take(2))
 
       val resultA = document.createElement("a").asInstanceOf[html.Anchor]
-      resultA.href = m.pageLocation
+      resultA.href = 
+        if(new URI(m.pageLocation).isAbsolute()) {
+          m.pageLocation
+        } else {
+          Globals.pathToRoot + m.pageLocation
+        } 
       resultA.text = m.functionName
       resultA.onclick = (event: Event) =>
         if (document.body.contains(rootDiv)) {

--- a/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
+++ b/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
@@ -22,6 +22,10 @@ class SearchbarComponent(engine: SearchbarEngine, inkuireEngine: InkuireJSSearch
       val resultA = document.createElement("a").asInstanceOf[html.Anchor]
       resultA.href = Globals.pathToRoot + p.location
       resultA.text = s"${p.fullName}"
+      resultA.onclick = (event: Event) =>
+        if (document.body.contains(rootDiv)) {
+          document.body.removeChild(rootDiv)
+        }
 
       val location = document.createElement("span")
       location.classList.add("pull-right")
@@ -53,6 +57,10 @@ class SearchbarComponent(engine: SearchbarEngine, inkuireEngine: InkuireJSSearch
       val resultA = document.createElement("a").asInstanceOf[html.Anchor]
       resultA.href = m.pageLocation
       resultA.text = m.functionName
+      resultA.onclick = (event: Event) =>
+        if (document.body.contains(rootDiv)) {
+          document.body.removeChild(rootDiv)
+        }
 
       val packageDiv = document.createElement("div").asInstanceOf[html.Div]
       packageDiv.classList.add("scaladoc-searchbar-inkuire-package")

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Locations.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Locations.scala
@@ -82,6 +82,7 @@ trait Locations(using ctx: DocContext):
 
   def resolveRoot(dri: DRI, path: String): String = resolveRoot(rawLocation(dri), path)
   def absolutePath(dri: DRI, extension: String = "html"): String = rawLocation(dri).mkString("", "/", s".$extension")
+  def absolutePathWithAnchor(dri: DRI, extension: String = "html"): String = s"${absolutePath(dri, extension)}#${dri.anchor}"
 
   def resolveLink(dri: DRI, url: String): String =
     if URI(url).isAbsolute then url else resolveRoot(dri, url)

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -133,7 +133,7 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
       }.mkString
 
     def mkEntry(dri: DRI, name: String, text: String, descr: String, kind: String) = jsonObject(
-        "l" -> jsonString(absolutePath(dri)),
+        "l" -> jsonString(absolutePathWithAnchor(dri)),
         "n" -> jsonString(name),
         "t" -> jsonString(text),
         "d" -> jsonString(descr),

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/InkuireSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/InkuireSupport.scala
@@ -4,6 +4,7 @@ import collection.JavaConverters._
 import dotty.tools.scaladoc._
 import dotty.tools.scaladoc.{Signature => DSignature}
 import dotty.tools.scaladoc.Inkuire
+import dotty.tools.scaladoc.renderers.Resources
 
 import scala.util.Random
 import scala.quoted._
@@ -13,9 +14,12 @@ import SymOps._
 import NameNormalizer._
 import SyntheticsSupport._
 
-trait InkuireSupport:
+trait InkuireSupport(using DocContext) extends Resources:
   self: TastyParser =>
   import qctx.reflect._
+
+  // Unused in InkuireSupport, required for Resources
+  override def effectiveMembers: Map[DRI, Member] = Map.empty
 
   private given qctx.type = qctx
 
@@ -110,7 +114,7 @@ trait InkuireSupport:
             ),
             name = name,
             packageName = ownerName,
-            uri = methodSymbol.dri.externalLink.getOrElse(""),
+            uri = methodSymbol.dri.externalLink.getOrElse(absolutePathWithAnchor(methodSymbol.dri)),
             entryType = "def"
           )
           val curriedSgn = sgn.copy(signature = Inkuire.curry(sgn.signature))
@@ -138,7 +142,7 @@ trait InkuireSupport:
             ),
             name = name,
             packageName = ownerName,
-            uri = valSymbol.dri.externalLink.getOrElse(""),
+            uri = valSymbol.dri.externalLink.getOrElse(absolutePathWithAnchor(valSymbol.dri)),
             entryType = "val"
           )
           val curriedSgn = sgn.copy(signature = Inkuire.curry(sgn.signature))


### PR DESCRIPTION
This PR includes following changes, each accompanied by a separate commit:
* id location attributes were added to anchors in searchbar - this way, even if a member is located 
* searchbar will now always be closed after clicking a result - this is to keep behavior of the search result being located in a separate URL (where searchbar would always be closed) and in a different location of the same URL (where, previously, searchbar would stay open, even after snapping to a different location).
* Linking to the internal docs via Inkuire was fixed - it felt related to the other two changes, so it's included in this PR (but I can split it up if necessary).