### PR TITLE
Switch our string interpolators to use Show/Shown

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -119,7 +119,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
       if (kind != overallKind) {
         bad = true
         report.error(
-            em"export overload conflicts with export of $firstSym: they are of different types ($kind / $overallKind)",
+            em"export overload conflicts with export of $firstSym: they are of different types (${kind.show} / ${overallKind.show})",
             info.pos)
       }
     }

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -119,7 +119,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
       if (kind != overallKind) {
         bad = true
         report.error(
-            em"export overload conflicts with export of $firstSym: they are of different types (${kind.show} / ${overallKind.show})",
+            em"export overload conflicts with export of $firstSym: they are of different types (${kind.tryToShow} / ${overallKind.tryToShow})",
             info.pos)
       }
     }

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -249,7 +249,7 @@ object Decorators {
   extension [T](x: T)
     def showing[U](
         op: WrappedResult[U] ?=> String,
-        printer: config.Printers.Printer = config.Printers.default)(using c: Conversion[T, U] = null): T = {
+        printer: config.Printers.Printer = config.Printers.default)(using c: Conversion[T, U] | Null = null): T = {
       // either the use of `$result` was driven by the expected type of `Shown`
       // which led to the summoning of `Conversion[T, Shown]` (which we'll invoke)
       // or no such conversion was found so we'll consume the result as it is instead
@@ -268,7 +268,7 @@ object Decorators {
               if !ctx.mode.is(Mode.PrintShowExceptions) && !ctx.settings.YshowPrintErrors.value =>
             val msg = ex match { case te: TypeError => te.toMessage case _ => ex.getMessage }
             s"[cannot display due to $msg, raw string = $x]"
-      case _ => String.valueOf(x)
+      case _ => String.valueOf(x).nn
 
   extension [T](x: T)
     def assertingErrorsReported(using Context): T = {

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -251,7 +251,7 @@ object Decorators {
         op: WrappedResult[U] ?=> String,
         printer: config.Printers.Printer = config.Printers.default)(using c: Conversion[T, U] = null): T = {
       // either the use of `$result` was driven by the expected type of `Shown`
-      // which lead to the summoning of `Conversion[T, Shown]` (which we'll invoke)
+      // which led to the summoning of `Conversion[T, Shown]` (which we'll invoke)
       // or no such conversion was found so we'll consume the result as it is instead
       val obj = if c == null then x.asInstanceOf[U] else c(x)
       printer.println(op(using WrappedResult(obj)))
@@ -259,8 +259,7 @@ object Decorators {
     }
 
     /** Instead of `toString` call `show` on `Showable` values, falling back to `toString` if an exception is raised. */
-    def show(using Context)(using z: Show[T] = null): String = x match
-      case _ if z != null => z.show(x).toString
+    def show(using Context): String = x match
       case x: Showable =>
         try x.show
         catch

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -2,12 +2,13 @@ package dotty.tools
 package dotc
 package core
 
-import annotation.tailrec
-import Symbols._
-import Contexts._, Names._, Phases._, printing.Texts._
-import collection.mutable.ListBuffer
-import dotty.tools.dotc.transform.MegaPhase
-import printing.Formatting._
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+import Contexts._, Names._, Phases._, Symbols._
+import printing.{ Printer, Showable }, printing.Formatting._, printing.Texts._
+import transform.MegaPhase
 
 /** This object provides useful implicit decorators for types defined elsewhere */
 object Decorators {
@@ -246,12 +247,29 @@ object Decorators {
       }
 
   extension [T](x: T)
-    def showing(
-        op: WrappedResult[T] ?=> String,
-        printer: config.Printers.Printer = config.Printers.default): T = {
-      printer.println(op(using WrappedResult(x)))
+    def showing[U](
+        op: WrappedResult[U] ?=> String,
+        printer: config.Printers.Printer = config.Printers.default)(using c: Conversion[T, U] = null): T = {
+      // either the use of `$result` was driven by the expected type of `Shown`
+      // which lead to the summoning of `Conversion[T, Shown]` (which we'll invoke)
+      // or no such conversion was found so we'll consume the result as it is instead
+      val obj = if c == null then x.asInstanceOf[U] else c(x)
+      printer.println(op(using WrappedResult(obj)))
       x
     }
+
+    /** Instead of `toString` call `show` on `Showable` values, falling back to `toString` if an exception is raised. */
+    def show(using Context)(using z: Show[T] = null): String = x match
+      case _ if z != null => z.show(x).toString
+      case x: Showable =>
+        try x.show
+        catch
+          case ex: CyclicReference => "... (caught cyclic reference) ..."
+          case NonFatal(ex)
+              if !ctx.mode.is(Mode.PrintShowExceptions) && !ctx.settings.YshowPrintErrors.value =>
+            val msg = ex match { case te: TypeError => te.toMessage case _ => ex.getMessage }
+            s"[cannot display due to $msg, raw string = $x]"
+      case _ => String.valueOf(x)
 
   extension [T](x: T)
     def assertingErrorsReported(using Context): T = {
@@ -269,19 +287,19 @@ object Decorators {
 
   extension (sc: StringContext)
     /** General purpose string formatting */
-    def i(args: Any*)(using Context): String =
+    def i(args: Shown*)(using Context): String =
       new StringFormatter(sc).assemble(args)
 
     /** Formatting for error messages: Like `i` but suppress follow-on
      *  error messages after the first one if some of their arguments are "non-sensical".
      */
-    def em(args: Any*)(using Context): String =
+    def em(args: Shown*)(using Context): String =
       new ErrorMessageFormatter(sc).assemble(args)
 
     /** Formatting with added explanations: Like `em`, but add explanations to
      *  give more info about type variables and to disambiguate where needed.
      */
-    def ex(args: Any*)(using Context): String =
+    def ex(args: Shown*)(using Context): String =
       explained(em(args: _*))
 
   extension [T <: AnyRef](arr: Array[T])

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -259,7 +259,7 @@ object Decorators {
     }
 
     /** Instead of `toString` call `show` on `Showable` values, falling back to `toString` if an exception is raised. */
-    def show(using Context): String = x match
+    def tryToShow(using Context): String = x match
       case x: Showable =>
         try x.show
         catch

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2713,15 +2713,16 @@ object TypeComparer {
      */
     val Fresh: Repr = 4
 
-    extension (approx: Repr)
-      def low: Boolean = (approx & LoApprox) != 0
-      def high: Boolean = (approx & HiApprox) != 0
-      def addLow: Repr = approx | LoApprox
-      def addHigh: Repr = approx | HiApprox
-      def show: String =
-        val lo = if low then " (left is approximated)" else ""
-        val hi = if high then " (right is approximated)" else ""
-        lo ++ hi
+    object Repr:
+      extension (approx: Repr)
+        def low: Boolean = (approx & LoApprox) != 0
+        def high: Boolean = (approx & HiApprox) != 0
+        def addLow: Repr = approx | LoApprox
+        def addHigh: Repr = approx | HiApprox
+        def show: String =
+          val lo = if low then " (left is approximated)" else ""
+          val hi = if high then " (right is approximated)" else ""
+          lo ++ hi
   end ApproxState
   type ApproxState = ApproxState.Repr
 

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -161,7 +161,7 @@ object Completion {
                           |                prefix  = ${completer.prefix},
                           |                term    = ${completer.mode.is(Mode.Term)},
                           |                type    = ${completer.mode.is(Mode.Type)}
-                          |                results = $backtickCompletions%, %""")
+                          |                results = $backtickedCompletions%, %""")
     (offset, backtickedCompletions)
   }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -606,7 +606,7 @@ object Parsers {
               if startIndentWidth <= nextIndentWidth then
                 i"""Line is indented too far to the right, or a `{` is missing before:
                    |
-                   |$t"""
+                   |${t.show}"""
               else
                 in.spaceTabMismatchMsg(startIndentWidth, nextIndentWidth),
               in.next.offset

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -606,7 +606,7 @@ object Parsers {
               if startIndentWidth <= nextIndentWidth then
                 i"""Line is indented too far to the right, or a `{` is missing before:
                    |
-                   |${t.show}"""
+                   |${t.tryToShow}"""
               else
                 in.spaceTabMismatchMsg(startIndentWidth, nextIndentWidth),
               in.next.offset

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -88,7 +88,7 @@ object Formatting {
    *     against accidentally treating an interpolated value as a margin.
    */
   class StringFormatter(protected val sc: StringContext) {
-    protected def showArg(arg: Any)(using Context): String = arg.show
+    protected def showArg(arg: Any)(using Context): String = arg.tryToShow
 
     private def treatArg(arg: Shown, suffix: String)(using Context): (Any, String) = arg match {
       case arg: Seq[?] if suffix.nonEmpty && suffix.head == '%' =>

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -1,47 +1,103 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package printing
 
 import scala.language.unsafeNulls
 
+import scala.collection.mutable
+
 import core._
 import Texts._, Types._, Flags._, Symbols._, Contexts._
-import collection.mutable
 import Decorators._
-import scala.util.control.NonFatal
 import reporting.Message
 import util.DiffUtil
 import Highlighting._
 
 object Formatting {
 
+  object ShownDef:
+    /** Represents a value that has been "shown" and can be consumed by StringFormatter.
+     *  Not just a string because it may be a Seq that StringFormatter will intersperse with the trailing separator.
+     *  Also, it's not a `String | Seq[String]` because then we'd need to a Context to call `Showable#show`.  We could
+     *  make Context a requirement for a Show instance but then we'd have lots of instances instead of just one ShowAny
+     *  instance.  We could also try to make `Show#show` require the Context, but then that breaks the Conversion. */
+    opaque type Shown = Any
+    object Shown:
+      given [A: Show]: Conversion[A, Shown] = Show[A].show(_)
+
+    sealed abstract class Show[-T]:
+      /** Show a value T by returning a "shown" result. */
+      def show(x: T): Shown
+
+    /** The base implementation, passing the argument to StringFormatter which will try to `.show` it. */
+    object ShowAny extends Show[Any]:
+      def show(x: Any): Shown = x
+
+    class ShowImplicits1:
+      given Show[ImplicitRef]      = ShowAny
+      given Show[Names.Designator] = ShowAny
+      given Show[util.SrcPos]      = ShowAny
+
+    object Show extends ShowImplicits1:
+      inline def apply[A](using inline z: Show[A]): Show[A] = z
+
+      given [X: Show]: Show[Seq[X]] with
+        def show(x: Seq[X]) = x.map(Show[X].show)
+
+      given [A: Show, B: Show]: Show[(A, B)] with
+        def show(x: (A, B)) = (Show[A].show(x._1), Show[B].show(x._2))
+
+      given Show[FlagSet] with
+        def show(x: FlagSet) = x.flagsString
+
+      given Show[TypeComparer.ApproxState] with
+        def show(x: TypeComparer.ApproxState) = TypeComparer.ApproxState.Repr.show(x)
+
+      given Show[Showable]                            = ShowAny
+      given Show[Shown]                               = ShowAny
+      given Show[Int]                                 = ShowAny
+      given Show[Char]                                = ShowAny
+      given Show[Boolean]                             = ShowAny
+      given Show[String]                              = ShowAny
+      given Show[Class[?]]                            = ShowAny
+      given Show[Exception]                           = ShowAny
+      given Show[StringBuffer]                        = ShowAny
+      given Show[Atoms]                               = ShowAny
+      given Show[Highlight]                           = ShowAny
+      given Show[HighlightBuffer]                     = ShowAny
+      given Show[CompilationUnit]                     = ShowAny
+      given Show[Mode]                                = ShowAny
+      given Show[Phases.Phase]                        = ShowAny
+      given Show[Signature]                           = ShowAny
+      given Show[TyperState]                          = ShowAny
+      given Show[config.ScalaVersion]                 = ShowAny
+      given Show[io.AbstractFile]                     = ShowAny
+      given Show[parsing.Scanners.IndentWidth]        = ShowAny
+      given Show[parsing.Scanners.Scanner]            = ShowAny
+      given Show[util.SourceFile]                     = ShowAny
+      given Show[util.Spans.Span]                     = ShowAny
+      given Show[dotty.tools.tasty.TastyBuffer.Addr]  = ShowAny
+      given Show[tasty.TreeUnpickler#OwnerTree]       = ShowAny
+      given Show[interactive.Completion]              = ShowAny
+      given Show[transform.sjs.JSSymUtils.JSName]     = ShowAny
+      given Show[org.scalajs.ir.Position]             = ShowAny
+    end Show
+  end ShownDef
+  export ShownDef.{ Show, Shown }
+
   /** General purpose string formatter, with the following features:
    *
-   *  1) On all Showables, `show` is called instead of `toString`
-   *  2) Exceptions raised by a `show` are handled by falling back to `toString`.
-   *  3) Sequences can be formatted using the desired separator between two `%` signs,
+   *  1. Invokes the `show` extension method on the interpolated arguments.
+   *  2. Sequences can be formatted using the desired separator between two `%` signs,
    *     eg `i"myList = (${myList}%, %)"`
-   *  4) Safe handling of multi-line margins. Left margins are skipped om the parts
+   *  3. Safe handling of multi-line margins. Left margins are stripped on the parts
    *     of the string context *before* inserting the arguments. That way, we guard
    *     against accidentally treating an interpolated value as a margin.
    */
   class StringFormatter(protected val sc: StringContext) {
-    protected def showArg(arg: Any)(using Context): String = arg match {
-      case arg: Showable =>
-        try arg.show
-        catch {
-          case ex: CyclicReference => "... (caught cyclic reference) ..."
-          case NonFatal(ex)
-          if !ctx.mode.is(Mode.PrintShowExceptions) &&
-             !ctx.settings.YshowPrintErrors.value =>
-            val msg = ex match
-              case te: TypeError => te.toMessage
-              case _ => ex.getMessage
-            s"[cannot display due to $msg, raw string = ${arg.toString}]"
-        }
-      case _ => String.valueOf(arg)
-    }
+    protected def showArg(arg: Any)(using Context): String = arg.show
 
-    private def treatArg(arg: Any, suffix: String)(using Context): (Any, String) = arg match {
+    private def treatArg(arg: Shown, suffix: String)(using Context): (Any, String) = arg match {
       case arg: Seq[?] if suffix.nonEmpty && suffix.head == '%' =>
         val (rawsep, rest) = suffix.tail.span(_ != '%')
         val sep = StringContext.processEscapes(rawsep)
@@ -51,7 +107,7 @@ object Formatting {
         (showArg(arg), suffix)
     }
 
-    def assemble(args: Seq[Any])(using Context): String = {
+    def assemble(args: Seq[Shown])(using Context): String = {
       def isLineBreak(c: Char) = c == '\n' || c == '\f' // compatible with StringLike#isLineBreak
       def stripTrailingPart(s: String) = {
         val (pre, post) = s.span(c => !isLineBreak(c))
@@ -76,18 +132,6 @@ object Formatting {
   class ErrorMessageFormatter(sc: StringContext) extends StringFormatter(sc):
     override protected def showArg(arg: Any)(using Context): String =
       wrapNonSensical(arg, super.showArg(arg)(using errorMessageCtx))
-
-  class SyntaxFormatter(sc: StringContext) extends StringFormatter(sc) {
-    override protected def showArg(arg: Any)(using Context): String =
-      arg match {
-        case hl: Highlight =>
-          hl.show
-        case hb: HighlightBuffer =>
-          hb.toString
-        case _ =>
-          SyntaxHighlighting.highlight(super.showArg(arg))
-      }
-  }
 
   private def wrapNonSensical(arg: Any, str: String)(using Context): String = {
     import Message._

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -33,7 +33,10 @@ object Formatting {
     object ShowAny extends Show[Any]:
       def show(x: Any): Shown = x
 
-    class ShowImplicits1:
+    class ShowImplicits2:
+      given Show[Product] = ShowAny
+
+    class ShowImplicits1 extends ShowImplicits2:
       given Show[ImplicitRef]      = ShowAny
       given Show[Names.Designator] = ShowAny
       given Show[util.SrcPos]      = ShowAny
@@ -62,25 +65,15 @@ object Formatting {
       given Show[Class[?]]                            = ShowAny
       given Show[Exception]                           = ShowAny
       given Show[StringBuffer]                        = ShowAny
-      given Show[Atoms]                               = ShowAny
-      given Show[Highlight]                           = ShowAny
-      given Show[HighlightBuffer]                     = ShowAny
       given Show[CompilationUnit]                     = ShowAny
-      given Show[Mode]                                = ShowAny
       given Show[Phases.Phase]                        = ShowAny
-      given Show[Signature]                           = ShowAny
       given Show[TyperState]                          = ShowAny
       given Show[config.ScalaVersion]                 = ShowAny
       given Show[io.AbstractFile]                     = ShowAny
-      given Show[parsing.Scanners.IndentWidth]        = ShowAny
       given Show[parsing.Scanners.Scanner]            = ShowAny
       given Show[util.SourceFile]                     = ShowAny
       given Show[util.Spans.Span]                     = ShowAny
-      given Show[dotty.tools.tasty.TastyBuffer.Addr]  = ShowAny
       given Show[tasty.TreeUnpickler#OwnerTree]       = ShowAny
-      given Show[interactive.Completion]              = ShowAny
-      given Show[transform.sjs.JSSymUtils.JSName]     = ShowAny
-      given Show[org.scalajs.ir.Position]             = ShowAny
     end Show
   end ShownDef
   export ShownDef.{ Show, Shown }

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -50,6 +50,9 @@ object Formatting {
       given [A: Show, B: Show]: Show[(A, B)] with
         def show(x: (A, B)) = (Show[A].show(x._1), Show[B].show(x._2))
 
+      given [X: Show]: Show[X | Null] with
+        def show(x: X | Null) = if x == null then "null" else Show[X].show(x.nn)
+
       given Show[FlagSet] with
         def show(x: FlagSet) = x.flagsString
 

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -18,7 +18,7 @@ object Formatting {
   object ShownDef:
     /** Represents a value that has been "shown" and can be consumed by StringFormatter.
      *  Not just a string because it may be a Seq that StringFormatter will intersperse with the trailing separator.
-     *  Also, it's not a `String | Seq[String]` because then we'd need to a Context to call `Showable#show`.  We could
+     *  Also, it's not a `String | Seq[String]` because then we'd need a Context to call `Showable#show`.  We could
      *  make Context a requirement for a Show instance but then we'd have lots of instances instead of just one ShowAny
      *  instance.  We could also try to make `Show#show` require the Context, but then that breaks the Conversion. */
     opaque type Shown = Any

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1759,7 +1759,7 @@ import transform.SymUtils._
 
   class ClassAndCompanionNameClash(cls: Symbol, other: Symbol)(using Context)
     extends NamingMsg(ClassAndCompanionNameClashID) {
-    def msg = em"Name clash: both ${cls.owner} and its companion object defines ${cls.name.stripModuleClassSuffix}"
+    def msg = em"Name clash: both ${cls.owner} and its companion object defines ${cls.name.stripModuleClassSuffix.show}"
     def explain =
       em"""|A ${cls.kindString} and its companion object cannot both define a ${hl("class")}, ${hl("trait")} or ${hl("object")} with the same name:
            |  - ${cls.owner} defines ${cls}

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1759,7 +1759,9 @@ import transform.SymUtils._
 
   class ClassAndCompanionNameClash(cls: Symbol, other: Symbol)(using Context)
     extends NamingMsg(ClassAndCompanionNameClashID) {
-    def msg = em"Name clash: both ${cls.owner} and its companion object defines ${cls.name.stripModuleClassSuffix.show}"
+    def msg =
+      val name = cls.name.stripModuleClassSuffix
+      em"Name clash: both ${cls.owner} and its companion object defines $name"
     def explain =
       em"""|A ${cls.kindString} and its companion object cannot both define a ${hl("class")}, ${hl("trait")} or ${hl("object")} with the same name:
            |  - ${cls.owner} defines ${cls}

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -776,7 +776,7 @@ private class ExtractAPICollector(using Context) extends ThunkHolder {
           case n: Name =>
             h = nameHash(n, h)
           case elem =>
-            cannotHash(what = i"`$elem` of unknown class ${elem.getClass}", elem, tree)
+            cannotHash(what = i"`${elem.show}` of unknown class ${elem.getClass}", elem, tree)
       h
     end iteratorHash
 

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -776,7 +776,7 @@ private class ExtractAPICollector(using Context) extends ThunkHolder {
           case n: Name =>
             h = nameHash(n, h)
           case elem =>
-            cannotHash(what = i"`${elem.show}` of unknown class ${elem.getClass}", elem, tree)
+            cannotHash(what = i"`${elem.tryToShow}` of unknown class ${elem.getClass}", elem, tree)
       h
     end iteratorHash
 

--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -58,7 +58,7 @@ abstract class AccessProxies {
 
   /** Add all needed accessors to the `body` of class `cls` */
   def addAccessorDefs(cls: Symbol, body: List[Tree])(using Context): List[Tree] = {
-    val accDefs = accessorDefs(cls)
+    val accDefs = accessorDefs(cls).toList
     transforms.println(i"add accessors for $cls: $accDefs%, %")
     if (accDefs.isEmpty) body else body ++ accDefs
   }

--- a/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DropOuterAccessors.scala
@@ -80,7 +80,7 @@ class DropOuterAccessors extends MiniPhase with IdentityDenotTransformer:
             cpy.Block(rhs)(inits.filterNot(dropOuterInit), expr)
         })
     assert(droppedParamAccessors.isEmpty,
-      i"""Failed to eliminate: $droppedParamAccessors
+      i"""Failed to eliminate: ${droppedParamAccessors.toList}
           when dropping outer accessors for ${ctx.owner} with
           $impl""")
     cpy.Template(impl)(constr = constr1, body = body1)

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -266,7 +266,7 @@ object Erasure {
     def constant(tree: Tree, const: Tree)(using Context): Tree =
       (if (isPureExpr(tree)) const else Block(tree :: Nil, const)).withSpan(tree.span)
 
-    final def box(tree: Tree, target: => String = "")(using Context): Tree = trace(i"boxing ${tree.showSummary}: ${tree.tpe} into $target") {
+    final def box(tree: Tree, target: => String = "")(using Context): Tree = trace(i"boxing ${tree.showSummary()}: ${tree.tpe} into $target") {
       tree.tpe.widen match {
         case ErasedValueType(tycon, _) =>
           New(tycon, cast(tree, underlyingOfValueClass(tycon.symbol.asClass)) :: Nil) // todo: use adaptToType?
@@ -286,7 +286,7 @@ object Erasure {
       }
     }
 
-    def unbox(tree: Tree, pt: Type)(using Context): Tree = trace(i"unboxing ${tree.showSummary}: ${tree.tpe} as a $pt") {
+    def unbox(tree: Tree, pt: Type)(using Context): Tree = trace(i"unboxing ${tree.showSummary()}: ${tree.tpe} as a $pt") {
       pt match {
         case ErasedValueType(tycon, underlying) =>
           def unboxedTree(t: Tree) =
@@ -1031,7 +1031,7 @@ object Erasure {
     }
 
     override def adapt(tree: Tree, pt: Type, locked: TypeVars, tryGadtHealing: Boolean)(using Context): Tree =
-      trace(i"adapting ${tree.showSummary}: ${tree.tpe} to $pt", show = true) {
+      trace(i"adapting ${tree.showSummary()}: ${tree.tpe} to $pt", show = true) {
         if ctx.phase != erasurePhase && ctx.phase != erasurePhase.next then
           // this can happen when reading annotations loaded during erasure,
           // since these are loaded at phase typer.

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1197,7 +1197,7 @@ trait Checking {
     case _: TypeTree =>
     case _ =>
       if tree.tpe.typeParams.nonEmpty then
-        val what = if tree.symbol.exists then tree.symbol else i"type $tree"
+        val what = if tree.symbol.exists then tree.symbol.show else i"type $tree"
         report.error(em"$what takes type parameters", tree.srcPos)
 
   /** Check that we are in an inline context (inside an inline method or in inline code) */


### PR DESCRIPTION
As it was our string interpolators were taking Any values and then
trying to pattern match back their classes to try to show them nicely.
This inevitably fails for things like the opaque type FlagSet, which
interpolates as an indecipherable long number.

Now, instead, they take "Shown" arguments, for which there is an
implicit conversion in scope, given there is a Show instance for value.
I captured some desired results in some new unit test cases.

In the process a small handful of bugs were discovered, the only
particularly bad one was consuming a Iterator when the "transforms"
printer was enabled (accessorDefs), followed by an unintentional
eta-expansion of a method with a defaulted argument (showSummary).

I also lifted out the Showable and exception fallback function as an
extension method, so I could use it more broadly.

The use of WrappedResult and its `result` in `showing` was also
impacted, because the new expected Shown type was driving `result`'s
context lookup.  Fortunately I was able to continue to use WrappedResult
and `result` as defined by handling this API change inside `showing`
alone.

I wasn't, however, able to find a solution to the impact the new Shown
expected type was having on the `stripModuleClassSuffix` extension
method, sadly.

JSExportsGen is interpolating a private type, so rather than open its
access or giving it a Show instance I changed the string interpolation.

SyntaxFormatter was no longer used, since the "hl" interpolator was
dropped.

[test_windows_full]