### PR TITLE
Fix backend assertion when using an exported enum

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -390,7 +390,7 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
           def genLoadQualUnlessElidable(): Unit = { if (!qualSafeToElide) { genLoadQualifier(tree) } }
 
           // receiverClass is used in the bytecode to access the field. using sym.owner may lead to IllegalAccessError
-          def receiverClass = qualifier.tpe.typeSymbol
+          def receiverClass = qualifier.tpe.widenTermRefExpr.finalResultType.typeSymbol
           if (sym.is(Module)) {
             genLoadQualUnlessElidable()
             genLoadModule(tree)

--- a/tests/pos/i13490.scala
+++ b/tests/pos/i13490.scala
@@ -1,0 +1,17 @@
+object MyApi {
+  enum MyEnum(a: Int) {
+    case A extends MyEnum(1)
+  }
+  case class Foo(a: MyEnum)
+}
+
+object Test {
+  export MyApi.*
+  import MyEnum.*
+  Foo(MyEnum.A) match {
+    case Foo(a) =>
+      a match {
+        case A =>
+      }
+  }
+}

--- a/tests/run/i13490.min.scala
+++ b/tests/run/i13490.min.scala
@@ -1,0 +1,13 @@
+object MyTypes:
+  enum MyEnum:
+    case Foo
+    case Bar
+
+object MyApi:
+  export MyTypes.*
+
+object MyUse:
+  import MyApi.MyEnum.Foo
+  def foo = Foo
+
+@main def Test = assert(MyUse.foo.toString == "Foo")


### PR DESCRIPTION
An exported enum is a <static> final method of the enum object.  When
selecting an inner enum case from it, that method will be the prefix.
The method doesn't have a type symbol, we have to widen to method type
and reach for its result type before we can get a handle on the type
symbol to key off of.

I wonder whether this widening and going to the result type is something
that should happen during Erasure's denotation transformation though...

Co-authored-by: Seth Tisue <seth@tisue.net>
