### PR TITLE
Fix safe-init error in MegaPhase

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -455,11 +455,6 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
 
   // Initialization code
 
-  for ((phase, idx) <- miniPhases.zipWithIndex) {
-    phase.superPhase = this
-    phase.idxInGroup = idx
-  }
-
   /** Class#getDeclaredMethods is slow, so we cache its output */
   private val clsMethodsCache = new java.util.IdentityHashMap[Class[?], Array[java.lang.reflect.Method]]
 
@@ -563,6 +558,11 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
   private val nxUnitTransPhase = init("transformUnit")
   private val nxOtherPrepPhase = init("prepareForOther")
   private val nxOtherTransPhase = init("transformOther")
+
+  for ((phase, idx) <- miniPhases.zipWithIndex) {
+    phase.superPhase = this
+    phase.idxInGroup = idx
+  }
 
   // Boilerplate snippets
 


### PR DESCRIPTION
When bootstrapping the compiler with the `-Ysafe-init` flag, we would
get the following error:
```
[error] -- Error: /****/dotty/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala:458:7
[error] 458 |  for ((phase, idx) <- miniPhases.zipWithIndex) {
[error]     |       ^
[error]     |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
[error]     |
[error]     |The unsafe promotion may cause the following problem:
[error]     |Cannot prove that the value is fully initialized. May only assign fully initialized value.
[error] 459 |    phase.superPhase = this
[error] 460 |    phase.idxInGroup = idx
[error] 461 |  }
```

This fixes the initialization order to address this error.

Review by @liufengyun 