### PR TITLE
Reposition assertion to respect safe initialization

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3877,9 +3877,6 @@ object Types {
     val paramInfos: List[TypeBounds] = paramInfosExp(this)
     val resType: Type = resultTypeExp(this)
 
-    assert(resType.isInstanceOf[TermType], this)
-    assert(paramNames.nonEmpty)
-
     private def setVariances(tparams: List[LambdaParam], vs: List[Variance]): Unit =
       if tparams.nonEmpty then
         tparams.head.declaredVariance = vs.head
@@ -3931,6 +3928,9 @@ object Types {
       if isDeclaredVarianceLambda then
         s"HKTypeLambda($paramNames, $paramInfos, $resType, ${declaredVariances.map(_.flagsString)})"
       else super.toString
+
+    assert(resType.isInstanceOf[TermType], this)
+    assert(paramNames.nonEmpty)
   }
 
   /** The type of a polymorphic method. It has the same form as HKTypeLambda,


### PR DESCRIPTION
Passing `this` to `assert` before object members are fully initialized
does not pass safe init check:
```
[error] -- Error: library/src/scala/runtime/stdLibPatches/Predef.scala:7:64 ------------
[error] 7 |    if !assertion then scala.runtime.Scala3RunTime.assertFailed(message)
[error]   |                                                                ^^^^^^^
[error]   |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
```

This change fixes the above error.

Review by @liufengyun