### PR TITLE
Supress safe initialization warning in Run class

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -57,40 +57,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
    */
   @volatile var isCancelled = false
 
-  /** Produces the following contexts, from outermost to innermost
-   *
-   *    bootStrap:   A context with next available runId and a scope consisting of
-   *                 the RootPackage _root_
-   *    start        A context with RootClass as owner and the necessary initializations
-   *                 for type checking.
-   *    imports      For each element of RootImports, an import context
-   */
-  protected def rootContext(using Context): Context = {
-    ctx.initialize()
-    ctx.base.setPhasePlan(comp.phases)
-    val rootScope = new MutableScope(0)
-    val bootstrap = ctx.fresh
-      .setPeriod(Period(comp.nextRunId, FirstPhaseId))
-      .setScope(rootScope)
-    rootScope.enter(ctx.definitions.RootPackage)(using bootstrap)
-    var start = bootstrap.fresh
-      .setOwner(defn.RootClass)
-      .setTyper(new Typer)
-      .addMode(Mode.ImplicitsEnabled)
-      .setTyperState(ctx.typerState.fresh(ctx.reporter))
-    if ctx.settings.YexplicitNulls.value && !Feature.enabledBySetting(nme.unsafeNulls) then
-      start = start.addMode(Mode.SafeNulls)
-    ctx.initialize()(using start) // re-initialize the base context with start
-    start.setRun(this)
-  }
-
   private var compiling = false
-
-  private var myCtx = rootContext(using ictx)
-
-  /** The context created for this run */
-  given runContext[Dummy_so_its_a_def]: Context = myCtx
-  assert(runContext.runId <= Periods.MaxPossibleRunId)
 
   private var myUnits: List[CompilationUnit] = _
   private var myUnitsCached: List[CompilationUnit] = _
@@ -369,4 +336,39 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     myUnits = null
     myUnitsCached = null
   }
+
+  /** Produces the following contexts, from outermost to innermost
+   *
+   *    bootStrap:   A context with next available runId and a scope consisting of
+   *                 the RootPackage _root_
+   *    start        A context with RootClass as owner and the necessary initializations
+   *                 for type checking.
+   *    imports      For each element of RootImports, an import context
+   */
+  protected def rootContext(using Context): Context = {
+    ctx.initialize()
+    ctx.base.setPhasePlan(comp.phases)
+    val rootScope = new MutableScope(0)
+    val bootstrap = ctx.fresh
+      .setPeriod(Period(comp.nextRunId, FirstPhaseId))
+      .setScope(rootScope)
+    rootScope.enter(ctx.definitions.RootPackage)(using bootstrap)
+    var start = bootstrap.fresh
+      .setOwner(defn.RootClass)
+      .setTyper(new Typer)
+      .addMode(Mode.ImplicitsEnabled)
+      .setTyperState(ctx.typerState.fresh(ctx.reporter))
+    if ctx.settings.YexplicitNulls.value && !Feature.enabledBySetting(nme.unsafeNulls) then
+      start = start.addMode(Mode.SafeNulls)
+    ctx.initialize()(using start) // re-initialize the base context with start
+    start
+  }
+
+  private var myCtx = rootContext(using ictx)
+
+  /** The context created for this run */
+  given runContext[Dummy_so_its_a_def]: Context = myCtx
+  assert(runContext.runId <= Periods.MaxPossibleRunId)
+
+  myCtx = myCtx.fresh.setRun(this)
 }


### PR DESCRIPTION
Closes #14465

Due to the `this` pointer being passed to `start.setRun` in a function called during initialization, the initialization checker cannot prove that `this` is fully initialized.

We would get the following error:
```
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/Run.scala:84:17
[error] 84 |    start.setRun(this)
[error]    |                 ^^^^
[error]    |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
[error]    | -> val run = new Run(this, initCtx) {  [ ReplCompiler.scala:42 ]
[error]    |  -> class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with ConstraintRunInfo {iler-b[ Run.scala:38 ]
[error]    |   -> private var myCtx = rootContext(using ictx)   [ Run.scala:89 ]
[error]    |    -> val rootCtx = super.rootContext.fresh    [ ReplCompiler.scala:62 ]
```

This sets the store after `myCtx` is set in order to address this error.

Review by @liufengyun