### PR TITLE
Scaladoc: Follow renames in content contributors script

### DIFF
--- a/scaladoc-js/contributors/src/Globals.scala
+++ b/scaladoc-js/contributors/src/Globals.scala
@@ -7,5 +7,6 @@ import scala.scalajs.js.annotation.JSGlobalScope
 @JSGlobalScope
 object Globals extends js.Object {
   val githubContributorsUrl: String = js.native
+  val githubContributorsFilename: String = js.native
 }
 

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -82,11 +82,14 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
       script(raw(s"""var pathToRoot = "${pathToRoot(page.link.dri)}";""")),
       (page.content match
         case ResolvedTemplate(loadedTemplate, _) =>
-          val path = loadedTemplate.file.toPath
+          val path = loadedTemplate.templateFile.file.toPath
           ctx.sourceLinks.repoSummary(path) match
             case Some(DefinedRepoSummary("github", org, repo)) =>
               val tag: TagArg = ctx.sourceLinks.fullPath(relativePath(path)).fold("") { githubContributors =>
-                script(raw(s"""var githubContributorsUrl = "https://api.github.com/repos/$org/$repo/commits?path=$githubContributors";"""))
+                Seq(
+                  script(raw(s"""var githubContributorsUrl = "https://api.github.com/repos/$org/$repo";""")),
+                  script(raw(s"""var githubContributorsFilename = "$githubContributors";"""))
+                )
               }
               tag // for some reason inference fails so had to state the type explicitly
             case _ => ""


### PR DESCRIPTION
Unfortunately, Github checks git history without `--follow` argument. Due to that, after moving docs, the content contributors widget on site lost information about contributors. With these changes, the script follows renames and shows all contributors.