### PR TITLE
fix typo in docs example capability checking

### DIFF
--- a/docs/_docs/reference/experimental/cc.md
+++ b/docs/_docs/reference/experimental/cc.md
@@ -500,7 +500,7 @@ def escaped(xs: Double*): (() => Double) throws LimitExceeded =
 val crasher = escaped(1, 2, 10e+11)
 crasher()
 ```
-This code needs to be rejected since otherwise the call to `later()` would cause
+This code needs to be rejected since otherwise the call to `crasher()` would cause
 an unhandled `LimitExceeded` exception to be thrown.
 
 Under `-Ycc`, the code is indeed rejected


### PR DESCRIPTION
Changed the name of the method from `later` to `crasher` as the name `later` is probably from some previous version of the example, and `crasher` is the name from the code above. 