### PR TITLE
Expand span errorTermTree to include skipped span.

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
@@ -131,7 +131,7 @@ object MarkupParsers {
             try handle.parseAttribute(Span(start, curOffset, mid), tmp)
             catch {
               case e: RuntimeException =>
-                errorAndResult("error parsing attribute value", parser.errorTermTree)
+                errorAndResult("error parsing attribute value", parser.errorTermTree(parser.in.offset))
             }
 
           case '{'  =>
@@ -334,7 +334,7 @@ object MarkupParsers {
       finally parser.in.resume(saved)
 
       if (output == null)
-        parser.errorTermTree
+        parser.errorTermTree(parser.in.offset)
       else
         output
     }

--- a/language-server/test/dotty/tools/languageserver/DiagnosticsTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DiagnosticsTest.scala
@@ -21,9 +21,7 @@ class DiagnosticsTest {
           |  Nil.map(x => x).filter(x$m1 =>$m2)$m3
           |}""".withSource
       .diagnostics(m1,
-        (m2 to m2, "expression expected but ')' found", Error, Some(IllegalStartSimpleExprID)),
-        (m1 to m1, """Found:    Null
-                     |Required: Boolean""".stripMargin, Error, Some(TypeMismatchID))
+        (m2 to m2, "expression expected but ')' found", Error, Some(IllegalStartSimpleExprID))
       )
 
   @Test def diagnosticPureExpression: Unit =

--- a/tests/neg/arg-eof.scala
+++ b/tests/neg/arg-eof.scala
@@ -1,3 +1,3 @@
 object Test:
   case class Widget(name: String, other: Int = 5)
-  Widget(name = "foo", // error // error
+  Widget(name = "foo", // error

--- a/tests/neg/errpos.scala
+++ b/tests/neg/errpos.scala
@@ -10,7 +10,7 @@ object Test {
   val b = type // error: expression expected (on "type")
 
   1 match {
-    case            // error: pattern expected // error: cannot compare with Null
+    case            // error: pattern expected
     case 2 => ""
   }
 }

--- a/tests/neg/i12150.check
+++ b/tests/neg/i12150.check
@@ -4,9 +4,3 @@
   |             expression expected but [31mend[0m found
   |
   | longer explanation available when compiling with `-explain`
--- [E129] Potential Issue Warning: tests/neg/i12150.scala:1:11 ---------------------------------------------------------
-1 |def f: Unit = // error
-  |           ^
-  |           A pure expression does nothing in statement position; you may be omitting necessary parentheses
-  |
-  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i1846.scala
+++ b/tests/neg/i1846.scala
@@ -3,17 +3,17 @@ object Test {
     val x = 42
     val Y = "42"
 
-    x match { case { 42 }           => () } // error // error
-    x match { case { 42.toString }  => () } // error // error
-    x match { case { 42 }.toString  => () } // error // error
+    x match { case { 42 }           => () } // error
+    x match { case { 42.toString }  => () } // error
+    x match { case { 42 }.toString  => () } // error
     x match { case "42".toInt       => () } // error
-    x match { case { "42".toInt }   => () } // error // error
-    x match { case { "42" }.toInt   => () } // error // error
-    x match { case { "42".toInt }   => () } // error // error
+    x match { case { "42".toInt }   => () } // error
+    x match { case { "42" }.toInt   => () } // error
+    x match { case { "42".toInt }   => () } // error
     x match { case Y                => () } // error
-    x match { case { Y.toInt }      => () } // error // error
-    x match { case { Y }.toInt      => () } // error // error
-    x match { case { Y }.toString   => () } // error // error
-    x match { case { Y.toString }   => () } // error // error
+    x match { case { Y.toInt }      => () } // error
+    x match { case { Y }.toInt      => () } // error
+    x match { case { Y }.toString   => () } // error
+    x match { case { Y.toString }   => () } // error
   }
 }

--- a/tests/neg/i3812.scala
+++ b/tests/neg/i3812.scala
@@ -3,11 +3,11 @@ object Test {
     val x = 42
     val Y = "42"
 
-    x match { case { 42 }           => () } // error // error
-    x match { case { "42".toInt }   => () } // error // error
-    x match { case { "42" }.toInt   => () } // error // error
-    x match { case { "42".toInt }   => () } // error // error
-    x match { case { Y.toInt }      => () } // error // error
-    x match { case { Y }.toInt      => () } // error // error
+    x match { case { 42 }           => () } // error
+    x match { case { "42".toInt }   => () } // error
+    x match { case { "42" }.toInt   => () } // error
+    x match { case { "42".toInt }   => () } // error
+    x match { case { Y.toInt }      => () } // error
+    x match { case { Y }.toInt      => () } // error
   }
 }

--- a/tests/neg/i5004.scala
+++ b/tests/neg/i5004.scala
@@ -1,6 +1,6 @@
 object i0 {
 1 match {
 def this(): Int  // error
-  def this()
+  def this()  // error
 }
 }

--- a/tests/neg/i7742.scala
+++ b/tests/neg/i7742.scala
@@ -1,3 +1,3 @@
 object A {
-    for // error // error
+    for // error
 }

--- a/tests/neg/parser-stability-25.scala
+++ b/tests/neg/parser-stability-25.scala
@@ -11,5 +11,5 @@ class D extends (Int => 1) {
 }
 
 class Wrap(x: Int)
-class E extends (Wrap)( // error
+class E extends (Wrap)(
 // error

--- a/tests/neg/parser-stability-27.scala
+++ b/tests/neg/parser-stability-27.scala
@@ -1,2 +1,2 @@
-class F extends (Int => 1)( // error
+class F extends (Int => 1)(
 // error

--- a/tests/neg/parser-stability-5.scala
+++ b/tests/neg/parser-stability-5.scala
@@ -1,4 +1,4 @@
 trait x0 {
 x1 : {   // error
-var x2   // error
+var x2
 // error

--- a/tests/neg/t5702-neg-bad-and-wild.check
+++ b/tests/neg/t5702-neg-bad-and-wild.check
@@ -1,15 +1,19 @@
 -- [E032] Syntax Error: tests/neg/t5702-neg-bad-and-wild.scala:10:22 ---------------------------------------------------
-10 |      case List(1, _*,) => // error: pattern expected // error
+10 |      case List(1, _*,) => // error: pattern expected
    |                      ^
    |                      pattern expected
    |
    | longer explanation available when compiling with `-explain`
 -- [E032] Syntax Error: tests/neg/t5702-neg-bad-and-wild.scala:12:23 ---------------------------------------------------
-12 |      case List(1, _*3,) => // error: pattern expected // error // error
+12 |      case List(1, _*3,) => // error: pattern expected // error
    |                       ^
    |                       pattern expected
    |
    | longer explanation available when compiling with `-explain`
+-- [E040] Syntax Error: tests/neg/t5702-neg-bad-and-wild.scala:13:23 ---------------------------------------------------
+13 |      case List(1, _*3:) =>  // error // error
+   |                       ^
+   |                       an identifier expected, but ')' found
 -- [E032] Syntax Error: tests/neg/t5702-neg-bad-and-wild.scala:15:18 ---------------------------------------------------
 15 |      case List(x*, 1) => // error: pattern expected
    |                  ^
@@ -34,17 +38,15 @@
    |    x is already defined as value x
    |
    |    Note that overloaded methods must all be defined in the same group of toplevel definitions
--- Error: tests/neg/t5702-neg-bad-and-wild.scala:10:21 -----------------------------------------------------------------
-10 |      case List(1, _*,) => // error: pattern expected // error
-   |                     ^
-   |                     Values of types Null and Int cannot be compared with == or !=
 -- [E006] Not Found Error: tests/neg/t5702-neg-bad-and-wild.scala:12:20 ------------------------------------------------
-12 |      case List(1, _*3,) => // error: pattern expected // error // error
+12 |      case List(1, _*3,) => // error: pattern expected // error
    |                    ^
    |                    Not found: *
    |
    | longer explanation available when compiling with `-explain`
--- Error: tests/neg/t5702-neg-bad-and-wild.scala:12:22 -----------------------------------------------------------------
-12 |      case List(1, _*3,) => // error: pattern expected // error // error
-   |                      ^
-   |                      Values of types Null and Int cannot be compared with == or !=
+-- [E006] Not Found Error: tests/neg/t5702-neg-bad-and-wild.scala:13:20 ------------------------------------------------
+13 |      case List(1, _*3:) =>  // error // error
+   |                    ^
+   |                    Not found: *
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/t5702-neg-bad-and-wild.scala
+++ b/tests/neg/t5702-neg-bad-and-wild.scala
@@ -7,10 +7,10 @@ object Test {
     val is = List(1,2,3)
 
     is match {
-      case List(1, _*,) => // error: pattern expected // error
+      case List(1, _*,) => // error: pattern expected
 
-      case List(1, _*3,) => // error: pattern expected // error // error
-      //case List(1, _*3:) =>  // poor recovery by parens
+      case List(1, _*3,) => // error: pattern expected // error
+      case List(1, _*3:) =>  // error // error
       case List(1, x*) => // ok
       case List(x*, 1) => // error: pattern expected
       case (1, x*) => //ok

--- a/tests/neg/trailingCommas.scala
+++ b/tests/neg/trailingCommas.scala
@@ -2,10 +2,10 @@ package foo
 
 // Multi-line only cases: make sure trailing commas are only supported when multi-line
 
-trait ArgumentExprs1 { validMethod(23, "bar", )(Ev0, Ev1) } // error // error
-trait ArgumentExprs2 { validMethod(23, "bar")(Ev0, Ev1, ) } // error // error
-trait ArgumentExprs3 { new ValidClass(23, "bar", )(Ev0, Ev1) } // error // error
-trait ArgumentExprs4 { new ValidClass(23, "bar")(Ev0, Ev1, ) } // error // error
+trait ArgumentExprs1 { validMethod(23, "bar", )(Ev0, Ev1) } // error
+trait ArgumentExprs2 { validMethod(23, "bar")(Ev0, Ev1, ) } // error
+trait ArgumentExprs3 { new ValidClass(23, "bar", )(Ev0, Ev1) } // error
+trait ArgumentExprs4 { new ValidClass(23, "bar")(Ev0, Ev1, ) } // error
 
 trait Params1 { def f(foo: Int, bar: String, )(implicit ev0: Ev0, ev1: Ev1, ) = 1 } // error // error
 


### PR DESCRIPTION
At present, when the parser encounters an error and produces `errorTermTree`, it first issues a syntax error, which has the side effect of skipping to the nearest "safe point" (`)`, newline, etc.). This means that the `errorTermTree` conceptually covers the whole skipped span, but only the position right before the safe point token is included in the span of the error. 

This PR keeps track of the `lastOffset` before skipping tokens and includes everything from that offset up to the safe point in the span of the error. So for example, in `foo(5, :)`, previously, the `errorTermTree` returned would not include the `:`. 

This reduces the number of (redundant) errors, and in particular removes type-checking errors that arise from the presumably-private implementation detail of producing `Constant(null)` as the `errorTermTree`.