### PR TITLE
Set proper position for ValDefs generated from tuples

### DIFF
--- a/language-server/test/dotty/tools/languageserver/HoverTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HoverTest.scala
@@ -234,7 +234,13 @@ class HoverTest {
   
   @Test def tuple: Unit = {
     code"""|object A:
-           |  val (${m1}first${m2}, second) = (1, 2)""".withSource
-      .hover(m1 to m2, hoverContent("Int"))
+           |  val (${m1}first${m2}, second) = (1.0, 2)""".withSource
+      .hover(m1 to m2, hoverContent("Double"))
+  }
+
+  @Test def multiAssigment: Unit = {
+    code"""|val ${m1}x${m2}, ${m3}y${m4} = 42.0""".withSource
+      .hover(m1 to m2, hoverContent("Double"))
+      .hover(m3 to m4, hoverContent("Double"))
   }
 }

--- a/language-server/test/dotty/tools/languageserver/WorksheetTest.scala
+++ b/language-server/test/dotty/tools/languageserver/WorksheetTest.scala
@@ -93,12 +93,6 @@ class WorksheetTest {
         ((m1 to m2), "val res0: String = odd"))
   }
 
-  @Test def patternMatching1: Unit = {
-    ws"""${m1}val (foo, bar) = (1, 2)${m2}""".withSource
-      .run(m1,
-        ((m1 to m2), s"val foo: Int = 1${nl}val bar: Int = 2"))
-  }
-
   @Test def evaluationException: Unit = {
     ws"""${m1}val foo = 1 / 0${m2}
          ${m3}val bar = 2${m4}""".withSource

--- a/tests/neg/t5702-neg-bad-and-wild.check
+++ b/tests/neg/t5702-neg-bad-and-wild.check
@@ -23,11 +23,17 @@
    |
    | longer explanation available when compiling with `-explain`
 -- [E032] Syntax Error: tests/neg/t5702-neg-bad-and-wild.scala:23:17 ---------------------------------------------------
-23 |    val K(ns @ _*, x) = k // error: pattern expected
+23 |    val K(ns @ _*, xx) = k // error: pattern expected
    |                 ^
    |                 pattern expected
    |
    | longer explanation available when compiling with `-explain`
+-- [E161] Naming Error: tests/neg/t5702-neg-bad-and-wild.scala:24:10 ---------------------------------------------------
+24 |    val K(x) = k // error: x is already defined as value x
+   |    ^^^^^^^^^^^^
+   |    x is already defined as value x
+   |
+   |    Note that overloaded methods must all be defined in the same group of toplevel definitions
 -- Error: tests/neg/t5702-neg-bad-and-wild.scala:10:21 -----------------------------------------------------------------
 10 |      case List(1, _*,) => // error: pattern expected // error
    |                     ^

--- a/tests/neg/t5702-neg-bad-and-wild.scala
+++ b/tests/neg/t5702-neg-bad-and-wild.scala
@@ -20,7 +20,8 @@ object Test {
 // good syntax, bad semantics, detected by typer
 //gowild.scala:14: error: star patterns must correspond with varargs parameters
     val K(x @ _*) = k
-    val K(ns @ _*, x) = k // error: pattern expected
+    val K(ns @ _*, xx) = k // error: pattern expected
+    val K(x) = k // error: x is already defined as value x
     val (b, _ * ) = (5,6) // ok
 // no longer complains
 //bad-and-wild.scala:15: error: ')' expected but '}' found.


### PR DESCRIPTION
Previously, the span for ValDefs generated for tuples would encompas the entire expression, which led to difficulties identifying the exact path to the current position. Now, we set the span to be the same as the name underneath.

Not sure if this is a proper solution, since normally ValDefs ecompans the entire span, but in this case it makes 2 different ValDef have the same span. An alternative solution would be to find the one with point nearer to the current position.

This popped up within the Nightly tests we do in Metals.