### PR TITLE
fix(#11202): special case type trees in syntax highlighting

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -112,7 +112,7 @@ object SyntaxHighlighting {
               highlightPosition(tree.nameSpan, TypeColor)
             case tree: Ident if tree.isType =>
               highlightPosition(tree.span, TypeColor)
-            case _: TypTree =>
+            case _: TypeTree =>
               highlightPosition(tree.span, TypeColor)
             case _ =>
           }

--- a/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
+++ b/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
@@ -23,7 +23,9 @@ class SyntaxHighlightingTests extends DottyTest {
 
     if (expected != highlighted) {
       // assertEquals produces weird expected/found message
-      fail(s"expected: $expected but was: $highlighted")
+      fail(s"""|
+               |expected:      $expected
+               |highlighted:   $highlighted""".stripMargin)
     }
   }
 
@@ -41,6 +43,8 @@ class SyntaxHighlightingTests extends DottyTest {
     test("type Foo = Int", "<K|type> <T|Foo> = <T|Int>")
     test("type A = String | Int", "<K|type> <T|A> = <T|String> <T||> <T|Int>")
     test("type B = String & Int", "<K|type> <T|B> = <T|String> <T|&> <T|Int>")
+    test("type Id[A] = A", "<K|type> <T|Id>[<T|A>] = <T|A>")
+    test("type Foo = [X] =>> List[X]", "<K|type> <T|Foo> = [<T|X>] =>> <T|List>[<T|X>]")
   }
 
   @Test
@@ -88,6 +92,10 @@ class SyntaxHighlightingTests extends DottyTest {
     test("val foo",       "<K|val> <V|foo>")
     test("val foo =",     "<K|val> <V|foo> =")
     test("val foo = 123", "<K|val> <V|foo> = <L|123>")
+    test(
+      "val foo: List[List[Int]] = List(List(1))",
+      "<K|val> <V|foo>: <T|List>[<T|List>[<T|Int>]] = List(List(<L|1>))"
+    )
 
     test("var",                "<K|var>")
     test("var foo",            "<K|var> <V|foo>")
@@ -111,7 +119,7 @@ class SyntaxHighlightingTests extends DottyTest {
     test("def f1(x: Int) = 123", "<K|def> <V|f1>(<V|x>: <T|Int>) = <L|123>")
     test("def f2[T](x: T) = { 123 }", "<K|def> <V|f2>[<T|T>](<V|x>: <T|T>) = { <L|123> }")
 
-    test("def f3[T[_", "<K|def> <V|f3>[<T|T>[<T|_>")
+    test("def f3[T[_", "<K|def> <V|f3>[<T|T>[_")
   }
 
   @Test


### PR DESCRIPTION
This fixes #11202 and ensures that when a LambdaTypeTree is encountered
we are only highlighting the actual type params.

### Before

<img width="301" alt="Screenshot 2022-02-19 at 13 23 27" src="https://user-images.githubusercontent.com/13974112/154800606-d68533d3-f617-44ec-84cd-d487d2f3afc9.png">

<img width="356" alt="Screenshot 2022-02-19 at 13 24 42" src="https://user-images.githubusercontent.com/13974112/154800653-0ba3423a-4400-437d-953b-57f851bce66b.png">

### After

<img width="301" alt="Screenshot 2022-02-19 at 13 23 52" src="https://user-images.githubusercontent.com/13974112/154800668-aba6e18b-307d-44ed-b03e-980eb5b773f5.png">

<img width="356" alt="Screenshot 2022-02-19 at 13 25 06" src="https://user-images.githubusercontent.com/13974112/154800677-00a8531c-f841-471b-9ee6-0f1776bac5fe.png">


