### PR TITLE
fix(parser): make empty catch an incomplete.

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -280,6 +280,12 @@ object Parsers {
         syntaxError(msg, offset)
         skip(stopAtComma = true)
 
+    def syntaxErrorOrIncomplete(msg: Message, span: Span): Unit =
+      if (in.token == EOF) incompleteInputError(msg)
+      else
+        syntaxError(msg, span)
+        skip(stopAtComma = true)
+
     /** Consume one token of the specified type, or
       * signal an error if it is not there.
       *
@@ -2003,7 +2009,7 @@ object Parsers {
           handler match {
             case Block(Nil, EmptyTree) =>
               assert(handlerStart != -1)
-              syntaxError(
+              syntaxErrorOrIncomplete(
                 EmptyCatchBlock(body),
                 Span(handlerStart, endOffset(handler))
               )

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -300,4 +300,14 @@ class ReplVerboseTests extends ReplTest(ReplTest.defaultOptions :+ "-verbose"):
     run("val a = 42")
     assert(storedOutput().trim().endsWith("val a: Int = 42"))
   }
+
+  @Test def `i4393-incomplete-catch`: Unit = contextually {
+    assert(ParseResult.isIncomplete("""|try {
+                                       |  ???
+                                       |} catch""".stripMargin))
+    assert(ParseResult.isIncomplete("""|try {
+                                       |  ???
+                                       |} catch {""".stripMargin))
+  }
+
 end ReplVerboseTests


### PR DESCRIPTION
When parsing a `TRY` if there is an empty catch block instead of just
returning a syntax error return an incomplete if you're at the EOF. This
ensures that in the REPL if you are in a position like:

```scala
scala> try {
     | ???
     | } catch
```

And you hit enter you'll still be able to continue.

Fixes #4393