### PR TITLE
improvement(repl): add in feedback when resetting REPL state

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -391,7 +391,16 @@ class ReplDriver(settings: Array[String],
       state
 
     case Reset(arg) =>
-      resetToInitial(tokenize(arg))
+      val tokens = tokenize(arg)
+
+      if tokens.nonEmpty then
+        out.println(s"""|Resetting REPL state with the following settings:
+                        |  ${tokens.mkString("\n  ")}
+                        |""".stripMargin)
+      else
+        out.println("Resetting REPL state.")
+
+      resetToInitial(tokens)
       initialState
 
     case Imports =>

--- a/compiler/test-resources/repl/reset-command
+++ b/compiler/test-resources/repl/reset-command
@@ -3,6 +3,8 @@ there were 1 deprecation warning(s); re-run with -deprecation for details
 def f(thread: Thread): Unit
 
 scala>:reset -deprecation
+Resetting REPL state with the following settings:
+  -deprecation
 
 scala> def f(thread: Thread) = thread.stop()
 1 warning found
@@ -16,6 +18,7 @@ scala> def resetNoArgsStillWorks = 1
 def resetNoArgsStillWorks: Int
 
 scala>:reset
+Resetting REPL state.
 
 scala> resetNoArgsStillWorks
 -- [E006] Not Found Error: -----------------------------------------------------


### PR DESCRIPTION
As a user I'm a big fan of getting feedback from the tools I'm working
with. Without out, you have to go on assumption that what you just tried
worked unless it explodes. In Scala 2 when you do a `:reset` in the REPL
you get a nice message about it being reset and even some details about
what exactly was reset.

Following that train of thought this just adds in small note when you
reset your session. Here are a couple examples which you can also see in
the changed tests:

```none
scala>:reset -deprecation
Resetting REPL state with the following settings:
  -deprecation
```

```none
scala>:reset
Resetting REPL state.
```