### PR TITLE
Warn unused imports

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -135,6 +135,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     val rename: TermName = renamed match
       case Ident(rename: TermName) => rename
       case _ => name
+
+    def isMask: Boolean = !isWildcard && rename == nme.WILDCARD
   }
 
   case class Number(digits: String, kind: NumberKind)(implicit @constructorOnly src: SourceFile) extends TermTree

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -6,11 +6,11 @@ import scala.language.unsafeNulls
 import dotty.tools.dotc.config.PathResolver.Defaults
 import dotty.tools.dotc.config.Settings.{Setting, SettingGroup}
 import dotty.tools.dotc.config.SourceVersion
-import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.rewrites.Rewrites
 import dotty.tools.io.{AbstractFile, Directory, JDK9Reflectors, PlainDirectory}
 
-import scala.util.chaining._
+import scala.util.chaining.*
 
 class ScalaSettings extends SettingGroup with AllScalaSettings
 
@@ -162,12 +162,13 @@ private sealed trait WarningSettings:
     name = "-Wunused",
     helpArg = "warning",
     descr = "Enable or disable specific `unused` warnings",
-    choices = List("nowarn", "all"),
+    choices = List("nowarn", "all", "imports"),
     default = Nil
   )
   object WunusedHas:
     def allOr(s: String)(using Context) = Wunused.value.pipe(us => us.contains("all") || us.contains(s))
     def nowarn(using Context) = allOr("nowarn")
+    def imports(using Context) = allOr("imports")
 
   val Wconf: Setting[List[String]] = MultiStringSetting(
     "-Wconf",
@@ -343,5 +344,7 @@ private sealed trait YSettings:
   val YinstrumentDefs: Setting[Boolean] = BooleanSetting("-Yinstrument-defs", "Add instrumentation code that counts method calls; needs -Yinstrument to be set, too.")
 
   val YforceInlineWhileTyping: Setting[Boolean] = BooleanSetting("-Yforce-inline-while-typing", "Make non-transparent inline methods inline when typing. Emulates the old inlining behavior of 3.0.0-M3.")
+
+  val YrewriteImports: Setting[Boolean] = BooleanSetting("-Yrewrite-imports", "Rewrite unused imports. Requires -Wunused:imports.")
 end YSettings
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2736,8 +2736,8 @@ object Types {
     override def eql(that: Type): Boolean = this eq that // safe because named types are hash-consed separately
   }
 
-  /** A reference to an implicit definition. This can be either a TermRef or a
-   *  Implicits.RenamedImplicitRef.
+  /** A reference to an implicit definition. This can be either a TermRef or
+   *  an Implicits.{ImportedImplicitRef, RenamedImplicitRef}.
    */
   trait ImplicitRef {
     def implicitName(using Context): TermName

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -148,7 +148,7 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
   def run(uri: URI, sourceCode: String): List[Diagnostic] = run(uri, toSource(uri, sourceCode))
 
   def run(uri: URI, source: SourceFile): List[Diagnostic] = {
-    import typer.ImportInfo._
+    import typer.ImportInfo.withRootImports
 
     val previousCtx = myCtx
     try {

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -59,6 +59,8 @@ class ImportInfo(symf: Context ?=> Symbol,
                  val enclosingSpan: Span,
                  val isRootImport: Boolean = false) extends Showable {
 
+  override def toString = selectors.mkString(s"ImportInfo#$hashCode(", ",", s") at $enclosingSpan")
+
   private def symNameOpt = qualifier match {
     case ref: untpd.RefTree => Some(ref.name.asTermName)
     case _                  => None

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -393,7 +393,7 @@ class Namer { typer: Typer =>
         setDocstring(pkg, stat)
         ctx
       case imp: Import =>
-        ctx.importContext(imp, createSymbol(imp))
+        ctx.importContext(imp, createSymbol(imp), enteringSyms = true)
       case mdef: DefTree =>
         val sym = createSymbol(mdef)
         enterSymbol(sym)

--- a/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
@@ -59,6 +59,94 @@ class TyperPhase(addRootImports: Boolean = true) extends Phase {
       JavaChecks.check(unit.tpdTree)
   }
 
+  /** Report unused imports.
+   *
+   *  If `-Yrewrite-imports`, emit patches instead.
+   *  Patches are applied if `-rewrite` and no errors.
+   */
+  def emitDiagnostics(using Context): Unit =
+    import ast.Trees.*
+    import ast.untpd
+    import parsing.Parsers
+    import rewrites.Rewrites.patch
+    import util.SourceFile
+    import Decorators.*
+    def reportSelectors(sels: List[untpd.ImportSelector]) = sels.foreach(sel => report.warning(s"Unused import", pos = sel.srcPos))
+    // format the import clause, qual.{ selectors }
+    def toText(qual: untpd.Tree, sels: List[untpd.ImportSelector]): String =
+      def selected(sel: untpd.ImportSelector) =
+        if sel.isGiven then
+          if sel.bound.isEmpty then "given" else "given " + sel.bound.show
+        else if sel.isWildcard then "*"
+        else if sel.name == sel.rename then sel.name.show
+        else s"${sel.name.show} as ${sel.rename.show}"
+      val selections = sels.map(selected)
+      if sels.length > 1 then selections.mkString(i"$qual.{", ", ", "}") else i"$qual.${selections.head}"
+    end toText
+    // begin
+    val unused = ctx.usages.unused    //ImportInfo, owner Symbol, unused List[untpd.ImportSelector]
+    if !ctx.settings.YrewriteImports.value then
+      unused.foreach { (info, owner, selectors) => reportSelectors(selectors) }
+    else if unused.nonEmpty then
+      val byLocation = unused.groupBy((info, owner, selectors) => info.qualifier.sourcePos.withSpan(info.enclosingSpan))
+      byLocation.foreach { (enclosingPos, grouped) =>
+        val importText = enclosingPos.spanText
+        val lineSource = SourceFile.virtual(name = "import-line.scala", content = importText)
+        val PackageDef(_, clauses) = Parsers.Parser(lineSource).parse(): @unchecked
+        val edited =
+          clauses.map {
+            case importTree @ Import(pqual, pselectors) =>
+              //val importPrefix = raw"import\s+".r
+              //val prologue = importPrefix.findPrefixMatchOf(importText).map(_.end).getOrElse(0)
+              // uncorrupt span of first clause, which starts at keyword but really starts at point
+              val span =
+                if importTree.span.point != importTree.span.start then importTree.span.withStart(importTree.span.point)
+                else importTree.span
+              val zone = span.shift(enclosingPos.span.start)
+              grouped.find { (info, _, _) => zone.contains(info.qualifier.span) } match
+                case Some((_, _, selectors)) =>
+                  val retained = pselectors.filterNot(psel => selectors.exists(_.sameTree(psel)))
+                  (zone, pqual, retained, true)
+                case _ =>
+                  (zone, pqual, pselectors, false)
+          }
+        val src = ctx.compilationUnit.source
+        // Simple deletion, or replace import statement with nonempty clauses; or if multiline, patch the emended bits
+        if edited.forall(_._3.isEmpty) then
+          val spanToDelete =
+            val lines = enclosingPos.lineContent.linesIterator
+            val line = lines.next()
+            val (gutter, text) = line.splitAt(enclosingPos.startColumn)
+            if !lines.hasNext && gutter.forall(Character.isWhitespace) && text == importText then
+              enclosingPos.source.lineSpan(enclosingPos.point)
+            else enclosingPos.span
+          patch(src, spanToDelete, "")
+        else if !importText.contains('\n') then
+          val patched = edited.flatMap {
+            case (_, qual, retained, _) if retained.nonEmpty => Some(toText(qual, retained))
+            case _ => None
+          }.mkString("import ", ", ", "")
+          patch(src, enclosingPos.span, patched)
+        else
+          edited.zipWithIndex.foreach {
+            case ((span, qual, retained, emended), index) =>
+              if emended then
+                if retained.isEmpty then
+                  // adjust span to include a comma
+                  val adjustedSpan =
+                    if index == edited.length - 1 then span.withStart(edited(index - 1)._1.end) // TODO don't overlap
+                    else span.withEnd(edited(1)._1.start)
+                  patch(src, adjustedSpan, "")
+                else
+                  patch(src, span, toText(qual, retained))
+          }
+        end if
+      }
+  end emitDiagnostics
+
+  def clearDiagnostics()(using Context): Unit =
+    ctx.usages.clear()
+
   protected def discardAfterTyper(unit: CompilationUnit)(using Context): Boolean =
     unit.isJava || unit.suspended
 
@@ -88,6 +176,9 @@ class TyperPhase(addRootImports: Boolean = true) extends Phase {
     unitContexts.foreach(typeCheck(using _))
     record("total trees after typer", ast.Trees.ntrees)
     unitContexts.foreach(javaCheck(using _)) // after typechecking to avoid cycles
+
+    unitContexts.foreach(emitDiagnostics(using _))
+    clearDiagnostics()
 
     val newUnits = unitContexts.map(_.compilationUnit).filterNot(discardAfterTyper)
     ctx.run.nn.checkSuspendedUnits(newUnits)

--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -11,7 +11,6 @@ import core.Contexts._
 import scala.io.Codec
 import Chars._
 import scala.annotation.internal.sharable
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.chaining.given
 
@@ -19,7 +18,6 @@ import java.io.File.separator
 import java.nio.charset.StandardCharsets
 import java.nio.file.{FileSystemException, NoSuchFileException}
 import java.util.Optional
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 
 object ScriptSourceFile {
@@ -60,7 +58,6 @@ object ScriptSourceFile {
 }
 
 class SourceFile(val file: AbstractFile, computeContent: => Array[Char]) extends interfaces.SourceFile {
-  import SourceFile._
 
   private var myContent: Array[Char] | Null = null
 
@@ -190,6 +187,10 @@ class SourceFile(val file: AbstractFile, computeContent: => Array[Char]) extends
   /** The content of the line containing position `offset` */
   def lineContent(offset: Int): String =
     content.slice(startOfLine(offset), nextLine(offset)).mkString
+
+  /** The span of the line containing position `offset` */
+  def lineSpan(offset: Int): Span =
+    Spans.Span(startOfLine(offset), nextLine(offset))
 
   /** The column corresponding to `offset`, starting at 0 */
   def column(offset: Int): Int = {

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -33,6 +33,12 @@ extends SrcPos, interfaces.SourcePosition, Showable {
   def linesSlice: Array[Char] =
     source.content.slice(source.startOfLine(start), source.nextLine(end))
 
+  /** Extract exactly the span from the source file. */
+  def spanSlice: Array[Char] = source.content.slice(start, end)
+
+  /** Extract exactly the span from the source file as a String. */
+  def spanText: String = String(spanSlice)
+
   /** The lines of the position */
   def lines: Range = {
     val startOffset = source.offsetToLine(start)

--- a/compiler/src/dotty/tools/dotc/util/Spans.scala
+++ b/compiler/src/dotty/tools/dotc/util/Spans.scala
@@ -144,6 +144,10 @@ object Spans {
     def ==(that: Span): Boolean = this.coords == that.coords
     def !=(that: Span): Boolean = this.coords != that.coords
   }
+  object Span:
+    extension (span: Span)
+      def spread: Int = span.end - span.start
+  end Span
 
   private def fromOffsets(start: Int, end: Int, pointDelta: Int) =
     //assert(start <= end || start == 1 && end == 0, s"$start..$end")

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -83,6 +83,8 @@ class CompilationTests {
       compileFile("tests/rewrites/i9632.scala", defaultOptions.and("-indent", "-rewrite")),
       compileFile("tests/rewrites/i11895.scala", defaultOptions.and("-indent", "-rewrite")),
       compileFile("tests/rewrites/i12340.scala", unindentOptions.and("-rewrite")),
+      compileFile("tests/rewrites/unused-imports.scala", defaultOptions),
+      compileFile("tests/rewrites/unused-imports-stylized.scala", defaultOptions),
     ).checkRewrites()
   }
 

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -774,8 +774,8 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       lazy val actualErrors = reporters.foldLeft(0)(_ + _.errorCount)
       lazy val (expected, unexpected) = getMissingExpectedErrors(errorMap, reporters.iterator.flatMap(_.errors))
       def hasMissingAnnotations = expected.nonEmpty || unexpected.nonEmpty
-      def showErrors = "-> following the errors:\n" +
-        reporters.flatMap(_.allErrors.sortBy(_.pos.line).map(e => s"${e.pos.line + 1}: ${e.message}")).mkString(" at ", "\n at ", "")
+      def showErrors = "Reported errors:\n" +
+        reporters.flatMap(_.allErrors.sortBy(_.pos.line).map(e => s"${e.pos.line + 1}: ${e.message.linesIterator.mkString("\\")}")).mkString(" at ", "\n at ", "")
 
       Option {
         if compilerCrashed then s"Compiler crashed when compiling: ${testSource.title}"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -193,7 +193,7 @@ object Build {
       "-deprecation",
       "-unchecked",
       //"-Wconf:cat=deprecation&msg=Unsafe:s",    // example usage
-      "-Xfatal-warnings",                         // -Werror in modern usage
+      "-Werror",
       "-encoding", "UTF8",
       "-language:implicitConversions",
     ),
@@ -791,6 +791,11 @@ object Build {
         "-Ddotty.tests.classes.dottyTastyInspector=" + jars("scala3-tasty-inspector"),
       )
     },
+    scalacOptions ++= Seq(
+      //"-Wunused:imports",
+      //"-rewrite",
+      //"-Yrewrite-imports",
+    ),
     packageAll := {
       (`scala3-compiler` / packageAll).value ++ Seq(
         "scala3-compiler" -> (Compile / packageBin).value.getAbsolutePath,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -193,7 +193,7 @@ object Build {
       "-deprecation",
       "-unchecked",
       //"-Wconf:cat=deprecation&msg=Unsafe:s",    // example usage
-      "-Werror",
+      "-Xfatal-warnings",                         // -Werror in modern usage
       "-encoding", "UTF8",
       "-language:implicitConversions",
     ),
@@ -791,11 +791,6 @@ object Build {
         "-Ddotty.tests.classes.dottyTastyInspector=" + jars("scala3-tasty-inspector"),
       )
     },
-    scalacOptions ++= Seq(
-      //"-Wunused:imports",
-      //"-rewrite",
-      //"-Yrewrite-imports",
-    ),
     packageAll := {
       (`scala3-compiler` / packageAll).value ++ Seq(
         "scala3-compiler" -> (Compile / packageBin).value.getAbsolutePath,

--- a/tests/neg/i13558.check
+++ b/tests/neg/i13558.check
@@ -9,8 +9,8 @@
    |                failed with:
    |
    |                    Reference to id is ambiguous,
-   |                    it is both imported by import testcode.ExtensionB._
-   |                    and imported subsequently by import testcode.ExtensionA._
+   |                    it is both imported by import testcode.ExtensionB.*
+   |                    and imported subsequently by import testcode.ExtensionA.*
 -- [E008] Not Found Error: tests/neg/i13558.scala:29:14 ----------------------------------------------------------------
 29 |    println(a.id) // error
    |            ^^^^
@@ -22,5 +22,5 @@
    |                failed with:
    |
    |                    Reference to id is ambiguous,
-   |                    it is both imported by import testcode.ExtensionA._
-   |                    and imported subsequently by import testcode.ExtensionB._
+   |                    it is both imported by import testcode.ExtensionA.*
+   |                    and imported subsequently by import testcode.ExtensionB.*

--- a/tests/neg/t12690a.scala
+++ b/tests/neg/t12690a.scala
@@ -1,0 +1,16 @@
+
+// scalac: -Werror -Wunused:imports
+
+class X
+class Y extends X
+object A { implicit val x: X = new X }
+object B { implicit val y: Y = new Y }
+class C {
+  import B._
+  import A._ // error: unused
+  def t = implicitly[X]
+}
+
+object Test extends App {
+  println(new C().t)
+}

--- a/tests/neg/t12690b.scala
+++ b/tests/neg/t12690b.scala
@@ -1,0 +1,16 @@
+
+// scalac: -Werror -Wunused:imports
+
+class X
+class Y extends X
+object A { implicit val x: X = new X }
+object B { implicit val y: Y = new Y }
+class C {
+  import A._ // error: unused
+  import B._
+  def t = implicitly[X]
+}
+
+object Test extends App {
+  println(new C().t)
+}

--- a/tests/neg/unused-imports.check
+++ b/tests/neg/unused-imports.check
@@ -1,0 +1,40 @@
+-- Error: tests/neg/unused-imports.scala:5:16 --------------------------------------------------------------------------
+5 |import language.postfixOps // error
+  |                ^^^^^^^^^^
+  |                Unused import
+-- Error: tests/neg/unused-imports.scala:6:24 --------------------------------------------------------------------------
+6 |import scala.concurrent.* // error
+  |                        ^
+  |                        Unused import
+-- Error: tests/neg/unused-imports.scala:11:43 -------------------------------------------------------------------------
+11 |  import scala.collection.mutable.{HashMap as GoodMap, Seq as _, ListBuffer, Buffer, Set as OK} // error // error
+   |                                   ^^^^^^^^^^^^^^^^^^
+   |                                   Unused import
+-- Error: tests/neg/unused-imports.scala:11:77 -------------------------------------------------------------------------
+11 |  import scala.collection.mutable.{HashMap as GoodMap, Seq as _, ListBuffer, Buffer, Set as OK} // error // error
+   |                                                                             ^^^^^^
+   |                                                                             Unused import
+-- Error: tests/neg/unused-imports.scala:51:38 -------------------------------------------------------------------------
+51 |    import Givens.{given Ordering[C], *}, E.{given, *} // error // error // error
+   |                                      ^
+   |                                      Unused import
+-- Error: tests/neg/unused-imports.scala:51:45 -------------------------------------------------------------------------
+51 |    import Givens.{given Ordering[C], *}, E.{given, *} // error // error // error
+   |                                             ^^^^^
+   |                                             Unused import
+-- Error: tests/neg/unused-imports.scala:51:52 -------------------------------------------------------------------------
+51 |    import Givens.{given Ordering[C], *}, E.{given, *} // error // error // error
+   |                                                    ^
+   |                                                    Unused import
+-- Error: tests/neg/unused-imports.scala:57:14 -------------------------------------------------------------------------
+57 |    import E.{given, *}, Givens.{given Ordering[C], *} // error // error // error
+   |              ^^^^^
+   |              Unused import
+-- Error: tests/neg/unused-imports.scala:57:21 -------------------------------------------------------------------------
+57 |    import E.{given, *}, Givens.{given Ordering[C], *} // error // error // error
+   |                     ^
+   |                     Unused import
+-- Error: tests/neg/unused-imports.scala:57:52 -------------------------------------------------------------------------
+57 |    import E.{given, *}, Givens.{given Ordering[C], *} // error // error // error
+   |                                                    ^
+   |                                                    Unused import

--- a/tests/neg/unused-imports.scala
+++ b/tests/neg/unused-imports.scala
@@ -1,0 +1,76 @@
+// scalac: -Wunused:imports -Werror -feature
+
+import language.future
+import language.implicitConversions
+import language.postfixOps // error
+import scala.concurrent.* // error
+import scala.concurrent.ExecutionContext.Implicits.*
+
+class C:
+  def c = 42
+  import scala.collection.mutable.{HashMap as GoodMap, Seq as _, ListBuffer, Buffer, Set as OK} // error // error
+
+  def buf = ListBuffer.empty[String]
+  def ok: OK[Int] = ???
+  def f   = concurrent.Future(42)  // implicit usage
+
+  import Thread.*
+  import State.{NEW, BLOCKED}
+
+  def state(t: Thread) =
+    t.getState match
+      case NEW =>
+        import State.RUNNABLE
+        t.getState match
+          case RUNNABLE => 0
+          case BLOCKED => 1
+          case _ => -1
+      case _ => -1
+
+  enum E:
+    case E0, E1
+
+  def e(x: E) =
+    x match
+      case E.E0 => "e0"
+      case E.E1 => "e1"
+
+  locally {
+    import Givens.{*, given}
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.{cOrdering, *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.{given Ordering[C], *}, E.{given, *} // error // error // error
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+  locally {
+    import E.{given, *}, Givens.{given Ordering[C], *} // error // error // error
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+end C
+
+object Givens:
+  given cOrdering: Ordering[C] with
+    override def compare(c0: C, c1: C) = 0
+  val greeting = "we love Givens"
+
+class A:
+  def f(b: B): Unit = b.f(this)
+
+object A:
+  implicit val a2b: Conversion[A, B] = _ => B()
+
+class B:
+  def f(b: B): Unit = ()

--- a/tests/rewrites/unused-imports-stylized.check
+++ b/tests/rewrites/unused-imports-stylized.check
@@ -1,0 +1,84 @@
+// scalac: -Wunused:imports -Werror -feature -rewrite -Yrewrite-imports
+
+import language.{ future,
+                  implicitConversions,
+                  postfixOps,
+                }
+import scala.concurrent.*, ExecutionContext.Implicits.*
+
+class C:
+  def c = 42
+  import collection.mutable, mutable.ListBuffer, mutable.{Seq as _, Set as OK}
+
+  def buf = ListBuffer.empty[String]
+  def ok: OK[Int] = ???
+  def f = concurrent.Future(42)  // implicit usage
+
+  import Thread.*
+  import State.{
+    NEW,
+    BLOCKED}
+
+  def state(t: Thread) =
+    t.getState match
+      case NEW =>
+        import State.RUNNABLE
+        t.getState match
+          case RUNNABLE => 0
+          case BLOCKED => 1
+          case _ => -1
+      case _ => -1
+
+  enum E:
+    case E0, E1
+
+  def e(x: E) =
+    x match
+      case E.E0 => "e0"
+      case E.E1 => "e1"
+
+  locally {
+    import Givens.{
+      *,
+      given
+    }
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.{
+      cOrdering,
+      *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.given Ordering[C]
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+  locally {
+    import
+      Givens.given Ordering[C]
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+end C
+
+object Givens:
+  given cOrdering: Ordering[C] with
+    override def compare(c0: C, c1: C) = 0
+  val greeting = "we love Givens"
+
+class A:
+  def f(b: B): Unit = b.f(this)
+
+object A:
+  implicit val a2b: Conversion[A, B] = _ => B()
+
+class B:
+  def f(b: B): Unit = ()

--- a/tests/rewrites/unused-imports-stylized.check
+++ b/tests/rewrites/unused-imports-stylized.check
@@ -37,7 +37,7 @@ class C:
       case E.E0 => "e0"
       case E.E1 => "e1"
 
-  locally {
+  locally:
     import Givens.{
       *,
       given
@@ -45,28 +45,24 @@ class C:
 
     def g(s: String)(using Ordering[C]) = ???
     def ordered = g(greeting)
-  }
-  locally {
+  locally:
     import Givens.{
       cOrdering,
       *}
 
     def g(s: String)(using Ordering[C]) = ???
     def ordered = g(greeting)
-  }
-  locally {
+  locally:
     import Givens.given Ordering[C]
 
     def g(s: String)(using Ordering[C]) = ???
     println(g(""))
-  }
-  locally {
+  locally:
     import
       Givens.given Ordering[C]
 
     def g(s: String)(using Ordering[C]) = ???
     println(g(""))
-  }
 end C
 
 object Givens:

--- a/tests/rewrites/unused-imports-stylized.scala
+++ b/tests/rewrites/unused-imports-stylized.scala
@@ -1,0 +1,88 @@
+// scalac: -Wunused:imports -Werror -feature -rewrite -Yrewrite-imports
+
+import language.{ future,
+                  implicitConversions,
+                  postfixOps,
+                }
+import scala.concurrent.*, ExecutionContext.Implicits.*
+
+class C:
+  def c = 42
+  import collection.mutable, mutable.ListBuffer, mutable.{HashMap as GoodMap, Seq as _, Buffer, Set as OK}
+
+  def buf = ListBuffer.empty[String]
+  def ok: OK[Int] = ???
+  def f = concurrent.Future(42)  // implicit usage
+
+  import Thread.*
+  import State.{
+    NEW,
+    BLOCKED}
+
+  def state(t: Thread) =
+    t.getState match
+      case NEW =>
+        import State.RUNNABLE
+        t.getState match
+          case RUNNABLE => 0
+          case BLOCKED => 1
+          case _ => -1
+      case _ => -1
+
+  enum E:
+    case E0, E1
+
+  def e(x: E) =
+    x match
+      case E.E0 => "e0"
+      case E.E1 => "e1"
+
+  locally {
+    import Givens.{
+      *,
+      given
+    }
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.{
+      cOrdering,
+      *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens
+           .{given Ordering[C], *},
+           E
+           .{given, *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+  locally {
+    import
+      E.{given, *},
+      Givens.{given Ordering[C], *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+end C
+
+object Givens:
+  given cOrdering: Ordering[C] with
+    override def compare(c0: C, c1: C) = 0
+  val greeting = "we love Givens"
+
+class A:
+  def f(b: B): Unit = b.f(this)
+
+object A:
+  implicit val a2b: Conversion[A, B] = _ => B()
+
+class B:
+  def f(b: B): Unit = ()

--- a/tests/rewrites/unused-imports.check
+++ b/tests/rewrites/unused-imports.check
@@ -33,30 +33,26 @@ class C:
       case E.E0 => "e0"
       case E.E1 => "e1"
 
-  locally {
+  locally:
     import Givens.{*, given}
 
     def g(s: String)(using Ordering[C]) = ???
     def ordered = g(greeting)
-  }
-  locally {
+  locally:
     import Givens.{cOrdering, *}
 
     def g(s: String)(using Ordering[C]) = ???
     def ordered = g(greeting)
-  }
-  locally {
+  locally:
     import Givens.given Ordering[C]
 
     def g(s: String)(using Ordering[C]) = ???
     println(g(""))
-  }
-  locally {
+  locally:
     import Givens.given Ordering[C]
 
     def g(s: String)(using Ordering[C]) = ???
     println(g(""))
-  }
 end C
 
 object Givens:

--- a/tests/rewrites/unused-imports.check
+++ b/tests/rewrites/unused-imports.check
@@ -1,0 +1,74 @@
+// scalac: -Wunused:imports -Werror -feature -rewrite -Yrewrite-imports
+
+import language.future
+import language.implicitConversions
+import scala.concurrent.ExecutionContext.Implicits.*
+
+class C:
+  def c = 42
+  import scala.collection.mutable.{Seq as _, ListBuffer, Set as OK} //?error //?error
+
+  def buf = ListBuffer.empty[String]
+  def ok: OK[Int] = ???
+  def f   = concurrent.Future(42)  // implicit usage
+
+  import Thread.*
+  import State.{NEW, BLOCKED}
+
+  def state(t: Thread) =
+    t.getState match
+      case NEW =>
+        import State.RUNNABLE
+        t.getState match
+          case RUNNABLE => 0
+          case BLOCKED => 1
+          case _ => -1
+      case _ => -1
+
+  enum E:
+    case E0, E1
+
+  def e(x: E) =
+    x match
+      case E.E0 => "e0"
+      case E.E1 => "e1"
+
+  locally {
+    import Givens.{*, given}
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.{cOrdering, *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.given Ordering[C]
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+  locally {
+    import Givens.given Ordering[C]
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+end C
+
+object Givens:
+  given cOrdering: Ordering[C] with
+    override def compare(c0: C, c1: C) = 0
+  val greeting = "we love Givens"
+
+class A:
+  def f(b: B): Unit = b.f(this)
+
+object A:
+  implicit val a2b: Conversion[A, B] = _ => B()
+
+class B:
+  def f(b: B): Unit = ()

--- a/tests/rewrites/unused-imports.scala
+++ b/tests/rewrites/unused-imports.scala
@@ -1,0 +1,76 @@
+// scalac: -Wunused:imports -Werror -feature -rewrite -Yrewrite-imports
+
+import language.future
+import language.implicitConversions
+import language.postfixOps
+import scala.concurrent.*
+import scala.concurrent.ExecutionContext.Implicits.*
+
+class C:
+  def c = 42
+  import scala.collection.mutable.{HashMap as GoodMap, Seq as _, ListBuffer, Buffer, Set as OK} //?error //?error
+
+  def buf = ListBuffer.empty[String]
+  def ok: OK[Int] = ???
+  def f   = concurrent.Future(42)  // implicit usage
+
+  import Thread.*
+  import State.{NEW, BLOCKED}
+
+  def state(t: Thread) =
+    t.getState match
+      case NEW =>
+        import State.RUNNABLE
+        t.getState match
+          case RUNNABLE => 0
+          case BLOCKED => 1
+          case _ => -1
+      case _ => -1
+
+  enum E:
+    case E0, E1
+
+  def e(x: E) =
+    x match
+      case E.E0 => "e0"
+      case E.E1 => "e1"
+
+  locally {
+    import Givens.{*, given}
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.{cOrdering, *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    def ordered = g(greeting)
+  }
+  locally {
+    import Givens.{given Ordering[C], *}, E.{given, *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+  locally {
+    import E.{given, *}, Givens.{given Ordering[C], *}
+
+    def g(s: String)(using Ordering[C]) = ???
+    println(g(""))
+  }
+end C
+
+object Givens:
+  given cOrdering: Ordering[C] with
+    override def compare(c0: C, c1: C) = 0
+  val greeting = "we love Givens"
+
+class A:
+  def f(b: B): Unit = b.f(this)
+
+object A:
+  implicit val a2b: Conversion[A, B] = _ => B()
+
+class B:
+  def f(b: B): Unit = ()


### PR DESCRIPTION
Forward port the Scala 2 feature, tracking imports when contexts are created, and registering when selectors are used.

Some support for `-rewrite` to remove unused selectors (if there is only one import on the source line), disabled.