### PR TITLE
Don't generate Mirror.Sum for simple enum cases

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -273,7 +273,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
     val cls = mirroredType.classSymbol
     val useCompanion = cls.useCompanionAsSumMirror
 
-    if cls.isGenericSum(if useCompanion then cls.linkedClass else ctx.owner) then
+    if (!mirroredType.termSymbol.isEnumCase && (cls.isGenericSum(if useCompanion then cls.linkedClass else ctx.owner))) then
       val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
 
       def solve(sym: Symbol): Type = sym match

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -274,8 +274,10 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
     val useCompanion = cls.useCompanionAsSumMirror
 
     def acceptable(tp: Type): Boolean = tp match
+      case tp: TermRef => false
+      case tp: TypeProxy => acceptable(tp.underlying)
       case OrType(tp1, tp2) => acceptable(tp1) && acceptable(tp2)
-      case _                => !tp.termSymbol.isEnumCase && (tp.classSymbol eq cls)
+      case _            => tp.classSymbol eq cls
 
     if acceptable(mirroredType) && cls.isGenericSum(if useCompanion then cls.linkedClass else ctx.owner) then
       val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))

--- a/tests/neg/scala_enum_testing.scala
+++ b/tests/neg/scala_enum_testing.scala
@@ -16,6 +16,10 @@ object Singletons {
   object B
 }
 
+type SumOfK1[F[_]] = Mirror.Sum { type MirroredType[T] = F[T] }
+
+class refined extends scala.annotation.RefiningAnnotation
+
 object Test {
 
     def main(args: Array[String]): Unit = {
@@ -24,5 +28,13 @@ object Test {
       summon[Mirror.SumOf[Color.Red.type | Color.Green.type]] // error
       summon[Mirror.SumOf[Bar.A | Bar.B]] // error
       summon[Mirror.SumOf[Singletons.A.type | Singletons.B.type]] // error
+      summon[SumOfK1[[X] =>> Bar]]
+      summon[SumOfK1[[X] =>> Bar.A | Bar.B]] // error
+      summon[SumOfK1[[X] =>> (Bar.A | Bar.B) @refined]] // error
+      object opaques {
+        opaque type Query[X] = (Bar.A | Bar.B) @refined
+      }
+      summon[SumOfK1[opaques.Query]] // error
+      summon[SumOfK1[[X] =>> (Bar.A @refined) | Bar.B]] // error
     }
 }

--- a/tests/neg/scala_enum_testing.scala
+++ b/tests/neg/scala_enum_testing.scala
@@ -1,0 +1,15 @@
+import scala.util.NotGiven
+import scala.compiletime.*
+import scala.deriving.Mirror
+
+enum Color:
+  case Red, Green, Blue
+end Color
+
+object Test {
+
+    def main(args: Array[String]): Unit = {
+      summon[Mirror.ProductOf[Color]] // error
+      summon[Mirror.SumOf[Color.Red.type]] // error
+    }
+}

--- a/tests/neg/scala_enum_testing.scala
+++ b/tests/neg/scala_enum_testing.scala
@@ -6,10 +6,23 @@ enum Color:
   case Red, Green, Blue
 end Color
 
+enum Bar:
+  case A(i: Int)
+  case B(b: Boolean)
+  case C(s: String)
+
+object Singletons {
+  object A
+  object B
+}
+
 object Test {
 
     def main(args: Array[String]): Unit = {
       summon[Mirror.ProductOf[Color]] // error
       summon[Mirror.SumOf[Color.Red.type]] // error
+      summon[Mirror.SumOf[Color.Red.type | Color.Green.type]] // error
+      summon[Mirror.SumOf[Bar.A | Bar.B]] // error
+      summon[Mirror.SumOf[Singletons.A.type | Singletons.B.type]] // error
     }
 }

--- a/tests/run/scala_enum_testing.scala
+++ b/tests/run/scala_enum_testing.scala
@@ -1,0 +1,17 @@
+import scala.util.NotGiven
+import scala.compiletime.*
+import scala.deriving.Mirror
+
+enum Color:
+  case Red, Green, Blue
+end Color
+
+object Test {
+
+    def main(args: Array[String]): Unit = {
+      summon[Mirror.Of[Color.Red.type]]
+      summon[Mirror.Of[Color]]
+      summon[Mirror.ProductOf[Color.Red.type]]
+      summon[Mirror.SumOf[Color]]
+    }
+}


### PR DESCRIPTION
From my understanding simple enum cases are not real classes, but instances of enum object class. Because of that they inherit their Mirror.Sum which may confuse tools like Shapeless (and also I feel it's not valid, because class cannot have both Product and Sum at the same time).