### PR TITLE
Stop parsing incorrect trailing commas and improve error recovery in comma-separated lists.

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -276,7 +276,7 @@ object Scanners {
     /** Are we in a `${ }` block? such that RBRACE exits back into multiline string. */
     private def inMultiLineInterpolatedExpression =
       currentRegion match {
-        case InBraces(InString(true, _)) => true
+        case InBraces(InString(true, _), _) => true
         case _ => false
       }
 
@@ -310,7 +310,7 @@ object Scanners {
         dropBraces()
       case RPAREN | RBRACKET =>
         currentRegion match {
-          case InParens(prefix, outer) if prefix + 1 == lastToken => currentRegion = outer
+          case InParens(prefix, outer, _) if prefix + 1 == lastToken => currentRegion = outer
           case _ =>
         }
       case STRINGLIT =>
@@ -645,13 +645,6 @@ object Scanners {
               insert(OUTDENT, offset)
               currentRegion = r.outer
             case _ =>
-              lookAhead()
-              if isAfterLineEnd
-                 && (token == RPAREN || token == RBRACKET || token == RBRACE || token == OUTDENT)
-              then
-                () /* skip the trailing comma */
-              else
-                reset()
         case END =>
           if !isEndMarker then token = IDENTIFIER
         case COLON =>
@@ -1441,7 +1434,7 @@ object Scanners {
     def proposeKnownWidth(width: IndentWidth, lastToken: Token) =
       if knownWidth == null then
         this match
-          case InParens(_, _) if lastToken != LPAREN =>
+          case InParens(_, _, _) if lastToken != LPAREN =>
             useOuterWidth()
           case _ =>
             knownWidth = width
@@ -1452,8 +1445,8 @@ object Scanners {
 
     private def delimiter = this match
       case _: InString => "}(in string)"
-      case InParens(LPAREN, _) => ")"
-      case InParens(LBRACKET, _) => "]"
+      case InParens(LPAREN, _, _) => ")"
+      case InParens(LBRACKET, _, _) => "]"
       case _: InBraces => "}"
       case _: InCase => "=>"
       case _: Indented => "UNDENT"
@@ -1468,8 +1461,8 @@ object Scanners {
   end Region
 
   case class InString(multiLine: Boolean, outer: Region) extends Region
-  case class InParens(prefix: Token, outer: Region) extends Region
-  case class InBraces(outer: Region) extends Region
+  case class InParens(prefix: Token, outer: Region, commaSeparated: Boolean = false) extends Region
+  case class InBraces(outer: Region, commaSeparated: Boolean = false) extends Region
   case class InCase(outer: Region) extends Region
 
   /** A class describing an indentation region.

--- a/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
@@ -417,7 +417,7 @@ object MarkupParsers {
 
     /** xScalaPatterns  ::= patterns
      */
-    def xScalaPatterns: List[Tree] = escapeToScala(parser.patterns(), "pattern")
+    def xScalaPatterns: List[Tree] = escapeToScala(parser.patterns(delimited = false), "pattern")
 
     def reportSyntaxError(offset: Int, str: String): Unit = parser.syntaxError(str, offset)
     def reportSyntaxError(str: String): Unit = {

--- a/tests/neg/comma-separated-errors.check
+++ b/tests/neg/comma-separated-errors.check
@@ -1,0 +1,36 @@
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:3:21 ----------------------------------------------------
+3 |  def foo(x: Int = 5 6, y Int = 7, z: Int 5, x = 5): Unit = () // error // error // error // error
+  |                     ^
+  |                     ')' expected, but integer literal found
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:3:26 ----------------------------------------------------
+3 |  def foo(x: Int = 5 6, y Int = 7, z: Int 5, x = 5): Unit = () // error // error // error // error
+  |                          ^^^
+  |                          ':' expected, but identifier found
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:3:42 ----------------------------------------------------
+3 |  def foo(x: Int = 5 6, y Int = 7, z: Int 5, x = 5): Unit = () // error // error // error // error
+  |                                          ^
+  |                                          ')' expected, but integer literal found
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:3:47 ----------------------------------------------------
+3 |  def foo(x: Int = 5 6, y Int = 7, z: Int 5, x = 5): Unit = () // error // error // error // error
+  |                                               ^
+  |                                               ':' expected, but '=' found
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:11:16 ---------------------------------------------------
+11 |    case Plus(4 1) => // error
+   |                ^
+   |                ')' expected, but integer literal found
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:12:16 ---------------------------------------------------
+12 |    case Plus(4 5 6 7, 1, 2 3) => // error // error
+   |                ^
+   |                ')' expected, but integer literal found
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:12:28 ---------------------------------------------------
+12 |    case Plus(4 5 6 7, 1, 2 3) => // error // error
+   |                            ^
+   |                            ')' expected, but integer literal found
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:14:12 ---------------------------------------------------
+14 |  val x: A[T=Int, T=Int] = ??? // error // error
+   |            ^
+   |            ']' expected, but '=' found
+-- [E040] Syntax Error: tests/neg/comma-separated-errors.scala:14:19 ---------------------------------------------------
+14 |  val x: A[T=Int, T=Int] = ??? // error // error
+   |                   ^
+   |                   ']' expected, but '=' found

--- a/tests/neg/comma-separated-errors.scala
+++ b/tests/neg/comma-separated-errors.scala
@@ -1,0 +1,15 @@
+class A[T]
+object o {
+  def foo(x: Int = 5 6, y Int = 7, z: Int 5, x = 5): Unit = () // error // error // error // error
+
+  case class Plus(a: Int, b: Int)
+
+  object Plus {
+    def unapply(r: Int): Plus = Plus(r - 1, 1)
+  }
+  5 match {
+    case Plus(4 1) => // error
+    case Plus(4 5 6 7, 1, 2 3) => // error // error
+  }
+  val x: A[T=Int, T=Int] = ??? // error // error
+}

--- a/tests/neg/i1679.scala
+++ b/tests/neg/i1679.scala
@@ -1,5 +1,5 @@
 class A[T]
 object o {
   // Testing compiler crash, this test should be modified when named type argument are completely implemented
-  val x: A[T=Int, T=Int] = ??? // error: ']' expected, but '=' found // error
+  val x: A[T=Int, T=Int] = ??? // error: ']' expected, but '=' found // error: ']' expected, but '=' found
 }

--- a/tests/neg/t11900.check
+++ b/tests/neg/t11900.check
@@ -1,0 +1,18 @@
+-- Error: tests/neg/t11900.scala:44:16 ---------------------------------------------------------------------------------
+44 |      a => a + 1,   // error: weird comma
+   |                ^
+   |                end of statement expected but ',' found
+-- Error: tests/neg/t11900.scala:48:16 ---------------------------------------------------------------------------------
+48 |    println("a"),   // error: weird comma
+   |                ^
+   |                end of statement expected but ',' found
+-- Error: tests/neg/t11900.scala:52:16 ---------------------------------------------------------------------------------
+52 |    println("b"),   // error: weird comma
+   |                ^
+   |                end of statement expected but ',' found
+-- [E032] Syntax Error: tests/neg/t11900.scala:64:8 --------------------------------------------------------------------
+64 |      _*, // error
+   |        ^
+   |        pattern expected
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/t11900.scala
+++ b/tests/neg/t11900.scala
@@ -1,0 +1,79 @@
+
+trait t11900 {
+  // cf pos/trailing-commas
+  //
+  import scala.collection.{
+    immutable,
+    mutable,
+  }
+
+  def h[A,
+  ]: List[A] = Nil
+
+  def u(
+      x: Int,
+      y: Int,
+  )(using List[Int],
+      Set[Int],
+  )(using l: List[Int],
+    s : Set[Int],
+  ): Int = 1
+
+  def g = List(
+    1,
+    2,
+    3,
+  )
+
+  def star =
+    List(1, 2, 3, 4, 5) match {
+      case List(
+      1,
+      2,
+      3,
+      ) => false
+      case List(
+      1,
+      2,
+      _*,
+      ) => true
+    }
+
+  def f =
+    List(1, 2, 3).map {
+      a => a + 1,   // error: weird comma
+    }
+
+  class A() {
+    println("a"),   // error: weird comma
+  }
+
+  def b() = {
+    println("b"),   // error: weird comma
+  }
+
+  def starcrossed =
+    List(1, 2, 3, 4, 5) match {
+      case List(
+      1,
+      2,
+      3,
+      ) => false
+      case List(
+      1,
+      _*, // error
+      2,
+      ) => true
+    }
+
+  def p(p: (Int,
+      String,
+      )
+  ): Unit
+
+  def q: (Int,
+      String,
+      )
+
+  val z = 42
+}

--- a/tests/neg/trailingCommas.scala
+++ b/tests/neg/trailingCommas.scala
@@ -56,3 +56,27 @@ object `package` {
   case class Foo(foo: Any)
   case class Bar(foo: Any)
 }
+
+// Unparenthesized lists
+trait Deriv1[T]
+object Deriv1 {
+  def derived[T]: Deriv1[T] = new Deriv1[T] {}
+}
+
+trait Deriv2[T]
+object Deriv2 {
+  def derived[T]: Deriv2[T] = new Deriv2[T] {}
+}
+
+class Derives1 derives Deriv1, Deriv2,
+object End // error: an identifier expected, but 'object' found
+
+class Derives2 derives Deriv1,
+     Deriv2,
+object End2 // error: an identifier expected, but 'object' found
+
+val a,
+    b,
+    c,
+    = (1, 2, 3) // error
+val x, y, z, = (1, 2, 3) // error // error

--- a/tests/pos/comma-separated.scala
+++ b/tests/pos/comma-separated.scala
@@ -1,0 +1,19 @@
+trait Bar[T]
+object Bar {
+  def derived[T]: Bar[T] = new Bar[T] {}
+}
+
+trait Baz[T]
+object Baz {
+  def derived[T]: Baz[T] = new Baz[T] {}
+}
+
+class Foo derives Bar, Baz
+
+class Foo2 derives Bar,
+   Baz
+
+val x, y, z = (1, 2, 3)
+val a,
+    b,
+    c = (1, 2, 3)


### PR DESCRIPTION
Instead of handling trailing commas in the scanner, which leads to buggy behavior where trailing commas are accepted in places they shouldn't, handle trailing commas in the parser. Accomplished by adding a `isCommaSeparated` field to the `InParens` region. A redux of https://github.com/scala/scala/pull/8780. 

A combination of #14509 and #14517, but with some feedback from @odersky. I put the two together because the need to handle trailing commas outside of the scanner is more apparent with both changes. 