### PR TITLE
Fix TreeTypeMap to correctly substitute type parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -204,11 +204,23 @@ class TreeTypeMap(
       lazy val origCls = mapped.zip(syms).filter(_._1.isClass).toMap
       mapped.filter(_.isClass).foldLeft(substMap) { (tmap, cls) =>
         val origDcls = cls.info.decls.toList.filterNot(_.is(TypeParam))
-        val mappedDcls = mapSymbols(origDcls, tmap, mapAlways = true)
+        val tmap0 = tmap.withSubstitution(origCls(cls).typeParams, cls.typeParams)
+        val mappedDcls = mapSymbols(origDcls, tmap0, mapAlways = true)
         val tmap1 = tmap.withMappedSyms(
           origCls(cls).typeParams ::: origDcls,
           cls.typeParams ::: mappedDcls)
         origDcls.lazyZip(mappedDcls).foreach(cls.asClass.replace)
         tmap1
       }
+
+  override def toString =
+    def showSyms(syms: List[Symbol]) =
+      syms.map(sym => s"$sym#${sym.id}").mkString(", ")
+    s"""TreeTypeMap(
+       |typeMap   = $typeMap
+       |treeMap   = $treeMap
+       |oldOwners = ${showSyms(oldOwners)}
+       |newOwners = ${showSyms(newOwners)}
+       |substFrom = ${showSyms(substFrom)}
+       |substTo   = ${showSyms(substTo)}""".stripMargin
 }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -1040,7 +1040,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       else if (sym.is(ModuleClass) && sym.isPackageObject && sym.name.stripModuleClassSuffix == tpnme.PACKAGE)
         nameString(sym.owner.name)
       else if (sym.is(ModuleClass))
-        nameString(sym.name.stripModuleClassSuffix)
+        nameString(sym.name.stripModuleClassSuffix) + idString(sym)
       else if (hasMeaninglessName(sym))
         simpleNameString(sym.owner) + idString(sym)
       else

--- a/compiler/src/dotty/tools/dotc/reporting/trace.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/trace.scala
@@ -76,7 +76,7 @@ trait TraceSyntax:
     else
       // Avoid evaluating question multiple time, since each evaluation
       // may cause some extra logging output.
-      val q = question.replace('\n', ' ')
+      val q = question
       val leading = s"==> $q?"
       val trailing = (res: T) => s"<== $q = ${showOp(res)}"
       var finalized = false

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -140,7 +140,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
           val parentEnum = vdef.owner.companionClass
           val children = parentEnum.children.zipWithIndex
           val candidate: Option[Int] = children.collectFirst { case (child, idx) if child == vdef => idx }
-          assert(candidate.isDefined, i"could not find child for $vdef")
+          assert(candidate.isDefined, i"could not find child for $vdef in ${parentEnum.children}%, % of $parentEnum")
           Literal(Constant(candidate.get))
 
       def toStringBody(vrefss: List[List[Tree]]): Tree =

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -52,6 +52,9 @@ class ReTyper(nestingLevel: Int = 0) extends Typer(nestingLevel) with ReChecking
   override def typedSuper(tree: untpd.Super, pt: Type)(using Context): Tree =
     promote(tree)
 
+  override def typedImport(tree: untpd.Import, sym: Symbol)(using Context): Tree =
+    promote(tree)
+
   override def typedTyped(tree: untpd.Typed, pt: Type)(using Context): Tree = {
     assertTyped(tree)
 

--- a/tests/pos/i12508.scala
+++ b/tests/pos/i12508.scala
@@ -1,0 +1,8 @@
+class Test {
+  inline def test(fun: Any): Any = ???
+  test {
+    class Foo[X]:
+      def x: X = ???
+      def foo: Unit = this.x.toString
+  }
+}

--- a/tests/pos/i12508.scala
+++ b/tests/pos/i12508.scala
@@ -6,3 +6,12 @@ class Test {
       def foo: Unit = this.x.toString
   }
 }
+class Test2 {
+  inline def test(fun: => Any): Any = fun
+  test {
+    case class Pair[X, Y](
+      x: X,
+      y: Y,
+    )
+  }
+}

--- a/tests/pos/i12508a.scala
+++ b/tests/pos/i12508a.scala
@@ -1,0 +1,14 @@
+def fun(a: Any, b: Any = 2): Any = ???
+def test =
+  fun(
+    b = println(1),
+    a = {
+      class Foo[X]:
+        def x: X = ???
+        def foo: Unit = this.x.toString
+        locally {
+          def x: X = ???
+          println(x.toString)
+        }
+    }
+  )

--- a/tests/pos/i12508b.scala
+++ b/tests/pos/i12508b.scala
@@ -1,0 +1,13 @@
+def fun(a: Any, b: Any = 2): Any = ???
+def test =
+  fun(
+    b = println(1),
+    a = {
+      sealed class Foo[X]:
+        def x: X = ???
+        def foo: Unit = this.x.toString
+      class Bar extends Foo[String]
+      class Baz[Y] extends Foo[Y]
+      if ??? then Bar() else Baz[Int]
+    }
+  )

--- a/tests/pos/i12508c.scala
+++ b/tests/pos/i12508c.scala
@@ -1,0 +1,12 @@
+def fun(a: Any, b: Any = 2): Any = ???
+
+def test =
+  fun(
+    b = println(1),
+    a = {
+      enum Option[+X]:
+        case Some(x: X)
+        case None
+      if ??? then Option.Some(1) else Option.None
+    }
+  )


### PR DESCRIPTION

Fix TreeTypeMap to correctly substitute parameters when copying local class members.

Fixes #12508