### PR TITLE
Scaladoc: fix #14481: certain functions not being shown in searchbar

### DIFF
--- a/scaladoc-testcases/src/tests/inheritedMembersFromHidden.scala
+++ b/scaladoc-testcases/src/tests/inheritedMembersFromHidden.scala
@@ -1,0 +1,9 @@
+package tests
+package inheritedMembersFromHidden
+
+private[inheritedMembersFromHidden] trait HiddenTrait { //unexpected
+  def method: Unit
+    = ???
+}
+
+object PublicObject extends HiddenTrait //expected: object PublicObject

--- a/scaladoc/src/dotty/tools/scaladoc/api.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/api.scala
@@ -82,7 +82,7 @@ enum Origin:
 
 case class Overridden(name: String, dri: DRI)
 
-case class InheritedFrom(name: String, dri: DRI)
+case class InheritedFrom(name: String, dri: DRI, isSourceSuperclassHidden: Boolean)
 
 case class Annotation(val dri: DRI, val params: List[Annotation.AnnotationParameter])
 

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
@@ -29,7 +29,9 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
     case _ => Nil
 
   def inheritedFrom(m: Member) = m.inheritedFrom match
-    case Some(InheritedFrom(name, dri)) => tableRow("Inherited from:", signatureRenderer.renderLink(name, dri))
+    case Some(InheritedFrom(name, dri, isSourceSuperclassHidden)) =>
+      val hiddenNameSuffix = if isSourceSuperclassHidden then " (hidden)" else "" 
+      tableRow("Inherited from:", signatureRenderer.renderLink(name + hiddenNameSuffix, dri))
     case _ => Nil
 
   def docAttributes(m: Member): Seq[AppliedTag] =

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -150,7 +150,7 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
             val entry = mkEntry(member.dri, member.name, flattenToText(sig), descr, member.kind.name)
             val children = member
                 .membersBy(m => m.kind != Kind.Package && !m.kind.isInstanceOf[Classlike])
-                .filter(m => m.origin == Origin.RegularlyDefined && m.inheritedFrom.isEmpty)
+                .filter(m => m.origin == Origin.RegularlyDefined && m.inheritedFrom.fold(false)(_.isSourceSuperclassHidden))
             Seq(entry) ++ children.flatMap(processMember)
 
           processMember(m)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -183,7 +183,7 @@ trait ClassLikeSupport:
   }
 
   private def parseInheritedMember(c: ClassDef)(s: Tree): Option[Member] =
-    def inheritance = Some(InheritedFrom(s.symbol.owner.normalizedName, s.symbol.dri))
+    def inheritance = Some(InheritedFrom(s.symbol.owner.normalizedName, s.symbol.dri, s.symbol.owner.isHiddenByVisibility))
     processTreeOpt(s)(s match
       case c: ClassDef if c.symbol.shouldDocumentClasslike => Some(parseClasslike(c, signatureOnly = true))
       case other => {

--- a/scaladoc/src/dotty/tools/scaladoc/translators/FilterAttributes.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/translators/FilterAttributes.scala
@@ -14,7 +14,7 @@ object FilterAttributes:
     Map("visibility" -> m.visibility.name)
 
   private def inheritedFrom(m: Member): Map[String, String] = m.inheritedFrom match
-    case Some(InheritedFrom(name, _)) => Map("inherited" -> name)
+    case Some(InheritedFrom(name, _, _)) => Map("inherited" -> name)
     case _ => Map.empty
 
   private def origin(m: Member): Map[String, String] = m.origin match

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -58,6 +58,8 @@ class InheritanceLoop extends SignatureTest("inheritanceLoop", SignatureTest.all
 class InheritedMembers extends SignatureTest("inheritedMembers2", SignatureTest.all.filter(_ != "class"),
   sourceFiles = List("inheritedMembers1", "inheritedMembers2"))
 
+class InheritedFromHiddenClasslike extends SignatureTest("inheritedMembersFromHidden", SignatureTest.all)
+
 class ComplexNames extends SignatureTest("complexNames", Seq("def", "class"))
 
 class WrongDocumentationLinks extends SignatureTest("links", Seq("def"))


### PR DESCRIPTION
Allows to search for public members inherited from hidden classlikes in Scaladoc. Additionally, to avoid confusing users about the missing link in the "Inherited from:" field, a `(hidden)` adnotation was also added to the superclass name of those function members.

Fixes #14481