### PR TITLE
silence a warning in the build definition

### DIFF
--- a/project/ScaladocGeneration.scala
+++ b/project/ScaladocGeneration.scala
@@ -13,7 +13,7 @@ object ScaladocGeneration {
       value match {
         case s: String => s"$key ${escape(s)}"
         case true => s"$key"
-        case list: List[String] => s"$key:${list.map(escape).mkString(",")}"
+        case list: List[String @unchecked] => s"$key:${list.map(escape).mkString(",")}"
         case _ =>
           println(s"Unsupported setting: $key -> $value")
           ""


### PR DESCRIPTION
```
[warn] /Users/tisue/dotty/project/ScaladocGeneration.scala:16:20: non-variable type argument String in type pattern List[String] (the underlying of List[String]) is unchecked since it is eliminated by erasure
[warn]         case list: List[String] => s"$key:${list.map(escape).mkString(",")}"
[warn]                    ^
```