### PR TITLE
improvement(repl): end marker now has the same color as its definition in repl (fix #14535)

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -107,9 +107,11 @@ object SyntaxHighlighting {
             case tree: ValOrDefDef =>
               highlightAnnotations(tree)
               highlightPosition(tree.nameSpan, ValDefColor)
+              highlightPosition(tree.endSpan, ValDefColor)
             case tree: MemberDef /* ModuleDef | TypeDef */ =>
               highlightAnnotations(tree)
               highlightPosition(tree.nameSpan, TypeColor)
+              highlightPosition(tree.endSpan, TypeColor)
             case tree: Ident if tree.isType =>
               highlightPosition(tree.span, TypeColor)
             case _: TypeTree =>


### PR DESCRIPTION
In this PR, we fixed issue [#14535](https://github.com/lampepfl/dotty/issues/14535) for repl improvement.
Now end markers in definitions of `val`, `def` and various kinds of types have the same color as its definition name.

## `Enum` example
### Before
<img width="259" alt="image" src="https://user-images.githubusercontent.com/73305492/155510910-3835160b-bbc0-4cb4-a3d3-c0f873a1ec24.png">

### Now
<img width="250" alt="image" src="https://user-images.githubusercontent.com/73305492/155510785-f2411bca-fc6d-4b3e-8e71-5fc89fdfbfad.png">
