### PR TITLE
Fix lookahead logic in Scanner

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -321,30 +321,27 @@ object Scanners {
       case _ =>
     }
 
-    /** Produce next token, filling TokenData fields of Scanner.
-     */
-    def nextToken(): Unit = {
-      val lastToken = token
-      adjustSepRegions(lastToken)
-
-      // Read a token or copy it from `next` tokenData
-      if (next.token == EMPTY) {
+    /** Read a token or copy it from `next` tokenData */
+    private def getNextToken(lastToken: Token): Unit =
+      if next.token == EMPTY then
         lastOffset = lastCharOffset
-        currentRegion match {
+        currentRegion match
           case InString(multiLine, _) if lastToken != STRINGPART => fetchStringPart(multiLine)
           case _ => fetchToken()
-        }
-        if (token == ERROR) adjustSepRegions(STRINGLIT) // make sure we exit enclosing string literal
-      }
-      else {
+        if token == ERROR then adjustSepRegions(STRINGLIT) // make sure we exit enclosing string literal
+      else
         this.copyFrom(next)
         next.token = EMPTY
-      }
 
-      if (isAfterLineEnd) handleNewLine(lastToken)
+    /** Produce next token, filling TokenData fields of Scanner.
+     */
+    def nextToken(): Unit =
+      val lastToken = token
+      adjustSepRegions(lastToken)
+      getNextToken(lastToken)
+      if isAfterLineEnd then handleNewLine(lastToken)
       postProcessToken()
       printState()
-    }
 
     final def printState() =
       if debugTokenStream && (showLookAheadOnDebug || !isInstanceOf[LookaheadScanner]) then
@@ -602,12 +599,10 @@ object Scanners {
         insert(OUTDENT, offset)
       case _ =>
 
-    def lookAhead() = {
+    def lookAhead() =
       prev.copyFrom(this)
-      lastOffset = lastCharOffset
-      fetchToken()
+      getNextToken(token)
       if token == END && !isEndMarker then token = IDENTIFIER
-    }
 
     def reset() = {
       next.copyFrom(this)

--- a/tests/neg/i1779.scala
+++ b/tests/neg/i1779.scala
@@ -8,6 +8,6 @@ object Test {
   def f = {
     val _parent = 3
     q"val hello = $_parent"
-    q"class $_" // error // error // error
+    q"class $_" // error // error
   }
 }

--- a/tests/pos/fewer-braces.scala
+++ b/tests/pos/fewer-braces.scala
@@ -1,0 +1,5 @@
+import language.experimental.fewerBraces
+
+object Test:
+
+  assert((new Object: Any).isInstanceOf[Object])


### PR DESCRIPTION
Executing lookaheads/reset pairs from the same position caused a token to be lost.

Fixes problem observed in #14561 