### PR TITLE
Constrain pattern types when typing a match type case

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1713,6 +1713,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       val pat1 = withMode(Mode.Pattern) {
         checkSimpleKinded(typedType(cdef.pat, mapPatternBounds = true))
       }
+      if !ctx.isAfterTyper && pt != defn.ImplicitScrutineeTypeRef then
+        withMode(Mode.GadtConstraintInference) {
+          TypeComparer.constrainPatternType(pat1.tpe, selType)
+        }
       val pat2 = indexPattern(cdef).transform(pat1)
       var body1 = typedType(cdef.body, pt)
       if !body1.isType then

--- a/tests/pos/i14151.scala
+++ b/tests/pos/i14151.scala
@@ -1,0 +1,2 @@
+class BoundedPair[A, B <: A]:
+  type Second[A, T <: BoundedPair[A, _ <: A]] <: A = T match { case BoundedPair[A, b] => b }

--- a/tests/pos/i14151b.scala
+++ b/tests/pos/i14151b.scala
@@ -1,0 +1,2 @@
+class Single[B](val value: B):
+  type Retrieve[A, T <: Single[_ <: A]] <: A = T match { case Single[b] => b }

--- a/tests/pos/i14151c.scala
+++ b/tests/pos/i14151c.scala
@@ -1,0 +1,2 @@
+class Single[B](val value: B):
+  type Retrieve[A] <: A = Single[A] match { case Single[b] => b }


### PR DESCRIPTION
This was missing, compared to typedType, and was causing constraints to
be missing, leading to legal code not compiling.
