### PR TITLE
Scaladoc: Add necessary parentheses in function types

### DIFF
--- a/scaladoc-testcases/src/tests/functionTypeSignatures.scala
+++ b/scaladoc-testcases/src/tests/functionTypeSignatures.scala
@@ -1,0 +1,10 @@
+package tests.functionTypeSignatures
+
+type A = ((Int, Int)) => Int
+
+type B = (Int | String) => Int
+
+type C = (Int & String) => Int
+
+type E = (A => B) => B
+

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -199,9 +199,11 @@ trait TypesSupport:
             case Seq(rtpe) =>
               plain("()").l ++ keyword(arrow).l ++ inner(rtpe)
             case Seq(arg, rtpe) =>
+              def withParentheses(tpe: TypeRepr) = plain("(").l ++ inner(tpe) ++ plain(")").l
               val partOfSignature = arg match
-                case byName: ByNameType => plain("(").l ++ inner(byName) ++ plain(")").l
-                case _ => inner(arg)
+                case tpe @ (_:TermRef | _:TypeRef | _:ConstantType | _: ParamRef) => inner(arg)
+                case tpe: AppliedType if !tpe.isFunctionType && !tpe.isTupleN => inner(arg)
+                case _ => withParentheses(arg)
               partOfSignature ++ keyword(arrow).l ++ inner(rtpe)
             case args =>
               plain("(").l ++ commas(args.init.map(inner)) ++ plain(")").l ++ keyword(arrow).l ++ inner(args.last)

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -94,3 +94,5 @@ class Exports extends SignatureTest("exports2", SignatureTest.all, sourceFiles =
 class ContextFunctions extends SignatureTest("contextfunctions", SignatureTest.all)
 
 class MarkdownCode extends SignatureTest("markdowncode", SignatureTest.all)
+
+class FunctionTypeSignatures extends SignatureTest("functionTypeSignatures", SignatureTest.all)


### PR DESCRIPTION
closes: #14511 

