### PR TITLE
CI: Escape invalid characters from doc destination.

### DIFF
--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -68,7 +68,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           inlineScript: |
-            DOC_DEST=pr-${PR_NUMBER:-${GITHUB_REF##*/}}
+            DOC_DEST=$(echo pr-${PR_NUMBER:-${GITHUB_REF##*/}} | tr -d -c "[-A-Za-z0-9]")
             echo uplading docs to https://scala3doc.virtuslab.com/$DOC_DEST
             az storage container create --name $DOC_DEST --account-name scala3docstorage --public-access container
             az storage blob upload-batch -s scaladoc/output -d $DOC_DEST --account-name scala3docstorage


### PR DESCRIPTION
The job that uploads test documentation to Azure was occasionally failing due to invalid characters in branch name. This change filters all invalid characters from doc destination.