### PR TITLE
Fix safe-init errors in ContextBase

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -872,11 +872,11 @@ object Contexts {
     /** The loader that loads the members of _root_ */
     def rootLoader(root: TermSymbol)(using Context): SymbolLoader = platform.rootLoader(root)
 
-    // Set up some phases to get started */
-    usePhases(List(SomePhase))
-
     /** The standard definitions */
     val definitions: Definitions = new Definitions
+
+    // Set up some phases to get started */
+    usePhases(List(SomePhase))
 
     /** Initializes the `ContextBase` with a starting context.
      *  This initializes the `platform` and the `definitions`.


### PR DESCRIPTION
When bootstrapping the compiler with the `-Ysafe-init` flag, we would
get the following errors:
```
[error] -- Error: /Users/********/dotty/compiler/src/dotty/tools/dotc/core/Phases.scala:164:19
[error] 164 |            p.init(this, miniPhases.head.id, miniPhases.last.id)
[error]     |                   ^^^^
[error]     |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
[error]     | -> usePhases(List(SomePhase)) [ Contexts.scala:876 ]
[error] -- Error: /Users/********/dotty/compiler/src/dotty/tools/dotc/core/Phases.scala:161:30
[error] 161 |            miniPhases.foreach{ phase =>
[error]     |                              ^
[error]     |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
[error]     | Calling trace:
[error]     | -> usePhases(List(SomePhase)) [ Contexts.scala:876 ]
[error]     |
[error]     |The unsafe promotion may cause the following problem:
[error]     |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
[error]     | -> usePhases(List(SomePhase)) [ Contexts.scala:876 ]
[error] 162 |              checkRequirements(phase)
[error] 163 |              phase.init(this, nextPhaseId)}
[error] -- Error: /Users/********/dotty/compiler/src/dotty/tools/dotc/core/Phases.scala:166:23
[error] 166 |            phase.init(this, nextPhaseId)
[error]     |                       ^^^^
[error]     |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
[error]     | -> usePhases(List(SomePhase)) [ Contexts.scala:876 ]
```

This fixes the initialization order to address these errors.

Review by @liufengyun