### PR TITLE
Publish back the release notes of 0.1.2

### DIFF
--- a/docs/_docs/release-notes-0.1.2.md
+++ b/docs/_docs/release-notes-0.1.2.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: 0.1.2 release notes
+redirectFrom: /docs/release-notes/0.1.2.html
 ---
 
 0.1.2 will be the first public release of Dotty.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -188,3 +188,5 @@ subsection:
       - page: internals/type-system.md
       - page: internals/dotty-internals-1-notes.md
       - page: internals/debug-macros.md
+  - page: release-notes-0.1.2.md
+    hidden: true


### PR DESCRIPTION
The CI of the https://scala-lang.org website is failing because the page https://dotty.epfl.ch/docs/release-notes/0.1.2.html does not exist anymore.

This PR publishes back the page. However, there is a problem. My intention was to not include the page in the sidebar, yet I had to create an “empty” entry in the sidebar:

![Screenshot from 2022-02-28 16-43-15](https://user-images.githubusercontent.com/332812/156014234-139a1e86-4ec9-4fcd-831f-477298504055.png)

What we can do to solve this issue is either to support custom output path for pages, or to publish the page at the root of the website (https://dotty.epfl.ch/0.1.2.html) and update the link that points to it in scala/scala-lang#1346. Do you have any preference?