### PR TITLE
Fix casting of generic tuple selection

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1489,10 +1489,11 @@ class Definitions {
    * @return true if the dealiased type of `tp` is `TupleN[T1, T2, ..., Tn]`
    */
   def isTupleNType(tp: Type)(using Context): Boolean = {
-    val arity = tp.dealias.argInfos.length
+    val tp1 = tp.dealias
+    val arity = tp1.argInfos.length
     arity <= MaxTupleArity && {
       val tupletp = TupleType(arity)
-      tupletp != null && tp.isRef(tupletp.symbol)
+      tupletp != null && tp1.isRef(tupletp.symbol)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -336,8 +336,7 @@ object PatternMatcher {
 
         if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length)
           def tupleSel(sym: Symbol) = ref(scrutinee).select(sym)
-          val isGenericTuple = defn.isTupleClass(caseClass) &&
-            !defn.isTupleNType(tree.tpe match { case tp: OrType => tp.join case tp => tp }) // widen even hard unions, to see if it's a union of tuples
+          val isGenericTuple = defn.isTupleClass(caseClass) && !defn.isTupleNType(tree.tpe)
           val components = if isGenericTuple then caseAccessors.indices.toList.map(tupleApp(_, ref(scrutinee))) else caseAccessors.map(tupleSel)
           matchArgsPlan(components, args, onSuccess)
         else if (unapp.tpe <:< (defn.BooleanType))

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -336,7 +336,8 @@ object PatternMatcher {
 
         if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length)
           def tupleSel(sym: Symbol) = ref(scrutinee).select(sym)
-          val isGenericTuple = defn.isTupleClass(caseClass) && !defn.isTupleNType(tree.tpe)
+          val isGenericTuple = defn.isTupleClass(caseClass) &&
+            !defn.isTupleNType(tree.tpe match { case tp: OrType => tp.join case tp => tp }) // widen even hard unions, to see if it's a union of tuples
           val components = if isGenericTuple then caseAccessors.indices.toList.map(tupleApp(_, ref(scrutinee))) else caseAccessors.map(tupleSel)
           matchArgsPlan(components, args, onSuccess)
         else if (unapp.tpe <:< (defn.BooleanType))

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -329,21 +329,16 @@ object PatternMatcher {
         def isSyntheticScala2Unapply(sym: Symbol) =
           sym.isAllOf(SyntheticCase) && sym.owner.is(Scala2x)
 
-        def tupleApp(tuple: Type, i: Int, receiver: Tree) = // manually inlining the call to NonEmptyTuple#apply, because it's an inline method
+        def tupleApp(i: Int, receiver: Tree) = // manually inlining the call to NonEmptyTuple#apply, because it's an inline method
           ref(defn.RuntimeTuplesModule)
             .select(defn.RuntimeTuples_apply)
             .appliedTo(receiver, Literal(Constant(i)))
-            .cast(tuple.tupleElementTypes.applyOrElse(i, (_: Int) => NoType).ensuring(_ != NoType, i"Failed to find type at index $i in $tuple (${tree.sourcePos})"))
 
         if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length)
           def tupleSel(sym: Symbol) = ref(scrutinee).select(sym)
-          val isGenericTuple = defn.isTupleClass(caseClass) && {
-            val tp = tree.tpe match // widen even hard unions, to see if it's a union of tuples
-              case tp @ OrType(l, r) => (if tp.isSoft then tp else tp.derivedOrType(l, r, soft = true)).widenUnion
-              case tp                => tp
-            !defn.isTupleNType(tp)
-          }
-          val components = if isGenericTuple then caseAccessors.indices.toList.map(tupleApp(tree.tpe.dealias, _, ref(scrutinee))) else caseAccessors.map(tupleSel)
+          val isGenericTuple = defn.isTupleClass(caseClass) &&
+            !defn.isTupleNType(tree.tpe match { case tp: OrType => tp.join case tp => tp }) // widen even hard unions, to see if it's a union of tuples
+          val components = if isGenericTuple then caseAccessors.indices.toList.map(tupleApp(_, ref(scrutinee))) else caseAccessors.map(tupleSel)
           matchArgsPlan(components, args, onSuccess)
         else if (unapp.tpe <:< (defn.BooleanType))
           TestPlan(GuardTest, unapp, unapp.span, onSuccess)
@@ -363,7 +358,7 @@ object PatternMatcher {
               unapplySeqPlan(unappResult, args)
             }
             else if unappResult.info <:< defn.NonEmptyTupleTypeRef then
-              val components = (0 until foldApplyTupleType(unappResult.denot.info).length).toList.map(tupleApp(unappResult.info, _, ref(unappResult)))
+              val components = (0 until foldApplyTupleType(unappResult.denot.info).length).toList.map(tupleApp(_, ref(unappResult)))
               matchArgsPlan(components, args, onSuccess)
             else {
               assert(isGetMatch(unapp.tpe))

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -9,6 +9,7 @@ import Symbols._, Contexts._, Types._, StdNames._, NameOps._
 import util.Spans._
 import typer.Applications.*
 import SymUtils._
+import TypeUtils.*
 import Flags._, Constants._
 import Decorators._
 import NameKinds.{PatMatStdBinderName, PatMatAltsName, PatMatResultName}
@@ -328,16 +329,16 @@ object PatternMatcher {
         def isSyntheticScala2Unapply(sym: Symbol) =
           sym.isAllOf(SyntheticCase) && sym.owner.is(Scala2x)
 
-        def tupleApp(i: Int, receiver: Tree) = // manually inlining the call to NonEmptyTuple#apply, because it's an inline method
+        def tupleApp(tuple: Type, i: Int, receiver: Tree) = // manually inlining the call to NonEmptyTuple#apply, because it's an inline method
           ref(defn.RuntimeTuplesModule)
             .select(defn.RuntimeTuples_apply)
             .appliedTo(receiver, Literal(Constant(i)))
-            .cast(args(i).tpe.widen)
+            .cast(tuple.tupleElementTypes.applyOrElse(i, (_: Int) => NoType).ensuring(_ != NoType, i"Failed to find type at index $i in $tuple (${tree.sourcePos})"))
 
         if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length)
           def tupleSel(sym: Symbol) = ref(scrutinee).select(sym)
           val isGenericTuple = defn.isTupleClass(caseClass) && !defn.isTupleNType(tree.tpe)
-          val components = if isGenericTuple then caseAccessors.indices.toList.map(tupleApp(_, ref(scrutinee))) else caseAccessors.map(tupleSel)
+          val components = if isGenericTuple then caseAccessors.indices.toList.map(tupleApp(tree.tpe.dealias, _, ref(scrutinee))) else caseAccessors.map(tupleSel)
           matchArgsPlan(components, args, onSuccess)
         else if (unapp.tpe <:< (defn.BooleanType))
           TestPlan(GuardTest, unapp, unapp.span, onSuccess)
@@ -357,7 +358,7 @@ object PatternMatcher {
               unapplySeqPlan(unappResult, args)
             }
             else if unappResult.info <:< defn.NonEmptyTupleTypeRef then
-              val components = (0 until foldApplyTupleType(unappResult.denot.info).length).toList.map(tupleApp(_, ref(unappResult)))
+              val components = (0 until foldApplyTupleType(unappResult.denot.info).length).toList.map(tupleApp(unappResult.info, _, ref(unappResult)))
               matchArgsPlan(components, args, onSuccess)
             else {
               assert(isGetMatch(unapp.tpe))

--- a/tests/pos/i14587.hard-union-tuples.scala
+++ b/tests/pos/i14587.hard-union-tuples.scala
@@ -1,0 +1,10 @@
+// scalac: -Werror
+class Test:
+  type Foo = Option[String] | Option[Int]
+
+  def test(foo: Foo) =
+    val (_, foo2: Foo) = // was: the type test for Test.this.Foo cannot be checked at runtime
+      foo match
+        case Some(s: String) => ((), s)
+        case _               => ((), 0)
+    foo2

--- a/tests/run/i14587.min.scala
+++ b/tests/run/i14587.min.scala
@@ -1,0 +1,10 @@
+object Test:
+  def test(cond: Boolean) =
+    val tup: (String, Unit) | (Int, Unit) = if cond then ("", ()) else (1, ())
+    tup match
+      case (s: String, _) => s
+      case _ => "n/a"
+
+  def main(args: Array[String]): Unit =
+    test(true)  // works
+    test(false) // was: ClassCastException: class scala.None$ cannot be cast to class scala.Some

--- a/tests/run/i14587.opaques.scala
+++ b/tests/run/i14587.opaques.scala
@@ -1,0 +1,8 @@
+object Test:
+  opaque type Tup = (Int, String)
+
+  def test(tup: Tup) =
+    val (n, s) = tup
+    assert(n == 1 && s == "")
+
+  def main(args: Array[String]): Unit = test((1, ""))

--- a/tests/run/i14587.scala
+++ b/tests/run/i14587.scala
@@ -1,0 +1,16 @@
+def test(foo: String): Unit = {
+  // Does not crash if the type is written explicitly as: Option[(Option[Int], String)]
+  val bar = {
+    if (foo.isEmpty) Some((Some(1), ""))
+    else Some((None, ""))
+  }
+
+  bar.foreach {
+    case (Some(_), "") =>
+    case _ =>
+  }
+}
+
+@main def Test() =
+  test("") // works
+  test("a")


### PR DESCRIPTION
Obviously, in hindsight, we can't use the types of the unapply arguments
as the type for selecting the components of a (generic) tuple...

Fixes #14587

[test_non_bootstrapped]