### PR TITLE
Only make the staged parts of a quote inlineable

### DIFF
--- a/tests/pos-macros/i14603.scala
+++ b/tests/pos-macros/i14603.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+class Macro(using qctx: Quotes): // Anti-pattern: put Quotes in a field
+  import qctx.reflect._
+
+  def apply: Expr[Unit] = '{
+    println("in quote")
+    ${ val a: Term = '{ println("in nested quote") }.asTerm; ??? }
+  }

--- a/tests/pos-macros/i14603b.scala
+++ b/tests/pos-macros/i14603b.scala
@@ -1,0 +1,17 @@
+import scala.language.experimental.macros
+import scala.quoted.*
+
+class Runtime
+
+class Macro(using qctx: Quotes) { // Anti-pattern: put Quotes in a field
+  import qctx.reflect._
+
+  def apply[A: Type](x: Expr[A]): Expr[Unit] = {
+    '{
+      val rt: Runtime = ???
+      ${Block(doExprs('{ rt }.asTerm), '{ () }.asTerm).asExprOf[Unit]}
+    }
+  }
+
+  private def doExprs(rt: Term): List[Term] = Nil
+}


### PR DESCRIPTION
Contents of splices do not need to be transformed as they will be
evaluated before the code is inlined. Therefore we only want to make
code at staging level 1 or grater inlineable. If the quote is in an
inline method, we also need to make the contents of the splices
inlineable (i.e. for any level).

Fix #14603