### PR TITLE
Support MatchType for SemanticDB

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -420,19 +420,20 @@ class ExtractSemanticDB extends Phase:
       else
         val symkinds = mutable.HashSet.empty[SymbolKind]
         tree match
-        case tree: ValDef =>
-          if !tree.symbol.is(Param) then
-            symkinds += (if tree.mods is Mutable then SymbolKind.Var else SymbolKind.Val)
-          if tree.rhs.isEmpty && !tree.symbol.isOneOf(TermParam | CaseAccessor | ParamAccessor) then
-            symkinds += SymbolKind.Abstract
-        case tree: DefDef =>
-          if tree.isSetterDef then
-            symkinds += SymbolKind.Setter
-          else if tree.rhs.isEmpty then
-            symkinds += SymbolKind.Abstract
-        case tree: Bind =>
-          symkinds += SymbolKind.Val
-        case _ =>
+          case tree: ValDef =>
+            if !tree.symbol.is(Param) then
+              symkinds += (if tree.mods is Mutable then SymbolKind.Var else SymbolKind.Val)
+            if tree.rhs.isEmpty && !tree.symbol.isOneOf(TermParam | CaseAccessor | ParamAccessor) then
+              symkinds += SymbolKind.Abstract
+          case tree: DefDef =>
+            if tree.isSetterDef then
+              symkinds += SymbolKind.Setter
+            else if tree.rhs.isEmpty then
+              symkinds += SymbolKind.Abstract
+          // if symbol isType, it's type variable
+          case tree: Bind if (!tree.symbol.isType) =>
+            symkinds += SymbolKind.Val
+          case _ =>
         symkinds.toSet
 
     private def ctorParams(

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -433,6 +433,8 @@ class ExtractSemanticDB extends Phase:
           // if symbol isType, it's type variable
           case tree: Bind if (!tree.symbol.isType) =>
             symkinds += SymbolKind.Val
+          case tree: Bind if (tree.symbol.isType) =>
+            symkinds += SymbolKind.TypeVal
           case _ =>
         symkinds.toSet
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -109,16 +109,13 @@ class ExtractSemanticDB extends Phase:
       || sym.isOldStyleImplicitConversion(forImplicitClassOnly = true)
 
     /** Uses of this symbol where the reference has given span should be excluded from semanticdb */
-    private def excludeUse(qualifier: Option[Symbol], sym: SemanticSymbol)(using Context): Boolean =
-      sym match
-        case sym: Symbol =>
-          !sym.exists
-          || excludeDefOrUse(sym)
-          || sym.isConstructor && sym.owner.isAnnotation
-          || sym == defn.Any_typeCast
-          || sym.owner == defn.OpsPackageClass
-          || qualifier.exists(excludeQual)
-        case fake: FakeSymbol => false // do not exclude fake symbols
+    private def excludeUse(qualifier: Option[Symbol], sym: Symbol)(using Context): Boolean =
+      !sym.exists
+      || excludeDefOrUse(sym)
+      || sym.isConstructor && sym.owner.isAnnotation
+      || sym == defn.Any_typeCast
+      || sym.owner == defn.OpsPackageClass
+      || qualifier.exists(excludeQual)
 
     private def traverseAnnotsOfDefinition(sym: Symbol)(using Context): Unit =
       for annot <- sym.annotations do
@@ -337,11 +334,11 @@ class ExtractSemanticDB extends Phase:
         occurrences += occ
         generated += occ
 
-    private def registerUseGuarded(qualSym: Option[Symbol], sym: SemanticSymbol, span: Span, treeSource: SourceFile)(using Context) =
+    private def registerUseGuarded(qualSym: Option[Symbol], sym: Symbol, span: Span, treeSource: SourceFile)(using Context) =
       if !excludeUse(qualSym, sym) && !span.isZeroExtent then
         registerUse(sym, span, treeSource)
 
-    private def registerUse(sym: SemanticSymbol, span: Span, treeSource: SourceFile)(using Context): Unit =
+    private def registerUse(sym: Symbol, span: Span, treeSource: SourceFile)(using Context): Unit =
       registerUse(sym.symbolName, span, treeSource)
 
     private def registerUse(symbol: String, span: Span, treeSource: SourceFile)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -109,13 +109,16 @@ class ExtractSemanticDB extends Phase:
       || sym.isOldStyleImplicitConversion(forImplicitClassOnly = true)
 
     /** Uses of this symbol where the reference has given span should be excluded from semanticdb */
-    private def excludeUse(qualifier: Option[Symbol], sym: Symbol)(using Context): Boolean =
-      !sym.exists
-      || excludeDefOrUse(sym)
-      || sym.isConstructor && sym.owner.isAnnotation
-      || sym == defn.Any_typeCast
-      || sym.owner == defn.OpsPackageClass
-      || qualifier.exists(excludeQual)
+    private def excludeUse(qualifier: Option[Symbol], sym: SemanticSymbol)(using Context): Boolean =
+      sym match
+        case sym: Symbol =>
+          !sym.exists
+          || excludeDefOrUse(sym)
+          || sym.isConstructor && sym.owner.isAnnotation
+          || sym == defn.Any_typeCast
+          || sym.owner == defn.OpsPackageClass
+          || qualifier.exists(excludeQual)
+        case fake: FakeSymbol => false // do not exclude fake symbols
 
     private def traverseAnnotsOfDefinition(sym: Symbol)(using Context): Unit =
       for annot <- sym.annotations do
@@ -232,7 +235,12 @@ class ExtractSemanticDB extends Phase:
           val sym = tree.symbol.adjustIfCtorTyparam
           if qualSpan.exists && qualSpan.hasLength then
             traverse(qual)
-          registerUseGuarded(qual.symbol.ifExists, sym, selectSpan(tree), tree.source)
+          if (sym != NoSymbol)
+            registerUseGuarded(qual.symbol.ifExists, sym, selectSpan(tree), tree.source)
+          else
+            qual.symbol.info.lookupSym(tree.name).foreach(sym =>
+              registerUseGuarded(qual.symbol.ifExists, sym, selectSpan(tree), tree.source)
+            )
         case tree: Import =>
           if tree.span.exists && tree.span.hasLength then
             traverseChildren(tree)
@@ -329,11 +337,11 @@ class ExtractSemanticDB extends Phase:
         occurrences += occ
         generated += occ
 
-    private def registerUseGuarded(qualSym: Option[Symbol], sym: Symbol, span: Span, treeSource: SourceFile)(using Context) =
+    private def registerUseGuarded(qualSym: Option[Symbol], sym: SemanticSymbol, span: Span, treeSource: SourceFile)(using Context) =
       if !excludeUse(qualSym, sym) && !span.isZeroExtent then
         registerUse(sym, span, treeSource)
 
-    private def registerUse(sym: Symbol, span: Span, treeSource: SourceFile)(using Context): Unit =
+    private def registerUse(sym: SemanticSymbol, span: Span, treeSource: SourceFile)(using Context): Unit =
       registerUse(sym.symbolName, span, treeSource)
 
     private def registerUse(symbol: String, span: Span, treeSource: SourceFile)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
@@ -125,7 +125,8 @@ class SymbolInformationPrinter (symtab: PrinterSymtab):
           if (tparams.infos.nonEmpty)
             sb.append(tparams.infos.map(pprintDef).mkString("[", ", ", "]"))
           if (lo == hi) {
-            sb.append(s" = ${pprint(lo)}")
+            if (lo == Type.Empty) ()
+            else sb.append(s" = ${pprint(lo)}")
           } else {
             lo match
               case TypeRef(Type.Empty, "scala/Nothing#", Nil) => ()
@@ -191,7 +192,16 @@ class SymbolInformationPrinter (symtab: PrinterSymtab):
           s"=> ${normal(utpe)}"
         case RepeatedType(utpe) =>
           s"${normal(utpe)}*"
-        case _ =>
+        case MatchType(scrutinee, cases) =>
+          val casesStr = cases.map { caseType =>
+            s"${pprint(caseType.key)} => ${pprint(caseType.body)}"
+          }.mkString(", ")
+          s"${pprint(scrutinee)} match { ${casesStr} }"
+        case LambdaType(params, result) =>
+          val paramsStr = params.infos.map(pprintDef).mkString("[", ", ", "]")
+          val resultStr = pprint(result)
+          s"${paramsStr} =>> ${resultStr}"
+        case x =>
           "<?>"
 
       def normal(tpe: Type): String = tpe match

--- a/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
@@ -197,10 +197,6 @@ class SymbolInformationPrinter (symtab: PrinterSymtab):
             s"${pprint(caseType.key)} => ${pprint(caseType.body)}"
           }.mkString(", ")
           s"${pprint(scrutinee)} match { ${casesStr} }"
-        case LambdaType(params, result) =>
-          val paramsStr = params.infos.map(pprintDef).mkString("[", ", ", "]")
-          val resultStr = pprint(result)
-          s"${paramsStr} =>> ${resultStr}"
         case x =>
           "<?>"
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
@@ -125,8 +125,7 @@ class SymbolInformationPrinter (symtab: PrinterSymtab):
           if (tparams.infos.nonEmpty)
             sb.append(tparams.infos.map(pprintDef).mkString("[", ", ", "]"))
           if (lo == hi) {
-            if (lo == Type.Empty) ()
-            else sb.append(s" = ${pprint(lo)}")
+            sb.append(s" = ${pprint(lo)}")
           } else {
             lo match
               case TypeRef(Type.Empty, "scala/Nothing#", Nil) => ()

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -12,6 +12,7 @@ import core.StdNames.nme
 import SymbolInformation.{Kind => k}
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.Spans.Span
+import dotty.tools.dotc.core.Names.Designator
 
 import java.lang.Character.{isJavaIdentifierPart, isJavaIdentifierStart}
 
@@ -34,7 +35,7 @@ object Scala3:
     val (endLine, endCol) = lineCol(span.end)
     Some(Range(startLine, startCol, endLine, endCol))
 
-  def namePresentInSource(sym: Symbol, span: Span, source:SourceFile)(using Context): Boolean =
+  def namePresentInSource(desig: Designator, span: Span, source:SourceFile)(using Context): Boolean =
     if !span.exists then false
     else
       val content = source.content()
@@ -42,15 +43,22 @@ object Scala3:
         if content.lift(span.end - 1).exists(_ == '`') then
           (span.start + 1, span.end - 1)
         else (span.start, span.end)
+      // println(s"${start}, $end")
       val nameInSource = content.slice(start, end).mkString
       // for secondary constructors `this`
-      if sym.isConstructor && nameInSource == nme.THISkw.toString then
-        true
-      else
-        val target =
-          if sym.isPackageObject then sym.owner
-          else sym
-        nameInSource == target.name.stripModuleClassSuffix.lastPart.toString
+      desig match
+        case sym: Symbol =>
+          if sym.isConstructor && nameInSource == nme.THISkw.toString then
+            true
+          else
+            val target =
+              if sym.isPackageObject then sym.owner
+              else sym
+            nameInSource == target.name.stripModuleClassSuffix.lastPart.toString
+        case name: Name =>
+          // println(nameInSource)
+          // println(name.mangledString)
+          nameInSource == name.mangledString
 
   sealed trait FakeSymbol {
     private[Scala3] var sname: Option[String] = None

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -153,12 +153,13 @@ object Scala3:
   enum SymbolKind derives CanEqual:
     kind =>
 
-    case Val, Var, Setter, Abstract
+    case Val, Var, Setter, Abstract, TypeVal
 
     def isVar: Boolean = kind match
       case Var | Setter => true
       case _            => false
     def isVal: Boolean = kind == Val
+    def isTypeVal: Boolean = kind == TypeVal
     def isVarOrVal: Boolean = kind.isVar || kind.isVal
 
   end SymbolKind
@@ -309,7 +310,9 @@ object Scala3:
           props |= SymbolInformation.Property.IMPLICIT.value
         if sym.is(Lazy, butNot=Module) then
           props |= SymbolInformation.Property.LAZY.value
-        if sym.isAllOf(Case | Module) || sym.is(CaseClass) || sym.isAllOf(EnumCase) then
+        if sym.isAllOf(Case | Module) ||
+          (sym.is(CaseClass) && !symkinds.exists(_.isTypeVal)) || // `t` of `case List[t] =>` (which has `CaseClass` flag) shouldn't be `CASE`
+          sym.isAllOf(EnumCase) then
           props |= SymbolInformation.Property.CASE.value
         if sym.is(Covariant) then
           props |= SymbolInformation.Property.COVARIANT.value

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -81,7 +81,7 @@ class TypeOps:
         case _ =>
           symbolNotFound(name, tpe.typeSymbol)
           None
-      loop(tpe)
+      loop(tpe.dealias)
     }
 
     def toSemanticSig(using LinkMode, Context, SemanticSymbolBuilder)(sym: Symbol): s.Signature =

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -228,18 +228,14 @@ class TypeOps:
           val stpe = loop(tpe)
           s.ByNameType(stpe)
 
-        case TypeRef(pre, sym: Symbol) =>
+        case tr @ TypeRef(pre, _) =>
           val spre = if tpe.hasTrivialPrefix then s.Type.Empty else loop(pre)
-          val ssym = sym.symbolName
+          val ssym = tr.symbol.symbolName
           s.TypeRef(spre, ssym, Seq.empty)
 
-        case tr @ TypeRef(_, _: Name) =>
-          val ssym = tr.symbol.symbolName
-          s.TypeRef(s.Type.Empty, ssym, Seq.empty)
-
-        case TermRef(pre, sym: Symbol) =>
+        case tr @ TermRef(pre, _) =>
           val spre = if(tpe.hasTrivialPrefix) s.Type.Empty else loop(pre)
-          val ssym = sym.symbolName
+          val ssym = tr.symbol.symbolName
           s.SingleType(spre, ssym)
 
         case ThisType(TypeRef(_, sym: Symbol)) =>
@@ -453,10 +449,10 @@ class TypeOps:
       def checkTrivialPrefix(pre: Type, sym: Symbol)(using Context): Boolean =
         pre =:= sym.owner.thisType
       tpe match {
-        case TypeRef(pre, sym: Symbol) =>
-          checkTrivialPrefix(pre, sym)
-        case TermRef(pre, sym: Symbol) =>
-          checkTrivialPrefix(pre, sym)
+        case tr @ TypeRef(pre, _) =>
+          checkTrivialPrefix(pre, tr.symbol)
+        case tr @ TermRef(pre, _) =>
+          checkTrivialPrefix(pre, tr.symbol)
         case _ => false
       }
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -233,6 +233,14 @@ class TypeOps:
           val ssym = sym.symbolName
           s.TypeRef(spre, ssym, Seq.empty)
 
+        case TypeRef(pre, sym: Name) =>
+          // val spre = if tpe.hasTrivialPrefix then s.Type.Empty else loop(pre)
+          // Craft semanticdb symbol
+          // prefix symbol (e.g. "scala/") + name (e.g. "Nothing") + Global symbol suffix ("#")
+          // see: https://scalameta.org/docs/semanticdb/specification.html#symbol
+          val ssym = s"${pre.typeSymbol.symbolName}${sym.mangledString}#"
+          s.TypeRef(s.Type.Empty, ssym, Seq.empty)
+
         case TermRef(pre, sym: Symbol) =>
           val spre = if(tpe.hasTrivialPrefix) s.Type.Empty else loop(pre)
           val ssym = sym.symbolName

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -79,7 +79,6 @@ class TypeOps:
         case OrType(tp1, tp2) =>
           loop(tp1).orElse(loop(tp2))
         case _ =>
-          symbolNotFound(name, tpe.typeSymbol)
           None
       loop(tpe.dealias)
     }

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -233,12 +233,8 @@ class TypeOps:
           val ssym = sym.symbolName
           s.TypeRef(spre, ssym, Seq.empty)
 
-        case TypeRef(pre, sym: Name) =>
-          // val spre = if tpe.hasTrivialPrefix then s.Type.Empty else loop(pre)
-          // Craft semanticdb symbol
-          // prefix symbol (e.g. "scala/") + name (e.g. "Nothing") + Global symbol suffix ("#")
-          // see: https://scalameta.org/docs/semanticdb/specification.html#symbol
-          val ssym = s"${pre.typeSymbol.symbolName}${sym.mangledString}#"
+        case tr @ TypeRef(_, _: Name) =>
+          val ssym = tr.symbol.symbolName
           s.TypeRef(s.Type.Empty, ssym, Seq.empty)
 
         case TermRef(pre, sym: Symbol) =>

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -162,6 +162,12 @@ class TypeOps:
             enterRefined(expr.resType)
           case m: LambdaType =>
             enterRefined(m.resType)
+          case AndType(t1, t2) =>
+            enterRefined(t1)
+            enterRefined(t2)
+          case OrType(t1, t2) =>
+            enterRefined(t1)
+            enterRefined(t2)
           case _ => ()
         }
       if sym.exists && sym.owner.exists then

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Type.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Type.scala
@@ -18,10 +18,10 @@ sealed trait Type  extends SemanticdbGeneratedSealedOneof  derives CanEqual {
 
 object Type {
   case object Empty extends dotty.tools.dotc.semanticdb.Type
-
+  
   sealed trait NonEmpty extends dotty.tools.dotc.semanticdb.Type
   def defaultInstance: dotty.tools.dotc.semanticdb.Type = Empty
-
+  
   implicit val TypeTypeMapper: SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] = new SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] {
     override def toCustom(__base: dotty.tools.dotc.semanticdb.TypeMessage): dotty.tools.dotc.semanticdb.Type = __base.sealedValue match {
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.TypeRef => __v.value
@@ -38,7 +38,6 @@ object Type {
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.UniversalType => __v.value
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType => __v.value
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType => __v.value
-      case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType => __v.value
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType => __v.value
       case dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty => Empty
     }
@@ -57,7 +56,6 @@ object Type {
       case __v: dotty.tools.dotc.semanticdb.UniversalType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.UniversalType(__v)
       case __v: dotty.tools.dotc.semanticdb.ByNameType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType(__v)
       case __v: dotty.tools.dotc.semanticdb.RepeatedType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__v)
-      case __v: dotty.tools.dotc.semanticdb.LambdaType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__v)
       case __v: dotty.tools.dotc.semanticdb.MatchType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__v)
       case Empty => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty
     })
@@ -127,10 +125,6 @@ final case class TypeMessage(
         val __value = sealedValue.repeatedType.get
         __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       };
-      if (sealedValue.lambdaType.isDefined) {
-        val __value = sealedValue.lambdaType.get
-        __size += 2 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
-      };
       if (sealedValue.matchType.isDefined) {
         val __value = sealedValue.matchType.get
         __size += 2 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
@@ -144,7 +138,7 @@ final case class TypeMessage(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       sealedValue.typeRef.foreach { __v =>
@@ -231,12 +225,6 @@ final case class TypeMessage(
         _output__.writeUInt32NoTag(__m.serializedSize)
         __m.writeTo(_output__)
       };
-      sealedValue.lambdaType.foreach { __v =>
-        val __m = __v
-        _output__.writeTag(24, 2)
-        _output__.writeUInt32NoTag(__m.serializedSize)
-        __m.writeTo(_output__)
-      };
       sealedValue.matchType.foreach { __v =>
         val __m = __v
         _output__.writeTag(25, 2)
@@ -272,16 +260,14 @@ final case class TypeMessage(
     def withByNameType(__v: dotty.tools.dotc.semanticdb.ByNameType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType(__v))
     def getRepeatedType: dotty.tools.dotc.semanticdb.RepeatedType = sealedValue.repeatedType.getOrElse(dotty.tools.dotc.semanticdb.RepeatedType.defaultInstance)
     def withRepeatedType(__v: dotty.tools.dotc.semanticdb.RepeatedType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__v))
-    def getLambdaType: dotty.tools.dotc.semanticdb.LambdaType = sealedValue.lambdaType.getOrElse(dotty.tools.dotc.semanticdb.LambdaType.defaultInstance)
-    def withLambdaType(__v: dotty.tools.dotc.semanticdb.LambdaType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__v))
     def getMatchType: dotty.tools.dotc.semanticdb.MatchType = sealedValue.matchType.getOrElse(dotty.tools.dotc.semanticdb.MatchType.defaultInstance)
     def withMatchType(__v: dotty.tools.dotc.semanticdb.MatchType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__v))
     def clearSealedValue: TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty)
     def withSealedValue(__v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue): TypeMessage = copy(sealedValue = __v)
-
-
-
-
+    
+    
+    
+    
     def toType: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.Type.TypeTypeMapper.toCustom(this)
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.Type])
 }
@@ -323,8 +309,6 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
           __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType(__sealedValue.byNameType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.ByNameType](_input__))(LiteParser.readMessage(_input__, _)))
         case 114 =>
           __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__sealedValue.repeatedType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.RepeatedType](_input__))(LiteParser.readMessage(_input__, _)))
-        case 194 =>
-          __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__sealedValue.lambdaType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.LambdaType](_input__))(LiteParser.readMessage(_input__, _)))
         case 202 =>
           __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__sealedValue.matchType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.MatchType](_input__))(LiteParser.readMessage(_input__, _)))
         case tag => _input__.skipField(tag)
@@ -334,12 +318,12 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
         sealedValue = __sealedValue
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.TypeMessage(
     sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty
   )
@@ -360,7 +344,6 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
     def isUniversalType: _root_.scala.Boolean = false
     def isByNameType: _root_.scala.Boolean = false
     def isRepeatedType: _root_.scala.Boolean = false
-    def isLambdaType: _root_.scala.Boolean = false
     def isMatchType: _root_.scala.Boolean = false
     def typeRef: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeRef] = _root_.scala.None
     def singleType: _root_.scala.Option[dotty.tools.dotc.semanticdb.SingleType] = _root_.scala.None
@@ -376,7 +359,6 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
     def universalType: _root_.scala.Option[dotty.tools.dotc.semanticdb.UniversalType] = _root_.scala.None
     def byNameType: _root_.scala.Option[dotty.tools.dotc.semanticdb.ByNameType] = _root_.scala.None
     def repeatedType: _root_.scala.Option[dotty.tools.dotc.semanticdb.RepeatedType] = _root_.scala.None
-    def lambdaType: _root_.scala.Option[dotty.tools.dotc.semanticdb.LambdaType] = _root_.scala.None
     def matchType: _root_.scala.Option[dotty.tools.dotc.semanticdb.MatchType] = _root_.scala.None
   }
   object SealedValue {
@@ -388,7 +370,7 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
       override def number: _root_.scala.Int = 0
       override def value: _root_.scala.Nothing = throw new java.util.NoSuchElementException("Empty.value")
     }
-
+  
     @SerialVersionUID(0L)
     final case class TypeRef(value: dotty.tools.dotc.semanticdb.TypeRef) extends dotty.tools.dotc.semanticdb.TypeMessage.SealedValue  derives CanEqual {
       type ValueType = dotty.tools.dotc.semanticdb.TypeRef
@@ -488,13 +470,6 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
       override def number: _root_.scala.Int = 14
     }
     @SerialVersionUID(0L)
-    final case class LambdaType(value: dotty.tools.dotc.semanticdb.LambdaType) extends dotty.tools.dotc.semanticdb.TypeMessage.SealedValue  derives CanEqual {
-      type ValueType = dotty.tools.dotc.semanticdb.LambdaType
-      override def isLambdaType: _root_.scala.Boolean = true
-      override def lambdaType: _root_.scala.Option[dotty.tools.dotc.semanticdb.LambdaType] = Some(value)
-      override def number: _root_.scala.Int = 24
-    }
-    @SerialVersionUID(0L)
     final case class MatchType(value: dotty.tools.dotc.semanticdb.MatchType) extends dotty.tools.dotc.semanticdb.TypeMessage.SealedValue  derives CanEqual {
       type ValueType = dotty.tools.dotc.semanticdb.MatchType
       override def isMatchType: _root_.scala.Boolean = true
@@ -516,7 +491,6 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
   final val UNIVERSAL_TYPE_FIELD_NUMBER = 10
   final val BY_NAME_TYPE_FIELD_NUMBER = 13
   final val REPEATED_TYPE_FIELD_NUMBER = 14
-  final val LAMBDA_TYPE_FIELD_NUMBER = 24
   final val MATCH_TYPE_FIELD_NUMBER = 25
   def of(
     sealedValue: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue
@@ -536,14 +510,14 @@ final case class TypeRef(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.TypeRef._typemapper_prefix.toBase(prefix)
         if (__value.serializedSize != 0) {
           __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
         }
       };
-
+      
       {
         val __value = symbol
         if (!__value.isEmpty) {
@@ -563,7 +537,7 @@ final case class TypeRef(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -593,10 +567,10 @@ final case class TypeRef(
     def addTypeArguments(__vs: dotty.tools.dotc.semanticdb.Type *): TypeRef = addAllTypeArguments(__vs)
     def addAllTypeArguments(__vs: Iterable[dotty.tools.dotc.semanticdb.Type]): TypeRef = copy(typeArguments = typeArguments ++ __vs)
     def withTypeArguments(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type]): TypeRef = copy(typeArguments = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.TypeRef])
 }
 
@@ -626,12 +600,12 @@ object TypeRef  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.sem
         typeArguments = __typeArguments.result()
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.TypeRef(
     prefix = dotty.tools.dotc.semanticdb.TypeRef._typemapper_prefix.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     symbol = "",
@@ -665,14 +639,14 @@ final case class SingleType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.SingleType._typemapper_prefix.toBase(prefix)
         if (__value.serializedSize != 0) {
           __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
         }
       };
-
+      
       {
         val __value = symbol
         if (!__value.isEmpty) {
@@ -688,7 +662,7 @@ final case class SingleType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -708,10 +682,10 @@ final case class SingleType(
     }
     def withPrefix(__v: dotty.tools.dotc.semanticdb.Type): SingleType = copy(prefix = __v)
     def withSymbol(__v: _root_.scala.Predef.String): SingleType = copy(symbol = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.SingleType])
 }
 
@@ -737,12 +711,12 @@ object SingleType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.
         symbol = __symbol
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.SingleType(
     prefix = dotty.tools.dotc.semanticdb.SingleType._typemapper_prefix.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     symbol = ""
@@ -769,7 +743,7 @@ final case class ThisType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = symbol
         if (!__value.isEmpty) {
@@ -785,7 +759,7 @@ final case class ThisType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -796,10 +770,10 @@ final case class ThisType(
       };
     }
     def withSymbol(__v: _root_.scala.Predef.String): ThisType = copy(symbol = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.ThisType])
 }
 
@@ -821,12 +795,12 @@ object ThisType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.se
         symbol = __symbol
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.ThisType(
     symbol = ""
   )
@@ -848,14 +822,14 @@ final case class SuperType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.SuperType._typemapper_prefix.toBase(prefix)
         if (__value.serializedSize != 0) {
           __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
         }
       };
-
+      
       {
         val __value = symbol
         if (!__value.isEmpty) {
@@ -871,7 +845,7 @@ final case class SuperType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -891,10 +865,10 @@ final case class SuperType(
     }
     def withPrefix(__v: dotty.tools.dotc.semanticdb.Type): SuperType = copy(prefix = __v)
     def withSymbol(__v: _root_.scala.Predef.String): SuperType = copy(symbol = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.SuperType])
 }
 
@@ -920,12 +894,12 @@ object SuperType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
         symbol = __symbol
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.SuperType(
     prefix = dotty.tools.dotc.semanticdb.SuperType._typemapper_prefix.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     symbol = ""
@@ -952,7 +926,7 @@ final case class ConstantType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.ConstantType._typemapper_constant.toBase(constant)
         if (__value.serializedSize != 0) {
@@ -968,7 +942,7 @@ final case class ConstantType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -981,10 +955,10 @@ final case class ConstantType(
       };
     }
     def withConstant(__v: dotty.tools.dotc.semanticdb.Constant): ConstantType = copy(constant = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.ConstantType])
 }
 
@@ -1006,12 +980,12 @@ object ConstantType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dot
         constant = dotty.tools.dotc.semanticdb.ConstantType._typemapper_constant.toCustom(__constant.getOrElse(dotty.tools.dotc.semanticdb.ConstantMessage.defaultInstance))
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.ConstantType(
     constant = dotty.tools.dotc.semanticdb.ConstantType._typemapper_constant.toCustom(dotty.tools.dotc.semanticdb.ConstantMessage.defaultInstance)
   )
@@ -1047,7 +1021,7 @@ final case class IntersectionType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       types.foreach { __v =>
@@ -1061,10 +1035,10 @@ final case class IntersectionType(
     def addTypes(__vs: dotty.tools.dotc.semanticdb.Type *): IntersectionType = addAllTypes(__vs)
     def addAllTypes(__vs: Iterable[dotty.tools.dotc.semanticdb.Type]): IntersectionType = copy(types = types ++ __vs)
     def withTypes(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type]): IntersectionType = copy(types = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.IntersectionType])
 }
 
@@ -1086,12 +1060,12 @@ object IntersectionType  extends SemanticdbGeneratedMessageCompanion[dotty.tools
         types = __types.result()
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.IntersectionType(
     types = _root_.scala.Seq.empty
   )
@@ -1127,7 +1101,7 @@ final case class UnionType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       types.foreach { __v =>
@@ -1141,10 +1115,10 @@ final case class UnionType(
     def addTypes(__vs: dotty.tools.dotc.semanticdb.Type *): UnionType = addAllTypes(__vs)
     def addAllTypes(__vs: Iterable[dotty.tools.dotc.semanticdb.Type]): UnionType = copy(types = types ++ __vs)
     def withTypes(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type]): UnionType = copy(types = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.UnionType])
 }
 
@@ -1166,12 +1140,12 @@ object UnionType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
         types = __types.result()
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.UnionType(
     types = _root_.scala.Seq.empty
   )
@@ -1207,7 +1181,7 @@ final case class WithType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       types.foreach { __v =>
@@ -1221,10 +1195,10 @@ final case class WithType(
     def addTypes(__vs: dotty.tools.dotc.semanticdb.Type *): WithType = addAllTypes(__vs)
     def addAllTypes(__vs: Iterable[dotty.tools.dotc.semanticdb.Type]): WithType = copy(types = types ++ __vs)
     def withTypes(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type]): WithType = copy(types = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.WithType])
 }
 
@@ -1246,12 +1220,12 @@ object WithType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.se
         types = __types.result()
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.WithType(
     types = _root_.scala.Seq.empty
   )
@@ -1275,7 +1249,7 @@ final case class StructuralType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.StructuralType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1295,7 +1269,7 @@ final case class StructuralType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1317,10 +1291,10 @@ final case class StructuralType(
     def getDeclarations: dotty.tools.dotc.semanticdb.Scope = declarations.getOrElse(dotty.tools.dotc.semanticdb.Scope.defaultInstance)
     def clearDeclarations: StructuralType = copy(declarations = _root_.scala.None)
     def withDeclarations(__v: dotty.tools.dotc.semanticdb.Scope): StructuralType = copy(declarations = Option(__v))
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.StructuralType])
 }
 
@@ -1346,12 +1320,12 @@ object StructuralType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.d
         declarations = __declarations
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.StructuralType(
     tpe = dotty.tools.dotc.semanticdb.StructuralType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     declarations = _root_.scala.None
@@ -1383,7 +1357,7 @@ final case class AnnotatedType(
         val __value = __item
         __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       }
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.AnnotatedType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1399,7 +1373,7 @@ final case class AnnotatedType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1422,10 +1396,10 @@ final case class AnnotatedType(
     def addAllAnnotations(__vs: Iterable[dotty.tools.dotc.semanticdb.Annotation]): AnnotatedType = copy(annotations = annotations ++ __vs)
     def withAnnotations(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Annotation]): AnnotatedType = copy(annotations = __v)
     def withTpe(__v: dotty.tools.dotc.semanticdb.Type): AnnotatedType = copy(tpe = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.AnnotatedType])
 }
 
@@ -1451,12 +1425,12 @@ object AnnotatedType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.do
         tpe = dotty.tools.dotc.semanticdb.AnnotatedType._typemapper_tpe.toCustom(__tpe.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.AnnotatedType(
     annotations = _root_.scala.Seq.empty,
     tpe = dotty.tools.dotc.semanticdb.AnnotatedType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
@@ -1484,7 +1458,7 @@ final case class ExistentialType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.ExistentialType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1504,7 +1478,7 @@ final case class ExistentialType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1526,10 +1500,10 @@ final case class ExistentialType(
     def getDeclarations: dotty.tools.dotc.semanticdb.Scope = declarations.getOrElse(dotty.tools.dotc.semanticdb.Scope.defaultInstance)
     def clearDeclarations: ExistentialType = copy(declarations = _root_.scala.None)
     def withDeclarations(__v: dotty.tools.dotc.semanticdb.Scope): ExistentialType = copy(declarations = Option(__v))
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.ExistentialType])
 }
 
@@ -1555,12 +1529,12 @@ object ExistentialType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.
         declarations = __declarations
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.ExistentialType(
     tpe = dotty.tools.dotc.semanticdb.ExistentialType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     declarations = _root_.scala.None
@@ -1592,7 +1566,7 @@ final case class UniversalType(
         val __value = typeParameters.get
         __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       };
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.UniversalType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1608,7 +1582,7 @@ final case class UniversalType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1630,10 +1604,10 @@ final case class UniversalType(
     def clearTypeParameters: UniversalType = copy(typeParameters = _root_.scala.None)
     def withTypeParameters(__v: dotty.tools.dotc.semanticdb.Scope): UniversalType = copy(typeParameters = Option(__v))
     def withTpe(__v: dotty.tools.dotc.semanticdb.Type): UniversalType = copy(tpe = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.UniversalType])
 }
 
@@ -1659,12 +1633,12 @@ object UniversalType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.do
         tpe = dotty.tools.dotc.semanticdb.UniversalType._typemapper_tpe.toCustom(__tpe.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.UniversalType(
     typeParameters = _root_.scala.None,
     tpe = dotty.tools.dotc.semanticdb.UniversalType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
@@ -1691,7 +1665,7 @@ final case class ByNameType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.ByNameType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1707,7 +1681,7 @@ final case class ByNameType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1720,10 +1694,10 @@ final case class ByNameType(
       };
     }
     def withTpe(__v: dotty.tools.dotc.semanticdb.Type): ByNameType = copy(tpe = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.ByNameType])
 }
 
@@ -1745,12 +1719,12 @@ object ByNameType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.
         tpe = dotty.tools.dotc.semanticdb.ByNameType._typemapper_tpe.toCustom(__tpe.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.ByNameType(
     tpe = dotty.tools.dotc.semanticdb.ByNameType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
   )
@@ -1773,7 +1747,7 @@ final case class RepeatedType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.RepeatedType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1789,7 +1763,7 @@ final case class RepeatedType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1802,10 +1776,10 @@ final case class RepeatedType(
       };
     }
     def withTpe(__v: dotty.tools.dotc.semanticdb.Type): RepeatedType = copy(tpe = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.RepeatedType])
 }
 
@@ -1827,12 +1801,12 @@ object RepeatedType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dot
         tpe = dotty.tools.dotc.semanticdb.RepeatedType._typemapper_tpe.toCustom(__tpe.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.RepeatedType(
     tpe = dotty.tools.dotc.semanticdb.RepeatedType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
   )
@@ -1848,110 +1822,6 @@ object RepeatedType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dot
 }
 
 @SerialVersionUID(0L)
-final case class LambdaType(
-    parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None,
-    returnType: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
-    )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
-    @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
-      var __size = 0
-      if (parameters.isDefined) {
-        val __value = parameters.get
-        __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
-      };
-
-      {
-        val __value = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toBase(returnType)
-        if (__value.serializedSize != 0) {
-          __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
-        }
-      };
-      __size
-    }
-    override def serializedSize: _root_.scala.Int = {
-      var __size = __serializedSizeMemoized
-      if (__size == 0) {
-        __size = __computeSerializedSize() + 1
-        __serializedSizeMemoized = __size
-      }
-      __size - 1
-
-    }
-    def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
-      parameters.foreach { __v =>
-        val __m = __v
-        _output__.writeTag(1, 2)
-        _output__.writeUInt32NoTag(__m.serializedSize)
-        __m.writeTo(_output__)
-      };
-      {
-        val __v = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toBase(returnType)
-        if (__v.serializedSize != 0) {
-          _output__.writeTag(2, 2)
-          _output__.writeUInt32NoTag(__v.serializedSize)
-          __v.writeTo(_output__)
-        }
-      };
-    }
-    def getParameters: dotty.tools.dotc.semanticdb.Scope = parameters.getOrElse(dotty.tools.dotc.semanticdb.Scope.defaultInstance)
-    def clearParameters: LambdaType = copy(parameters = _root_.scala.None)
-    def withParameters(__v: dotty.tools.dotc.semanticdb.Scope): LambdaType = copy(parameters = Option(__v))
-    def withReturnType(__v: dotty.tools.dotc.semanticdb.Type): LambdaType = copy(returnType = __v)
-
-
-
-
-    // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.LambdaType])
-}
-
-object LambdaType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType] {
-  implicit def messageCompanion: SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType] = this
-  def parseFrom(`_input__`: SemanticdbInputStream): dotty.tools.dotc.semanticdb.LambdaType = {
-    var __parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None
-    var __returnType: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeMessage] = _root_.scala.None
-    var _done__ = false
-    while (!_done__) {
-      val _tag__ = _input__.readTag()
-      _tag__ match {
-        case 0 => _done__ = true
-        case 10 =>
-          __parameters = Option(__parameters.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.Scope](_input__))(LiteParser.readMessage(_input__, _)))
-        case 18 =>
-          __returnType = _root_.scala.Some(__returnType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.TypeMessage](_input__))(LiteParser.readMessage(_input__, _)))
-        case tag => _input__.skipField(tag)
-      }
-    }
-    dotty.tools.dotc.semanticdb.LambdaType(
-        parameters = __parameters,
-        returnType = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(__returnType.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
-    )
-  }
-
-
-
-
-
-
-  lazy val defaultInstance = dotty.tools.dotc.semanticdb.LambdaType(
-    parameters = _root_.scala.None,
-    returnType = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
-  )
-  final val PARAMETERS_FIELD_NUMBER = 1
-  final val RETURN_TYPE_FIELD_NUMBER = 2
-  @transient @sharable
-  private[semanticdb] val _typemapper_returnType: SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] = implicitly[SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type]]
-  def of(
-    parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope],
-    returnType: dotty.tools.dotc.semanticdb.Type
-  ): _root_.dotty.tools.dotc.semanticdb.LambdaType = _root_.dotty.tools.dotc.semanticdb.LambdaType(
-    parameters,
-    returnType
-  )
-  // @@protoc_insertion_point(GeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType])
-}
-
-@SerialVersionUID(0L)
 final case class MatchType(
     scrutinee: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.MatchType._typemapper_scrutinee.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     cases: _root_.scala.Seq[dotty.tools.dotc.semanticdb.MatchType.CaseType] = _root_.scala.Seq.empty
@@ -1960,7 +1830,7 @@ final case class MatchType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-
+      
       {
         val __value = dotty.tools.dotc.semanticdb.MatchType._typemapper_scrutinee.toBase(scrutinee)
         if (__value.serializedSize != 0) {
@@ -1980,7 +1850,7 @@ final case class MatchType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-
+      
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -2003,10 +1873,10 @@ final case class MatchType(
     def addCases(__vs: dotty.tools.dotc.semanticdb.MatchType.CaseType *): MatchType = addAllCases(__vs)
     def addAllCases(__vs: Iterable[dotty.tools.dotc.semanticdb.MatchType.CaseType]): MatchType = copy(cases = cases ++ __vs)
     def withCases(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.MatchType.CaseType]): MatchType = copy(cases = __v)
-
-
-
-
+    
+    
+    
+    
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.MatchType])
 }
 
@@ -2032,12 +1902,12 @@ object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
         cases = __cases.result()
     )
   }
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.MatchType(
     scrutinee = dotty.tools.dotc.semanticdb.MatchType._typemapper_scrutinee.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     cases = _root_.scala.Seq.empty
@@ -2051,14 +1921,14 @@ object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
       private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
       private[this] def __computeSerializedSize(): _root_.scala.Int = {
         var __size = 0
-
+        
         {
           val __value = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_key.toBase(key)
           if (__value.serializedSize != 0) {
             __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
           }
         };
-
+        
         {
           val __value = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toBase(body)
           if (__value.serializedSize != 0) {
@@ -2074,7 +1944,7 @@ object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
           __serializedSizeMemoized = __size
         }
         __size - 1
-
+        
       }
       def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
         {
@@ -2096,13 +1966,13 @@ object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
       }
       def withKey(__v: dotty.tools.dotc.semanticdb.Type): CaseType = copy(key = __v)
       def withBody(__v: dotty.tools.dotc.semanticdb.Type): CaseType = copy(body = __v)
-
-
-
-
+      
+      
+      
+      
       // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.MatchType.CaseType])
   }
-
+  
   object CaseType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType.CaseType] {
     implicit def messageCompanion: SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType.CaseType] = this
     def parseFrom(`_input__`: SemanticdbInputStream): dotty.tools.dotc.semanticdb.MatchType.CaseType = {
@@ -2125,12 +1995,12 @@ object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
           body = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toCustom(__body.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
       )
     }
-
-
-
-
-
-
+    
+    
+    
+    
+    
+    
     lazy val defaultInstance = dotty.tools.dotc.semanticdb.MatchType.CaseType(
       key = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_key.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
       body = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
@@ -2150,7 +2020,7 @@ object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
     )
     // @@protoc_insertion_point(GeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType.CaseType])
   }
-
+  
   final val SCRUTINEE_FIELD_NUMBER = 1
   final val CASES_FIELD_NUMBER = 2
   @transient @sharable

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Type.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Type.scala
@@ -18,10 +18,10 @@ sealed trait Type  extends SemanticdbGeneratedSealedOneof  derives CanEqual {
 
 object Type {
   case object Empty extends dotty.tools.dotc.semanticdb.Type
-  
+
   sealed trait NonEmpty extends dotty.tools.dotc.semanticdb.Type
   def defaultInstance: dotty.tools.dotc.semanticdb.Type = Empty
-  
+
   implicit val TypeTypeMapper: SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] = new SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] {
     override def toCustom(__base: dotty.tools.dotc.semanticdb.TypeMessage): dotty.tools.dotc.semanticdb.Type = __base.sealedValue match {
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.TypeRef => __v.value
@@ -38,6 +38,8 @@ object Type {
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.UniversalType => __v.value
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType => __v.value
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType => __v.value
+      case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType => __v.value
+      case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType => __v.value
       case dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty => Empty
     }
     override def toBase(__custom: dotty.tools.dotc.semanticdb.Type): dotty.tools.dotc.semanticdb.TypeMessage = dotty.tools.dotc.semanticdb.TypeMessage(__custom match {
@@ -55,6 +57,8 @@ object Type {
       case __v: dotty.tools.dotc.semanticdb.UniversalType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.UniversalType(__v)
       case __v: dotty.tools.dotc.semanticdb.ByNameType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType(__v)
       case __v: dotty.tools.dotc.semanticdb.RepeatedType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__v)
+      case __v: dotty.tools.dotc.semanticdb.LambdaType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__v)
+      case __v: dotty.tools.dotc.semanticdb.MatchType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__v)
       case Empty => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty
     })
   }
@@ -123,6 +127,14 @@ final case class TypeMessage(
         val __value = sealedValue.repeatedType.get
         __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       };
+      if (sealedValue.lambdaType.isDefined) {
+        val __value = sealedValue.lambdaType.get
+        __size += 2 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      };
+      if (sealedValue.matchType.isDefined) {
+        val __value = sealedValue.matchType.get
+        __size += 2 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      };
       __size
     }
     override def serializedSize: _root_.scala.Int = {
@@ -132,7 +144,7 @@ final case class TypeMessage(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       sealedValue.typeRef.foreach { __v =>
@@ -219,6 +231,18 @@ final case class TypeMessage(
         _output__.writeUInt32NoTag(__m.serializedSize)
         __m.writeTo(_output__)
       };
+      sealedValue.lambdaType.foreach { __v =>
+        val __m = __v
+        _output__.writeTag(24, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      };
+      sealedValue.matchType.foreach { __v =>
+        val __m = __v
+        _output__.writeTag(25, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      };
     }
     def getTypeRef: dotty.tools.dotc.semanticdb.TypeRef = sealedValue.typeRef.getOrElse(dotty.tools.dotc.semanticdb.TypeRef.defaultInstance)
     def withTypeRef(__v: dotty.tools.dotc.semanticdb.TypeRef): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.TypeRef(__v))
@@ -248,12 +272,16 @@ final case class TypeMessage(
     def withByNameType(__v: dotty.tools.dotc.semanticdb.ByNameType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType(__v))
     def getRepeatedType: dotty.tools.dotc.semanticdb.RepeatedType = sealedValue.repeatedType.getOrElse(dotty.tools.dotc.semanticdb.RepeatedType.defaultInstance)
     def withRepeatedType(__v: dotty.tools.dotc.semanticdb.RepeatedType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__v))
+    def getLambdaType: dotty.tools.dotc.semanticdb.LambdaType = sealedValue.lambdaType.getOrElse(dotty.tools.dotc.semanticdb.LambdaType.defaultInstance)
+    def withLambdaType(__v: dotty.tools.dotc.semanticdb.LambdaType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__v))
+    def getMatchType: dotty.tools.dotc.semanticdb.MatchType = sealedValue.matchType.getOrElse(dotty.tools.dotc.semanticdb.MatchType.defaultInstance)
+    def withMatchType(__v: dotty.tools.dotc.semanticdb.MatchType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__v))
     def clearSealedValue: TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty)
     def withSealedValue(__v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue): TypeMessage = copy(sealedValue = __v)
-    
-    
-    
-    
+
+
+
+
     def toType: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.Type.TypeTypeMapper.toCustom(this)
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.Type])
 }
@@ -295,6 +323,10 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
           __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType(__sealedValue.byNameType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.ByNameType](_input__))(LiteParser.readMessage(_input__, _)))
         case 114 =>
           __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__sealedValue.repeatedType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.RepeatedType](_input__))(LiteParser.readMessage(_input__, _)))
+        case 194 =>
+          __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__sealedValue.lambdaType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.LambdaType](_input__))(LiteParser.readMessage(_input__, _)))
+        case 202 =>
+          __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__sealedValue.matchType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.MatchType](_input__))(LiteParser.readMessage(_input__, _)))
         case tag => _input__.skipField(tag)
       }
     }
@@ -302,12 +334,12 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
         sealedValue = __sealedValue
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.TypeMessage(
     sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty
   )
@@ -328,6 +360,8 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
     def isUniversalType: _root_.scala.Boolean = false
     def isByNameType: _root_.scala.Boolean = false
     def isRepeatedType: _root_.scala.Boolean = false
+    def isLambdaType: _root_.scala.Boolean = false
+    def isMatchType: _root_.scala.Boolean = false
     def typeRef: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeRef] = _root_.scala.None
     def singleType: _root_.scala.Option[dotty.tools.dotc.semanticdb.SingleType] = _root_.scala.None
     def thisType: _root_.scala.Option[dotty.tools.dotc.semanticdb.ThisType] = _root_.scala.None
@@ -342,6 +376,8 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
     def universalType: _root_.scala.Option[dotty.tools.dotc.semanticdb.UniversalType] = _root_.scala.None
     def byNameType: _root_.scala.Option[dotty.tools.dotc.semanticdb.ByNameType] = _root_.scala.None
     def repeatedType: _root_.scala.Option[dotty.tools.dotc.semanticdb.RepeatedType] = _root_.scala.None
+    def lambdaType: _root_.scala.Option[dotty.tools.dotc.semanticdb.LambdaType] = _root_.scala.None
+    def matchType: _root_.scala.Option[dotty.tools.dotc.semanticdb.MatchType] = _root_.scala.None
   }
   object SealedValue {
     @SerialVersionUID(0L)
@@ -352,7 +388,7 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
       override def number: _root_.scala.Int = 0
       override def value: _root_.scala.Nothing = throw new java.util.NoSuchElementException("Empty.value")
     }
-  
+
     @SerialVersionUID(0L)
     final case class TypeRef(value: dotty.tools.dotc.semanticdb.TypeRef) extends dotty.tools.dotc.semanticdb.TypeMessage.SealedValue  derives CanEqual {
       type ValueType = dotty.tools.dotc.semanticdb.TypeRef
@@ -451,6 +487,20 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
       override def repeatedType: _root_.scala.Option[dotty.tools.dotc.semanticdb.RepeatedType] = Some(value)
       override def number: _root_.scala.Int = 14
     }
+    @SerialVersionUID(0L)
+    final case class LambdaType(value: dotty.tools.dotc.semanticdb.LambdaType) extends dotty.tools.dotc.semanticdb.TypeMessage.SealedValue  derives CanEqual {
+      type ValueType = dotty.tools.dotc.semanticdb.LambdaType
+      override def isLambdaType: _root_.scala.Boolean = true
+      override def lambdaType: _root_.scala.Option[dotty.tools.dotc.semanticdb.LambdaType] = Some(value)
+      override def number: _root_.scala.Int = 24
+    }
+    @SerialVersionUID(0L)
+    final case class MatchType(value: dotty.tools.dotc.semanticdb.MatchType) extends dotty.tools.dotc.semanticdb.TypeMessage.SealedValue  derives CanEqual {
+      type ValueType = dotty.tools.dotc.semanticdb.MatchType
+      override def isMatchType: _root_.scala.Boolean = true
+      override def matchType: _root_.scala.Option[dotty.tools.dotc.semanticdb.MatchType] = Some(value)
+      override def number: _root_.scala.Int = 25
+    }
   }
   final val TYPE_REF_FIELD_NUMBER = 2
   final val SINGLE_TYPE_FIELD_NUMBER = 20
@@ -466,6 +516,8 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
   final val UNIVERSAL_TYPE_FIELD_NUMBER = 10
   final val BY_NAME_TYPE_FIELD_NUMBER = 13
   final val REPEATED_TYPE_FIELD_NUMBER = 14
+  final val LAMBDA_TYPE_FIELD_NUMBER = 24
+  final val MATCH_TYPE_FIELD_NUMBER = 25
   def of(
     sealedValue: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue
   ): _root_.dotty.tools.dotc.semanticdb.TypeMessage = _root_.dotty.tools.dotc.semanticdb.TypeMessage(
@@ -484,14 +536,14 @@ final case class TypeRef(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.TypeRef._typemapper_prefix.toBase(prefix)
         if (__value.serializedSize != 0) {
           __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
         }
       };
-      
+
       {
         val __value = symbol
         if (!__value.isEmpty) {
@@ -511,7 +563,7 @@ final case class TypeRef(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -541,10 +593,10 @@ final case class TypeRef(
     def addTypeArguments(__vs: dotty.tools.dotc.semanticdb.Type *): TypeRef = addAllTypeArguments(__vs)
     def addAllTypeArguments(__vs: Iterable[dotty.tools.dotc.semanticdb.Type]): TypeRef = copy(typeArguments = typeArguments ++ __vs)
     def withTypeArguments(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type]): TypeRef = copy(typeArguments = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.TypeRef])
 }
 
@@ -574,12 +626,12 @@ object TypeRef  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.sem
         typeArguments = __typeArguments.result()
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.TypeRef(
     prefix = dotty.tools.dotc.semanticdb.TypeRef._typemapper_prefix.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     symbol = "",
@@ -613,14 +665,14 @@ final case class SingleType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.SingleType._typemapper_prefix.toBase(prefix)
         if (__value.serializedSize != 0) {
           __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
         }
       };
-      
+
       {
         val __value = symbol
         if (!__value.isEmpty) {
@@ -636,7 +688,7 @@ final case class SingleType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -656,10 +708,10 @@ final case class SingleType(
     }
     def withPrefix(__v: dotty.tools.dotc.semanticdb.Type): SingleType = copy(prefix = __v)
     def withSymbol(__v: _root_.scala.Predef.String): SingleType = copy(symbol = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.SingleType])
 }
 
@@ -685,12 +737,12 @@ object SingleType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.
         symbol = __symbol
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.SingleType(
     prefix = dotty.tools.dotc.semanticdb.SingleType._typemapper_prefix.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     symbol = ""
@@ -717,7 +769,7 @@ final case class ThisType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = symbol
         if (!__value.isEmpty) {
@@ -733,7 +785,7 @@ final case class ThisType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -744,10 +796,10 @@ final case class ThisType(
       };
     }
     def withSymbol(__v: _root_.scala.Predef.String): ThisType = copy(symbol = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.ThisType])
 }
 
@@ -769,12 +821,12 @@ object ThisType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.se
         symbol = __symbol
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.ThisType(
     symbol = ""
   )
@@ -796,14 +848,14 @@ final case class SuperType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.SuperType._typemapper_prefix.toBase(prefix)
         if (__value.serializedSize != 0) {
           __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
         }
       };
-      
+
       {
         val __value = symbol
         if (!__value.isEmpty) {
@@ -819,7 +871,7 @@ final case class SuperType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -839,10 +891,10 @@ final case class SuperType(
     }
     def withPrefix(__v: dotty.tools.dotc.semanticdb.Type): SuperType = copy(prefix = __v)
     def withSymbol(__v: _root_.scala.Predef.String): SuperType = copy(symbol = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.SuperType])
 }
 
@@ -868,12 +920,12 @@ object SuperType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
         symbol = __symbol
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.SuperType(
     prefix = dotty.tools.dotc.semanticdb.SuperType._typemapper_prefix.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     symbol = ""
@@ -900,7 +952,7 @@ final case class ConstantType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.ConstantType._typemapper_constant.toBase(constant)
         if (__value.serializedSize != 0) {
@@ -916,7 +968,7 @@ final case class ConstantType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -929,10 +981,10 @@ final case class ConstantType(
       };
     }
     def withConstant(__v: dotty.tools.dotc.semanticdb.Constant): ConstantType = copy(constant = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.ConstantType])
 }
 
@@ -954,12 +1006,12 @@ object ConstantType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dot
         constant = dotty.tools.dotc.semanticdb.ConstantType._typemapper_constant.toCustom(__constant.getOrElse(dotty.tools.dotc.semanticdb.ConstantMessage.defaultInstance))
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.ConstantType(
     constant = dotty.tools.dotc.semanticdb.ConstantType._typemapper_constant.toCustom(dotty.tools.dotc.semanticdb.ConstantMessage.defaultInstance)
   )
@@ -995,7 +1047,7 @@ final case class IntersectionType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       types.foreach { __v =>
@@ -1009,10 +1061,10 @@ final case class IntersectionType(
     def addTypes(__vs: dotty.tools.dotc.semanticdb.Type *): IntersectionType = addAllTypes(__vs)
     def addAllTypes(__vs: Iterable[dotty.tools.dotc.semanticdb.Type]): IntersectionType = copy(types = types ++ __vs)
     def withTypes(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type]): IntersectionType = copy(types = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.IntersectionType])
 }
 
@@ -1034,12 +1086,12 @@ object IntersectionType  extends SemanticdbGeneratedMessageCompanion[dotty.tools
         types = __types.result()
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.IntersectionType(
     types = _root_.scala.Seq.empty
   )
@@ -1075,7 +1127,7 @@ final case class UnionType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       types.foreach { __v =>
@@ -1089,10 +1141,10 @@ final case class UnionType(
     def addTypes(__vs: dotty.tools.dotc.semanticdb.Type *): UnionType = addAllTypes(__vs)
     def addAllTypes(__vs: Iterable[dotty.tools.dotc.semanticdb.Type]): UnionType = copy(types = types ++ __vs)
     def withTypes(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type]): UnionType = copy(types = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.UnionType])
 }
 
@@ -1114,12 +1166,12 @@ object UnionType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
         types = __types.result()
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.UnionType(
     types = _root_.scala.Seq.empty
   )
@@ -1155,7 +1207,7 @@ final case class WithType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       types.foreach { __v =>
@@ -1169,10 +1221,10 @@ final case class WithType(
     def addTypes(__vs: dotty.tools.dotc.semanticdb.Type *): WithType = addAllTypes(__vs)
     def addAllTypes(__vs: Iterable[dotty.tools.dotc.semanticdb.Type]): WithType = copy(types = types ++ __vs)
     def withTypes(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type]): WithType = copy(types = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.WithType])
 }
 
@@ -1194,12 +1246,12 @@ object WithType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.se
         types = __types.result()
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.WithType(
     types = _root_.scala.Seq.empty
   )
@@ -1223,7 +1275,7 @@ final case class StructuralType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.StructuralType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1243,7 +1295,7 @@ final case class StructuralType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1265,10 +1317,10 @@ final case class StructuralType(
     def getDeclarations: dotty.tools.dotc.semanticdb.Scope = declarations.getOrElse(dotty.tools.dotc.semanticdb.Scope.defaultInstance)
     def clearDeclarations: StructuralType = copy(declarations = _root_.scala.None)
     def withDeclarations(__v: dotty.tools.dotc.semanticdb.Scope): StructuralType = copy(declarations = Option(__v))
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.StructuralType])
 }
 
@@ -1294,12 +1346,12 @@ object StructuralType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.d
         declarations = __declarations
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.StructuralType(
     tpe = dotty.tools.dotc.semanticdb.StructuralType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     declarations = _root_.scala.None
@@ -1331,7 +1383,7 @@ final case class AnnotatedType(
         val __value = __item
         __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       }
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.AnnotatedType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1347,7 +1399,7 @@ final case class AnnotatedType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1370,10 +1422,10 @@ final case class AnnotatedType(
     def addAllAnnotations(__vs: Iterable[dotty.tools.dotc.semanticdb.Annotation]): AnnotatedType = copy(annotations = annotations ++ __vs)
     def withAnnotations(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Annotation]): AnnotatedType = copy(annotations = __v)
     def withTpe(__v: dotty.tools.dotc.semanticdb.Type): AnnotatedType = copy(tpe = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.AnnotatedType])
 }
 
@@ -1399,12 +1451,12 @@ object AnnotatedType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.do
         tpe = dotty.tools.dotc.semanticdb.AnnotatedType._typemapper_tpe.toCustom(__tpe.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.AnnotatedType(
     annotations = _root_.scala.Seq.empty,
     tpe = dotty.tools.dotc.semanticdb.AnnotatedType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
@@ -1432,7 +1484,7 @@ final case class ExistentialType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.ExistentialType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1452,7 +1504,7 @@ final case class ExistentialType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1474,10 +1526,10 @@ final case class ExistentialType(
     def getDeclarations: dotty.tools.dotc.semanticdb.Scope = declarations.getOrElse(dotty.tools.dotc.semanticdb.Scope.defaultInstance)
     def clearDeclarations: ExistentialType = copy(declarations = _root_.scala.None)
     def withDeclarations(__v: dotty.tools.dotc.semanticdb.Scope): ExistentialType = copy(declarations = Option(__v))
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.ExistentialType])
 }
 
@@ -1503,12 +1555,12 @@ object ExistentialType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.
         declarations = __declarations
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.ExistentialType(
     tpe = dotty.tools.dotc.semanticdb.ExistentialType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
     declarations = _root_.scala.None
@@ -1540,7 +1592,7 @@ final case class UniversalType(
         val __value = typeParameters.get
         __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       };
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.UniversalType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1556,7 +1608,7 @@ final case class UniversalType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1578,10 +1630,10 @@ final case class UniversalType(
     def clearTypeParameters: UniversalType = copy(typeParameters = _root_.scala.None)
     def withTypeParameters(__v: dotty.tools.dotc.semanticdb.Scope): UniversalType = copy(typeParameters = Option(__v))
     def withTpe(__v: dotty.tools.dotc.semanticdb.Type): UniversalType = copy(tpe = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.UniversalType])
 }
 
@@ -1607,12 +1659,12 @@ object UniversalType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.do
         tpe = dotty.tools.dotc.semanticdb.UniversalType._typemapper_tpe.toCustom(__tpe.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.UniversalType(
     typeParameters = _root_.scala.None,
     tpe = dotty.tools.dotc.semanticdb.UniversalType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
@@ -1639,7 +1691,7 @@ final case class ByNameType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.ByNameType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1655,7 +1707,7 @@ final case class ByNameType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1668,10 +1720,10 @@ final case class ByNameType(
       };
     }
     def withTpe(__v: dotty.tools.dotc.semanticdb.Type): ByNameType = copy(tpe = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.ByNameType])
 }
 
@@ -1693,12 +1745,12 @@ object ByNameType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.
         tpe = dotty.tools.dotc.semanticdb.ByNameType._typemapper_tpe.toCustom(__tpe.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.ByNameType(
     tpe = dotty.tools.dotc.semanticdb.ByNameType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
   )
@@ -1721,7 +1773,7 @@ final case class RepeatedType(
     private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
     private[this] def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = dotty.tools.dotc.semanticdb.RepeatedType._typemapper_tpe.toBase(tpe)
         if (__value.serializedSize != 0) {
@@ -1737,7 +1789,7 @@ final case class RepeatedType(
         __serializedSizeMemoized = __size
       }
       __size - 1
-      
+
     }
     def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
       {
@@ -1750,10 +1802,10 @@ final case class RepeatedType(
       };
     }
     def withTpe(__v: dotty.tools.dotc.semanticdb.Type): RepeatedType = copy(tpe = __v)
-    
-    
-    
-    
+
+
+
+
     // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.RepeatedType])
 }
 
@@ -1775,12 +1827,12 @@ object RepeatedType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dot
         tpe = dotty.tools.dotc.semanticdb.RepeatedType._typemapper_tpe.toCustom(__tpe.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
     )
   }
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
   lazy val defaultInstance = dotty.tools.dotc.semanticdb.RepeatedType(
     tpe = dotty.tools.dotc.semanticdb.RepeatedType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
   )
@@ -1793,4 +1845,322 @@ object RepeatedType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dot
     tpe
   )
   // @@protoc_insertion_point(GeneratedMessageCompanion[dotty.tools.dotc.semanticdb.RepeatedType])
+}
+
+@SerialVersionUID(0L)
+final case class LambdaType(
+    parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None,
+    returnType: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
+    )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
+    @transient @sharable
+    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
+    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+      var __size = 0
+      if (parameters.isDefined) {
+        val __value = parameters.get
+        __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      };
+
+      {
+        val __value = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toBase(returnType)
+        if (__value.serializedSize != 0) {
+          __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+        }
+      };
+      __size
+    }
+    override def serializedSize: _root_.scala.Int = {
+      var __size = __serializedSizeMemoized
+      if (__size == 0) {
+        __size = __computeSerializedSize() + 1
+        __serializedSizeMemoized = __size
+      }
+      __size - 1
+
+    }
+    def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
+      parameters.foreach { __v =>
+        val __m = __v
+        _output__.writeTag(1, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      };
+      {
+        val __v = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toBase(returnType)
+        if (__v.serializedSize != 0) {
+          _output__.writeTag(2, 2)
+          _output__.writeUInt32NoTag(__v.serializedSize)
+          __v.writeTo(_output__)
+        }
+      };
+    }
+    def getParameters: dotty.tools.dotc.semanticdb.Scope = parameters.getOrElse(dotty.tools.dotc.semanticdb.Scope.defaultInstance)
+    def clearParameters: LambdaType = copy(parameters = _root_.scala.None)
+    def withParameters(__v: dotty.tools.dotc.semanticdb.Scope): LambdaType = copy(parameters = Option(__v))
+    def withReturnType(__v: dotty.tools.dotc.semanticdb.Type): LambdaType = copy(returnType = __v)
+
+
+
+
+    // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.LambdaType])
+}
+
+object LambdaType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType] {
+  implicit def messageCompanion: SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType] = this
+  def parseFrom(`_input__`: SemanticdbInputStream): dotty.tools.dotc.semanticdb.LambdaType = {
+    var __parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None
+    var __returnType: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeMessage] = _root_.scala.None
+    var _done__ = false
+    while (!_done__) {
+      val _tag__ = _input__.readTag()
+      _tag__ match {
+        case 0 => _done__ = true
+        case 10 =>
+          __parameters = Option(__parameters.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.Scope](_input__))(LiteParser.readMessage(_input__, _)))
+        case 18 =>
+          __returnType = _root_.scala.Some(__returnType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.TypeMessage](_input__))(LiteParser.readMessage(_input__, _)))
+        case tag => _input__.skipField(tag)
+      }
+    }
+    dotty.tools.dotc.semanticdb.LambdaType(
+        parameters = __parameters,
+        returnType = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(__returnType.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
+    )
+  }
+
+
+
+
+
+
+  lazy val defaultInstance = dotty.tools.dotc.semanticdb.LambdaType(
+    parameters = _root_.scala.None,
+    returnType = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
+  )
+  final val PARAMETERS_FIELD_NUMBER = 1
+  final val RETURN_TYPE_FIELD_NUMBER = 2
+  @transient @sharable
+  private[semanticdb] val _typemapper_returnType: SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] = implicitly[SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type]]
+  def of(
+    parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope],
+    returnType: dotty.tools.dotc.semanticdb.Type
+  ): _root_.dotty.tools.dotc.semanticdb.LambdaType = _root_.dotty.tools.dotc.semanticdb.LambdaType(
+    parameters,
+    returnType
+  )
+  // @@protoc_insertion_point(GeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType])
+}
+
+@SerialVersionUID(0L)
+final case class MatchType(
+    scrutinee: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.MatchType._typemapper_scrutinee.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
+    cases: _root_.scala.Seq[dotty.tools.dotc.semanticdb.MatchType.CaseType] = _root_.scala.Seq.empty
+    )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
+    @transient @sharable
+    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
+    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+      var __size = 0
+
+      {
+        val __value = dotty.tools.dotc.semanticdb.MatchType._typemapper_scrutinee.toBase(scrutinee)
+        if (__value.serializedSize != 0) {
+          __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+        }
+      };
+      cases.foreach { __item =>
+        val __value = __item
+        __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      }
+      __size
+    }
+    override def serializedSize: _root_.scala.Int = {
+      var __size = __serializedSizeMemoized
+      if (__size == 0) {
+        __size = __computeSerializedSize() + 1
+        __serializedSizeMemoized = __size
+      }
+      __size - 1
+
+    }
+    def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
+      {
+        val __v = dotty.tools.dotc.semanticdb.MatchType._typemapper_scrutinee.toBase(scrutinee)
+        if (__v.serializedSize != 0) {
+          _output__.writeTag(1, 2)
+          _output__.writeUInt32NoTag(__v.serializedSize)
+          __v.writeTo(_output__)
+        }
+      };
+      cases.foreach { __v =>
+        val __m = __v
+        _output__.writeTag(2, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      };
+    }
+    def withScrutinee(__v: dotty.tools.dotc.semanticdb.Type): MatchType = copy(scrutinee = __v)
+    def clearCases = copy(cases = _root_.scala.Seq.empty)
+    def addCases(__vs: dotty.tools.dotc.semanticdb.MatchType.CaseType *): MatchType = addAllCases(__vs)
+    def addAllCases(__vs: Iterable[dotty.tools.dotc.semanticdb.MatchType.CaseType]): MatchType = copy(cases = cases ++ __vs)
+    def withCases(__v: _root_.scala.Seq[dotty.tools.dotc.semanticdb.MatchType.CaseType]): MatchType = copy(cases = __v)
+
+
+
+
+    // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.MatchType])
+}
+
+object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType] {
+  implicit def messageCompanion: SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType] = this
+  def parseFrom(`_input__`: SemanticdbInputStream): dotty.tools.dotc.semanticdb.MatchType = {
+    var __scrutinee: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeMessage] = _root_.scala.None
+    val __cases: _root_.scala.collection.immutable.VectorBuilder[dotty.tools.dotc.semanticdb.MatchType.CaseType] = new _root_.scala.collection.immutable.VectorBuilder[dotty.tools.dotc.semanticdb.MatchType.CaseType]
+    var _done__ = false
+    while (!_done__) {
+      val _tag__ = _input__.readTag()
+      _tag__ match {
+        case 0 => _done__ = true
+        case 10 =>
+          __scrutinee = _root_.scala.Some(__scrutinee.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.TypeMessage](_input__))(LiteParser.readMessage(_input__, _)))
+        case 18 =>
+          __cases += LiteParser.readMessage[dotty.tools.dotc.semanticdb.MatchType.CaseType](_input__)
+        case tag => _input__.skipField(tag)
+      }
+    }
+    dotty.tools.dotc.semanticdb.MatchType(
+        scrutinee = dotty.tools.dotc.semanticdb.MatchType._typemapper_scrutinee.toCustom(__scrutinee.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)),
+        cases = __cases.result()
+    )
+  }
+
+
+
+
+
+
+  lazy val defaultInstance = dotty.tools.dotc.semanticdb.MatchType(
+    scrutinee = dotty.tools.dotc.semanticdb.MatchType._typemapper_scrutinee.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
+    cases = _root_.scala.Seq.empty
+  )
+  @SerialVersionUID(0L)
+  final case class CaseType(
+      key: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_key.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
+      body: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
+      )  extends SemanticdbGeneratedMessage  derives CanEqual {
+      @transient @sharable
+      private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
+      private[this] def __computeSerializedSize(): _root_.scala.Int = {
+        var __size = 0
+
+        {
+          val __value = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_key.toBase(key)
+          if (__value.serializedSize != 0) {
+            __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+          }
+        };
+
+        {
+          val __value = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toBase(body)
+          if (__value.serializedSize != 0) {
+            __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+          }
+        };
+        __size
+      }
+      override def serializedSize: _root_.scala.Int = {
+        var __size = __serializedSizeMemoized
+        if (__size == 0) {
+          __size = __computeSerializedSize() + 1
+          __serializedSizeMemoized = __size
+        }
+        __size - 1
+
+      }
+      def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
+        {
+          val __v = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_key.toBase(key)
+          if (__v.serializedSize != 0) {
+            _output__.writeTag(1, 2)
+            _output__.writeUInt32NoTag(__v.serializedSize)
+            __v.writeTo(_output__)
+          }
+        };
+        {
+          val __v = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toBase(body)
+          if (__v.serializedSize != 0) {
+            _output__.writeTag(2, 2)
+            _output__.writeUInt32NoTag(__v.serializedSize)
+            __v.writeTo(_output__)
+          }
+        };
+      }
+      def withKey(__v: dotty.tools.dotc.semanticdb.Type): CaseType = copy(key = __v)
+      def withBody(__v: dotty.tools.dotc.semanticdb.Type): CaseType = copy(body = __v)
+
+
+
+
+      // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.MatchType.CaseType])
+  }
+
+  object CaseType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType.CaseType] {
+    implicit def messageCompanion: SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType.CaseType] = this
+    def parseFrom(`_input__`: SemanticdbInputStream): dotty.tools.dotc.semanticdb.MatchType.CaseType = {
+      var __key: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeMessage] = _root_.scala.None
+      var __body: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeMessage] = _root_.scala.None
+      var _done__ = false
+      while (!_done__) {
+        val _tag__ = _input__.readTag()
+        _tag__ match {
+          case 0 => _done__ = true
+          case 10 =>
+            __key = _root_.scala.Some(__key.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.TypeMessage](_input__))(LiteParser.readMessage(_input__, _)))
+          case 18 =>
+            __body = _root_.scala.Some(__body.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.TypeMessage](_input__))(LiteParser.readMessage(_input__, _)))
+          case tag => _input__.skipField(tag)
+        }
+      }
+      dotty.tools.dotc.semanticdb.MatchType.CaseType(
+          key = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_key.toCustom(__key.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)),
+          body = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toCustom(__body.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
+      )
+    }
+
+
+
+
+
+
+    lazy val defaultInstance = dotty.tools.dotc.semanticdb.MatchType.CaseType(
+      key = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_key.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance),
+      body = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
+    )
+    final val KEY_FIELD_NUMBER = 1
+    final val BODY_FIELD_NUMBER = 2
+    @transient @sharable
+    private[semanticdb] val _typemapper_key: SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] = implicitly[SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type]]
+    @transient @sharable
+    private[semanticdb] val _typemapper_body: SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] = implicitly[SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type]]
+    def of(
+      key: dotty.tools.dotc.semanticdb.Type,
+      body: dotty.tools.dotc.semanticdb.Type
+    ): _root_.dotty.tools.dotc.semanticdb.MatchType.CaseType = _root_.dotty.tools.dotc.semanticdb.MatchType.CaseType(
+      key,
+      body
+    )
+    // @@protoc_insertion_point(GeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType.CaseType])
+  }
+
+  final val SCRUTINEE_FIELD_NUMBER = 1
+  final val CASES_FIELD_NUMBER = 2
+  @transient @sharable
+  private[semanticdb] val _typemapper_scrutinee: SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] = implicitly[SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type]]
+  def of(
+    scrutinee: dotty.tools.dotc.semanticdb.Type,
+    cases: _root_.scala.Seq[dotty.tools.dotc.semanticdb.MatchType.CaseType]
+  ): _root_.dotty.tools.dotc.semanticdb.MatchType = _root_.dotty.tools.dotc.semanticdb.MatchType(
+    scrutinee,
+    cases
+  )
+  // @@protoc_insertion_point(GeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType])
 }

--- a/tests/semanticdb/expect/Advanced.expect.scala
+++ b/tests/semanticdb/expect/Advanced.expect.scala
@@ -42,6 +42,10 @@ object Test/*<-advanced::Test.*/ {
         ()
     }
   }
+
+  // see: https://github.com/lampepfl/dotty/pull/14608#discussion_r835642563
+  lazy val foo/*<-advanced::Test.foo.*/: (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local16*/ = Int/*->scala::Int#*/ }) &/*->scala::`&`#*/ (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local17*/ = Int/*->scala::Int#*/; val a/*<-local18*/: A/*->local17*/ }) = ???/*->scala::Predef.`???`().*/
+  def bar/*<-advanced::Test.bar().*/: foo/*->advanced::Test.foo.*/.A = foo/*->advanced::Test.foo.*/.a
 }
 
 

--- a/tests/semanticdb/expect/Advanced.expect.scala
+++ b/tests/semanticdb/expect/Advanced.expect.scala
@@ -14,6 +14,7 @@ class Structural/*<-advanced::Structural#*/ {
   def s2/*<-advanced::Structural#s2().*/: { val x/*<-local1*/: Int/*->scala::Int#*/ } = new { val x/*<-local2*/: Int/*->scala::Int#*/ = ???/*->scala::Predef.`???`().*/ }
   def s3/*<-advanced::Structural#s3().*/: { def m/*<-local6*/(x/*<-local5*/: Int/*->scala::Int#*/): Int/*->scala::Int#*/ } = new { def m/*<-local8*/(x/*<-local7*/: Int/*->scala::Int#*/): Int/*->scala::Int#*/ = ???/*->scala::Predef.`???`().*/ }
   def s4/*<-advanced::Structural#s4().*/(a/*<-advanced::Structural#s4().(a)*/: Int/*->scala::Int#*/): { val x/*<-local11*/: Int/*->scala::Int#*/ } = ???/*->scala::Predef.`???`().*/
+  trait T/*<-advanced::Structural#T#*/[A/*<-advanced::Structural#T#[A]*/] { val foo/*<-advanced::Structural#T#foo.*/: { type B/*<-local12*/ = A/*->advanced::Structural#T#[A]*/ } = ???/*->scala::Predef.`???`().*/; def bar/*<-advanced::Structural#T#bar().*/(b/*<-advanced::Structural#T#bar().(b)*/: foo/*->advanced::Structural#T#foo.*/.B) = () } // from tests/pos/t8177e.scala
 }
 
 class Wildcards/*<-advanced::Wildcards#*/ {
@@ -36,8 +37,8 @@ object Test/*<-advanced::Test.*/ {
 
   {
     (???/*->scala::Predef.`???`().*/ : Any/*->scala::Any#*/) match {
-      case e3/*<-local12*/: List/*->scala::package.List#*/[_] =>
-        val e3x/*<-local14*/ = e3/*->local12*/.head/*->scala::collection::IterableOps#head().*/
+      case e3/*<-local13*/: List/*->scala::package.List#*/[_] =>
+        val e3x/*<-local15*/ = e3/*->local13*/.head/*->scala::collection::IterableOps#head().*/
         ()
     }
   }

--- a/tests/semanticdb/expect/Advanced.expect.scala
+++ b/tests/semanticdb/expect/Advanced.expect.scala
@@ -45,7 +45,7 @@ object Test/*<-advanced::Test.*/ {
 
   // see: https://github.com/lampepfl/dotty/pull/14608#discussion_r835642563
   lazy val foo/*<-advanced::Test.foo.*/: (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local16*/ = Int/*->scala::Int#*/ }) &/*->scala::`&`#*/ (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local17*/ = Int/*->scala::Int#*/; val a/*<-local18*/: A/*->local17*/ }) = ???/*->scala::Predef.`???`().*/
-  def bar/*<-advanced::Test.bar().*/: foo/*->advanced::Test.foo.*/.A/*->local19*/ = foo/*->advanced::Test.foo.*/.a
+  def bar/*<-advanced::Test.bar().*/: foo/*->advanced::Test.foo.*/.A/*->local17*/ = foo/*->advanced::Test.foo.*/.a
 }
 
 

--- a/tests/semanticdb/expect/Advanced.expect.scala
+++ b/tests/semanticdb/expect/Advanced.expect.scala
@@ -14,7 +14,7 @@ class Structural/*<-advanced::Structural#*/ {
   def s2/*<-advanced::Structural#s2().*/: { val x/*<-local1*/: Int/*->scala::Int#*/ } = new { val x/*<-local2*/: Int/*->scala::Int#*/ = ???/*->scala::Predef.`???`().*/ }
   def s3/*<-advanced::Structural#s3().*/: { def m/*<-local6*/(x/*<-local5*/: Int/*->scala::Int#*/): Int/*->scala::Int#*/ } = new { def m/*<-local8*/(x/*<-local7*/: Int/*->scala::Int#*/): Int/*->scala::Int#*/ = ???/*->scala::Predef.`???`().*/ }
   def s4/*<-advanced::Structural#s4().*/(a/*<-advanced::Structural#s4().(a)*/: Int/*->scala::Int#*/): { val x/*<-local11*/: Int/*->scala::Int#*/ } = ???/*->scala::Predef.`???`().*/
-  trait T/*<-advanced::Structural#T#*/[A/*<-advanced::Structural#T#[A]*/] { val foo/*<-advanced::Structural#T#foo.*/: { type B/*<-local12*/ = A/*->advanced::Structural#T#[A]*/ } = ???/*->scala::Predef.`???`().*/; def bar/*<-advanced::Structural#T#bar().*/(b/*<-advanced::Structural#T#bar().(b)*/: foo/*->advanced::Structural#T#foo.*/.B) = () } // from tests/pos/t8177e.scala
+  trait T/*<-advanced::Structural#T#*/[A/*<-advanced::Structural#T#[A]*/] { val foo/*<-advanced::Structural#T#foo.*/: { type B/*<-local12*/ = A/*->advanced::Structural#T#[A]*/ } = ???/*->scala::Predef.`???`().*/; def bar/*<-advanced::Structural#T#bar().*/(b/*<-advanced::Structural#T#bar().(b)*/: foo/*->advanced::Structural#T#foo.*/.B/*->local12*/) = () } // from tests/pos/t8177e.scala
 }
 
 class Wildcards/*<-advanced::Wildcards#*/ {
@@ -45,7 +45,7 @@ object Test/*<-advanced::Test.*/ {
 
   // see: https://github.com/lampepfl/dotty/pull/14608#discussion_r835642563
   lazy val foo/*<-advanced::Test.foo.*/: (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local16*/ = Int/*->scala::Int#*/ }) &/*->scala::`&`#*/ (reflect.Selectable/*->scala::reflect::Selectable#*/ { type A/*<-local17*/ = Int/*->scala::Int#*/; val a/*<-local18*/: A/*->local17*/ }) = ???/*->scala::Predef.`???`().*/
-  def bar/*<-advanced::Test.bar().*/: foo/*->advanced::Test.foo.*/.A = foo/*->advanced::Test.foo.*/.a
+  def bar/*<-advanced::Test.bar().*/: foo/*->advanced::Test.foo.*/.A/*->local19*/ = foo/*->advanced::Test.foo.*/.a
 }
 
 

--- a/tests/semanticdb/expect/Advanced.scala
+++ b/tests/semanticdb/expect/Advanced.scala
@@ -14,6 +14,7 @@ class Structural {
   def s2: { val x: Int } = new { val x: Int = ??? }
   def s3: { def m(x: Int): Int } = new { def m(x: Int): Int = ??? }
   def s4(a: Int): { val x: Int } = ???
+  trait T[A] { val foo: { type B = A } = ???; def bar(b: foo.B) = () } // from tests/pos/t8177e.scala
 }
 
 class Wildcards {

--- a/tests/semanticdb/expect/Advanced.scala
+++ b/tests/semanticdb/expect/Advanced.scala
@@ -42,6 +42,10 @@ object Test {
         ()
     }
   }
+
+  // see: https://github.com/lampepfl/dotty/pull/14608#discussion_r835642563
+  lazy val foo: (reflect.Selectable { type A = Int }) & (reflect.Selectable { type A = Int; val a: A }) = ???
+  def bar: foo.A = foo.a
 }
 
 

--- a/tests/semanticdb/expect/MatchType.expect.scala
+++ b/tests/semanticdb/expect/MatchType.expect.scala
@@ -1,0 +1,10 @@
+package example
+
+type Elem/*<-example::MatchType$package.Elem#*/[X/*<-example::MatchType$package.Elem#[X]*/] = X/*->example::MatchType$package.Elem#[X]*/ match
+  case String/*->scala::Predef.String#*/ => Char/*->scala::Char#*/
+  case Array/*->scala::Array#*/[t/*<-local0*/] => t/*->local0*/
+  case Iterable/*->scala::package.Iterable#*/[t/*<-local1*/] => t/*->local1*/
+
+type Concat/*<-example::MatchType$package.Concat#*/[Xs/*<-example::MatchType$package.Concat#[Xs]*/ <: Tuple/*->scala::Tuple#*/, +Ys/*<-example::MatchType$package.Concat#[Ys]*/ <: Tuple/*->scala::Tuple#*/] <: Tuple/*->scala::Tuple#*/ = Xs/*->example::MatchType$package.Concat#[Xs]*/ match
+  case EmptyTuple/*->scala::Tuple$package.EmptyTuple#*/ => Ys/*->example::MatchType$package.Concat#[Ys]*/
+  case x/*<-local2*/ *:/*->scala::`*:`#*/ xs/*<-local3*/ => x/*->local2*/ *:/*->scala::`*:`#*/ Concat/*->example::MatchType$package.Concat#*/[xs/*->local3*/, Ys/*->example::MatchType$package.Concat#[Ys]*/]

--- a/tests/semanticdb/expect/MatchType.scala
+++ b/tests/semanticdb/expect/MatchType.scala
@@ -1,0 +1,10 @@
+package example
+
+type Elem[X] = X match
+  case String => Char
+  case Array[t] => t
+  case Iterable[t] => t
+
+type Concat[Xs <: Tuple, +Ys <: Tuple] <: Tuple = Xs match
+  case EmptyTuple => Ys
+  case x *: xs => x *: Concat[xs, Ys]

--- a/tests/semanticdb/expect/dep-match.expect.scala
+++ b/tests/semanticdb/expect/dep-match.expect.scala
@@ -1,0 +1,9 @@
+object Test_depmatch/*<-_empty_::Test_depmatch.*/ {
+  type Foo/*<-_empty_::Test_depmatch.Foo#*/ = Int/*->scala::Int#*/ { type U/*<-local0*/ }
+  type Bar/*<-_empty_::Test_depmatch.Bar#*/[T/*<-_empty_::Test_depmatch.Bar#[T]*/] = T/*->_empty_::Test_depmatch.Bar#[T]*/ match {
+    case Unit/*->scala::Unit#*/ => Unit/*->scala::Unit#*/
+  }
+  inline def baz/*<-_empty_::Test_depmatch.baz().*/(foo/*<-_empty_::Test_depmatch.baz().(foo)*/: Foo/*->_empty_::Test_depmatch.Foo#*/): Unit/*->scala::Unit#*/ = {
+    val v/*<-local1*/: Bar/*->_empty_::Test_depmatch.Bar#*/[foo/*->_empty_::Test_depmatch.baz().(foo)*/.U] = ???/*->scala::Predef.`???`().*/
+  }
+}

--- a/tests/semanticdb/expect/dep-match.expect.scala
+++ b/tests/semanticdb/expect/dep-match.expect.scala
@@ -4,6 +4,6 @@ object Test_depmatch/*<-_empty_::Test_depmatch.*/ {
     case Unit/*->scala::Unit#*/ => Unit/*->scala::Unit#*/
   }
   inline def baz/*<-_empty_::Test_depmatch.baz().*/(foo/*<-_empty_::Test_depmatch.baz().(foo)*/: Foo/*->_empty_::Test_depmatch.Foo#*/): Unit/*->scala::Unit#*/ = {
-    val v/*<-local1*/: Bar/*->_empty_::Test_depmatch.Bar#*/[foo/*->_empty_::Test_depmatch.baz().(foo)*/.U] = ???/*->scala::Predef.`???`().*/
+    val v/*<-local1*/: Bar/*->_empty_::Test_depmatch.Bar#*/[foo/*->_empty_::Test_depmatch.baz().(foo)*/.U/*->local0*/] = ???/*->scala::Predef.`???`().*/
   }
 }

--- a/tests/semanticdb/expect/dep-match.scala
+++ b/tests/semanticdb/expect/dep-match.scala
@@ -1,0 +1,9 @@
+object Test_depmatch {
+  type Foo = Int { type U }
+  type Bar[T] = T match {
+    case Unit => Unit
+  }
+  inline def baz(foo: Foo): Unit = {
+    val v: Bar[foo.U] = ???
+  }
+}

--- a/tests/semanticdb/expect/i5854.expect.scala
+++ b/tests/semanticdb/expect/i5854.expect.scala
@@ -1,0 +1,11 @@
+package i5854
+
+class B/*<-i5854::B#*/ {
+  // Known issue: Can't lookup the symbol of `b.A`
+  // we have to register the symbol of `b { type A }` to the refinementSymtab first
+  // then resolve, or assign same semanticdb symbol for both
+  // fake symbol for b.A, and real symbol of A in b
+  val a/*<-i5854::B#a.*/: String/*->scala::Predef.String#*/ = (((1: Any/*->scala::Any#*/): b/*->i5854::B#b.*/.A): Nothing/*->scala::Nothing#*/): String/*->scala::Predef.String#*/
+  val b/*<-i5854::B#b.*/: { type A/*<-local0*/ >: Any/*->scala::Any#*/ <: Nothing/*->scala::Nothing#*/ } = loop/*->i5854::B#loop().*/()         // error
+  def loop/*<-i5854::B#loop().*/(): Nothing/*->scala::Nothing#*/ = loop/*->i5854::B#loop().*/()
+}

--- a/tests/semanticdb/expect/i5854.scala
+++ b/tests/semanticdb/expect/i5854.scala
@@ -1,0 +1,11 @@
+package i5854
+
+class B {
+  // Known issue: Can't lookup the symbol of `b.A`
+  // we have to register the symbol of `b { type A }` to the refinementSymtab first
+  // then resolve, or assign same semanticdb symbol for both
+  // fake symbol for b.A, and real symbol of A in b
+  val a: String = (((1: Any): b.A): Nothing): String
+  val b: { type A >: Any <: Nothing } = loop()         // error
+  def loop(): Nothing = loop()
+}

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -71,8 +71,8 @@ advanced/Structural# => class Structural extends Object { self: Structural => +6
 advanced/Structural#T# => trait T [typeparam A ] extends Object { self: T[A] => +4 decls }
 advanced/Structural#T#[A] => typeparam A 
 advanced/Structural#T#`<init>`(). => primary ctor <init> [typeparam A ](): T[A]
-advanced/Structural#T#bar(). => method bar (param b: <?>): Unit
-advanced/Structural#T#bar().(b) => param b: <?>
+advanced/Structural#T#bar(). => method bar (param b: foo.B): Unit
+advanced/Structural#T#bar().(b) => param b: foo.B
 advanced/Structural#T#foo. => val method foo Object { type B  = A }
 advanced/Structural#`<init>`(). => primary ctor <init> (): Structural
 advanced/Structural#s1(). => method s1 => Object { abstract val method x Int }
@@ -3702,6 +3702,46 @@ Occurrences:
 [4:14..4:17): Seq -> scala/package.Seq#
 [4:18..4:21): Int -> scala/Int#
 [4:26..4:30): Unit -> scala/Unit#
+
+expect/dep-match.scala
+----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => dep-match.scala
+Text => empty
+Language => Scala
+Symbols => 8 entries
+Occurrences => 17 entries
+
+Symbols:
+_empty_/Test_depmatch. => final object Test_depmatch extends Object { self: Test_depmatch.type => +4 decls }
+_empty_/Test_depmatch.Bar# => type Bar [typeparam T ] = T match { Unit => Unit }
+_empty_/Test_depmatch.Bar#[T] => typeparam T 
+_empty_/Test_depmatch.Foo# => type Foo  = Int { type U  }
+_empty_/Test_depmatch.baz(). => inline macro baz (param foo: Foo): Unit
+_empty_/Test_depmatch.baz().(foo) => param foo: Foo
+local0 => type U 
+local1 => val local v: Bar[foo.U]
+
+Occurrences:
+[0:7..0:20): Test_depmatch <- _empty_/Test_depmatch.
+[1:7..1:10): Foo <- _empty_/Test_depmatch.Foo#
+[1:13..1:16): Int -> scala/Int#
+[1:24..1:25): U <- local0
+[2:7..2:10): Bar <- _empty_/Test_depmatch.Bar#
+[2:11..2:12): T <- _empty_/Test_depmatch.Bar#[T]
+[2:16..2:17): T -> _empty_/Test_depmatch.Bar#[T]
+[3:9..3:13): Unit -> scala/Unit#
+[3:17..3:21): Unit -> scala/Unit#
+[5:13..5:16): baz <- _empty_/Test_depmatch.baz().
+[5:17..5:20): foo <- _empty_/Test_depmatch.baz().(foo)
+[5:22..5:25): Foo -> _empty_/Test_depmatch.Foo#
+[5:28..5:32): Unit -> scala/Unit#
+[6:8..6:9): v <- local1
+[6:11..6:14): Bar -> _empty_/Test_depmatch.Bar#
+[6:15..6:18): foo -> _empty_/Test_depmatch.baz().(foo)
+[6:24..6:27): ??? -> scala/Predef.`???`().
 
 expect/exports-example-Codec.scala
 ----------------------------------

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -49,7 +49,7 @@ Uri => Advanced.scala
 Text => empty
 Language => Scala
 Symbols => 62 entries
-Occurrences => 130 entries
+Occurrences => 132 entries
 Synthetics => 4 entries
 
 Symbols:
@@ -169,6 +169,7 @@ Occurrences:
 [16:50..16:53): bar <- advanced/Structural#T#bar().
 [16:54..16:55): b <- advanced/Structural#T#bar().(b)
 [16:57..16:60): foo -> advanced/Structural#T#foo.
+[16:61..16:62): B -> local12
 [19:6..19:15): Wildcards <- advanced/Wildcards#
 [20:6..20:8): e1 <- advanced/Wildcards#e1().
 [20:10..20:14): List -> scala/package.List#
@@ -230,6 +231,7 @@ Occurrences:
 [46:106..46:109): ??? -> scala/Predef.`???`().
 [47:6..47:9): bar <- advanced/Test.bar().
 [47:11..47:14): foo -> advanced/Test.foo.
+[47:15..47:16): A -> local19
 [47:19..47:22): foo -> advanced/Test.foo.
 [52:6..52:13): HKClass <- advanced/HKClass#
 [52:14..52:15): F <- advanced/HKClass#[F]

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -2034,10 +2034,10 @@ example/MatchType$package.Concat#[Xs] => typeparam Xs  <: Tuple
 example/MatchType$package.Concat#[Ys] => covariant typeparam Ys  <: Tuple
 example/MatchType$package.Elem# => type Elem [typeparam X ] = X match { String => Char, Array[t] => t, Iterable[t] => t }
 example/MatchType$package.Elem#[X] => typeparam X 
-local0 => case type t 
-local1 => case type t 
-local2 => case type x 
-local3 => case type xs  <: Tuple
+local0 => type t 
+local1 => type t 
+local2 => type x 
+local3 => type xs  <: Tuple
 
 Occurrences:
 [0:8..0:15): example <- example/
@@ -4087,9 +4087,9 @@ Occurrences => 46 entries
 Synthetics => 3 entries
 
 Symbols:
-local0 => case type N$1  <: Nat
+local0 => type N$1  <: Nat
 local1 => val local p: N$1
-local2 => case type N$2  <: Nat
+local2 => type N$2  <: Nat
 local3 => val local p: N$2
 local4 => val local Nat_this: Zero.type
 local5 => val local Nat_this: Succ[Zero.type]
@@ -4271,7 +4271,7 @@ flags/p/package.y(). => protected implicit var method y Int
 flags/p/package.z(). => method z (param pp: Int): Int
 flags/p/package.z().(pp) => param pp: Int
 local0 => val local xs2: Nothing
-local1 => case type t 
+local1 => type t 
 
 Occurrences:
 [0:8..0:13): flags <- flags/

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -54,22 +54,22 @@ Synthetics => 4 entries
 
 Symbols:
 advanced/C# => class C [typeparam T ] extends Object { self: C[T] => +3 decls }
-advanced/C#[T] => typeparam T
+advanced/C#[T] => typeparam T 
 advanced/C#`<init>`(). => primary ctor <init> [typeparam T ](): C[T]
 advanced/C#t(). => method t => T
 advanced/HKClass# => class HKClass [typeparam F [typeparam T ] <: <?>] extends Object { self: HKClass[F] => +3 decls }
 advanced/HKClass#[F] => typeparam F [typeparam T ] <: <?>
-advanced/HKClass#[F][T] => typeparam T
+advanced/HKClass#[F][T] => typeparam T 
 advanced/HKClass#`<init>`(). => primary ctor <init> [typeparam F [typeparam T ] <: <?>](): HKClass[F]
-advanced/HKClass#`<init>`().[F][T] => typeparam T
-advanced/HKClass#`<init>`().[F][U] => typeparam U
+advanced/HKClass#`<init>`().[F][T] => typeparam T 
+advanced/HKClass#`<init>`().[F][U] => typeparam U 
 advanced/HKClass#foo(). => method foo [typeparam T , typeparam U ](param x: F[T, U]): String
 advanced/HKClass#foo().(x) => param x: F[T, U]
-advanced/HKClass#foo().[T] => typeparam T
-advanced/HKClass#foo().[U] => typeparam U
+advanced/HKClass#foo().[T] => typeparam T 
+advanced/HKClass#foo().[U] => typeparam U 
 advanced/Structural# => class Structural extends Object { self: Structural => +6 decls }
 advanced/Structural#T# => trait T [typeparam A ] extends Object { self: T[A] => +4 decls }
-advanced/Structural#T#[A] => typeparam A
+advanced/Structural#T#[A] => typeparam A 
 advanced/Structural#T#`<init>`(). => primary ctor <init> [typeparam A ](): T[A]
 advanced/Structural#T#bar(). => method bar (param b: foo.B): Unit
 advanced/Structural#T#bar().(b) => param b: foo.B
@@ -270,8 +270,8 @@ Symbols:
 annot/Alias. => final object Alias extends Object { self: Alias.type => +2 decls }
 annot/Alias.A# => type A  = ClassAnnotation @param
 annot/Annotations# => @ClassAnnotation class Annotations [@TypeParameterAnnotation typeparam T ] extends Object { self: AnyRef & Annotations[T] => +6 decls }
-annot/Annotations#S# => @TypeAnnotation type S
-annot/Annotations#[T] => @TypeParameterAnnotation typeparam T
+annot/Annotations#S# => @TypeAnnotation type S 
+annot/Annotations#[T] => @TypeParameterAnnotation typeparam T 
 annot/Annotations#`<init>`(). => primary ctor <init> [@TypeParameterAnnotation typeparam T ](@ParameterAnnotation param x: T): Annotations[T]
 annot/Annotations#`<init>`().(x) => @ParameterAnnotation param x: T
 annot/Annotations#field. => @FieldAnnotation val method field Int
@@ -285,7 +285,7 @@ annot/B#throwing(). => @throws[Exception] method throwing => Nothing
 annot/B#x. => private[this] val method x Int
 annot/M. => @ObjectAnnotation final object M extends Object { self: M.type => +1 decls }
 annot/M.m(). => @MacroAnnotation macro m [typeparam TT ]: Int
-annot/M.m().[TT] => typeparam TT
+annot/M.m().[TT] => typeparam TT 
 annot/T# => @TraitAnnotation trait T extends Object { self: T => +1 decls }
 annot/T#`<init>`(). => primary ctor <init> (): T
 local0 => selfparam self: AnyRef
@@ -369,10 +369,10 @@ example/Anonymous#`<init>`(). => primary ctor <init> (): Anonymous
 example/Anonymous#foo. => val method foo Foo
 example/Anonymous#locally(). => method locally [typeparam A ](param x: A): A
 example/Anonymous#locally().(x) => param x: A
-example/Anonymous#locally().[A] => typeparam A
+example/Anonymous#locally().[A] => typeparam A 
 example/Anonymous#m1(). => method m1 [typeparam T [type _ ]]: Nothing
 example/Anonymous#m1().[T] => typeparam T [type _ ]
-example/Anonymous#m1().[T][_] => type _
+example/Anonymous#m1().[T][_] => type _ 
 example/Anonymous#m2(). => method m2 => Map[_, List[_] forSome { type _  }] forSome { type _  }
 local0 => val local x: Function1[Int, Int]
 local1 => final class $anon extends Object with Foo { self: $anon => +1 decls }
@@ -525,7 +525,7 @@ classes/C11#foo(). => inline macro foo => Int
 classes/C12# => class C12 extends Object { self: C12 => +8 decls }
 classes/C12#Context# => class Context extends Object { self: Context => +2 decls }
 classes/C12#Context#Expr# => type Expr [typeparam T ]
-classes/C12#Context#Expr#[T] => typeparam T
+classes/C12#Context#Expr#[T] => typeparam T 
 classes/C12#Context#`<init>`(). => primary ctor <init> (): Context
 classes/C12#`<init>`(). => primary ctor <init> (): C12
 classes/C12#foo1(). => macro foo1 (param x: Int): Int
@@ -933,29 +933,29 @@ _empty_/Enums.Directions.valueOf(). => method valueOf (param $name: String): Dir
 _empty_/Enums.Directions.valueOf().($name) => param $name: String
 _empty_/Enums.Directions.values(). => method values => Array[Directions]
 _empty_/Enums.Maybe# => abstract sealed enum class Maybe [covariant typeparam A ] extends Object with Enum { self: Maybe[A] => +2 decls }
-_empty_/Enums.Maybe#[A] => covariant typeparam A
+_empty_/Enums.Maybe#[A] => covariant typeparam A 
 _empty_/Enums.Maybe#`<init>`(). => primary ctor <init> [covariant typeparam A ](): Maybe[A]
 _empty_/Enums.Maybe. => final object Maybe extends Object { self: Maybe.type => +6 decls }
 _empty_/Enums.Maybe.Just# => final case enum class Just [covariant typeparam A ] extends Maybe[A] { self: Just[A] => +7 decls }
-_empty_/Enums.Maybe.Just#[A] => covariant typeparam A
+_empty_/Enums.Maybe.Just#[A] => covariant typeparam A 
 _empty_/Enums.Maybe.Just#_1(). => method _1 => A
 _empty_/Enums.Maybe.Just#`<init>`(). => primary ctor <init> [covariant typeparam A ](val param value: A): Just[A]
 _empty_/Enums.Maybe.Just#`<init>`().(value) => val param value: A
 _empty_/Enums.Maybe.Just#copy$default$1(). => method copy$default$1 [covariant typeparam A ]: A
-_empty_/Enums.Maybe.Just#copy$default$1().[A] => typeparam A
+_empty_/Enums.Maybe.Just#copy$default$1().[A] => typeparam A 
 _empty_/Enums.Maybe.Just#copy(). => method copy [covariant typeparam A ](param value: A): Just[A]
 _empty_/Enums.Maybe.Just#copy().(value) => param value: A
-_empty_/Enums.Maybe.Just#copy().[A] => typeparam A
+_empty_/Enums.Maybe.Just#copy().[A] => typeparam A 
 _empty_/Enums.Maybe.Just#ordinal(). => method ordinal => Int <: scala/reflect/Enum#ordinal().
 _empty_/Enums.Maybe.Just#value. => val method value A
 _empty_/Enums.Maybe.Just. => final object Just extends Object { self: Just.type => +4 decls }
 _empty_/Enums.Maybe.Just.apply(). => method apply [typeparam A ](param value: A): Just[A]
 _empty_/Enums.Maybe.Just.apply().(value) => param value: A
-_empty_/Enums.Maybe.Just.apply().[A] => typeparam A
+_empty_/Enums.Maybe.Just.apply().[A] => typeparam A 
 _empty_/Enums.Maybe.Just.toString(). => method toString => String <: scala/Any#toString().
 _empty_/Enums.Maybe.Just.unapply(). => method unapply [typeparam A ](param x$1: Just[A]): Just[A]
 _empty_/Enums.Maybe.Just.unapply().(x$1) => param x$1: Just[A]
-_empty_/Enums.Maybe.Just.unapply().[A] => typeparam A
+_empty_/Enums.Maybe.Just.unapply().[A] => typeparam A 
 _empty_/Enums.Maybe.None. => case val static enum method None Maybe[Nothing]
 _empty_/Enums.Maybe.fromOrdinal(). => method fromOrdinal (param ordinal: Int): Maybe[_] forSome { type _  }
 _empty_/Enums.Maybe.fromOrdinal().(ordinal) => param ordinal: Int
@@ -1006,7 +1006,7 @@ _empty_/Enums.Suits.valueOf(). => method valueOf (param $name: String): Suits
 _empty_/Enums.Suits.valueOf().($name) => param $name: String
 _empty_/Enums.Suits.values(). => method values => Array[Suits]
 _empty_/Enums.Tag# => abstract sealed enum class Tag [typeparam A ] extends Object with Enum { self: Tag[A] => +2 decls }
-_empty_/Enums.Tag#[A] => typeparam A
+_empty_/Enums.Tag#[A] => typeparam A 
 _empty_/Enums.Tag#`<init>`(). => primary ctor <init> [typeparam A ](): Tag[A]
 _empty_/Enums.Tag. => final object Tag extends Object { self: Tag.type => +7 decls }
 _empty_/Enums.Tag.$values. => private[this] val method $values Array[Tag[_] forSome { type _  }]
@@ -1037,33 +1037,33 @@ _empty_/Enums.WeekDays.valueOf(). => method valueOf (param $name: String): WeekD
 _empty_/Enums.WeekDays.valueOf().($name) => param $name: String
 _empty_/Enums.WeekDays.values(). => method values => Array[WeekDays]
 _empty_/Enums.`<:<`# => abstract sealed enum class <:< [contravariant typeparam A , typeparam B ] extends Object with Enum { self: <:<[A, B] => +3 decls }
-_empty_/Enums.`<:<`#[A] => contravariant typeparam A
-_empty_/Enums.`<:<`#[B] => typeparam B
+_empty_/Enums.`<:<`#[A] => contravariant typeparam A 
+_empty_/Enums.`<:<`#[B] => typeparam B 
 _empty_/Enums.`<:<`#`<init>`(). => primary ctor <init> [contravariant typeparam A , typeparam B ](): <:<[A, B]
 _empty_/Enums.`<:<`. => final object <:< extends Object { self: <:<.type => +6 decls }
 _empty_/Enums.`<:<`.Refl# => final case enum class Refl [typeparam C ] extends <:<[C, C] { self: Refl[C] => +4 decls }
-_empty_/Enums.`<:<`.Refl#[C] => typeparam C
+_empty_/Enums.`<:<`.Refl#[C] => typeparam C 
 _empty_/Enums.`<:<`.Refl#`<init>`(). => primary ctor <init> [typeparam C ](): Refl[C]
 _empty_/Enums.`<:<`.Refl#copy(). => method copy [typeparam C ](): Refl[C]
-_empty_/Enums.`<:<`.Refl#copy().[C] => typeparam C
+_empty_/Enums.`<:<`.Refl#copy().[C] => typeparam C 
 _empty_/Enums.`<:<`.Refl#ordinal(). => method ordinal => Int <: scala/reflect/Enum#ordinal().
 _empty_/Enums.`<:<`.Refl. => final object Refl extends Object { self: Refl.type => +4 decls }
 _empty_/Enums.`<:<`.Refl.apply(). => method apply [typeparam C ](): Refl[C]
-_empty_/Enums.`<:<`.Refl.apply().[C] => typeparam C
+_empty_/Enums.`<:<`.Refl.apply().[C] => typeparam C 
 _empty_/Enums.`<:<`.Refl.toString(). => method toString => String <: scala/Any#toString().
 _empty_/Enums.`<:<`.Refl.unapply(). => method unapply [typeparam C ](param x$1: Refl[C]): true
 _empty_/Enums.`<:<`.Refl.unapply().(x$1) => param x$1: Refl[C]
-_empty_/Enums.`<:<`.Refl.unapply().[C] => typeparam C
+_empty_/Enums.`<:<`.Refl.unapply().[C] => typeparam C 
 _empty_/Enums.`<:<`.`given_<:<_T_T`(). => final implicit given method given_<:<_T_T [typeparam T ]: <:<[T, T]
-_empty_/Enums.`<:<`.`given_<:<_T_T`().[T] => typeparam T
+_empty_/Enums.`<:<`.`given_<:<_T_T`().[T] => typeparam T 
 _empty_/Enums.`<:<`.fromOrdinal(). => method fromOrdinal (param ordinal: Int): <:<[_, _] forSome { type _ ; type _  }
 _empty_/Enums.`<:<`.fromOrdinal().(ordinal) => param ordinal: Int
 _empty_/Enums.some1. => val method some1 Option[Int]
 _empty_/Enums.unwrap(). => method unwrap [typeparam A , typeparam B ](param opt: Option[A])(implicit given param ev: <:<[A, Option[B]]): Option[B]
 _empty_/Enums.unwrap().(ev) => implicit given param ev: <:<[A, Option[B]]
 _empty_/Enums.unwrap().(opt) => param opt: Option[A]
-_empty_/Enums.unwrap().[A] => typeparam A
-_empty_/Enums.unwrap().[B] => typeparam B
+_empty_/Enums.unwrap().[A] => typeparam A 
+_empty_/Enums.unwrap().[B] => typeparam B 
 local0 => param x: Option[B]
 
 Occurrences:
@@ -1329,18 +1329,18 @@ ext/Extension$package.foo().(s) => param s: String
 ext/Extension$package.readInto(). => method readInto [typeparam T ](param s: String)(implicit given param x$2: Read[T]): Option[T]
 ext/Extension$package.readInto().(s) => param s: String
 ext/Extension$package.readInto().(x$2) => implicit given param x$2: Read[T]
-ext/Extension$package.readInto().[T] => typeparam T
+ext/Extension$package.readInto().[T] => typeparam T 
 ext/Functor# => trait Functor [typeparam F [type _ ]] extends Object { self: Functor[F] => +3 decls }
 ext/Functor#[F] => typeparam F [type _ ]
-ext/Functor#[F][_] => type _
+ext/Functor#[F][_] => type _ 
 ext/Functor#`<init>`(). => primary ctor <init> [typeparam F [type _ ]](): Functor[F]
 ext/Functor#map(). => abstract method map [typeparam T , typeparam U ](param t: F[T])(param f: Function1[T, U]): F[U]
 ext/Functor#map().(f) => param f: Function1[T, U]
 ext/Functor#map().(t) => param t: F[T]
-ext/Functor#map().[T] => typeparam T
-ext/Functor#map().[U] => typeparam U
+ext/Functor#map().[T] => typeparam T 
+ext/Functor#map().[U] => typeparam U 
 ext/Read# => trait Read [covariant typeparam T ] extends Object { self: Read[T] => +3 decls }
-ext/Read#[T] => covariant typeparam T
+ext/Read#[T] => covariant typeparam T 
 ext/Read#`<init>`(). => primary ctor <init> [covariant typeparam T ](): Read[T]
 ext/Read#fromString(). => abstract method fromString (param s: String): Option[T]
 ext/Read#fromString().(s) => param s: String
@@ -1504,7 +1504,7 @@ Synthetics => 3 entries
 Symbols:
 a/b/Givens. => final object Givens extends Object { self: Givens.type => +12 decls }
 a/b/Givens.Monoid# => trait Monoid [typeparam A ] extends Object { self: Monoid[A] => +4 decls }
-a/b/Givens.Monoid#[A] => typeparam A
+a/b/Givens.Monoid#[A] => typeparam A 
 a/b/Givens.Monoid#`<init>`(). => primary ctor <init> [typeparam A ](): Monoid[A]
 a/b/Givens.Monoid#combine(). => abstract method combine (param x: A)(param y: A): A
 a/b/Givens.Monoid#combine().(x) => param x: A
@@ -1512,7 +1512,7 @@ a/b/Givens.Monoid#combine().(y) => param y: A
 a/b/Givens.Monoid#empty(). => abstract method empty => A
 a/b/Givens.foo(). => method foo [typeparam A ](implicit given param A: Monoid[A]): A
 a/b/Givens.foo().(A) => implicit given param A: Monoid[A]
-a/b/Givens.foo().[A] => typeparam A
+a/b/Givens.foo().[A] => typeparam A 
 a/b/Givens.given_Monoid_String. => final implicit given object given_Monoid_String extends Object with Monoid[String] { self: given_Monoid_String.type => +3 decls }
 a/b/Givens.given_Monoid_String.combine(). => method combine (param x: String)(param y: String): String <: a/b/Givens.Monoid#combine().
 a/b/Givens.given_Monoid_String.combine().(x) => param x: String
@@ -1523,13 +1523,13 @@ a/b/Givens.hello1. => val method hello1 String
 a/b/Givens.int2String(). => final implicit given inline macro int2String => Conversion[Int, String]
 a/b/Givens.sayGoodbye(). => method sayGoodbye [typeparam B ](param any: B): String
 a/b/Givens.sayGoodbye().(any) => param any: B
-a/b/Givens.sayGoodbye().[B] => typeparam B
+a/b/Givens.sayGoodbye().[B] => typeparam B 
 a/b/Givens.sayHello(). => method sayHello [typeparam A ](param any: A): String
 a/b/Givens.sayHello().(any) => param any: A
-a/b/Givens.sayHello().[A] => typeparam A
+a/b/Givens.sayHello().[A] => typeparam A 
 a/b/Givens.saySoLong(). => method saySoLong [typeparam B ](param any: B): String
 a/b/Givens.saySoLong().(any) => param any: B
-a/b/Givens.saySoLong().[B] => typeparam B
+a/b/Givens.saySoLong().[B] => typeparam B 
 a/b/Givens.soLong1. => val method soLong1 String
 
 Occurrences:
@@ -1630,7 +1630,7 @@ example/ImplicitConversion#tuple. => val method tuple Tuple2[Int, Int]
 example/ImplicitConversion#x. => val method x Int
 example/ImplicitConversion. => final object ImplicitConversion extends Object { self: ImplicitConversion.type => +6 decls }
 example/ImplicitConversion.newAny2stringadd# => final implicit class newAny2stringadd [typeparam A ] extends AnyVal { self: newAny2stringadd[A] => +4 decls }
-example/ImplicitConversion.newAny2stringadd#[A] => typeparam A
+example/ImplicitConversion.newAny2stringadd#[A] => typeparam A 
 example/ImplicitConversion.newAny2stringadd#`+`(). => method + (param other: String): String
 example/ImplicitConversion.newAny2stringadd#`+`().(other) => param other: String
 example/ImplicitConversion.newAny2stringadd#`<init>`(). => primary ctor <init> [typeparam A ](param self: A): newAny2stringadd[A]
@@ -1638,7 +1638,7 @@ example/ImplicitConversion.newAny2stringadd#`<init>`().(self) => param self: A
 example/ImplicitConversion.newAny2stringadd#self. => private val method self A
 example/ImplicitConversion.newAny2stringadd(). => final implicit method newAny2stringadd [typeparam A ](param self: A): newAny2stringadd[A]
 example/ImplicitConversion.newAny2stringadd().(self) => param self: A
-example/ImplicitConversion.newAny2stringadd().[A] => typeparam A
+example/ImplicitConversion.newAny2stringadd().[A] => typeparam A 
 example/ImplicitConversion.newAny2stringadd. => final object newAny2stringadd extends Object { self: newAny2stringadd.type => +2 decls }
 
 Occurrences:
@@ -1843,7 +1843,7 @@ givens/InventedNames$package.given_Double(). => final implicit given method give
 givens/InventedNames$package.given_Double().(x$1) => implicit given param x$1: Int
 givens/InventedNames$package.given_Float. => final implicit lazy val given method given_Float Float
 givens/InventedNames$package.given_List_T(). => final implicit given method given_List_T [typeparam T ]: List[T]
-givens/InventedNames$package.given_List_T().[T] => typeparam T
+givens/InventedNames$package.given_List_T().[T] => typeparam T 
 givens/InventedNames$package.given_String. => final implicit lazy val given method given_String String
 givens/InventedNames$package.given_X. => final implicit given object given_X extends Object with X { self: given_X.type => +2 decls }
 givens/InventedNames$package.given_X.doX(). => method doX => Int <: givens/X#doX().
@@ -1855,11 +1855,11 @@ givens/InventedNames$package.given_Y#x$1. => protected implicit val given method
 givens/InventedNames$package.given_Y(). => final implicit given method given_Y (implicit given param x$1: X): given_Y
 givens/InventedNames$package.given_Y().(x$1) => implicit given param x$1: X
 givens/InventedNames$package.given_Z_T# => implicit given class given_Z_T [typeparam T ] extends Object with Z[T] { self: given_Z_T[T] => +3 decls }
-givens/InventedNames$package.given_Z_T#[T] => typeparam T
+givens/InventedNames$package.given_Z_T#[T] => typeparam T 
 givens/InventedNames$package.given_Z_T#`<init>`(). => primary ctor <init> [typeparam T ](): given_Z_T[T]
 givens/InventedNames$package.given_Z_T#doZ(). => method doZ => List[T] <: givens/Z#doZ().
 givens/InventedNames$package.given_Z_T(). => final implicit given method given_Z_T [typeparam T ]: given_Z_T[T]
-givens/InventedNames$package.given_Z_T().[T] => typeparam T
+givens/InventedNames$package.given_Z_T().[T] => typeparam T 
 givens/InventedNames$package.intValue. => final implicit lazy val given method intValue Int
 givens/InventedNames$package.x. => val method x given_X.type
 givens/InventedNames$package.y. => val method y given_Y
@@ -1871,7 +1871,7 @@ givens/Y# => trait Y extends Object { self: Y => +2 decls }
 givens/Y#`<init>`(). => primary ctor <init> (): Y
 givens/Y#doY(). => abstract method doY => String
 givens/Z# => trait Z [typeparam T ] extends Object { self: Z[T] => +3 decls }
-givens/Z#[T] => typeparam T
+givens/Z#[T] => typeparam T 
 givens/Z#`<init>`(). => primary ctor <init> [typeparam T ](): Z[T]
 givens/Z#doZ(). => abstract method doZ => List[T]
 
@@ -2009,7 +2009,7 @@ Symbols:
 example/Local# => class Local extends Object { self: Local => +2 decls }
 example/Local#`<init>`(). => primary ctor <init> (): Local
 example/Local#a(). => method a (): Int
-local0 => typeparam A
+local0 => typeparam A 
 local1 => param a: A
 local2 => local id: [typeparam A ](param a: A): A
 
@@ -2073,10 +2073,10 @@ example/MatchType$package.Concat# => type Concat [typeparam Xs  <: Tuple, covari
 example/MatchType$package.Concat#[Xs] => typeparam Xs  <: Tuple
 example/MatchType$package.Concat#[Ys] => covariant typeparam Ys  <: Tuple
 example/MatchType$package.Elem# => type Elem [typeparam X ] = X match { String => Char, Array[t] => t, Iterable[t] => t }
-example/MatchType$package.Elem#[X] => typeparam X
-local0 => type t
-local1 => type t
-local2 => type x
+example/MatchType$package.Elem#[X] => typeparam X 
+local0 => type t 
+local1 => type t 
+local2 => type x 
 local3 => type xs  <: Tuple
 
 Occurrences:
@@ -2314,11 +2314,11 @@ Occurrences => 153 entries
 Symbols:
 example/Methods# => class Methods [typeparam T ] extends Object { self: Methods[T] => +44 decls }
 example/Methods#AList# => type AList [typeparam T ] = List[T]
-example/Methods#AList#[T] => typeparam T
+example/Methods#AList#[T] => typeparam T 
 example/Methods#List# => class List [typeparam T ] extends Object { self: List[T] => +2 decls }
-example/Methods#List#[T] => typeparam T
+example/Methods#List#[T] => typeparam T 
 example/Methods#List#`<init>`(). => primary ctor <init> [typeparam T ](): List[T]
-example/Methods#[T] => typeparam T
+example/Methods#[T] => typeparam T 
 example/Methods#`<init>`(). => primary ctor <init> [typeparam T ](): Methods[T]
 example/Methods#`m8().`(). => method m8(). (): Nothing
 example/Methods#`m9().`# => class m9(). extends Object { self: m9(). => +1 decls }
@@ -2346,7 +2346,7 @@ example/Methods#m7(). => method m7 [typeparam U ](param c: Methods[T], param l: 
 example/Methods#m7().(c) => param c: Methods[T]
 example/Methods#m7().(evidence$1) => implicit param evidence$1: Ordering[U]
 example/Methods#m7().(l) => param l: List[U]
-example/Methods#m7().[U] => typeparam U
+example/Methods#m7().[U] => typeparam U 
 example/Methods#m9(). => method m9 (param x: m9().): Nothing
 example/Methods#m9().(x) => param x: m9().
 example/Methods#m10(). => method m10 (param x: List[T]): Nothing
@@ -2702,18 +2702,18 @@ Occurrences => 15 entries
 
 Symbols:
 _empty_/NewModifiers$package. => final package object _empty_ extends Object { self: _empty_.type { opaque type OpaqueB  } => +2 decls }
-_empty_/NewModifiers$package.OpaqueB# => opaque type OpaqueB
+_empty_/NewModifiers$package.OpaqueB# => opaque type OpaqueB 
 _empty_/NewModifiers. => final object NewModifiers extends Object { self: NewModifiers.type { opaque type A  } => +3 decls }
-_empty_/NewModifiers.A# => opaque type A
+_empty_/NewModifiers.A# => opaque type A 
 _empty_/NewModifiers.foo. => val inline method foo "foo"
 _empty_/NewModifiersClass# => opaque class NewModifiersClass extends Object { self: Any { opaque type C  } & NewModifiersClass => +5 decls }
-_empty_/NewModifiersClass#C# => opaque type C
+_empty_/NewModifiersClass#C# => opaque type C 
 _empty_/NewModifiersClass#Nested# => opaque class Nested extends Object { self: Any { opaque type NestedOpaque  } & Nested => +2 decls }
-_empty_/NewModifiersClass#Nested#NestedOpaque# => opaque type NestedOpaque
+_empty_/NewModifiersClass#Nested#NestedOpaque# => opaque type NestedOpaque 
 _empty_/NewModifiersClass#Nested#`<init>`(). => primary ctor <init> (): Nested
 _empty_/NewModifiersClass#`<init>`(). => primary ctor <init> (): NewModifiersClass
 _empty_/NewModifiersTrait# => opaque trait NewModifiersTrait extends Object { self: Any { opaque type D  } & NewModifiersTrait => +2 decls }
-_empty_/NewModifiersTrait#D# => opaque type D
+_empty_/NewModifiersTrait#D# => opaque type D 
 _empty_/NewModifiersTrait#`<init>`(). => primary ctor <init> (): NewModifiersTrait
 
 Occurrences:
@@ -2796,13 +2796,13 @@ Occurrences => 48 entries
 Symbols:
 prefixes/C# => class C extends Object { self: C => +6 decls }
 prefixes/C#N. => final object N extends Object { self: N.type => +2 decls }
-prefixes/C#N.U# => type U
-prefixes/C#T# => type T
+prefixes/C#N.U# => type U 
+prefixes/C#T# => type T 
 prefixes/C#`<init>`(). => primary ctor <init> (): C
 prefixes/C#k1(). => method k1 => U
 prefixes/C#m1(). => method m1 => T
 prefixes/M. => final object M extends Object { self: M.type => +3 decls }
-prefixes/M.T# => type T
+prefixes/M.T# => type T 
 prefixes/M.n1(). => method n1 => T
 prefixes/O. => final object O extends C { self: O.type => +2 decls }
 prefixes/O.o1(). => method o1 => O.this.T
@@ -2878,13 +2878,13 @@ Synthetics => 3 entries
 
 Symbols:
 example/C# => class C extends Object { self: C => +3 decls }
-example/C#T1# => type T1
-example/C#T2# => type T2
+example/C#T1# => type T1 
+example/C#T2# => type T2 
 example/C#`<init>`(). => primary ctor <init> (): C
 example/PickOneRefinement_1# => class PickOneRefinement_1 [typeparam S  <: SpecialRefinement { abstract method pickOne [typeparam T ](param as: T*): Option[String] }] extends Object { self: PickOneRefinement_1[S] => +3 decls }
 example/PickOneRefinement_1#[S] => typeparam S  <: SpecialRefinement { abstract method pickOne [typeparam T ](param as: T*): Option[String] }
 example/PickOneRefinement_1#[S](as) => param as: T*
-example/PickOneRefinement_1#[S][T] => typeparam T
+example/PickOneRefinement_1#[S][T] => typeparam T 
 example/PickOneRefinement_1#`<init>`(). => primary ctor <init> [typeparam S  <: SpecialRefinement { abstract method pickOne [typeparam T ](param as: T*): Option[String] }](): PickOneRefinement_1[S]
 example/PickOneRefinement_1#run(). => method run (param s: S, param as: String*): Option[String]
 example/PickOneRefinement_1#run().(as) => param as: String*
@@ -2893,7 +2893,7 @@ example/PolyHolder# => trait PolyHolder extends Object { self: PolyHolder => +2 
 example/PolyHolder#`<init>`(). => primary ctor <init> (): PolyHolder
 example/PolyHolder#foo(). => abstract method foo [typeparam T ](param t: T): Any
 example/PolyHolder#foo().(t) => param t: T
-example/PolyHolder#foo().[T] => typeparam T
+example/PolyHolder#foo().[T] => typeparam T 
 example/RecOrRefined$package. => final package object example extends Object { self: example.type => +9 decls }
 example/RecOrRefined$package.C2# => type C2  = C { type T2  = T1 <: example/C#T2#; type T1  <: example/C#T1# }
 example/RecOrRefined$package.Person# => type Person  = Record { abstract val method age Int; abstract val method name String }
@@ -2907,9 +2907,9 @@ example/RecOrRefined$package.m4(). => method m4 (param x: PolyHolder { abstract 
 example/RecOrRefined$package.m4().(x) => param x: PolyHolder { abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo(). }
 example/RecOrRefined$package.m5(). => method m5 [typeparam Z ](param x: Int): PolyHolder { abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo(). }
 example/RecOrRefined$package.m5().(x) => param x: Int
-example/RecOrRefined$package.m5().[Z] => typeparam Z
+example/RecOrRefined$package.m5().[Z] => typeparam Z 
 example/RecOrRefined$package.m6# => type m6 [typeparam X ] = PolyHolder { abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo(). }
-example/RecOrRefined$package.m6#[X] => typeparam X
+example/RecOrRefined$package.m6#[X] => typeparam X 
 example/Record# => class Record extends Object with Selectable { self: Record => +4 decls }
 example/Record#`<init>`(). => primary ctor <init> (param elems: Tuple2[String, Any]*): Record
 example/Record#`<init>`().(elems) => param elems: Tuple2[String, Any]*
@@ -2921,9 +2921,9 @@ example/SpecialRefinement# => trait SpecialRefinement extends Object { self: Spe
 example/SpecialRefinement#`<init>`(). => primary ctor <init> (): SpecialRefinement
 example/SpecialRefinement#pickOne(). => abstract method pickOne [typeparam T ](param as: T*): Option[Any]
 example/SpecialRefinement#pickOne().(as) => param as: T*
-example/SpecialRefinement#pickOne().[T] => typeparam T
+example/SpecialRefinement#pickOne().[T] => typeparam T 
 local0 => abstract method pickOne [typeparam T ](param as: T*): Option[String]
-local1 => typeparam T
+local1 => typeparam T 
 local2 => param as: T*
 local3 => abstract method pickOne [typeparam T ](param as: T*): Option[String] <: example/SpecialRefinement#pickOne().
 local4 => abstract val method x Int
@@ -2931,14 +2931,14 @@ local5 => abstract val method x Int
 local6 => abstract method y => Int
 local7 => abstract val method x Int
 local8 => abstract method y => Int
-local9 => type z
-local10 => typeparam T
+local9 => type z 
+local10 => typeparam T 
 local11 => param t: T
 local12 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
-local13 => typeparam T
+local13 => typeparam T 
 local14 => param t: T
 local15 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
-local16 => typeparam T
+local16 => typeparam T 
 local17 => param t: T
 local18 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
 local19 => abstract val method name String
@@ -3167,7 +3167,7 @@ example/Synthetic#Contexts.m4(). => method m4 => Nothing
 example/Synthetic#F# => class F extends Object { self: F => +1 decls }
 example/Synthetic#F#`<init>`(). => primary ctor <init> (): F
 example/Synthetic#J# => class J [typeparam T ] extends Object { self: J[T] => +4 decls }
-example/Synthetic#J#[T] => typeparam T
+example/Synthetic#J#[T] => typeparam T 
 example/Synthetic#J#`<init>`(). => primary ctor <init> [typeparam T ]()(implicit param evidence$1: Manifest[T]): J[T]
 example/Synthetic#J#`<init>`().(evidence$1) => implicit param evidence$1: Manifest[T]
 example/Synthetic#J#arr. => val method arr Array[T]
@@ -3741,11 +3741,11 @@ Occurrences => 17 entries
 Symbols:
 _empty_/Test_depmatch. => final object Test_depmatch extends Object { self: Test_depmatch.type => +4 decls }
 _empty_/Test_depmatch.Bar# => type Bar [typeparam T ] = T match { Unit => Unit }
-_empty_/Test_depmatch.Bar#[T] => typeparam T
+_empty_/Test_depmatch.Bar#[T] => typeparam T 
 _empty_/Test_depmatch.Foo# => type Foo  = Int { type U  }
 _empty_/Test_depmatch.baz(). => inline macro baz (param foo: Foo): Unit
 _empty_/Test_depmatch.baz().(foo) => param foo: Foo
-local0 => type U
+local0 => type U 
 local1 => val local v: Bar[foo.U]
 
 Occurrences:
@@ -3780,7 +3780,7 @@ Occurrences => 30 entries
 
 Symbols:
 exports/example/Codec# => trait Codec [typeparam T ] extends Object with Decoder[T] with Encoder[T] { self: Codec[T] => +6 decls }
-exports/example/Codec#[T] => typeparam T
+exports/example/Codec#[T] => typeparam T 
 exports/example/Codec#`<init>`(). => primary ctor <init> [typeparam T ](param decode: Decoder[T], param encode: Encoder[T]): Codec[T]
 exports/example/Codec#`<init>`().(decode) => param decode: Decoder[T]
 exports/example/Codec#`<init>`().(encode) => param encode: Encoder[T]
@@ -3791,12 +3791,12 @@ exports/example/Codec#encode(). => final method encode (param t: T): Array[Byte]
 exports/example/Codec#encode().(t) => param t: T
 exports/example/Codec#encode. => private[this] val method encode Encoder[T]
 exports/example/Decoder# => trait Decoder [covariant typeparam T ] extends Object { self: Decoder[T] => +3 decls }
-exports/example/Decoder#[T] => covariant typeparam T
+exports/example/Decoder#[T] => covariant typeparam T 
 exports/example/Decoder#`<init>`(). => primary ctor <init> [covariant typeparam T ](): Decoder[T]
 exports/example/Decoder#decode(). => abstract method decode (param a: Array[Byte]): T
 exports/example/Decoder#decode().(a) => param a: Array[Byte]
 exports/example/Encoder# => trait Encoder [contravariant typeparam T ] extends Object { self: Encoder[T] => +3 decls }
-exports/example/Encoder#[T] => contravariant typeparam T
+exports/example/Encoder#[T] => contravariant typeparam T 
 exports/example/Encoder#`<init>`(). => primary ctor <init> [contravariant typeparam T ](): Encoder[T]
 exports/example/Encoder#encode(). => abstract method encode (param t: T): Array[Byte]
 exports/example/Encoder#encode().(t) => param t: T
@@ -3847,11 +3847,11 @@ Occurrences => 5 entries
 Symbols:
 exports/`exports-package$package`. => final package object exports extends Object { self: exports.type => +4 decls }
 exports/`exports-package$package`.Codec# => final type Codec [typeparam T ] = Codec[T]
-exports/`exports-package$package`.Codec#[T] => typeparam T
+exports/`exports-package$package`.Codec#[T] => typeparam T 
 exports/`exports-package$package`.Decoder# => final type Decoder [typeparam T ] = Decoder[T]
-exports/`exports-package$package`.Decoder#[T] => typeparam T
+exports/`exports-package$package`.Decoder#[T] => typeparam T 
 exports/`exports-package$package`.Encoder# => final type Encoder [typeparam T ] = Encoder[T]
-exports/`exports-package$package`.Encoder#[T] => typeparam T
+exports/`exports-package$package`.Encoder#[T] => typeparam T 
 
 Occurrences:
 [0:8..0:15): exports <- exports/
@@ -4107,11 +4107,11 @@ _empty_/Concrete#`<init>`(). => primary ctor <init> (): Concrete
 _empty_/Concrete#nullary2(). => method nullary2 => Int <: _empty_/NullaryTest#nullary2().
 _empty_/Concrete#nullary3(). => method nullary3 => List[Int] <: _empty_/NullaryTest#nullary3().
 _empty_/NullaryTest# => abstract class NullaryTest [typeparam T , typeparam m [typeparam s ]] extends Object { self: NullaryTest[T, m] => +9 decls }
-_empty_/NullaryTest#[T] => typeparam T
+_empty_/NullaryTest#[T] => typeparam T 
 _empty_/NullaryTest#[m] => typeparam m [typeparam s ]
-_empty_/NullaryTest#[m][s] => typeparam s
+_empty_/NullaryTest#[m][s] => typeparam s 
 _empty_/NullaryTest#`<init>`(). => primary ctor <init> [typeparam T , typeparam m [typeparam s ]](): NullaryTest[T, m]
-_empty_/NullaryTest#`<init>`().[m][s] => typeparam s
+_empty_/NullaryTest#`<init>`().[m][s] => typeparam s 
 _empty_/NullaryTest#nullary(). => method nullary => String
 _empty_/NullaryTest#nullary2(). => abstract method nullary2 => T
 _empty_/NullaryTest#nullary3(). => abstract method nullary3 => m[T]
@@ -4314,9 +4314,9 @@ flags/p/package.AA#x. => private[this] val method x Int
 flags/p/package.AA#y. => val method y Int
 flags/p/package.AA#z(). => var method z Int
 flags/p/package.C# => abstract class C [covariant typeparam T , contravariant typeparam U , typeparam V ] extends Object { self: C[T, U, V] => +10 decls }
-flags/p/package.C#[T] => covariant typeparam T
-flags/p/package.C#[U] => contravariant typeparam U
-flags/p/package.C#[V] => typeparam V
+flags/p/package.C#[T] => covariant typeparam T 
+flags/p/package.C#[U] => contravariant typeparam U 
+flags/p/package.C#[V] => typeparam V 
 flags/p/package.C#`<init>`(). => primary ctor <init> [covariant typeparam T , contravariant typeparam U , typeparam V ](param x: T, param y: U, param z: V): C[T, U, V]
 flags/p/package.C#`<init>`().(x) => param x: T
 flags/p/package.C#`<init>`().(y) => param y: U
@@ -4329,11 +4329,11 @@ flags/p/package.C#x. => private[this] val method x T
 flags/p/package.C#y. => private[this] val method y U
 flags/p/package.C#z. => private[this] val method z V
 flags/p/package.S# => class S [@specialized typeparam T ] extends Object { self: S[T] => +2 decls }
-flags/p/package.S#[T] => @specialized typeparam T
+flags/p/package.S#[T] => @specialized typeparam T 
 flags/p/package.S#`<init>`(). => primary ctor <init> [@specialized typeparam T ](): S[T]
 flags/p/package.T1# => type T1  = Int
 flags/p/package.T2# => type T2 [typeparam T ] = S[T]
-flags/p/package.T2#[T] => typeparam T
+flags/p/package.T2#[T] => typeparam T 
 flags/p/package.U# => type U  <: Int
 flags/p/package.V# => type V  >: Int
 flags/p/package.X. => final case object X extends Object with Product with Serializable { self: X.type => +1 decls }
@@ -4344,14 +4344,14 @@ flags/p/package.Z#`<init>`(). => primary ctor <init> (): Z
 flags/p/package.`y_=`(). => protected var method y_= (param x$1: Int): Unit
 flags/p/package.`y_=`().(x$1) => param x$1: Int
 flags/p/package.m(). => macro m [typeparam TT ]: Int
-flags/p/package.m().[TT] => typeparam TT
+flags/p/package.m().[TT] => typeparam TT 
 flags/p/package.x. => private[flags/p/] lazy val method x Int
 flags/p/package.xs1. => val method xs1 Nothing
 flags/p/package.y(). => protected implicit var method y Int
 flags/p/package.z(). => method z (param pp: Int): Int
 flags/p/package.z().(pp) => param pp: Int
 local0 => val local xs2: Nothing
-local1 => type t
+local1 => type t 
 
 Occurrences:
 [0:8..0:13): flags <- flags/
@@ -4452,7 +4452,7 @@ local3 => final class $anon extends Object { self: $anon => +2 decls }
 local5 => final class $anon extends M with N { self: $anon => +1 decls }
 local7 => method k => Int
 local8 => final class $anon extends M with N { self: $anon => +2 decls }
-local10 => typeparam T
+local10 => typeparam T 
 local11 => type L [typeparam T ] = List[T]
 types/B# => class B extends Object { self: B => +1 decls }
 types/B#`<init>`(). => primary ctor <init> (): B
@@ -4498,7 +4498,7 @@ types/Test.C#ClassInfoType2# => class ClassInfoType2 extends B { self: ClassInfo
 types/Test.C#ClassInfoType2#`<init>`(). => primary ctor <init> (): ClassInfoType2
 types/Test.C#ClassInfoType2#x(). => method x => Int
 types/Test.C#ClassInfoType3# => trait ClassInfoType3 [typeparam T ] extends Object { self: ClassInfoType3[T] => +2 decls }
-types/Test.C#ClassInfoType3#[T] => typeparam T
+types/Test.C#ClassInfoType3#[T] => typeparam T 
 types/Test.C#ClassInfoType3#`<init>`(). => primary ctor <init> [typeparam T ](): ClassInfoType3[T]
 types/Test.C#Either. => val method Either Either.type
 types/Test.C#MethodType. => final object MethodType extends Object { self: MethodType.type => +7 decls }
@@ -4508,7 +4508,7 @@ types/Test.C#MethodType.m5(). => method m5 (param x: Int): Int
 types/Test.C#MethodType.m5().(x) => param x: Int
 types/Test.C#MethodType.m6(). => method m6 [typeparam T ](param x: T): T
 types/Test.C#MethodType.m6().(x) => param x: T
-types/Test.C#MethodType.m6().[T] => typeparam T
+types/Test.C#MethodType.m6().[T] => typeparam T 
 types/Test.C#MethodType.x1(). => method x1 => Int
 types/Test.C#MethodType.x2(). => method x2 => Int
 types/Test.C#RepeatedType# => case class RepeatedType extends Object with Product with Serializable { self: RepeatedType => +4 decls }
@@ -4525,15 +4525,15 @@ types/Test.C#RepeatedType.toString(). => method toString => String <: scala/Any#
 types/Test.C#RepeatedType.unapplySeq(). => method unapplySeq (param x$1: RepeatedType): RepeatedType
 types/Test.C#RepeatedType.unapplySeq().(x$1) => param x$1: RepeatedType
 types/Test.C#TypeType. => final object TypeType extends Object { self: TypeType.type => +6 decls }
-types/Test.C#TypeType.T1# => type T1
+types/Test.C#TypeType.T1# => type T1 
 types/Test.C#TypeType.T4# => type T4  = C
 types/Test.C#TypeType.T5# => type T5 [typeparam U ] = U
-types/Test.C#TypeType.T5#[U] => typeparam U
+types/Test.C#TypeType.T5#[U] => typeparam U 
 types/Test.C#TypeType.m2(). => method m2 [typeparam T2  = C]: Nothing
 types/Test.C#TypeType.m2().[T2] => typeparam T2  = C
 types/Test.C#TypeType.m3(). => method m3 [typeparam M3 [type _ ]]: Nothing
 types/Test.C#TypeType.m3().[M3] => typeparam M3 [type _ ]
-types/Test.C#TypeType.m3().[M3][_] => type _
+types/Test.C#TypeType.m3().[M3][_] => type _ 
 types/Test.C#`<init>`(). => primary ctor <init> (): C
 types/Test.C#annType1. => val method annType1 T @ann[T]
 types/Test.C#annType2. => val method annType2 T @ann1 @ann2
@@ -4556,7 +4556,7 @@ types/Test.C#thisType1. => val method thisType1 C.this.type
 types/Test.C#thisType2. => val method thisType2 C.this.type
 types/Test.C#typeLambda1(). => method typeLambda1 [typeparam M [type _ ]]: Nothing
 types/Test.C#typeLambda1().[M] => typeparam M [type _ ]
-types/Test.C#typeLambda1().[M][_] => type _
+types/Test.C#typeLambda1().[M][_] => type _ 
 types/Test.C#typeRef1. => val method typeRef1 C
 types/Test.C#typeRef2. => val method typeRef2 p.C
 types/Test.C#typeRef3. => val method typeRef3 T#C
@@ -4581,7 +4581,7 @@ types/Test.N# => trait N extends Object { self: N => +2 decls }
 types/Test.N#`<init>`(). => primary ctor <init> (): N
 types/Test.N#n(). => method n => Int
 types/ann# => class ann [typeparam T ] extends Annotation with StaticAnnotation { self: ann[T] => +3 decls }
-types/ann#[T] => typeparam T
+types/ann#[T] => typeparam T 
 types/ann#`<init>`(). => primary ctor <init> [typeparam T ](param x: T): ann[T]
 types/ann#`<init>`().(x) => param x: T
 types/ann#x. => private[this] val method x T

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -48,8 +48,8 @@ Schema => SemanticDB v4
 Uri => Advanced.scala
 Text => empty
 Language => Scala
-Symbols => 48 entries
-Occurrences => 105 entries
+Symbols => 55 entries
+Occurrences => 114 entries
 Synthetics => 3 entries
 
 Symbols:
@@ -67,7 +67,13 @@ advanced/HKClass#foo(). => method foo [typeparam T , typeparam U ](param x: F[T,
 advanced/HKClass#foo().(x) => param x: F[T, U]
 advanced/HKClass#foo().[T] => typeparam T 
 advanced/HKClass#foo().[U] => typeparam U 
-advanced/Structural# => class Structural extends Object { self: Structural => +5 decls }
+advanced/Structural# => class Structural extends Object { self: Structural => +6 decls }
+advanced/Structural#T# => trait T [typeparam A ] extends Object { self: T[A] => +4 decls }
+advanced/Structural#T#[A] => typeparam A 
+advanced/Structural#T#`<init>`(). => primary ctor <init> [typeparam A ](): T[A]
+advanced/Structural#T#bar(). => method bar (param b: <?>): Unit
+advanced/Structural#T#bar().(b) => param b: <?>
+advanced/Structural#T#foo. => val method foo Object { type B  = A }
 advanced/Structural#`<init>`(). => primary ctor <init> (): Structural
 advanced/Structural#s1(). => method s1 => Object { abstract val method x Int }
 advanced/Structural#s2(). => method s2 => Object { abstract val method x Int }
@@ -99,8 +105,9 @@ local7 => param x: Int
 local8 => method m (param x: Int): Int
 local9 => final class $anon extends Object { self: $anon => +2 decls }
 local11 => abstract val method x Int
-local12 => val local e3: List[local13]
-local14 => val local e3x: local13
+local12 => type B  = A
+local13 => val local e3: List[local14]
+local15 => val local e3x: local14
 
 Occurrences:
 [0:8..0:16): advanced <- advanced/
@@ -146,73 +153,82 @@ Occurrences:
 [15:24..15:25): x <- local11
 [15:27..15:30): Int -> scala/Int#
 [15:35..15:38): ??? -> scala/Predef.`???`().
-[18:6..18:15): Wildcards <- advanced/Wildcards#
-[19:6..19:8): e1 <- advanced/Wildcards#e1().
-[19:10..19:14): List -> scala/package.List#
-[19:20..19:23): ??? -> scala/Predef.`???`().
-[20:6..20:8): e2 <- advanced/Wildcards#e2().
+[16:8..16:9): T <- advanced/Structural#T#
+[16:10..16:11): A <- advanced/Structural#T#[A]
+[16:19..16:22): foo <- advanced/Structural#T#foo.
+[16:31..16:32): B <- local12
+[16:35..16:36): A -> advanced/Structural#T#[A]
+[16:41..16:44): ??? -> scala/Predef.`???`().
+[16:50..16:53): bar <- advanced/Structural#T#bar().
+[16:54..16:55): b <- advanced/Structural#T#bar().(b)
+[16:57..16:60): foo -> advanced/Structural#T#foo.
+[19:6..19:15): Wildcards <- advanced/Wildcards#
+[20:6..20:8): e1 <- advanced/Wildcards#e1().
 [20:10..20:14): List -> scala/package.List#
-[20:20..20:23): Int -> scala/Int#
-[20:27..20:30): ??? -> scala/Predef.`???`().
-[23:7..23:11): Test <- advanced/Test.
-[24:6..24:7): s <- advanced/Test.s.
-[24:14..24:24): Structural -> advanced/Structural#
-[25:6..25:8): s1 <- advanced/Test.s1.
-[25:11..25:12): s -> advanced/Test.s.
-[25:13..25:15): s1 -> advanced/Structural#s1().
-[26:6..26:9): s1x <- advanced/Test.s1x.
-[26:12..26:13): s -> advanced/Test.s.
-[26:14..26:16): s1 -> advanced/Structural#s1().
-[27:6..27:8): s2 <- advanced/Test.s2.
-[27:11..27:12): s -> advanced/Test.s.
-[27:13..27:15): s2 -> advanced/Structural#s2().
-[28:6..28:9): s2x <- advanced/Test.s2x.
-[28:12..28:13): s -> advanced/Test.s.
-[28:14..28:16): s2 -> advanced/Structural#s2().
-[29:6..29:8): s3 <- advanced/Test.s3.
-[29:11..29:12): s -> advanced/Test.s.
-[29:13..29:15): s3 -> advanced/Structural#s3().
-[30:6..30:9): s3x <- advanced/Test.s3x.
-[30:12..30:13): s -> advanced/Test.s.
-[30:14..30:16): s3 -> advanced/Structural#s3().
-[30:19..30:22): ??? -> scala/Predef.`???`().
-[32:6..32:7): e <- advanced/Test.e.
-[32:14..32:23): Wildcards -> advanced/Wildcards#
-[33:6..33:8): e1 <- advanced/Test.e1.
-[33:11..33:12): e -> advanced/Test.e.
-[33:13..33:15): e1 -> advanced/Wildcards#e1().
-[34:6..34:9): e1x <- advanced/Test.e1x.
-[34:12..34:13): e -> advanced/Test.e.
-[34:14..34:16): e1 -> advanced/Wildcards#e1().
-[34:17..34:21): head -> scala/collection/IterableOps#head().
-[37:5..37:8): ??? -> scala/Predef.`???`().
-[37:11..37:14): Any -> scala/Any#
-[38:11..38:13): e3 <- local12
-[38:15..38:19): List -> scala/package.List#
-[39:12..39:15): e3x <- local14
-[39:18..39:20): e3 -> local12
-[39:21..39:25): head -> scala/collection/IterableOps#head().
-[47:6..47:13): HKClass <- advanced/HKClass#
-[47:14..47:15): F <- advanced/HKClass#[F]
-[47:20..47:21): T <- advanced/HKClass#`<init>`().[F][T]
-[47:28..47:29): U <- advanced/HKClass#`<init>`().[F][U]
-[47:36..47:37): U -> advanced/HKClass#`<init>`().[F][U]
-[47:39..47:40): T -> advanced/HKClass#`<init>`().[F][T]
-[48:6..48:9): foo <- advanced/HKClass#foo().
-[48:10..48:11): T <- advanced/HKClass#foo().[T]
-[48:12..48:13): U <- advanced/HKClass#foo().[U]
-[48:15..48:16): x <- advanced/HKClass#foo().(x)
-[48:18..48:19): F -> advanced/HKClass#[F]
-[48:20..48:21): T -> advanced/HKClass#foo().[T]
-[48:23..48:24): U -> advanced/HKClass#foo().[U]
-[48:28..48:34): String -> scala/Predef.String#
-[48:37..48:38): x -> advanced/HKClass#foo().(x)
-[48:39..48:47): toString -> scala/Tuple2#toString().
+[20:20..20:23): ??? -> scala/Predef.`???`().
+[21:6..21:8): e2 <- advanced/Wildcards#e2().
+[21:10..21:14): List -> scala/package.List#
+[21:20..21:23): Int -> scala/Int#
+[21:27..21:30): ??? -> scala/Predef.`???`().
+[24:7..24:11): Test <- advanced/Test.
+[25:6..25:7): s <- advanced/Test.s.
+[25:14..25:24): Structural -> advanced/Structural#
+[26:6..26:8): s1 <- advanced/Test.s1.
+[26:11..26:12): s -> advanced/Test.s.
+[26:13..26:15): s1 -> advanced/Structural#s1().
+[27:6..27:9): s1x <- advanced/Test.s1x.
+[27:12..27:13): s -> advanced/Test.s.
+[27:14..27:16): s1 -> advanced/Structural#s1().
+[28:6..28:8): s2 <- advanced/Test.s2.
+[28:11..28:12): s -> advanced/Test.s.
+[28:13..28:15): s2 -> advanced/Structural#s2().
+[29:6..29:9): s2x <- advanced/Test.s2x.
+[29:12..29:13): s -> advanced/Test.s.
+[29:14..29:16): s2 -> advanced/Structural#s2().
+[30:6..30:8): s3 <- advanced/Test.s3.
+[30:11..30:12): s -> advanced/Test.s.
+[30:13..30:15): s3 -> advanced/Structural#s3().
+[31:6..31:9): s3x <- advanced/Test.s3x.
+[31:12..31:13): s -> advanced/Test.s.
+[31:14..31:16): s3 -> advanced/Structural#s3().
+[31:19..31:22): ??? -> scala/Predef.`???`().
+[33:6..33:7): e <- advanced/Test.e.
+[33:14..33:23): Wildcards -> advanced/Wildcards#
+[34:6..34:8): e1 <- advanced/Test.e1.
+[34:11..34:12): e -> advanced/Test.e.
+[34:13..34:15): e1 -> advanced/Wildcards#e1().
+[35:6..35:9): e1x <- advanced/Test.e1x.
+[35:12..35:13): e -> advanced/Test.e.
+[35:14..35:16): e1 -> advanced/Wildcards#e1().
+[35:17..35:21): head -> scala/collection/IterableOps#head().
+[38:5..38:8): ??? -> scala/Predef.`???`().
+[38:11..38:14): Any -> scala/Any#
+[39:11..39:13): e3 <- local13
+[39:15..39:19): List -> scala/package.List#
+[40:12..40:15): e3x <- local15
+[40:18..40:20): e3 -> local13
+[40:21..40:25): head -> scala/collection/IterableOps#head().
+[48:6..48:13): HKClass <- advanced/HKClass#
+[48:14..48:15): F <- advanced/HKClass#[F]
+[48:20..48:21): T <- advanced/HKClass#`<init>`().[F][T]
+[48:28..48:29): U <- advanced/HKClass#`<init>`().[F][U]
+[48:36..48:37): U -> advanced/HKClass#`<init>`().[F][U]
+[48:39..48:40): T -> advanced/HKClass#`<init>`().[F][T]
+[49:6..49:9): foo <- advanced/HKClass#foo().
+[49:10..49:11): T <- advanced/HKClass#foo().[T]
+[49:12..49:13): U <- advanced/HKClass#foo().[U]
+[49:15..49:16): x <- advanced/HKClass#foo().(x)
+[49:18..49:19): F -> advanced/HKClass#[F]
+[49:20..49:21): T -> advanced/HKClass#foo().[T]
+[49:23..49:24): U -> advanced/HKClass#foo().[U]
+[49:28..49:34): String -> scala/Predef.String#
+[49:37..49:38): x -> advanced/HKClass#foo().(x)
+[49:39..49:47): toString -> scala/Tuple2#toString().
 
 Synthetics:
-[26:12..26:16):s.s1 => reflectiveSelectable(*)
-[28:12..28:16):s.s2 => reflectiveSelectable(*)
-[30:12..30:16):s.s3 => reflectiveSelectable(*)
+[27:12..27:16):s.s1 => reflectiveSelectable(*)
+[29:12..29:16):s.s2 => reflectiveSelectable(*)
+[31:12..31:16):s.s3 => reflectiveSelectable(*)
 
 expect/Annotations.scala
 ------------------------

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -48,28 +48,28 @@ Schema => SemanticDB v4
 Uri => Advanced.scala
 Text => empty
 Language => Scala
-Symbols => 62 entries
+Symbols => 60 entries
 Occurrences => 132 entries
 Synthetics => 4 entries
 
 Symbols:
 advanced/C# => class C [typeparam T ] extends Object { self: C[T] => +3 decls }
-advanced/C#[T] => typeparam T 
+advanced/C#[T] => typeparam T
 advanced/C#`<init>`(). => primary ctor <init> [typeparam T ](): C[T]
 advanced/C#t(). => method t => T
 advanced/HKClass# => class HKClass [typeparam F [typeparam T ] <: <?>] extends Object { self: HKClass[F] => +3 decls }
 advanced/HKClass#[F] => typeparam F [typeparam T ] <: <?>
-advanced/HKClass#[F][T] => typeparam T 
+advanced/HKClass#[F][T] => typeparam T
 advanced/HKClass#`<init>`(). => primary ctor <init> [typeparam F [typeparam T ] <: <?>](): HKClass[F]
-advanced/HKClass#`<init>`().[F][T] => typeparam T 
-advanced/HKClass#`<init>`().[F][U] => typeparam U 
+advanced/HKClass#`<init>`().[F][T] => typeparam T
+advanced/HKClass#`<init>`().[F][U] => typeparam U
 advanced/HKClass#foo(). => method foo [typeparam T , typeparam U ](param x: F[T, U]): String
 advanced/HKClass#foo().(x) => param x: F[T, U]
-advanced/HKClass#foo().[T] => typeparam T 
-advanced/HKClass#foo().[U] => typeparam U 
+advanced/HKClass#foo().[T] => typeparam T
+advanced/HKClass#foo().[U] => typeparam U
 advanced/Structural# => class Structural extends Object { self: Structural => +6 decls }
 advanced/Structural#T# => trait T [typeparam A ] extends Object { self: T[A] => +4 decls }
-advanced/Structural#T#[A] => typeparam A 
+advanced/Structural#T#[A] => typeparam A
 advanced/Structural#T#`<init>`(). => primary ctor <init> [typeparam A ](): T[A]
 advanced/Structural#T#bar(). => method bar (param b: foo.B): Unit
 advanced/Structural#T#bar().(b) => param b: foo.B
@@ -85,7 +85,7 @@ advanced/Test.bar(). => method bar => foo.A
 advanced/Test.e. => val method e Wildcards
 advanced/Test.e1. => val method e1 List[_] forSome { type _  }
 advanced/Test.e1x. => val method e1x Any
-advanced/Test.foo. => lazy val method foo Selectable { abstract type A  = Int } & Selectable { abstract field a: local20; abstract type A  = Int }
+advanced/Test.foo. => lazy val method foo Selectable { type A  = Int } & Selectable { abstract val method a A; type A  = Int }
 advanced/Test.s. => val method s Structural
 advanced/Test.s1. => val method s1 Object { abstract val method x Int }
 advanced/Test.s1x. => val method s1x Int
@@ -113,8 +113,6 @@ local15 => val local e3x: local14
 local16 => type A  = Int
 local17 => type A  = Int
 local18 => abstract val method a A
-local19 => abstract type A  = Int
-local21 => abstract field a: A
 
 Occurrences:
 [0:8..0:16): advanced <- advanced/
@@ -231,7 +229,7 @@ Occurrences:
 [46:106..46:109): ??? -> scala/Predef.`???`().
 [47:6..47:9): bar <- advanced/Test.bar().
 [47:11..47:14): foo -> advanced/Test.foo.
-[47:15..47:16): A -> local19
+[47:15..47:16): A -> local17
 [47:19..47:22): foo -> advanced/Test.foo.
 [52:6..52:13): HKClass <- advanced/HKClass#
 [52:14..52:15): F <- advanced/HKClass#[F]
@@ -272,8 +270,8 @@ Symbols:
 annot/Alias. => final object Alias extends Object { self: Alias.type => +2 decls }
 annot/Alias.A# => type A  = ClassAnnotation @param
 annot/Annotations# => @ClassAnnotation class Annotations [@TypeParameterAnnotation typeparam T ] extends Object { self: AnyRef & Annotations[T] => +6 decls }
-annot/Annotations#S# => @TypeAnnotation type S 
-annot/Annotations#[T] => @TypeParameterAnnotation typeparam T 
+annot/Annotations#S# => @TypeAnnotation type S
+annot/Annotations#[T] => @TypeParameterAnnotation typeparam T
 annot/Annotations#`<init>`(). => primary ctor <init> [@TypeParameterAnnotation typeparam T ](@ParameterAnnotation param x: T): Annotations[T]
 annot/Annotations#`<init>`().(x) => @ParameterAnnotation param x: T
 annot/Annotations#field. => @FieldAnnotation val method field Int
@@ -287,7 +285,7 @@ annot/B#throwing(). => @throws[Exception] method throwing => Nothing
 annot/B#x. => private[this] val method x Int
 annot/M. => @ObjectAnnotation final object M extends Object { self: M.type => +1 decls }
 annot/M.m(). => @MacroAnnotation macro m [typeparam TT ]: Int
-annot/M.m().[TT] => typeparam TT 
+annot/M.m().[TT] => typeparam TT
 annot/T# => @TraitAnnotation trait T extends Object { self: T => +1 decls }
 annot/T#`<init>`(). => primary ctor <init> (): T
 local0 => selfparam self: AnyRef
@@ -371,10 +369,10 @@ example/Anonymous#`<init>`(). => primary ctor <init> (): Anonymous
 example/Anonymous#foo. => val method foo Foo
 example/Anonymous#locally(). => method locally [typeparam A ](param x: A): A
 example/Anonymous#locally().(x) => param x: A
-example/Anonymous#locally().[A] => typeparam A 
+example/Anonymous#locally().[A] => typeparam A
 example/Anonymous#m1(). => method m1 [typeparam T [type _ ]]: Nothing
 example/Anonymous#m1().[T] => typeparam T [type _ ]
-example/Anonymous#m1().[T][_] => type _ 
+example/Anonymous#m1().[T][_] => type _
 example/Anonymous#m2(). => method m2 => Map[_, List[_] forSome { type _  }] forSome { type _  }
 local0 => val local x: Function1[Int, Int]
 local1 => final class $anon extends Object with Foo { self: $anon => +1 decls }
@@ -527,7 +525,7 @@ classes/C11#foo(). => inline macro foo => Int
 classes/C12# => class C12 extends Object { self: C12 => +8 decls }
 classes/C12#Context# => class Context extends Object { self: Context => +2 decls }
 classes/C12#Context#Expr# => type Expr [typeparam T ]
-classes/C12#Context#Expr#[T] => typeparam T 
+classes/C12#Context#Expr#[T] => typeparam T
 classes/C12#Context#`<init>`(). => primary ctor <init> (): Context
 classes/C12#`<init>`(). => primary ctor <init> (): C12
 classes/C12#foo1(). => macro foo1 (param x: Int): Int
@@ -935,29 +933,29 @@ _empty_/Enums.Directions.valueOf(). => method valueOf (param $name: String): Dir
 _empty_/Enums.Directions.valueOf().($name) => param $name: String
 _empty_/Enums.Directions.values(). => method values => Array[Directions]
 _empty_/Enums.Maybe# => abstract sealed enum class Maybe [covariant typeparam A ] extends Object with Enum { self: Maybe[A] => +2 decls }
-_empty_/Enums.Maybe#[A] => covariant typeparam A 
+_empty_/Enums.Maybe#[A] => covariant typeparam A
 _empty_/Enums.Maybe#`<init>`(). => primary ctor <init> [covariant typeparam A ](): Maybe[A]
 _empty_/Enums.Maybe. => final object Maybe extends Object { self: Maybe.type => +6 decls }
 _empty_/Enums.Maybe.Just# => final case enum class Just [covariant typeparam A ] extends Maybe[A] { self: Just[A] => +7 decls }
-_empty_/Enums.Maybe.Just#[A] => covariant typeparam A 
+_empty_/Enums.Maybe.Just#[A] => covariant typeparam A
 _empty_/Enums.Maybe.Just#_1(). => method _1 => A
 _empty_/Enums.Maybe.Just#`<init>`(). => primary ctor <init> [covariant typeparam A ](val param value: A): Just[A]
 _empty_/Enums.Maybe.Just#`<init>`().(value) => val param value: A
 _empty_/Enums.Maybe.Just#copy$default$1(). => method copy$default$1 [covariant typeparam A ]: A
-_empty_/Enums.Maybe.Just#copy$default$1().[A] => typeparam A 
+_empty_/Enums.Maybe.Just#copy$default$1().[A] => typeparam A
 _empty_/Enums.Maybe.Just#copy(). => method copy [covariant typeparam A ](param value: A): Just[A]
 _empty_/Enums.Maybe.Just#copy().(value) => param value: A
-_empty_/Enums.Maybe.Just#copy().[A] => typeparam A 
+_empty_/Enums.Maybe.Just#copy().[A] => typeparam A
 _empty_/Enums.Maybe.Just#ordinal(). => method ordinal => Int <: scala/reflect/Enum#ordinal().
 _empty_/Enums.Maybe.Just#value. => val method value A
 _empty_/Enums.Maybe.Just. => final object Just extends Object { self: Just.type => +4 decls }
 _empty_/Enums.Maybe.Just.apply(). => method apply [typeparam A ](param value: A): Just[A]
 _empty_/Enums.Maybe.Just.apply().(value) => param value: A
-_empty_/Enums.Maybe.Just.apply().[A] => typeparam A 
+_empty_/Enums.Maybe.Just.apply().[A] => typeparam A
 _empty_/Enums.Maybe.Just.toString(). => method toString => String <: scala/Any#toString().
 _empty_/Enums.Maybe.Just.unapply(). => method unapply [typeparam A ](param x$1: Just[A]): Just[A]
 _empty_/Enums.Maybe.Just.unapply().(x$1) => param x$1: Just[A]
-_empty_/Enums.Maybe.Just.unapply().[A] => typeparam A 
+_empty_/Enums.Maybe.Just.unapply().[A] => typeparam A
 _empty_/Enums.Maybe.None. => case val static enum method None Maybe[Nothing]
 _empty_/Enums.Maybe.fromOrdinal(). => method fromOrdinal (param ordinal: Int): Maybe[_] forSome { type _  }
 _empty_/Enums.Maybe.fromOrdinal().(ordinal) => param ordinal: Int
@@ -1008,7 +1006,7 @@ _empty_/Enums.Suits.valueOf(). => method valueOf (param $name: String): Suits
 _empty_/Enums.Suits.valueOf().($name) => param $name: String
 _empty_/Enums.Suits.values(). => method values => Array[Suits]
 _empty_/Enums.Tag# => abstract sealed enum class Tag [typeparam A ] extends Object with Enum { self: Tag[A] => +2 decls }
-_empty_/Enums.Tag#[A] => typeparam A 
+_empty_/Enums.Tag#[A] => typeparam A
 _empty_/Enums.Tag#`<init>`(). => primary ctor <init> [typeparam A ](): Tag[A]
 _empty_/Enums.Tag. => final object Tag extends Object { self: Tag.type => +7 decls }
 _empty_/Enums.Tag.$values. => private[this] val method $values Array[Tag[_] forSome { type _  }]
@@ -1039,33 +1037,33 @@ _empty_/Enums.WeekDays.valueOf(). => method valueOf (param $name: String): WeekD
 _empty_/Enums.WeekDays.valueOf().($name) => param $name: String
 _empty_/Enums.WeekDays.values(). => method values => Array[WeekDays]
 _empty_/Enums.`<:<`# => abstract sealed enum class <:< [contravariant typeparam A , typeparam B ] extends Object with Enum { self: <:<[A, B] => +3 decls }
-_empty_/Enums.`<:<`#[A] => contravariant typeparam A 
-_empty_/Enums.`<:<`#[B] => typeparam B 
+_empty_/Enums.`<:<`#[A] => contravariant typeparam A
+_empty_/Enums.`<:<`#[B] => typeparam B
 _empty_/Enums.`<:<`#`<init>`(). => primary ctor <init> [contravariant typeparam A , typeparam B ](): <:<[A, B]
 _empty_/Enums.`<:<`. => final object <:< extends Object { self: <:<.type => +6 decls }
 _empty_/Enums.`<:<`.Refl# => final case enum class Refl [typeparam C ] extends <:<[C, C] { self: Refl[C] => +4 decls }
-_empty_/Enums.`<:<`.Refl#[C] => typeparam C 
+_empty_/Enums.`<:<`.Refl#[C] => typeparam C
 _empty_/Enums.`<:<`.Refl#`<init>`(). => primary ctor <init> [typeparam C ](): Refl[C]
 _empty_/Enums.`<:<`.Refl#copy(). => method copy [typeparam C ](): Refl[C]
-_empty_/Enums.`<:<`.Refl#copy().[C] => typeparam C 
+_empty_/Enums.`<:<`.Refl#copy().[C] => typeparam C
 _empty_/Enums.`<:<`.Refl#ordinal(). => method ordinal => Int <: scala/reflect/Enum#ordinal().
 _empty_/Enums.`<:<`.Refl. => final object Refl extends Object { self: Refl.type => +4 decls }
 _empty_/Enums.`<:<`.Refl.apply(). => method apply [typeparam C ](): Refl[C]
-_empty_/Enums.`<:<`.Refl.apply().[C] => typeparam C 
+_empty_/Enums.`<:<`.Refl.apply().[C] => typeparam C
 _empty_/Enums.`<:<`.Refl.toString(). => method toString => String <: scala/Any#toString().
 _empty_/Enums.`<:<`.Refl.unapply(). => method unapply [typeparam C ](param x$1: Refl[C]): true
 _empty_/Enums.`<:<`.Refl.unapply().(x$1) => param x$1: Refl[C]
-_empty_/Enums.`<:<`.Refl.unapply().[C] => typeparam C 
+_empty_/Enums.`<:<`.Refl.unapply().[C] => typeparam C
 _empty_/Enums.`<:<`.`given_<:<_T_T`(). => final implicit given method given_<:<_T_T [typeparam T ]: <:<[T, T]
-_empty_/Enums.`<:<`.`given_<:<_T_T`().[T] => typeparam T 
+_empty_/Enums.`<:<`.`given_<:<_T_T`().[T] => typeparam T
 _empty_/Enums.`<:<`.fromOrdinal(). => method fromOrdinal (param ordinal: Int): <:<[_, _] forSome { type _ ; type _  }
 _empty_/Enums.`<:<`.fromOrdinal().(ordinal) => param ordinal: Int
 _empty_/Enums.some1. => val method some1 Option[Int]
 _empty_/Enums.unwrap(). => method unwrap [typeparam A , typeparam B ](param opt: Option[A])(implicit given param ev: <:<[A, Option[B]]): Option[B]
 _empty_/Enums.unwrap().(ev) => implicit given param ev: <:<[A, Option[B]]
 _empty_/Enums.unwrap().(opt) => param opt: Option[A]
-_empty_/Enums.unwrap().[A] => typeparam A 
-_empty_/Enums.unwrap().[B] => typeparam B 
+_empty_/Enums.unwrap().[A] => typeparam A
+_empty_/Enums.unwrap().[B] => typeparam B
 local0 => param x: Option[B]
 
 Occurrences:
@@ -1331,18 +1329,18 @@ ext/Extension$package.foo().(s) => param s: String
 ext/Extension$package.readInto(). => method readInto [typeparam T ](param s: String)(implicit given param x$2: Read[T]): Option[T]
 ext/Extension$package.readInto().(s) => param s: String
 ext/Extension$package.readInto().(x$2) => implicit given param x$2: Read[T]
-ext/Extension$package.readInto().[T] => typeparam T 
+ext/Extension$package.readInto().[T] => typeparam T
 ext/Functor# => trait Functor [typeparam F [type _ ]] extends Object { self: Functor[F] => +3 decls }
 ext/Functor#[F] => typeparam F [type _ ]
-ext/Functor#[F][_] => type _ 
+ext/Functor#[F][_] => type _
 ext/Functor#`<init>`(). => primary ctor <init> [typeparam F [type _ ]](): Functor[F]
 ext/Functor#map(). => abstract method map [typeparam T , typeparam U ](param t: F[T])(param f: Function1[T, U]): F[U]
 ext/Functor#map().(f) => param f: Function1[T, U]
 ext/Functor#map().(t) => param t: F[T]
-ext/Functor#map().[T] => typeparam T 
-ext/Functor#map().[U] => typeparam U 
+ext/Functor#map().[T] => typeparam T
+ext/Functor#map().[U] => typeparam U
 ext/Read# => trait Read [covariant typeparam T ] extends Object { self: Read[T] => +3 decls }
-ext/Read#[T] => covariant typeparam T 
+ext/Read#[T] => covariant typeparam T
 ext/Read#`<init>`(). => primary ctor <init> [covariant typeparam T ](): Read[T]
 ext/Read#fromString(). => abstract method fromString (param s: String): Option[T]
 ext/Read#fromString().(s) => param s: String
@@ -1506,7 +1504,7 @@ Synthetics => 3 entries
 Symbols:
 a/b/Givens. => final object Givens extends Object { self: Givens.type => +12 decls }
 a/b/Givens.Monoid# => trait Monoid [typeparam A ] extends Object { self: Monoid[A] => +4 decls }
-a/b/Givens.Monoid#[A] => typeparam A 
+a/b/Givens.Monoid#[A] => typeparam A
 a/b/Givens.Monoid#`<init>`(). => primary ctor <init> [typeparam A ](): Monoid[A]
 a/b/Givens.Monoid#combine(). => abstract method combine (param x: A)(param y: A): A
 a/b/Givens.Monoid#combine().(x) => param x: A
@@ -1514,7 +1512,7 @@ a/b/Givens.Monoid#combine().(y) => param y: A
 a/b/Givens.Monoid#empty(). => abstract method empty => A
 a/b/Givens.foo(). => method foo [typeparam A ](implicit given param A: Monoid[A]): A
 a/b/Givens.foo().(A) => implicit given param A: Monoid[A]
-a/b/Givens.foo().[A] => typeparam A 
+a/b/Givens.foo().[A] => typeparam A
 a/b/Givens.given_Monoid_String. => final implicit given object given_Monoid_String extends Object with Monoid[String] { self: given_Monoid_String.type => +3 decls }
 a/b/Givens.given_Monoid_String.combine(). => method combine (param x: String)(param y: String): String <: a/b/Givens.Monoid#combine().
 a/b/Givens.given_Monoid_String.combine().(x) => param x: String
@@ -1525,13 +1523,13 @@ a/b/Givens.hello1. => val method hello1 String
 a/b/Givens.int2String(). => final implicit given inline macro int2String => Conversion[Int, String]
 a/b/Givens.sayGoodbye(). => method sayGoodbye [typeparam B ](param any: B): String
 a/b/Givens.sayGoodbye().(any) => param any: B
-a/b/Givens.sayGoodbye().[B] => typeparam B 
+a/b/Givens.sayGoodbye().[B] => typeparam B
 a/b/Givens.sayHello(). => method sayHello [typeparam A ](param any: A): String
 a/b/Givens.sayHello().(any) => param any: A
-a/b/Givens.sayHello().[A] => typeparam A 
+a/b/Givens.sayHello().[A] => typeparam A
 a/b/Givens.saySoLong(). => method saySoLong [typeparam B ](param any: B): String
 a/b/Givens.saySoLong().(any) => param any: B
-a/b/Givens.saySoLong().[B] => typeparam B 
+a/b/Givens.saySoLong().[B] => typeparam B
 a/b/Givens.soLong1. => val method soLong1 String
 
 Occurrences:
@@ -1632,7 +1630,7 @@ example/ImplicitConversion#tuple. => val method tuple Tuple2[Int, Int]
 example/ImplicitConversion#x. => val method x Int
 example/ImplicitConversion. => final object ImplicitConversion extends Object { self: ImplicitConversion.type => +6 decls }
 example/ImplicitConversion.newAny2stringadd# => final implicit class newAny2stringadd [typeparam A ] extends AnyVal { self: newAny2stringadd[A] => +4 decls }
-example/ImplicitConversion.newAny2stringadd#[A] => typeparam A 
+example/ImplicitConversion.newAny2stringadd#[A] => typeparam A
 example/ImplicitConversion.newAny2stringadd#`+`(). => method + (param other: String): String
 example/ImplicitConversion.newAny2stringadd#`+`().(other) => param other: String
 example/ImplicitConversion.newAny2stringadd#`<init>`(). => primary ctor <init> [typeparam A ](param self: A): newAny2stringadd[A]
@@ -1640,7 +1638,7 @@ example/ImplicitConversion.newAny2stringadd#`<init>`().(self) => param self: A
 example/ImplicitConversion.newAny2stringadd#self. => private val method self A
 example/ImplicitConversion.newAny2stringadd(). => final implicit method newAny2stringadd [typeparam A ](param self: A): newAny2stringadd[A]
 example/ImplicitConversion.newAny2stringadd().(self) => param self: A
-example/ImplicitConversion.newAny2stringadd().[A] => typeparam A 
+example/ImplicitConversion.newAny2stringadd().[A] => typeparam A
 example/ImplicitConversion.newAny2stringadd. => final object newAny2stringadd extends Object { self: newAny2stringadd.type => +2 decls }
 
 Occurrences:
@@ -1845,7 +1843,7 @@ givens/InventedNames$package.given_Double(). => final implicit given method give
 givens/InventedNames$package.given_Double().(x$1) => implicit given param x$1: Int
 givens/InventedNames$package.given_Float. => final implicit lazy val given method given_Float Float
 givens/InventedNames$package.given_List_T(). => final implicit given method given_List_T [typeparam T ]: List[T]
-givens/InventedNames$package.given_List_T().[T] => typeparam T 
+givens/InventedNames$package.given_List_T().[T] => typeparam T
 givens/InventedNames$package.given_String. => final implicit lazy val given method given_String String
 givens/InventedNames$package.given_X. => final implicit given object given_X extends Object with X { self: given_X.type => +2 decls }
 givens/InventedNames$package.given_X.doX(). => method doX => Int <: givens/X#doX().
@@ -1857,11 +1855,11 @@ givens/InventedNames$package.given_Y#x$1. => protected implicit val given method
 givens/InventedNames$package.given_Y(). => final implicit given method given_Y (implicit given param x$1: X): given_Y
 givens/InventedNames$package.given_Y().(x$1) => implicit given param x$1: X
 givens/InventedNames$package.given_Z_T# => implicit given class given_Z_T [typeparam T ] extends Object with Z[T] { self: given_Z_T[T] => +3 decls }
-givens/InventedNames$package.given_Z_T#[T] => typeparam T 
+givens/InventedNames$package.given_Z_T#[T] => typeparam T
 givens/InventedNames$package.given_Z_T#`<init>`(). => primary ctor <init> [typeparam T ](): given_Z_T[T]
 givens/InventedNames$package.given_Z_T#doZ(). => method doZ => List[T] <: givens/Z#doZ().
 givens/InventedNames$package.given_Z_T(). => final implicit given method given_Z_T [typeparam T ]: given_Z_T[T]
-givens/InventedNames$package.given_Z_T().[T] => typeparam T 
+givens/InventedNames$package.given_Z_T().[T] => typeparam T
 givens/InventedNames$package.intValue. => final implicit lazy val given method intValue Int
 givens/InventedNames$package.x. => val method x given_X.type
 givens/InventedNames$package.y. => val method y given_Y
@@ -1873,7 +1871,7 @@ givens/Y# => trait Y extends Object { self: Y => +2 decls }
 givens/Y#`<init>`(). => primary ctor <init> (): Y
 givens/Y#doY(). => abstract method doY => String
 givens/Z# => trait Z [typeparam T ] extends Object { self: Z[T] => +3 decls }
-givens/Z#[T] => typeparam T 
+givens/Z#[T] => typeparam T
 givens/Z#`<init>`(). => primary ctor <init> [typeparam T ](): Z[T]
 givens/Z#doZ(). => abstract method doZ => List[T]
 
@@ -2011,7 +2009,7 @@ Symbols:
 example/Local# => class Local extends Object { self: Local => +2 decls }
 example/Local#`<init>`(). => primary ctor <init> (): Local
 example/Local#a(). => method a (): Int
-local0 => typeparam A 
+local0 => typeparam A
 local1 => param a: A
 local2 => local id: [typeparam A ](param a: A): A
 
@@ -2075,10 +2073,10 @@ example/MatchType$package.Concat# => type Concat [typeparam Xs  <: Tuple, covari
 example/MatchType$package.Concat#[Xs] => typeparam Xs  <: Tuple
 example/MatchType$package.Concat#[Ys] => covariant typeparam Ys  <: Tuple
 example/MatchType$package.Elem# => type Elem [typeparam X ] = X match { String => Char, Array[t] => t, Iterable[t] => t }
-example/MatchType$package.Elem#[X] => typeparam X 
-local0 => type t 
-local1 => type t 
-local2 => type x 
+example/MatchType$package.Elem#[X] => typeparam X
+local0 => type t
+local1 => type t
+local2 => type x
 local3 => type xs  <: Tuple
 
 Occurrences:
@@ -2316,11 +2314,11 @@ Occurrences => 153 entries
 Symbols:
 example/Methods# => class Methods [typeparam T ] extends Object { self: Methods[T] => +44 decls }
 example/Methods#AList# => type AList [typeparam T ] = List[T]
-example/Methods#AList#[T] => typeparam T 
+example/Methods#AList#[T] => typeparam T
 example/Methods#List# => class List [typeparam T ] extends Object { self: List[T] => +2 decls }
-example/Methods#List#[T] => typeparam T 
+example/Methods#List#[T] => typeparam T
 example/Methods#List#`<init>`(). => primary ctor <init> [typeparam T ](): List[T]
-example/Methods#[T] => typeparam T 
+example/Methods#[T] => typeparam T
 example/Methods#`<init>`(). => primary ctor <init> [typeparam T ](): Methods[T]
 example/Methods#`m8().`(). => method m8(). (): Nothing
 example/Methods#`m9().`# => class m9(). extends Object { self: m9(). => +1 decls }
@@ -2348,7 +2346,7 @@ example/Methods#m7(). => method m7 [typeparam U ](param c: Methods[T], param l: 
 example/Methods#m7().(c) => param c: Methods[T]
 example/Methods#m7().(evidence$1) => implicit param evidence$1: Ordering[U]
 example/Methods#m7().(l) => param l: List[U]
-example/Methods#m7().[U] => typeparam U 
+example/Methods#m7().[U] => typeparam U
 example/Methods#m9(). => method m9 (param x: m9().): Nothing
 example/Methods#m9().(x) => param x: m9().
 example/Methods#m10(). => method m10 (param x: List[T]): Nothing
@@ -2704,18 +2702,18 @@ Occurrences => 15 entries
 
 Symbols:
 _empty_/NewModifiers$package. => final package object _empty_ extends Object { self: _empty_.type { opaque type OpaqueB  } => +2 decls }
-_empty_/NewModifiers$package.OpaqueB# => opaque type OpaqueB 
+_empty_/NewModifiers$package.OpaqueB# => opaque type OpaqueB
 _empty_/NewModifiers. => final object NewModifiers extends Object { self: NewModifiers.type { opaque type A  } => +3 decls }
-_empty_/NewModifiers.A# => opaque type A 
+_empty_/NewModifiers.A# => opaque type A
 _empty_/NewModifiers.foo. => val inline method foo "foo"
 _empty_/NewModifiersClass# => opaque class NewModifiersClass extends Object { self: Any { opaque type C  } & NewModifiersClass => +5 decls }
-_empty_/NewModifiersClass#C# => opaque type C 
+_empty_/NewModifiersClass#C# => opaque type C
 _empty_/NewModifiersClass#Nested# => opaque class Nested extends Object { self: Any { opaque type NestedOpaque  } & Nested => +2 decls }
-_empty_/NewModifiersClass#Nested#NestedOpaque# => opaque type NestedOpaque 
+_empty_/NewModifiersClass#Nested#NestedOpaque# => opaque type NestedOpaque
 _empty_/NewModifiersClass#Nested#`<init>`(). => primary ctor <init> (): Nested
 _empty_/NewModifiersClass#`<init>`(). => primary ctor <init> (): NewModifiersClass
 _empty_/NewModifiersTrait# => opaque trait NewModifiersTrait extends Object { self: Any { opaque type D  } & NewModifiersTrait => +2 decls }
-_empty_/NewModifiersTrait#D# => opaque type D 
+_empty_/NewModifiersTrait#D# => opaque type D
 _empty_/NewModifiersTrait#`<init>`(). => primary ctor <init> (): NewModifiersTrait
 
 Occurrences:
@@ -2798,13 +2796,13 @@ Occurrences => 48 entries
 Symbols:
 prefixes/C# => class C extends Object { self: C => +6 decls }
 prefixes/C#N. => final object N extends Object { self: N.type => +2 decls }
-prefixes/C#N.U# => type U 
-prefixes/C#T# => type T 
+prefixes/C#N.U# => type U
+prefixes/C#T# => type T
 prefixes/C#`<init>`(). => primary ctor <init> (): C
 prefixes/C#k1(). => method k1 => U
 prefixes/C#m1(). => method m1 => T
 prefixes/M. => final object M extends Object { self: M.type => +3 decls }
-prefixes/M.T# => type T 
+prefixes/M.T# => type T
 prefixes/M.n1(). => method n1 => T
 prefixes/O. => final object O extends C { self: O.type => +2 decls }
 prefixes/O.o1(). => method o1 => O.this.T
@@ -2880,13 +2878,13 @@ Synthetics => 3 entries
 
 Symbols:
 example/C# => class C extends Object { self: C => +3 decls }
-example/C#T1# => type T1 
-example/C#T2# => type T2 
+example/C#T1# => type T1
+example/C#T2# => type T2
 example/C#`<init>`(). => primary ctor <init> (): C
 example/PickOneRefinement_1# => class PickOneRefinement_1 [typeparam S  <: SpecialRefinement { abstract method pickOne [typeparam T ](param as: T*): Option[String] }] extends Object { self: PickOneRefinement_1[S] => +3 decls }
 example/PickOneRefinement_1#[S] => typeparam S  <: SpecialRefinement { abstract method pickOne [typeparam T ](param as: T*): Option[String] }
 example/PickOneRefinement_1#[S](as) => param as: T*
-example/PickOneRefinement_1#[S][T] => typeparam T 
+example/PickOneRefinement_1#[S][T] => typeparam T
 example/PickOneRefinement_1#`<init>`(). => primary ctor <init> [typeparam S  <: SpecialRefinement { abstract method pickOne [typeparam T ](param as: T*): Option[String] }](): PickOneRefinement_1[S]
 example/PickOneRefinement_1#run(). => method run (param s: S, param as: String*): Option[String]
 example/PickOneRefinement_1#run().(as) => param as: String*
@@ -2895,7 +2893,7 @@ example/PolyHolder# => trait PolyHolder extends Object { self: PolyHolder => +2 
 example/PolyHolder#`<init>`(). => primary ctor <init> (): PolyHolder
 example/PolyHolder#foo(). => abstract method foo [typeparam T ](param t: T): Any
 example/PolyHolder#foo().(t) => param t: T
-example/PolyHolder#foo().[T] => typeparam T 
+example/PolyHolder#foo().[T] => typeparam T
 example/RecOrRefined$package. => final package object example extends Object { self: example.type => +9 decls }
 example/RecOrRefined$package.C2# => type C2  = C { type T2  = T1 <: example/C#T2#; type T1  <: example/C#T1# }
 example/RecOrRefined$package.Person# => type Person  = Record { abstract val method age Int; abstract val method name String }
@@ -2909,9 +2907,9 @@ example/RecOrRefined$package.m4(). => method m4 (param x: PolyHolder { abstract 
 example/RecOrRefined$package.m4().(x) => param x: PolyHolder { abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo(). }
 example/RecOrRefined$package.m5(). => method m5 [typeparam Z ](param x: Int): PolyHolder { abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo(). }
 example/RecOrRefined$package.m5().(x) => param x: Int
-example/RecOrRefined$package.m5().[Z] => typeparam Z 
+example/RecOrRefined$package.m5().[Z] => typeparam Z
 example/RecOrRefined$package.m6# => type m6 [typeparam X ] = PolyHolder { abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo(). }
-example/RecOrRefined$package.m6#[X] => typeparam X 
+example/RecOrRefined$package.m6#[X] => typeparam X
 example/Record# => class Record extends Object with Selectable { self: Record => +4 decls }
 example/Record#`<init>`(). => primary ctor <init> (param elems: Tuple2[String, Any]*): Record
 example/Record#`<init>`().(elems) => param elems: Tuple2[String, Any]*
@@ -2923,9 +2921,9 @@ example/SpecialRefinement# => trait SpecialRefinement extends Object { self: Spe
 example/SpecialRefinement#`<init>`(). => primary ctor <init> (): SpecialRefinement
 example/SpecialRefinement#pickOne(). => abstract method pickOne [typeparam T ](param as: T*): Option[Any]
 example/SpecialRefinement#pickOne().(as) => param as: T*
-example/SpecialRefinement#pickOne().[T] => typeparam T 
+example/SpecialRefinement#pickOne().[T] => typeparam T
 local0 => abstract method pickOne [typeparam T ](param as: T*): Option[String]
-local1 => typeparam T 
+local1 => typeparam T
 local2 => param as: T*
 local3 => abstract method pickOne [typeparam T ](param as: T*): Option[String] <: example/SpecialRefinement#pickOne().
 local4 => abstract val method x Int
@@ -2933,14 +2931,14 @@ local5 => abstract val method x Int
 local6 => abstract method y => Int
 local7 => abstract val method x Int
 local8 => abstract method y => Int
-local9 => type z 
-local10 => typeparam T 
+local9 => type z
+local10 => typeparam T
 local11 => param t: T
 local12 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
-local13 => typeparam T 
+local13 => typeparam T
 local14 => param t: T
 local15 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
-local16 => typeparam T 
+local16 => typeparam T
 local17 => param t: T
 local18 => abstract method foo [typeparam T ](param t: T): T <: example/PolyHolder#foo().
 local19 => abstract val method name String
@@ -3169,7 +3167,7 @@ example/Synthetic#Contexts.m4(). => method m4 => Nothing
 example/Synthetic#F# => class F extends Object { self: F => +1 decls }
 example/Synthetic#F#`<init>`(). => primary ctor <init> (): F
 example/Synthetic#J# => class J [typeparam T ] extends Object { self: J[T] => +4 decls }
-example/Synthetic#J#[T] => typeparam T 
+example/Synthetic#J#[T] => typeparam T
 example/Synthetic#J#`<init>`(). => primary ctor <init> [typeparam T ]()(implicit param evidence$1: Manifest[T]): J[T]
 example/Synthetic#J#`<init>`().(evidence$1) => implicit param evidence$1: Manifest[T]
 example/Synthetic#J#arr. => val method arr Array[T]
@@ -3743,11 +3741,11 @@ Occurrences => 17 entries
 Symbols:
 _empty_/Test_depmatch. => final object Test_depmatch extends Object { self: Test_depmatch.type => +4 decls }
 _empty_/Test_depmatch.Bar# => type Bar [typeparam T ] = T match { Unit => Unit }
-_empty_/Test_depmatch.Bar#[T] => typeparam T 
+_empty_/Test_depmatch.Bar#[T] => typeparam T
 _empty_/Test_depmatch.Foo# => type Foo  = Int { type U  }
 _empty_/Test_depmatch.baz(). => inline macro baz (param foo: Foo): Unit
 _empty_/Test_depmatch.baz().(foo) => param foo: Foo
-local0 => type U 
+local0 => type U
 local1 => val local v: Bar[foo.U]
 
 Occurrences:
@@ -3782,7 +3780,7 @@ Occurrences => 30 entries
 
 Symbols:
 exports/example/Codec# => trait Codec [typeparam T ] extends Object with Decoder[T] with Encoder[T] { self: Codec[T] => +6 decls }
-exports/example/Codec#[T] => typeparam T 
+exports/example/Codec#[T] => typeparam T
 exports/example/Codec#`<init>`(). => primary ctor <init> [typeparam T ](param decode: Decoder[T], param encode: Encoder[T]): Codec[T]
 exports/example/Codec#`<init>`().(decode) => param decode: Decoder[T]
 exports/example/Codec#`<init>`().(encode) => param encode: Encoder[T]
@@ -3793,12 +3791,12 @@ exports/example/Codec#encode(). => final method encode (param t: T): Array[Byte]
 exports/example/Codec#encode().(t) => param t: T
 exports/example/Codec#encode. => private[this] val method encode Encoder[T]
 exports/example/Decoder# => trait Decoder [covariant typeparam T ] extends Object { self: Decoder[T] => +3 decls }
-exports/example/Decoder#[T] => covariant typeparam T 
+exports/example/Decoder#[T] => covariant typeparam T
 exports/example/Decoder#`<init>`(). => primary ctor <init> [covariant typeparam T ](): Decoder[T]
 exports/example/Decoder#decode(). => abstract method decode (param a: Array[Byte]): T
 exports/example/Decoder#decode().(a) => param a: Array[Byte]
 exports/example/Encoder# => trait Encoder [contravariant typeparam T ] extends Object { self: Encoder[T] => +3 decls }
-exports/example/Encoder#[T] => contravariant typeparam T 
+exports/example/Encoder#[T] => contravariant typeparam T
 exports/example/Encoder#`<init>`(). => primary ctor <init> [contravariant typeparam T ](): Encoder[T]
 exports/example/Encoder#encode(). => abstract method encode (param t: T): Array[Byte]
 exports/example/Encoder#encode().(t) => param t: T
@@ -3849,11 +3847,11 @@ Occurrences => 5 entries
 Symbols:
 exports/`exports-package$package`. => final package object exports extends Object { self: exports.type => +4 decls }
 exports/`exports-package$package`.Codec# => final type Codec [typeparam T ] = Codec[T]
-exports/`exports-package$package`.Codec#[T] => typeparam T 
+exports/`exports-package$package`.Codec#[T] => typeparam T
 exports/`exports-package$package`.Decoder# => final type Decoder [typeparam T ] = Decoder[T]
-exports/`exports-package$package`.Decoder#[T] => typeparam T 
+exports/`exports-package$package`.Decoder#[T] => typeparam T
 exports/`exports-package$package`.Encoder# => final type Encoder [typeparam T ] = Encoder[T]
-exports/`exports-package$package`.Encoder#[T] => typeparam T 
+exports/`exports-package$package`.Encoder#[T] => typeparam T
 
 Occurrences:
 [0:8..0:15): exports <- exports/
@@ -4109,11 +4107,11 @@ _empty_/Concrete#`<init>`(). => primary ctor <init> (): Concrete
 _empty_/Concrete#nullary2(). => method nullary2 => Int <: _empty_/NullaryTest#nullary2().
 _empty_/Concrete#nullary3(). => method nullary3 => List[Int] <: _empty_/NullaryTest#nullary3().
 _empty_/NullaryTest# => abstract class NullaryTest [typeparam T , typeparam m [typeparam s ]] extends Object { self: NullaryTest[T, m] => +9 decls }
-_empty_/NullaryTest#[T] => typeparam T 
+_empty_/NullaryTest#[T] => typeparam T
 _empty_/NullaryTest#[m] => typeparam m [typeparam s ]
-_empty_/NullaryTest#[m][s] => typeparam s 
+_empty_/NullaryTest#[m][s] => typeparam s
 _empty_/NullaryTest#`<init>`(). => primary ctor <init> [typeparam T , typeparam m [typeparam s ]](): NullaryTest[T, m]
-_empty_/NullaryTest#`<init>`().[m][s] => typeparam s 
+_empty_/NullaryTest#`<init>`().[m][s] => typeparam s
 _empty_/NullaryTest#nullary(). => method nullary => String
 _empty_/NullaryTest#nullary2(). => abstract method nullary2 => T
 _empty_/NullaryTest#nullary3(). => abstract method nullary3 => m[T]
@@ -4316,9 +4314,9 @@ flags/p/package.AA#x. => private[this] val method x Int
 flags/p/package.AA#y. => val method y Int
 flags/p/package.AA#z(). => var method z Int
 flags/p/package.C# => abstract class C [covariant typeparam T , contravariant typeparam U , typeparam V ] extends Object { self: C[T, U, V] => +10 decls }
-flags/p/package.C#[T] => covariant typeparam T 
-flags/p/package.C#[U] => contravariant typeparam U 
-flags/p/package.C#[V] => typeparam V 
+flags/p/package.C#[T] => covariant typeparam T
+flags/p/package.C#[U] => contravariant typeparam U
+flags/p/package.C#[V] => typeparam V
 flags/p/package.C#`<init>`(). => primary ctor <init> [covariant typeparam T , contravariant typeparam U , typeparam V ](param x: T, param y: U, param z: V): C[T, U, V]
 flags/p/package.C#`<init>`().(x) => param x: T
 flags/p/package.C#`<init>`().(y) => param y: U
@@ -4331,11 +4329,11 @@ flags/p/package.C#x. => private[this] val method x T
 flags/p/package.C#y. => private[this] val method y U
 flags/p/package.C#z. => private[this] val method z V
 flags/p/package.S# => class S [@specialized typeparam T ] extends Object { self: S[T] => +2 decls }
-flags/p/package.S#[T] => @specialized typeparam T 
+flags/p/package.S#[T] => @specialized typeparam T
 flags/p/package.S#`<init>`(). => primary ctor <init> [@specialized typeparam T ](): S[T]
 flags/p/package.T1# => type T1  = Int
 flags/p/package.T2# => type T2 [typeparam T ] = S[T]
-flags/p/package.T2#[T] => typeparam T 
+flags/p/package.T2#[T] => typeparam T
 flags/p/package.U# => type U  <: Int
 flags/p/package.V# => type V  >: Int
 flags/p/package.X. => final case object X extends Object with Product with Serializable { self: X.type => +1 decls }
@@ -4346,14 +4344,14 @@ flags/p/package.Z#`<init>`(). => primary ctor <init> (): Z
 flags/p/package.`y_=`(). => protected var method y_= (param x$1: Int): Unit
 flags/p/package.`y_=`().(x$1) => param x$1: Int
 flags/p/package.m(). => macro m [typeparam TT ]: Int
-flags/p/package.m().[TT] => typeparam TT 
+flags/p/package.m().[TT] => typeparam TT
 flags/p/package.x. => private[flags/p/] lazy val method x Int
 flags/p/package.xs1. => val method xs1 Nothing
 flags/p/package.y(). => protected implicit var method y Int
 flags/p/package.z(). => method z (param pp: Int): Int
 flags/p/package.z().(pp) => param pp: Int
 local0 => val local xs2: Nothing
-local1 => type t 
+local1 => type t
 
 Occurrences:
 [0:8..0:13): flags <- flags/
@@ -4454,7 +4452,7 @@ local3 => final class $anon extends Object { self: $anon => +2 decls }
 local5 => final class $anon extends M with N { self: $anon => +1 decls }
 local7 => method k => Int
 local8 => final class $anon extends M with N { self: $anon => +2 decls }
-local10 => typeparam T 
+local10 => typeparam T
 local11 => type L [typeparam T ] = List[T]
 types/B# => class B extends Object { self: B => +1 decls }
 types/B#`<init>`(). => primary ctor <init> (): B
@@ -4500,7 +4498,7 @@ types/Test.C#ClassInfoType2# => class ClassInfoType2 extends B { self: ClassInfo
 types/Test.C#ClassInfoType2#`<init>`(). => primary ctor <init> (): ClassInfoType2
 types/Test.C#ClassInfoType2#x(). => method x => Int
 types/Test.C#ClassInfoType3# => trait ClassInfoType3 [typeparam T ] extends Object { self: ClassInfoType3[T] => +2 decls }
-types/Test.C#ClassInfoType3#[T] => typeparam T 
+types/Test.C#ClassInfoType3#[T] => typeparam T
 types/Test.C#ClassInfoType3#`<init>`(). => primary ctor <init> [typeparam T ](): ClassInfoType3[T]
 types/Test.C#Either. => val method Either Either.type
 types/Test.C#MethodType. => final object MethodType extends Object { self: MethodType.type => +7 decls }
@@ -4510,7 +4508,7 @@ types/Test.C#MethodType.m5(). => method m5 (param x: Int): Int
 types/Test.C#MethodType.m5().(x) => param x: Int
 types/Test.C#MethodType.m6(). => method m6 [typeparam T ](param x: T): T
 types/Test.C#MethodType.m6().(x) => param x: T
-types/Test.C#MethodType.m6().[T] => typeparam T 
+types/Test.C#MethodType.m6().[T] => typeparam T
 types/Test.C#MethodType.x1(). => method x1 => Int
 types/Test.C#MethodType.x2(). => method x2 => Int
 types/Test.C#RepeatedType# => case class RepeatedType extends Object with Product with Serializable { self: RepeatedType => +4 decls }
@@ -4527,15 +4525,15 @@ types/Test.C#RepeatedType.toString(). => method toString => String <: scala/Any#
 types/Test.C#RepeatedType.unapplySeq(). => method unapplySeq (param x$1: RepeatedType): RepeatedType
 types/Test.C#RepeatedType.unapplySeq().(x$1) => param x$1: RepeatedType
 types/Test.C#TypeType. => final object TypeType extends Object { self: TypeType.type => +6 decls }
-types/Test.C#TypeType.T1# => type T1 
+types/Test.C#TypeType.T1# => type T1
 types/Test.C#TypeType.T4# => type T4  = C
 types/Test.C#TypeType.T5# => type T5 [typeparam U ] = U
-types/Test.C#TypeType.T5#[U] => typeparam U 
+types/Test.C#TypeType.T5#[U] => typeparam U
 types/Test.C#TypeType.m2(). => method m2 [typeparam T2  = C]: Nothing
 types/Test.C#TypeType.m2().[T2] => typeparam T2  = C
 types/Test.C#TypeType.m3(). => method m3 [typeparam M3 [type _ ]]: Nothing
 types/Test.C#TypeType.m3().[M3] => typeparam M3 [type _ ]
-types/Test.C#TypeType.m3().[M3][_] => type _ 
+types/Test.C#TypeType.m3().[M3][_] => type _
 types/Test.C#`<init>`(). => primary ctor <init> (): C
 types/Test.C#annType1. => val method annType1 T @ann[T]
 types/Test.C#annType2. => val method annType2 T @ann1 @ann2
@@ -4558,7 +4556,7 @@ types/Test.C#thisType1. => val method thisType1 C.this.type
 types/Test.C#thisType2. => val method thisType2 C.this.type
 types/Test.C#typeLambda1(). => method typeLambda1 [typeparam M [type _ ]]: Nothing
 types/Test.C#typeLambda1().[M] => typeparam M [type _ ]
-types/Test.C#typeLambda1().[M][_] => type _ 
+types/Test.C#typeLambda1().[M][_] => type _
 types/Test.C#typeRef1. => val method typeRef1 C
 types/Test.C#typeRef2. => val method typeRef2 p.C
 types/Test.C#typeRef3. => val method typeRef3 T#C
@@ -4583,7 +4581,7 @@ types/Test.N# => trait N extends Object { self: N => +2 decls }
 types/Test.N#`<init>`(). => primary ctor <init> (): N
 types/Test.N#n(). => method n => Int
 types/ann# => class ann [typeparam T ] extends Annotation with StaticAnnotation { self: ann[T] => +3 decls }
-types/ann#[T] => typeparam T 
+types/ann#[T] => typeparam T
 types/ann#`<init>`(). => primary ctor <init> [typeparam T ](param x: T): ann[T]
 types/ann#`<init>`().(x) => param x: T
 types/ann#x. => private[this] val method x T

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3736,7 +3736,7 @@ Uri => dep-match.scala
 Text => empty
 Language => Scala
 Symbols => 8 entries
-Occurrences => 17 entries
+Occurrences => 18 entries
 
 Symbols:
 _empty_/Test_depmatch. => final object Test_depmatch extends Object { self: Test_depmatch.type => +4 decls }
@@ -3765,6 +3765,7 @@ Occurrences:
 [6:8..6:9): v <- local1
 [6:11..6:14): Bar -> _empty_/Test_depmatch.Bar#
 [6:15..6:18): foo -> _empty_/Test_depmatch.baz().(foo)
+[6:19..6:20): U -> local0
 [6:24..6:27): ??? -> scala/Predef.`???`().
 
 expect/exports-example-Codec.scala

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -48,9 +48,9 @@ Schema => SemanticDB v4
 Uri => Advanced.scala
 Text => empty
 Language => Scala
-Symbols => 55 entries
-Occurrences => 114 entries
-Synthetics => 3 entries
+Symbols => 62 entries
+Occurrences => 130 entries
+Synthetics => 4 entries
 
 Symbols:
 advanced/C# => class C [typeparam T ] extends Object { self: C[T] => +3 decls }
@@ -80,10 +80,12 @@ advanced/Structural#s2(). => method s2 => Object { abstract val method x Int }
 advanced/Structural#s3(). => method s3 => Object { abstract method m (param x: Int): Int }
 advanced/Structural#s4(). => method s4 (param a: Int): Object { abstract val method x Int }
 advanced/Structural#s4().(a) => param a: Int
-advanced/Test. => final object Test extends Object { self: Test.type => +11 decls }
+advanced/Test. => final object Test extends Object { self: Test.type => +13 decls }
+advanced/Test.bar(). => method bar => foo.A
 advanced/Test.e. => val method e Wildcards
 advanced/Test.e1. => val method e1 List[_] forSome { type _  }
 advanced/Test.e1x. => val method e1x Any
+advanced/Test.foo. => lazy val method foo Selectable { abstract type A  = Int } & Selectable { abstract field a: local20; abstract type A  = Int }
 advanced/Test.s. => val method s Structural
 advanced/Test.s1. => val method s1 Object { abstract val method x Int }
 advanced/Test.s1x. => val method s1x Int
@@ -108,6 +110,11 @@ local11 => abstract val method x Int
 local12 => type B  = A
 local13 => val local e3: List[local14]
 local15 => val local e3x: local14
+local16 => type A  = Int
+local17 => type A  = Int
+local18 => abstract val method a A
+local19 => abstract type A  = Int
+local21 => abstract field a: A
 
 Occurrences:
 [0:8..0:16): advanced <- advanced/
@@ -208,27 +215,44 @@ Occurrences:
 [40:12..40:15): e3x <- local15
 [40:18..40:20): e3 -> local13
 [40:21..40:25): head -> scala/collection/IterableOps#head().
-[48:6..48:13): HKClass <- advanced/HKClass#
-[48:14..48:15): F <- advanced/HKClass#[F]
-[48:20..48:21): T <- advanced/HKClass#`<init>`().[F][T]
-[48:28..48:29): U <- advanced/HKClass#`<init>`().[F][U]
-[48:36..48:37): U -> advanced/HKClass#`<init>`().[F][U]
-[48:39..48:40): T -> advanced/HKClass#`<init>`().[F][T]
-[49:6..49:9): foo <- advanced/HKClass#foo().
-[49:10..49:11): T <- advanced/HKClass#foo().[T]
-[49:12..49:13): U <- advanced/HKClass#foo().[U]
-[49:15..49:16): x <- advanced/HKClass#foo().(x)
-[49:18..49:19): F -> advanced/HKClass#[F]
-[49:20..49:21): T -> advanced/HKClass#foo().[T]
-[49:23..49:24): U -> advanced/HKClass#foo().[U]
-[49:28..49:34): String -> scala/Predef.String#
-[49:37..49:38): x -> advanced/HKClass#foo().(x)
-[49:39..49:47): toString -> scala/Tuple2#toString().
+[46:11..46:14): foo <- advanced/Test.foo.
+[46:17..46:24): reflect -> scala/reflect/
+[46:25..46:35): Selectable -> scala/reflect/Selectable#
+[46:43..46:44): A <- local16
+[46:47..46:50): Int -> scala/Int#
+[46:54..46:55): & -> scala/`&`#
+[46:57..46:64): reflect -> scala/reflect/
+[46:65..46:75): Selectable -> scala/reflect/Selectable#
+[46:83..46:84): A <- local17
+[46:87..46:90): Int -> scala/Int#
+[46:96..46:97): a <- local18
+[46:99..46:100): A -> local17
+[46:106..46:109): ??? -> scala/Predef.`???`().
+[47:6..47:9): bar <- advanced/Test.bar().
+[47:11..47:14): foo -> advanced/Test.foo.
+[47:19..47:22): foo -> advanced/Test.foo.
+[52:6..52:13): HKClass <- advanced/HKClass#
+[52:14..52:15): F <- advanced/HKClass#[F]
+[52:20..52:21): T <- advanced/HKClass#`<init>`().[F][T]
+[52:28..52:29): U <- advanced/HKClass#`<init>`().[F][U]
+[52:36..52:37): U -> advanced/HKClass#`<init>`().[F][U]
+[52:39..52:40): T -> advanced/HKClass#`<init>`().[F][T]
+[53:6..53:9): foo <- advanced/HKClass#foo().
+[53:10..53:11): T <- advanced/HKClass#foo().[T]
+[53:12..53:13): U <- advanced/HKClass#foo().[U]
+[53:15..53:16): x <- advanced/HKClass#foo().(x)
+[53:18..53:19): F -> advanced/HKClass#[F]
+[53:20..53:21): T -> advanced/HKClass#foo().[T]
+[53:23..53:24): U -> advanced/HKClass#foo().[U]
+[53:28..53:34): String -> scala/Predef.String#
+[53:37..53:38): x -> advanced/HKClass#foo().(x)
+[53:39..53:47): toString -> scala/Tuple2#toString().
 
 Synthetics:
 [27:12..27:16):s.s1 => reflectiveSelectable(*)
 [29:12..29:16):s.s2 => reflectiveSelectable(*)
 [31:12..31:16):s.s3 => reflectiveSelectable(*)
+[47:19..47:24):foo.a => *[foo.A]
 
 expect/Annotations.scala
 ------------------------

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3880,6 +3880,43 @@ Occurrences:
 [0:8..0:15): example <- example/
 [2:6..2:24): FilenameWithSpaces <- example/FilenameWithSpaces#
 
+expect/i5854.scala
+------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => i5854.scala
+Text => empty
+Language => Scala
+Symbols => 6 entries
+Occurrences => 16 entries
+
+Symbols:
+i5854/B# => class B extends Object { self: B => +4 decls }
+i5854/B#`<init>`(). => primary ctor <init> (): B
+i5854/B#a. => val method a String
+i5854/B#b. => val method b Object { type A  >: Any <: Nothing }
+i5854/B#loop(). => method loop (): Nothing
+local0 => type A  >: Any <: Nothing
+
+Occurrences:
+[0:8..0:13): i5854 <- i5854/
+[2:6..2:7): B <- i5854/B#
+[7:6..7:7): a <- i5854/B#a.
+[7:9..7:15): String -> scala/Predef.String#
+[7:24..7:27): Any -> scala/Any#
+[7:30..7:31): b -> i5854/B#b.
+[7:36..7:43): Nothing -> scala/Nothing#
+[7:46..7:52): String -> scala/Predef.String#
+[8:6..8:7): b <- i5854/B#b.
+[8:16..8:17): A <- local0
+[8:21..8:24): Any -> scala/Any#
+[8:28..8:35): Nothing -> scala/Nothing#
+[8:40..8:44): loop -> i5854/B#loop().
+[9:6..9:10): loop <- i5854/B#loop().
+[9:14..9:21): Nothing -> scala/Nothing#
+[9:24..9:28): loop -> i5854/B#loop().
+
 expect/i9727.scala
 ------------------
 

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -2034,10 +2034,10 @@ example/MatchType$package.Concat#[Xs] => typeparam Xs  <: Tuple
 example/MatchType$package.Concat#[Ys] => covariant typeparam Ys  <: Tuple
 example/MatchType$package.Elem# => type Elem [typeparam X ] = X match { String => Char, Array[t] => t, Iterable[t] => t }
 example/MatchType$package.Elem#[X] => typeparam X 
-local0 => case val method t 
-local1 => case val method t 
-local2 => case val method x 
-local3 => case val method xs 
+local0 => case type t 
+local1 => case type t 
+local2 => case type x 
+local3 => case type xs  <: Tuple
 
 Occurrences:
 [0:8..0:15): example <- example/
@@ -4087,9 +4087,9 @@ Occurrences => 46 entries
 Synthetics => 3 entries
 
 Symbols:
-local0 => case val method N$1  <: Nat
+local0 => case type N$1  <: Nat
 local1 => val local p: N$1
-local2 => case val method N$2  <: Nat
+local2 => case type N$2  <: Nat
 local3 => val local p: N$2
 local4 => val local Nat_this: Zero.type
 local5 => val local Nat_this: Succ[Zero.type]
@@ -4271,7 +4271,7 @@ flags/p/package.y(). => protected implicit var method y Int
 flags/p/package.z(). => method z (param pp: Int): Int
 flags/p/package.z().(pp) => param pp: Int
 local0 => val local xs2: Nothing
-local1 => case val method t 
+local1 => case type t 
 
 Occurrences:
 [0:8..0:13): flags <- flags/

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -2016,6 +2016,60 @@ Occurrences:
 Synthetics:
 [5:4..5:8):List => *.apply[Int]
 
+expect/MatchType.scala
+----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => MatchType.scala
+Text => empty
+Language => Scala
+Symbols => 10 entries
+Occurrences => 29 entries
+
+Symbols:
+example/MatchType$package. => final package object example extends Object { self: example.type => +3 decls }
+example/MatchType$package.Concat# => type Concat [typeparam Xs  <: Tuple, covariant typeparam Ys  <: Tuple] = Xs match { EmptyTuple => Ys, *:[x, xs] => *:[x, Concat[xs, Ys]] }
+example/MatchType$package.Concat#[Xs] => typeparam Xs  <: Tuple
+example/MatchType$package.Concat#[Ys] => covariant typeparam Ys  <: Tuple
+example/MatchType$package.Elem# => type Elem [typeparam X ] = X match { String => Char, Array[t] => t, Iterable[t] => t }
+example/MatchType$package.Elem#[X] => typeparam X 
+local0 => case val method t 
+local1 => case val method t 
+local2 => case val method x 
+local3 => case val method xs 
+
+Occurrences:
+[0:8..0:15): example <- example/
+[2:5..2:9): Elem <- example/MatchType$package.Elem#
+[2:10..2:11): X <- example/MatchType$package.Elem#[X]
+[2:15..2:16): X -> example/MatchType$package.Elem#[X]
+[3:7..3:13): String -> scala/Predef.String#
+[3:17..3:21): Char -> scala/Char#
+[4:7..4:12): Array -> scala/Array#
+[4:13..4:14): t <- local0
+[4:19..4:20): t -> local0
+[5:7..5:15): Iterable -> scala/package.Iterable#
+[5:16..5:17): t <- local1
+[5:22..5:23): t -> local1
+[7:5..7:11): Concat <- example/MatchType$package.Concat#
+[7:12..7:14): Xs <- example/MatchType$package.Concat#[Xs]
+[7:18..7:23): Tuple -> scala/Tuple#
+[7:26..7:28): Ys <- example/MatchType$package.Concat#[Ys]
+[7:32..7:37): Tuple -> scala/Tuple#
+[7:42..7:47): Tuple -> scala/Tuple#
+[7:50..7:52): Xs -> example/MatchType$package.Concat#[Xs]
+[8:7..8:17): EmptyTuple -> scala/Tuple$package.EmptyTuple#
+[8:21..8:23): Ys -> example/MatchType$package.Concat#[Ys]
+[9:7..9:8): x <- local2
+[9:9..9:11): *: -> scala/`*:`#
+[9:12..9:14): xs <- local3
+[9:18..9:19): x -> local2
+[9:20..9:22): *: -> scala/`*:`#
+[9:23..9:29): Concat -> example/MatchType$package.Concat#
+[9:30..9:32): xs -> local3
+[9:34..9:36): Ys -> example/MatchType$package.Concat#[Ys]
+
 expect/MetacJava.scala
 ----------------------
 


### PR DESCRIPTION
`/generated` sources are generated from https://github.com/tanishiking/semanticdb-for-scala3/pull/50
See the discussion about protobuf schema here https://github.com/scalameta/scalameta/pull/2414

For example, the following program

```
type Elem[X] <: Any = X match
  case String => Char
  case Array[t] => t
```

is modeled as:

```
TypeSignature(
  Some(Scope(List(matchtype/MatchType$package.Elem#[X]),List())),
  MatchType(
    TypeRef(Empty,matchtype/MatchType$package.Elem#[X],List()),
    List(
      CaseType(
        TypeRef(Empty,scala/Predef.String#,List()),
        TypeRef(Empty,scala/Char#,List())
      ),
      CaseType(
        TypeRef(Empty,scala/Array#,List(TypeRef(Empty,local0,List()))),
        TypeRef(Empty,local0,List())
      )
    )
  ),
  TypeRef(Empty,scala/Any#,List())
)
```

Once this PR is approved I'm going to create a PR that support MatchType extracted from https://github.com/scalameta/scalameta/pull/2414 :)