### PR TITLE
Fix intercept TypeApply in explicit nulls

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -784,9 +784,11 @@ object Erasure {
       }
 
     override def typedTypeApply(tree: untpd.TypeApply, pt: Type)(using Context): Tree = {
-      val ntree = atPhase(erasurePhase)(
-        interceptTypeApply(tree.asInstanceOf[TypeApply])
-      ).withSpan(tree.span)
+      val ntree = atPhase(erasurePhase){
+        // Use erased-type semantic to intercept TypeApply in explicit nulls
+        val interceptCtx = if ctx.explicitNulls then ctx.retractMode(Mode.SafeNulls) else ctx
+        interceptTypeApply(tree.asInstanceOf[TypeApply])(using interceptCtx)
+      }.withSpan(tree.span)
 
       ntree match {
         case TypeApply(fun, args) =>

--- a/tests/explicit-nulls/pos-patmat/match-pat.scala
+++ b/tests/explicit-nulls/pos-patmat/match-pat.scala
@@ -1,0 +1,27 @@
+// Ensure we don't get "the type test for argType cannot be checked at runtime" warning
+
+class Symbol {
+  type ThisName
+}
+
+type TermSymbol = Symbol { type ThisName = String }
+
+type TermSymbolOrNull = TermSymbol | Null
+
+def testSimple =
+  val x: Symbol | Null = ???
+  x match
+    case key: Symbol => 1
+    case null => 0
+
+def testWithRefinedType =
+  val x: TermSymbol | Null = ???
+  x match
+    case key: TermSymbol => 1
+    case null => 0
+
+def testWithAlias =
+  val x: TermSymbolOrNull = ???
+  x match
+    case key: TermSymbol => 1
+    case null => 0


### PR DESCRIPTION
Use erased-type semantic to intercept TypeApply in explicit nulls, so the following example doesn't have warning about "the type test for argType cannot be checked at runtime".

```scala
class Symbol {
  type ThisName
}

type TermSymbol = Symbol { type ThisName = String }

def f(x: TermSymbol | Null) =
  x match
    case key: TermSymbol => 1
    case null => 0
```