### PR TITLE
feat(repl): autocomplete repl commands

### DIFF
--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -152,6 +152,14 @@ final class JLineTerminal extends java.io.Closeable {
           // using dummy values, resulting parsed input is probably unused
           defaultParsedLine
 
+        // In the situation where we have a partial command that we want to
+        // complete we need to ensure that the :<partial-word> isn't split into
+        // 2 tokens, but rather the entire thing is treated as the "word", in
+        //   order to insure the : is replaced in the completion.
+        case ParseContext.COMPLETE if
+          ParseResult.commands.exists(command => command._1.startsWith(input)) =>
+            parsedLine(input, cursor)
+
         case ParseContext.COMPLETE =>
           // Parse to find completions (typically after a Tab).
           def isCompletable(token: Token) = isIdentifier(token) || isKeyword(token)

--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -127,7 +127,7 @@ object ParseResult {
     stats
   }
 
-  private val commands: List[(String, String => ParseResult)] = List(
+  private[repl] val commands: List[(String, String => ParseResult)] = List(
     Quit.command -> (_ => Quit),
     Quit.alias -> (_ => Quit),
     Help.command -> (_  => Help),

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -220,7 +220,15 @@ class ReplDriver(settings: Array[String],
     }
 
     if expr.startsWith(":") then
-      ParseResult.commands.map(command => makeCandidate(command._1))
+      ParseResult.commands.collect {
+        // If expr is only : then we return the commands with : since jline
+        // correctly handles them
+        case command if expr == ":" => makeCandidate(command._1)
+        // However if there is more than just the : we filter by it and then
+        // drop the : since jline will correctly complete it but you'll end up
+        // with ::import for example instead of :import
+        case command if command._1.startsWith(expr) => makeCandidate(command._1.drop(1))
+      }
     else
       given state: State = newRun(state0)
       compiler

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -205,7 +205,7 @@ class ReplDriver(settings: Array[String],
       label
 
   /** Extract possible completions at the index of `cursor` in `expr` */
-  protected final def completions(cursor: Int, expr: String, state0: State): List[Candidate] = {
+  protected final def completions(cursor: Int, expr: String, state0: State): List[Candidate] =
     def makeCandidate(label: String) = {
 
       new Candidate(
@@ -218,20 +218,24 @@ class ReplDriver(settings: Array[String],
         /* complete = */ false  // if true adds space when completing
       )
     }
-    implicit val state = newRun(state0)
-    compiler
-      .typeCheck(expr, errorsAllowed = true)
-      .map { tree =>
-        val file = SourceFile.virtual("<completions>", expr, maybeIncomplete = true)
-        val unit = CompilationUnit(file)(using state.context)
-        unit.tpdTree = tree
-        given Context = state.context.fresh.setCompilationUnit(unit)
-        val srcPos = SourcePosition(file, Span(cursor))
-        val (_, completions) = Completion.completions(srcPos)
-        completions.map(_.label).distinct.map(makeCandidate)
-      }
-      .getOrElse(Nil)
-  }
+
+    if expr.startsWith(":") then
+      ParseResult.commands.map(command => makeCandidate(command._1))
+    else
+      given state: State = newRun(state0)
+      compiler
+        .typeCheck(expr, errorsAllowed = true)
+        .map { tree =>
+          val file = SourceFile.virtual("<completions>", expr, maybeIncomplete = true)
+          val unit = CompilationUnit(file)(using state.context)
+          unit.tpdTree = tree
+          given Context = state.context.fresh.setCompilationUnit(unit)
+          val srcPos = SourcePosition(file, Span(cursor))
+          val (_, completions) = Completion.completions(srcPos)
+          completions.map(_.label).distinct.map(makeCandidate)
+        }
+        .getOrElse(Nil)
+  end completions 
 
   private def interpret(res: ParseResult)(implicit state: State): State = {
     res match {

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -221,13 +221,7 @@ class ReplDriver(settings: Array[String],
 
     if expr.startsWith(":") then
       ParseResult.commands.collect {
-        // If expr is only : then we return the commands with : since jline
-        // correctly handles them
-        case command if expr == ":" => makeCandidate(command._1)
-        // However if there is more than just the : we filter by it and then
-        // drop the : since jline will correctly complete it but you'll end up
-        // with ::import for example instead of :import
-        case command if command._1.startsWith(expr) => makeCandidate(command._1.drop(1))
+        case command if command._1.startsWith(expr) => makeCandidate(command._1)
       }
     else
       given state: State = newRun(state0)

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -191,4 +191,20 @@ class TabcompleteTests extends ReplTest {
                      |Foo.`bac"""stripMargin))
   }
 
+  @Test def commands = initially {
+    assertEquals(
+      List(
+        ":doc",
+        ":exit",
+        ":help",
+        ":imports",
+        ":load",
+        ":quit",
+        ":reset",
+        ":settings",
+        ":type"
+      ),
+      tabComplete(":")
+    )
+  }
 }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -211,7 +211,7 @@ class TabcompleteTests extends ReplTest {
   @Test def commandPreface = initially {
     // This looks odd, but if we return :doc here it will result in ::doc in the REPL
     assertEquals(
-      List("doc"),
+      List(":doc"),
       tabComplete(":d")
     )
   }

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -207,4 +207,12 @@ class TabcompleteTests extends ReplTest {
       tabComplete(":")
     )
   }
+
+  @Test def commandPreface = initially {
+    // This looks odd, but if we return :doc here it will result in ::doc in the REPL
+    assertEquals(
+      List("doc"),
+      tabComplete(":d")
+    )
+  }
 }


### PR DESCRIPTION
This adds in completion for the available commands in the repl just like
there is for Scala 2. For example you can do `:@@` which will give you
back all the commands.

![2022-03-06 09 16 23](https://user-images.githubusercontent.com/13974112/156914985-e83f725f-fa6d-4d2a-9b24-4ec05d0b5372.gif)