### PR TITLE
Handle more corner cases in etaReduce

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1594,6 +1594,9 @@ class Definitions {
     yield
       nme.apply.specializedFunction(r, List(t1, t2)).asTermName
 
+  @tu lazy val FunctionSpecializedApplyNames: collection.Set[Name] =
+    Function0SpecializedApplyNames ++ Function1SpecializedApplyNames ++ Function2SpecializedApplyNames
+
   def functionArity(tp: Type)(using Context): Int = tp.dropDependentRefinement.dealias.argInfos.length - 1
 
   /** Return underlying context function type (i.e. instance of an ContextFunctionN class)

--- a/tests/run/i14623.scala
+++ b/tests/run/i14623.scala
@@ -1,0 +1,15 @@
+object Thunk {
+  private[this] val impl =
+    ((x: Any) => x).asInstanceOf[(=> Any) => Function0[Any]]
+
+  def asFunction0[A](thunk: => A): Function0[A] = impl(thunk).asInstanceOf[Function0[A]]
+}
+
+@main def Test =
+  var i = 0
+  val f1 = { () => i += 1; "" }
+  assert(Thunk.asFunction0(f1()) eq f1)
+  val f2 = { () => i += 1; i }
+  assert(Thunk.asFunction0(f2()) eq f2)
+  val f3 = { () => i += 1 }
+  assert(Thunk.asFunction0(f3()) eq f3)


### PR DESCRIPTION
Generalize eta reduce so that it also handles eta expansions that are subject to
adaptation or specialization.

Fixes #14623