### PR TITLE
Revert "Upgrade to Scala.js 1.9.0."

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -4563,14 +4563,7 @@ class JSCodeGen()(using genCtx: Context) {
         val module = annot.argumentConstantString(0).getOrElse {
           unexpected("could not read the module argument as a string literal")
         }
-        val path = annot.argumentConstantString(1).fold {
-          if (annot.arguments.sizeIs < 2)
-            parsePath(sym.defaultJSName)
-          else
-            Nil
-        } { pathName =>
-          parsePath(pathName)
-        }
+        val path = annot.argumentConstantString(1).fold[List[String]](Nil)(parsePath)
         val importSpec = Import(module, path)
         annot.argumentConstantString(2).fold[js.JSNativeLoadSpec] {
           importSpec

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object Build {
 
   val referenceVersion = "3.1.2-RC1"
 
-  val baseVersion = "3.2.0-RC1"
+  val baseVersion = "3.1.3-RC1"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 //
 // e.g. addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.9.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 

--- a/tests/neg-scalajs/native-load-spec-need-explicit-name.check
+++ b/tests/neg-scalajs/native-load-spec-need-explicit-name.check
@@ -1,48 +1,8 @@
 -- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:6:2 ----------------------------------------------
 6 |  @JSGlobal // error
   |  ^^^^^^^^^
-  |  Native JS definitions named 'apply' must have an explicit name in @JSGlobal
+  |  Native JS members inside non-native objects must have an explicit name in @JSGlobal
 -- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:10:2 ---------------------------------------------
 10 |  @JSGlobal // error
    |  ^^^^^^^^^
-   |  Native JS definitions named 'apply' must have an explicit name in @JSGlobal
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:14:2 ---------------------------------------------
-14 |  @JSGlobal // error
-   |  ^^^^^^^^^
-   |  Native JS definitions with a name ending in '_=' must have an explicit name in @JSGlobal
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:20:2 ---------------------------------------------
-20 |  @JSGlobal // error
-   |  ^^^^^^^^^
-   |  Native JS definitions with a name ending in '_=' must have an explicit name in @JSGlobal
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:19:2 ---------------------------------------------
-19 |  @js.native // error
-   |  ^^^^^^^^^^
-   |  @js.native is not allowed on vars, lazy vals and setter defs
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:24:2 ---------------------------------------------
-24 |  @JSGlobal // error
-   |  ^^^^^^^^^
-   |  Native JS definitions named 'apply' must have an explicit name in @JSGlobal
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:30:3 ---------------------------------------------
-30 |  @JSImport("bar.js") // error
-   |  ^^^^^^^^^^^^^^^^^^^
-   |  Native JS definitions named 'apply' must have an explicit name in @JSImport
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:34:3 ---------------------------------------------
-34 |  @JSImport("bar.js") // error
-   |  ^^^^^^^^^^^^^^^^^^^
-   |  Native JS definitions named 'apply' must have an explicit name in @JSImport
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:38:3 ---------------------------------------------
-38 |  @JSImport("bar.js") // error
-   |  ^^^^^^^^^^^^^^^^^^^
-   |  Native JS definitions with a name ending in '_=' must have an explicit name in @JSImport
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:44:3 ---------------------------------------------
-44 |  @JSImport("bar.js") // error
-   |  ^^^^^^^^^^^^^^^^^^^
-   |  Native JS definitions with a name ending in '_=' must have an explicit name in @JSImport
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:43:2 ---------------------------------------------
-43 |  @js.native // error
-   |  ^^^^^^^^^^
-   |  @js.native is not allowed on vars, lazy vals and setter defs
--- Error: tests/neg-scalajs/native-load-spec-need-explicit-name.scala:48:3 ---------------------------------------------
-48 |  @JSImport("bar.js") // error
-   |  ^^^^^^^^^^^^^^^^^^^
-   |  Native JS definitions named 'apply' must have an explicit name in @JSImport
+   |  Native JS members inside non-native objects must have an explicit name in @JSGlobal

--- a/tests/neg-scalajs/native-load-spec-need-explicit-name.scala
+++ b/tests/neg-scalajs/native-load-spec-need-explicit-name.scala
@@ -1,52 +1,14 @@
 import scala.scalajs.js
 import scala.scalajs.js.annotation.*
 
-object A1 {
+object A {
   @js.native
   @JSGlobal // error
-  class apply extends js.Object
-
-  @js.native
-  @JSGlobal // error
-  object apply extends js.Object
+  class B extends js.Object
 
   @js.native
   @JSGlobal // error
-  class foo_= extends js.Object
-}
-
-object A2 {
-  @js.native // error
-  @JSGlobal // error
-  def foo_=(x: Int): Unit = js.native
-
-  @js.native
-  @JSGlobal // error
-  def apply(x: Int): Int = js.native
-}
-
-object B1 {
-  @js.native
-  @JSImport("bar.js") // error
-  class apply extends js.Object
-
-  @js.native
-  @JSImport("bar.js") // error
-  object apply extends js.Object
-
-  @js.native
-  @JSImport("bar.js") // error
-  class foo_= extends js.Object
-}
-
-object B2 {
-  @js.native // error
-  @JSImport("bar.js") // error
-  def foo_=(x: Int): Unit = js.native
-
-  @js.native
-  @JSImport("bar.js") // error
-  def apply(x: Int): Int = js.native
+  object C extends js.Object
 }
 
 // scala-js#2401


### PR DESCRIPTION
Reverts lampepfl/dotty#14610 since it requires a minor version bump but we decided to hold off on moving to 3.2.0-RC1 and release 3.1.3-RC1 first (see https://github.com/lampepfl/dotty/milestones). This gives us more time to figure out what will be in 3.2.