### PR TITLE
Fix safe-init error in ParamOwner

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -49,9 +49,8 @@ object Parsers {
     case InBlock       extends Location(false, false, false)
     case ElseWhere     extends Location(false, false, false)
 
-  @sharable object ParamOwner extends Enumeration {
-    val Class, Type, TypeParam, Def: Value = Value
-  }
+  enum ParamOwner:
+    case Class, Type, TypeParam, Def
 
   type StageKind = Int
   object StageKind {
@@ -2927,7 +2926,7 @@ object Parsers {
      *  HkTypeParamClause ::=  ‘[’ HkTypeParam {‘,’ HkTypeParam} ‘]’
      *  HkTypeParam       ::=  {Annotation} [‘+’ | ‘-’] (id [HkTypePamClause] | ‘_’) TypeBounds
      */
-    def typeParamClause(ownerKind: ParamOwner.Value): List[TypeDef] = inBrackets {
+    def typeParamClause(ownerKind: ParamOwner): List[TypeDef] = inBrackets {
 
       def variance(vflag: FlagSet): FlagSet =
         if ownerKind == ParamOwner.Def || ownerKind == ParamOwner.TypeParam then
@@ -2962,7 +2961,7 @@ object Parsers {
       commaSeparated(() => typeParam())
     }
 
-    def typeParamClauseOpt(ownerKind: ParamOwner.Value): List[TypeDef] =
+    def typeParamClauseOpt(ownerKind: ParamOwner): List[TypeDef] =
       if (in.token == LBRACKET) typeParamClause(ownerKind) else Nil
 
     /** ContextTypes   ::=  FunArgType {‘,’ FunArgType}


### PR DESCRIPTION
When bootstrapping the compiler with the `-Ysafe-init` flag, we would
get the following error:
```
[error] -- Error: /Users/rrampersad/Documents/school/URA/dotty/compiler/src/dotty/tools/dotc/parsing/Parsers.scala:53:45
[error] 53 |    val Class, Type, TypeParam, Def: Value = Value
[error]    |                                             ^^^^^
[error]    |Calling the external method method Value may cause initialization errors.
```

This error orginates from the Scala 2 `Enumeration` class definition. In order to circumvent this issue, we instead define `ParamOwner` using a Scala 3 enum.  This eliminates the error.

Review by @liufengyun