### PR TITLE
Add context to safe-init warnings for inlined methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -1239,8 +1239,9 @@ object Semantic {
         Result(Hot, ress.flatMap(_.errors))
 
       case Inlined(call, bindings, expansion) =>
+        val trace1 = trace.add(expr)
         val ress = eval(bindings, thisV, klass)
-        eval(expansion, thisV, klass) ++ ress.flatMap(_.errors)
+        withTrace(trace1)(eval(expansion, thisV, klass)) ++ ress.flatMap(_.errors)
 
       case Thicket(List()) =>
         // possible in try/catch/finally, see tests/crash/i6914.scala

--- a/tests/init/neg/inlined-method.check
+++ b/tests/init/neg/inlined-method.check
@@ -1,0 +1,5 @@
+-- Error: tests/init/neg/inlined-method.scala:8:45 ---------------------------------------------------------------------
+8 |    scala.runtime.Scala3RunTime.assertFailed(message) // error
+  |                                             ^^^^^^^
+  |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
+  | -> Assertion.failAssert(this)	[ inlined-method.scala:2 ]

--- a/tests/init/neg/inlined-method.scala
+++ b/tests/init/neg/inlined-method.scala
@@ -1,0 +1,8 @@
+class InlineError {
+  Assertion.failAssert(this)
+  val v = 2;
+}
+
+object Assertion:
+  transparent inline def failAssert(inline message: => Any): Unit =
+    scala.runtime.Scala3RunTime.assertFailed(message) // error


### PR DESCRIPTION
Closes #14467

- Adds the calling context of the inlined method to the stack trace for safe-init warnings

For source code:
```Scala
class InlineError {
  Assertion.failAssert(this)
  val v = 2;
}

object Assertion:
  transparent inline def failAssert(inline message: => Any): Unit =
    scala.runtime.Scala3RunTime.assertFailed(message)
```

Old warning:
```
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/InlineError.scala:10:45
[error] 10 |    scala.runtime.Scala3RunTime.assertFailed(message)
[error]    |                                             ^^^^^^^
[error]    |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
```

New warning:
```
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/InlineError.scala:10:45
[error] 10 |    scala.runtime.Scala3RunTime.assertFailed(message)
[error]    |                                             ^^^^^^^
[error]    |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
[error]    | -> Assertion.failAssert(this)	[ InlineError.scala:4 ]
```

Review by @liufengyun