### PR TITLE
Fix the Java 8 CI

### DIFF
--- a/tests/disabled/pos/i12956.java
+++ b/tests/disabled/pos/i12956.java
@@ -1,0 +1,5 @@
+// Disable because it requires Java 9+ but our CI still runs on Java 8 and our
+// testing infrastructure doesn't let us run a test only on Java 9+.
+interface Foo {
+  private void bar() {}
+}

--- a/tests/pos/i12956.java
+++ b/tests/pos/i12956.java
@@ -1,3 +1,0 @@
-interface Foo {
-  private void bar() {}
-}


### PR DESCRIPTION
This disables the test added in #14643 which broke the CI because it requires
Java 9+ and unfortunately we don't have a way to selectively run tests on
specific Java versions currently.

[test_java8]