### PR TITLE
Scaladoc: Warn about special characters in filenames according to the default Jekyll rules

### DIFF
--- a/scaladoc-testcases/src/docs/tests/Adoc.scala
+++ b/scaladoc-testcases/src/docs/tests/Adoc.scala
@@ -1,4 +1,4 @@
-package _docs.tests
+package docs.tests
 
 class Adoc:
   def foo = 123

--- a/scaladoc-testcases/src/example/JekyllIncompat.scala
+++ b/scaladoc-testcases/src/example/JekyllIncompat.scala
@@ -1,0 +1,5 @@
+package example
+
+package jekyllIncompat:
+  object #~
+  object ~>~

--- a/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
@@ -229,5 +229,6 @@ object Scaladoc:
     given docContext: DocContext = new DocContext(args, ctx)
     val module = ScalaModuleProvider.mkModule()
     new dotty.tools.scaladoc.renderers.HtmlRenderer(module.rootPackage, module.members).render()
+    docContext.reportPathCompatIssues()
     report.inform("generation completed successfully")
     docContext

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Locations.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Locations.scala
@@ -47,6 +47,7 @@ trait Locations(using ctx: DocContext):
               case "<empty>" :: tail => "_empty_" :: tail
               case other => other
             if ctx.args.apiSubdirectory then "api" :: fqn else fqn
+        ctx.checkPathCompat(path)
         cache.put(dri, path)
         path
       case cached => cached

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Renderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Renderer.scala
@@ -120,7 +120,7 @@ abstract class Renderer(rootPackage: Member, val members: Map[DRI, Member], prot
     val all = navigablePage +: redirectPages
     // We need to check for conflicts only if we have top-level member called docs
     val hasPotentialConflict =
-      rootPackage.members.exists(m => m.name.startsWith("_docs"))
+      rootPackage.members.exists(m => m.name.startsWith("docs"))
 
     if hasPotentialConflict then
       def walk(page: Page): Unit =

--- a/scaladoc/src/dotty/tools/scaladoc/site/StaticSiteContext.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/StaticSiteContext.scala
@@ -23,7 +23,12 @@ class StaticSiteContext(
   val docsPath = root.toPath.resolve("_docs")
   val blogPath = root.toPath.resolve("_blog")
 
-  val relativizeFrom = if args.apiSubdirectory then docsPath else root.toPath
+  def relativize(path: Path): Path = 
+    if args.apiSubdirectory then 
+      docsPath.relativize(path)
+    else
+      val relativised = docsPath.relativize(path)
+      Paths.get("docs").resolve(relativised)
 
   val siteExtensions = Set(".html", ".md")
 
@@ -47,7 +52,7 @@ class StaticSiteContext(
       val redirectFrom = loadedTemplate.templateFile.settings.getOrElse("page", Map.empty).asInstanceOf[Map[String, Object]].get("redirectFrom")
       def redirectToTemplate(redirectFrom: String) =
         val path = if redirectFrom.startsWith("/")
-          then relativizeFrom.resolve(redirectFrom.drop(1))
+          then docsPath.resolve(redirectFrom.drop(1))
           else loadedTemplate.file.toPath.resolveSibling(redirectFrom)
         val driFrom = driFor(path)
         val driTo = driFor(loadedTemplate.file.toPath)
@@ -93,7 +98,7 @@ class StaticSiteContext(
     }
 
   def driFor(dest: Path): DRI =
-    val rawFilePath = relativizeFrom.relativize(dest)
+    val rawFilePath = relativize(dest)
     val pageName = dest.getFileName.toString
     val dotIndex = pageName.lastIndexOf('.')
 

--- a/scaladoc/src/dotty/tools/scaladoc/util/check.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/util/check.scala
@@ -1,0 +1,14 @@
+package dotty.tools.scaladoc.util
+
+object Check:
+  /**  
+   *  Jekyll (also used by GitHub Pages) by default makes a couple characters 
+   *  illegal to use in file name beginnings.
+   */
+  def checkJekyllIncompatPath(path: Seq[String]): Boolean =
+    path.find( filename =>
+      filename.matches("^~.*")
+       || filename.matches("^\\_.*")
+       || filename.matches("^\\..*")
+       || filename.matches("^\\#.*")
+    ).isDefined

--- a/scaladoc/test/dotty/tools/scaladoc/ReportingTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/ReportingTest.scala
@@ -76,11 +76,11 @@ class ReportingTest:
     val docsRoot = testDocPath.resolve("conflicts-pages").toString
     checkReportedDiagnostics(_.copy(
       docsRoot = Some(docsRoot),
-      tastyFiles = tastyFiles("tests", rootPck = "_docs")
+      tastyFiles = tastyFiles("tests", rootPck = "docs")
     )){ diag =>
       assertNoWarning(diag)
       val Seq(msg) = diag.errorMsgs.map(_.toLowerCase)
-      Seq("conflict","api", "static", "page", "_docs/tests/adoc.html")
+      Seq("conflict","api", "static", "page", "docs/tests/adoc.html")
       .foreach( word =>
           Assert.assertTrue(s"Error message: $msg should contains $word", msg.contains(word))
         )

--- a/scaladoc/test/dotty/tools/scaladoc/site/NavigationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/NavigationTest.scala
@@ -44,5 +44,5 @@ class NavigationTest extends BaseHtmlTest:
       )),
     ))
 
-    testNavMenu("_docs/Adoc.html", topLevelNav)
+    testNavMenu("docs/Adoc.html", topLevelNav)
   }

--- a/scaladoc/test/dotty/tools/scaladoc/site/SiteGeneratationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SiteGeneratationTest.scala
@@ -32,13 +32,13 @@ class SiteGeneratationTest extends BaseHtmlTest:
       }
 
   def testDocPages()(using ProjectContext) =
-    checkFile("_docs/Adoc.html")(title = "Adoc", header = "Header in Adoc", parents = Seq(projectName))
-    checkFile("_docs/dir/index.html")(title = "A directory", header = "A directory", parents = Seq(projectName))
-    checkFile("_docs/dir/nested.html")(
+    checkFile("docs/Adoc.html")(title = "Adoc", header = "Header in Adoc", parents = Seq(projectName))
+    checkFile("docs/dir/index.html")(title = "A directory", header = "A directory", parents = Seq(projectName))
+    checkFile("docs/dir/nested.html")(
       title = "Nested in a directory", header = "Nested in a directory", parents = Seq(projectName, "A directory"))
 
   def testDocIndexPage()(using ProjectContext) =
-    checkFile("_docs/index.html")(title = projectName, header = s"$projectName in header")
+    checkFile("docs/index.html")(title = projectName, header = s"$projectName in header")
 
   def testApiPages(
     mainTitle: String = "API",
@@ -66,13 +66,13 @@ class SiteGeneratationTest extends BaseHtmlTest:
     testDocIndexPage()
     testApiPages()
 
-    withHtmlFile("_docs/Adoc.html"){ content  =>
+    withHtmlFile("docs/Adoc.html"){ content  =>
         content.assertAttr("p a","href", "../tests/site/SomeClass.html")
     }
 
     withHtmlFile("tests/site/SomeClass.html"){ content  =>
       content.assertAttr(".breadcrumbs a","href",
-        "../../_docs/index.html", "../../index.html", "../site.html", "SomeClass.html"
+        "../../docs/index.html", "../../index.html", "../site.html", "SomeClass.html"
       )
     }
   }
@@ -98,7 +98,7 @@ class SiteGeneratationTest extends BaseHtmlTest:
   @Test
   def staticLinking() = withGeneratedSite(testDocPath.resolve("static-links")){
 
-    withHtmlFile("_docs/Adoc.html"){ content  =>
+    withHtmlFile("docs/Adoc.html"){ content  =>
         content.assertAttr("p a","href",
         "dir/html.html",
         "dir/name...with..dots..html",


### PR DESCRIPTION
~~This PR adds functionality of escaping special characters in generated filenames. These rules consist of the default Jekyll rules, which do not allow to put some chars in certain places of names of the deployed files - otherwise those file are not being generated. Since GitHub Pages uses Jekyll for deployment, an effect of these rules can be wide (even if the Jekyll itself can have those rules changed). 
Those rules can be found [here](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll).~~
~~They consist of:~~
~~* _ at the beginning of the filenames~~
~~* ~ at the beginning of the filenames (docs above mention the end of the filenames, but neither the original issue nor my tests confirm)~~
~~* \# at the beginning of the filenames~~
~~* . at the beginning of the filenames (doesn’t really matter here, but added for clarity and to future-proof)~~

~~Tests were adjusted to accomodate the changes.
I also tested GitHub Pages manually: [without the PR](https://jchyb.github.io/testcases/example/jekyllEscapes.html), [with the PR](https://jchyb.github.io/testcases-fixed/example/jekyllEscapes.html).~~

Instead of escaping the characters, we collect them and report them in a warning after generating the documentation, hinting about adding a `.nojekyll` file if using GitHub Pages.

Important: will break links (previous _docs will become docs if -Yapi-subdirectory is not used).

Fixes #14612