### PR TITLE
Supress safe initialization warning in Types.scala

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3014,7 +3014,7 @@ object Types {
     private[Types] var opened: Boolean = false
     private[Types] var openedTwice: Boolean = false
 
-    val parent: Type = parentExp(this)
+    val parent: Type = parentExp(this: @unchecked)
 
     private var myRecThis: RecThis | Null = null
 
@@ -3705,8 +3705,8 @@ object Types {
 
     type This = MethodType
 
-    val paramInfos: List[Type] = paramInfosExp(this)
-    val resType: Type = resultTypeExp(this)
+    val paramInfos: List[Type] = paramInfosExp(this: @unchecked)
+    val resType: Type = resultTypeExp(this: @unchecked)
     assert(resType.exists)
 
     def companion: MethodTypeCompanion
@@ -3879,8 +3879,8 @@ object Types {
     type This = HKTypeLambda
     def companion: HKTypeLambda.type = HKTypeLambda
 
-    val paramInfos: List[TypeBounds] = paramInfosExp(this)
-    val resType: Type = resultTypeExp(this)
+    val paramInfos: List[TypeBounds] = paramInfosExp(this: @unchecked)
+    val resType: Type = resultTypeExp(this: @unchecked)
 
     private def setVariances(tparams: List[LambdaParam], vs: List[Variance]): Unit =
       if tparams.nonEmpty then
@@ -3948,8 +3948,8 @@ object Types {
     type This = PolyType
     def companion: PolyType.type = PolyType
 
-    val paramInfos: List[TypeBounds] = paramInfosExp(this)
-    val resType: Type = resultTypeExp(this)
+    val paramInfos: List[TypeBounds] = paramInfosExp(this: @unchecked)
+    val resType: Type = resultTypeExp(this: @unchecked)
 
     assert(resType.isInstanceOf[TermType], this)
     assert(paramNames.nonEmpty)


### PR DESCRIPTION
This change supresses the following 7 safe-init errors that occur in
Types.scala, but are too complicated for the checker to reason about:
```
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/core/Types.scala:3951:53
[error] 3951 |    val paramInfos: List[TypeBounds] = paramInfosExp(this)
[error]      |                                                     ^^^^
[error]      |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/core/Types.scala:3952:38
[error] 3952 |    val resType: Type = resultTypeExp(this)
[error]      |                                      ^^^^
[error]      |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/core/Types.scala:3882:53
[error] 3882 |    val paramInfos: List[TypeBounds] = paramInfosExp(this)
[error]      |                                                     ^^^^
[error]      |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/core/Types.scala:3883:38
[error] 3883 |    val resType: Type = resultTypeExp(this)
[error]      |                                      ^^^^
[error]      |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/core/Types.scala:3708:47
[error] 3708 |    val paramInfos: List[Type] = paramInfosExp(this)
[error]      |                                               ^^^^
[error]      |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
[error]      | -> extends MethodType(paramNames)(paramInfosExp, resultTypeExp)  [ Types.scala:3730 ]
[error]      |  -> abstract case class MethodType(paramNames: List[TermName])(  [ Types.scala:3701 ]
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/core/Types.scala:3709:38
[error] 3709 |    val resType: Type = resultTypeExp(this)
[error]      |                                      ^^^^
[error]      |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments. Calling trace:
[error]      | -> extends MethodType(paramNames)(paramInfosExp, resultTypeExp)  [ Types.scala:3730 ]
[error]      |  -> abstract case class MethodType(paramNames: List[TermName])(  [ Types.scala:3701 ]
[error] -- Error: /*******/dotty/compiler/src/dotty/tools/dotc/core/Types.scala:3017:33
[error] 3017 |    val parent: Type = parentExp(this)
[error]      |                                 ^^^^
[error]      |Cannot prove that the value is fully initialized. Only initialized values may be used as arguments.
```

Due to the `this` pointer being passed to an external method during initialization, the initialization checker cannot prove that these are safe.

Review by @liufengyun