### PR TITLE
Set compiler options when compiling Dotty in benchmarks

### DIFF
--- a/bench/profiles/projects.yml
+++ b/bench/profiles/projects.yml
@@ -26,7 +26,7 @@ charts:
 
 scripts:
     dotty:
-        - measure -with-compiler $(find $PROG_HOME/dotty/compiler/src/dotty -name *.scala -o -name *.java)
+        - measure -feature -deprecation -unchecked -Xfatal-warnings -encoding UTF8 -language:existentials,higherKinds,implicitConversions,postfixOps -Yexplicit-nulls -with-compiler $(find $PROG_HOME/dotty/compiler/src/dotty -name *.scala -o -name *.java)
 
     re2s:
         - measure $(find $PROG_HOME/tests/re2s/src -name *.scala)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -164,6 +164,7 @@ object Build {
     organizationName := "LAMP/EPFL",
     organizationHomepage := Some(url("http://lamp.epfl.ch")),
 
+    // Note: bench/profiles/projects.yml should be updated accordingly.
     scalacOptions ++= Seq(
       "-feature",
       "-deprecation",


### PR DESCRIPTION
The `dotty` benchmark (that measure the time it takes to compile dotty itself) fails since #4533 because of missing language features like:

```
-- Error: /home/bench/bench/dotty/compiler/src/dotty/tools/backend/jvm/BytecodeWriters.scala:103:61 
103 |      val asmpFile = segments.foldLeft(baseDir: Path)(_ / _) changeExtension "asmp" toFile;
      |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |postfix operator `toFile` needs to be enabled
      |by making the implicit value scala.language.postfixOps visible.
      |----
      |This can be achieved by adding the import clause 'import scala.language.postfixOps'
      |or by setting the compiler option -language:postfixOps.
      |See the Scaladoc for value scala.language.postfixOps for a discussion
      |why the feature needs to be explicitly enabled.
```

This is due to the removal of the `import scala.language.{postfixOps, implicitConversions}` imports in #4533. This does not matter when compiling from SBT as ` -language:existentials,higherKinds,implicitConversions,postfixOps` is set in `Build.scala`, but fails when compiling from the benchmarks where these options are not set. This PR fixes it by using the same options for compiling dotty in the benchmark as these set in `Build.scala`.

Setting these options does not significantly impact the running time of the benchmark:

```
# Run progress: 0.00% complete, ETA 00:00:50
# Fork: 1 of 1
# Warmup Iteration   1: 93333.096 ms/op
# Warmup Iteration   2: 51658.465 ms/op
# Warmup Iteration   3: 48529.844 ms/op
# Warmup Iteration   4: 45069.616 ms/op
# Warmup Iteration   5: 44276.632 ms/op
# Warmup Iteration   6: 44249.543 ms/op
# Warmup Iteration   7: 43832.332 ms/op
# Warmup Iteration   8: 45169.822 ms/op
# Warmup Iteration   9: 44017.520 ms/op
# Warmup Iteration  10: 43512.763 ms/op
# Warmup Iteration  11: 44010.859 ms/op
# Warmup Iteration  12: 43260.302 ms/op
# Warmup Iteration  13: 44645.430 ms/op
# Warmup Iteration  14: 43335.751 ms/op
# Warmup Iteration  15: 43365.219 ms/op
# Warmup Iteration  16: 43878.094 ms/op
# Warmup Iteration  17: 43102.525 ms/op
# Warmup Iteration  18: 44902.818 ms/op
# Warmup Iteration  19: 43228.540 ms/op
# Warmup Iteration  20: 43254.206 ms/op
# Warmup Iteration  21: 43861.114 ms/op
```