### PR TITLE
Tolerate some faults when copying trees in InlineTreeMap

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -37,7 +37,8 @@ class TreeTypeMap(
   val oldOwners: List[Symbol] = Nil,
   val newOwners: List[Symbol] = Nil,
   val substFrom: List[Symbol] = Nil,
-  val substTo: List[Symbol] = Nil)(using Context) extends tpd.TreeMap {
+  val substTo: List[Symbol] = Nil,
+  cpy: tpd.TreeCopier = tpd.cpy)(using Context) extends tpd.TreeMap(cpy) {
   import tpd._
 
   def copy(

--- a/tests/neg/i14653.scala
+++ b/tests/neg/i14653.scala
@@ -1,0 +1,18 @@
+type Amount = Amount.Type
+object Amount:
+  opaque type Type = BigDecimal
+  inline def apply(inline dec: BigDecimal): Type = dec
+
+  extension (self: Type)
+    inline def value: BigDecimal = self
+    inline def +(y: Type): Type = self + y
+
+@main def r(): Unit =
+  val aa: Amount = Amount(1)
+  val ab: Amount = Amount(2)
+  val ac: Amount = Amount(2)
+  val as1: Amount = aa + ab  // error
+  val as2: Amount = aa + ab + ac // error
+
+  println(s"aa + ab = ${as1}")
+  println(s"aa + ab = ${as2}")


### PR DESCRIPTION
As a preparatory step the inliner maps the inlined body with a tree type map.
This map adjusts the tree and at the same time sets up the environment for
typing the tree. But this has the potential that re-typing during copying
will fail since the environment is not yet set up correctly. We avoid the
problem by ignoring a specific failure (function type in application does
not exist) and proceeding with the previous type.