### PR TITLE
Remove postfixOps from dotty benchmark options

### DIFF
--- a/bench/profiles/projects.yml
+++ b/bench/profiles/projects.yml
@@ -26,7 +26,7 @@ charts:
 
 scripts:
     dotty:
-        - measure -feature -deprecation -unchecked -Xfatal-warnings -encoding UTF8 -language:existentials,higherKinds,implicitConversions -Yexplicit-nulls -with-compiler $(find $PROG_HOME/dotty/compiler/src/dotty -name *.scala -o -name *.java)
+        - measure -feature -deprecation -unchecked -Xfatal-warnings -encoding UTF8 -language:implicitConversions -Yexplicit-nulls -with-compiler $(find $PROG_HOME/dotty/compiler/src/dotty -name *.scala -o -name *.java)
 
     re2s:
         - measure $(find $PROG_HOME/tests/re2s/src -name *.scala)

--- a/bench/profiles/projects.yml
+++ b/bench/profiles/projects.yml
@@ -26,7 +26,7 @@ charts:
 
 scripts:
     dotty:
-        - measure -feature -deprecation -unchecked -Xfatal-warnings -encoding UTF8 -language:existentials,higherKinds,implicitConversions,postfixOps -Yexplicit-nulls -with-compiler $(find $PROG_HOME/dotty/compiler/src/dotty -name *.scala -o -name *.java)
+        - measure -feature -deprecation -unchecked -Xfatal-warnings -encoding UTF8 -language:existentials,higherKinds,implicitConversions -Yexplicit-nulls -with-compiler $(find $PROG_HOME/dotty/compiler/src/dotty -name *.scala -o -name *.java)
 
     re2s:
         - measure $(find $PROG_HOME/tests/re2s/src -name *.scala)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -171,7 +171,7 @@ object Build {
       "-unchecked",
       "-Xfatal-warnings",
       "-encoding", "UTF8",
-      "-language:existentials,higherKinds,implicitConversions"
+      "-language:implicitConversions"
     ),
 
     (Compile / compile / javacOptions) ++= Seq("-Xlint:unchecked", "-Xlint:deprecation"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -770,6 +770,7 @@ object Build {
       )
     },
 
+    // Note: bench/profiles/projects.yml should be updated accordingly.
     Compile / scalacOptions ++= Seq("-Yexplicit-nulls"),
 
     repl := (Compile / console).value,


### PR DESCRIPTION
The option was removed from build settings in #14677. This PR also removes it from the dotty benchmark options.