### PR TITLE
Add language reference generation to Scaladoc's GH Actions workflow

### DIFF
--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -52,6 +52,9 @@ jobs:
       - name: Generate testcases documentation
         run: ./project/scripts/sbt scaladoc/generateTestcasesDocumentation
 
+      - name: Generate reference documentation
+        run: ./project/scripts/sbt scaladoc/generateReferenceDocumentation
+
       - name: Generate Scala 3 documentation
         run: ./project/scripts/sbt scaladoc/generateScalaDocumentation
 


### PR DESCRIPTION
Needed to show example language reference documentation [here](https://github.com/lampepfl/dotty/pull/14669).

