### PR TITLE
add 3.2 language mode internally, treat it like 3.0, 3.1

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -89,9 +89,9 @@ object Feature:
    *  and return `true`, otherwise return `false`.
    */
   def warnOnMigration(msg: Message, pos: SrcPos,
-      version: SourceVersion = defaultSourceVersion)(using Context): Boolean =
+      version: SourceVersion)(using Context): Boolean =
     if sourceVersion.isMigrating && sourceVersion.stable == version
-       || (version == `3.0` || version == `3.1`) && migrateTo3
+       || (version == `3.0` || version == `3.1` || version == `3.2`) && migrateTo3
     then
       report.migrationWarning(msg, pos)
       true

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -6,7 +6,7 @@ import core.Decorators.*
 import util.Property
 
 enum SourceVersion:
-  case `3.0-migration`, `3.0`, `3.1`, `future-migration`, `future`
+  case `3.0-migration`, `3.0`, `3.1`, `3.2`, `future-migration`, `future`
 
   val isMigrating: Boolean = toString.endsWith("-migration")
 
@@ -16,7 +16,6 @@ enum SourceVersion:
   def isAtLeast(v: SourceVersion) = stable.ordinal >= v.ordinal
 
 object SourceVersion extends Property.Key[SourceVersion]:
-  def defaultSourceVersion = `3.0`
 
   val allSourceVersionNames = values.toList.map(_.toString.toTermName)
 end SourceVersion

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -439,7 +439,7 @@ object Parsers {
         case t: Typed =>
           report.errorOrMigrationWarning(
             em"parentheses are required around the parameter of a lambda${rewriteNotice()}",
-            in.sourcePos())
+            in.sourcePos(), from = `3.0`)
           if migrateTo3 then
             patch(source, t.span.startPos, "(")
             patch(source, t.span.endPos, ")")
@@ -1180,7 +1180,7 @@ object Parsers {
                     |or enclose in braces '{$name} if you want a quoted expression.
                     |For now, you can also `import language.deprecated.symbolLiterals` to accept
                     |the idiom, but this possibility might no longer be available in the future.""",
-                in.sourcePos())
+                in.sourcePos(), from = `3.0`)
               if migrateTo3 then
                 patch(source, Span(in.offset, in.offset + 1), "Symbol(\"")
                 patch(source, Span(in.charOffset - 1), "\")")
@@ -1272,7 +1272,7 @@ object Parsers {
             i"""This opening brace will start a new statement in Scala 3.
                |It needs to be indented to the right to keep being treated as
                |an argument to the previous expression.${rewriteNotice()}""",
-            in.sourcePos())
+            in.sourcePos(), from = `3.0`)
           patch(source, Span(in.offset), "  ")
 
     def possibleTemplateStart(isNew: Boolean = false): Unit =
@@ -1826,7 +1826,7 @@ object Parsers {
       else if in.token == VIEWBOUND then
         report.errorOrMigrationWarning(
           "view bounds `<%' are no longer supported, use a context bound `:' instead",
-          in.sourcePos())
+          in.sourcePos(), from = `3.0`)
         atSpan(in.skipToken()) {
           Function(Ident(pname) :: Nil, toplevelTyp())
         } :: contextBounds(pname)
@@ -1976,7 +1976,7 @@ object Parsers {
         report.errorOrMigrationWarning(
           i"""`do <body> while <cond>` is no longer supported,
              |use `while <body> ; <cond> do ()` instead.${rewriteNotice()}""",
-          in.sourcePos())
+          in.sourcePos(), from = `3.0`)
         val start = in.skipToken()
         atSpan(start) {
           val body = expr()
@@ -2096,7 +2096,7 @@ object Parsers {
             report.errorOrMigrationWarning(
               em"""`_*` can be used only for last argument of method application.
                   |It is no longer allowed in operands of infix operations.""",
-              in.sourcePos(uscoreStart))
+              in.sourcePos(uscoreStart), from = `3.0`)
           else
             syntaxError(SeqWildcardPatternPos(), uscoreStart)
           Typed(t, atSpan(uscoreStart) { Ident(tpnme.WILDCARD_STAR) })
@@ -3347,7 +3347,7 @@ object Parsers {
         if migrateTo3 then
           report.errorOrMigrationWarning(
             s"Procedure syntax no longer supported; `$toInsert` should be inserted here",
-            in.sourcePos())
+            in.sourcePos(), from = `3.0`)
           patch(source, Span(in.lastOffset), toInsert)
           true
         else
@@ -3756,7 +3756,7 @@ object Parsers {
           if (in.token == LBRACE || in.token == COLONEOL) {
             report.errorOrMigrationWarning(
               "`extends` must be followed by at least one parent",
-              in.sourcePos())
+              in.sourcePos(), from = `3.0`)
             Nil
           }
           else constrApps()

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -18,6 +18,7 @@ import scala.collection.immutable.SortedMap
 import rewrites.Rewrites.patch
 import config.Feature
 import config.Feature.migrateTo3
+import config.SourceVersion.`3.0`
 
 object Scanners {
 
@@ -255,7 +256,10 @@ object Scanners {
       def handleMigration(keyword: Token): Token =
         if scala3keywords.contains(keyword) && migrateTo3 then
           val what = tokenString(keyword)
-          report.errorOrMigrationWarning(i"$what is now a keyword, write `$what` instead of $what to keep it as an identifier", sourcePos())
+          report.errorOrMigrationWarning(
+            i"$what is now a keyword, write `$what` instead of $what to keep it as an identifier",
+            sourcePos(),
+            from = `3.0`)
           patch(source, Span(offset), "`")
           patch(source, Span(offset + identifier.length), "`")
           IDENTIFIER
@@ -427,7 +431,7 @@ object Scanners {
             em"""$what starts with an operator;
                 |it is now treated as a continuation of the $previous,
                 |not as a separate statement.""",
-            sourcePos())
+            sourcePos(), from = `3.0`)
         true
       }
 

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -68,7 +68,7 @@ object report:
     if ctx.settings.YdebugTypeError.value then ex.printStackTrace()
 
   def errorOrMigrationWarning(msg: Message, pos: SrcPos = NoSourcePosition,
-      from: SourceVersion = SourceVersion.defaultSourceVersion)(using Context): Unit =
+      from: SourceVersion)(using Context): Unit =
     if sourceVersion.isAtLeast(from) then
       if sourceVersion.isMigrating && sourceVersion.ordinal <= from.ordinal then migrationWarning(msg, pos)
       else error(msg, pos)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -117,7 +117,7 @@ object Checking {
         if tp.isUnreducibleWild then
           report.errorOrMigrationWarning(
             showInferred(UnreducibleApplication(tycon), tp, tpt),
-            tree.srcPos)
+            tree.srcPos, from = `3.0`)
       case _ =>
     }
     def checkValidIfApply(using Context): Unit =
@@ -189,7 +189,8 @@ object Checking {
   def checkRealizable(tp: Type, pos: SrcPos, what: String = "path")(using Context): Unit = {
     val rstatus = realizability(tp)
     if (rstatus ne Realizable)
-      report.errorOrMigrationWarning(em"$tp is not a legal $what\nsince it${rstatus.msg}", pos)
+      report.errorOrMigrationWarning(
+        em"$tp is not a legal $what\nsince it${rstatus.msg}", pos, from = `3.0`)
   }
 
   /** Given a parent `parent` of a class `cls`, if `parent` is a trait check that
@@ -641,7 +642,7 @@ object Checking {
     }
     val notPrivate = new NotPrivate
     val info = notPrivate(sym.info)
-    notPrivate.errors.foreach(error => report.errorOrMigrationWarning(error(), sym.srcPos))
+    notPrivate.errors.foreach(error => report.errorOrMigrationWarning(error(), sym.srcPos, from = `3.0`))
     info
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -385,7 +385,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 if !symsMatch && !suppressErrors then
                   report.errorOrMigrationWarning(
                     AmbiguousReference(name, Definition, Inheritance, prevCtx)(using outer),
-                    pos)
+                    pos, from = `3.0`)
                   if migrateTo3 then
                     patch(Span(pos.span.start),
                       if prevCtx.owner == refctx.owner.enclosingClass then "this."
@@ -2661,7 +2661,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       case closure(_, _, _) =>
       case _ =>
         val recovered = typed(qual)(using ctx.fresh.setExploreTyperState())
-        report.errorOrMigrationWarning(OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen), tree.srcPos)
+        report.errorOrMigrationWarning(OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen), tree.srcPos, from = `3.0`)
         if (migrateTo3) {
           // Under -rewrite, patch `x _` to `(() => x)`
           patch(Span(tree.span.start), "(() => ")
@@ -2813,7 +2813,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                     then ", use `_` to denote a higher-kinded type parameter"
                     else ""
                   val namePos = tree.sourcePos.withSpan(tree.nameSpan)
-                  report.errorOrMigrationWarning(s"`?` is not a valid type name$addendum", namePos)
+                  report.errorOrMigrationWarning(
+                    s"`?` is not a valid type name$addendum", namePos, from = `3.0`)
                 if tree.isClassDef then
                   typedClassDef(tree, sym.asClass)(using ctx.localContext(tree, sym))
                 else
@@ -3596,7 +3597,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       def isAutoApplied(sym: Symbol): Boolean =
         sym.isConstructor
         || sym.matchNullaryLoosely
-        || Feature.warnOnMigration(MissingEmptyArgumentList(sym.show), tree.srcPos)
+        || Feature.warnOnMigration(MissingEmptyArgumentList(sym.show), tree.srcPos, version = `3.0`)
            && { patch(tree.span.endPos, "()"); true }
 
       // Reasons NOT to eta expand:


### PR DESCRIPTION
So far this adds 3.2 as basically a No-op,

it is not available to be set by the user.
Future PR can make it visible to the user, add it to the library, make it default, etc.

this is a precursor to https://github.com/lampepfl/dotty/pull/14629