### PR TITLE
Add Playground to make debugging easier in Metals

### DIFF
--- a/compiler/test/dotty/tools/dotc/Playground.scala
+++ b/compiler/test/dotty/tools/dotc/Playground.scala
@@ -1,0 +1,13 @@
+package dotty.tools.dotc
+
+import dotty.tools.vulpix._
+import org.junit.Test
+import org.junit.Ignore
+
+@Ignore class Playground:
+  import TestConfiguration._
+  import CompilationTests._
+
+  @Test def example: Unit =
+    implicit val testGroup: TestGroup = TestGroup("playground")
+    compileFile("tests/playground/example.scala", defaultOptions).checkCompile()

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -106,7 +106,7 @@ class SettingsTests {
         false
 
     val default = Settings.defaultState
-    assertThrows[IllegalArgumentException](checkMessage("found: not an option of type java.lang.String, required: Boolean")) {
+    dotty.tools.assertThrows[IllegalArgumentException](checkMessage("found: not an option of type java.lang.String, required: Boolean")) {
       Settings.option.updateIn(default, "not an option")
     }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -251,7 +251,7 @@ object Build {
     // Prevent sbt from rewriting our dependencies
     scalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(false))),
 
-    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
+    libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
 
     // If someone puts a source file at the root (e.g., for manual testing),
     // don't pick it up as part of any project.
@@ -1327,7 +1327,7 @@ object Build {
         "org.jsoup" % "jsoup" % "1.14.3", // Needed to process .html files for static site
         Dependencies.`jackson-dataformat-yaml`,
 
-        "com.novocode" % "junit-interface" % "0.11" % "test",
+        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
       ),
       Compile / mainClass := Some("dotty.tools.scaladoc.Main"),
       Compile / buildInfoKeys := Seq[BuildInfoKey](version),

--- a/tests/playground/example.scala
+++ b/tests/playground/example.scala
@@ -1,0 +1,4 @@
+object Test:
+  val foo: Int = 2
+  def bar(x: Int): Int = x + x
+  bar(foo)


### PR DESCRIPTION
1. Bump junit-interface to 0.13.3
This is needed by Metals to have the test explorer working ([source](https://github.com/scalameta/metals/blob/f0addba469ddccf743e4ffb68347597b27f2605e/metals/src/main/scala/scala/meta/internal/troubleshoot/ScalaProblem.scala#L90))

2. Add `Playground` class in `scala3-compiler-test` to make debugging easier
It contains an example test that check the compilation of the `tests/playground/example.scala` file.
The `Playground` class is annotated with `@org.junit.Ignore`: you need to remove it to run the test.

Demo:
![debug](https://user-images.githubusercontent.com/13123162/158412328-d696d68a-c79c-43f6-a51b-ad2b14916729.gif)

