### PR TITLE
Clean up SourceFile creation and error handling

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -104,7 +104,7 @@ object CompilationUnit {
   /** Make a compilation unit for top class `clsd` with the contents of the `unpickled` tree */
   def apply(clsd: ClassDenotation, unpickled: Tree, forceTrees: Boolean)(using Context): CompilationUnit =
     val file = clsd.symbol.associatedFile.nn
-    apply(new SourceFile(file, Array.empty[Char]), unpickled, forceTrees)
+    apply(SourceFile(file, Array.empty[Char]), unpickled, forceTrees)
 
   /** Make a compilation unit, given picked bytes and unpickled tree */
   def apply(source: SourceFile, unpickled: Tree, forceTrees: Boolean)(using Context): CompilationUnit = {

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -307,12 +307,9 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
   def compileFromStrings(scalaSources: List[String], javaSources: List[String] = Nil): Unit = {
     def sourceFile(source: String, isJava: Boolean): SourceFile = {
       val uuid = java.util.UUID.randomUUID().toString
-      val ext = if (isJava) ".java" else ".scala"
-      val virtualFile = new VirtualFile(s"compileFromString-$uuid.$ext")
-      val writer = new BufferedWriter(new OutputStreamWriter(virtualFile.output, StandardCharsets.UTF_8.nn.name)) // buffering is still advised by javadoc
-      writer.write(source)
-      writer.close()
-      new SourceFile(virtualFile, Codec.UTF8)
+      val ext = if (isJava) "java" else "scala"
+      val name = s"compileFromString-$uuid.$ext"
+      SourceFile.virtual(name, source)
     }
     val sources =
       scalaSources.map(sourceFile(_, isJava = false)) ++

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -297,14 +297,8 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
     cleanupTree(tree)
   }
 
-  private def toSource(uri: URI, sourceCode: String): SourceFile = {
-    val path = Paths.get(uri)
-    val virtualFile = new VirtualFile(path.getFileName.toString, path.toString)
-    val writer = new BufferedWriter(new OutputStreamWriter(virtualFile.output, StandardCharsets.UTF_8.name))
-    writer.write(sourceCode)
-    writer.close()
-    new SourceFile(virtualFile, Codec.UTF8)
-  }
+  private def toSource(uri: URI, sourceCode: String): SourceFile =
+    SourceFile.virtual(Paths.get(uri).toString, sourceCode)
 
   /**
    * Initialize this driver and compiler.

--- a/compiler/src/dotty/tools/io/VirtualFile.scala
+++ b/compiler/src/dotty/tools/io/VirtualFile.scala
@@ -28,15 +28,15 @@ class VirtualFile(val name: String, override val path: String) extends AbstractF
   def this(name: String) = this(name, name)
 
   /**
-    * Initializes this instance with the specified name and an
-    * identical path.
+    * Initializes this instance with the specified path
+    * and a name taken from the last path element.
     *
-    * @param name the name of the virtual file to be created
+    * @param path the path of the virtual file to be created
     * @param content the initial contents of the virtual file
     * @return     the created virtual file
     */
-  def this(name: String, content: Array[Byte]) = {
-    this(name)
+  def this(path: String, content: Array[Byte]) = {
+    this(VirtualFile.nameOf(path), path)
     this.content = content
   }
 
@@ -104,3 +104,7 @@ class VirtualFile(val name: String, override val path: String) extends AbstractF
    */
   def lookupNameUnchecked(name: String, directory: Boolean): AbstractFile = unsupported()
 }
+object VirtualFile:
+  private def nameOf(path: String): String =
+    val i = path.lastIndexOf('/')
+    if i >= 0 && i < path.length - 1 then path.substring(i + 1) else path

--- a/compiler/test/dotty/tools/dotc/parsing/ParserTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ParserTest.scala
@@ -21,7 +21,7 @@ class ParserTest extends DottyTest {
     parsedTrees.clear()
   }
 
-  def parse(file: PlainFile): Tree = parseSource(new SourceFile(file, Codec.UTF8))
+  def parse(file: PlainFile): Tree = parseSource(SourceFile(file, Codec.UTF8))
 
   private def parseSource(source: SourceFile): Tree = {
     //println("***** parsing " + source.file)

--- a/compiler/test/dotty/tools/dotc/parsing/ScannerTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ScannerTest.scala
@@ -19,7 +19,7 @@ class ScannerTest extends DottyTest {
 
   def scan(file: PlainFile): Unit = {
     //println("***** scanning " + file)
-    val source = new SourceFile(file, Codec.UTF8)
+    val source = SourceFile(file, Codec.UTF8)
     val scanner = new Scanner(source)
     var i = 0
     while (scanner.token != EOF) {

--- a/language-server/test/dotty/tools/languageserver/util/CodeRange.scala
+++ b/language-server/test/dotty/tools/languageserver/util/CodeRange.scala
@@ -3,7 +3,7 @@ package dotty.tools.languageserver.util
 import dotty.tools.languageserver.util.embedded.{CodeInRange, CodeMarker}
 import dotty.tools.languageserver.util.server.TestFile
 
-import org.eclipse.lsp4j._
+import org.eclipse.lsp4j.{Location, Range, SymbolKind}
 
 import PositionContext._
 

--- a/scaladoc/src/dotty/tools/scaladoc/DocContext.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/DocContext.scala
@@ -40,8 +40,7 @@ def throwableToString(t: Throwable)(using CompilerContext): String =
 
 private def sourcePostionFor(f: File)(using CompilerContext) =
     val relPath = relativePath(f.toPath)
-    val virtualFile = new VirtualFile(relPath.toString, relPath.toString)
-    val sourceFile = new SourceFile(virtualFile, Codec.UTF8)
+    val sourceFile = SourceFile.virtual(relPath.toString, content = "")
     SourcePosition(sourceFile, Spans.NoSpan)
 
 // TODO (https://github.com/lampepfl/scala3doc/issues/238): provide proper error handling


### PR DESCRIPTION
Allow REPL to start in presence of a file named "library".

Clean up some API for `SourceFile`, which unfortunately is not shared code with Scala 2.

This doesn't address what REPL does differently from scalac. Confirmed that it's not the context class loader.

Also need to concoct a test for the REPL behavior, depending on what that is.

Fixes #14664 