### PR TITLE
Harden REPL in presence of values that fail to initialize

### DIFF
--- a/compiler/src/dotty/tools/repl/ReplCompiler.scala
+++ b/compiler/src/dotty/tools/repl/ReplCompiler.scala
@@ -61,7 +61,7 @@ class ReplCompiler extends Compiler {
         val rootCtx = super.rootContext.fresh
           .setOwner(defn.EmptyPackageClass)
           .withRootImports
-        (1 to state.objectIndex).foldLeft(rootCtx)((ctx, id) =>
+        (state.validObjectIndexes).foldLeft(rootCtx)((ctx, id) =>
           importPreviousRun(id)(using ctx))
       }
     }

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -243,6 +243,97 @@ class ReplCompilerTests extends ReplTest:
     assertEquals(List("// defined class C"), lines())
   }
 
+  def assertNotFoundError(id: String): Unit =
+    val lines = storedOutput().linesIterator
+    assert(lines.next().startsWith("-- [E006] Not Found Error:"))
+    assert(lines.drop(2).next().trim().endsWith(s"Not found: $id"))
+
+  @Test def i4416 = initially {
+    val state = run("val x = 1 / 0")
+    val all = lines()
+    assertEquals(2, all.length)
+    assert(all.head.startsWith("java.lang.ArithmeticException:"))
+    state
+  } andThen {
+    val state = run("def foo = x")
+    assertNotFoundError("x")
+    state
+  } andThen {
+    run("x")
+    assertNotFoundError("x")
+  }
+
+  @Test def i4416b = initially {
+    val state = run("val a = 1234")
+    val _ = storedOutput() // discard output
+    state
+  } andThen {
+    val state = run("val a = 1; val x = ???; val y = x")
+    val all = lines()
+    assertEquals(3, all.length)
+    assertEquals("scala.NotImplementedError: an implementation is missing", all.head)
+    state
+  } andThen {
+    val state = run("x")
+    assertNotFoundError("x")
+    state
+  } andThen {
+    val state = run("y")
+    assertNotFoundError("y")
+    state
+  } andThen {
+    run("a")   // `a` should retain its original binding
+    assertEquals("val res0: Int = 1234", storedOutput().trim)
+  }
+
+  @Test def i4416_imports = initially {
+    run("import scala.collection.mutable")
+  } andThen {
+    val state = run("import scala.util.Try; val x = ???")
+    val _ = storedOutput() // discard output
+    state
+  } andThen {
+    run(":imports")  // scala.util.Try should not be imported
+    assertEquals("import scala.collection.mutable", storedOutput().trim)
+  }
+
+  @Test def i4416_types_defs_aliases = initially {
+    val state =
+      run("""|type Foo = String
+             |trait Bar
+             |def bar: Bar = ???
+             |val x = ???
+             |""".stripMargin)
+    val all = lines()
+    assertEquals(3, all.length)
+    assertEquals("scala.NotImplementedError: an implementation is missing", all.head)
+    assert("type alias in failed wrapper should not be rendered",
+      !all.exists(_.startsWith("// defined alias type Foo = String")))
+    assert("type definitions in failed wrapper should not be rendered",
+      !all.exists(_.startsWith("// defined trait Bar")))
+    assert("defs in failed wrapper should not be rendered",
+      !all.exists(_.startsWith("def bar: Bar")))
+    state
+  } andThen {
+    val state = run("def foo: Foo = ???")
+    assertNotFoundError("type Foo")
+    state
+  } andThen {
+    val state = run("type B = Bar")
+    assertNotFoundError("type Bar")
+    state
+  } andThen {
+    run("bar")
+    assertNotFoundError("bar")
+  }
+
+  @Test def i14473 = initially {
+    run("""val (x,y) = if true then "hi" else (42,17)""")
+    val all = lines()
+    assertEquals(2, all.length)
+    assertEquals("scala.MatchError: hi (of class java.lang.String)", all.head)
+  }
+
   @Test def i14491 =
     initially {
       run("import language.experimental.fewerBraces")

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -334,6 +334,19 @@ class ReplCompilerTests extends ReplTest:
     assertEquals("scala.MatchError: hi (of class java.lang.String)", all.head)
   }
 
+  @Test def i14701 = initially {
+    val state = run("val _ = ???")
+    val all = lines()
+    assertEquals(3, all.length)
+    assertEquals("scala.NotImplementedError: an implementation is missing", all.head)
+    state
+  } andThen {
+    run("val _ = assert(false)")
+    val all = lines()
+    assertEquals(3, all.length)
+    assertEquals("java.lang.AssertionError: assertion failed", all.head)
+  }
+
   @Test def i14491 =
     initially {
       run("import language.experimental.fewerBraces")


### PR DESCRIPTION
The right hand side of value definitions in the REPL are computed in the static
initializer for the wrapper object created for that input line (e.g. rs$line$1).
If any of these definitions throws an exception, the wrapper class will fail to
initialize, and further attempts to use the class will throw NoClassDefFoundError.

In this PR, we avoid all reflective access on a wrapper class once we notice
that it failed to initialize, and mark that wrapper object as invalid in the REPL
state. We discard all input from the failed wrapper (which may have been multi-line
containing many statements and definitions); any types, terms, aliases, or imports
defined there will not override any existing with the same name, and will not be
accessible in subsequent runs.

We also avoid crashing the REPL when the input is of the form `val _ = ???`,
where the RHS throws any subclass of java.lang.Error that is non-fatal.

Fixes #4416
Fixes #14473
Fixes #14701
