### PR TITLE
Remove false unchecked warnings on refined types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1764,11 +1764,11 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     case _ => false
 
   /** Does type `tp1` have a member with name `name` whose normalized type is a subtype of
-   *  the normalized type of the refinement `tp2`?
+   *  the normalized type of the refinement of `tp2`?
    *  Normalization is as follows: If `tp2` contains a skolem to its refinement type,
    *  rebase both itself and the member info of `tp` on a freshly created skolem type.
    */
-  protected def hasMatchingMember(name: Name, tp1: Type, tp2: RefinedType): Boolean =
+  def hasMatchingMember(name: Name, tp1: Type, tp2: RefinedType): Boolean =
     trace(i"hasMatchingMember($tp1 . $name :? ${tp2.refinedInfo}), mbr: ${tp1.member(name).info}", subtyping) {
 
       def qualifies(m: SingleDenotation): Boolean =
@@ -2749,6 +2749,9 @@ object TypeComparer {
 
   def matchesType(tp1: Type, tp2: Type, relaxed: Boolean)(using Context): Boolean =
     comparing(_.matchesType(tp1, tp2, relaxed))
+
+  def hasMatchingMember(name: Name, tp1: Type, tp2: RefinedType)(using Context): Boolean =
+    comparing(_.hasMatchingMember(name, tp1, tp2))
 
   def matchingMethodParams(tp1: MethodType, tp2: MethodType)(using Context): Boolean =
     comparing(_.matchingMethodParams(tp1, tp2))

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -150,7 +150,7 @@ object TypeTestsCasts {
       case AndType(tp1, tp2)    => recur(X, tp1) && recur(X, tp2)
       case OrType(tp1, tp2)     => recur(X, tp1) && recur(X, tp2)
       case AnnotatedType(t, _)  => recur(X, t)
-      case _: RefinedType       => false
+      case tp2: RefinedType     => recur(X, tp2.parent) && TypeComparer.hasMatchingMember(tp2.refinedName, X, tp2)
       case _                    => true
     })
 

--- a/tests/neg-custom-args/isInstanceOf/refined-types.scala
+++ b/tests/neg-custom-args/isInstanceOf/refined-types.scala
@@ -1,0 +1,22 @@
+class A
+class B extends A
+type AA = A { type T = Int }
+type BA = B { type T = Int }
+type AL = A { type T >: Int }
+type BL = B { type T >: Int }
+type AU = A { type T <: Int }
+type BU = B { type T <: Int }
+
+def aa(x: AA) = x.isInstanceOf[BA] // was: the type test for BA cannot be checked at runtime
+def al(x: AL) = x.isInstanceOf[BL] // was: the type test for BL cannot be checked at runtime
+def au(x: AU) = x.isInstanceOf[BU] // was: the type test for BU cannot be checked at runtime
+
+// an alias leaves nothing unchecked when type testing against one bound:
+def bl(x: AA) = x.isInstanceOf[BL] // was: the type test for BL cannot be checked at runtime
+def bu(x: AA) = x.isInstanceOf[BU] // was: the type test for BU cannot be checked at runtime
+
+// but static knowledge of only one bound makes checking against an alias unchecked:
+def al_ba(x: AL) = x.isInstanceOf[BA] // error: the type test for BA cannot be checked at runtime
+def au_ba(x: AU) = x.isInstanceOf[BA] // error: the type test for BA cannot be checked at runtime
+def al_bu(x: AL) = x.isInstanceOf[BU] // error: the type test for BU cannot be checked at runtime
+def au_bl(x: AU) = x.isInstanceOf[BL] // error: the type test for BL cannot be checked at runtime


### PR DESCRIPTION
Motivation: Driven by the warnings that came out of studying a fix for #11834 (which we might resolve by making the situation impossible), I have a refactor of our typed/untyped trees which uses type members instead of type parameters (i.e. refined types instead of applied types).  But doing a type test, via isInstanceOf or via pattern matching syntax, on a refined type (also) can produce spurious, i.e false positive, unchecked warnings.  So with this fix I get rid of the fatal warnings in boostrapping the compiler with my Trees refactor.