### PR TITLE
Upgrade to ASM 9.2

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
@@ -52,6 +52,7 @@ trait BCodeIdiomatic {
     case "15" => asm.Opcodes.V15
     case "16" => asm.Opcodes.V16
     case "17" => asm.Opcodes.V17
+    case "18" => asm.Opcodes.V18
   }
 
   lazy val majorVersion: Int = (classfileVersion & 0xFF)

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -16,7 +16,7 @@ class ScalaSettings extends SettingGroup with AllScalaSettings
 object ScalaSettings:
   // Keep synchronized with `classfileVersion` in `BCodeIdiomatic`
   private val minTargetVersion = 8
-  private val maxTargetVersion = 17
+  private val maxTargetVersion = 18
 
   def supportedTargetVersions: List[String] =
     (minTargetVersion to maxTargetVersion).toList.map(_.toString)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -519,7 +519,7 @@ object Build {
 
       // get libraries onboard
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" % "scala-asm" % "9.1.0-scala-1", // used by the backend
+        "org.scala-lang.modules" % "scala-asm" % "9.2.0-scala-1", // used by the backend
         Dependencies.oldCompilerInterface, // we stick to the old version to avoid deprecation warnings
         "org.jline" % "jline-reader" % "3.19.0",   // used by the REPL
         "org.jline" % "jline-terminal" % "3.19.0",


### PR DESCRIPTION
Scala 2 PR: https://github.com/scala/scala/pull/9702

JDK 18 GA is [scheduled for release](https://openjdk.java.net/projects/jdk/18/#Schedule) a few days from now (on the 22nd)