### PR TITLE
Fix hoisting local symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -94,20 +94,7 @@ object LambdaLift:
     private def liftLocals()(using Context): Unit = {
       for ((local, lOwner) <- deps.logicalOwner) {
         val (newOwner, maybeStatic) =
-          if (lOwner is Package) {
-            val encClass = local.enclosingClass
-            val topClass = local.topLevelClass
-            val preferEncClass =
-              encClass.isStatic &&
-                // non-static classes can capture owners, so should be avoided
-              (encClass.isProperlyContainedIn(topClass) ||
-                // can be false for symbols which are defined in some weird combination of supercalls.
-               encClass.is(ModuleClass, butNot = Package)
-                // needed to not cause deadlocks in classloader. see t5375.scala
-              )
-            if (preferEncClass) (encClass, EmptyFlags)
-            else (topClass, JavaStatic)
-          }
+          if lOwner is Package then (local.topLevelClass, JavaStatic)
           else (lOwner, EmptyFlags)
         // Drop Module because class is no longer a singleton in the lifted context.
         var initFlags = local.flags &~ Module | Private | Lifted | maybeStatic

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -418,12 +418,16 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
         }
     }
 
-    if (tree.source != ctx.source && tree.source.exists)
-      transformTree(tree, start)(using ctx.withSource(tree.source))
-    else if (tree.isInstanceOf[NameTree])
-      transformNamed(tree, start, ctx)
-    else
-      transformUnnamed(tree, start, ctx)
+    // try
+      if (tree.source != ctx.source && tree.source.exists)
+        transformTree(tree, start)(using ctx.withSource(tree.source))
+      else if (tree.isInstanceOf[NameTree])
+        transformNamed(tree, start, ctx)
+      else
+        transformUnnamed(tree, start, ctx)
+    // catch case ex: AssertionError =>
+    //  println(i"error while transforming $tree")
+    //  throw ex
   }
 
   def transformSpecificTree[T <: Tree](tree: T, start: Int)(using Context): T =

--- a/tests/pos/i14707.scala
+++ b/tests/pos/i14707.scala
@@ -1,0 +1,17 @@
+object M {
+  class A {{
+    def f(v: => Int): Int = 0
+    def g: Int = 0
+    new { f(g) }
+  }}
+}
+
+object M2 {
+  abstract class A {
+    def local = {
+      def f(v: () => Int): Int = 0
+      def g(): Int = 0
+      new AnyRef { def h = f(() => g()) }
+    }
+  }
+}


### PR DESCRIPTION
The previous algorithm computed a "logical owner" of term-owned symbols
from dependencies. But it would switch back from the computed logical
owner to the enclosing class under certain conditions. The problem is
that such a decision cannot be done independently for each symbol, since
it also affects dependent symbols. We now move this distinction into
the logical owner initialization itself, instead of doing it as a
post processing step.

Fixes #14707