### PR TITLE
refactor: align "given instance" language instead of implicit

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -306,15 +306,13 @@ class ImplicitSearchError(
 
   private def location(preposition: String) = if (where.isEmpty) "" else s" $preposition $where"
 
-  private def defaultAmbiguousImplicitMsg(ambi: AmbiguousImplicits) = {
-    formatMsg(s"ambiguous implicit arguments: ${ambi.explanation}${location("of")}")(
-      s"ambiguous implicit arguments of type ${pt.show} found${location("for")}"
+  private def defaultAmbiguousImplicitMsg(ambi: AmbiguousImplicits) =
+    formatMsg(s"ambiguous given instances: ${ambi.explanation}${location("of")}")(
+      s"ambiguous given instances of type ${pt.show} found${location("for")}"
     )
-  }
 
-  private def defaultImplicitNotFoundMessage = {
-    ex"no implicit argument of type $pt was found${location("for")}"
-  }
+  private def defaultImplicitNotFoundMessage =
+    ex"no given instance of type $pt was found${location("for")}"
 
   /** Construct a custom error message given an ambiguous implicit
    *  candidate `alt` and a user defined message `raw`.

--- a/tests/neg-custom-args/i13838.check
+++ b/tests/neg-custom-args/i13838.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg-custom-args/i13838.scala:10:5 ----------------------------------------------------------------------
 10 |  foo  // error
    |     ^
-   |no implicit argument of type Order[X] was found for parameter x$1 of method foo in object FooT
+   |no given instance of type Order[X] was found for parameter x$1 of method foo in object FooT
    |
    |where:    X is a type variable
    |.

--- a/tests/neg-macros/i6436.check
+++ b/tests/neg-macros/i6436.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg-macros/i6436.scala:5:9 -----------------------------------------------------------------------------
 5 |    case '{ StringContext(${Varargs(parts)}*) } => // error
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |         no implicit argument of type scala.quoted.Quotes was found
+  |         no given instance of type scala.quoted.Quotes was found
 -- [E006] Not Found Error: tests/neg-macros/i6436.scala:6:34 -----------------------------------------------------------
 6 |      val ps: Seq[Expr[String]] = parts // error
   |                                  ^^^^^

--- a/tests/neg-macros/i9014b.check
+++ b/tests/neg-macros/i9014b.check
@@ -2,9 +2,9 @@
 -- Error: tests/neg-macros/i9014b/Test_2.scala:1:23 --------------------------------------------------------------------
 1 |val tests = summon[Bar] // error
   |                       ^
-  |                     no implicit argument of type Bar was found for parameter x of method summon in object Predef.
-  |                     I found:
+  |                       no given instance of type Bar was found for parameter x of method summon in object Predef.
+  |                       I found:
   |
-  |                         given_Bar
+  |                           given_Bar
   |
-  |                     But given instance given_Bar does not match type Bar.
+  |                       But given instance given_Bar does not match type Bar.

--- a/tests/neg-scalajs/jsconstructortag-error-in-typer.check
+++ b/tests/neg-scalajs/jsconstructortag-error-in-typer.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-typer.scala:9:39 -------------------------------------------------
 9 |  val a = js.constructorTag[ScalaClass] // error
   |                                       ^
-  |no implicit argument of type scala.scalajs.js.ConstructorTag[ScalaClass] was found for parameter tag of method constructorTag in package scala.scalajs.js.
+  |no given instance of type scala.scalajs.js.ConstructorTag[ScalaClass] was found for parameter tag of method constructorTag in package scala.scalajs.js.
   |I found:
   |
   |    scala.scalajs.js.ConstructorTag.materialize[T]
@@ -10,7 +10,7 @@
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-typer.scala:10:39 ------------------------------------------------
 10 |  val b = js.constructorTag[ScalaTrait] // error
    |                                       ^
-   |no implicit argument of type scala.scalajs.js.ConstructorTag[ScalaTrait] was found for parameter tag of method constructorTag in package scala.scalajs.js.
+   |no given instance of type scala.scalajs.js.ConstructorTag[ScalaTrait] was found for parameter tag of method constructorTag in package scala.scalajs.js.
    |I found:
    |
    |    scala.scalajs.js.ConstructorTag.materialize[T]
@@ -19,7 +19,7 @@
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-typer.scala:11:45 ------------------------------------------------
 11 |  val c = js.constructorTag[ScalaObject.type] // error
    |                                             ^
-   |no implicit argument of type scala.scalajs.js.ConstructorTag[ScalaObject.type] was found for parameter tag of method constructorTag in package scala.scalajs.js.
+   |no given instance of type scala.scalajs.js.ConstructorTag[ScalaObject.type] was found for parameter tag of method constructorTag in package scala.scalajs.js.
    |I found:
    |
    |    scala.scalajs.js.ConstructorTag.materialize[T]

--- a/tests/neg/i10603a.check
+++ b/tests/neg/i10603a.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i10603a.scala:2:35 ---------------------------------------------------------------------------------
 2 |  val x = implicitly[List[Boolean]] // error
   |                                   ^
-  |        no implicit argument of type List[Boolean] was found for parameter e of method implicitly in object Predef
+  |           no given instance of type List[Boolean] was found for parameter e of method implicitly in object Predef

--- a/tests/neg/i10901.check
+++ b/tests/neg/i10901.check
@@ -38,4 +38,4 @@
    |
    |              Test.foo("abc")(/* missing */summon[C])    failed with
    |
-   |                  no implicit argument of type C was found for parameter x$2 of method foo in object Test
+   |                  no given instance of type C was found for parameter x$2 of method foo in object Test

--- a/tests/neg/i11066.check
+++ b/tests/neg/i11066.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i11066.scala:15:37 ---------------------------------------------------------------------------------
 15 |val x = Greeter.greet("Who's there?") // error
    |                                     ^
-   |ambiguous implicit arguments: both given instance joesPrompt in object JoesPrefs and given instance jillsPrompt in object JillsPrefs match type PreferredPrompt of parameter prompt of method greet in object Greeter
+   |ambiguous given instances: both given instance joesPrompt in object JoesPrefs and given instance jillsPrompt in object JillsPrefs match type PreferredPrompt of parameter prompt of method greet in object Greeter

--- a/tests/neg/i11897.check
+++ b/tests/neg/i11897.check
@@ -26,20 +26,20 @@
 -- Error: tests/neg/i11897.scala:16:18 ---------------------------------------------------------------------------------
 16 |  assert(summon[A] == A(23)) // error
    |                  ^
-   |                  no implicit argument of type A was found for parameter x of method summon in object Predef
+   |                  no given instance of type A was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i11897.scala:17:18 ---------------------------------------------------------------------------------
 17 |  assert(summon[B] == B(false)) // error
    |                  ^
-   |                  no implicit argument of type B was found for parameter x of method summon in object Predef
+   |                  no given instance of type B was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i11897.scala:18:18 ---------------------------------------------------------------------------------
 18 |  assert(summon[C] == C("c")) // error
    |                  ^
-   |                  no implicit argument of type C was found for parameter x of method summon in object Predef
+   |                  no given instance of type C was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i11897.scala:19:18 ---------------------------------------------------------------------------------
 19 |  assert(summon[E] == E(93)) // error
    |                  ^
-   |                  no implicit argument of type E was found for parameter x of method summon in object Predef
+   |                  no given instance of type E was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i11897.scala:20:18 ---------------------------------------------------------------------------------
 20 |  assert(summon[G] == G(101)) // error
    |                  ^
-   |                  no implicit argument of type G was found for parameter x of method summon in object Predef
+   |                  no given instance of type G was found for parameter x of method summon in object Predef

--- a/tests/neg/i12049.check
+++ b/tests/neg/i12049.check
@@ -34,17 +34,17 @@
 -- Error: tests/neg/i12049.scala:24:20 ---------------------------------------------------------------------------------
 24 |val _ = summon[M[B]]  // error
    |                    ^
-   |                   no implicit argument of type M[B] was found for parameter x of method summon in object Predef
+   |                    no given instance of type M[B] was found for parameter x of method summon in object Predef
    |
-   |                   Note: a match type could not be fully reduced:
+   |                    Note: a match type could not be fully reduced:
    |
-   |                     trying to reduce  M[B]
-   |                     failed since selector  B
-   |                     does not match  case A => Int
-   |                     and cannot be shown to be disjoint from it either.
-   |                     Therefore, reduction cannot advance to the remaining case
+   |                      trying to reduce  M[B]
+   |                      failed since selector  B
+   |                      does not match  case A => Int
+   |                      and cannot be shown to be disjoint from it either.
+   |                      Therefore, reduction cannot advance to the remaining case
    |
-   |                       case B => String
+   |                        case B => String
 -- Error: tests/neg/i12049.scala:25:26 ---------------------------------------------------------------------------------
 25 |val _ = summon[String =:= Last[Int *: Int *: Boolean *: String *: EmptyTuple]] // error
    |                          ^

--- a/tests/neg/i12232.check
+++ b/tests/neg/i12232.check
@@ -1,12 +1,12 @@
 -- Error: tests/neg/i12232.scala:17:15 ---------------------------------------------------------------------------------
 17 |  foo(min(3, 4)) // error: works in Scala 2, not in 3
    |               ^
-   |             no implicit argument of type Op[Int, Int, V] was found for parameter op of method min in object Foo
+   |               no given instance of type Op[Int, Int, V] was found for parameter op of method min in object Foo
    |
-   |             where:    V is a type variable with constraint <: Double
+   |               where:    V is a type variable with constraint <: Double
 -- Error: tests/neg/i12232.scala:19:16 ---------------------------------------------------------------------------------
 19 |  foo(minR(3, 4)) // error: works in Scala 2, not in 3
    |                ^
-   |            no implicit argument of type Op[Int, Int, R] was found for parameter op of method minR in object Foo
+   |               no given instance of type Op[Int, Int, R] was found for parameter op of method minR in object Foo
    |
-   |            where:    R is a type variable with constraint <: Double
+   |               where:    R is a type variable with constraint <: Double

--- a/tests/neg/i12591.check
+++ b/tests/neg/i12591.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i12591/Inner.scala:12:31 ---------------------------------------------------------------------------
 12 |val badSummon = summon[TC[Bar]] // error here
    |                               ^
-   |ambiguous implicit arguments: both outer.inner.Foo.ofFoo and outer.Foo.ofFoo match type outer.inner.Foo.TC[outer.Bar] of parameter x of method summon in object Predef
+   |ambiguous given instances: both outer.inner.Foo.ofFoo and outer.Foo.ofFoo match type outer.inner.Foo.TC[outer.Bar] of parameter x of method summon in object Predef

--- a/tests/neg/i13991.check
+++ b/tests/neg/i13991.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/i13991.scala:5:7 -----------------------------------------------------------------------------------
  5 |  first[String] // error // before line 10 to test alignment of the error message `|`
    |  ^^^^^^^^^^^^^
-   |  no implicit argument of type Foo[String] was found
+   |  no given instance of type Foo[String] was found
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/neg/i5498-postfixOps.check
+++ b/tests/neg/i5498-postfixOps.check
@@ -13,4 +13,4 @@
 -- Error: tests/neg/i5498-postfixOps.scala:6:0 -------------------------------------------------------------------------
 6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error
   |^
-  |no implicit argument of type scala.concurrent.duration.DurationConversions.Classifier[Null] was found for parameter ev of method second in trait DurationConversions
+  |no given instance of type scala.concurrent.duration.DurationConversions.Classifier[Null] was found for parameter ev of method second in trait DurationConversions

--- a/tests/neg/i7613.check
+++ b/tests/neg/i7613.check
@@ -1,8 +1,8 @@
 -- Error: tests/neg/i7613.scala:10:16 ----------------------------------------------------------------------------------
 10 |  new BazLaws[A] {}  // error // error
    |                ^
-   |         no implicit argument of type Baz[A] was found for parameter x$1 of constructor BazLaws in trait BazLaws
+   |            no given instance of type Baz[A] was found for parameter x$1 of constructor BazLaws in trait BazLaws
 -- Error: tests/neg/i7613.scala:10:2 -----------------------------------------------------------------------------------
 10 |  new BazLaws[A] {}  // error // error
    |  ^
-   |  no implicit argument of type Bar[A] was found for parameter x$1 of constructor BarLaws in trait BarLaws
+   |  no given instance of type Bar[A] was found for parameter x$1 of constructor BarLaws in trait BarLaws

--- a/tests/neg/i9185.check
+++ b/tests/neg/i9185.check
@@ -8,11 +8,11 @@
   |      /* ambiguous: both object listMonad in object M and object optionMonad in object M match type M[F] */summon[M[F]]
   |    )    failed with
   |
-  |        ambiguous implicit arguments: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
+  |        ambiguous given instances: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
 -- Error: tests/neg/i9185.scala:8:28 -----------------------------------------------------------------------------------
 8 |  val value3 = M.pure("ola") // error
   |                            ^
-  |ambiguous implicit arguments: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
+  |ambiguous given instances: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
 -- [E008] Not Found Error: tests/neg/i9185.scala:11:16 -----------------------------------------------------------------
 11 |  val l = "abc".len  // error
    |          ^^^^^^^^^

--- a/tests/neg/i9568.check
+++ b/tests/neg/i9568.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/i9568.scala:13:10 ----------------------------------------------------------------------------------
 13 |  blaMonad.foo(bla) // error: diverges
    |          ^
-   |          no implicit argument of type => Monad[F] was found for parameter ev of method blaMonad in object Test
+   |          no given instance of type => Monad[F] was found for parameter ev of method blaMonad in object Test
    |
    |          where:    F is a type variable with constraint <: [_] =>> Any
    |          .

--- a/tests/neg/i9958.check
+++ b/tests/neg/i9958.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/i9958.scala:1:30 -----------------------------------------------------------------------------------
 1 |val x = summon[[X] =>> (X, X)] // error
   |                              ^
-  |           no implicit argument of type [X] =>> (X, X) was found for parameter x of method summon in object Predef
+  |              no given instance of type [X] =>> (X, X) was found for parameter x of method summon in object Predef
 -- [E007] Type Mismatch Error: tests/neg/i9958.scala:8:10 --------------------------------------------------------------
 8 |def b = f(a) // error
   |          ^

--- a/tests/neg/implicitSearch.check
+++ b/tests/neg/implicitSearch.check
@@ -1,13 +1,13 @@
 -- Error: tests/neg/implicitSearch.scala:13:12 -------------------------------------------------------------------------
 13 |    sort(xs)  // error (with a partially constructed implicit argument shown)
    |            ^
-   |   no implicit argument of type Test.Ord[List[List[T]]] was found for parameter o of method sort in object Test.
-   |   I found:
+   |      no given instance of type Test.Ord[List[List[T]]] was found for parameter o of method sort in object Test.
+   |      I found:
    |
-   |       Test.listOrd[List[T]](Test.listOrd[T](/* missing */summon[Test.Ord[T]]))
+   |          Test.listOrd[List[T]](Test.listOrd[T](/* missing */summon[Test.Ord[T]]))
    |
-   |   But no implicit values were found that match type Test.Ord[T].
+   |      But no implicit values were found that match type Test.Ord[T].
 -- Error: tests/neg/implicitSearch.scala:15:38 -------------------------------------------------------------------------
 15 |    listOrd(listOrd(implicitly[Ord[T]] /*not found*/)) // error
    |                                      ^
-   |        no implicit argument of type Test.Ord[T] was found for parameter e of method implicitly in object Predef
+   |           no given instance of type Test.Ord[T] was found for parameter e of method implicitly in object Predef

--- a/tests/neg/missing-implicit1.check
+++ b/tests/neg/missing-implicit1.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/missing-implicit1.scala:17:4 -----------------------------------------------------------------------
 17 |  ff // error
    |    ^
-   |no implicit argument of type testObjectInstance.Zip[Option] was found for parameter xs of method ff in object testObjectInstance
+   |no given instance of type testObjectInstance.Zip[Option] was found for parameter xs of method ff in object testObjectInstance
    |
    |The following import might fix the problem:
    |
@@ -19,7 +19,7 @@
 -- Error: tests/neg/missing-implicit1.scala:23:42 ----------------------------------------------------------------------
 23 |    List(1, 2, 3).traverse(x => Option(x)) // error
    |                                          ^
-   |no implicit argument of type testObjectInstance.Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
+   |no given instance of type testObjectInstance.Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
    |
    |The following import might fix the problem:
    |

--- a/tests/neg/missing-implicit2.check
+++ b/tests/neg/missing-implicit2.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/missing-implicit2.scala:10:18 ----------------------------------------------------------------------
 10 |    f(using xFromY) // error
    |                  ^
-   |                  no implicit argument of type Y was found for parameter y of given instance xFromY
+   |                  no given instance of type Y was found for parameter y of given instance xFromY
    |
    |                  The following import might fix the problem:
    |
@@ -10,7 +10,7 @@
 -- Error: tests/neg/missing-implicit2.scala:16:5 -----------------------------------------------------------------------
 16 |    f // error
    |     ^
-   |     no implicit argument of type X was found for parameter x of method f in object test
+   |     no given instance of type X was found for parameter x of method f in object test
    |
    |     The following import might make progress towards fixing the problem:
    |

--- a/tests/neg/missing-implicit3.check
+++ b/tests/neg/missing-implicit3.check
@@ -1,9 +1,9 @@
 -- Error: tests/neg/missing-implicit3.scala:13:36 ----------------------------------------------------------------------
 13 |val sortedFoos = sort(List(new Foo)) // error
    |                                    ^
-   |no implicit argument of type ord.Ord[ord.Foo] was found for an implicit parameter of method sort in package ord.
-   |I found:
+   |   no given instance of type ord.Ord[ord.Foo] was found for an implicit parameter of method sort in package ord.
+   |   I found:
    |
-   |    ord.Ord.ordered[ord.Foo](/* missing */summon[ord.Foo => Comparable[? >: ord.Foo]])
+   |       ord.Ord.ordered[ord.Foo](/* missing */summon[ord.Foo => Comparable[? >: ord.Foo]])
    |
-   |But no implicit values were found that match type ord.Foo => Comparable[? >: ord.Foo].
+   |   But no implicit values were found that match type ord.Foo => Comparable[? >: ord.Foo].

--- a/tests/neg/missing-implicit4.check
+++ b/tests/neg/missing-implicit4.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/missing-implicit4.scala:14:4 -----------------------------------------------------------------------
 14 |  ff // error
    |    ^
-   |    no implicit argument of type Zip[Option] was found for parameter xs of method ff
+   |    no given instance of type Zip[Option] was found for parameter xs of method ff
    |
    |    The following import might fix the problem:
    |
@@ -19,9 +19,9 @@
 -- Error: tests/neg/missing-implicit4.scala:20:42 ----------------------------------------------------------------------
 20 |    List(1, 2, 3).traverse(x => Option(x)) // error
    |                                          ^
-   |no implicit argument of type Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
+   |  no given instance of type Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
    |
-   |The following import might fix the problem:
+   |  The following import might fix the problem:
    |
-   |  import instances.zipOption
+   |    import instances.zipOption
    |

--- a/tests/neg/summon-function.check
+++ b/tests/neg/summon-function.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/summon-function.scala:2:23 -------------------------------------------------------------------------
 2 |  summon[Int => String] // error
   |                       ^
-  |            no implicit argument of type Int => String was found for parameter x of method summon in object Predef
+  |               no given instance of type Int => String was found for parameter x of method summon in object Predef


### PR DESCRIPTION
This changes some of the remaining messages that warn about "no
implicit" to the new verbiage of "no given instance".

fixes #7710