### PR TITLE
Don't replace typevars by their f-bounds in error messages

### DIFF
--- a/tests/neg/i14363.check
+++ b/tests/neg/i14363.check
@@ -1,0 +1,16 @@
+-- [E007] Type Mismatch Error: tests/neg/i14363.scala:2:13 -------------------------------------------------------------
+2 |def test = f(1)  // error
+  |             ^
+  |             Found:    (1 : Int)
+  |             Required: T
+  |
+  |             where:    T is a type variable with constraint <: Ordered[T]
+  |
+  |
+  |             One of the following imports might fix the problem:
+  |
+  |               import math.BigDecimal.int2bigDecimal
+  |               import math.BigInt.int2bigInt
+  |
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i14363.scala
+++ b/tests/neg/i14363.scala
@@ -1,0 +1,2 @@
+def f[T <: Ordered[T]](t: T): T = t
+def test = f(1)  // error


### PR DESCRIPTION
We sometimes replace type variables by their bounds to make an error message clearer. But we should never do that if the bound is recursive.

Fixes #14363
