### PR TITLE
Extend "cannot override mutable variable" restriction to deferred var…

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -474,7 +474,11 @@ object RefChecks {
           overrideError("needs `override` modifier")
       else if (other.is(AbsOverride) && other.isIncompleteIn(clazz) && !member.is(AbsOverride))
         overrideError("needs `abstract override` modifiers")
-      else if member.is(Override) && other.is(Accessor, butNot = Deferred) && other.accessedFieldOrGetter.is(Mutable, butNot = Lazy) then
+      else if member.is(Override)
+          && (other.is(Mutable)
+              || other.is(Accessor, butNot = Deferred)
+                  && other.accessedFieldOrGetter.is(Mutable, butNot = Lazy))
+      then
         overrideError("cannot override a mutable variable")
       else if (member.isAnyOverride &&
         !(member.owner.thisType.baseClasses exists (_ isSubClass other.owner)) &&

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -474,11 +474,7 @@ object RefChecks {
           overrideError("needs `override` modifier")
       else if (other.is(AbsOverride) && other.isIncompleteIn(clazz) && !member.is(AbsOverride))
         overrideError("needs `abstract override` modifiers")
-      else if member.is(Override)
-          && (other.is(Mutable)
-              || other.is(Accessor, butNot = Deferred)
-                  && other.accessedFieldOrGetter.is(Mutable, butNot = Lazy))
-      then
+      else if member.is(Override) && other.is(Mutable) then
         overrideError("cannot override a mutable variable")
       else if (member.isAnyOverride &&
         !(member.owner.thisType.baseClasses exists (_ isSubClass other.owner)) &&

--- a/tests/neg/i13019.scala
+++ b/tests/neg/i13019.scala
@@ -10,4 +10,4 @@ class Ok2C extends Ok2 { override var i: Int = 1 }
 
 // was: variable i of type Int cannot override a mutable variable
 trait NotOk {var i: Int}
-class NotOkC extends NotOk { override var i: Int = 1 }
+class NotOkC extends NotOk { override var i: Int = 1 } // error

--- a/tests/neg/i14722.scala
+++ b/tests/neg/i14722.scala
@@ -7,3 +7,14 @@ object Test extends App {
   entity.id = "0002"
   println(entity.id)
 }
+
+trait HasId2:
+  var id: String = ""
+
+case class Entity2(override val id: String) extends HasId2 // error
+
+trait HasId3:
+  def id: String
+  def id_=(x: String): Unit
+
+case class Entity3(override var id: String) extends HasId3 // ok

--- a/tests/neg/i14722.scala
+++ b/tests/neg/i14722.scala
@@ -1,0 +1,9 @@
+abstract class HasId(var id: String)
+
+case class Entity(override val id: String) extends HasId(id) // error
+
+object Test extends App {
+  val entity = Entity("0001")
+  entity.id = "0002"
+  println(entity.id)
+}


### PR DESCRIPTION
…iables.

Extend "cannot override mutable variable" restriction also to deferred variables.
This aligns the behavior with Scala 2.

Fixes #14722