### PR TITLE
Fix picking default syntax for comments

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1839,7 +1839,8 @@ object ScaladocConfigs {
       .add(DocRootContent(docRootFile.toString))
       .add(CommentSyntax(List(
         s"${dottyLibRoot}=markdown",
-        s"${stdLibRoot}=wiki"
+        s"${stdLibRoot}=wiki",
+        "wiki"
       )))
       .add(VersionsDictionaryUrl("https://scala-lang.org/api/versions.json"))
       .add(DocumentSyntheticTypes(true))

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/CommentSyntaxArgs.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/CommentSyntaxArgs.scala
@@ -17,10 +17,14 @@ object CommentSyntax:
   val default = CommentSyntax.Markdown
 
 case class CommentSyntaxArgs(csFormats: PathBased[CommentSyntax]):
+  val defaultSyntax = csFormats.get(csFormats.projectRoot)
+    .map(_.elem)
+    .getOrElse(CommentSyntax.default)
+
   def get(path: Option[Path]): CommentSyntax =
     path
       .flatMap(p => csFormats.get(p).map(_.elem))
-      .getOrElse(CommentSyntax.default)
+      .getOrElse(defaultSyntax)
 
 object CommentSyntaxArgs:
   val usage =


### PR DESCRIPTION
Recently, there was a PR merged that changed -comment-syntax setting in Scaladoc to PathBased. It introduced a small regression in our docs: https://dotty.epfl.ch/api/index.html. The problem was that when we didn't find an entry that matched the path, we were always using default syntax which is Markdown. What we actually need to do is try to find a fallback entry (one without path specified) and use its syntax. Only if there's no such entry, we should fall back to Markdown.