### PR TITLE
Avoid unsound GADT constraints derived from subtyping relations between singletons and refined types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1813,6 +1813,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           || symInfo.isInstanceOf[MethodType]
               && symInfo.signature.consistentParams(info2.signature)
 
+        def tp1IsSingleton: Boolean = tp1.isInstanceOf[SingletonType]
+
         // A relaxed version of isSubType, which compares method types
         // under the standard arrow rule which is contravarient in the parameter types,
         // but under the condition that signatures might have to match (see sigsOK)
@@ -1827,8 +1829,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                   matchingMethodParams(info1, info2, precise = false)
                   && isSubInfo(info1.resultType, info2.resultType.subst(info2, info1), symInfo1.resultType)
                   && sigsOK(symInfo1, info2)
-                case _ => isSubType(info1, info2)
-            case _ => isSubType(info1, info2)
+                case _ => inFrozenGadtIf(tp1IsSingleton) { isSubType(info1, info2) }
+            case _ => inFrozenGadtIf(tp1IsSingleton) { isSubType(info1, info2) }
 
         val info1 = m.info.widenExpr
         isSubInfo(info1, tp2.refinedInfo.widenExpr, m.symbol.info.orElse(info1))

--- a/tests/neg/gadt-sngl-refined.scala
+++ b/tests/neg/gadt-sngl-refined.scala
@@ -1,0 +1,18 @@
+trait Foo {
+  type A >: Nothing <: Any
+}
+
+enum SUB[-A, +B]:
+  case Refl[X]() extends SUB[X, X]
+
+import SUB._
+
+def test[X](foo: Foo, e: SUB[foo.type, Foo {type A <: X}], x: Any): X = e match
+  case Refl() =>
+    // From foo.type <:< Foo{type A <: X} we should not infer GADT constraints.
+    x   // error
+
+val foo = new Foo { type A = Nothing }
+
+def unsound(x: Any): Nothing =
+  test[Nothing](foo, Refl(), x)


### PR DESCRIPTION
This PR freezes GADT constraints when comparing the type member bounds of singleton types and refined types, since the GADT constraints derived from the comparison can be overly-strong (unsound).

The following code snippet is unsound, but accepted by the compiler.
```Scala
trait Foo {
  type A >: Nothing <: Any
}

enum SUB[-A, +B]:
  case Refl[X]() extends SUB[X, X]

import SUB._

def test[X](foo: Foo, e: SUB[foo.type, Foo {type A <: X}], x: Any): X = e match
  case Refl() =>
    // Here we try to infer GADT constraints from
    // the subtyping relation foo.type <:< Foo { type A <: X }.
    // This will try to infer constr from [ >: Nothing <: Any ] <:< [ >: Nothing <: X ],
    // which results in the unsound constraint Any <: X.

    // We can set foo = new Foo { type A = Nothing } and X = Nothing,
    // to get the unsound subtyping constraint Any <: Nothing.
    x

val foo = new Foo { type A = Nothing }

def unsound(x: Any): Nothing =
  test[Nothing](foo, Refl(), x)
```

In the above code snippet, we will try to extract GADT constraint from the subtyping relation `foo.type <:< Foo {type A <: X}`. When comparing these two types, the type comparer will try to compare the bounds of the type member `This`: `isSubType [ >: Nothing <: Any ] <: [ >: Nothing <: X ]`, which will give us the constraint `Any <: X`. However, deriving GADT constraints from this comparison can be unsound, since, by comparing the type member bounds of `foo.type` and `Foo {type A <: X}`, what we do is essentially upcasting the singleton type `foo.type` to `Foo` and compare `Foo#This` to `(Foo {type A <: X})#This`. We can not extract GADT constraints from this since the LHS is upcasted.

Therefore, we may have to freeze GADT constraints under such conditions to avoid deriving unsound constraints.