### PR TITLE
Improve overloading resolution if expected type is not FunProto

### DIFF
--- a/tests/pos/i14729.scala
+++ b/tests/pos/i14729.scala
@@ -1,0 +1,19 @@
+class Foo():
+  def normal: Unit = println("normal")
+
+extension (f: Foo)
+  def ext: Unit = println("ext")
+
+object Bar:
+  def makeFoo[A]: Foo = Foo()
+  def makeFoo[A](s: String): Foo = Foo()
+
+def tests: Unit =
+  Bar.makeFoo[Int].ext // error
+
+  (Bar.makeFoo[Int]).ext // error
+
+  val foo = Bar.makeFoo[Int]
+  foo.ext // ok
+
+  Bar.makeFoo[Int].normal // ok


### PR DESCRIPTION
If expected type is a selection proto or similar we picked all alternatives
that were compatible with it. But if the expected type was meant to be
used after extension method expansion, then no alternative would be classified
as compatible.

We now drop all method alternatives in this case. If only one alternative remains,
we pick that one.

Fixes #14729 