### PR TITLE
fix: don't add extra newlines when there aren't extra sections in doc markdown

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/ParsedComment.scala
+++ b/compiler/src/dotty/tools/dotc/util/ParsedComment.scala
@@ -53,24 +53,26 @@ class ParsedComment(val comment: Comment) {
    *
    * The different sections are formatted according to the mapping in `knownTags`.
    */
-  def renderAsMarkdown(using Context): String = {
+  def renderAsMarkdown(using Context): String =
     val buf = new StringBuilder
-    buf.append(mainDoc + System.lineSeparator + System.lineSeparator)
+    buf.append(mainDoc)
     val groupedSections = CommentParsing.groupedSections(content, tagIndex)
 
-    for {
+    val sections = for {
       (tag, formatter) <- ParsedComment.knownTags
       boundss <- groupedSections.get(tag)
       texts = boundss.map { case (start, end) => clean(content.slice(start, end)) }
       formatted <- formatter(texts)
-    }
-    {
-      buf.append(formatted)
-      buf.append(System.lineSeparator)
-    }
+    } yield formatted
 
+    if sections.nonEmpty then
+      buf.append(System.lineSeparator + System.lineSeparator)
+      sections.foreach { section =>
+        buf.append(section)
+        buf.append(System.lineSeparator)
+      }
     buf.toString
-  }
+  end renderAsMarkdown
 
   /**
    * The `@param` section corresponding to `name`.


### PR DESCRIPTION
Currently if you have a simple scaladoc and you use `renderAsMarkdown`
(which Metals does) to render markdown for hovers, there are extra
newlines added that aren't necessary. Normally you can't tell as it
seems some editors just trim off the extra newlines, but you can see
in certain editors and in the REPL as well.

_Notice how it removes two lines_
```diff
scala> :doc CanEqual
Companion object containing a few universally known `CanEqual` instances.
  CanEqual instances involving primitive types or the Null type are handled directly in
  the compiler (see Implicits.synthesizedCanEqual), so they are not included here.

-
-
```

This just ensures that we add the extra two newlines only when we know
we have more sections coming.

fixes https://github.com/scalameta/metals/issues/3740