### PR TITLE
Prevent implicit conversion chaining

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3270,7 +3270,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               if isExtension then return found
               else
                 checkImplicitConversionUseOK(found)
-                return typedSelect(tree, pt, found)
+                return withoutMode(Mode.ImplicitsEnabled)(typedSelect(tree, pt, found))
             case failure: SearchFailure =>
               if failure.isAmbiguous then
                 return

--- a/tests/neg/i13900.scala
+++ b/tests/neg/i13900.scala
@@ -1,0 +1,9 @@
+opaque type Inlined[T] = T
+
+object Inlined:
+
+  given fromValueWide[Wide]: Conversion[Wide, Inlined[Wide]] = ???
+
+  // TODO: This used to make the compiler run into an infinite loop.
+  // Now it fails instead but shouldn't, see discussion in https://github.com/lampepfl/dotty/issues/13900#issuecomment-1075580792
+  def myMax: Int = 1 max 2 // error


### PR DESCRIPTION
Just like in tryInsertImplicitOnQualifier, we need to turn off implicit search
when typing a selection after inserting an implicit conversion on the qualifier in
tryExtensionOrConversion.

Partially fixes #13900, see test case.