### PR TITLE
-Xlint 1l

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -10,7 +10,7 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.rewrites.Rewrites
 import dotty.tools.io.{AbstractFile, Directory, JDK9Reflectors, PlainDirectory}
 
-import scala.util.chaining._
+import scala.util.chaining.given
 
 class ScalaSettings extends SettingGroup with AllScalaSettings
 
@@ -156,6 +156,8 @@ private sealed trait WarningSettings:
   self: SettingGroup =>
   val Whelp: Setting[Boolean] = BooleanSetting("-W", "Print a synopsis of warning options.")
   val XfatalWarnings: Setting[Boolean] = BooleanSetting("-Werror", "Fail the compilation if there are any warnings.", aliases = List("-Xfatal-warnings"))
+  val Xlint: Setting[List[String]] = EnumSetting("-Wlint", "warning", "Enable recommended warnings.", LintWarning.values, default = Nil, aliases = List("-Xlint"))
+  def isLintEnabled(w: LintWarning)(using Context): Boolean = Xlint.value.contains(w.toString)
 
   val Wunused: Setting[List[String]] = MultiChoiceSetting(
     name = "-Wunused",
@@ -339,3 +341,7 @@ private sealed trait YSettings:
   val YforceInlineWhileTyping: Setting[Boolean] = BooleanSetting("-Yforce-inline-while-typing", "Make non-transparent inline methods inline when typing. Emulates the old inlining behavior of 3.0.0-M3.")
 end YSettings
 
+/** Warnings that may be queried with `ctx.settings.isLintEnabled`. */
+enum LintWarning:
+  case deprecation, longLit
+end LintWarning

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -9,7 +9,7 @@ import dotty.tools.io.{AbstractFile, Directory, JarArchive, PlainDirectory}
 
 import annotation.tailrec
 import collection.mutable.ArrayBuffer
-import reflect.ClassTag
+import reflect.{ClassTag, Enum}
 import scala.util.{Success, Failure}
 
 object Settings:
@@ -61,7 +61,8 @@ object Settings:
     prefix: String = "",
     aliases: List[String] = Nil,
     depends: List[(Setting[?], Any)] = Nil,
-    propertyClass: Option[Class[?]] = None)(private[Settings] val idx: Int) {
+    propertyClass: Option[Class[?]] = None,
+  )(private[Settings] val idx: Int) {
 
     private var changed: Boolean = false
 
@@ -264,6 +265,9 @@ object Settings:
 
     def MultiChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: List[String], aliases: List[String] = Nil): Setting[List[String]] =
       publish(Setting(name, descr, default, helpArg, Some(choices), aliases = aliases))
+
+    def EnumSetting[E <: Enum](name: String, helpArg: String, descr: String, choices: Array[E], default: List[String], aliases: List[String] = Nil): Setting[List[String]] =
+      publish(Setting(name, descr, default, helpArg, Some(choices.toList.map(_.toString)), aliases = aliases))
 
     def IntSetting(name: String, descr: String, default: Int, aliases: List[String] = Nil): Setting[Int] =
       publish(Setting(name, descr, default, aliases = aliases))

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1182,9 +1182,9 @@ object Parsers {
             case EXPOLIT => return Number(digits, NumberKind.Floating)
             case _ =>
           }
-        import scala.util.FromDigits._
+        import scala.util.FromDigits.*
         val value =
-          try token match {
+          try token match
             case INTLIT                        => intFromDigits(digits, in.base)
             case LONGLIT                       => longFromDigits(digits, in.base)
             case FLOATLIT                      => floatFromDigits(digits)
@@ -1194,15 +1194,11 @@ object Parsers {
             case TRUE                          => true
             case FALSE                         => false
             case NULL                          => null
-            case _                             =>
-              syntaxErrorOrIncomplete(IllegalLiteral())
-              null
-          }
-          catch {
-            case ex: FromDigitsException => syntaxErrorOrIncomplete(ex.getMessage)
-          }
+            case _                             => syntaxErrorOrIncomplete(IllegalLiteral()); null
+          catch case ex: FromDigitsException => syntaxError(ex.getMessage)
         Literal(Constant(value))
       }
+      end literalOf
 
       if (inStringInterpolation) {
         val t = in.token match {
@@ -1252,6 +1248,7 @@ object Parsers {
         }
       }
     }
+    end literal
 
     private def interpolatedString(inPattern: Boolean = false): Tree = atSpan(in.offset) {
       val segmentBuf = new ListBuffer[Tree]

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -11,6 +11,7 @@ import util.Chars._
 import util.{SourcePosition, CharBuffer}
 import util.Spans.Span
 import config.Config
+import config.LintWarning
 import Tokens._
 import scala.annotation.{switch, tailrec}
 import scala.collection.mutable
@@ -1488,7 +1489,7 @@ object Scanners {
         getFraction()
       // 1l is an acknowledged bad practice
       def lintel(): Unit =
-        if ch == 'l' then
+        if ch == 'l' && ctx.settings.isLintEnabled(LintWarning.longLit) then
           val msg = "Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead"
           report.deprecationWarning(msg, sourcePos(offset + litBuf.length))
       // after int: 5e7f, 42L, 42.toDouble but not 42b.

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -891,9 +891,10 @@ object Scanners {
             }
             if base != 10 && !isNumberSeparator(ch) && digit2int(ch, base) < 0 then
               error("invalid literal number")
+            else
+              getNumber()
           }
           fetchLeadingZero()
-          getNumber()
         case '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
           base = 10
           getNumber()

--- a/tests/neg/literals.scala
+++ b/tests/neg/literals.scala
@@ -1,11 +1,6 @@
 trait RejectedLiterals {
-  def missingHex: Int    = { 0x }        // error: invalid literal number
-}
-/*
-// nsc: -Ywarn-octal-literal -Xfatal-warnings -deprecation
-trait RejectedLiterals {
 
-  def missingHex: Int    = { 0x }        // line 4: was: not reported, taken as zero
+  def missingHex: Int    = { 0x }        // error: invalid literal number
 
   def leadingZeros: Int  = { 01 }        // line 6: no leading zero
 
@@ -13,17 +8,17 @@ trait RejectedLiterals {
 
   def zeroOfNine: Int    = { 09 }        // line 10: no leading zero
 
-  def orphanDot: Int     = { 9. }        // line 12: ident expected
+  def orphanDot: Int     = { 9. }        // error: ident expected
 
-  def zeroOfNineDot: Int = { 09. }       // line 14: malformed integer, ident expected
+  def zeroOfNineDot: Int = { 09. }       // error: malformed integer, ident expected
 
-  def noHexFloat: Double = { 0x1.2 }     // line 16: ';' expected but double literal found.
+  def noHexFloat: Double = { 0x1.2 }     // error: ';' expected but double literal found.
 
 }
 
 trait Braceless {
 
-  def missingHex: Int    = 0x            // line 22: was: not reported, taken as zero
+  def missingHex: Int    = 0x            // error: was: not reported, taken as zero
 
   def leadingZeros: Int  = 01            // line 24: no leading zero
 
@@ -31,28 +26,27 @@ trait Braceless {
 
   def zeroOfNine: Int    = 09            // line 28: no leading zero
 
-  def orphanDot: Int     = 9.            // line 30: ident expected
+  def orphanDot: Int     = 9.            // should be: ident expected
 
-  def zeroOfNineDot: Int = 09.           // line 32: malformed integer, ident expected
+  def zeroOfNineDot: Int = 09.           // error: an identifier expected, but 'def' found, shoule be ident expected
 
-  def noHexFloat: Double = 0x1.2         // line 34: ';' expected but double literal found.
+  def noHexFloat: Double = 0x1.2         // should be: ';' expected but double literal found.
 }
 
 trait MoreSadness {
 
-  def tooTiny: Float     = { 0.7e-45f }      // floating point number too small
+  def tooTiny: Float     = { 0.7e-45f }      // error: floating point number too small
 
-  def twoTiny: Double    = { 2.0e-324 }      // double precision floating point number too small
+  def twoTiny: Double    = { 2.0e-324 }      // error: double precision floating point number too small
 
-  def tooHuge: Float     = { 3.4028236E38f } // floating point number too large
+  def tooHuge: Float     = { 3.4028236E38f } // error: floating point number too large
 
-  def twoHuge: Double    = { 1.7976931348623159e308 } // double precision floating point number too large
-}
+  def twoHuge: Double    = { 1.7976931348623159e308 } // error: double precision floating point number too large
+} // error: Found: Unit etc, sad
 
 trait Lengthy {
 
   def bad = 1l
 
   def worse = 123l
-}
-*/
+} // error: Found: Unit etc, sad // anypos-error: '}' expected, but eof found, sad

--- a/tests/neg/literals.scala
+++ b/tests/neg/literals.scala
@@ -42,11 +42,11 @@ trait MoreSadness {
   def tooHuge: Float     = { 3.4028236E38f } // error: floating point number too large
 
   def twoHuge: Double    = { 1.7976931348623159e308 } // error: double precision floating point number too large
-} // error: Found: Unit etc, sad
+}
 
 trait Lengthy {
 
   def bad = 1l
 
   def worse = 123l
-} // error: Found: Unit etc, sad // anypos-error: '}' expected, but eof found, sad
+}

--- a/tests/neg/longlit.scala
+++ b/tests/neg/longlit.scala
@@ -1,0 +1,11 @@
+// scalac: -Werror -Xlint:longLit,deprecation -deprecation
+
+trait DejectedLiterals:
+
+  def bad = 1l        // error
+
+  def worse = 123l    // error
+
+  def worstest = 32l  // error
+
+// Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead

--- a/tests/neg/t6124.check
+++ b/tests/neg/t6124.check
@@ -43,9 +43,13 @@
    |             ^
    |             trailing separator is not allowed
 -- Error: tests/neg/t6124.scala:24:12 ----------------------------------------------------------------------------------
-24 |  val x5 = 0_x52 // error
+24 |  val x5 = 0_x52 // error // error
    |            ^
    |            trailing separator is not allowed
+-- Error: tests/neg/t6124.scala:24:11 ----------------------------------------------------------------------------------
+24 |  val x5 = 0_x52 // error // error
+   |           ^
+   |           Invalid literal number
 -- Error: tests/neg/t6124.scala:26:13 ----------------------------------------------------------------------------------
 26 |  val x8 = 0x52_ // error
    |             ^

--- a/tests/neg/t6124.scala
+++ b/tests/neg/t6124.scala
@@ -21,7 +21,7 @@ trait T {
   val x1 = _52 // error
   val x3 = 52_ // error
 
-  val x5 = 0_x52 // error
+  val x5 = 0_x52 // error // error
   val x6 = 0x_52
   val x8 = 0x52_ // error
   val x9 = 0_52


### PR DESCRIPTION
Add `-Xlint` setting and `EnumSetting` and `onUpdate` to enable post-processing such as linking another flag.

`-Xlint` can enable `-deprecation`, and `-Xlint:longlit` deprecates `1l`. (It is regular deprecation on Scala 2, but treading gently.)

Eventually `EnumSetting` will want to avoid string comparisons.

The `FromDigits` error handling is a regular error because otherwise subsequent parse is worse.

Forward porting from
https://github.com/scala/scala/pull/4182
https://github.com/scala/scala/pull/7685