### PR TITLE
Alternative trailing comma handling

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -700,6 +700,7 @@ object Scanners {
             case _ =>
               lookAhead()
               if isAfterLineEnd
+                 && currentRegion.commasExpected
                  && (token == RPAREN || token == RBRACKET || token == RBRACE || token == OUTDENT)
               then
                 () /* skip the trailing comma */

--- a/tests/neg/imports.scala
+++ b/tests/neg/imports.scala
@@ -1,0 +1,2 @@
+import scala.collection.{*, View} // error
+object test


### PR DESCRIPTION
Do it in Lexer but take into account whether commas are expected
in current region.

Also fixes an issue in #14741 regarding import parsing.