### PR TITLE
Drop special treatment for Scala-2 code in unapply

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -827,7 +827,7 @@ object TypeOps:
     }
 
     def instantiate(): Type = {
-      maximizeType(protoTp1, NoSpan, fromScala2x = false)
+      maximizeType(protoTp1, NoSpan)
       wildApprox(protoTp1)
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -109,7 +109,7 @@ object TypeTestsCasts {
       // which conform to the skeleton pre.F[_] and X. Then we have to make
       // sure all of them are actually of the type P, which implies that the
       // type arguments in P are trivial (no runtime check needed).
-      maximizeType(P1, span, fromScala2x = false)
+      maximizeType(P1, span)
 
       debug.println("after " + ctx.typerState.constraint.show)
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1326,8 +1326,6 @@ trait Applications extends Compatibility {
         unapp
     }
 
-    def fromScala2x = unapplyFn.symbol.exists && (unapplyFn.symbol.owner is Scala2x)
-
     unapplyFn.tpe.widen match {
       case mt: MethodType if mt.paramInfos.length == 1 =>
         val unapplyArgType = mt.paramInfos.head
@@ -1343,7 +1341,7 @@ trait Applications extends Compatibility {
             // Constraining only fails if the pattern cannot possibly match,
             // but useless pattern checks detect more such cases, so we simply rely on them instead.
             withMode(Mode.GadtConstraintInference)(TypeComparer.constrainPatternType(unapplyArgType, selType))
-            val patternBound = maximizeType(unapplyArgType, tree.span, fromScala2x)
+            val patternBound = maximizeType(unapplyArgType, tree.span)
             if (patternBound.nonEmpty) unapplyFn = addBinders(unapplyFn, patternBound)
             unapp.println(i"case 2 $unapplyArgType ${ctx.typerState.constraint}")
             unapplyArgType

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -399,7 +399,7 @@ object Inferencing {
    *  @return   The list of type symbols that were created
    *            to instantiate undetermined type variables that occur non-variantly
    */
-  def maximizeType(tp: Type, span: Span, fromScala2x: Boolean)(using Context): List[Symbol] = {
+  def maximizeType(tp: Type, span: Span)(using Context): List[Symbol] = {
     Stats.record("maximizeType")
     val vs = variances(tp)
     val patternBindings = new mutable.ListBuffer[(Symbol, TypeParamRef)]
@@ -409,7 +409,7 @@ object Inferencing {
         else if (v == -1) tvar.instantiate(fromBelow = true)
         else {
           val bounds = TypeComparer.fullBounds(tvar.origin)
-          if (bounds.hi <:< bounds.lo || bounds.hi.classSymbol.is(Final) || fromScala2x)
+          if bounds.hi <:< bounds.lo || bounds.hi.classSymbol.is(Final) then
             tvar.instantiate(fromBelow = false)
           else {
             // We do not add the created symbols to GADT constraint immediately, since they may have inter-dependencies.

--- a/tests/run/i14693.check
+++ b/tests/run/i14693.check
@@ -1,0 +1,1 @@
+Success!

--- a/tests/run/i14693.scala
+++ b/tests/run/i14693.scala
@@ -1,0 +1,9 @@
+object Test {
+  val a: Array[Long] = Array(1L)
+
+  def test(x: Any) = x match {
+    case Array(i: Long) => println("Success!")
+    case _              => println("Failure!") }
+
+  def main(args: Array[String]): Unit = test(a)
+}


### PR DESCRIPTION
It seems our GADT handling is now able to do without.

Fixes #14693