### PR TITLE
Scaladoc: Fix regression with extension methods not being shown in searchbar

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -151,7 +151,7 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
             val entry = mkEntry(member.dri, member.name, flattenToText(sig), descr, member.kind.name)
             val children = member
                 .membersBy(m => m.kind != Kind.Package && !m.kind.isInstanceOf[Classlike])
-                .filter(m => m.origin == Origin.RegularlyDefined && m.inheritedFrom.fold(false)(_.isSourceSuperclassHidden))
+                .filter(m => m.origin == Origin.RegularlyDefined && m.inheritedFrom.fold(true)(_.isSourceSuperclassHidden))
             Seq(entry) ++ children.flatMap(processMember)
 
           processMember(m)


### PR DESCRIPTION
An error was introduced in 598b8d3383c6331ef3aa8a4a81b2a603cac19e96 that made it so that some methods were incorrectly omitted from the search bar. This was caused by mistakenly filtering members with defined inheritedFrom methods instead of the ones with empty. `m.inheritedFrom.isEmpty` became `m.inheritedFrom.fold(false)(_.isSourceSuperclassHidden))` but should have been `m.inheritedFrom.fold(true)(_.isSourceSuperclassHidden))` - the intent was to also allow to search for inherited from hidden superclasses, but not exclusively, like it was done by mistake.

Fixes #14778

https://scala3doc.virtuslab.com/pr-fix-searchbar-extensions/scala3/index.html