### PR TITLE
Make lazy vals and object native image friendly

### DIFF
--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -106,6 +106,13 @@ object LazyVals {
     r
   }
 
+  def getOffsetStatic(field: java.lang.reflect.Field) =
+    val r = unsafe.objectFieldOffset(field)
+    if (debug)
+      println(s"getOffset(${field.getDeclaringClass}, ${field.getName}) = $r")
+    r
+
+
   object Names {
     final val state = "STATE"
     final val cas = "CAS"

--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -1,5 +1,7 @@
 package scala.runtime
 
+import scala.annotation.since
+
 /**
  * Helper methods used in thread-safe lazy vals.
  */
@@ -106,6 +108,7 @@ object LazyVals {
     r
   }
 
+  @since("3.2")
   def getOffsetStatic(field: java.lang.reflect.Field) =
     val r = unsafe.objectFieldOffset(field)
     if (debug)


### PR DESCRIPTION
Currently, creating a graal native image from scala 3 code is really cubersome, custom configuration needs to be provided for each object and lazy val. It is caused by reflection in LazyVals object.

This PR inlines reflection within each class and in this form Graal is able to inline such calls without any additional config.

Before each PR for each `lazy val` (object are also implemented as lazy vals) similar code is added to the static initializer for the class:

```
<0bitmap$1> = scala.runtime.LazyVals.getOffset (getClass, "<0bitmap$1>")
```

This PR changes it into:


```
<0bitmap$1> = scala.runtime.LazyVals.getOffsetStatic (getClass.getDeclaredFiels( "<0bitmap$1>"))
```
