### PR TITLE
fix: use correct ErrorMessageID for EmptyCatchOrFinallyBlock

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -78,7 +78,7 @@ import transform.SymUtils._
     def kind = "Reference"
 
   abstract class EmptyCatchOrFinallyBlock(tryBody: untpd.Tree, errNo: ErrorMessageID)(using Context)
-  extends SyntaxMsg(EmptyCatchOrFinallyBlockID) {
+  extends SyntaxMsg(errNo) {
     def explain = {
       val tryString = tryBody match {
         case Block(Nil, untpd.EmptyTree) => "{}"

--- a/compiler/test-resources/repl/i13208.default.scala
+++ b/compiler/test-resources/repl/i13208.default.scala
@@ -1,6 +1,6 @@
 scala> try 1
 1 warning found
--- [E000] Syntax Warning: ------------------------------------------------------
+-- [E002] Syntax Warning: ------------------------------------------------------
 1 | try 1
   | ^^^^^
   | A try without catch or finally is equivalent to putting

--- a/compiler/test-resources/repl/nowarn.scala
+++ b/compiler/test-resources/repl/nowarn.scala
@@ -1,6 +1,6 @@
 scala> @annotation.nowarn def f = try 1 // @nowarn doesn't work on first line, ctx.run is null in issueIfNotSuppressed
 1 warning found
--- [E000] Syntax Warning: ------------------------------------------------------
+-- [E002] Syntax Warning: ------------------------------------------------------
 1 | @annotation.nowarn def f = try 1 // @nowarn doesn't work on first line, ctx.run is null in issueIfNotSuppressed
   |                            ^^^^^
   |                   A try without catch or finally is equivalent to putting
@@ -12,7 +12,7 @@ scala> @annotation.nowarn def f = try 1
 def f: Int
 scala> def f = try 1
 1 warning found
--- [E000] Syntax Warning: ------------------------------------------------------
+-- [E002] Syntax Warning: ------------------------------------------------------
 1 | def f = try 1
   |         ^^^^^
   |         A try without catch or finally is equivalent to putting

--- a/tests/neg-custom-args/nowarn/nowarn-parser-error.check
+++ b/tests/neg-custom-args/nowarn/nowarn-parser-error.check
@@ -4,7 +4,7 @@
   |      an identifier expected, but 'def' found
   |
   | longer explanation available when compiling with `-explain`
--- [E000] Syntax Warning: tests/neg-custom-args/nowarn/nowarn-parser-error.scala:2:10 ----------------------------------
+-- [E002] Syntax Warning: tests/neg-custom-args/nowarn/nowarn-parser-error.scala:2:10 ----------------------------------
 2 |  def a = try 1 // warn
   |          ^^^^^
   |          A try without catch or finally is equivalent to putting

--- a/tests/neg-custom-args/nowarn/nowarn.check
+++ b/tests/neg-custom-args/nowarn/nowarn.check
@@ -1,32 +1,32 @@
--- [E000] Syntax Warning: tests/neg-custom-args/nowarn/nowarn.scala:9:10 -----------------------------------------------
+-- [E002] Syntax Warning: tests/neg-custom-args/nowarn/nowarn.scala:9:10 -----------------------------------------------
 9 |def t1a = try 1 // warning (parser)
   |          ^^^^^
   |          A try without catch or finally is equivalent to putting
   |          its body in a block; no exceptions are handled.
   |
   | longer explanation available when compiling with `-explain`
--- [E000] Syntax Warning: tests/neg-custom-args/nowarn/nowarn.scala:23:25 ----------------------------------------------
+-- [E002] Syntax Warning: tests/neg-custom-args/nowarn/nowarn.scala:23:25 ----------------------------------------------
 23 |@nowarn(o.inl) def t2d = try 1   // two warnings (`inl` is not a compile-time constant)
    |                         ^^^^^
    |                         A try without catch or finally is equivalent to putting
    |                         its body in a block; no exceptions are handled.
    |
    | longer explanation available when compiling with `-explain`
--- [E000] Syntax Warning: tests/neg-custom-args/nowarn/nowarn.scala:31:26 ----------------------------------------------
+-- [E002] Syntax Warning: tests/neg-custom-args/nowarn/nowarn.scala:31:26 ----------------------------------------------
 31 |@nowarn("id=1") def t4d = try 1 // error and warning (unused nowarn, wrong id)
    |                          ^^^^^
    |                          A try without catch or finally is equivalent to putting
    |                          its body in a block; no exceptions are handled.
    |
    | longer explanation available when compiling with `-explain`
--- [E000] Syntax Warning: tests/neg-custom-args/nowarn/nowarn.scala:33:28 ----------------------------------------------
+-- [E002] Syntax Warning: tests/neg-custom-args/nowarn/nowarn.scala:33:28 ----------------------------------------------
 33 |@nowarn("verbose") def t5 = try 1 // warning with details
    |                            ^^^^^
    |                            A try without catch or finally is equivalent to putting
    |                            its body in a block; no exceptions are handled.
 Matching filters for @nowarn or -Wconf:
-  - id=E0
-  - name=EmptyCatchOrFinallyBlock
+  - id=E2
+  - name=EmptyCatchAndFinallyBlock
    |
    | longer explanation available when compiling with `-explain`
 -- [E129] Potential Issue Warning: tests/neg-custom-args/nowarn/nowarn.scala:13:11 -------------------------------------

--- a/tests/neg-custom-args/nowarn/nowarn.scala
+++ b/tests/neg-custom-args/nowarn/nowarn.scala
@@ -25,9 +25,9 @@ object o:
 @nowarn("id=E129") def t3a = { 1; 2 }
 @nowarn("name=PureExpressionInStatementPosition") def t3b = { 1; 2 }
 
-@nowarn("id=E000") def t4a = try 1
-@nowarn("id=E0") def t4b = try 1
-@nowarn("id=0") def t4c = try 1
+@nowarn("id=E002") def t4a = try 1
+@nowarn("id=E2") def t4b = try 1
+@nowarn("id=2") def t4c = try 1
 @nowarn("id=1") def t4d = try 1 // error and warning (unused nowarn, wrong id)
 
 @nowarn("verbose") def t5 = try 1 // warning with details


### PR DESCRIPTION
Previously we were always assigning this to `EmptyCatchOrFinallyBlockID`
but both `EmptyCatchBlock` and `EmptyCatchAndFinallyBlock` both use this
class and pass in their corresponding `ErrorMessageID`. This caused the
following two code samples to give the same `ErrorMessageID` when they
should have been different:

```scala
try {}
```

```scala
try {} catch {} finally {}
```

The second one gave this as an error:

```
scala> try {} catch {} finally {}
-- [E000] Syntax Error: --------------------------------------------------------
1 |try {} catch {} finally {}
  |       ^^^^^^^^
  |       The catch block does not contain a valid expression, try
  |       adding a case like - case e: Exception => to the block
  |
  | longer explanation available when compiling with `-explain`

```

When the ID should be `E001`, `EmptyCatchBlockId`. Now this correctly
returns:

```
scala> try {} catch{} finally {}
-- [E001] Syntax Error: --------------------------------------------------------
1 |try {} catch{} finally {}
  |       ^^^^^^^
  |       The catch block does not contain a valid expression, try
  |       adding a case like - case e: Exception => to the block
  |
  | longer explanation available when compiling with `-explain`
```

The first example should actually be using `E002` since it's missing both the
catch and finally blocks.