### PR TITLE
Fix safe-init error in TreePickler

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPickler.scala
@@ -81,6 +81,4 @@ class TastyPickler(val rootCls: ClassSymbol) {
     assert(all.length == totalSize && all.bytes.length == totalSize, s"totalSize = $totalSize, all.length = ${all.length}, all.bytes.length = ${all.bytes.length}")
     all.bytes
   }
-
-  val treePkl: TreePickler = new TreePickler(this)
 }

--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -8,7 +8,7 @@ import dotty.tools.dotc.core.Decorators._
 import dotty.tools.dotc.core.Mode
 import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.core.Types._
-import dotty.tools.dotc.core.tasty.{ PositionPickler, TastyPickler, TastyPrinter }
+import dotty.tools.dotc.core.tasty.{ PositionPickler, TastyPickler, TastyPrinter, TreePickler }
 import dotty.tools.dotc.core.tasty.DottyUnpickler
 import dotty.tools.dotc.core.tasty.TreeUnpickler.UnpickleMode
 import dotty.tools.dotc.report
@@ -154,7 +154,7 @@ object PickledQuotes {
   private def pickle(tree: Tree)(using Context): Array[Byte] = {
     quotePickling.println(i"**** pickling quote of\n$tree")
     val pickler = new TastyPickler(defn.RootClass)
-    val treePkl = pickler.treePkl
+    val treePkl = new TreePickler(pickler)
     treePkl.pickle(tree :: Nil)
     treePkl.compactify()
     if tree.span.exists then

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -68,7 +68,7 @@ class Pickler extends Phase {
       if ctx.settings.YtestPickler.value then
         beforePickling(cls) = tree.show
         picklers(cls) = pickler
-      val treePkl = pickler.treePkl
+      val treePkl = new TreePickler(pickler)
       treePkl.pickle(tree :: Nil)
       val positionWarnings = new mutable.ListBuffer[String]()
       val pickledF = inContext(ctx.fresh) {


### PR DESCRIPTION
When bootstrapping the compiler with the `-Ysafe-init` flag, we would get the following error:

```
[error] -- Error: /*************/dotty/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala:24:20
[error] 24 |  pickler.newSection(ASTsSection, buf)
[error]    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |Call method TreePickler.this.pickler.newSection("ASTs",
[error]    |  dotty.tools.dotc.core.tasty.TreePickler.this.buf
[error]    |) on a value with an unknown initialization. Calling trace:
[error]    | -> val treePkl: TreePickler = new TreePickler(this)	[ TastyPickler.scala:85 ]
[error]    |   -> class TreePickler(pickler: TastyPickler) {	[ TreePickler.scala:22 ]
```

This supresses the warning for this case.

Review by @liufengyun