### PR TITLE
fix: ensure DeprecatedWithOperator is shown to user when used.

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1555,8 +1555,7 @@ object Parsers {
         if in.token == LBRACE || in.token == INDENT then
           t
         else
-          if sourceVersion.isAtLeast(future) then
-            deprecationWarning(DeprecatedWithOperator(), withOffset)
+          deprecationWarning(DeprecatedWithOperator(), withOffset)
           atSpan(startOffset(t)) { makeAndType(t, withType()) }
       else t
 


### PR DESCRIPTION
Right now a user can use a `with` operator without any deprecation
notice when this has been deprecated for quite some time. I think this
was missed recently with some of the changes to sourceVersion and this
was still checking against `future`. I believe this should just be
removed and always shown now correct?