### PR TITLE
fix: correct highlight interpolation in explain message

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -589,9 +589,8 @@ import transform.SymUtils._
     def explain =
       em"""|An abstract declaration must have a return type. For example:
            |
-           |trait Shape {hl(
-           |  def area: Double // abstract declaration returning a ${"Double"}
-           |)}"""
+           |trait Shape:
+           |  ${hl("def area: Double")} // abstract declaration returning a Double"""
   }
 
   class MissingReturnTypeWithReturnStatement(method: Symbol)(using Context)


### PR DESCRIPTION
Currently the output of `explain` when you are missing a return type in
an abstract declaration looks like this:

```
scala> trait Foo:
     |   def foo
-- [E019] Syntax Error: --------------------------------------------------------
2 |  def foo
  |         ^
  |         Missing return type
  |-----------------------------------------------------------------------------
  | Explanation (enabled by `-explain`)
  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  | An abstract declaration must have a return type. For example:
  |
  | trait Shape {hl(
  |   def area: Double // abstract declaration returning a Double
  | )}
   -----------------------------------------------------------------------------
```

This fixes the interpolation issue so the return correctly shows:

```
scala> trait Foo:
     |   def foo
-- [E019] Syntax Error: --------------------------------------------------------
2 |  def foo
  |         ^
  |         Missing return type
  |-----------------------------------------------------------------------------
  | Explanation (enabled by `-explain`)
  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  | An abstract declaration must have a return type. For example:
  |
  | trait Shape:
  |   def area: Double // abstract declaration returning a Double
   -----------------------------------------------------------------------------
```
The `def area: Double` is now also correctly colored.