### PR TITLE
refactor: use existing IllegalVariableInPatternAlternative message

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1869,7 +1869,7 @@ object desugar {
         elems foreach collect
       case Alternative(trees) =>
         for (tree <- trees; (vble, _) <- getVariables(tree, shouldAddGiven))
-          report.error(IllegalVariableInPatternAlternative(), vble.srcPos)
+          report.error(IllegalVariableInPatternAlternative(vble.symbol.name), vble.srcPos)
       case Annotated(arg, _) =>
         collect(arg)
       case InterpolatedString(_, segments) =>

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -738,9 +738,9 @@ import transform.SymUtils._
     }
   }
 
-  class IllegalVariableInPatternAlternative()(using Context)
+  class IllegalVariableInPatternAlternative(name: Name)(using Context)
   extends SyntaxMsg(IllegalVariableInPatternAlternativeID) {
-    def msg = "Variables are not allowed in alternative patterns"
+    def msg = em"Illegal variable $name in pattern alternative"
     def explain = {
       val varInAlternative =
         """|def g(pair: (Int,Int)): Int = pair match {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2115,7 +2115,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           val sym = newPatternBoundSymbol(name, symTp, tree.span)
           if (pt == defn.ImplicitScrutineeTypeRef || tree.mods.is(Given)) sym.setFlag(Given)
           if (ctx.mode.is(Mode.InPatternAlternative))
-            report.error(i"Illegal variable ${sym.name} in pattern alternative", tree.srcPos)
+            report.error(IllegalVariableInPatternAlternative(sym.name), tree.srcPos)
           assignType(cpy.Bind(tree)(name, body1), sym)
         }
     }


### PR DESCRIPTION
We have a `IllegalVariableInPatternAlternative` message that already
exists and was used in `Desugar`, but not in the more common place
people will see it in `Typer`. This just changes the message to align
with the one that people are used to seeing, but also adds in the
`explain` since we're re-using the existing message.

_Example before_
```
scala> Option((1, 2)) match
     |   case (1, n) | (n, 1) => "got a one!"
     |
-- Error: ----------------------------------------------------------------------
2 |  case (1, n) | (n, 1) => "got a one!"
  |           ^
  |           Illegal variable n in pattern alternative
-- Error: ----------------------------------------------------------------------
2 |  case (1, n) | (n, 1) => "got a one!"
  |                 ^
  |                 Illegal variable n in pattern alternative
2 errors found
```

_Example after_

```
scala> Option((1, 2)) match
     |   case (1, n) | (n, 1) => "got a one!"
     |
-- [E024] Syntax Error: --------------------------------------------------------
2 |  case (1, n) | (n, 1) => "got a one!"
  |           ^
  |           Illegal variable n in pattern alternative
  |
  | longer explanation available when compiling with `-explain`
-- [E024] Syntax Error: --------------------------------------------------------
2 |  case (1, n) | (n, 1) => "got a one!"
  |                 ^
  |                 Illegal variable n in pattern alternative
  |
  | longer explanation available when compiling with `-explain`
2 errors found
```