### PR TITLE
Handle SummonFrom in reflect TreeAccumulator 

### DIFF
--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -4714,8 +4714,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           case tree: ClassDef =>
             val constructor @ DefDef(_, _, _, _) = transformStatement(tree.constructor)(tree.symbol)
             val parents = tree.parents.map(transformTree(_)(tree.symbol))
+            val self = tree.self.map { slf =>
+              transformStatement(slf)(tree.symbol) match
+                case self: ValDef => self
+            }
             val body = tree.body.map(transformStatement(_)(tree.symbol))
-            ClassDef.copy(tree)(tree.name, constructor, parents, tree.self, body)
+            ClassDef.copy(tree)(tree.name, constructor, parents, self, body)
           case tree: Import =>
             Import.copy(tree)(transformTerm(tree.expr)(owner), tree.selectors)
           case tree: Export =>

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -4621,6 +4621,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           case Bind(_, body) => foldTree(x, body)(owner)
           case Unapply(fun, implicits, patterns) => foldTrees(foldTrees(foldTree(x, fun)(owner), implicits)(owner), patterns)(owner)
           case Alternatives(patterns) => foldTrees(x, patterns)(owner)
+          case SummonFrom(cases) => foldTrees(x, cases)(owner)
           case _ => throw MatchError(tree.show(using Printer.TreeStructure))
         }
       }

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -4621,6 +4621,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           case Bind(_, body) => foldTree(x, body)(owner)
           case Unapply(fun, implicits, patterns) => foldTrees(foldTrees(foldTree(x, fun)(owner), implicits)(owner), patterns)(owner)
           case Alternatives(patterns) => foldTrees(x, patterns)(owner)
+          case _ => throw MatchError(tree.show(using Printer.TreeStructure))
         }
       }
     end TreeAccumulator
@@ -4685,6 +4686,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
             Alternatives.copy(pattern)(transformTrees(pattern.patterns)(owner))
           case TypedOrTest(inner, tpt) =>
             TypedOrTest.copy(tree)(transformTree(inner)(owner), transformTypeTree(tpt)(owner))
+          case _ =>
+            throw MatchError(tree.show(using Printer.TreeStructure))
         }
       }
 
@@ -4713,6 +4716,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
             Import.copy(tree)(transformTerm(tree.expr)(owner), tree.selectors)
           case tree: Export =>
             tree
+          case _ =>
+            throw MatchError(tree.show(using Printer.TreeStructure))
         }
       }
 
@@ -4758,6 +4763,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
             Repeated.copy(tree)(transformTerms(elems)(owner), transformTypeTree(elemtpt)(owner))
           case Inlined(call, bindings, expansion) =>
             Inlined.copy(tree)(call, transformSubTrees(bindings)(owner), transformTerm(expansion)(owner))
+          case _ =>
+            throw MatchError(tree.show(using Printer.TreeStructure))
         }
       }
 
@@ -4786,6 +4793,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           TypeBind.copy(tree)(tree.name, tree.body)
         case tree: TypeBlock =>
           TypeBlock.copy(tree)(tree.aliases, tree.tpt)
+        case _ =>
+          throw MatchError(tree.show(using Printer.TreeStructure))
       }
 
       def transformCaseDef(tree: CaseDef)(owner: Symbol): CaseDef = {

--- a/tests/run-custom-args/tasty-inspector/i14789.scala
+++ b/tests/run-custom-args/tasty-inspector/i14789.scala
@@ -23,8 +23,10 @@ import scala.tasty.inspector.*
           }
         }
       }
+      val mapper = new TreeMap { }
       tastys.foreach{ tasty =>
         traverser.traverseTree(tasty.ast)(tasty.ast.symbol)
+        mapper.transformTree(tasty.ast)(tasty.ast.symbol)
       }
     }
   }

--- a/tests/run-custom-args/tasty-inspector/i14789.scala
+++ b/tests/run-custom-args/tasty-inspector/i14789.scala
@@ -1,0 +1,43 @@
+import scala.quoted.*
+import scala.tasty.inspector.*
+
+@main def Test = {
+  // Artefact of the current test infrastructure
+  // TODO improve infrastructure to avoid needing this code on each test
+  val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
+  val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.extension == "tasty").map(_.toString).toList
+  val tastyFiles = allTastyFiles.filter(_.contains("App"))
+
+  // in dotty-example-project
+  val inspector = new Inspector {
+    def inspect(using Quotes)(tastys: List[Tasty[quotes.type]]): Unit = {
+      import quotes.reflect.*
+      val traverser = new TreeTraverser {
+        override def traverseTree(tree: Tree)(owner: Symbol): Unit = {
+          try {
+            super.traverseTree(tree)(owner)
+          } catch {
+            case e =>
+              report.error(s"unexpected error ${e}", tree.pos)
+              throw e
+          }
+        }
+      }
+      tastys.foreach{ tasty =>
+        traverser.traverseTree(tasty.ast)(tasty.ast.symbol)
+      }
+    }
+  }
+  TastyInspector.inspectTastyFiles(tastyFiles)(inspector)
+}
+
+object App {
+  import scala.compiletime.*
+
+  transparent inline def summonFirst0[T]: Any =
+    inline erasedValue[T] match
+      case _: (a *: b) => summonFrom {
+        case instance: `a` => instance
+        case _ => summonFirst0[b]
+      }
+}


### PR DESCRIPTION
SummonFrom can never be seen from macros as they are always evaluated away before expanding the macro. This can be seen if an inline tree definition is loaded and traversed as is the case with the TastyInspector.

Fixes #14789