### PR TITLE
Fix universal check for inferred types

### DIFF
--- a/docs/_docs/reference/experimental/cc.md
+++ b/docs/_docs/reference/experimental/cc.md
@@ -368,7 +368,7 @@ again on access, the capture information "pops out" again. For instance, even th
 () => p.fst : {ct} () -> {ct} Int -> String
 ```
 In other words, references to capabilities "tunnel through" in generic instantiations from creation to access; they do not affect the capture set of the enclosing generic data constructor applications.
-This principle may seem surprising at first, but it is the key to make capture checking concise and practical.
+This principle plays an important part in making capture checking concise and practical.
 
 ## Escape Checking
 
@@ -398,7 +398,7 @@ This error message was produced by the following logic:
 
  - The `f` parameter has type `{*} FileOutputStream`, which makes it a capability.
  - Therefore, the type of the expression `() => f.write(0)` is `{f} () -> Unit`.
- - This makes the whole type of the closure passed to `usingLogFile` the dependent function type
+ - This makes the type of the whole closure passed to `usingLogFile` the dependent function type
    `(f: {*} FileOutputStream) -> {f} () -> Unit`.
  - The expected type of the closure is a simple, parametric, impure function type `({*} FileOutputStream) => T`,
    for some instantiation of the type variable `T`.

--- a/tests/neg-custom-args/captures/usingLogFile.check
+++ b/tests/neg-custom-args/captures/usingLogFile.check
@@ -18,3 +18,18 @@
    |  ^^^^^^^^
    |  The expression's type {*} () -> Unit is not allowed to capture the root capability `*`.
    |  This usually means that a capability persists longer than its allowed lifetime.
+-- Error: tests/neg-custom-args/captures/usingLogFile.scala:47:27 ------------------------------------------------------
+47 |  val later = usingLogFile { f => () => f.write(0) } // error
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              The expression's type {*} () -> Unit is not allowed to capture the root capability `*`.
+   |              This usually means that a capability persists longer than its allowed lifetime.
+-- Error: tests/neg-custom-args/captures/usingLogFile.scala:62:25 ------------------------------------------------------
+62 |    val later = usingFile("out", f => (y: Int) => xs.foreach(x => f.write(x + y))) // error
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                The expression's type {*} (x$0: Int) -> Unit is not allowed to capture the root capability `*`.
+   |                This usually means that a capability persists longer than its allowed lifetime.
+-- Error: tests/neg-custom-args/captures/usingLogFile.scala:71:48 ------------------------------------------------------
+71 |    val later = usingFile("logfile", usingLogger(_, l => () => l.log("test"))) // error
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                         The expression's type {*} () -> Unit is not allowed to capture the root capability `*`.
+   |                         This usually means that a capability persists longer than its allowed lifetime.

--- a/tests/neg-custom-args/captures/usingLogFile.scala
+++ b/tests/neg-custom-args/captures/usingLogFile.scala
@@ -1,4 +1,4 @@
-import java.io.FileOutputStream
+import java.io.*
 import annotation.capability
 
 object Test1:
@@ -36,3 +36,37 @@ object Test2:
   usingLogFile { f => later4 = Cell(() => f.write(0)) }
   later4.x() // error
 
+object Test3:
+
+  def usingLogFile[T](op: ({*} FileOutputStream) => T) =
+    val logFile = FileOutputStream("log")
+    val result = op(logFile)
+    logFile.close()
+    result
+
+  val later = usingLogFile { f => () => f.write(0) } // error
+
+object Test4:
+  class Logger(f: {*} OutputStream):
+    def log(msg: String): Unit = ???
+
+  def usingFile[T](name: String, op: ({*} OutputStream) => T): T =
+    val f = new FileOutputStream(name)
+    val result = op(f)
+    f.close()
+    result
+
+  val xs: List[Int] = ???
+  def good = usingFile("out", f => xs.foreach(x => f.write(x)))
+  def fail =
+    val later = usingFile("out", f => (y: Int) => xs.foreach(x => f.write(x + y))) // error
+    later(1)
+
+
+  def usingLogger[T](f: {*} OutputStream, op: ({f} Logger) => T): T =
+    val logger = Logger(f)
+    op(logger)
+
+  def test =
+    val later = usingFile("logfile", usingLogger(_, l => () => l.log("test"))) // error
+    later()


### PR DESCRIPTION
Checking against capturing the universal capability now works also for inferred types.