### PR TITLE
Fix parameter untupling

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -39,6 +39,10 @@ object desugar {
    */
   val MultiLineInfix: Property.Key[Unit] = Property.StickyKey()
 
+  /** An attachment key to indicate that a ValDef originated from parameter untupling.
+   */
+  val UntupledParam: Property.Key[Unit] = Property.StickyKey()
+
   /** What static check should be applied to a Match? */
   enum MatchCheck {
     case None, Exhaustive, IrrefutablePatDef, IrrefutableGenFrom
@@ -1426,7 +1430,9 @@ object desugar {
     val vdefs =
       params.zipWithIndex.map {
         case (param, idx) =>
-          DefDef(param.name, Nil, param.tpt, selector(idx)).withSpan(param.span)
+          ValDef(param.name, param.tpt, selector(idx))
+            .withSpan(param.span)
+            .withAttachment(UntupledParam, ())
       }
     Function(param :: Nil, Block(vdefs, body))
   }

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -413,7 +413,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       Ident(tp)
     else
       val pre = tp.prefix
-      if (pre.isSingleton) followOuterLinks(singleton(pre.dealias)).select(tp)
+      if (pre.isSingleton) followOuterLinks(singleton(pre.dealias, needLoad)).select(tp)
       else
         val res = Select(TypeTree(pre), tp)
         if needLoad && !res.symbol.isStatic then
@@ -431,11 +431,11 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       t
   }
 
-  def singleton(tp: Type)(using Context): Tree = tp.dealias match {
-    case tp: TermRef => ref(tp)
+  def singleton(tp: Type, needLoad: Boolean = true)(using Context): Tree = tp.dealias match {
+    case tp: TermRef => ref(tp, needLoad)
     case tp: ThisType => This(tp.cls)
-    case tp: SkolemType => singleton(tp.narrow)
-    case SuperType(qual, _) => singleton(qual)
+    case tp: SkolemType => singleton(tp.narrow, needLoad)
+    case SuperType(qual, _) => singleton(qual, needLoad)
     case ConstantType(value) => Literal(value)
   }
 

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -85,9 +85,9 @@ object Completion {
    * @param content The source content that we'll check the positions for the prefix
    * @param start The start position we'll start to look for the prefix at
    * @param end The end position we'll look for the prefix at
-   * @return Either the full prefix including the ` or an empty string 
+   * @return Either the full prefix including the ` or an empty string
    */
-  private def checkBacktickPrefix(content: Array[Char], start: Int, end: Int): String = 
+  private def checkBacktickPrefix(content: Array[Char], start: Int, end: Int): String =
     content.lift(start) match
       case Some(char) if char == '`' =>
         content.slice(start, end).mkString
@@ -111,7 +111,7 @@ object Completion {
       // Foo.`se<TAB> will result in Select(Ident(Foo), <error>)
       case (select: untpd.Select) :: _ if select.name == nme.ERROR =>
         checkBacktickPrefix(select.source.content(), select.nameSpan.start, select.span.end)
-     
+
       // import scala.util.chaining.`s<TAB> will result in a Ident(<error>)
       case (ident: untpd.Ident) :: _ if ident.name == nme.ERROR =>
         checkBacktickPrefix(ident.source.content(), ident.span.start, ident.span.end)
@@ -177,14 +177,14 @@ object Completion {
   // https://github.com/com-lihaoyi/Ammonite/blob/73a874173cd337f953a3edc9fb8cb96556638fdd/amm/util/src/main/scala/ammonite/util/Model.scala
   private def needsBacktick(s: String) =
     val chunks = s.split("_", -1)
-    
+
     val validChunks = chunks.zipWithIndex.forall { case (chunk, index) =>
       chunk.forall(Chars.isIdentifierPart) ||
       (chunk.forall(Chars.isOperatorPart) &&
         index == chunks.length - 1 &&
         !(chunks.lift(index - 1).contains("") && index - 1 == 0))
     }
-    
+
     val validStart =
       Chars.isIdentifierStart(s(0)) || chunks(0).forall(Chars.isOperatorPart)
 
@@ -312,7 +312,7 @@ object Completion {
 
     /** Replaces underlying type with reduced one, when it's MatchType */
     def reduceUnderlyingMatchType(qual: Tree)(using Context): Tree=
-      qual.tpe.widen match 
+      qual.tpe.widen match
         case ctx.typer.MatchTypeInDisguise(mt) => qual.withType(mt)
         case _ => qual
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -705,7 +705,7 @@ trait Applications extends Compatibility {
     def fail(msg: Message): Unit =
       ok = false
     def appPos: SrcPos = NoSourcePosition
-    @threadUnsafe lazy val normalizedFun:   Tree = ref(methRef)
+    @threadUnsafe lazy val normalizedFun: Tree = ref(methRef, needLoad = false)
     init()
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2268,7 +2268,7 @@ trait Applications extends Compatibility {
       case TypeApply(fun, args) => TypeApply(replaceCallee(fun, replacement), args)
       case _ => replacement
 
-    val methodRefTree = ref(methodRef)
+    val methodRefTree = ref(methodRef, needLoad = false)
     val truncatedSym = methodRef.symbol.asTerm.copy(info = truncateExtension(methodRef.info))
     val truncatedRefTree = untpd.TypedSplice(ref(truncatedSym)).withSpan(receiver.span)
     val newCtx = ctx.fresh.setNewScope.setReporter(new reporting.ThrowingReporter(ctx.reporter))

--- a/tests/neg/function-arity-2.scala
+++ b/tests/neg/function-arity-2.scala
@@ -1,0 +1,7 @@
+object Test {
+
+  class T[A] { def foo(f: (=> A) => Int) = f(???) }
+
+  def main(args: Array[String]): Unit =
+    new T[(Int, Int)].foo((x, y) => 0) // error // error Parameter untupling cannot be used for call-by-name parameters (twice)
+}

--- a/tests/neg/i14783.scala
+++ b/tests/neg/i14783.scala
@@ -1,0 +1,3 @@
+object Test:
+  def foo(f: (=> (Int, Int)) => Int) = ???
+  foo((a, b) => a + b) // error // error

--- a/tests/pos/i14783.scala
+++ b/tests/pos/i14783.scala
@@ -1,0 +1,51 @@
+object Wart:
+  def bar(using c: Ctx)(ws: List[Wrap[c.type]]): Unit =
+    ws.zipWithIndex.foreach { (w, _) => w.x.foo }
+
+trait Wrap[C <: Ctx & Singleton]:
+  val ctx: C
+  def x: ctx.inner.X
+
+trait Ctx:
+  object inner:
+    type X
+    extension (self: X) def foo: Int = ???
+
+
+object WartInspector:
+  def myWartTraverser: WartTraverser = ???
+  def inspect(using q: Quotes)(tastys: List[Tasty[q.type]]): Unit = {
+    val universe: WartUniverse.Aux[q.type] = WartUniverse(q)
+    val traverser = myWartTraverser.get(universe)
+    tastys.zipWithIndex.foreach { (tasty, index) =>
+      val tree = tasty.ast
+      traverser.traverseTree(tree)(tree.symbol)
+    }
+  }
+
+object WartUniverse:
+  type Aux[X <: Quotes] = WartUniverse { type Q = X }
+  def apply[Q <: Quotes](quotes: Q): Aux[Q] = ???
+
+
+abstract class WartUniverse:
+  type Q <: Quotes
+  val quotes: Q
+  abstract class Traverser extends quotes.reflect.TreeTraverser
+
+
+abstract class WartTraverser:
+  def get(u: WartUniverse): u.Traverser
+
+trait Tasty[Q <: Quotes & Singleton]:
+  val quotes: Q
+  def path: String
+  def ast: quotes.reflect.Tree
+
+trait Quotes:
+  object reflect:
+    type Tree
+    extension (self: Tree) def symbol: Symbol = ???
+    type Symbol
+    trait TreeTraverser:
+      def traverseTree(tree: Tree)(symbol: Symbol): Unit

--- a/tests/run/function-arity.scala
+++ b/tests/run/function-arity.scala
@@ -3,6 +3,6 @@ object Test {
 
   def main(args: Array[String]): Unit = {
     new T[(Int, Int)].foo((ii) => 0)
-    new T[(Int, Int)].foo((x, y) => 0) // check that this does not run into ???
+    //new T[(Int, Int)].foo((x, y) => 0) // not allowed anymore
   }
 }


### PR DESCRIPTION
As a preliminary: #14783 shows an example where an implicit reference was generated that started in a type.
The backend then crashed since it could not emit instructions to load that reference. We
now detect such references when they are created and flag them as errors.

The main commit is to fix the issue that created the bad reference in the first place.
Make untupled parameters ValDefs instead of DefDefs so that their references are
stable paths. Add an additional check that untupled parameters don't come from 
call-by-name parameters (in that case, ValDefs would be unsound).

I was trying hard to allow paramater untupling for cbn parameters, but this seems to be
very hard since parameter untupling happens as a desugaring step when the expected 
parameter type is not yet known. And it seems really hard to change from stable to
unstable (or vice versa) later in the compilation pipleline without doing a lot of
re-checking. 

Since untupled cbn parameters are a pretty extreme corner case anyway I think it's 
OK to just disallow them.

Fixes #14783 



