### PR TITLE
Split mvn and github publishing steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -600,11 +600,10 @@ jobs:
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
-      - name: Publish Release
+      - name: Prepare Release
         run: |
           ./project/scripts/sbt dist/packArchive
           sha256sum dist/target/scala3-* > dist/target/sha256sum.txt
-          ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
           echo "RELEASE_TAG=${GITHUB_REF#*refs/tags/}" >> $GITHUB_ENV
 
       - name: Create GitHub Release
@@ -615,9 +614,9 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body:
-          draft: false
-          prerelease: ${{ contains(env.RELEASE_TAG, 'M') }}
+          body_path: ./changelogs/${{ env.RELEASE_TAG }}.md
+          draft: true
+          prerelease: ${{ contains(env.RELEASE_TAG, '-') }}
 
       - name: Upload zip archive to GitHub Release
         uses: actions/upload-release-asset@v1
@@ -648,6 +647,10 @@ jobs:
           asset_path: ./dist/target/sha256sum.txt
           asset_name: sha256sum.txt
           asset_content_type: text/plain
+
+      - name: Publish Release
+        run: ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
+
 
   open_issue_on_failure:
     runs-on: [self-hosted, Linux]


### PR DESCRIPTION
This pr:
- moves mvn publication to the separate, last step of the `publish_release` job
- changes detection of unstable release from checking `M` occurrences to checking `-` occurrences
- makes every release draft by default - we can "undraft" them while we are announcing the release
- automatically fills in the body of the release from the file pushed to the release branch