### PR TITLE
Fix capturing conditions of HOAS quote patterns

### DIFF
--- a/tests/run-macros/pattern-scope-extrusion.check
+++ b/tests/run-macros/pattern-scope-extrusion.check
@@ -1,0 +1,7 @@
+(42: scala.Int)
+((x: scala.Int) => x.+(x)).apply(1)
+
+(42: scala.Int)
+((x: scala.Int) => x.+(x)).apply(1)
+((y: scala.Int) => y.+(y)).apply(2)
+((x: scala.Int, y: scala.Int) => x.+(y)).apply(1, 2)

--- a/tests/run-macros/pattern-scope-extrusion/quoted_1.scala
+++ b/tests/run-macros/pattern-scope-extrusion/quoted_1.scala
@@ -1,0 +1,18 @@
+import scala.quoted.*
+
+inline def test1(inline x: Int): String = ${ test1Expr('x) }
+inline def test2(inline x: Int): String = ${ test2Expr('x) }
+
+private def test1Expr(x: Expr[Int])(using Quotes) : Expr[String] =
+  x match
+    case '{ val x: Int = 1; $z: Int } => Expr(z.show)
+    case '{ val x: Int = 1; $z(x): Int } => Expr('{$z(1)}.show)
+    case _ => '{"No match"}
+
+private def test2Expr(x: Expr[Int])(using Quotes) : Expr[String] =
+  x match
+    case '{ val x: Int = 1; val y: Int = 2; $z: Int } => Expr(z.show)
+    case '{ val x: Int = 1; val y: Int = 2; $z(x): Int } => Expr('{$z(1)}.show)
+    case '{ val x: Int = 1; val y: Int = 2; $z(y): Int } => Expr('{$z(2)}.show)
+    case '{ val x: Int = 1; val y: Int = 2; $z(x,y): Int } => Expr('{$z(1, 2)}.show)
+    case _ => '{"No match"}

--- a/tests/run-macros/pattern-scope-extrusion/quoted_2.scala
+++ b/tests/run-macros/pattern-scope-extrusion/quoted_2.scala
@@ -1,0 +1,34 @@
+@main def Test =
+  println(test1 {
+    val a: Int = 1
+    42: Int
+  })
+  println(test1 {
+    val a: Int = 1
+    a + a
+  })
+
+  println()
+
+  println(test2 {
+    val a: Int = 1
+    val b: Int = 2
+    42: Int
+  })
+  println(test2 {
+    val a: Int = 1
+    val b: Int = 2
+    a + a
+  })
+
+  println(test2 {
+    val a: Int = 1
+    val b: Int = 2
+    b + b
+  })
+
+  println(test2 {
+    val a: Int = 1
+    val b: Int = 2
+    a + b
+  })


### PR DESCRIPTION
We did not properly check that the scrutinee was closed under the
environment minus the captured arguments.
This corresponds to the check 
![Screenshot 2022-04-01 at 13 18 37](https://user-images.githubusercontent.com/3648029/161253442-bcf42599-690c-49f4-8225-a4a51a9a5bf5.png) 

Where `env` corresponds to ϕ and `args.map(_.symbol).toSet` is the set on the right-hand side.

Of this rule in https://dl.acm.org/doi/abs/10.1145/3486609.3487203
![Screenshot 2022-04-01 at 13 14 46](https://user-images.githubusercontent.com/3648029/161252933-4bbaeb19-15da-4e30-b9a6-b5ee973c75eb.png)

