### PR TITLE
io.Path uses java.io.File for string path

### DIFF
--- a/compiler/src/dotty/tools/io/Path.scala
+++ b/compiler/src/dotty/tools/io/Path.scala
@@ -52,7 +52,7 @@ object Path {
 
   def roots: List[Path] = FileSystems.getDefault.getRootDirectories.iterator().asScala.map(Path.apply).toList
 
-  def apply(path: String): Path = apply(Paths.get(path))
+  def apply(path: String): Path = apply(new java.io.File(path).toPath)
   def apply(jpath: JPath): Path = try {
     if (Files.isRegularFile(jpath)) new File(jpath)
     else if (Files.isDirectory(jpath)) new Directory(jpath)


### PR DESCRIPTION
This is to let `java.io.File` handle platform-dependent absolute path on windows.

This is a reversion to previous usage.

Noticed at https://github.com/lampepfl/dotty/pull/14801#issuecomment-1086558253

[test_windows_full]