### PR TITLE
Handle situation where an inline info cannot be computed

### DIFF
--- a/tests/neg/i14772.check
+++ b/tests/neg/i14772.check
@@ -10,6 +10,6 @@
   |         no given instance of type quoted.ToExpr[Unit] was found for parameter x$2 of method apply in object Expr.
   |         I found:
   |
-  |             quoted.ToExpr.IntToExpr[T]
+  |             quoted.ToExpr.ClassToExpr[T]
   |
-  |         But given instance IntToExpr in object ToExpr does not match type quoted.ToExpr[Unit].
+  |         But given instance ClassToExpr in object ToExpr does not match type quoted.ToExpr[Unit].

--- a/tests/neg/i14772.check
+++ b/tests/neg/i14772.check
@@ -1,0 +1,15 @@
+-- [E044] Cyclic Error: tests/neg/i14772.scala:7:7 ---------------------------------------------------------------------
+7 |    foo(a)    // error
+  |       ^
+  |       Overloaded or recursive method impl needs return type
+  |
+  | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/i14772.scala:8:12 ----------------------------------------------------------------------------------
+8 |    Expr(())  // error
+  |            ^
+  |         no given instance of type quoted.ToExpr[Unit] was found for parameter x$2 of method apply in object Expr.
+  |         I found:
+  |
+  |             quoted.ToExpr.IntToExpr[T]
+  |
+  |         But given instance IntToExpr in object ToExpr does not match type quoted.ToExpr[Unit].

--- a/tests/neg/i14772.scala
+++ b/tests/neg/i14772.scala
@@ -1,0 +1,10 @@
+import scala.quoted.*
+
+object A {
+  transparent inline def foo(a: Any): Any = ${ impl('a) }
+
+  def impl(a: Expr[Any])(using Quotes)/*: Expr[Any]*/ = {
+    foo(a)    // error
+    Expr(())  // error
+  }
+}


### PR DESCRIPTION
Handle situation where an inline info cannot be computed due to a cyclic reference involving a macro.

Fixes #14772