### PR TITLE
Fix scaladoc build on main: Overwrite scaladoc azure storages on new action

### DIFF
--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -74,7 +74,7 @@ jobs:
             DOC_DEST=$(echo pr-${PR_NUMBER:-${GITHUB_REF##*/}} | tr -d -c "[-A-Za-z0-9]")
             echo uplading docs to https://scala3doc.virtuslab.com/$DOC_DEST
             az storage container create --name $DOC_DEST --account-name scala3docstorage --public-access container
-            az storage blob upload-batch -s scaladoc/output -d $DOC_DEST --account-name scala3docstorage
+            az storage blob upload-batch --overwrite true -s scaladoc/output -d $DOC_DEST --account-name scala3docstorage
 
   stdlib-sourcelinks-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default bahavior of `az cli` seems to have changed, it no longer overwrites existing storages by default. [release notes](https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli)