### PR TITLE
Don't issue implicit errors if parameter has default value

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3539,14 +3539,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             val namedArgs = wtp.paramNames.lazyZip(args).flatMap { (pname, arg) =>
               if (arg.tpe.isError) Nil else untpd.NamedArg(pname, untpd.TypedSplice(arg)) :: Nil
             }
-            tryEither {
-              val app = cpy.Apply(tree)(untpd.TypedSplice(tree), namedArgs)
-              if (wtp.isContextualMethod) app.setApplyKind(ApplyKind.Using)
-              typr.println(i"try with default implicit args $app")
-              typed(app, pt, locked)
-            } { (_, _) =>
-              issueErrors()
-            }
+            val app = cpy.Apply(tree)(untpd.TypedSplice(tree), namedArgs)
+            if (wtp.isContextualMethod) app.setApplyKind(ApplyKind.Using)
+            typr.println(i"try with default implicit args $app")
+            typed(app, pt, locked)
           else issueErrors()
         }
         else tree match {

--- a/tests/neg/i14772.check
+++ b/tests/neg/i14772.check
@@ -4,12 +4,3 @@
   |       Overloaded or recursive method impl needs return type
   |
   | longer explanation available when compiling with `-explain`
--- Error: tests/neg/i14772.scala:8:12 ----------------------------------------------------------------------------------
-8 |    Expr(())  // error
-  |            ^
-  |         no given instance of type quoted.ToExpr[Unit] was found for parameter x$2 of method apply in object Expr.
-  |         I found:
-  |
-  |             quoted.ToExpr.ClassToExpr[T]
-  |
-  |         But given instance ClassToExpr in object ToExpr does not match type quoted.ToExpr[Unit].

--- a/tests/neg/i14772.scala
+++ b/tests/neg/i14772.scala
@@ -5,6 +5,6 @@ object A {
 
   def impl(a: Expr[Any])(using Quotes)/*: Expr[Any]*/ = {
     foo(a)    // error
-    Expr(())  // error
+    ???
   }
 }

--- a/tests/neg/i14842.check
+++ b/tests/neg/i14842.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/i14842.scala:11:35 ------------------------------------------------------------
+11 |  val x: Either[Int, Any] = node.as[Any] // error
+   |                            ^^^^^^^^^^^^
+   |                            Found:    Either[String, Any]
+   |                            Required: Either[Int, Any]
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i14842.scala
+++ b/tests/neg/i14842.scala
@@ -1,0 +1,12 @@
+class Dummy
+object Dummy:
+  val empty = new Dummy
+
+sealed trait Node:
+  def as[T](using d: Dummy = Dummy.empty): Either[String, T] = ???
+
+object Sample extends App {
+  val node: Node = ???
+
+  val x: Either[Int, Any] = node.as[Any] // error
+}


### PR DESCRIPTION
If implicit parameters have default values then we try to re-type the
application with default values supplied as arguments. So far we
fell back to the original errors if retyping failed, which can lead
to confusing error messages. We now stick with the retyping in all cases.

Fixes #14842