### PR TITLE
Add 3.2 to the list of ScalaRelease

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaRelease.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaRelease.scala
@@ -3,6 +3,7 @@ package dotty.tools.dotc.config
 enum ScalaRelease(val majorVersion: Int, val minorVersion: Int) extends Ordered[ScalaRelease]:
   case Release3_0 extends ScalaRelease(3, 0)
   case Release3_1 extends ScalaRelease(3, 1)
+  case Release3_2 extends ScalaRelease(3, 2)
 
   def show = s"$majorVersion.$minorVersion"
 
@@ -16,4 +17,5 @@ object ScalaRelease:
   def parse(name: String) = name match
     case "3.0" => Some(Release3_0)
     case "3.1" => Some(Release3_1)
+    case "3.2" => Some(Release3_2)
     case _ => None


### PR DESCRIPTION
This change is needed to be able to annotate methods as `@since("3.2")`. If I understood correctly, in addition to that diff, we will also need to make a new release, and bump the `previousDottyVersion` in `Build.scala` to use that release.