### PR TITLE
Recursion brake for joins in TypeComparer

### DIFF
--- a/tests/pos-deep-subtype/i14870.scala
+++ b/tests/pos-deep-subtype/i14870.scala
@@ -1,0 +1,6 @@
+abstract class Quantity[A <: Quantity[A]]
+class Energy extends Quantity[Energy]
+class Time extends Quantity[Time]
+class Dimensionless extends Quantity[Dimensionless]
+
+class Price[Q <: Quantity[Q] & (Energy | Time | Dimensionless)]


### PR DESCRIPTION
Don't recursively apply joins on the left hand side if it contains
an AndType, in order to prevent possible exponential explosions.

Fixes #14870