### PR TITLE
Survive unpickling crashes when completing from Tasty

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -261,6 +261,7 @@ private sealed trait YSettings:
   val YdebugTreeWithId: Setting[Int] = IntSetting("-Ydebug-tree-with-id", "Print the stack trace when the tree with the given id is created.", Int.MinValue)
   val YdebugTypeError: Setting[Boolean] = BooleanSetting("-Ydebug-type-error", "Print the stack trace when a TypeError is caught", false)
   val YdebugError: Setting[Boolean] = BooleanSetting("-Ydebug-error", "Print the stack trace when any error is caught.", false)
+  val YdebugUnpickling: Setting[Boolean] = BooleanSetting("-Ydebug-unpickling", "Print the stack trace when an error occurs when reading Tasty.", false)
   val YtermConflict: Setting[String] = ChoiceSetting("-Yresolve-term-conflict", "strategy", "Resolve term conflicts", List("package", "object", "error"), "error")
   val Ylog: Setting[List[String]] = PhasesSetting("-Ylog", "Log operations during")
   val YlogClasspath: Setting[Boolean] = BooleanSetting("-Ylog-classpath", "Output information about what classpath is being applied.")

--- a/tests/neg/i12482.check
+++ b/tests/neg/i12482.check
@@ -1,0 +1,6 @@
+-- [E006] Not Found Error: tests/neg/i12482.scala:3:2 ------------------------------------------------------------------
+3 |  FileZipArchive // error
+  |  ^^^^^^^^^^^^^^
+  |  Not found: FileZipArchive
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i12482.scala
+++ b/tests/neg/i12482.scala
@@ -1,0 +1,4 @@
+package dotty.tools.io
+object ZipArchive {
+  FileZipArchive // error
+}


### PR DESCRIPTION
Survive unpickling crashes when completing symbols from Tasty.
Crashes can happen in a number of circumstances, from overwritten
symbols (as in the test) to corrupted Tasty files. We should
survive them and present a regular error message.

Fixes #12482