### PR TITLE
Add safe-init test to prevent adding cold elements to hot arrays

### DIFF
--- a/tests/init/neg/cold-insert-hot-array.scala
+++ b/tests/init/neg/cold-insert-hot-array.scala
@@ -1,0 +1,9 @@
+object A:
+  def foo[T](x: T, array: Array[T]): Unit = array(0) = x
+
+class B {
+  var a = new Array[B](2)
+  A.foo(this, a) //error
+  println(a(0).i)
+  val i = 99
+}

--- a/tests/init/neg/cold-insert-hot-array.scala
+++ b/tests/init/neg/cold-insert-hot-array.scala
@@ -3,7 +3,7 @@ object A:
 
 class B {
   var a = new Array[B](2)
-  A.foo(this, a) //error
+  A.foo(this, a) // error
   println(a(0).i)
   val i = 99
 }


### PR DESCRIPTION
This adds a negative test to ensure that the initialization checker doesn't allow cold values to be inserted into hot arrays through a method call.