### PR TITLE
Allow Null in isInstanceOf checks

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1256,7 +1256,7 @@ class Definitions {
 
   @tu lazy val topClasses: Set[Symbol] = Set(AnyClass, MatchableClass, ObjectClass, AnyValClass)
 
-  @tu lazy val untestableClasses: Set[Symbol] = Set(NothingClass, NullClass, SingletonClass)
+  @tu lazy val untestableClasses: Set[Symbol] = Set(NothingClass, SingletonClass)
 
   @tu lazy val AbstractFunctionType: Array[TypeRef] = mkArityArray("scala.runtime.AbstractFunction", MaxImplementedFunctionArity, 0).asInstanceOf[Array[TypeRef]]
   val AbstractFunctionClassPerRun: PerRun[Array[Symbol]] = new PerRun(AbstractFunctionType.map(_.symbol.asClass))

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -245,9 +245,10 @@ object TypeTestsCasts {
 
           if (expr.tpe <:< testType) && inMatch then
             if expr.tpe.isNotNull then constant(expr, Literal(Constant(true)))
+            else if testCls == defn.NullClass then expr.testNull
             else expr.testNotNull
           else {
-            if expr.tpe.isBottomType then
+            if expr.tpe.widen.isNothingType then
               report.warning(TypeTestAlwaysDiverges(expr.tpe, testType), tree.srcPos)
             val nestedCtx = ctx.fresh.setNewTyperState()
             val foundClsSyms = foundClasses(expr.tpe.widen, Nil)
@@ -263,6 +264,8 @@ object TypeTestsCasts {
                 case _ =>
                   transformIsInstanceOf(
                     expr, defn.boxedType(testCls.typeRef), testCls.typeRef, flagUnrelated)
+            else if testCls == defn.NullClass then
+              expr.testNull
             else
               derivedTree(expr, defn.Any_isInstanceOf, testType)
           }
@@ -370,5 +373,5 @@ object TypeTestsCasts {
       case _ => EmptyTree
     }
     interceptWith(expr)
-  }
+  }//.showing(i"intercept $tree -> $result")
 }

--- a/tests/neg/i4004.scala
+++ b/tests/neg/i4004.scala
@@ -1,6 +1,4 @@
 @main def Test =
-  "a".isInstanceOf[Null] // error
-  null.isInstanceOf[Null] // error
   "a".isInstanceOf[Nothing] // error
   "a".isInstanceOf[Singleton] // error
 
@@ -9,8 +7,3 @@
   case _: Nothing => () // error
   case _: Singleton => () // error
   case _ => ()
-
-  null match
-  case _: Null => () // error
-  case _ => ()
-

--- a/tests/pos/i14896.scala
+++ b/tests/pos/i14896.scala
@@ -1,0 +1,2 @@
+object Ex  { def unapply(p: Any): Option[_ <: Int] = null }
+object Foo { val Ex(_) = null: @unchecked }

--- a/tests/run/i4004.scala
+++ b/tests/run/i4004.scala
@@ -1,0 +1,15 @@
+@main def Test =
+  assert(!("a": Any).isInstanceOf[Null])
+  assert(null.isInstanceOf[Null])
+  assert((null: Any).isInstanceOf[Null])
+
+  ("a": Any) match
+    case _: Null => assert(false)
+    case _ =>
+
+  null match
+    case _: Null => ()
+
+  (null: Any) match
+    case _: Null => ()
+


### PR DESCRIPTION
With -Yexplicit-nulls Null is a class like any other. No reason to treat it specially
in type tests. 

Aside: Going through the issues I have noted much higher-breakage rates than usual
in everything that concerns type test optimization and diagnostics. I don't think we
can afford much more breakage in this area. In the future, we should try harder to
err on the side of caution, which means no second guessing of what the programmer
wrote or what a previous phase generated. Default to a runtime test, unless you
know with 100% certainty that no possible scenario would be affected by that test's outcome.

