### PR TITLE
Avoid redundant type test for irrefutable @unchecked patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1378,7 +1378,7 @@ trait Applications extends Compatibility {
         val unapplyPatterns = bunchedArgs.lazyZip(argTypes) map (typed(_, _))
         val result = assignType(cpy.UnApply(tree)(unapplyFn, unapplyImplicits(unapplyApp), unapplyPatterns), ownType)
         unapp.println(s"unapply patterns = $unapplyPatterns")
-        if ((ownType eq selType) || ownType.isError) result
+        if (ownType.stripped eq selType.stripped) || ownType.isError then result
         else tryWithTypeTest(Typed(result, TypeTree(ownType)), selType)
       case tp =>
         val unapplyErr = if (tp.isError) unapplyFn else notAnExtractor(unapplyFn)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1599,7 +1599,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         result match {
           case result @ Match(sel, CaseDef(pat, _, _) :: _) =>
             tree.selector.removeAttachment(desugar.CheckIrrefutable) match {
-              case Some(checkMode) =>
+              case Some(checkMode) if !sel.tpe.hasAnnotation(defn.UncheckedAnnot) =>
                 val isPatDef = checkMode == desugar.MatchCheck.IrrefutablePatDef
                 if (!checkIrrefutable(sel, pat, isPatDef) && sourceVersion == `future-migration`)
                   if (isPatDef) patch(Span(tree.selector.span.end), ": @unchecked")

--- a/tests/pos/i14821.scala
+++ b/tests/pos/i14821.scala
@@ -1,0 +1,29 @@
+trait Statement
+trait Definition extends Statement
+
+trait ClassDef extends Definition:
+  def constructor: DefDef
+
+object ClassDef:
+  def copy(constr: DefDef): ClassDef = ???
+
+// >>> This abstract implementation of DefDef causes a compilation error in transform...
+type DefDef <: Definition
+val DefDef: DefDefModule = ???
+trait DefDefModule:
+  def unapply(ddef: DefDef): (String, List[AnyRef])
+// ...unless this given TypeTest is commented out, in which case we get only a type test warning
+given scala.reflect.TypeTest[Statement, DefDef] = ???
+
+// >>> This alternative works
+// trait DefDef extends Definition
+// object DefDef:
+//   def unapply(ddef: DefDef): (String, List[AnyRef]) = ???
+
+// >>> This alternative also works
+// case class DefDef(name: String, paramss: List[AnyRef]) extends Definition
+
+def transform(tree: Statement): Statement = tree match
+  case tree: ClassDef =>
+    val constructor @ DefDef(_, _) = transform(tree.constructor): @unchecked
+    ClassDef.copy(constructor)

--- a/tests/pos/i14896.scala
+++ b/tests/pos/i14896.scala
@@ -1,0 +1,2 @@
+object Ex  { def unapply(p: Any): Option[_ <: Int] = null }
+object Foo { val Ex(_) = null: @unchecked }

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -119,6 +119,16 @@ object RegressionTestScala3 {
       def bar(x: Long = 0): Foo = new Foo(x)
     }
   }
+
+  object Issue14896 {
+    val obj = new js.Object {
+      val a = 42
+      val b = "foo"
+    }
+
+    val entries = js.Object.entries(obj)
+    val js.Tuple2(k, v) = entries(0): @unchecked
+  }
 }
 
 // This class needs to be at the top-level, not in an object, to reproduce the issue


### PR DESCRIPTION
Fixes #14896
Fixes #14821 