### PR TITLE
Use `invokedynamic` for `case class` boilerplate

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -486,6 +486,10 @@ class Definitions {
   @tu lazy val ScalaCaseClassMethodsModule: Symbol = requiredModule("scala.runtime.CaseClassMethods")
     @tu lazy val ScalaCaseClassMethodsModule_caseHashCode: Symbol =
       ScalaCaseClassMethodsModule.requiredMethodRef(nme.caseHashCode).symbol
+    @tu lazy val ScalaCaseClassMethodsModule_caseEquals: Symbol =
+      ScalaCaseClassMethodsModule.requiredMethodRef(nme.caseEquals).symbol
+    @tu lazy val ScalaCaseClassMethodsModule_caseProductElement: Symbol =
+      ScalaCaseClassMethodsModule.requiredMethodRef(nme.caseProductElement).symbol
 
   @tu lazy val BoxesRunTimeModule: Symbol = requiredModule("scala.runtime.BoxesRunTime")
     @tu lazy val BoxesRunTimeModule_externalEquals: Symbol = BoxesRunTimeModule.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -483,6 +483,10 @@ class Definitions {
     @tu lazy val ScalaRuntime_toArray: Symbol = ScalaRuntimeModule.requiredMethod(nme.toArray)
     @tu lazy val ScalaRuntime_toObjectArray: Symbol = ScalaRuntimeModule.requiredMethod(nme.toObjectArray)
 
+  @tu lazy val ScalaCaseClassMethodsModule: Symbol = requiredModule("scala.runtime.CaseClassMethods")
+    @tu lazy val ScalaCaseClassMethodsModule_caseHashCode: Symbol =
+      ScalaCaseClassMethodsModule.requiredMethodRef(nme.caseHashCode).symbol
+
   @tu lazy val BoxesRunTimeModule: Symbol = requiredModule("scala.runtime.BoxesRunTime")
     @tu lazy val BoxesRunTimeModule_externalEquals: Symbol = BoxesRunTimeModule.info.decl(nme.equals_).suchThat(toDenot(_).info.firstParamTypes.size == 2).symbol
   @tu lazy val ScalaStaticsModule: Symbol = requiredModule("scala.runtime.Statics")

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -445,6 +445,8 @@ object StdNames {
     val canEqual_ : N           = "canEqual"
     val canEqualAny : N         = "canEqualAny"
     val caseHashCode : N        = "caseHashCode"
+    val caseEquals : N          = "caseEquals"
+    val caseProductElement : N  = "caseProductElement"
     val checkInitialized: N     = "checkInitialized"
     val ClassManifestFactory: N = "ClassManifestFactory"
     val classOf: N              = "classOf"

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -444,6 +444,7 @@ object StdNames {
     val bytes: N                = "bytes"
     val canEqual_ : N           = "canEqual"
     val canEqualAny : N         = "canEqualAny"
+    val caseHashCode : N        = "caseHashCode"
     val checkInitialized: N     = "checkInitialized"
     val ClassManifestFactory: N = "ClassManifestFactory"
     val classOf: N              = "classOf"

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -244,7 +244,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
      *  def equals(that: Any): Boolean =
      *    (this eq that) || {
      *      that match {
-     *        case x$0 @ (_: C @unchecked) => this.x == this$0.x && this.y == x$0.y && that.canEqual(this)
+     *        case that$0 @ (_: C @unchecked) => this.x == that$0.x && this.y == that$0.y && that$0.canEqual(this)
      *        case _ => false
      *     }
      *  ```
@@ -328,7 +328,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       if (clazz.is(ModuleClass))
         Literal(Constant(clazz.name.stripModuleClassSuffix.toString.hashCode))
       else if (accessors.exists(_.info.finalResultType.classSymbol.isPrimitiveValueClass))
-        caseHashCodeBody
+        ref(defn.ScalaCaseClassMethodsModule_caseHashCode).appliedTo(This(clazz)) // caseHashCodeBody
       else
         ref(defn.ScalaRuntime__hashCode).appliedTo(This(clazz))
 

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -182,6 +182,9 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
      *  ```
      */
     def productElementBody(arity: Int, index: Tree)(using Context): Tree = {
+      ref(defn.ScalaCaseClassMethodsModule_caseProductElement).appliedTo(This(clazz), index)
+
+      /*
       // case N => _${N + 1}
       val cases = 0.until(arity).map { i =>
         val sel = This(clazz).select(nme.selectorName(i), _.info.isParameterless)
@@ -189,6 +192,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       }
 
       Match(index, (cases :+ generateIOBECase(index)).toList)
+      */
     }
 
     /** The class
@@ -276,8 +280,9 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       val matchExpr = Match(that, List(matchingCase, defaultCase))
       if (isDerivedValueClass(clazz)) matchExpr
       else {
-        val eqCompare = This(clazz).select(defn.Object_eq).appliedTo(that.cast(defn.ObjectType))
-        eqCompare or matchExpr
+        ref(defn.ScalaCaseClassMethodsModule_caseEquals).appliedTo(This(clazz), that)
+       // val eqCompare = This(clazz).select(defn.Object_eq).appliedTo(that.cast(defn.ObjectType))
+       // eqCompare or matchExpr
       }
     }
 

--- a/library/src/scala/runtime/CaseClassMethods.java
+++ b/library/src/scala/runtime/CaseClassMethods.java
@@ -1,0 +1,149 @@
+package scala.runtime;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import static java.lang.invoke.MethodType.methodType;
+
+/** Exposes bootstrap method for abstracting away boilerplate implementations
+  * of case class methods.
+  */
+public final class CaseClassMethods {
+
+  // Method handles for hashing
+  private static final MethodHandle STRINGHASHCODE_HANDLE;
+  private static final MethodHandle PRODUCTPREFIX_HANDLE;
+  private static final MethodHandle MIX_HANDLE;
+  private static final MethodHandle FINALIZEHASH_HANDLE;
+  private static final MethodHandle ANYHASH_HANDLE;
+  private static final Map<Class<?>, MethodHandle> PRIMITIVE_HASHER_HANDLES;
+  private static final MethodHandle INITIALHASH_HANDLE;
+
+  static {
+    try {
+      final MethodHandles.Lookup lookup = MethodHandles.lookup();
+      final Class<?> STATICS_CLASS = Statics.class;
+
+      STRINGHASHCODE_HANDLE = lookup.findVirtual(
+        String.class,
+        "hashCode",
+        methodType(int.class)
+      );
+      PRODUCTPREFIX_HANDLE = lookup.findVirtual(
+        scala.Product.class,
+        "productPrefix",
+        methodType(String.class)
+      );
+      MIX_HANDLE = lookup.findStatic(
+        Statics.class,
+        "mix",
+        methodType(int.class, int.class, int.class)
+      );
+      FINALIZEHASH_HANDLE = lookup.findStatic(
+        Statics.class,
+        "finalizeHash",
+        methodType(int.class, int.class, int.class)
+      );
+      ANYHASH_HANDLE = lookup.findStatic(
+        Statics.class,
+        "anyHash",
+        methodType(int.class, Object.class)
+      );
+      INITIALHASH_HANDLE = MethodHandles.constant(int.class, 0xcafebabe);
+
+      PRIMITIVE_HASHER_HANDLES = new HashMap<Class<?>, MethodHandle>();
+      PRIMITIVE_HASHER_HANDLES.put(
+        boolean.class,
+        MethodHandles.guardWithTest(
+          MethodHandles.identity(boolean.class),
+          MethodHandles.dropArguments(MethodHandles.constant(int.class, 1231), 0, boolean.class),
+          MethodHandles.dropArguments(MethodHandles.constant(int.class, 1237), 0, boolean.class)
+        )
+      );
+      PRIMITIVE_HASHER_HANDLES.put(byte.class, MethodHandles.identity(int.class));
+      PRIMITIVE_HASHER_HANDLES.put(short.class, MethodHandles.identity(int.class));
+      PRIMITIVE_HASHER_HANDLES.put(char.class, MethodHandles.identity(int.class));
+      PRIMITIVE_HASHER_HANDLES.put(int.class, MethodHandles.identity(int.class));
+      PRIMITIVE_HASHER_HANDLES.put(
+        long.class,
+        lookup.findStatic(Statics.class, "longHash", methodType(int.class, long.class))
+      );
+      PRIMITIVE_HASHER_HANDLES.put(
+        double.class,
+        lookup.findStatic(Statics.class, "doubleHash", methodType(int.class, double.class))
+      );
+      PRIMITIVE_HASHER_HANDLES.put(
+        float.class,
+        lookup.findStatic(Statics.class, "floatHash", methodType(int.class, float.class))
+      );
+
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static ConstantCallSite bootstrap(
+    MethodHandles.Lookup lookup,
+    String methodName,
+    MethodType methodType,
+    Class<?> caseClass,
+    MethodHandle... fieldHandles
+  ) throws Throwable {
+    switch (methodName) {
+      case "productElement":
+      case "productElementName":
+      case "equals":
+        throw new UnsupportedOperationException();
+
+      case "hashCode":
+        var productPrefixHandle = lookup.findVirtual(
+          caseClass,
+          "productPrefix",
+          methodType(String.class)
+        );
+
+        // Accumulator hasher of type `(LMyCaseClass;)I`
+        var accHash = MethodHandles.filterReturnValue(
+          MethodHandles.filterReturnValue(productPrefixHandle, STRINGHASHCODE_HANDLE),
+          MethodHandles.insertArguments(MIX_HANDLE, 0, 0xcafebabe)
+        );
+
+        // Fold over fields, adding each field into the `accHash` handle
+        for (final var fieldHandle : fieldHandles) {
+          final Class<?> fieldType = fieldHandle.type().returnType();
+
+          // Handle of type `(LMyCaseClass;)I` for hashing just this field
+          final var fieldHash = MethodHandles.filterReturnValue(
+            fieldHandle,
+            PRIMITIVE_HASHER_HANDLES.getOrDefault(fieldType, ANYHASH_HANDLE.asType(methodType(int.class, fieldType)))
+          );
+
+          // Mix this field's hasher back into the accumulator hasher
+          accHash = MethodHandles.permuteArguments(
+            MethodHandles.filterArguments(MIX_HANDLE, 0, accHash, fieldHash),
+            accHash.type(),
+            0,
+            0
+          );
+        }
+
+        // Finalize the hash using the number of fields
+        final var finalizedHash = MethodHandles.filterReturnValue(
+          accHash,
+          MethodHandles.insertArguments(FINALIZEHASH_HANDLE, 1, fieldHandles.length)
+        );
+
+        return new ConstantCallSite(finalizedHash);
+
+      default:
+        throw new IllegalArgumentException(methodName);
+    }
+  }
+
+  public static int caseHashCode(scala.Product x) {
+    return scala.util.hashing.MurmurHash3$.MODULE$.productHash(x);
+  }
+}

--- a/library/src/scala/runtime/CaseClassMethods.java
+++ b/library/src/scala/runtime/CaseClassMethods.java
@@ -1,6 +1,8 @@
 package scala.runtime;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.List;
 import java.util.HashMap;
 import java.lang.invoke.ConstantCallSite;
 import java.lang.invoke.MethodHandle;
@@ -22,11 +24,27 @@ public final class CaseClassMethods {
   private static final Map<Class<?>, MethodHandle> PRIMITIVE_HASHER_HANDLES;
   private static final MethodHandle INITIALHASH_HANDLE;
 
-  static {
-    try {
-      final MethodHandles.Lookup lookup = MethodHandles.lookup();
-      final Class<?> STATICS_CLASS = Statics.class;
+  // Method handles for equality
+  private static final MethodHandle FALSE_HANDLE;
+  private static final MethodHandle TRUE_HANDLE;
+  private static final MethodHandle OBJECTEQUALS_HANDLE;
+  private static final MethodHandle OBJECTEQ_HANDLE;
+  private static final MethodHandle ISINSTANCE_HANDLE;
+  private static final Map<Class<?>, MethodHandle> PRIMITIVE_EQ_HANDLES;
 
+
+  // Method handles for product elements extraction
+  private static final MethodHandle INDEXOUTOFBOUNDS_HANDLE;
+
+  // MethodHandles for making MethodHandles (polyfill for older JVMs)
+  private static final MethodHandle TABLESWITCH_HANDLE;
+  private static final MethodHandle INRANGE_HANDLE;
+
+  static {
+    final MethodHandles.Lookup lookup = MethodHandles.lookup();
+    final Class<?> STATICS_CLASS = Statics.class;
+
+    try {
       STRINGHASHCODE_HANDLE = lookup.findVirtual(
         String.class,
         "hashCode",
@@ -55,18 +73,15 @@ public final class CaseClassMethods {
       INITIALHASH_HANDLE = MethodHandles.constant(int.class, 0xcafebabe);
 
       PRIMITIVE_HASHER_HANDLES = new HashMap<Class<?>, MethodHandle>();
-      PRIMITIVE_HASHER_HANDLES.put(
-        boolean.class,
-        MethodHandles.guardWithTest(
-          MethodHandles.identity(boolean.class),
-          MethodHandles.dropArguments(MethodHandles.constant(int.class, 1231), 0, boolean.class),
-          MethodHandles.dropArguments(MethodHandles.constant(int.class, 1237), 0, boolean.class)
-        )
+      final var primHashTypes = Arrays.asList(
+        byte.class, short.class, char.class, int.class, boolean.class
       );
-      PRIMITIVE_HASHER_HANDLES.put(byte.class, MethodHandles.identity(int.class));
-      PRIMITIVE_HASHER_HANDLES.put(short.class, MethodHandles.identity(int.class));
-      PRIMITIVE_HASHER_HANDLES.put(char.class, MethodHandles.identity(int.class));
-      PRIMITIVE_HASHER_HANDLES.put(int.class, MethodHandles.identity(int.class));
+      for (final var primType : primHashTypes) {
+        PRIMITIVE_HASHER_HANDLES.put(
+          primType,
+          lookup.findStatic(CaseClassMethods.class, "hash", methodType(int.class, primType))
+        );
+      }
       PRIMITIVE_HASHER_HANDLES.put(
         long.class,
         lookup.findStatic(Statics.class, "longHash", methodType(int.class, long.class))
@@ -80,10 +95,52 @@ public final class CaseClassMethods {
         lookup.findStatic(Statics.class, "floatHash", methodType(int.class, float.class))
       );
 
+      FALSE_HANDLE = MethodHandles.constant(boolean.class, false);
+      TRUE_HANDLE = MethodHandles.constant(boolean.class, true);
+      OBJECTEQUALS_HANDLE = lookup.findVirtual(Object.class, "equals", methodType(boolean.class, Object.class));
+      OBJECTEQ_HANDLE = lookup.findStatic(CaseClassMethods.class, "eq", methodType(boolean.class, Object.class, Object.class));
+      ISINSTANCE_HANDLE = lookup.findVirtual(Class.class, "isInstance", methodType(boolean.class, Object.class));
+
+      PRIMITIVE_EQ_HANDLES = new HashMap<Class<?>, MethodHandle>();
+      final var primEqTypes = Arrays.asList(
+        byte.class, short.class, char.class, int.class,
+        long.class, float.class, double.class, boolean.class
+      );
+      for (final var primType : primEqTypes) {
+        PRIMITIVE_EQ_HANDLES.put(
+          primType,
+          lookup.findStatic(CaseClassMethods.class, "eq", methodType(boolean.class, primType, primType))
+        );
+      }
+
+      INRANGE_HANDLE = lookup.findStatic(
+        CaseClassMethods.class,
+        "checkInRange",
+        methodType(boolean.class, int.class, int.class)
+      );
+
+      INDEXOUTOFBOUNDS_HANDLE = lookup.findConstructor(
+        IndexOutOfBoundsException.class,
+        methodType(void.class, int.class)
+      );
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
+
+    // If the runtime JVM has `tableSwitch`, use that
+    MethodHandle tableSwitchHandle = null;
+    try {
+      tableSwitchHandle = lookup.findStatic(
+        MethodHandles.class,
+        "tableSwitch",
+        methodType(MethodHandle.class, MethodHandle.class, MethodHandle[].class)
+      );
+    } catch (ReflectiveOperationException e) {
+      // Ignore - this is expected to fail for <17
+    }
+    TABLESWITCH_HANDLE = tableSwitchHandle;
   }
+
 
   public static ConstantCallSite bootstrap(
     MethodHandles.Lookup lookup,
@@ -92,58 +149,343 @@ public final class CaseClassMethods {
     Class<?> caseClass,
     MethodHandle... fieldHandles
   ) throws Throwable {
+    final MethodHandle methodHandle;
     switch (methodName) {
-      case "productElement":
-      case "productElementName":
       case "equals":
-        throw new UnsupportedOperationException();
+        checkMethod(methodName, methodType, methodType(boolean.class, caseClass, Object.class));
+        // TODO: skip `canEqual` when possible
+        methodHandle = caseClassEqualsHandle(
+          caseClass,
+          java.util.Arrays.asList(fieldHandles),
+          methodType,
+          lookup.findVirtual(caseClass, "canEqual", methodType(boolean.class, Object.class))
+        );
+        break;
 
       case "hashCode":
-        var productPrefixHandle = lookup.findVirtual(
+        checkMethod(methodName, methodType, methodType(int.class, caseClass));
+        // TODO: pass in actual `productPrefix` when class is final
+        methodHandle = caseClassHashCodeHandle(
           caseClass,
-          "productPrefix",
-          methodType(String.class)
+          java.util.Arrays.asList(fieldHandles),
+          methodType,
+          lookup.findVirtual(caseClass, "productPrefix", methodType(String.class))
         );
+        break;
 
-        // Accumulator hasher of type `(LMyCaseClass;)I`
-        var accHash = MethodHandles.filterReturnValue(
-          MethodHandles.filterReturnValue(productPrefixHandle, STRINGHASHCODE_HANDLE),
-          MethodHandles.insertArguments(MIX_HANDLE, 0, 0xcafebabe)
+      case "productElement":
+        checkMethod(methodName, methodType, methodType(Object.class, caseClass, int.class));
+        methodHandle = caseClassProductElementHandle(
+          caseClass,
+          Arrays.asList(fieldHandles),
+          methodType
         );
+        break;
 
-        // Fold over fields, adding each field into the `accHash` handle
-        for (final var fieldHandle : fieldHandles) {
-          final Class<?> fieldType = fieldHandle.type().returnType();
-
-          // Handle of type `(LMyCaseClass;)I` for hashing just this field
-          final var fieldHash = MethodHandles.filterReturnValue(
-            fieldHandle,
-            PRIMITIVE_HASHER_HANDLES.getOrDefault(fieldType, ANYHASH_HANDLE.asType(methodType(int.class, fieldType)))
-          );
-
-          // Mix this field's hasher back into the accumulator hasher
-          accHash = MethodHandles.permuteArguments(
-            MethodHandles.filterArguments(MIX_HANDLE, 0, accHash, fieldHash),
-            accHash.type(),
-            0,
-            0
-          );
-        }
-
-        // Finalize the hash using the number of fields
-        final var finalizedHash = MethodHandles.filterReturnValue(
-          accHash,
-          MethodHandles.insertArguments(FINALIZEHASH_HANDLE, 1, fieldHandles.length)
-        );
-
-        return new ConstantCallSite(finalizedHash);
-
+      case "productElementName":
       default:
-        throw new IllegalArgumentException(methodName);
+        throw new IllegalArgumentException("Invalid method name: " + methodName);
+    }
+
+    return new ConstantCallSite(methodHandle);
+  }
+
+  // Stubs
+  public static int caseHashCode(scala.Product thiz) {
+    return scala.util.hashing.MurmurHash3$.MODULE$.productHash(thiz);
+  }
+  public static boolean caseEquals(scala.Product thiz, Object other) {
+    throw new AssertionError();
+  }
+  public static Object caseProductElement(scala.Product thiz, int index) {
+    throw new AssertionError();
+  }
+
+  /**
+   * Assert the method type is the correct one.
+   *
+   * @param methodName name of the method
+   * @param found user provided method type
+   * @param expected expected type
+   */
+  private static void checkMethod(String name, MethodType found, MethodType expected) {
+    if (!found.equals(expected)) {
+      throw new IllegalArgumentException("Invalid type for " + name + ": " + found);
     }
   }
 
-  public static int caseHashCode(scala.Product x) {
-    return scala.util.hashing.MurmurHash3$.MODULE$.productHash(x);
+  /**
+   * Produce a method handle implementing `equals` for a case class.
+   *
+   * @param caseClass left hand side of the handle
+   * @param fieldHandles handles for extracting each of the case fields
+   * @param methodType type of the output method
+   * @param canEqualHandle if not null, include a call to this too
+   * @return handle implementing case class equality check
+   */
+  private static MethodHandle caseClassEqualsHandle(
+    Class<?> caseClass,
+    List<MethodHandle> fieldHandles,
+    MethodType methodType,
+    MethodHandle canEqualHandle
+  ) {
+
+    final var shortCutFalse = MethodHandles.dropArguments(FALSE_HANDLE, 0, caseClass, caseClass);
+    final var shortCutTrue = MethodHandles.dropArguments(TRUE_HANDLE, 0, caseClass, caseClass);
+
+    // Accumulator of type `(LMyCaseClass;LMyCaseClass;)Z`
+    var accEqual = shortCutTrue;
+    final var accType = accEqual.type();
+
+    // Invoke `canEqual`
+    if (canEqualHandle != null) {
+      accEqual = MethodHandles.guardWithTest(
+        canEqualHandle.asType(accType),
+        accEqual,
+        shortCutFalse
+      );
+    }
+
+    // Scan over reference fields
+    for (MethodHandle fieldHandle : fieldHandles) {
+      final Class<?> fieldType = fieldHandle.type().returnType();
+      if (fieldType.isPrimitive()) {
+        continue;
+      }
+      var fieldEq = OBJECTEQUALS_HANDLE.asType(methodType(boolean.class, fieldType, fieldType));
+
+      // Fold this field's equality back into the accumulator
+      accEqual = MethodHandles.guardWithTest(
+        MethodHandles.filterArguments(fieldEq, 0, fieldHandle, fieldHandle),
+        accEqual,
+        shortCutFalse
+      );
+    }
+
+    // Scan over primitive fieaccEqual = lds
+    for (MethodHandle fieldHandle : fieldHandles) {
+      final Class<?> fieldType = fieldHandle.type().returnType();
+      final var fieldEq = PRIMITIVE_EQ_HANDLES.get(fieldType);
+      if (fieldEq == null) {
+        continue;
+      }
+
+      // Fold this field's equality back into the accumulator
+      accEqual = MethodHandles.guardWithTest(
+        MethodHandles.filterArguments(fieldEq, 0, fieldHandle, fieldHandle),
+        accEqual,
+        shortCutFalse
+      );
+    }
+
+    // Check the second argument has the right type
+    final var typeCheckedEquality = MethodHandles.guardWithTest(
+      MethodHandles.dropArguments(ISINSTANCE_HANDLE.bindTo(caseClass), 0, caseClass),
+      accEqual.asType(methodType),
+      shortCutFalse.asType(methodType)
+    );
+
+    // Finally, short-cut on object equality
+    final var shortCuttingEquality = MethodHandles.guardWithTest(
+      OBJECTEQ_HANDLE.asType(methodType),
+      shortCutTrue.asType(methodType),
+      typeCheckedEquality
+    );
+
+    return shortCuttingEquality;
+  }
+
+  /**
+   * Produce a method handle implementing `hashCode` for a case class.
+   *
+   * TODO: for final classes, pass in and pre-compute the hash on `productPrefix`
+   *
+   * @param caseClass left hand side of the handle
+   * @param fieldHandles handles for extracting each of the case fields
+   * @param methodType type of the output method
+   * @param productPrefixHandle handle to `productPrefix`
+   * @return handle implementing case class hashing
+   */
+  private static MethodHandle caseClassHashCodeHandle(
+    Class<?> caseClass,
+    List<MethodHandle> fieldHandles,
+    MethodType methodType,
+    MethodHandle productPrefixHandle
+  ) {
+
+    // Accumulator hasher of type `(LMyCaseClass;)I`
+    var accHash = MethodHandles.filterReturnValue(
+      MethodHandles.filterReturnValue(productPrefixHandle, STRINGHASHCODE_HANDLE),
+      MethodHandles.insertArguments(MIX_HANDLE, 0, 0xcafebabe)
+    );
+
+    // Fold over fields, adding each field into the `accHash` handle
+    for (final var fieldHandle : fieldHandles) {
+      final Class<?> fieldType = fieldHandle.type().returnType();
+
+      // Handle of type `(LMyCaseClass;)I` for hashing just this field
+      final var fieldHash = MethodHandles.filterReturnValue(
+        fieldHandle,
+        PRIMITIVE_HASHER_HANDLES.getOrDefault(fieldType, ANYHASH_HANDLE.asType(methodType(int.class, fieldType)))
+      );
+
+      // Mix this field's hasher back into the accumulator hasher
+      accHash = MethodHandles.permuteArguments(
+        MethodHandles.filterArguments(MIX_HANDLE, 0, accHash, fieldHash),
+        accHash.type(),
+        0,
+        0
+      );
+    }
+
+    // Finalize the hash using the number of fields
+    final var finalizedHash = MethodHandles.filterReturnValue(
+      accHash,
+      MethodHandles.insertArguments(FINALIZEHASH_HANDLE, 1, fieldHandles.size())
+    );
+
+    return finalizedHash;
+  }
+
+  /**
+   * Produce a method handle implementing `productElement` for a case class.
+   *
+   * @param caseClass left hand side of the handle
+   * @param fieldHandles handles for extracting each of the case fields
+   * @param methodType type of the output method
+   * @return handle implementing case class product element selection
+   */
+  private static MethodHandle caseClassProductElementHandle(
+    Class<?> caseClass,
+    List<MethodHandle> fieldHandles,
+    MethodType methodType
+  ) {
+
+    // Prepare an array of handles for extracting boxed versions of fields
+    final var boxedFieldHandles = new MethodHandle[fieldHandles.size()];
+    final var boxedFieldHandleType = methodType.dropParameterTypes(1, 2);
+    for (int i = 0; i < boxedFieldHandles.length; i++) {
+      boxedFieldHandles[i] = fieldHandles.get(i).asType(boxedFieldHandleType);
+    }
+
+    // Fallback case - throws the right exception
+    final var indexOutOfBoundsHandle = MethodHandles.filterReturnValue(
+      MethodHandles.dropArguments(INDEXOUTOFBOUNDS_HANDLE, 1, caseClass),
+      MethodHandles.throwException(Object.class, IndexOutOfBoundsException.class)
+    );
+
+    return MethodHandles.permuteArguments(
+      tableSwitch(indexOutOfBoundsHandle, boxedFieldHandles),
+      methodType,
+      new int[] { 1, 0 }
+    );
+  }
+
+  /**
+   * Almost `MethodHandle.tableSwitch`, but only the fallback case takes a
+   * leading `int` argument and this will fallback to an array based
+   * implementation on oldee JVMs.
+   *
+   * All of `targets` and `fallback` must take an `int` as their first argument.
+   *
+   * @param fallback method handle to invoke if the switch index falls outside targets
+   * @param targets method handles to invoke for various indices
+   * @return handle dispatching to the right target based on a leading `int` argument
+   */
+  private static MethodHandle tableSwitch(MethodHandle fallback, MethodHandle[] targets) {
+    if (TABLESWITCH_HANDLE != null) {
+      try {
+        final var adaptedTargets = new MethodHandle[targets.length];
+        for (int i = 0; i < adaptedTargets.length; i++) {
+          adaptedTargets[i] = MethodHandles.dropArguments(targets[i], 0, int.class);
+        }
+        return (MethodHandle)TABLESWITCH_HANDLE.invoke(fallback, adaptedTargets);
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    // `(I)Ljava/lang/invoke/MethodHandle;`
+    final var getHandle = MethodHandles
+      .arrayElementGetter(MethodHandle[].class)
+      .bindTo(targets);
+
+    // `(I A1 A2 ...)R`, but only works for valid indices
+    final var uncheckedIndexHandle = MethodHandles.filterArguments(
+      MethodHandles.exactInvoker(fallback.type().dropParameterTypes(0, 1)),
+      0,
+      getHandle
+    );
+
+    return MethodHandles.guardWithTest(
+      MethodHandles.insertArguments(INRANGE_HANDLE, 1, targets.length),
+      uncheckedIndexHandle,
+      fallback
+    );
+  }
+
+  /**
+   * Check if an index is between zero and a specified length.
+   *
+   * @param index what to check
+   * @param length (non-inclusive) upper bound
+   * @return whether the index is in bounds
+   */
+  private static boolean checkInRange(int index, int length) {
+    return 0 <= index && index < length;
+  }
+
+  /* Equality helper methods (only ever used through method handle lookups).
+   *
+   * These should match the expected semantics of comparing two fields in a
+   * derived implementation of `equals` for a case class.
+   */
+  private static boolean eq(Object a, Object b) {
+    return a == b;
+  }
+  private static boolean eq(byte a, byte b) {
+    return a == b;
+  }
+  private static boolean eq(short a, short b) {
+    return a == b;
+  }
+  private static boolean eq(char a, char b) {
+    return a == b;
+  }
+  private static boolean eq(int a, int b) {
+    return a == b;
+  }
+  private static boolean eq(long a, long b) {
+    return a == b;
+  }
+  private static boolean eq(float a, float b) {
+    return a == b;
+  }
+  private static boolean eq(double a, double b) {
+    return a == b;
+  }
+  private static boolean eq(boolean a, boolean b) {
+    return a == b;
+  }
+
+  /* Hashing helper methods (only ever used through method handle lookups).
+   *
+   * These should match the expected semantics of hashing a fields in a
+   * derived implementation of `hashCode` for a case class.
+   */
+  private static int hash(boolean a) {
+    return a ? 1231 : 1237;
+  }
+  private static int hash(byte a) {
+    return a;
+  }
+  private static int hash(short a) {
+    return a;
+  }
+  private static int hash(char a) {
+    return a;
+  }
+  private static int hash(int a) {
+    return a;
   }
 }


### PR DESCRIPTION
This aspires to replace some of the boilerplate bytecode in case classes with `invokedynamic`.
Java does something similar for record classes (see `java.lang.runtime.ObjectMethods`).

See lampepfl/dotty-feature-requests/issues/196.