### PR TITLE
Cache skolem types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4621,11 +4621,12 @@ object Types {
    * Note that care is needed when creating them, since not all types need to be inhabited.
    * A skolem is equal to itself and no other type.
    */
-  case class SkolemType(info: Type) extends UncachedProxyType with ValueType with SingletonType {
+  case class SkolemType(info: Type) extends CachedProxyType with ValueType with SingletonType {
     override def underlying(using Context): Type = info
     def derivedSkolemType(info: Type)(using Context): SkolemType =
       if (info eq this.info) this else SkolemType(info)
-    override def hashCode: Int = System.identityHashCode(this)
+
+    override def computeHash(bs: Binders): Int = identityHash(bs)
     override def equals(that: Any): Boolean = this.eq(that.asInstanceOf[AnyRef])
 
     def withName(name: Name): this.type = { myRepr = name; this }


### PR DESCRIPTION
Skolem types were not cached, which means that any type containing a skolem type
was not cached either. This meant that the same match type with a skolem type as
selector was created many times instead of once, so its reduction was not cached
either. We now cache skolem types. It's a bet that in practice few skolem types are
created and that therefore the hashtable pollution with skolemtypes is less of
a problem than the potential problem of losing identity of types containing
skolem types.

Fixes #14903