### PR TITLE
Align PositionBridge#toString impl with Zinc

### DIFF
--- a/sbt-bridge/src/dotty/tools/xsbt/PositionBridge.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/PositionBridge.java
@@ -123,7 +123,11 @@ public class PositionBridge implements Position {
 
   @Override
   public String toString() {
-      return pos.toString();
+    Optional<String> path = sourcePath();
+    if (path.isPresent())
+      return path.get() + ":" + line().orElse(-1).toString();
+    else
+      return "";
   }
   
   @Override

--- a/sbt-bridge/src/dotty/tools/xsbt/PositionBridge.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/PositionBridge.java
@@ -123,11 +123,13 @@ public class PositionBridge implements Position {
 
   @Override
   public String toString() {
-    Optional<String> path = sourcePath();
-    if (path.isPresent())
-      return path.get() + ":" + line().orElse(-1).toString();
+    String path = sourcePath().orElse("");
+    Optional<Integer> l = line();
+    Integer column = pointer().orElse(1);
+    if (l.isPresent())
+      return String.format("%s:%d:%d", path, l.get(), column);
     else
-      return "";
+      return path;
   }
   
   @Override


### PR DESCRIPTION
In `sbt-bridge`, the `PositonBrdige#toString` should return `"<path>:<line>"` as in [Zinc](https://github.com/sbt/zinc/blob/c550e78216d159d7ebd495100792be292b27874e/internal/zinc-core/src/main/scala/sbt/internal/inc/VirtualFileUtil.scala#L63-L68).

Fixes https://github.com/sbt/zinc/issues/1089