### PR TITLE
Supress safe-init warnings for NameKind HashMaps

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -85,7 +85,7 @@ object NameKinds {
       case _ => None
     }
 
-    simpleNameKinds(tag) = this
+    simpleNameKinds(tag) = (this: @unchecked)
   }
 
   /** The kind of names that get formed by adding a prefix to an underlying name */
@@ -152,7 +152,7 @@ object NameKinds {
 
     def infoString: String = s"Qualified $separator"
 
-    qualifiedNameKinds(tag) = this
+    qualifiedNameKinds(tag) = (this: @unchecked)
   }
 
   /** An extractor for qualified names of an arbitrary kind */
@@ -190,7 +190,7 @@ object NameKinds {
       else -1
     }
 
-    numberedNameKinds(tag) = this
+    numberedNameKinds(tag) = (this: @unchecked)
   }
 
   /** An extractor for numbered names of arbitrary kind */
@@ -225,7 +225,7 @@ object NameKinds {
     def fresh(prefix: TypeName)(using Context): TypeName =
       fresh(prefix.toTermName).toTypeName
 
-    uniqueNameKinds(separator) = this
+    uniqueNameKinds(separator) = (this: @unchecked)
   }
 
   /** An extractor for unique names of arbitrary kind */


### PR DESCRIPTION
This adds the `@unchecked` annotation to each of the four lines that add the object under construction to the relevant HashMap.

In the `NameKinds.scala` file, all of the `NameKind`s are created and added to one of four HashMaps based on their superclass. The lines that add the NameKind to the HashMaps are at the end of the relevant superclasses. This leads to a safe-init error since subclasses can add further fields and initialization logic that gets run after these lines.

These warnings could be eliminated without the use of `@unchecked`, but it would require redundantly adding the same line to all `NameKind` subclasses that get initialized. This means that anyone who changes this code in the future would need to remember to do this for all of the relevant subclasses. This could also be fixed without `@unchecked` if there were a mechanism like `DelayedInit` in Scala3.

Thus, instead of making a more involved change that would render the code redundant, overly verbose, and less maintainable, I opted for using `@unchecked` instead.