### PR TITLE
Setup integration with the unmanaged community build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -551,10 +551,6 @@ jobs:
         run: |
           ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
 
-      - name: Trigger unmanaged community build
-        continue-on-error: true
-        run: .github/workflows/scripts/triggerUnmanagedCommunityBuild.sh "${{ secrets.BUILD_TOKEN }}" "$THISBUILD_VERSION"
-
   nightly_documentation:
     runs-on: [self-hosted, Linux]
     container:
@@ -604,6 +600,41 @@ jobs:
           external_repository: lampepfl/dotty-website
           publish_branch: gh-pages
 
+  nightly_unmanaged_community_build:
+    # Self-hosted runner is used only for getting current build version
+    runs-on: [self-hosted, Linux]
+    container:
+      image: lampepfl/dotty:2021-03-22
+      options: --cpu-shares 4096
+      volumes:
+        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
+        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
+        - ${{ github.workspace }}/../../cache/general:/root/.cache
+    needs: [publish_nightly]
+    steps:
+      - name: Reset existing repo
+        run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true
+
+      - name: Checkout cleanup script
+        uses: actions/checkout@v2
+
+      - name: Cleanup
+        run: .github/workflows/cleanup.sh
+
+      - name: Git Checkout
+        uses: actions/checkout@v2
+
+      - name: Add SBT proxy repositories
+        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
+
+      - name: Get version string for this build
+        run: |
+          ver=$(./project/scripts/sbt "print scala3-compiler-bootstrapped/version" | tail -n1)
+          echo "This build version: $ver"
+          echo "THISBUILD_VERSION=$ver" >> $GITHUB_ENV
+      # Steps above are copy-pasted from publish_nightly, needed only to resolve THISBUILD_VERSION
+      - name: Trigger unmanaged community build
+        run: .github/workflows/scripts/triggerUnmanagedCommunityBuild.sh "${{ secrets.BUILD_TOKEN }}" "$THISBUILD_VERSION"
 
   publish_release:
     runs-on: [self-hosted, Linux]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -611,6 +611,9 @@ jobs:
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
     needs: [publish_nightly]
+    if: "(github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'lampepfl/dotty'"
+    env:
+      NIGHTLYBUILD: yes
     steps:
       - name: Reset existing repo
         run: git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/lampepfl/dotty" && git reset --hard FETCH_HEAD || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -551,6 +551,10 @@ jobs:
         run: |
           ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
 
+      - name: Trigger unmanaged community build
+        continue-on-error: true
+        run: .github/workflows/scripts/triggerUnmanagedCommunityBuild.sh "${{ secrets.BUILD_TOKEN }}" "$THISBUILD_VERSION"
+
   nightly_documentation:
     runs-on: [self-hosted, Linux]
     container:

--- a/.github/workflows/scripts/triggerUnmanagedCommunityBuild.sh
+++ b/.github/workflows/scripts/triggerUnmanagedCommunityBuild.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# This is script for triggering unamanged community build upon releasing nightly version.
+# Script sends request to CB Jenkins instance to start the build for given released Scala version
+# Prints url of created job to stdout
+#
+# Requirement:
+#   - the latest (nightly) version of scala should be published
+
+set -u
+
+if [ $# -ne 2 ]; then
+  echo "Wrong number of script arguments, expected <token> <scala-version>, got $#: $@"
+  exit 1
+fi
+
+CB_ENDPOINT=https://scala3.westeurope.cloudapp.azure.com
+CB_BUILD_TOKEN="$1"
+SCALA_VERSION="$2"
+
+startRunResponse=$(curl "${CB_ENDPOINT}/job/runBuild/buildWithParameters?token=${CB_BUILD_TOKEN}&publishedScalaVersion=${SCALA_VERSION}" -v 2>&1)
+echo "${startRunResponse}"
+queueItem=$(echo "${startRunResponse}" | grep -oP "< Location: \K[\w\d:/.//]+")
+# Wait until Jenkins does acknowledge the build (max 1 min )
+for i in {1..12}; do
+  buildUrl=$(curl -s "${queueItem}/api/json?tree=executable[url]" | jq .executable.url)
+  if [[ "null" == "${buildUrl}" ]]; then
+    echo "Waiting for build start..."
+    sleep 5
+  else
+    echo "Created build url: ${buildUrl}"
+    exit 0
+  fi
+done
+
+# Set error if failed to resolve build url
+exit 1


### PR DESCRIPTION
This PR sets up integration with the [unmanaged community build](https://scala3.westeurope.cloudapp.azure.com/) by triggering the run with the latest nightly version of Scala

Before merging secret `BUILD_TOKEN` should be set for the Dotty repo based on the secure token set in the Jenkins instance of the unmanaged community build.

The unmanaged community build is not restricted to the list of maintained projects within dotty-staging and can run most of the OSS projects based on information fetched from Scaladex and Maven. Instead of maintaining forks of the projects and using them in the managed community build, we do build the projects using the last release tag. It supports handling dependencies between the builds - project builds are aware of both their upstream and downstream builds, which allows waiting until dependencies are being built and published to the custom Maven repository shared within the build. It supports both sbt and mill (limited) builds. The projects used for the build are picked by their popularity measured in GitHub stars.
The sources of the unmanaged community build can be found here: https://github.com/VirtusLab/community-build3
