### PR TITLE
Fix safe-init error in Trees.scala

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -812,7 +812,7 @@ object Trees {
   case class ValDef[-T >: Untyped] private[ast] (name: TermName, tpt: Tree[T], private var preRhs: LazyTree[T @uncheckedVariance])(implicit @constructorOnly src: SourceFile)
     extends ValOrDefDef[T], ValOrTypeDef[T] {
     type ThisTree[-T >: Untyped] = ValDef[T]
-    assert(isEmpty || tpt != genericEmptyTree)
+    assert(isEmpty || (tpt ne genericEmptyTree))
     def unforced: LazyTree[T] = preRhs
     protected def force(x: Tree[T @uncheckedVariance]): Unit = preRhs = x
   }
@@ -822,7 +822,7 @@ object Trees {
       paramss: List[ParamClause[T]], tpt: Tree[T], private var preRhs: LazyTree[T @uncheckedVariance])(implicit @constructorOnly src: SourceFile)
     extends ValOrDefDef[T] {
     type ThisTree[-T >: Untyped] = DefDef[T]
-    assert(tpt != genericEmptyTree)
+    assert(tpt ne genericEmptyTree)
     def unforced: LazyTree[T] = preRhs
     protected def force(x: Tree[T @uncheckedVariance]): Unit = preRhs = x
 


### PR DESCRIPTION
Fixes the following safe-init error that occurs during bootstrapping:
```
[error] -- Error: /***********/dotty/compiler/src/dotty/tools/dotc/ast/Trees.scala:815:22
[error] 815 |    assert(isEmpty || tpt != genericEmptyTree[T])
[error]     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]     |Call method ValDef.this.tpt.!=(dotty.tools.dotc.ast.Trees.genericEmptyTree[T]) on a value with an unknown initialization. Calling trace:
[error]     |-> @sharable val theEmptyValDef = new EmptyValDef[Type]()  [ Trees.scala:970 ]
[error]     |                                  ^^^^^^^^^^^^^^^^^^^^^^^
[error]     |-> class EmptyValDef[T >: Untyped] extends ValDef[T](  [ Trees.scala:961 ]
[error]     |   ^
[error]     |-> case class ValDef[-T >: Untyped] private[ast] (name: TermName, tpt: Tree[T], private var preRhs: LazyTree[T @uncheckedVariance])(implicit @constructorOnly src: SourceFile) [ Trees.scala:812 ]
[error]     |   ^
[error]     |-> assert(isEmpty || tpt != genericEmptyTree[T])   [ Trees.scala:815 ]
[error]     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]     |-> if !assertion then scala.runtime.Scala3RunTime.assertFailed()   [ Predef.scala:10 ]
```