### PR TITLE
Update compiler message links. use `docs.scala-lang.org`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -2003,7 +2003,7 @@ class Definitions {
     add(MatchableClass,
     """/** The base trait of types that can be safely pattern matched against.
       | *
-      | *   See [[https://dotty.epfl.ch/docs/reference/other-new-features/matchable.html]].
+      | *   See [[https://docs.scala-lang.org/scala3/reference/other-new-features/matchable.html]].
       | */
     """.stripMargin)
 
@@ -2112,21 +2112,21 @@ class Definitions {
     add(AnyKindClass,
     """/** The super-type of all types.
       | *
-      | *   See [[https://dotty.epfl.ch/docs/reference/other-new-features/kind-polymorphism.html]].
+      | *   See [[https://docs.scala-lang.org/scala3/reference/other-new-features/kind-polymorphism.html]].
       | */
     """.stripMargin)
 
     add(andType,
     """/** The intersection of two types.
       | *
-      | *   See [[https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html]].
+      | *   See [[https://docs.scala-lang.org/scala3/reference/new-types/intersection-types.html]].
       | */
     """.stripMargin)
 
     add(orType,
     """/** The union of two types.
       | *
-      | *   See [[https://dotty.epfl.ch/docs/reference/new-types/union-types.html]].
+      | *   See [[https://docs.scala-lang.org/scala3/reference/new-types/union-types.html]].
       | */
     """.stripMargin)
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3674,14 +3674,14 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 tree.symbol != defn.StringContext_f &&
                 tree.symbol != defn.StringContext_s)
           if (ctx.settings.XignoreScala2Macros.value) {
-            report.warning("Scala 2 macro cannot be used in Dotty, this call will crash at runtime. See https://dotty.epfl.ch/docs/reference/dropped-features/macros.html", tree.srcPos.startPos)
+            report.warning("Scala 2 macro cannot be used in Dotty, this call will crash at runtime. See https://docs.scala-lang.org/scala3/reference/dropped-features/macros.html", tree.srcPos.startPos)
             Throw(New(defn.MatchErrorClass.typeRef, Literal(Constant(s"Reached unexpanded Scala 2 macro call to ${tree.symbol.showFullName} compiled with -Xignore-scala2-macros.")) :: Nil))
               .withType(tree.tpe)
               .withSpan(tree.span)
           }
           else {
             report.error(
-              """Scala 2 macro cannot be used in Dotty. See https://dotty.epfl.ch/docs/reference/dropped-features/macros.html
+              """Scala 2 macro cannot be used in Dotty. See https://docs.scala-lang.org/scala3/reference/dropped-features/macros.html
                 |To turn this error into a warning, pass -Xignore-scala2-macros to the compiler""".stripMargin, tree.srcPos.startPos)
             tree
           }

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -171,7 +171,7 @@ class VarianceChecker(using Context) {
             val towner = tvar.owner
             if towner.isAllOf(EnumCase) && towner.isClass && tvar.is(Synthetic) then
               val example =
-                "See an example at http://dotty.epfl.ch/docs/reference/enums/adts.html#parameter-variance-of-enums"
+                "See an example at https://docs.scala-lang.org/scala3/reference/enums/adts.html#parameter-variance-of-enums"
               i"\n${hl("enum case")} ${towner.name} requires explicit declaration of $tvar to resolve this issue.\n$example"
             else
               ""

--- a/tests/neg-custom-args/fatal-warnings/enum-variance.check
+++ b/tests/neg-custom-args/fatal-warnings/enum-variance.check
@@ -1,9 +1,9 @@
 -- Error: tests/neg-custom-args/fatal-warnings/enum-variance.scala:2:12 ------------------------------------------------
 2 |  case Refl(f: T => T) // error: enum case Refl requires explicit declaration of type T
   |            ^^^^^^^^^
-  |            contravariant type T occurs in covariant position in type T => T of value f
-  |            enum case Refl requires explicit declaration of type T to resolve this issue.
-  |            See an example at http://dotty.epfl.ch/docs/reference/enums/adts.html#parameter-variance-of-enums
+  |        contravariant type T occurs in covariant position in type T => T of value f
+  |        enum case Refl requires explicit declaration of type T to resolve this issue.
+  |        See an example at https://docs.scala-lang.org/scala3/reference/enums/adts.html#parameter-variance-of-enums
 -- Error: tests/neg-custom-args/fatal-warnings/enum-variance.scala:5:16 ------------------------------------------------
 5 |  case Refl[-T](f: T => T) extends ExplicitView[T] // error: contravariant type T occurs in covariant position
   |                ^^^^^^^^^


### PR DESCRIPTION
`dotty.epfl.ch` says

> The content of this page is outdated. Click here to find the up to date version of this page.

https://github.com/lampepfl/dotty/commit/d3a2ac3aa88f3adea48d2aa86ccf99a8893091c7#diff-4ad5f37f83ab25acc8e1f0181bef41ba242dda2cb4cdfc54069ab02f560c3cfdR7

I think we should use `docs.scala-lang.org`