### PR TITLE
Fix paths on Windows for coverage tests, properly

### DIFF
--- a/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
+++ b/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
@@ -36,7 +36,7 @@ class CoverageTests:
     def fixWindowsPaths(lines: Buffer[String]): Buffer[String] =
       val separator = java.io.File.separatorChar
       if separator != '/' then
-        lines.map(_.replace("\\" + separator, "/")) // escape the separator
+        lines.map(_.replace(separator, '/'))
       else
         lines
     end fixWindowsPaths


### PR DESCRIPTION
Fixes #14949, robustly, this time.

As som-snytt said [here](https://github.com/lampepfl/dotty/pull/14937#issuecomment-1099535034), maybe this logic should be spread to all expect tests.