### PR TITLE
Accept soft modifiers separated by blank lines

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2873,7 +2873,7 @@ object Parsers {
           val isAccessMod = accessModifierTokens contains in.token
           val mods1 = addModifier(mods)
           loop(if (isAccessMod) accessQualifierOpt(mods1) else mods1)
-        else if (in.token == NEWLINE && (mods.hasFlags || mods.hasAnnotations)) {
+        else if (in.isNewLine && (mods.hasFlags || mods.hasAnnotations)) {
           in.nextToken()
           loop(mods)
         }

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -4,7 +4,7 @@ package scala.quoted
  *
  *  `Expr` has extension methods that are defined in `scala.quoted.Quotes`.
  */
-abstract class Expr[+T] private[scala]
+abstract class Expr[+T] private[scala] ()
 
 /** Constructors for expressions */
 object Expr {

--- a/tests/pos/i11712.scala
+++ b/tests/pos/i11712.scala
@@ -1,0 +1,21 @@
+object Test:
+
+  def transparent = println("transparent method called")
+
+  transparent
+  println()
+  inline def f1 = 1
+
+  transparent
+  inline def f2 = 2
+
+  transparent
+  trait T1
+
+  transparent
+
+  inline def f3 = 3
+
+  transparent
+
+  trait T2


### PR DESCRIPTION
This was handled inconsistently before. An identifier could be classified as
a soft modifier even if followed by newlines but then the modifier parsing code
would not skip the NEWLINES token. Now it does skip.

Fixes #11712