### PR TITLE
Treat all incomplete ifs as statements

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/internal/SemanticdbInputStream.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/internal/SemanticdbInputStream.scala
@@ -143,8 +143,7 @@ class SemanticdbInputStream private (buffer: Array[Byte], input: InputStream) {
       throw new IllegalStateException(
         s"refillBuffer() called when $n bytes were already available in buffer")
     }
-    if (totalBytesRetired + bufferPos + n > currentLimit) false
-    else if (input != null) {
+    if totalBytesRetired + bufferPos + n <= currentLimit && input != null then
       val pos: Int = bufferPos
       if (pos > 0) {
         if (bufferSize > pos) {
@@ -166,7 +165,6 @@ class SemanticdbInputStream private (buffer: Array[Byte], input: InputStream) {
         recomputeBufferSizeAfterLimit()
         return ((bufferSize >= n) || tryRefillBuffer(n))
       }
-    }
     false
   }
 

--- a/tests/pos/i14914.scala
+++ b/tests/pos/i14914.scala
@@ -1,0 +1,8 @@
+
+def Test(b: Boolean) =
+  val a =
+    if b then
+       1
+    else if !b then
+       2
+  val _: Unit = a


### PR DESCRIPTION
Previously only a one-armed if was treated as a statement
where all parts were typed with Unit as expected type. We now
extend that treatment also to multi-branch ifs that lack
a final part.

Fixes #14914