### PR TITLE
Fix outer reference detection in class parents

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -278,7 +278,8 @@ object ExplicitOuter {
           )
       case _ => false
     }
-    def hasOuterPrefix(tp: Type) = tp match {
+    def hasOuterPrefix(tp: Type): Boolean = tp.stripped match {
+      case AppliedType(tycon, _) => hasOuterPrefix(tycon)
       case TypeRef(prefix, _) => isOuterRef(prefix)
       case _ => false
     }

--- a/tests/pos/i14932.scala
+++ b/tests/pos/i14932.scala
@@ -1,0 +1,9 @@
+trait Core {
+  class Base[T]()
+}
+
+class Module(val core: Core) {
+  object Indirection {
+    class Extension[T]() extends core.Base[T]()
+  }
+}


### PR DESCRIPTION
The case where a class parent was an AppliedType was missing.
Hence, classes that referred to an outer this only via a parent
were mis-categorized.

Fixes https://github.com/lampepfl/dotty/issues/14932
