### PR TITLE
refactor: add `isActive` to `ErrorMessageID`

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -1,188 +1,191 @@
 package dotty.tools.dotc.reporting
 
-/** Unique IDs identifying the messages */
-enum ErrorMessageID extends java.lang.Enum[ErrorMessageID]:
+/** Unique IDs identifying the messages
+ *  @param isActive Whether or not the compile still emits this ErrorMessageID
+ **/
+enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMessageID]:
 
   // IMPORTANT: Add new IDs only at the end and never remove IDs
-  case
-    LazyErrorId, // // errorNumber: -2
-    NoExplanationID, // errorNumber: -1
+  case LazyErrorId // // errorNumber: -2
+  case NoExplanationID // errorNumber: -1
 
-    EmptyCatchOrFinallyBlockID, // errorNumber: 0
-    EmptyCatchBlockID, // errorNumber: 1
-    EmptyCatchAndFinallyBlockID, // errorNumber: 2
-    DeprecatedWithOperatorID,
-    CaseClassMissingParamListID,
-    DuplicateBindID,
-    MissingIdentID,
-    TypeMismatchID,
-    NotAMemberID,
-    EarlyDefinitionsNotSupportedID,
-    TopLevelImplicitClassID,
-    ImplicitCaseClassID,
-    ImplicitClassPrimaryConstructorArityID,
-    ObjectMayNotHaveSelfTypeID,
-    TupleTooLongID,
-    RepeatedModifierID,
-    InterpolatedStringErrorID,
-    UnboundPlaceholderParameterID,
-    IllegalStartSimpleExprID,
-    MissingReturnTypeID,
-    YieldOrDoExpectedInForComprehensionID,
-    ProperDefinitionNotFoundID,
-    ByNameParameterNotSupportedID,
-    WrongNumberOfTypeArgsID,
-    IllegalVariableInPatternAlternativeID,
-    IdentifierExpectedID,
-    AuxConstructorNeedsNonImplicitParameterID,
-    VarArgsParamMustComeLastID,
-    IllegalLiteralID,
-    PatternMatchExhaustivityID,
-    MatchCaseUnreachableID,
-    SeqWildcardPatternPosID,
-    IllegalStartOfSimplePatternID,
-    PkgDuplicateSymbolID,
-    ExistentialTypesNoLongerSupportedID,
-    UnboundWildcardTypeID,
-    DanglingThisInPathID,
-    OverridesNothingID,
-    OverridesNothingButNameExistsID,
-    ForwardReferenceExtendsOverDefinitionID,
-    ExpectedTokenButFoundID,
-    MixedLeftAndRightAssociativeOpsID,
-    CantInstantiateAbstractClassOrTraitID,
-    UnreducibleApplicationID,
-    OverloadedOrRecursiveMethodNeedsResultTypeID,
-    RecursiveValueNeedsResultTypeID,
-    CyclicReferenceInvolvingID,
-    CyclicReferenceInvolvingImplicitID,
-    SuperQualMustBeParentID,
-    AmbiguousReferenceID,
-    MethodDoesNotTakeParametersId,
-    AmbiguousOverloadID,
-    ReassignmentToValID,
-    TypeDoesNotTakeParametersID,
-    ParameterizedTypeLacksArgumentsID,
-    VarValParametersMayNotBeCallByNameID,
-    MissingTypeParameterForID,
-    DoesNotConformToBoundID,
-    DoesNotConformToSelfTypeID,
-    DoesNotConformToSelfTypeCantBeInstantiatedID,
-    AbstractMemberMayNotHaveModifierID,
-    TopLevelCantBeImplicitID,
-    TypesAndTraitsCantBeImplicitID,
-    OnlyClassesCanBeAbstractID,
-    AbstractOverrideOnlyInTraitsID,
-    TraitsMayNotBeFinalID,
-    NativeMembersMayNotHaveImplementationID,
-    OnlyClassesCanHaveDeclaredButUndefinedMembersID,
-    CannotExtendAnyValID,
-    CannotHaveSameNameAsID,
-    ValueClassesMayNotDefineInnerID,
-    ValueClassesMayNotDefineNonParameterFieldID,
-    ValueClassesMayNotDefineASecondaryConstructorID,
-    ValueClassesMayNotContainInitalizationID,
-    ValueClassesMayNotBeAbstractID,
-    ValueClassesMayNotBeContaintedID,
-    ValueClassesMayNotWrapAnotherValueClassID,
-    ValueClassParameterMayNotBeAVarID,
-    ValueClassNeedsExactlyOneValParamID,
-    UNUSED1,
-    UNUSED2,
-    AnonymousFunctionMissingParamTypeID,
-    SuperCallsNotAllowedInlineableID,
-    NotAPathID,
-    WildcardOnTypeArgumentNotAllowedOnNewID,
-    FunctionTypeNeedsNonEmptyParameterListID,
-    WrongNumberOfParametersID,
-    DuplicatePrivateProtectedQualifierID,
-    ExpectedStartOfTopLevelDefinitionID,
-    MissingReturnTypeWithReturnStatementID,
-    NoReturnFromInlineableID,
-    ReturnOutsideMethodDefinitionID,
-    UncheckedTypePatternID,
-    ExtendFinalClassID,
-    EnumCaseDefinitionInNonEnumOwnerID,
-    ExpectedTypeBoundOrEqualsID,
-    ClassAndCompanionNameClashID,
-    TailrecNotApplicableID,
-    FailureToEliminateExistentialID,
-    OnlyFunctionsCanBeFollowedByUnderscoreID,
-    MissingEmptyArgumentListID,
-    DuplicateNamedTypeParameterID,
-    UndefinedNamedTypeParameterID,
-    IllegalStartOfStatementID,
-    TraitIsExpectedID,
-    TraitRedefinedFinalMethodFromAnyRefID,
-    PackageNameAlreadyDefinedID,
-    UnapplyInvalidNumberOfArgumentsID,
-    UnapplyInvalidReturnTypeID,
-    StaticFieldsOnlyAllowedInObjectsID,
-    CyclicInheritanceID,
-    BadSymbolicReferenceID,
-    UnableToExtendSealedClassID,
-    SymbolHasUnparsableVersionNumberID,
-    SymbolChangedSemanticsInVersionID,
-    UnableToEmitSwitchID,
-    MissingCompanionForStaticID,
-    PolymorphicMethodMissingTypeInParentID,
-    ParamsNoInlineID,
-    JavaSymbolIsNotAValueID,
-    DoubleDefinitionID,
-    MatchCaseOnlyNullWarningID,
-    ImportRenamedTwiceID,
-    TypeTestAlwaysDivergesID,
-    TermMemberNeedsNeedsResultTypeForImplicitSearchID,
-    ClassCannotExtendEnumID,
-    ValueClassParameterMayNotBeCallByNameID,
-    NotAnExtractorID,
-    MemberWithSameNameAsStaticID,
-    PureExpressionInStatementPositionID,
-    TraitCompanionWithMutableStaticID,
-    LazyStaticFieldID,
-    StaticOverridingNonStaticMembersID,
-    OverloadInRefinementID,
-    NoMatchingOverloadID,
-    StableIdentPatternID,
-    StaticFieldsShouldPrecedeNonStaticID,
-    IllegalSuperAccessorID,
-    TraitParameterUsedAsParentPrefixID,
-    UnknownNamedEnclosingClassOrObjectID,
-    IllegalCyclicTypeReferenceID,
-    MissingTypeParameterInTypeAppID,
-    SkolemInInferredID,
-    ErasedTypesCanOnlyBeFunctionTypesID,
-    CaseClassMissingNonImplicitParamListID,
-    EnumerationsShouldNotBeEmptyID,
-    IllegalParameterInitID,
-    RedundantModifierID,
-    TypedCaseDoesNotExplicitlyExtendTypedEnumID,
-    IllegalRedefinitionOfStandardKindID,
-    NoExtensionMethodAllowedID,
-    ExtensionMethodCannotHaveTypeParamsID,
-    ExtensionCanOnlyHaveDefsID,
-    UnexpectedPatternForSummonFromID,
-    AnonymousInstanceCannotBeEmptyID,
-    TypeSpliceInValPatternID,
-    ModifierNotAllowedForDefinitionID,
-    CannotExtendJavaEnumID,
-    InvalidReferenceInImplicitNotFoundAnnotationID,
-    TraitMayNotDefineNativeMethodID,
-    JavaEnumParentArgsID,
-    AlreadyDefinedID,
-    CaseClassInInlinedCodeID,
-    OverrideTypeMismatchErrorID,
-    OverrideErrorID,
-    MatchableWarningID,
-    CannotExtendFunctionID,
-    LossyWideningConstantConversionID,
-    ImplicitSearchTooLargeID,
-    TargetNameOnTopLevelClassID
+  case EmptyCatchOrFinallyBlockID extends ErrorMessageID(isActive = false) // errorNumber: 0
+  case EmptyCatchBlockID // errorNumber: 1
+  case EmptyCatchAndFinallyBlockID // errorNumber: 2
+  case DeprecatedWithOperatorID // errorNumber: 3
+  case CaseClassMissingParamListID // errorNumber: 4
+  case DuplicateBindID // errorNumber: 5
+  case MissingIdentID // errorNumber: 6
+  case TypeMismatchID // errorNumber: 7
+  case NotAMemberID // errorNumber: 8
+  case EarlyDefinitionsNotSupportedID // errorNumber: 9
+  case TopLevelImplicitClassID extends ErrorMessageID(isActive = false) // errorNumber: 10 
+  case ImplicitCaseClassID // errorNumber: 11 
+  case ImplicitClassPrimaryConstructorArityID // errorNumber: 12
+  case ObjectMayNotHaveSelfTypeID // errorNumber: 13
+  case TupleTooLongID extends ErrorMessageID(isActive = false) // errorNumber: 14
+  case RepeatedModifierID // errorNumber: 15
+  case InterpolatedStringErrorID // errorNumber: 16
+  case UnboundPlaceholderParameterID // errorNumber: 17
+  case IllegalStartSimpleExprID // errorNumber: 18
+  case MissingReturnTypeID // errorNumber: 19
+  case YieldOrDoExpectedInForComprehensionID // errorNumber: 20
+  case ProperDefinitionNotFoundID // errorNumber: 21
+  case ByNameParameterNotSupportedID // errorNumber: 22
+  case WrongNumberOfTypeArgsID // errorNumber: 23
+  case IllegalVariableInPatternAlternativeID // errorNumber: 24
+  case IdentifierExpectedID // errorNumber: 25
+  case AuxConstructorNeedsNonImplicitParameterID // errorNumber: 26
+  case VarArgsParamMustComeLastID // errorNumber: 27
+  case IllegalLiteralID // errorNumber: 28
+  case PatternMatchExhaustivityID // errorNumber: 29
+  case MatchCaseUnreachableID // errorNumber: 30
+  case SeqWildcardPatternPosID // errorNumber: 31
+  case IllegalStartOfSimplePatternID // errorNumber: 32
+  case PkgDuplicateSymbolID // errorNumber: 33
+  case ExistentialTypesNoLongerSupportedID // errorNumber: 34
+  case UnboundWildcardTypeID // errorNumber: 35
+  case DanglingThisInPathID extends ErrorMessageID(isActive = false) // errorNumber: 36
+  case OverridesNothingID // errorNumber: 37
+  case OverridesNothingButNameExistsID // errorNumber: 38
+  case ForwardReferenceExtendsOverDefinitionID // errorNumber: 39
+  case ExpectedTokenButFoundID // errorNumber: 40
+  case MixedLeftAndRightAssociativeOpsID // errorNumber: 41
+  case CantInstantiateAbstractClassOrTraitID // errorNumber: 42
+  case UnreducibleApplicationID // errorNumber: 43
+  case OverloadedOrRecursiveMethodNeedsResultTypeID // errorNumber: 44
+  case RecursiveValueNeedsResultTypeID // errorNumber: 45
+  case CyclicReferenceInvolvingID // errorNumber: 46
+  case CyclicReferenceInvolvingImplicitID // errorNumber: 47
+  case SuperQualMustBeParentID // errorNumber: 48
+  case AmbiguousReferenceID // errorNumber: 49
+  case MethodDoesNotTakeParametersId // errorNumber: 50
+  case AmbiguousOverloadID // errorNumber: 51
+  case ReassignmentToValID // errorNumber: 52
+  case TypeDoesNotTakeParametersID // errorNumber: 53
+  case ParameterizedTypeLacksArgumentsID // errorNumber: 54
+  case VarValParametersMayNotBeCallByNameID // errorNumber: 55
+  case MissingTypeParameterForID // errorNumber: 56
+  case DoesNotConformToBoundID // errorNumber: 57
+  case DoesNotConformToSelfTypeID // errorNumber: 58
+  case DoesNotConformToSelfTypeCantBeInstantiatedID // errorNumber: 59
+  case AbstractMemberMayNotHaveModifierID // errorNumber: 60
+  case TopLevelCantBeImplicitID extends ErrorMessageID(isActive = false) // errorNumber: 61
+  case TypesAndTraitsCantBeImplicitID // errorNumber: 62
+  case OnlyClassesCanBeAbstractID // errorNumber: 63
+  case AbstractOverrideOnlyInTraitsID // errorNumber: 64
+  case TraitsMayNotBeFinalID // errorNumber: 65
+  case NativeMembersMayNotHaveImplementationID // errorNumber: 66
+  case OnlyClassesCanHaveDeclaredButUndefinedMembersID // errorNumber: 67
+  case CannotExtendAnyValID // errorNumber: 68
+  case CannotHaveSameNameAsID // errorNumber: 69
+  case ValueClassesMayNotDefineInnerID // errorNumber: 70
+  case ValueClassesMayNotDefineNonParameterFieldID // errorNumber: 71
+  case ValueClassesMayNotDefineASecondaryConstructorID // errorNumber: 72
+  case ValueClassesMayNotContainInitalizationID // errorNumber: 73
+  case ValueClassesMayNotBeAbstractID // errorNumber: 74
+  case ValueClassesMayNotBeContaintedID // errorNumber: 75
+  case ValueClassesMayNotWrapAnotherValueClassID // errorNumber: 76
+  case ValueClassParameterMayNotBeAVarID // errorNumber: 77
+  case ValueClassNeedsExactlyOneValParamID // errorNumber: 78
+  case OnlyCaseClassOrCaseObjectAllowedID extends ErrorMessageID(isActive = false) // errorNumber: 79
+  case ExpectedTopLevelDefID extends ErrorMessageID(isActive = false) // errorNumber: 80
+  case AnonymousFunctionMissingParamTypeID // errorNumber: 81
+  case SuperCallsNotAllowedInlineableID // errorNumber: 82
+  case NotAPathID // errorNumber: 83
+  case WildcardOnTypeArgumentNotAllowedOnNewID // errorNumber: 84
+  case FunctionTypeNeedsNonEmptyParameterListID // errorNumber: 85
+  case WrongNumberOfParametersID // errorNumber: 86
+  case DuplicatePrivateProtectedQualifierID // errorNumber: 87
+  case ExpectedStartOfTopLevelDefinitionID // errorNumber: 88 
+  case MissingReturnTypeWithReturnStatementID // errorNumber: 89
+  case NoReturnFromInlineableID // errorNumber: 90
+  case ReturnOutsideMethodDefinitionID // errorNumber: 91
+  case UncheckedTypePatternID // errorNumber: 92
+  case ExtendFinalClassID // errorNumber: 93
+  case EnumCaseDefinitionInNonEnumOwnerID // errorNumber: 94
+  case ExpectedTypeBoundOrEqualsID // errorNumber: 95
+  case ClassAndCompanionNameClashID // errorNumber: 96
+  case TailrecNotApplicableID // errorNumber: 97
+  case FailureToEliminateExistentialID // errorNumber: 98
+  case OnlyFunctionsCanBeFollowedByUnderscoreID // errorNumber: 99
+  case MissingEmptyArgumentListID // errorNumber: 100
+  case DuplicateNamedTypeParameterID // errorNumber: 101
+  case UndefinedNamedTypeParameterID // errorNumber: 102
+  case IllegalStartOfStatementID // errorNumber: 1033
+  case TraitIsExpectedID // errorNumber: 104
+  case TraitRedefinedFinalMethodFromAnyRefID // errorNumber: 105
+  case PackageNameAlreadyDefinedID // errorNumber: 106
+  case UnapplyInvalidNumberOfArgumentsID // errorNumber: 107
+  case UnapplyInvalidReturnTypeID // errorNumber: 108
+  case StaticFieldsOnlyAllowedInObjectsID // errorNumber: 109
+  case CyclicInheritanceID // errorNumber: 110
+  case BadSymbolicReferenceID // errorNumber: 111
+  case UnableToExtendSealedClassID // errorNumber: 112
+  case SymbolHasUnparsableVersionNumberID // errorNumber: 113
+  case SymbolChangedSemanticsInVersionID // errorNumber: 114
+  case UnableToEmitSwitchID // errorNumber: 115
+  case MissingCompanionForStaticID // errorNumber: 116
+  case PolymorphicMethodMissingTypeInParentID // errorNumber: 117
+  case ParamsNoInlineID // errorNumber: 118
+  case JavaSymbolIsNotAValueID // errorNumber: 119
+  case DoubleDefinitionID // errorNumber: 120
+  case MatchCaseOnlyNullWarningID // errorNumber: 121
+  case ImportRenamedTwiceID // errorNumber: 122
+  case TypeTestAlwaysDivergesID // errorNumber: 123
+  case TermMemberNeedsNeedsResultTypeForImplicitSearchID // errorNumber: 124
+  case ClassCannotExtendEnumID // errorNumber: 125
+  case ValueClassParameterMayNotBeCallByNameID // errorNumber: 126
+  case NotAnExtractorID // errorNumber: 127
+  case MemberWithSameNameAsStaticID // errorNumber: 128
+  case PureExpressionInStatementPositionID // errorNumber: 129
+  case TraitCompanionWithMutableStaticID // errorNumber: 130
+  case LazyStaticFieldID // errorNumber: 131
+  case StaticOverridingNonStaticMembersID // errorNumber: 132
+  case OverloadInRefinementID // errorNumber: 133
+  case NoMatchingOverloadID // errorNumber: 134
+  case StableIdentPatternID // errorNumber: 135
+  case StaticFieldsShouldPrecedeNonStaticID // errorNumber: 136
+  case IllegalSuperAccessorID // errorNumber: 137
+  case TraitParameterUsedAsParentPrefixID // errorNumber: 138
+  case UnknownNamedEnclosingClassOrObjectID // errorNumber: 139
+  case IllegalCyclicTypeReferenceID // errorNumber: 140
+  case MissingTypeParameterInTypeAppID // errorNumber: 141
+  case SkolemInInferredID // errorNumber: 142
+  case ErasedTypesCanOnlyBeFunctionTypesID // errorNumber: 143
+  case CaseClassMissingNonImplicitParamListID // errorNumber: 144
+  case EnumerationsShouldNotBeEmptyID // errorNumber: 145
+  case IllegalParameterInitID // errorNumber: 146
+  case RedundantModifierID // errorNumber: 147
+  case TypedCaseDoesNotExplicitlyExtendTypedEnumID // errorNumber: 148
+  case IllegalRedefinitionOfStandardKindID // errorNumber: 149
+  case NoExtensionMethodAllowedID // errorNumber: 150
+  case ExtensionMethodCannotHaveTypeParamsID // errorNumber: 151
+  case ExtensionCanOnlyHaveDefsID // errorNumber: 152
+  case UnexpectedPatternForSummonFromID // errorNumber: 153
+  case AnonymousInstanceCannotBeEmptyID // errorNumber: 154
+  case TypeSpliceInValPatternID // errorNumber: 155
+  case ModifierNotAllowedForDefinitionID // errorNumber: 156
+  case CannotExtendJavaEnumID // errorNumber: 157
+  case InvalidReferenceInImplicitNotFoundAnnotationID // errorNumber: 158
+  case TraitMayNotDefineNativeMethodID // errorNumber: 159
+  case JavaEnumParentArgsID // errorNumber: 160
+  case AlreadyDefinedID // errorNumber: 161
+  case CaseClassInInlinedCodeID // errorNumber: 162
+  case OverrideTypeMismatchErrorID // errorNumber: 163
+  case OverrideErrorID // errorNumber: 164
+  case MatchableWarningID // errorNumber: 165
+  case CannotExtendFunctionID // errorNumber: 166
+  case LossyWideningConstantConversionID // errorNumber: 167
+  case ImplicitSearchTooLargeID // errorNumber: 168
+  case TargetNameOnTopLevelClassID // errorNumber: 169
 
   def errorNumber = ordinal - 2
 
 object ErrorMessageID:
   def fromErrorNumber(n: Int): Option[ErrorMessageID] =
     val enumId = n + 2
-    if enumId >= 2 && enumId < ErrorMessageID.values.length then Some(fromOrdinal(enumId))
-    else None
+    if enumId >= 2 && enumId < ErrorMessageID.values.length then
+      Some(fromOrdinal(enumId))
+    else
+      None

--- a/compiler/src/dotty/tools/dotc/reporting/WConf.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/WConf.scala
@@ -70,8 +70,9 @@ object WConf:
       case "id" => conf match
         case ErrorId(num) =>
           ErrorMessageID.fromErrorNumber(num.toInt) match
-            case Some(errId) => Right(MessageID(errId))
-            case _ => Left(s"unknonw error message number: E$num")
+            case Some(errId) if errId.isActive => Right(MessageID(errId))
+            case Some(errId) => Left(s"E${num} is marked as inactive.")
+            case _ => Left(s"Unknown error message number: E${num}")
         case _ =>
           Left(s"invalid error message id: $conf")
       case "name" =>

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1066,37 +1066,6 @@ import transform.SymUtils._
            |"""
   }
 
-  class DanglingThisInPath()(using Context) extends SyntaxMsg(DanglingThisInPathID) {
-    def msg = em"""Expected an additional member selection after the keyword ${hl("this")}"""
-    def explain =
-      val contextCode: String =
-        """  trait Outer {
-          |    val member: Int
-          |    type Member
-          |    trait Inner {
-          |      ...
-          |    }
-          |  }"""
-      val importCode: String =
-        """  import Outer.this.member
-          |  //               ^^^^^^^"""
-      val typeCode: String =
-        """  type T = Outer.this.Member
-          |  //                 ^^^^^^^"""
-      em"""|Paths of imports and type selections must not end with the keyword ${hl("this")}.
-           |
-           |Maybe you forgot to select a member of ${hl("this")}? As an example, in the
-           |following context:
-           |${contextCode}
-           |
-           |- This is a valid import expression using a path
-           |${importCode}
-           |
-           |- This is a valid type using a path
-           |${typeCode}
-           |"""
-  }
-
   class OverridesNothing(member: Symbol)(using Context)
   extends DeclarationMsg(OverridesNothingID) {
     def msg = em"""${member} overrides nothing"""


### PR DESCRIPTION
Currently there is no way to tell if a given `ErrorMessageID` is emitted
at all from the compiler. While working on an index of all the IDs I
keep needing to dig into the code to see if there is a message that uses
an `ErrorMessageID` and then see if that message is actually used
anywhere. From what I can gather so far, the ones that I've marked as
`false` are no longer emitted and therefore marked `isActive = false`.

refs: #14904