### PR TITLE
Hande clashes between same-named exports

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2128,6 +2128,7 @@ import transform.SymUtils._
   class DoubleDefinition(decl: Symbol, previousDecl: Symbol, base: Symbol)(using Context) extends NamingMsg(DoubleDefinitionID) {
     def msg = {
       def nameAnd = if (decl.name != previousDecl.name) " name and" else ""
+      def erasedType = if ctx.erasedTypes then i" ${decl.info}" else ""
       def details(using Context): String =
         if (decl.isRealMethod && previousDecl.isRealMethod) {
           import Signature.MatchDegree._
@@ -2155,7 +2156,7 @@ import transform.SymUtils._
                      |Consider adding a @targetName annotation to one of the conflicting definitions
                      |for disambiguation."""
                 else ""
-              i"have the same$nameAnd type after erasure.$hint"
+              i"have the same$nameAnd type$erasedType after erasure.$hint"
           }
         }
         else ""

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2174,10 +2174,12 @@ import transform.SymUtils._
         else
           "Name clash between inherited members"
 
-      em"""$clashDescription:
-          |${previousDecl.showDcl} ${symLocation(previousDecl)} and
-          |${decl.showDcl} ${symLocation(decl)}
-          |""" + details
+      atPhase(typerPhase) {
+        em"""$clashDescription:
+            |${previousDecl.showDcl} ${symLocation(previousDecl)} and
+            |${decl.showDcl} ${symLocation(decl)}
+            |"""
+      } + details
     }
     def explain = ""
   }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1266,7 +1266,7 @@ class Namer { typer: Typer =>
                       |and  ${forwarder1.rhs.symbol}: ${alt2.widen}
                       |have the same signature after erasure and overloading resolution could not disambiguate.""",
                   exp.srcPos)
-              avoidClashWith(if cmp < 0 then forwarder else forwarder1, forwarders1)
+              avoidClashWith(if cmp < 0 then forwarder1 else forwarder, forwarders1)
             else
               val (forwarder2, forwarders2) = avoidClashWith(forwarder, forwarders1)
               (forwarder2, forwarders.derivedCons(forwarder1, forwarders2))

--- a/tests/neg/i14966.check
+++ b/tests/neg/i14966.check
@@ -1,10 +1,10 @@
--- [E120] Naming Error: tests/neg/i14966.scala:2:11 --------------------------------------------------------------------
-2 |  export s.* // error
-  |           ^
-  |           Double definition:
-  |           final def ++[B >: T](suffix: IterableOnce[B]): Set[B] in class B at line 2 and
-  |           final def ++(that: IterableOnce[T]): Set[T] in class B at line 2
-  |           have the same type after erasure.
-  |
-  |           Consider adding a @targetName annotation to one of the conflicting definitions
-  |           for disambiguation.
+-- Error: tests/neg/i14966.scala:10:9 ----------------------------------------------------------------------------------
+10 |  export s.*  // error
+   |  ^^^^^^^^^^
+   |  Clashing exports: The exported
+   |       method f: (x: List[Int]): Int
+   |  and  method f²: (x: List[String]): Int
+   |  have the same signature after erasure and overloading resolution could not disambiguate.
+   |
+   |  where:    f  is a method in trait S
+   |            f² is a method in trait I

--- a/tests/neg/i14966.check
+++ b/tests/neg/i14966.check
@@ -1,0 +1,10 @@
+-- [E120] Naming Error: tests/neg/i14966.scala:2:11 --------------------------------------------------------------------
+2 |  export s.* // error
+  |           ^
+  |           Double definition:
+  |           final def concat[B >: T](suffix: IterableOnce[B]): Set[B] in class B at line 2 and
+  |           final def concat(that: IterableOnce[T]): Set[T] in class B at line 2
+  |           have the same type after erasure.
+  |
+  |           Consider adding a @targetName annotation to one of the conflicting definitions
+  |           for disambiguation.

--- a/tests/neg/i14966.check
+++ b/tests/neg/i14966.check
@@ -2,8 +2,8 @@
 2 |  export s.* // error
   |           ^
   |           Double definition:
-  |           final def concat[B >: T](suffix: IterableOnce[B]): Set[B] in class B at line 2 and
-  |           final def concat(that: IterableOnce[T]): Set[T] in class B at line 2
+  |           final def ++[B >: T](suffix: IterableOnce[B]): Set[B] in class B at line 2 and
+  |           final def ++(that: IterableOnce[T]): Set[T] in class B at line 2
   |           have the same type after erasure.
   |
   |           Consider adding a @targetName annotation to one of the conflicting definitions

--- a/tests/neg/i14966.scala
+++ b/tests/neg/i14966.scala
@@ -1,0 +1,2 @@
+class B[T](val s: Set[T]):
+  export s.* // error

--- a/tests/neg/i14966.scala
+++ b/tests/neg/i14966.scala
@@ -1,2 +1,11 @@
-class B[T](val s: Set[T]):
-  export s.* // error
+trait I[A]:
+  def f(x: List[String]): A
+
+trait S:
+  def f(x: List[Int]): Int
+
+trait T[A] extends I[A], S
+
+class Test(s: T[Int]):
+  export s.*  // error
+

--- a/tests/neg/i14966a.check
+++ b/tests/neg/i14966a.check
@@ -1,0 +1,10 @@
+-- [E120] Naming Error: tests/neg/i14966a.scala:3:6 --------------------------------------------------------------------
+3 |  def f(x: List[Int]): String = ??? // error
+  |      ^
+  |      Double definition:
+  |      def f[X <: String](x: List[X]): String in class Test at line 2 and
+  |      def f(x: List[Int]): String in class Test at line 3
+  |      have the same type (x: scala.collection.immutable.List): String after erasure.
+  |
+  |      Consider adding a @targetName annotation to one of the conflicting definitions
+  |      for disambiguation.

--- a/tests/neg/i14966a.scala
+++ b/tests/neg/i14966a.scala
@@ -1,0 +1,4 @@
+class Test:
+  def f[X <: String](x: List[X]): String = ???
+  def f(x: List[Int]): String = ??? // error
+

--- a/tests/pos/i14966.scala
+++ b/tests/pos/i14966.scala
@@ -1,0 +1,13 @@
+trait I[+A] extends IOps[A, I[A]]
+
+trait S[A] extends I[A], SOps[A, S[A]]
+
+trait IOps[+A, +C <: I[A]]:
+  def concat[B >: A](other: IterableOnce[B]): C
+
+trait SOps[A, +C <: S[A]] extends IOps[A, C]:
+  def concat(other: IterableOnce[A]): C
+
+class Test(s: S[Int]):
+  export s.*
+

--- a/tests/pos/i14966a.scala
+++ b/tests/pos/i14966a.scala
@@ -1,0 +1,2 @@
+class B[T](val s: Set[T]):
+  export s.*


### PR DESCRIPTION
Fixes #14966

Two parts

 1. Better error message for "clashes after erasure message". We now print the original types of the clashing definitions as well as their common erased type.
 2. In most cases heal the clash between two export forwarders by picking the one which is better according to overloading resolution.