### PR TITLE
Erase `Int | Nothing` signatures types into `Int`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -363,13 +363,13 @@ object TypeErasure {
    *  which leads to more predictable bytecode and (?) faster dynamic dispatch.
    */
   def erasedLub(tp1: Type, tp2: Type)(using Context): Type = {
-    // After erasure, C | {Null, Nothing} is just C, if C is a reference type.
-    // We need to short-circuit this case here because the regular lub logic below
-    // relies on the class hierarchy, which doesn't properly capture `Null`s subtyping
-    // behaviour.
-    if (tp1.isBottomTypeAfterErasure && tp2.derivesFrom(defn.ObjectClass)) return tp2
-    if (tp2.isBottomTypeAfterErasure && tp1.derivesFrom(defn.ObjectClass)) return tp1
-    tp1 match {
+    // We need to short-circuit the following 2 case because the regular lub logic in the else relies on
+    // the class hierarchy, which doesn't properly capture `Nothing`/`Null` subtyping behaviour.
+    if tp1.isRef(defn.NothingClass) || (tp1.isRef(defn.NullClass) && tp2.derivesFrom(defn.ObjectClass)) then
+      tp2 // After erasure, Nothing | T is just T and Null | C is just C, if C is a reference type.
+    else if tp2.isRef(defn.NothingClass) || (tp2.isRef(defn.NullClass) && tp1.derivesFrom(defn.ObjectClass)) then
+      tp1 // After erasure, T | Nothing is just T and C | Null is just C, if C is a reference type.
+    else tp1 match {
       case JavaArrayType(elem1) =>
         import dotty.tools.dotc.transform.TypeUtils._
         tp2 match {

--- a/tests/neg/i5823.scala
+++ b/tests/neg/i5823.scala
@@ -7,7 +7,7 @@ class A
 class B
 
 class Foo {
-  
+
   // ok, because A and B are <: Object.
   def foo(a: A|Null): Unit = ()
   def foo(b: B|Null): Unit = ()
@@ -26,13 +26,15 @@ class Foo {
   def foo2(a: A|Nothing): Unit = ()
   def foo2(b: B|Nothing): Unit = ()
 
+  // ok because erased to primitive types
   def bar2(a: Int|Nothing): Unit = ()
-  def bar2(b: Boolean|Nothing): Unit = () // error: signatures match
+  def bar2(b: Boolean|Nothing): Unit = ()
 
   // ok, T is erased to `String` and `Integer`, respectively
   def gen3[T <: String](s: T|Nothing): Unit = ()
   def gen3[T <: Integer](i: T|Nothing): Unit = ()
 
+  // ok because erased to primitive types
   def gen4[T <: Int](i: T|Nothing): Unit = ()
-  def gen4[T <: Boolean](b: T|Nothing): Unit = () // error: signatures match
+  def gen4[T <: Boolean](b: T|Nothing): Unit = ()
 }

--- a/tests/run/i14964.scala
+++ b/tests/run/i14964.scala
@@ -1,0 +1,5 @@
+@main def Test: Unit =
+  val xs = (1, 2).toList
+  val a1 = xs.toArray
+  println((1, 2).toList.toArray)
+  val a2 = (1, 2).toList.toArray

--- a/tests/run/i14964b.check
+++ b/tests/run/i14964b.check
@@ -1,0 +1,4 @@
+Int
+Int
+Int
+Int

--- a/tests/run/i14964b.scala
+++ b/tests/run/i14964b.scala
@@ -1,0 +1,5 @@
+@main def Test: Unit =
+  println(summon[reflect.ClassTag[Int]]) // classOf[Int]
+  println(summon[reflect.ClassTag[Int | Int]]) // classOf[Int]
+  println(summon[reflect.ClassTag[Int | 1]]) // classOf[Int]
+  println(summon[reflect.ClassTag[Int | Nothing]]) // classOf[Int]

--- a/tests/run/i14970.scala
+++ b/tests/run/i14970.scala
@@ -1,0 +1,6 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val x: Array[Int | Nothing] = Array()
+    val y: Array[Int] = x
+  }
+}


### PR DESCRIPTION
Aligns `| Nothing` with `& Any` and `Nothing |` with `Any &` for value types.

This also fixes `summon[ClassTag[Int | Nothing]]` as it is now equivalent to `summon[ClassTag[Int]]`.

This applies to all value types.

Fixes #14970
Fixes #14964

> :warning: This is a binary breaking change :warning:
>
> the Previous version generated the `def f: Int` and `def f: Object` variants of the method.
> In the new one, we only generate the `def f: Int` version.
> Unfortunately, the previous version called the boxed version of the interface that does not exist anymore.
>
> Is this something that we encounter in practice?