### PR TITLE
Improve diagnostic for refutable extractors in pattern bindings

### DIFF
--- a/tests/neg/refutable-pattern-binding-messages.check
+++ b/tests/neg/refutable-pattern-binding-messages.check
@@ -1,0 +1,42 @@
+-- Error: tests/neg/refutable-pattern-binding-messages.scala:6:14 ------------------------------------------------------
+6 |  for Positive(i) <- List(1, 2, 3) do ()  // error: refutable extractor
+  |      ^^^^^^^^^^^
+  |      pattern binding uses refutable extractor `Test.Positive`
+  |
+  |      If this usage is intentional, this can be communicated by adding the `case` keyword before the full pattern,
+  |      which will result in a filtering for expression (using `withFilter`).
+-- Error: tests/neg/refutable-pattern-binding-messages.scala:11:11 -----------------------------------------------------
+11 |  for ((x: String) <- xs) do ()           // error: pattern type more specialized
+   |           ^^^^^^
+   | pattern's type String is more specialized than the right hand side expression's type AnyRef
+   |
+   | If the narrowing is intentional, this can be communicated by adding the `case` keyword before the full pattern,
+   | which will result in a filtering for expression (using `withFilter`).
+-- Error: tests/neg/refutable-pattern-binding-messages.scala:15:13 -----------------------------------------------------
+15 |  for none @ None <- ys do ()             // error: pattern type does not match
+   |             ^^^^
+   | pattern's type None.type does not match the right hand side expression's type (x$1 : Option[?])
+   |
+   | If the narrowing is intentional, this can be communicated by adding the `case` keyword before the full pattern,
+   | which will result in a filtering for expression (using `withFilter`).
+-- Error: tests/neg/refutable-pattern-binding-messages.scala:5:14 ------------------------------------------------------
+5 |  val Positive(p) = 5                     // error: refutable extractor
+  |      ^^^^^^^^^^^^^^^
+  |      pattern binding uses refutable extractor `Test.Positive`
+  |
+  |      If this usage is intentional, this can be communicated by adding `: @unchecked` after the expression,
+  |      which may result in a MatchError at runtime.
+-- Error: tests/neg/refutable-pattern-binding-messages.scala:10:20 -----------------------------------------------------
+10 |  val i :: is = List(1, 2, 3)             // error: pattern type more specialized
+   |                ^^^^^^^^^^^^^
+   |        pattern's type ::[Int] is more specialized than the right hand side expression's type List[Int]
+   |
+   |        If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,
+   |        which may result in a MatchError at runtime.
+-- Error: tests/neg/refutable-pattern-binding-messages.scala:16:10 -----------------------------------------------------
+16 |  val 1 = 2                               // error: pattern type does not match
+   |          ^
+   |        pattern's type (1 : Int) does not match the right hand side expression's type (2 : Int)
+   |
+   |        If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,
+   |        which may result in a MatchError at runtime.

--- a/tests/neg/refutable-pattern-binding-messages.scala
+++ b/tests/neg/refutable-pattern-binding-messages.scala
@@ -1,0 +1,17 @@
+// scalac: -source:future -Werror
+object Test {
+  // refutable extractor
+  object Positive { def unapply(i: Int): Option[Int] = Some(i).filter(_ > 0) }
+  val Positive(p) = 5                     // error: refutable extractor
+  for Positive(i) <- List(1, 2, 3) do ()  // error: refutable extractor
+
+  // more specialized
+  val xs: List[AnyRef] = ???
+  val i :: is = List(1, 2, 3)             // error: pattern type more specialized
+  for ((x: String) <- xs) do ()           // error: pattern type more specialized
+
+  // does not match
+  val ys: List[Option[?]] = ???
+  for none @ None <- ys do ()             // error: pattern type does not match
+  val 1 = 2                               // error: pattern type does not match
+}


### PR DESCRIPTION
Avoids nonsensical messages such as:
```
  pattern's type Int is more specialized than the right hand side expression's type Int
```
when the underlying cause is that the extractor is refutable.

Extracted from #14294 