### PR TITLE
fix #14432: check if scala 2 case class is accessible

### DIFF
--- a/sbt-test/scala2-compat/i14432/app1fail/Test.scala
+++ b/sbt-test/scala2-compat/i14432/app1fail/Test.scala
@@ -1,0 +1,3 @@
+import deriving.Mirror
+
+val mFoo = summon[Mirror.Of[Foo]] // error: `Foo.<init>(Int)` is not accessible from `<empty>`.

--- a/sbt-test/scala2-compat/i14432/app1ok/Test.scala
+++ b/sbt-test/scala2-compat/i14432/app1ok/Test.scala
@@ -1,0 +1,8 @@
+import deriving.Mirror
+
+package example {
+  val mFoo = summon[Mirror.Of[Foo]] // ok, we can access Foo's ctor from here.
+}
+
+@main def Test: Unit =
+  assert(example.mFoo.fromProduct(Some(23)) == example.Foo(23))

--- a/sbt-test/scala2-compat/i14432/app2fail/Test.scala
+++ b/sbt-test/scala2-compat/i14432/app2fail/Test.scala
@@ -1,0 +1,5 @@
+package example
+
+import deriving.Mirror
+
+val mFoo = summon[Mirror.Of[Foo]] // error: `Foo.<init>(Int)` is not accessible from any class.

--- a/sbt-test/scala2-compat/i14432/build.sbt
+++ b/sbt-test/scala2-compat/i14432/build.sbt
@@ -1,0 +1,30 @@
+val scala3Version = sys.props("plugin.scalaVersion")
+val scala2Version = sys.props("plugin.scala2Version")
+
+lazy val lib1 = project.in(file("lib1"))
+  .settings(
+    scalaVersion := scala2Version
+  )
+
+lazy val lib2 = project.in(file("lib2"))
+  .settings(
+    scalaVersion := scala2Version
+  )
+
+lazy val app1fail = project.in(file("app1fail"))
+  .dependsOn(lib1)
+  .settings(
+    scalaVersion := scala3Version
+  )
+
+lazy val app1ok = project.in(file("app1ok"))
+  .dependsOn(lib1)
+  .settings(
+    scalaVersion := scala3Version
+  )
+
+lazy val app2fail = project.in(file("app2fail"))
+  .dependsOn(lib2)
+  .settings(
+    scalaVersion := scala3Version
+  )

--- a/sbt-test/scala2-compat/i14432/lib1/Foo.scala
+++ b/sbt-test/scala2-compat/i14432/lib1/Foo.scala
@@ -1,0 +1,3 @@
+package example
+
+case class Foo private[example] (i: Int)

--- a/sbt-test/scala2-compat/i14432/lib2/Foo.scala
+++ b/sbt-test/scala2-compat/i14432/lib2/Foo.scala
@@ -1,0 +1,3 @@
+package example
+
+case class Foo private (i: Int)

--- a/sbt-test/scala2-compat/i14432/test
+++ b/sbt-test/scala2-compat/i14432/test
@@ -1,0 +1,5 @@
+> lib1/compile
+> lib2/compile
+-> app1fail/compile
+> app1ok/run
+-> app2fail/compile

--- a/tests/neg/i14432.check
+++ b/tests/neg/i14432.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i14432.scala:13:33 ---------------------------------------------------------------------------------
+13 |val mFoo = summon[Mirror.Of[Foo]] // error: no mirror found
+   |                                 ^
+   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef

--- a/tests/neg/i14432.scala
+++ b/tests/neg/i14432.scala
@@ -1,0 +1,13 @@
+package example
+
+import deriving.Mirror
+
+case class Foo private (i: Int)
+
+// case object companion here prevents Foo from caching
+// the mirror in its companion, so all potential mirrors for Foo will be anonymous.
+case object Foo
+
+// however we can not provide an anonymous mirror
+// at this call site because the constructor is not accessible.
+val mFoo = summon[Mirror.Of[Foo]] // error: no mirror found

--- a/tests/neg/i14432a.check
+++ b/tests/neg/i14432a.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i14432a.scala:14:43 --------------------------------------------------------------------------------
+14 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
+   |                                           ^
+   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef

--- a/tests/neg/i14432a.scala
+++ b/tests/neg/i14432a.scala
@@ -1,0 +1,15 @@
+import deriving.Mirror
+
+package example {
+  case class Foo private[example] (val i: Int)
+
+  // case object companion here prevents Foo from caching
+  // the mirror in its companion, so all potential mirrors for Foo will be anonymous.
+  case object Foo
+}
+
+@main def Test: Unit =
+  // however we can not provide an anonymous mirror
+  // at this call site because the constructor is not accessible.
+  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
+  assert(mFoo.fromProduct(Tuple1(1)).i == 1)

--- a/tests/neg/i14432b.check
+++ b/tests/neg/i14432b.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i14432b.scala:15:43 --------------------------------------------------------------------------------
+15 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
+   |                                           ^
+   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef

--- a/tests/neg/i14432b.scala
+++ b/tests/neg/i14432b.scala
@@ -1,0 +1,16 @@
+import deriving.Mirror
+
+package example {
+  case class Foo protected [example] (val i: Int)
+
+  // case object companion here prevents Foo from caching
+  // the mirror in its companion, so all potential mirrors for Foo will be anonymous.
+  case object Foo
+
+}
+
+class Bar extends example.Foo(23) {
+  // however we can not provide an anonymous mirror
+  // at this call site because the constructor is not accessible.
+  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
+}

--- a/tests/neg/i14432c.check
+++ b/tests/neg/i14432c.check
@@ -1,0 +1,12 @@
+-- Error: tests/neg/i14432c.scala:12:18 --------------------------------------------------------------------------------
+12 |class Bar extends example.Foo(23) { // error // error: cant access private[example] ctor
+   |                  ^^^^^^^^^^^
+   |                  constructor Foo cannot be accessed as a member of example.Foo from class Bar.
+-- Error: tests/neg/i14432c.scala:12:6 ---------------------------------------------------------------------------------
+12 |class Bar extends example.Foo(23) { // error // error: cant access private[example] ctor
+   |      ^
+   |      constructor Foo cannot be accessed as a member of example.Foo from class Bar.
+-- Error: tests/neg/i14432c.scala:16:43 --------------------------------------------------------------------------------
+16 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror
+   |                                           ^
+   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef

--- a/tests/neg/i14432c.scala
+++ b/tests/neg/i14432c.scala
@@ -1,0 +1,18 @@
+import deriving.Mirror
+
+package example {
+  case class Foo private [example] (val i: Int)
+
+  // case object companion here prevents Foo from caching
+  // the mirror in its companion, so all potential mirrors for Foo will be anonymous.
+  case object Foo
+
+}
+
+class Bar extends example.Foo(23) { // error // error: cant access private[example] ctor
+
+  // however we can not provide an anonymous mirror
+  // at this call site because the constructor is not accessible.
+  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror
+
+}

--- a/tests/neg/i14432d.check
+++ b/tests/neg/i14432d.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i14432d.scala:17:45 --------------------------------------------------------------------------------
+17 |    val mFoo = summon[Mirror.Of[example.Foo]] // error
+   |                                             ^
+   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef

--- a/tests/neg/i14432d.scala
+++ b/tests/neg/i14432d.scala
@@ -1,0 +1,20 @@
+import deriving.Mirror
+
+package example {
+  case class Foo protected [example] (val i: Int)
+
+  // case object companion here prevents Foo from caching
+  // the mirror in its companion, so all potential mirrors for Foo will be anonymous.
+  case object Foo
+
+}
+
+class Bar extends example.Foo(23) {
+
+  class Inner {
+    // however we can not provide an anonymous mirror
+    // at this call site because the constructor is not accessible.
+    val mFoo = summon[Mirror.Of[example.Foo]] // error
+  }
+
+}

--- a/tests/run/i14432.scala
+++ b/tests/run/i14432.scala
@@ -1,0 +1,11 @@
+import deriving.Mirror
+
+package example {
+  // Foo caches the mirror in its companion,
+  // which can still access the constructor.
+  case class Foo private (val i: Int)
+}
+
+@main def Test: Unit =
+  val mFoo = summon[Mirror.Of[example.Foo]]
+  assert(mFoo.fromProduct(Tuple1(1)).i == 1)

--- a/tests/run/i14432a.scala
+++ b/tests/run/i14432a.scala
@@ -1,0 +1,16 @@
+import deriving.Mirror
+
+package example {
+  case class Foo private[example] (val i: Int)
+
+  // case object companion here prevents Foo from caching
+  // the mirror in its companion, so all potential mirrors for Foo will be anonymous.
+  case object Foo
+
+  // here, we can synthesize an anonymous mirror
+  // because at this call site the constructor is accessible.
+  val mFoo = summon[Mirror.Of[example.Foo]]
+}
+
+@main def Test: Unit =
+  assert(example.mFoo.fromProduct(Tuple1(1)).i == 1)

--- a/tests/run/i14432b.scala
+++ b/tests/run/i14432b.scala
@@ -1,0 +1,20 @@
+import deriving.Mirror
+
+package example {
+  case class Foo protected [example] (val i: Int)
+
+  // case object companion here prevents Foo from caching
+  // the mirror in its companion, so all potential mirrors for Foo will be anonymous.
+  case object Foo
+
+  class Bar extends Foo(23) {
+    // here, we can synthesize an anonymous mirror
+    // because at this call site the constructor is accessible.
+    val mFoo = summon[Mirror.Of[example.Foo]]
+  }
+
+}
+
+@main def Test: Unit =
+  val bar = new example.Bar
+  assert(bar.mFoo.fromProduct(Tuple1(1)).i == 1)

--- a/tests/run/i14432c.scala
+++ b/tests/run/i14432c.scala
@@ -1,0 +1,23 @@
+import deriving.Mirror
+
+package example {
+  case class Foo protected [example] (val i: Int)
+
+  // case object companion here prevents Foo from caching
+  // the mirror in its companion, so all potential mirrors for Foo will be anonymous.
+  case object Foo
+
+  class Bar extends Foo(23) {
+    class Inner {
+      // here, we can synthesize an anonymous mirror
+      // because at this call site the constructor is accessible.
+      val mFoo = summon[Mirror.Of[example.Foo]]
+    }
+    val inner = Inner()
+  }
+
+}
+
+@main def Test: Unit =
+  val bar = new example.Bar
+  assert(bar.inner.mFoo.fromProduct(Tuple1(1)).i == 1)


### PR DESCRIPTION
closes #14432 

check the access flags of the constructor (including qualified private) for Mirrors of scala 2 case classes (this is because `fromProduct` needs to call the constructor).