### PR TITLE
fix #11764: generic sums can have no children

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -146,6 +146,7 @@ object SymUtils:
         s"it is not a sealed ${self.kindString}"
       else if (!self.isOneOf(AbstractOrTrait))
         s"it is not an abstract class"
+      else if self.is(CaseClass) then "it is a sealed abstract case class"
       else {
         val children = self.children
         val companionMirror = self.useCompanionAsSumMirror
@@ -169,8 +170,7 @@ object SymUtils:
             } else i"its child $child is not a generic product because $s"
           }
         }
-        if (children.isEmpty) "it does not have subclasses"
-        else children.map(problem).find(!_.isEmpty).getOrElse("")
+        children.map(problem).find(!_.isEmpty).getOrElse("")
       }
 
     def isGenericSum(declScope: Symbol)(using Context): Boolean = whyNotGenericSum(declScope).isEmpty

--- a/tests/neg/i11764.check
+++ b/tests/neg/i11764.check
@@ -1,0 +1,12 @@
+-- Error: tests/neg/i11764.scala:20:38 ---------------------------------------------------------------------------------
+20 |  val mFoo = summon[Mirror.SumOf[Foo]] // error
+   |                                      ^
+   |no given instance of type deriving.Mirror.SumOf[Foo] was found for parameter x of method summon in object Predef
+-- Error: tests/neg/i11764.scala:22:38 ---------------------------------------------------------------------------------
+22 |  val mBar = summon[Mirror.SumOf[Bar]] // error
+   |                                      ^
+   |no given instance of type deriving.Mirror.SumOf[Bar] was found for parameter x of method summon in object Predef
+-- Error: tests/neg/i11764.scala:23:42 ---------------------------------------------------------------------------------
+23 |  val mBaz = summon[Mirror.ProductOf[Bar]] // error
+   |                                          ^
+   |no given instance of type deriving.Mirror.ProductOf[Bar] was found for parameter x of method summon in object Predef

--- a/tests/neg/i11764.scala
+++ b/tests/neg/i11764.scala
@@ -1,0 +1,23 @@
+import deriving.Mirror
+
+// a sealed trait with inaccessible children should
+// still not be a generic sum.
+sealed trait Foo
+object Foo {
+  def local =
+    case class Local() extends Foo
+}
+
+// in `3.0-3.1`, sealed abstract case class was neither a
+// generic sum type (because it can't have `case` children),
+// or a generic product type (because we can't call the ctor),
+// but now sum types can have no children,
+// so we must restrict against case classes.
+sealed abstract case class Bar()
+
+def foo =
+
+  val mFoo = summon[Mirror.SumOf[Foo]] // error
+
+  val mBar = summon[Mirror.SumOf[Bar]] // error
+  val mBaz = summon[Mirror.ProductOf[Bar]] // error

--- a/tests/run/i11764.scala
+++ b/tests/run/i11764.scala
@@ -1,0 +1,15 @@
+import deriving.Mirror
+
+sealed trait Foo
+object Foo
+
+sealed trait Bar
+
+
+@main def Test =
+  val mFoo = summon[Mirror.SumOf[Foo]]
+  assert(mFoo eq Foo)
+  summon[mFoo.MirroredElemTypes =:= EmptyTuple]
+
+  val mBar = summon[Mirror.SumOf[Bar]] // also check anonymous case
+  summon[mBar.MirroredElemTypes =:= EmptyTuple]


### PR DESCRIPTION
closes #11764 

enable generic sum types to have no children, while also asserting that it is not a `sealed abstract case class`.