### PR TITLE
fix 14150 - constrain refinements to type parameters

### DIFF
--- a/tests/neg/7380a.scala
+++ b/tests/neg/7380a.scala
@@ -1,0 +1,29 @@
+import scala.deriving.Mirror
+
+object Lib {
+
+  trait HasFields[T]
+  trait HasFieldsOrNone[T]
+
+  given mirHasFields[T, ElemLabels <: NonEmptyTuple](using
+    mir: Mirror.ProductOf[T] { type MirroredElemLabels = ElemLabels }
+  ): HasFields[T]()
+
+  given mirHasFieldsOrNone[T, ElemLabels <: Tuple](using
+    mir: Mirror.ProductOf[T] { type MirroredElemLabels = ElemLabels }
+  ): HasFieldsOrNone[T]()
+
+}
+
+object Test {
+
+  Lib.mirHasFields[(Int, String), ("_1", "_2", "_3")] // error
+
+  summon[Lib.HasFields[(Int, String)]] // ok
+
+  case class NoFields()
+
+  summon[Lib.HasFields[NoFields]] // error
+  summon[Lib.HasFieldsOrNone[NoFields]] // ok
+
+}

--- a/tests/run-macros/i7987.check
+++ b/tests/run-macros/i7987.check
@@ -1,12 +1,7 @@
-scala.deriving.Mirror {
-  type MirroredType >: scala.Some[scala.Int] <: scala.Some[scala.Int]
-  type MirroredMonoType >: scala.Some[scala.Int] <: scala.Some[scala.Int]
-  type MirroredElemTypes >: scala.Nothing <: scala.Tuple
-} & scala.deriving.Mirror.Product {
+scala.deriving.Mirror.Product {
   type MirroredMonoType >: scala.Some[scala.Int] <: scala.Some[scala.Int]
   type MirroredType >: scala.Some[scala.Int] <: scala.Some[scala.Int]
   type MirroredLabel >: "Some" <: "Some"
-} {
   type MirroredElemTypes >: scala.*:[scala.Int, scala.Tuple$package.EmptyTuple] <: scala.*:[scala.Int, scala.Tuple$package.EmptyTuple]
   type MirroredElemLabels >: scala.*:["value", scala.Tuple$package.EmptyTuple] <: scala.*:["value", scala.Tuple$package.EmptyTuple]
 }

--- a/tests/run/i14150.scala
+++ b/tests/run/i14150.scala
@@ -1,0 +1,74 @@
+import scala.deriving.Mirror
+import scala.util.NotGiven
+import scala.compiletime.constValue
+
+trait GetConstValue[T] {
+    type Out
+    def get : Out
+}
+
+object GetConstValue {
+    type Aux[T, O] = GetConstValue[T] { type Out = O }
+
+    inline given value[T <: Singleton](
+        using
+        ev : NotGiven[T <:< Tuple],
+    ) : GetConstValue.Aux[T, T] = {
+        val out = constValue[T]
+
+        new GetConstValue[T] {
+            type Out = T
+            def get : Out = out
+        }
+    }
+
+    given empty : GetConstValue[EmptyTuple] with {
+        type Out = EmptyTuple
+        def get : Out = EmptyTuple
+    }
+
+    given nonEmpty[H, HRes, Tail <: Tuple, TRes <: Tuple](
+        using
+        head : GetConstValue.Aux[H, HRes],
+        tail : GetConstValue.Aux[Tail, TRes],
+    ) : GetConstValue[H *: Tail] with {
+        type Out = HRes *: TRes
+
+        def get : Out = head.get *: tail.get
+    }
+}
+
+trait MirrorNamesDeriver[T] {
+    type Derived <: Tuple
+    def derive : Derived
+}
+
+object MirrorNamesDeriver {
+    given mirDeriver[T, ElemLabels <: NonEmptyTuple](
+        using
+        mir: Mirror.SumOf[T] { type MirroredElemLabels = ElemLabels },
+        ev : GetConstValue.Aux[ElemLabels, ElemLabels],
+    ): MirrorNamesDeriver[T] with {
+        type Derived = ElemLabels
+
+        def derive: ElemLabels = ev.get
+    }
+
+    def derive[T](using d : MirrorNamesDeriver[T]) : d.Derived = d.derive
+}
+
+sealed trait SuperT
+final case class SubT1(int: Int) extends SuperT
+final case class SubT2(str: String, dbl : Double, bool : Boolean) extends SuperT
+
+@main def Test =
+
+  // Works when type parameters are set explicitly
+  val successfulLabels = MirrorNamesDeriver.mirDeriver[SuperT, ("SubT1", "SubT2")].derive
+  println(successfulLabels)
+  assert(successfulLabels == ("SubT1", "SubT2"))
+
+  // Fails when type parameters are inferred
+  val failedLabels = MirrorNamesDeriver.derive[SuperT]
+  println(successfulLabels)
+  assert(failedLabels == ("SubT1", "SubT2"))


### PR DESCRIPTION
constrain the synthesised refinements to the product/sum type against the formal before the intersection

closes #14150