### PR TITLE
Use markdown syntax in tasty-core documentation

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1846,6 +1846,8 @@ object ScaladocConfigs {
     val dottyManagesSources =
       (`stdlib-bootstrapped`/Compile/sourceManaged).value / "dotty-library-src"
 
+    val tastyCoreSources = projectRoot.relativize((`tasty-core-bootstrapped`/Compile/scalaSource).value.toPath().normalize())
+
     val dottyLibRoot = projectRoot.relativize(dottyManagesSources.toPath.normalize())
     DefaultGenerationConfig.value
       .add(ProjectName("Scala 3"))
@@ -1856,6 +1858,7 @@ object ScaladocConfigs {
       .add(CommentSyntax(List(
         s"${dottyLibRoot}=markdown",
         s"${stdLibRoot}=wiki",
+        s"${tastyCoreSources}=markdown",
         "wiki"
       )))
       .add(VersionsDictionaryUrl("https://scala-lang.org/api/versions.json"))

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -263,8 +263,6 @@ Standard Section: "Comments" Comment*
 ```none
   Comment       = Length Bytes LongInt      // Raw comment's bytes encoded as UTF-8, followed by the comment's coordinates.
 ```
-
-* @syntax markdown
 **************************************************************************************/
 
 object TastyFormat {


### PR DESCRIPTION
We didn't set markdown syntax for tasty-core but in turn, we had fallback to wiki for all paths that don't match. Because of that, the documentation doesn't look very good: https://scala-lang.org/api/3.x/dotty/tools/tasty/TastyFormat$.html .

This PR sets markdown syntax for tasty-core project and repairs the documentation.