### PR TITLE
Scaladoc: add extension suffixes and fqName to scaladoc searchbar

### DIFF
--- a/scaladoc-js/main/src/searchbar/PageEntry.scala
+++ b/scaladoc-js/main/src/searchbar/PageEntry.scala
@@ -6,6 +6,7 @@ import scala.scalajs.js
 trait PageEntryJS extends js.Object {
   val n: String  = js.native
   val t: String  = js.native
+  val i: String  = js.native
   val d: String  = js.native
   val l: String  = js.native
   val e: Boolean = js.native
@@ -15,6 +16,7 @@ trait PageEntryJS extends js.Object {
 case class PageEntry(
   fullName: String,
   description: String,
+  extensionTarget: String,
   location: String,
   isLocationExternal: Boolean,
   shortName: String,
@@ -35,6 +37,7 @@ object PageEntry {
   def apply(jsObj: PageEntryJS): PageEntry = PageEntry(
       jsObj.t,
       jsObj.d,
+      jsObj.i,
       jsObj.l,
       jsObj.e,
       jsObj.n.toLowerCase,

--- a/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
+++ b/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
@@ -23,9 +23,16 @@ class SearchbarComponent(engine: SearchbarEngine, inkuireEngine: InkuireJSSearch
         Globals.pathToRoot + p.location
       }
 
+      val extensionTargetMessage = if (p.extensionTarget.isEmpty()) {
+        ""
+      } else {
+        " extension on " + p.extensionTarget
+      }
+
       div(cls := "scaladoc-searchbar-row monospace", "result" := "")(
         a(href := location)(
           p.fullName,
+          span(i(extensionTargetMessage)),
           span(cls := "pull-right scaladoc-searchbar-location")(p.description)
         ).tap { _.onclick = (event: Event) =>
           if (document.body.contains(rootDiv)) {

--- a/scaladoc-js/main/test/dotty/tools/scaladoc/MatchersTest.scala
+++ b/scaladoc-js/main/test/dotty/tools/scaladoc/MatchersTest.scala
@@ -34,6 +34,7 @@ class MatchersTest:
     s"$kind $name",
     "",
     "",
+    "",
     false,
     s"$name",
     kind,

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -132,36 +132,44 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
         case Keyword(s) => s
       }.mkString
 
-    def mkEntry(dri: DRI, name: String, text: String, descr: String, kind: String) = jsonObject(
+    def mkEntry(dri: DRI, name: String, text: String, extensionTarget: String, descr: String, kind: String) = jsonObject(
         "l" -> jsonString(relativeInternalOrAbsoluteExternalPath(dri)),
         "e" -> (if dri.externalLink.isDefined then rawJSON("true") else rawJSON("false")),
+        "i" -> jsonString(extensionTarget),
         "n" -> jsonString(name),
         "t" -> jsonString(text),
         "d" -> jsonString(descr),
         "k" -> jsonString(kind)
       )
 
-    def processPage(page: Page): Seq[JSON] =
-      val res =  page.content match
+    def extensionTarget(member: Member): String =
+      member.kind match
+        case Kind.Extension(on, _) => flattenToText(on.signature)
+        case _ => ""
+
+    def processPage(page: Page, pageFQName: List[String]): Seq[(JSON, Seq[String])] =
+      val (res, pageName) =  page.content match
         case m: Member if m.kind != Kind.RootPackage =>
-          val descr = m.dri.asFileLocation
-          def processMember(member: Member): Seq[JSON] =
+          def processMember(member: Member, fqName: List[String]): Seq[(JSON, Seq[String])] =
             val signatureBuilder = ScalaSignatureProvider.rawSignature(member, InlineSignatureBuilder())().asInstanceOf[InlineSignatureBuilder]
             val sig = Signature(Plain(member.name)) ++ signatureBuilder.names.reverse
-            val entry = mkEntry(member.dri, member.name, flattenToText(sig), descr, member.kind.name)
+            val descr = fqName.mkString(".")
+            val entry = mkEntry(member.dri, member.name, flattenToText(sig), extensionTarget(member), descr, member.kind.name)
             val children = member
                 .membersBy(m => m.kind != Kind.Package && !m.kind.isInstanceOf[Classlike])
                 .filter(m => m.origin == Origin.RegularlyDefined && m.inheritedFrom.fold(true)(_.isSourceSuperclassHidden))
-            Seq(entry) ++ children.flatMap(processMember)
+            val updatedFqName = fqName :+ member.name
+            Seq((entry, updatedFqName)) ++ children.flatMap(processMember(_, updatedFqName))
 
-          processMember(m)
+          (processMember(m, pageFQName), m.name)
         case _ =>
-          Seq(mkEntry(page.link.dri, page.link.name, page.link.name, "", "static"))
+          (Seq((mkEntry(page.link.dri, page.link.name, page.link.name, "", "", "static"), pageFQName)), "")
 
-      res ++ page.children.flatMap(processPage)
+      val updatedFqName = if !pageName.isEmpty then pageFQName :+ pageName else pageFQName
+      res ++ page.children.flatMap(processPage(_, updatedFqName))
 
-    val entries = pages.flatMap(processPage)
-    Resource.Text(searchDataPath, s"pages = ${jsonList(entries)};")
+    val entries = pages.flatMap(processPage(_, Nil))
+    Resource.Text(searchDataPath, s"pages = ${jsonList(entries.map(_._1))};")
 
   def scastieConfiguration() =
     Resource.Text(scastieConfigurationPath, s"""scastieConfiguration = "${


### PR DESCRIPTION
Suffixes in the form of italic _extension on (...)_ for extension defs will allow to separate semantically different methods, which previously would have been displayed as the same in searchbar.
File-based location was also replaced with fully qualified name based, in an effort to improve overall readability.
Fixes #14486

Can be viewed on: https://scala3doc.virtuslab.com/pr-fix-searchbar-repeating/scala3/index.html

<img width="1281" alt="Zrzut ekranu 2022-04-27 o 11 59 36" src="https://user-images.githubusercontent.com/48855024/165523425-70e75bdd-8779-47de-9319-e549cd7d15e3.png">
