### PR TITLE
Keep annotation order

### DIFF
--- a/tests/pos/Annotations.scala
+++ b/tests/pos/Annotations.scala
@@ -1,0 +1,8 @@
+package foo.bar
+
+import jdk.jfr.Enabled
+
+@Enabled
+@Deprecated
+final class Annotations {
+}

--- a/tests/pos/annotations1/a.scala
+++ b/tests/pos/annotations1/a.scala
@@ -1,0 +1,2 @@
+class Annot1(s: String) extends scala.annotation.StaticAnnotation
+class Annot2(s: Class[_]) extends scala.annotation.StaticAnnotation

--- a/tests/pos/annotations1/b.scala
+++ b/tests/pos/annotations1/b.scala
@@ -1,0 +1,3 @@
+@Annot1("foo")
+@Annot2(classOf[AnyRef])
+class Test

--- a/tests/pos/annotationsJava/Annot1.java
+++ b/tests/pos/annotationsJava/Annot1.java
@@ -1,0 +1,5 @@
+import java.lang.annotation.*;
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@interface Annot1 { String value() default ""; }

--- a/tests/pos/annotationsJava/Annot2.java
+++ b/tests/pos/annotationsJava/Annot2.java
@@ -1,0 +1,5 @@
+import java.lang.annotation.*;
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@interface Annot2 { Class value(); }

--- a/tests/pos/annotationsJava/b.scala
+++ b/tests/pos/annotationsJava/b.scala
@@ -1,0 +1,1 @@
+@Annot1("foo") @Annot2(classOf[AnyRef]) class Test

--- a/tests/pos/annotationsJavaRepeatable/Annot1.java
+++ b/tests/pos/annotationsJavaRepeatable/Annot1.java
@@ -1,0 +1,13 @@
+import java.lang.annotation.*;
+
+@Repeatable(Annot1.Container.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@interface Annot1 { String value() default "";
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public static @interface Container {
+        Annot1[] value();
+    }
+}

--- a/tests/pos/annotationsJavaRepeatable/Annot2.java
+++ b/tests/pos/annotationsJavaRepeatable/Annot2.java
@@ -1,0 +1,6 @@
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@interface Annot2 { Class value(); }

--- a/tests/pos/annotationsJavaRepeatable/b.scala
+++ b/tests/pos/annotationsJavaRepeatable/b.scala
@@ -1,0 +1,1 @@
+@Annot1("foo") @Annot2(classOf[String]) @Annot1("bar") class Test


### PR DESCRIPTION
This change makes sure non-repeated annotations are kept in the order
they were found in the source code.

The motivation is not necessarily to have them in the original order,
but to have them in an order that is deterministic across rebuilds
(potentially even across different machines), for reasons discussed
further in #7661 and the corresponding scala/scala-dev#405

I tried adding an 'integration test' in `tests/pos` to be picked up by `IdempotencyCheck.scala`, but unfortunately couldn't reproduce the nondeterminism that way ~, so didn't end up including it in this commit~.

I didn't see an obvious place for a 'unit test' of this code, I'd be
happy to add one when someone can recommend a good place to put it.

This is basically the dotty equivalent of
https://github.com/scala/scala/commit/954c5d32d71a43b141be546877b01183a994a1b2

Fixes #14743