### PR TITLE
SourceFile converts File.separator

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -11,7 +11,7 @@ import Denotations.Denotation
 import typer.Typer
 import typer.ImportInfo.withRootImports
 import Decorators._
-import io.{AbstractFile, VirtualFile}
+import io.AbstractFile
 import Phases.unfusedPhases
 
 import util._

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -14,7 +14,7 @@ import java.util.zip._
 import scala.collection._
 import scala.io.Codec
 
-import dotty.tools.io.{ AbstractFile, VirtualFile }
+import dotty.tools.io.AbstractFile
 
 import ast.{Trees, tpd}
 import core._, core.Decorators._

--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -15,6 +15,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.chaining.given
 
+import java.io.File.separator
 import java.nio.charset.StandardCharsets
 import java.nio.file.{FileSystemException, NoSuchFileException}
 import java.util.Optional
@@ -217,8 +218,11 @@ object SourceFile {
 
   implicit def fromContext(using Context): SourceFile = ctx.source
 
+  /** A source file with an underlying virtual file. The name is taken as a file system path
+   *  with the local separator converted to "/". The last element of the path will be the simple name of the file.
+   */
   def virtual(name: String, content: String, maybeIncomplete: Boolean = false) =
-    SourceFile(new VirtualFile(name, content.getBytes(StandardCharsets.UTF_8)), content.toCharArray)
+    SourceFile(new VirtualFile(name.replace(separator, "/"), content.getBytes(StandardCharsets.UTF_8)), content.toCharArray)
       .tap(_._maybeInComplete = maybeIncomplete)
 
   /** Returns the relative path of `source` within the `reference` path

--- a/compiler/src/dotty/tools/io/VirtualDirectory.scala
+++ b/compiler/src/dotty/tools/io/VirtualDirectory.scala
@@ -56,7 +56,7 @@ extends AbstractFile {
 
   override def fileNamed(name: String): AbstractFile =
     Option(lookupName(name, directory = false)) getOrElse {
-      val newFile = new VirtualFile(name, path + '/' + name)
+      val newFile = new VirtualFile(name, s"$path/$name")
       files(name) = newFile
       newFile
     }

--- a/scaladoc/src/dotty/tools/scaladoc/DocContext.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/DocContext.scala
@@ -8,7 +8,6 @@ import java.nio.file.Paths
 import collection.JavaConverters._
 import dotty.tools.scaladoc.site.StaticSiteContext
 import dotty.tools.dotc.core.Contexts._
-import dotty.tools.io.VirtualFile
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans


### PR DESCRIPTION
SourceFile normalizes the virtual path so that finding the last element always works.

The virtual path separator is always "/". (`VirtualDirectory` constructs a path that way.)

Previously, `InteractiveDriver` used `Path` to determine the simple "file name" component.
```
val virtualFile = new VirtualFile(path.getFileName.toString, path.toString)
```

Fixes #15055 

[test_windows_full]