### PR TITLE
Three capture checking fixes

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -220,7 +220,7 @@ sealed abstract class CaptureSet extends Showable:
         else mapped
       else tm match
         case tm: IdempotentCaptRefMap => Mapped(asVar, tm, tm.variance, mapped)
-        case _ if false => OtherMapped(asVar, tm, tm.variance, mapped)
+        case _ if ccAllowUnsoundMaps => OtherMapped(asVar, tm, tm.variance, mapped)
 
   def substParams(tl: BindingType, to: List[Type])(using Context) =
     map(Substituters.SubstParamsMap(tl, to))
@@ -424,7 +424,7 @@ object CaptureSet:
         .andAlso(if origin ne source then source.tryInclude(newElems, this) else CompareResult.OK)
           // `tm` is assumed idempotent, propagate back elems from image set.
           // This is sound, since we know that for `r in newElems: tm(r) = r`, hence
-          // `r` is _one_ possible solition in `source` that would make an `r` appear in this set.
+          // `r` is _one_ possible solution in `source` that would make an `r` appear in this set.
           // It's not necessarily the only possible solultion, so the scheme is incomplete.
 
     protected def addNewElemsImpl(newElems: Refs, origin: CaptureSet)(using Context, VarState): CompareResult =

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -15,6 +15,7 @@ import printing.Texts.*
 import util.{SimpleIdentitySet, Property}
 import util.common.alwaysTrue
 import scala.collection.mutable
+import config.Config.ccAllowUnsoundMaps
 
 /** A class for capture sets. Capture sets can be constants or variables.
  *  Capture sets support inclusion constraints <:< where <:< is subcapturing.
@@ -196,7 +197,7 @@ sealed abstract class CaptureSet extends Showable:
    *  if `tm` is a bijection on capture references or it is idempotent on capture references.
    *  (see definition in IdempotentCapRefMap).
    *  If `tm` is a bijection we know that `tm^-1(x)` must be in `cs1`. If `tm` is idempotent
-   *  one possible is solution is that `x` is in `cs1`, which is what we assume in this case.
+   *  one possible solution is that `x` is in `cs1`, which is what we assume in this case.
    *  That strategy is sound but not complete.
    *
    *  If `tm` is some other map, we don't know how to handle this case. For now,
@@ -422,6 +423,9 @@ object CaptureSet:
       addNewElemsImpl(newElems: Refs, origin: CaptureSet)
         .andAlso(if origin ne source then source.tryInclude(newElems, this) else CompareResult.OK)
           // `tm` is assumed idempotent, propagate back elems from image set.
+          // This is sound, since we know that for `r in newElems: tm(r) = r`, hence
+          // `r` is _one_ possible solition in `source` that would make an `r` appear in this set.
+          // It's not necessarily the only possible solultion, so the scheme is incomplete.
 
     protected def addNewElemsImpl(newElems: Refs, origin: CaptureSet)(using Context, VarState): CompareResult =
       val added =

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -9,6 +9,7 @@ import Types.*, StdNames.*
 import config.Printers.capt
 import ast.tpd
 import transform.Recheck.*
+import CaptureSet.IdentityCaptRefMap
 
 class Setup(
   preRecheckPhase: DenotTransformer,

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -231,4 +231,10 @@ object Config {
    *  If false, print them in the form `T @retains(c)`.
    */
   inline val printCaptureSetsAsPrefix = true
+
+  /** If true, allow mappping capture set variables under -Ycc with maps that are neither
+   *  bijective nor idempotent. We currently do now know how to do this correctly in all
+   *  cases, though.
+   */
+  inline val ccAllowUnsoundMaps = false
 }

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -1,6 +1,8 @@
-package dotty.tools.dotc.core
+package dotty.tools.dotc
+package core
 
 import Types._, Symbols._, Contexts._
+import cc.CaptureSet.IdempotentCaptRefMap
 
 /** Substitution operations on types. See the corresponding `subst` and
  *  `substThis` methods on class Type for an explanation.
@@ -191,11 +193,11 @@ object Substituters:
     def apply(tp: Type): Type = substRecThis(tp, from, to, this)(using mapCtx)
   }
 
-  final class SubstParamMap(from: ParamRef, to: Type)(using Context) extends DeepTypeMap {
+  final class SubstParamMap(from: ParamRef, to: Type)(using Context) extends DeepTypeMap, IdempotentCaptRefMap {
     def apply(tp: Type): Type = substParam(tp, from, to, this)(using mapCtx)
   }
 
-  final class SubstParamsMap(from: BindingType, to: List[Type])(using Context) extends DeepTypeMap {
+  final class SubstParamsMap(from: BindingType, to: List[Type])(using Context) extends DeepTypeMap, IdempotentCaptRefMap {
     def apply(tp: Type): Type = substParams(tp, from, to, this)(using mapCtx)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -11,6 +11,7 @@ import util.Stats._
 import Names._
 import Flags.Module
 import dotty.tools.dotc.config.Config
+import cc.CaptureSet.IdentityCaptRefMap
 
 object TypeApplications {
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -19,7 +19,7 @@ import typer.Inferencing._
 import typer.IfBottom
 import reporting.TestingReporter
 import cc.{CapturingType, derivedCapturingType, CaptureSet}
-import CaptureSet.CompareResult
+import CaptureSet.{CompareResult, IdempotentCaptRefMap, IdentityCaptRefMap}
 
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
@@ -56,7 +56,7 @@ object TypeOps:
   }
 
   /** The TypeMap handling the asSeenFrom */
-  class AsSeenFromMap(pre: Type, cls: Symbol)(using Context) extends ApproximatingTypeMap {
+  class AsSeenFromMap(pre: Type, cls: Symbol)(using Context) extends ApproximatingTypeMap, IdempotentCaptRefMap {
     /** Set to true when the result of `apply` was approximated to avoid an unstable prefix. */
     var approximated: Boolean = false
 
@@ -192,7 +192,7 @@ object TypeOps:
     }
   }
 
-  class SimplifyMap(using Context) extends TypeMap {
+  class SimplifyMap(using Context) extends IdentityCaptRefMap {
     def apply(tp: Type): Type = simplify(tp, this)
   }
 
@@ -426,7 +426,7 @@ object TypeOps:
   }
 
   /** An approximating map that drops NamedTypes matching `toAvoid` and wildcard types. */
-  abstract class AvoidMap(using Context) extends AvoidWildcardsMap:
+  abstract class AvoidMap(using Context) extends AvoidWildcardsMap, IdempotentCaptRefMap:
     @threadUnsafe lazy val localParamRefs = util.HashSet[Type]()
 
     def toAvoid(tp: NamedType): Boolean

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -36,7 +36,7 @@ import config.Printers.{core, typr, matchTypes}
 import reporting.{trace, Message}
 import java.lang.ref.WeakReference
 import cc.{CapturingType, CaptureSet, derivedCapturingType, retainedElems, isBoxedCapturing, CapturingKind, EventuallyCapturingType}
-import CaptureSet.CompareResult
+import CaptureSet.{CompareResult, IdempotentCaptRefMap, IdentityCaptRefMap}
 
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
@@ -3686,7 +3686,7 @@ object Types {
 
     override def resultType(using Context): Type =
       if (dependencyStatus == FalseDeps) { // dealias all false dependencies
-        val dealiasMap = new TypeMap {
+        val dealiasMap = new TypeMap with IdentityCaptRefMap {
           def apply(tp: Type) = tp match {
             case tp @ TypeRef(pre, _) =>
               tp.info match {
@@ -3799,7 +3799,7 @@ object Types {
     /** The least supertype of `resultType` that does not contain parameter dependencies */
     def nonDependentResultApprox(using Context): Type =
       if isResultDependent then
-        val dropDependencies = new ApproximatingTypeMap {
+        val dropDependencies = new ApproximatingTypeMap with IdempotentCaptRefMap {
           def apply(tp: Type) = tp match {
             case tp @ TermParamRef(`thisLambdaType`, _) =>
               range(defn.NothingType, atVariance(1)(apply(tp.underlying)))

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3804,17 +3804,7 @@ object Types {
             case tp @ TermParamRef(`thisLambdaType`, _) =>
               range(defn.NothingType, atVariance(1)(apply(tp.underlying)))
             case CapturingType(parent, refs, boxed) =>
-              val parent1 = this(parent)
-              val elems1 = refs.elems.filter {
-                case tp @ TermParamRef(`thisLambdaType`, _) => false
-                case _ => true
-              }
-              if elems1.size == refs.elems.size then
-                derivedCapturingType(tp, parent1, refs)
-              else
-                range(
-                  CapturingType(parent1, CaptureSet(elems1), boxed),
-                  CapturingType(parent1, CaptureSet.universal, boxed))
+              mapOver(tp)
             case AnnotatedType(parent, ann) if ann.refersToParamOf(thisLambdaType) =>
               val parent1 = mapOver(parent)
               if ann.symbol == defn.RetainsAnnot || ann.symbol == defn.RetainsByNameAnnot then

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -25,6 +25,7 @@ import ast.Trees._
 import ast.untpd
 import ast.tpd
 import transform.SymUtils._
+import cc.CaptureSet.IdentityCaptRefMap
 
 /**  Messages
   *  ========
@@ -250,7 +251,7 @@ import transform.SymUtils._
     // the type mismatch on the bounds instead of the original TypeParamRefs, since
     // these are usually easier to analyze. We exclude F-bounds since these would
     // lead to a recursive infinite expansion.
-    object reported extends TypeMap:
+    object reported extends TypeMap, IdentityCaptRefMap:
       def setVariance(v: Int) = variance = v
       val constraint = mapCtx.typerState.constraint
       var fbounded = false

--- a/compiler/src/dotty/tools/dotc/typer/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CheckCaptures.scala
@@ -15,7 +15,7 @@ import transform.SymUtils.*
 import transform.{Recheck, PreRecheck}
 import Recheck.*
 import scala.collection.mutable
-import CaptureSet.withCaptureSetsExplained
+import CaptureSet.{withCaptureSetsExplained, IdempotentCaptRefMap}
 import StdNames.nme
 import reporting.trace
 
@@ -40,7 +40,7 @@ object CheckCaptures:
     def isOpen = !captured.isAlwaysEmpty && !isBoxed
 
   final class SubstParamsMap(from: BindingType, to: List[Type])(using Context)
-  extends ApproximatingTypeMap:
+  extends ApproximatingTypeMap, IdempotentCaptRefMap:
     def apply(tp: Type): Type = tp match
       case tp: ParamRef =>
         if tp.binder == from then to(tp.paramNum) else tp

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -582,6 +582,7 @@ object Checking {
   def checkNoPrivateLeaks(sym: Symbol)(using Context): Type = {
     class NotPrivate extends TypeMap {
       var errors: List[() => String] = Nil
+      var inCaptureSet: Boolean = false
 
       def accessBoundary(sym: Symbol): Symbol =
         if (sym.is(Private) || !sym.owner.isClass) sym.owner
@@ -595,12 +596,16 @@ object Checking {
        *  @pre  The signature of `sym` refers to `other`
        */
       def isLeaked(other: Symbol) =
-        other.is(Private, butNot = TypeParam) && {
+        other.is(Private, butNot = TypeParam)
+        && {
           val otherBoundary = other.owner
           val otherLinkedBoundary = otherBoundary.linkedClass
           !(symBoundary.isContainedIn(otherBoundary) ||
             otherLinkedBoundary.exists && symBoundary.isContainedIn(otherLinkedBoundary))
         }
+        && !(inCaptureSet && other.isAllOf(LocalParamAccessor))
+            // class parameters in capture sets are not treated as leaked since in
+            // phase -Ycc these are treated as normal vals.
 
       def apply(tp: Type): Type = tp match {
         case tp: NamedType =>
@@ -635,6 +640,13 @@ object Checking {
             declaredParents =
               tp.declaredParents.map(p => transformedParent(apply(p)))
             )
+        case tp @ AnnotatedType(underlying, annot)
+        if annot.symbol == defn.RetainsAnnot || annot.symbol == defn.RetainsByNameAnnot =>
+          val underlying1 = this(underlying)
+          inCaptureSet = true
+          val annot1 = annot.mapWith(this)
+          inCaptureSet = false
+          derivedAnnotatedType(tp, underlying1, annot1)
         case _ =>
           mapOver(tp)
       }

--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -319,6 +319,7 @@ trait ImportSuggestions:
    *  If there's nothing to suggest, an empty string is returned.
    */
   override def importSuggestionAddendum(pt: Type)(using Context): String =
+    if ctx.phase == Phases.checkCapturesPhase then return ""
     val (fullMatches, headMatches) =
       importSuggestions(pt)(using ctx.fresh.setExploreTyperState())
     implicits.println(i"suggestions for $pt in ${ctx.owner} = ($fullMatches%, %, $headMatches%, %)")

--- a/docs/_docs/reference/experimental/cc.md
+++ b/docs/_docs/reference/experimental/cc.md
@@ -368,7 +368,7 @@ again on access, the capture information "pops out" again. For instance, even th
 () => p.fst : {ct} () -> {ct} Int -> String
 ```
 In other words, references to capabilities "tunnel through" in generic instantiations from creation to access; they do not affect the capture set of the enclosing generic data constructor applications.
-This principle may seem surprising at first, but it is the key to make capture checking concise and practical.
+This principle plays an important part in making capture checking concise and practical.
 
 ## Escape Checking
 
@@ -398,7 +398,7 @@ This error message was produced by the following logic:
 
  - The `f` parameter has type `{*} FileOutputStream`, which makes it a capability.
  - Therefore, the type of the expression `() => f.write(0)` is `{f} () -> Unit`.
- - This makes the whole type of the closure passed to `usingLogFile` the dependent function type
+ - This makes the type of the whole closure passed to `usingLogFile` the dependent function type
    `(f: {*} FileOutputStream) -> {f} () -> Unit`.
  - The expected type of the closure is a simple, parametric, impure function type `({*} FileOutputStream) => T`,
    for some instantiation of the type variable `T`.

--- a/tests/neg-custom-args/captures/i15049.scala
+++ b/tests/neg-custom-args/captures/i15049.scala
@@ -1,0 +1,10 @@
+class Session:
+  def request = "Response"
+class Foo:
+  private val session: {*} Session = new Session
+  def withSession[T](f: ({*} Session) => T): T = f(session)
+
+def Test =
+  val f = new Foo
+  f.withSession(s => s).request // error
+  f.withSession[{*} Session](t => t) // error

--- a/tests/neg-custom-args/captures/unbox.scala
+++ b/tests/neg-custom-args/captures/unbox.scala
@@ -1,0 +1,5 @@
+type Proc = {*} () => Unit
+
+val xs: List[Proc] = ???
+
+val x = xs.head // error

--- a/tests/neg-custom-args/captures/usingLogFile.check
+++ b/tests/neg-custom-args/captures/usingLogFile.check
@@ -18,3 +18,18 @@
    |  ^^^^^^^^
    |  The expression's type {*} () -> Unit is not allowed to capture the root capability `*`.
    |  This usually means that a capability persists longer than its allowed lifetime.
+-- Error: tests/neg-custom-args/captures/usingLogFile.scala:47:27 ------------------------------------------------------
+47 |  val later = usingLogFile { f => () => f.write(0) } // error
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              The expression's type {*} () -> Unit is not allowed to capture the root capability `*`.
+   |              This usually means that a capability persists longer than its allowed lifetime.
+-- Error: tests/neg-custom-args/captures/usingLogFile.scala:62:25 ------------------------------------------------------
+62 |    val later = usingFile("out", f => (y: Int) => xs.foreach(x => f.write(x + y))) // error
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                The expression's type {*} (x$0: Int) -> Unit is not allowed to capture the root capability `*`.
+   |                This usually means that a capability persists longer than its allowed lifetime.
+-- Error: tests/neg-custom-args/captures/usingLogFile.scala:71:48 ------------------------------------------------------
+71 |    val later = usingFile("logfile", usingLogger(_, l => () => l.log("test"))) // error
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                         The expression's type {*} () -> Unit is not allowed to capture the root capability `*`.
+   |                         This usually means that a capability persists longer than its allowed lifetime.

--- a/tests/neg-custom-args/captures/usingLogFile.check
+++ b/tests/neg-custom-args/captures/usingLogFile.check
@@ -28,8 +28,8 @@
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                The expression's type {*} (x$0: Int) -> Unit is not allowed to capture the root capability `*`.
    |                This usually means that a capability persists longer than its allowed lifetime.
--- Error: tests/neg-custom-args/captures/usingLogFile.scala:71:48 ------------------------------------------------------
+-- Error: tests/neg-custom-args/captures/usingLogFile.scala:71:25 ------------------------------------------------------
 71 |    val later = usingFile("logfile", usingLogger(_, l => () => l.log("test"))) // error
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                         The expression's type {*} () -> Unit is not allowed to capture the root capability `*`.
-   |                         This usually means that a capability persists longer than its allowed lifetime.
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                The expression's type {*} () -> Unit is not allowed to capture the root capability `*`.
+   |                This usually means that a capability persists longer than its allowed lifetime.

--- a/tests/neg-custom-args/captures/usingLogFile.scala
+++ b/tests/neg-custom-args/captures/usingLogFile.scala
@@ -1,4 +1,4 @@
-import java.io.FileOutputStream
+import java.io.*
 import annotation.capability
 
 object Test1:
@@ -36,3 +36,37 @@ object Test2:
   usingLogFile { f => later4 = Cell(() => f.write(0)) }
   later4.x() // error
 
+object Test3:
+
+  def usingLogFile[T](op: ({*} FileOutputStream) => T) =
+    val logFile = FileOutputStream("log")
+    val result = op(logFile)
+    logFile.close()
+    result
+
+  val later = usingLogFile { f => () => f.write(0) } // error
+
+object Test4:
+  class Logger(f: {*} OutputStream):
+    def log(msg: String): Unit = ???
+
+  def usingFile[T](name: String, op: ({*} OutputStream) => T): T =
+    val f = new FileOutputStream(name)
+    val result = op(f)
+    f.close()
+    result
+
+  val xs: List[Int] = ???
+  def good = usingFile("out", f => xs.foreach(x => f.write(x)))
+  def fail =
+    val later = usingFile("out", f => (y: Int) => xs.foreach(x => f.write(x + y))) // error
+    later(1)
+
+
+  def usingLogger[T](f: {*} OutputStream, op: ({f} Logger) => T): T =
+    val logger = Logger(f)
+    op(logger)
+
+  def test =
+    val later = usingFile("logfile", usingLogger(_, l => () => l.log("test"))) // error
+    later()

--- a/tests/pos-custom-args/captures/compare-refined.scala
+++ b/tests/pos-custom-args/captures/compare-refined.scala
@@ -1,0 +1,12 @@
+abstract class LIST[+T]:
+  def map[U](f: T => U): LIST[U] = ???
+
+class C
+type Cap = {*} C
+
+def test(d: Cap) =
+  val zsc: LIST[{d} Cap -> Unit] = ???
+  val a4 = zsc.map[{d} Cap -> Unit]((x: {d} Cap -> Unit) => x)
+  val a5 = zsc.map[{d} Cap -> Unit](identity[{d} Cap -> Unit])
+  val a6 = zsc.map(identity[{d} Cap -> Unit])
+  val a7 = zsc.map(identity)

--- a/tests/pos-custom-args/captures/pairs.scala
+++ b/tests/pos-custom-args/captures/pairs.scala
@@ -19,8 +19,8 @@ object Generic:
 object Monomorphic:
 
   class Pair(x: Cap => Unit, y: {*} Cap -> Unit):
-    def fst = x
-    def snd = y
+    def fst: {x} Cap -> Unit = x
+    def snd: {y} Cap -> Unit = y
 
   def test(c: Cap, d: Cap) =
     def f(x: Cap): Unit = if c == x then ()

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -2022,9 +2022,6 @@ Occurrences:
 [5:4..5:8): List -> scala/package.List.
 [5:9..5:10): x -> local0
 
-Synthetics:
-[5:4..5:8):List => *.apply[Int]
-
 expect/MatchType.scala
 ----------------------
 


### PR DESCRIPTION
Three capture checking fixes

 1. Fix nonDependentResultApprox. The previous code would unneccessarily widen covariant occurrences to `*`.
 2. Add handling of cases like SingletonType <:< CapturingType.
 3. Propagate element additions in a AvoidMapped variable back to source

Also: 
 - Fix universal check for inferred types (accidentally left out during rebase)
 - Allow references to local class parameters in capture sets
 
Fixes #15049 
Fixes #15057 (duplicate of #15049)
Fixes #15058 

