### PR TITLE
Properly look for inline methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -192,7 +192,7 @@ trait QuotesAndSplices {
     assignType(tree, tpt)
 
   private def checkSpliceOutsideQuote(tree: untpd.Tree)(using Context): Unit =
-    if (level == 0 && !ctx.owner.ownersIterator.exists(_.is(Inline)))
+    if (level == 0 && !ctx.owner.ownersIterator.exists(_.isInlineMethod))
       report.error("Splice ${...} outside quotes '{...} or inline method", tree.srcPos)
     else if (level < 0)
       report.error(

--- a/tests/neg-macros/i14679.scala
+++ b/tests/neg-macros/i14679.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+object A {
+  inline val a = ${b} // error
+
+  def b(using Quotes): Expr[Unit] = '{ () }
+}


### PR DESCRIPTION
This fixes a false positive where we mistakenly interpreted an
`inline val` as an inline method.

Fixes #14679