### PR TITLE
Fix definition of task generateReferenceDocumentation

### DIFF
--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Generate reference documentation and test links
         run: |
           cd dotty
-          ./project/scripts/sbt scaladoc/generateReferenceDocumentation --no-regenerate-expected-links
+          ./project/scripts/sbt "scaladoc/generateReferenceDocumentation --no-regenerate-expected-links"
           ./project/scripts/docsLinksStability ./scaladoc/output/reference ./project/scripts/expected-links/reference-expected-links.txt
           cd ..
 

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -57,7 +57,7 @@ jobs:
         run: ./project/scripts/sbt scaladoc/generateTestcasesDocumentation
 
       - name: Generate reference documentation
-        run: ./project/scripts/sbt scaladoc/generateReferenceDocumentation --no-regenerate-expected-links
+        run: ./project/scripts/sbt scaladoc/generateReferenceDocumentation
 
       - name: Generate Scala 3 documentation
         run: ./project/scripts/sbt scaladoc/generateScalaDocumentation

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1380,7 +1380,7 @@ object Build {
       }.value,
 
       generateReferenceDocumentation := Def.inputTaskDyn {
-        val shouldRegenerateExpectedLinks = literal("--no-regenerate-expected-links").?.parsed.isEmpty
+        val shouldRegenerateExpectedLinks = (Space ~> literal("--no-regenerate-expected-links")).?.parsed.isEmpty
 
         val temp = IO.createTemporaryDirectory
         IO.copyDirectory(file("docs"), temp / "docs")


### PR DESCRIPTION
It’s argument parser was missing a leading `Space`, making it awkward to invoke.

Furthermore, invocations of the tasks were not using the right (shell) syntax, this is why we didn’t notice the mistake so far.