### PR TITLE
Handle `Block` and `If` in `BCodeBodyBuilder.genCond()`.

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1570,6 +1570,15 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
           emitLocalVarScopes()
           varsInScope = savedScope
 
+        case If(condp, thenp, elsep) =>
+          val innerSuccess = new asm.Label
+          val innerFailure = new asm.Label
+          genCond(condp, innerSuccess, innerFailure, targetIfNoJump = innerSuccess)
+          markProgramPoint(innerSuccess)
+          genCond(thenp, success, failure, targetIfNoJump = innerFailure)
+          markProgramPoint(innerFailure)
+          genCond(elsep, success, failure, targetIfNoJump)
+
         case _ => loadAndTestBoolean()
       }
 

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1052,15 +1052,21 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
       varsInScope = Nil
       stats foreach genStat
       genLoadTo(expr, expectedType, dest)
-      val end = currProgramPoint()
+      emitLocalVarScopes()
+      varsInScope = savedScope
+    }
+
+    /** Add entries to the `LocalVariableTable` JVM attribute for all the vars in
+     *  `varsInScope`, ending at the current program point.
+     */
+    def emitLocalVarScopes(): Unit =
       if (emitVars) {
-        // add entries to LocalVariableTable JVM attribute
+        val end = currProgramPoint()
         for ((sym, start) <- varsInScope.reverse) {
           emitLocalVarScope(sym, start, end)
         }
       }
-      varsInScope = savedScope
-    }
+    end emitLocalVarScopes
 
     def adapt(from: BType, to: BType): Unit = {
       if (!from.conformsTo(to)) {
@@ -1552,6 +1558,17 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
               } else
                 loadAndTestBoolean()
           }
+
+        case Block(stats, expr) =>
+          /* Push the decision further down the `expr`.
+           * This is particularly effective for the shape of do..while loops.
+           */
+          val savedScope = varsInScope
+          varsInScope = Nil
+          stats foreach genStat
+          genCond(expr, success, failure, targetIfNoJump)
+          emitLocalVarScopes()
+          varsInScope = savedScope
 
         case _ => loadAndTestBoolean()
       }

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -1355,13 +1355,7 @@ class TestBCode extends DottyBytecodeTest {
         Invoke(INVOKEVIRTUAL, "java/io/Writer", "write", "(I)V", false),
         VarOp(ILOAD, 2),
         Op(ICONST_0),
-        Jump(IF_ICMPEQ, Label(35)),
-        Op(ICONST_1),
-        Jump(GOTO, Label(38)),
-        Label(35),
-        Op(ICONST_0),
-        Label(38),
-        Jump(IFNE, Label(2)),
+        Jump(IF_ICMPNE, Label(2)),
         Op(RETURN),
       ))
     }


### PR DESCRIPTION
These are my last suggestions for a better codegen by construction. The first one, for `Block`, is always a win. The second one is sometimes a bit worse, as mentioned in the commit message.

For reference, the whole `scala3-compiler.jar` jardiff for the second commit can be seen here:
https://gist.github.com/sjrd/9ec0f9f53308fb8c8c747f4bd0e480f7