### PR TITLE
Demonstrate that `dependentParams` can break a precondition of `order`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -361,6 +361,8 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     // constraints on `this` instead?
     if param1 == param2 || current.isLess(param1, param2) then current
     else
+      assert(!current.isLess(param2, param1),
+        i"Attempted to add `$param1 <: $param2` when we already have `$param2 <: $param1`, this should go through ConstraintHandling#unify\ncurrent = $current")
       assert(current.contains(param1), i"$param1")
       assert(current.contains(param2), i"$param2")
       val unifying = direction != NoUnification

--- a/tests/pos/dependentParams.scala
+++ b/tests/pos/dependentParams.scala
@@ -1,0 +1,8 @@
+class LT[-X, +Y]
+object LT:
+ given lt[X <: Y, Y]: LT[X, Y] = ???
+
+class Contra[-A]
+object Test:
+  def foo[S <: T, T](using LT[T, S]): Unit = {}
+  foo


### PR DESCRIPTION
`ConstraintHandling#addLess(p1, p2)` takes care of calling
`ConstraintHandling#unify` instead of `OrderingConstraint#addLess` if we already
have `p2 <: p1` in our constraint set. But no corresponding logic exists when
`order` is called directly inside `OrderingConstraint` and this can happen in
practice as demonstrated by the added test case which triggers the added assert.

It seems like we either need a version of `unify` inside `OrderingConstraint` or
to move `dependentParams`/`stripParams` in ConstraintHandling so they can call
`ConstraintHandling#addLess` instead of `OrderingConstraint#addLess`, but I'm
really not sure how to proceed.

For reference, the test case stack trace is:
```scala
Attempted to add `Y <: S` when we already have `S <: Y`, this should go through ConstraintHandling#unify
current =  uninstantiated variables: S, T, X, Y
 constrained types: [S <: T, T](using x$1: LT[T, S])(x: Contra[S]): Unit,
  [X <: Y, Y] => LT[X, Y]
 bounds:
     S
     T
     X
     Y
 ordering:
     S <: T
     T <: X
     X <: Y
        at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
        at dotty.tools.dotc.core.OrderingConstraint.order(OrderingConstraint.scala:365)
        at dotty.tools.dotc.core.OrderingConstraint.addLess(OrderingConstraint.scala:439)
        at dotty.tools.dotc.core.OrderingConstraint.addLess(OrderingConstraint.scala:438)
        at dotty.tools.dotc.core.ConstraintHandling.dotty$tools$dotc$core$ConstraintHandling$$unify(ConstraintHandling.scala:358)
        at dotty.tools.dotc.core.ConstraintHandling.addLess(ConstraintHandling.scala:321)
        at dotty.tools.dotc.core.ConstraintHandling.addLess$(ConstraintHandling.scala:27)
        at dotty.tools.dotc.core.TypeComparer.addLess(TypeComparer.scala:30)
        at dotty.tools.dotc.core.ConstraintHandling.addParamBound$1(ConstraintHandling.scala:691)
        at dotty.tools.dotc.core.ConstraintHandling.addConstraint(ConstraintHandling.scala:711)
        at dotty.tools.dotc.core.ConstraintHandling.addConstraint$(ConstraintHandling.scala:27)
        at dotty.tools.dotc.core.TypeComparer.addConstraint(TypeComparer.scala:30)
        at dotty.tools.dotc.core.TypeComparer.compareTypeParamRef$1(TypeComparer.scala:411)
```