### PR TITLE
Drop usage of ensureLambdaSub

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1008,7 +1008,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                   otherArgs.take(d) ++ tl.paramRefs))
             else
               otherTycon
-          (assumedTrue(tycon) || directionalIsSubType(tycon, adaptedTycon.ensureLambdaSub)) &&
+          (assumedTrue(tycon) || directionalIsSubType(tycon, adaptedTycon)) &&
           directionalRecur(adaptedTycon.appliedTo(args), other)
         }
       }

--- a/tests/run-macros/tasty-simplified.check
+++ b/tests/run-macros/tasty-simplified.check
@@ -1,4 +1,4 @@
-Functor[[A >: scala.Nothing <: scala.Any] => scala.collection.immutable.List[A]]
+Functor[scala.collection.immutable.List]
 Unapply[[F >: scala.Nothing <: [_$9 >: scala.Nothing <: scala.Any] => scala.Any] => Functor[F], Wrap[scala.Int]]
 Unapply[[F >: scala.Nothing <: [_$9 >: scala.Nothing <: scala.Any] => scala.Any] => Functor[F], Wrap[Dummy]]
-Functor[[A >: scala.Nothing <: scala.Any] => scala.Option[A]]
+Functor[scala.Option]

--- a/tests/run-staging/i5965.check
+++ b/tests/run-staging/i5965.check
@@ -1,11 +1,11 @@
 {
-  val y: [A >: scala.Nothing <: scala.Any] => scala.collection.immutable.List[A][scala.Int] = scala.List.apply[scala.Int](1, 2, 3)
+  val y: scala.collection.immutable.List[scala.Int] = scala.List.apply[scala.Int](1, 2, 3)
 
   (y: scala.collection.immutable.List[scala.Int])
 }
 List(1, 2, 3)
 {
-  val y: [A >: scala.Nothing <: scala.Any] => scala.Option[A][scala.Int] = scala.Option.apply[scala.Int](4)
+  val y: scala.Option[scala.Int] = scala.Option.apply[scala.Int](4)
 
   (y: scala.Option[scala.Int])
 }


### PR DESCRIPTION
It doesn't seem to be needed anymore and as demonstrated in the commit message
of a8641c5cbe6ad22707ea52c639ee894cfa09db57, it can lead to unnecessary checks.