### PR TITLE
[backport] Relax avoidance checks more for match type reduction

### DIFF
--- a/tests/pos/i14921/A_1.scala
+++ b/tests/pos/i14921/A_1.scala
@@ -1,0 +1,28 @@
+import scala.compiletime.ops.int.*
+
+final class Label (val getLabel: String)
+
+trait ShapelessPolyfill {
+
+  type Represented[R] = R match {
+    case IndexedSeq[a] => a
+  }
+
+  type TupleSized[R, A, N <: Int] <: Tuple = N match {
+    case 0 => EmptyTuple
+    case S[n] => A *: TupleSized[R, A, n]
+  }
+
+  extension [R, A, N <: Int] (s: TupleSized[R, A, N]) {
+    def unsized: IndexedSeq[A] = s.productIterator.toIndexedSeq.asInstanceOf[IndexedSeq[A]]
+  }
+
+  type Nat = Int
+
+  type Sized[Repr, L <: Nat] = TupleSized[Repr, Represented[Repr], L]
+
+  object Sized {
+    def apply[A](a1: A): Sized[IndexedSeq[A], 1] = Tuple1(a1)
+  }
+}
+object poly extends ShapelessPolyfill

--- a/tests/pos/i14921/B_2.scala
+++ b/tests/pos/i14921/B_2.scala
@@ -1,0 +1,3 @@
+import poly.*
+
+def failing: Tuple1[Label] = Sized(new Label("foo"))


### PR DESCRIPTION
This backports #15036 which fixes a regression introduced in 3.1.2.