### PR TITLE
fix for #13760 - running script compiled jar no longer restricted to java.base module

### DIFF
--- a/compiler/src/dotty/tools/runner/ScalaClassLoader.scala
+++ b/compiler/src/dotty/tools/runner/ScalaClassLoader.scala
@@ -62,7 +62,7 @@ object ScalaClassLoader {
   def setContext(cl: ClassLoader) = Thread.currentThread.setContextClassLoader(cl)
 
   def fromURLsParallelCapable(urls: Seq[URL], parent: ClassLoader | Null = null): URLClassLoader =
-    new URLClassLoader(urls.toArray, if parent == null then bootClassLoader else parent)
+    new URLClassLoader(urls.toArray, if parent == null then ClassLoader.getSystemClassLoader.getParent else parent)
 
   @sharable private[this] val bootClassLoader: ClassLoader =
     if scala.util.Properties.isJavaAtLeast("9") then

--- a/compiler/src/dotty/tools/runner/ScalaClassLoader.scala
+++ b/compiler/src/dotty/tools/runner/ScalaClassLoader.scala
@@ -62,12 +62,12 @@ object ScalaClassLoader {
   def setContext(cl: ClassLoader) = Thread.currentThread.setContextClassLoader(cl)
 
   def fromURLsParallelCapable(urls: Seq[URL], parent: ClassLoader | Null = null): URLClassLoader =
-    new URLClassLoader(urls.toArray, if parent == null then ClassLoader.getSystemClassLoader.getParent else parent)
+    new URLClassLoader(urls.toArray, if parent == null then bootClassLoader else parent)
 
   @sharable private[this] val bootClassLoader: ClassLoader =
     if scala.util.Properties.isJavaAtLeast("9") then
       try
-        MethodHandles.lookup().findStatic(classOf[ClassLoader], "getPlatformClassLoader", MethodType.methodType(classOf[ClassLoader])).invoke().asInstanceOf[ClassLoader]
+        ClassLoader.getSystemClassLoader.getParent 
       catch case _: Throwable => null
     else null
 

--- a/compiler/test-resources/scripting/sqlDateError.sc
+++ b/compiler/test-resources/scripting/sqlDateError.sc
@@ -1,4 +1,4 @@
-#!bin/scala -nosave
+#!bin/scala
 
 def main(args: Array[String]): Unit = {
   println(new java.sql.Date(100L))


### PR DESCRIPTION
This resolves the problem described in #13760.

The essence of the problem: running a script with the `-save` option will throw a `ClassNotFoundException`, but only when running from the compiled jar, and only if the script references modules other than `java.base` .  The jar is fine when run via `java -jar <jarfile>`, the issue only occurs when scala launches the jar. 

The workaround for the problem has been to append the `-nosave` option to the hashbang line.

The cause of the problem is that `bootClassLoader` in [ScalaClassLoader](https://github.com/lampepfl/dotty/blob/8a83f909b20952939b2b0e7593a17d4403af4e88/compiler/src/dotty/tools/runner/ScalaClassLoader.scala#L70) is set to `null` when running in `jdk9+`.
The following command line illustrates the problem code at `ScalaClassLoader line 70`:
```scala
$ /opt/scala3/bin/scala -e 'import java.lang.invoke.*; MethodHandles.lookup().findStatic(classOf[ClassLoader], "getPlatformClassLoader", MethodType.methodType(classOf[ClassLoader])).invoke().asInstanceOf[ClassLoader]'
```
<details>
<pre>
```scala
$ /opt/scala3/bin/scala -e 'import java.lang.invoke.*; MethodHandles.lookup().findStatic(classOf[ClassLoader], "getPlatformClassLoader", MethodType.methodType(classOf[ClassLoader])).invoke().asInstan
ceOf[ClassLoader]'
Exception in thread "main" java.lang.invoke.WrongMethodTypeException: cannot convert MethodHandle()ClassLoader to (Object[])Object
        at java.base/java.lang.invoke.MethodHandle.asTypeUncached(MethodHandle.java:861)
        at java.base/java.lang.invoke.MethodHandle.asType(MethodHandle.java:847)
        at java.base/java.lang.invoke.MethodHandleImpl$WrappedMember.asTypeUncached(MethodHandleImpl.java:1371)
        at java.base/java.lang.invoke.MethodHandle.asType(MethodHandle.java:847)
        at java.base/java.lang.invoke.Invokers.checkGenericType(Invokers.java:495)
        at compileFromString$minus08906c21$minusee54$minus45f1$minusb470$minusfe08bfbca561$package$.main(compileFromString-08906c21-ee54-45f1-b470-fe08bfbca561.scala:2)
        at main.main(compileFromString-08906c21-ee54-45f1-b470-fe08bfbca561.scala:1)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at dotty.tools.scripting.StringDriver.compileAndRun(StringDriver.scala:36)
        at dotty.tools.MainGenericRunner$.run$1(MainGenericRunner.scala:257)
        at dotty.tools.MainGenericRunner$.main(MainGenericRunner.scala:267)
        at dotty.tools.MainGenericRunner.main(MainGenericRunner.scala)
```
</pre>
</details>

An explanation of why this code no longer works for `jdk9+` is described here:  [Regression in behavior of a null parent ClassLoader](https://bugs.openjdk.java.net/browse/JDK-8161269)

The proposed fix is based on the fix to #11658.
