### PR TITLE
Invalidate some denotations in earlier phases

### DIFF
--- a/compiler/test-resources/repl/i10044
+++ b/compiler/test-resources/repl/i10044
@@ -1,0 +1,12 @@
+scala> object Foo { opaque type Bar = Int; object Bar { extension (b: Bar) def flip: Bar = -b; def apply(x: Int): Bar = x }}
+// defined object Foo
+scala> val a = Foo.Bar(42)
+val a: Foo.Bar = 42
+scala> val b = a.flip
+val b: Foo.Bar = -42
+scala> val c = b.flip
+val c: Foo.Bar = 42
+scala> val d = c.flip
+val d: Foo.Bar = -42
+scala> val e = d.flip
+val e: Foo.Bar = 42


### PR DESCRIPTION
This addresses the specific problem raised by #10044: A denotation
of a NamedType goes from a UniqueRefDenotation to a SymDenotation
after erasure and is then not reset to the original since the
SymDenotation is valid at all phases. We remember in this case
in the NamedType the first phase in which the SymDenotaton is valid
and force a recompute in earlier phases.

Fixes #10044