### PR TITLE
Alternative fix for #10044

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -24,13 +24,8 @@ class Compiler {
    *  all refs to it would become outdated - they could not be dereferenced in the
    *  new phase.
    *
-   *  After erasure, signature changing denot-transformers are OK because erasure
-   *  will make sure that only term refs with fixed SymDenotations survive beyond it. This
-   *  is possible because:
-   *
-   *   - splitter has run, so every ident or select refers to a unique symbol
-   *   - after erasure, asSeenFrom is the identity, so every reference has a
-   *     plain SymDenotation, as opposed to a UniqueRefDenotation.
+   *  After erasure, signature changing denot-transformers are OK because signatures
+   *  are never recomputed later than erasure.
    */
   def phases: List[List[Phase]] =
     frontendPhases ::: picklerPhases ::: transformPhases ::: backendPhases

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -189,7 +189,9 @@ object GenericSignatures {
             fullNameInSig(tp.typeSymbol)
             builder.append(';')
           case _ =>
-            boxedSig(tp)
+            boxedSig(tp.widenDealias.widenNullaryMethod)
+              // `tp` might be a singleton type referring to a getter.
+              // Hence the widenNullaryMethod.
         }
 
       if (pre.exists) {

--- a/compiler/test-resources/repl/i10044
+++ b/compiler/test-resources/repl/i10044
@@ -1,0 +1,12 @@
+scala> object Foo { opaque type Bar = Int; object Bar { extension (b: Bar) def flip: Bar = -b; def apply(x: Int): Bar = x }}
+// defined object Foo
+scala> val a = Foo.Bar(42)
+val a: Foo.Bar = 42
+scala> val b = a.flip
+val b: Foo.Bar = -42
+scala> val c = b.flip
+val c: Foo.Bar = 42
+scala> val d = c.flip
+val d: Foo.Bar = -42
+scala> val e = d.flip
+val e: Foo.Bar = 42


### PR DESCRIPTION
This is a better alternative to fix #10044 than #15120. Unfortunately, it fails
dotty.tools.dotc.BootstrappedOnlyCompilationTests.runWithCompiler in the
tasty interpreter test. Here I see:
```
-- Error: tests/run-custom-args/tasty-interpreter/interpreter/jvm/Interpreter.scala:13:6 -------------------------------
13 |  val jvmReflection = new JVMReflection(using q)
   |      ^
   |compiler bug: created invalid generic signature for getter jvmReflection in scala.tasty.interpreter.jvm.Interpreter
   |signature: ()Lscala/tasty/interpreter/jvm/JVMReflection<()Ljava/lang/Object;>;
   |if this is reproducible, please report bug at https://github.com/lampepfl/dotty/issues
Error while emitting Interpreter.scala
```
If I turn on printing in line 2583 in Types.scala, I see the last output as follows:
```
overwrite TermRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,module class jvm)),class Interpreter)),method q) / getter q, class dotty.tools.dotc.core.Denotations$UniqueRefDenotation with getter q at 106
```
So it does overwrite, and the overwrite looks OK, but somehow changing a SymDenotation with a UniqueRefDenotation for the same symbol messes up generic signature generation.

Can someone help me digging deeper here? 
