### PR TITLE
Fixed a typo in the documentation (reference/using-clauses.md)

### DIFF
--- a/docs/_docs/reference/contextual/using-clauses.md
+++ b/docs/_docs/reference/contextual/using-clauses.md
@@ -93,8 +93,7 @@ With this setup, the following calls are all well-formed, and they all normalize
 ```scala
 minimum(xs)
 maximum(xs)(using descending)
-maximum(xs)(using descending(using listOrd))
-maximum(xs)(using descending(using listOrd(using intOrd)))
+maximum(xs)(using descending(using intOrd))
 ```
 
 ## Multiple `using` Clauses


### PR DESCRIPTION
Method `descending` is defined as:
```
def descending[T](using asc: Ord[T]): Ord[T] = new Ord[T]:
  def compare(x: T, y: T) = asc.compare(y, x)
```

We can see [in the doc **Using Clauses**](https://docs.scala-lang.org/scala3/reference/contextual/using-clauses.html#inferring-complex-arguments) the following:

```
With this setup, the following calls are all well-formed, and they all normalize to the last one:

minimum(xs)
maximum(xs)(using descending)
maximum(xs)(using descending(using listOrd))
maximum(xs)(using descending(using listOrd(using intOrd)))
```

But `descending` accepts the parameter with type `Ord[T]`, not `Ord[List[T]]`

Details:
https://scastie.scala-lang.org/BQptFRQLQHW1MKJ7HBQrVA