### PR TITLE
Introduce wildcard context bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -28,6 +28,7 @@ object Feature:
   val symbolLiterals = deprecated("symbolLiterals")
   val fewerBraces = experimental("fewerBraces")
   val saferExceptions = experimental("saferExceptions")
+  val wildcardContextBounds = experimental("wildcardContextBounds")
 
   /** Is `feature` enabled by by a command-line setting? The enabling setting is
    *

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1692,7 +1692,8 @@ object Parsers {
         Ident(identName).withSpan(Span(start, in.lastOffset, start))
       else if isIdent(nme.?) then
         val start = in.skipToken()
-        typeBounds().withSpan(Span(start, in.lastOffset, start))
+        val tpt = if (in.featureEnabled(Feature.wildcardContextBounds)) typeParamBounds(tpnme.?) else typeBounds()
+        tpt.withSpan(Span(start, in.lastOffset, start))
       else
         def singletonArgs(t: Tree): Tree =
           if in.token == LPAREN && in.featureEnabled(Feature.dependent)

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -204,6 +204,7 @@ class CompilationTests {
       compileFile("tests/run-custom-args/i5256.scala", allowDeepSubtypes),
       compileFile("tests/run-custom-args/no-useless-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
       compileFile("tests/run-custom-args/defaults-serizaliable-no-forwarders.scala", defaultOptions and "-Xmixin-force-forwarders:false"),
+      compileFile("tests/run-special/wildcard-context-bounds-multiple.scala", defaultOptions.and("-Ykind-projector:underscores","-language:experimental.wildcardContextBounds")),
       compileFilesInDir("tests/run-custom-args/erased", defaultOptions.and("-language:experimental.erasedDefinitions")),
       compileFilesInDir("tests/run-custom-args/fatal-warnings", defaultOptions.and("-Xfatal-warnings")),
       compileDir("tests/run-custom-args/Xmacro-settings/simple", defaultOptions.and("-Xmacro-settings:one,two,three")),

--- a/docs/_docs/reference/experimental/overview.md
+++ b/docs/_docs/reference/experimental/overview.md
@@ -15,6 +15,7 @@ They are enabled by importing the feature or using the `-language` compiler flag
 * [`genericNumberLiterals`](./numeric-literals.md): Enable support for generic number literals.
 * [`namedTypeArguments`](./named-typeargs.md): Enable support for named type arguments
 * [`saferExceptions`](./canthrow.md): Enable support for checked exceptions.
+* [`wildcardContextBounds`](./wildcard-context-bounds.md): Enable support for anonymous context bounds.
 
 ### Experimental language imports
 

--- a/docs/_docs/reference/experimental/wildcard-context-bounds.md
+++ b/docs/_docs/reference/experimental/wildcard-context-bounds.md
@@ -1,0 +1,78 @@
+---
+layout: doc-page
+title: "Wildcard Context Bounds"
+---
+
+This page describes experimental support for context bounds on wildcard types Scala 3, available in 3.2 or later. It is enabled by the language import
+```scala
+import language.experimental.wildcardContextBounds
+```
+The reason for publishing this extension now is to get feedback on its usefulness.
+
+## Why Wildcard Context Bounds?
+
+Typeclasses are [first-class consideration of Scala 3](https://docs.scala-lang.org/scala3/book/ca-type-classes.html) 
+and [context bound sugar](https://docs.scala-lang.org/scala3/book/ca-context-bounds.html) already exists to support their use.
+Taking an example from [here](https://docs.scala-lang.org/scala3/book/ca-type-classes.html), context bounds allow one
+to write
+```scala
+trait ShowableTypeclass[T] {
+  def show(t: T): String
+}
+
+def showAll[S: ShowableTypeclass](xs: Set[S]): Unit = xs.foreach(x => println(x.show))
+```
+
+instead of
+
+```scala
+def showAll[S](xs: Set[S])(using ShowableTypeclass[S]): Unit = xs.foreach(x => println(x.show))
+```
+
+See [this StackOverflow answer](https://stackoverflow.com/questions/4465948/what-are-scala-context-and-view-bounds/4467012#4467012)
+for more discussion and motivation. At the same time, Scala 3 has sought to avoid forcing the user to 
+[provide names that are never referenced](https://docs.scala-lang.org/scala3/reference/contextual/). When using
+typeclasses, it is often the case that the type parameter is never referenced -- all that matters is that
+that the compiler can prove that a `given` instance is available for that type. The `wildcardContextBounds` extension
+allows the user to avoid specifying a name for the type of a parameter with a context bound:
+
+```scala
+def showAll(xs: Set[? : ShowableTypeclass]): Unit = xs.foreach(x => println(x.show))
+```
+
+is sugar for
+
+```scala
+def showAll[S: ShowableTypeclass](xs: Set[S]): Unit = xs.foreach(x => println(x.show))
+```
+
+which further desugars as above. Rust, which also has first-class support for typeclasses,
+has a similar syntax with its [`impl` traits](https://doc.rust-lang.org/reference/types/impl-trait.html)
+
+
+## Syntax
+
+The syntax closely follows existing syntax for type bounds: note the similarity to 
+```scala
+trait ShowableInheritance {
+  def show: String
+}
+
+def showAll(xs: Set[? <: ShowableInheritance]): Unit = xs.foreach(x => println(x.show))
+```
+
+and
+
+```scala
+def showAll[S <: ShowableInheritance](xs: Set[S]): Unit = xs.foreach(x => println(x.show))
+```
+
+Unlike type bounds on wildcard types, context bounds on wildcard types can appear as the top-level type of a parameter.
+
+```scala
+def showOne(x: ? : ShowableTypeclass): Unit = x.show // okay
+def showOne[S <: ShowableInheritance](x: S): Unit = x.show // okay
+def showOne(x: ? <: ShowableInheritance): Unit = x.show // error: Unbound wildcard type
+```
+
+

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -152,6 +152,7 @@ subsection:
           - page: reference/experimental/main-annotation.md
           - page: reference/experimental/cc.md
           - page: reference/experimental/tupled-function.md
+          - page: reference/experimental/wildcard-context-bounds.md
       - page: reference/syntax.md
       - title: Language Versions
         index: reference/language-versions/language-versions.md

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -60,6 +60,13 @@ object language:
     @compileTimeOnly("`saferExceptions` can only be used at compile time in import statements")
     object saferExceptions
 
+    /** Experimental support for anonymous context bounds
+      *
+      *  @see [[https://dotty.epfl.ch/docs/reference/experimental/wildcard-context-bounds]]
+      */
+    @compileTimeOnly("`wildcardContextBounds` can only be used at compile time in import statements")
+    object wildcardContextBounds
+
   end experimental
 
   /** The deprecated object contains features that are no longer officially suypported in Scala.

--- a/project/resources/referenceReplacements/sidebar.yml
+++ b/project/resources/referenceReplacements/sidebar.yml
@@ -148,6 +148,7 @@ subsection:
       - page: reference/experimental/main-annotation.md
       - page: reference/experimental/cc.md
       - page: reference/experimental/tupled-function.md
+      - page: reference/experimental/wildcard-context-bounds.md
   - page: reference/syntax.md
   - title: Language Versions
     index: reference/language-versions/language-versions.md

--- a/tests/neg/wildcard-context-bounds.scala
+++ b/tests/neg/wildcard-context-bounds.scala
@@ -1,0 +1,35 @@
+import language.experimental.wildcardContextBounds
+
+trait Showable[A] {
+  extension(a: A) def show: String
+}
+object Showable
+
+given Showable[String] with
+  extension(a: String) def show: String = a
+
+given Showable[Int] with
+  extension(a: Int) def show: String = a.toString
+
+def returns: ? : Showable = ??? // error
+
+def ascription: Unit = {
+  val x: ? : Showable = ??? // error
+}
+
+def lambda: Unit = {
+  (x: ? : Showable) => x.show // error // error
+}
+
+def ascribedLambda1: Unit = {
+  (x => x + 1): (Int => ? : Showable) // error
+}
+
+def ascribedLambda2: Unit = {
+  ((x: Int) => x + 1): (? : Showable => Showable) // error // error
+}
+
+trait Foo extends Seq[? : Showable] // error
+
+type Alias[? : Showable] = Int // error // error
+type OtherAlias = ? : Showable // error

--- a/tests/run-special/wildcard-context-bounds-multiple.scala
+++ b/tests/run-special/wildcard-context-bounds-multiple.scala
@@ -1,0 +1,19 @@
+
+
+trait Conversion[A, B] {
+  extension(a: A) def into(): B
+}
+
+given Conversion[String, Int] with
+  extension(a: String) def into(): Int = a.toInt
+
+def multipleTypeParamsNoSugar[T: Conversion[_, Int]](xs: List[T]): Int = xs.map(_.into()).reduce(_ + _)
+def multipleTypeParams(xs: List[? : Conversion[_, Int]]): Int = xs.map(_.into()).reduce(_ + _)
+type Into[B] = Conversion[_, B]
+def multipleTypeParamsAlias(xs: List[? : Into[Int]]): Int = xs.map(_.into()).reduce(_ + _)
+
+
+@main def Test =
+  assert(multipleTypeParamsNoSugar(List("1", "2")) == 3)
+  assert(multipleTypeParams(List("1", "2")) == 3)
+  assert(multipleTypeParamsAlias(List("1", "2")) == 3)

--- a/tests/run/wildcard-context-bounds.scala
+++ b/tests/run/wildcard-context-bounds.scala
@@ -1,0 +1,39 @@
+import language.experimental.wildcardContextBounds
+
+trait Showable[A] {
+  extension(a: A) def show: String
+}
+object Showable
+
+given Showable[String] with
+  extension(a: String) def show: String = a
+
+given Showable[Int] with
+  extension(a: Int) def show: String = a.toString
+
+def simple(xs: List[? : Showable]): String = xs.map(_.show).mkString(":")
+def one(x: ? : Showable): String = x.show
+def two(x: ? : Showable, y: ? : Showable): String = s"${x.show} :: ${y.show}"
+
+def typeBounds(x: ? <: CharSequence : Showable): String = s"${x.show}!"
+def existingTypeParam[T](x: T, y: ? : Showable): String = s"${x.toString} :: ${y.show}"
+def bothKindsOfSugar[T: Showable](x: T, y: ? : Showable): String = s"${x.show} :: ${y.show}"
+
+def showPair(p: (? : Showable, ? : Showable)): String = s"${p._1.show} :: ${p._2.show}"
+def showLambda[I: Showable](i: I)(f: I => ? : Showable): String = s"${i.show} => ${f(i).show}"
+
+class OnClass(u: ? : Showable) {
+  def show: String = u.show
+}
+
+
+@main def Test =
+  assert(simple(List(1, 2)) == "1:2")
+  assert(one(1) == "1")
+  assert(two("str", 1) == "str :: 1")
+  assert(typeBounds("str") == "str!")
+  assert(existingTypeParam(true, 1) == "true :: 1")
+  assert(bothKindsOfSugar("str", 1) == "str :: 1")
+  assert(showPair("str", 1) == "str :: 1")
+  assert(showLambda("1")(s => s"'$s'") == "1 => '1'")
+  assert(OnClass("str").show == "str")


### PR DESCRIPTION
Implements the proposal discussed [here](https://contributors.scala-lang.org/t/pre-sip-additional-syntactic-sugar-for-typeclasses/5675/27): allows

```scala
def showAll(xs: List[? : Showable]): Unit = xs.foreach(x => println(x.show))
```
to be sugar for 
```scala
def showAll[S: Showable](xs: List[S]): Unit = xs.foreach(x => println(x.show))
``` 
which is already sugar for
```scala
def showAll[S](xs: List[S])(using Showable[S]): Unit = xs.foreach(x => println(x.show))
```

As far as I understand, the SIP process is dormant right now, so I'm not sure how to get agreement on these things. I thought I'd put up the PR to show how simple this change is, in the likely-unrealistic hopes that it makes it in before 3.2.0. 