### PR TITLE
Add error reporting for mirror synthesis

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -79,10 +79,10 @@ object SymUtils:
     *  parameter section.
     */
     def whyNotGenericProduct(using Context): String =
-      if (!self.is(CaseClass)) "it is not a case class"
-      else if (self.is(Abstract)) "it is an abstract class"
-      else if (self.primaryConstructor.info.paramInfoss.length != 1) "it takes more than one parameter list"
-      else if (isDerivedValueClass(self)) "it is a value class"
+      if (!self.is(CaseClass)) i"$self is not a case class"
+      else if (self.is(Abstract)) i"$self is an abstract class"
+      else if (self.primaryConstructor.info.paramInfoss.length != 1) i"$self takes more than one parameter list"
+      else if (isDerivedValueClass(self)) i"$self is a value class"
       else ""
 
     def isGenericProduct(using Context): Boolean = whyNotGenericProduct.isEmpty
@@ -144,9 +144,9 @@ object SymUtils:
     */
     def whyNotGenericSum(declScope: Symbol)(using Context): String =
       if (!self.is(Sealed))
-        s"it is not a sealed ${self.kindString}"
+        s"$self is not a sealed ${self.kindString}"
       else if (!self.isOneOf(AbstractOrTrait))
-        s"it is not an abstract class"
+        s"$self is not an abstract class"
       else {
         val children = self.children
         val companionMirror = self.useCompanionAsSumMirror
@@ -157,8 +157,8 @@ object SymUtils:
             (self.isContainedIn(sym) && (companionMirror || declScope.isContainedIn(sym)))
             || sym.is(Module) && isAccessible(sym.owner)
 
-          if (child == self) "it has anonymous or inaccessible subclasses"
-          else if (!isAccessible(child.owner)) i"its child $child is not accessible"
+          if (child == self) i"$self has anonymous or inaccessible subclasses"
+          else if (!isAccessible(child.owner)) i"$self's child $child is not accessible"
           else if (!child.isClass) ""
           else {
             val s = child.whyNotGenericProduct
@@ -166,11 +166,11 @@ object SymUtils:
             else if (child.is(Sealed)) {
               val s = child.whyNotGenericSum(if child.useCompanionAsSumMirror then child.linkedClass else ctx.owner)
               if (s.isEmpty) s
-              else i"its child $child is not a generic sum because $s"
-            } else i"its child $child is not a generic product because $s"
+              else i"$self's child $child is not a generic sum because $s"
+            } else i"$self's child $child is not a generic product because $s"
           }
         }
-        if (children.isEmpty) "it does not have subclasses"
+        if (children.isEmpty) i"$self does not have subclasses"
         else children.map(problem).find(!_.isEmpty).getOrElse("")
       }
 

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -79,10 +79,10 @@ object SymUtils:
     *  parameter section.
     */
     def whyNotGenericProduct(using Context): String =
-      if (!self.is(CaseClass)) i"$self is not a case class"
-      else if (self.is(Abstract)) i"$self is an abstract class"
-      else if (self.primaryConstructor.info.paramInfoss.length != 1) i"$self takes more than one parameter list"
-      else if (isDerivedValueClass(self)) i"$self is a value class"
+      if (!self.is(CaseClass)) "it is not a case class"
+      else if (self.is(Abstract)) "it is an abstract class"
+      else if (self.primaryConstructor.info.paramInfoss.length != 1) "it takes more than one parameter list"
+      else if (isDerivedValueClass(self)) "it is a value class"
       else ""
 
     def isGenericProduct(using Context): Boolean = whyNotGenericProduct.isEmpty
@@ -144,9 +144,9 @@ object SymUtils:
     */
     def whyNotGenericSum(declScope: Symbol)(using Context): String =
       if (!self.is(Sealed))
-        s"$self is not a sealed ${self.kindString}"
+        s"it is not a sealed ${self.kindString}"
       else if (!self.isOneOf(AbstractOrTrait))
-        s"$self is not an abstract class"
+        "it is not an abstract class"
       else {
         val children = self.children
         val companionMirror = self.useCompanionAsSumMirror
@@ -157,8 +157,8 @@ object SymUtils:
             (self.isContainedIn(sym) && (companionMirror || declScope.isContainedIn(sym)))
             || sym.is(Module) && isAccessible(sym.owner)
 
-          if (child == self) i"$self has anonymous or inaccessible subclasses"
-          else if (!isAccessible(child.owner)) i"$self's child $child is not accessible"
+          if (child == self) "it has anonymous or inaccessible subclasses"
+          else if (!isAccessible(child.owner)) i"its child $child is not accessible"
           else if (!child.isClass) ""
           else {
             val s = child.whyNotGenericProduct
@@ -166,11 +166,11 @@ object SymUtils:
             else if (child.is(Sealed)) {
               val s = child.whyNotGenericSum(if child.useCompanionAsSumMirror then child.linkedClass else ctx.owner)
               if (s.isEmpty) s
-              else i"$self's child $child is not a generic sum because $s"
-            } else i"$self's child $child is not a generic product because $s"
+              else i"its child $child is not a generic sum because $s"
+            } else i"its child $child is not a generic product because $s"
           }
         }
-        if (children.isEmpty) i"$self does not have subclasses"
+        if (children.isEmpty) "it does not have subclasses"
         else children.map(problem).find(!_.isEmpty).getOrElse("")
       }
 

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -266,24 +266,26 @@ class ImplicitSearchError(
       ++ ErrorReporting.matchReductionAddendum(pt)
   }
 
-  private def formatMsg(shortForm: String)(headline: String = shortForm) = arg match {
+  private def formatMsg(shortForm: String)(headline: String = shortForm) = arg match 
     case arg: Trees.SearchFailureIdent[?] =>
-      shortForm
+      arg.tpe match
+        case _: NoMatchingImplicits => headline
+        case tpe: SearchFailureType =>
+          i"$headline. ${tpe.explanation}"
+        case _ => headline
     case _ =>
-      arg.tpe match {
+      arg.tpe match
         case tpe: SearchFailureType =>
           val original = arg match
             case Inlined(call, _, _) => call
             case _ => arg
-
           i"""$headline.
             |I found:
             |
             |    ${original.show.replace("\n", "\n    ")}
             |
             |But ${tpe.explanation}."""
-      }
-  }
+        case _ => headline
 
   private def userDefinedErrorString(raw: String, paramNames: List[String], args: List[Type]): String = {
     def translate(name: String): Option[String] = {
@@ -307,12 +309,10 @@ class ImplicitSearchError(
   private def location(preposition: String) = if (where.isEmpty) "" else s" $preposition $where"
 
   private def defaultAmbiguousImplicitMsg(ambi: AmbiguousImplicits) =
-    formatMsg(s"ambiguous given instances: ${ambi.explanation}${location("of")}")(
-      s"ambiguous given instances of type ${pt.show} found${location("for")}"
-    )
+    s"Ambiguous given instances: ${ambi.explanation}${location("of")}"
 
   private def defaultImplicitNotFoundMessage =
-    ex"no given instance of type $pt was found${location("for")}"
+    ex"No given instance of type $pt was found${location("for")}"
 
   /** Construct a custom error message given an ambiguous implicit
    *  candidate `alt` and a user defined message `raw`.

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -549,6 +549,18 @@ object Implicits:
     override def msg(using Context) = _msg
     def explanation(using Context) = msg.toString
 
+  /** A search failure type for failed synthesis of terms for special types */ 
+  class SynthesisFailure(reasons: List[String], val expectedType: Type) extends SearchFailureType:
+    def argument = EmptyTree
+
+    private def formatReasons = 
+      if reasons.length > 1 then 
+        reasons.mkString("\n\t* ", "\n\t* ", "") 
+      else 
+        reasons.mkString
+      
+    def explanation(using Context) = em"Failed to synthesize implicit of type ${clarify(expectedType)}: ${formatReasons}"
+
 end Implicits
 
 import Implicits._
@@ -854,7 +866,12 @@ trait Implicits:
         if fail.isAmbiguous then failed
         else
           if synthesizer == null then synthesizer = Synthesizer(this)
-          synthesizer.uncheckedNN.tryAll(formal, span).orElse(failed)
+          val (tree, errors) = synthesizer.uncheckedNN.tryAll(formal, span)
+          if errors.nonEmpty then
+            SearchFailure(new SynthesisFailure(errors, formal), span).tree
+          else
+            tree.orElse(failed)
+          
 
   /** Search an implicit argument and report error if not found */
   def implicitArgTree(formal: Type, span: Span)(using Context): Tree = {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -559,7 +559,7 @@ object Implicits:
       else 
         reasons.mkString
       
-    def explanation(using Context) = em"Failed to synthesize implicit of type ${clarify(expectedType)}: ${formatReasons}"
+    def explanation(using Context) = em"Failed to synthesize an instance of type ${clarify(expectedType)}: ${formatReasons}"
 
 end Implicits
 

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -327,7 +327,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       val reason = if !cls.isGenericProduct then
         i"because ${cls.whyNotGenericProduct}"
       else if !canAccessCtor(cls) then
-        i"because constructor of $cls is unnaccessible from the calling scope."
+        i"because the constructor of $cls is innaccessible from the calling scope."
       else 
         ""
       i"$cls is not a generic product $reason"
@@ -618,7 +618,7 @@ object Synthesizer:
   private def orElse(treeWithErrors1: TreeWithErrors, treeWithErrors2: => TreeWithErrors): TreeWithErrors = treeWithErrors1 match
     case (tree, errors) if tree eq genericEmptyTree => 
       val (tree2, errors2) = treeWithErrors2
-      (tree2, errors2 ::: errors)
+      (tree2, errors ::: errors2)
     case _ => treeWithErrors1
 
   private def clearErrorsIfNotEmpty(treeWithErrors: TreeWithErrors) = treeWithErrors match 

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -17,20 +17,12 @@ import transform.SyntheticMembers._
 import util.Property
 import ast.Trees.genericEmptyTree
 import annotation.{tailrec, constructorOnly}
+import ast.tpd._
+import Synthesizer._
 
 /** Synthesize terms for special classes */
 class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
-  import ast.tpd._
 
-  /** Tuple used to store the synthesis result with a list of errors */ 
-  private type TreeWithErrors = (Tree, List[String])
-  private def withNoErrors(tree: Tree): TreeWithErrors = (tree, List.empty)
-
-  private val EmptyTreeNoError: TreeWithErrors = withNoErrors(EmptyTree)
-  private def orElse(treeWithErrors1: TreeWithErrors, treeWithErrors2: => TreeWithErrors): TreeWithErrors = treeWithErrors1 match
-    case (tree, errors) if tree eq genericEmptyTree => (treeWithErrors2._1, treeWithErrors2._2 ::: errors)
-    case _                                          => treeWithErrors1
-      
   /** Handlers to synthesize implicits for special types */
   type SpecialHandler = (Type, Span) => Context ?=> TreeWithErrors
   private type SpecialHandlers = List[(ClassSymbol, SpecialHandler)]
@@ -619,4 +611,16 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
         EmptyTreeNoError
     recur(specialHandlers)
 
+end Synthesizer
+
+object Synthesizer:
+
+  /** Tuple used to store the synthesis result with a list of errors */ 
+  type TreeWithErrors = (Tree, List[String])
+  private def withNoErrors(tree: Tree): TreeWithErrors = (tree, List.empty)
+
+  private val EmptyTreeNoError: TreeWithErrors = withNoErrors(EmptyTree)
+  private def orElse(treeWithErrors1: TreeWithErrors, treeWithErrors2: => TreeWithErrors): TreeWithErrors = treeWithErrors1 match
+    case (tree, errors) if tree eq genericEmptyTree => (treeWithErrors2._1, treeWithErrors2._2 ::: errors)
+    case _                                          => treeWithErrors1
 end Synthesizer

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -5,7 +5,7 @@ package typer
 import core._
 import util.Spans.Span
 import Contexts._
-import Types._, Flags._, Symbols._, Types._, Names._, StdNames._, Constants._
+import Types._, Flags._, Symbols._, Names._, StdNames._, Constants._
 import TypeErasure.{erasure, hasStableErasure}
 import Decorators._
 import ProtoTypes._
@@ -15,23 +15,33 @@ import transform.SymUtils._
 import transform.TypeUtils._
 import transform.SyntheticMembers._
 import util.Property
+import ast.Trees.genericEmptyTree
 import annotation.{tailrec, constructorOnly}
 
 /** Synthesize terms for special classes */
 class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
   import ast.tpd._
 
-  /** Handlers to synthesize implicits for special types */
-  type SpecialHandler = (Type, Span) => Context ?=> Tree
-  private type SpecialHandlers = List[(ClassSymbol, SpecialHandler)]
+  /** Tuple used to store the synthesis result with a list of errors */ 
+  private type TreeWithErrors = (Tree, List[String])
+  private def withNoErrors(tree: Tree): TreeWithErrors = (tree, List.empty)
 
+  private val EmptyTreeNoError: TreeWithErrors = withNoErrors(EmptyTree)
+  private def orElse(treeWithErrors1: TreeWithErrors, treeWithErrors2: => TreeWithErrors): TreeWithErrors = treeWithErrors1 match
+    case (tree, errors) if tree eq genericEmptyTree => (treeWithErrors2._1, treeWithErrors2._2 ::: errors)
+    case _                                          => treeWithErrors1
+      
+  /** Handlers to synthesize implicits for special types */
+  type SpecialHandler = (Type, Span) => Context ?=> TreeWithErrors
+  private type SpecialHandlers = List[(ClassSymbol, SpecialHandler)]
+  
   val synthesizedClassTag: SpecialHandler = (formal, span) =>
     formal.argInfos match
       case arg :: Nil =>
         fullyDefinedType(arg, "ClassTag argument", span) match
           case defn.ArrayOf(elemTp) =>
             val etag = typer.inferImplicitArg(defn.ClassTagClass.typeRef.appliedTo(elemTp), span)
-            if etag.tpe.isError then EmptyTree else etag.select(nme.wrap)
+            if etag.tpe.isError then EmptyTreeNoError else withNoErrors(etag.select(nme.wrap))
           case tp if hasStableErasure(tp) && !defn.isBottomClassAfterErasure(tp.typeSymbol) =>
             val sym = tp.typeSymbol
             val classTag = ref(defn.ClassTagModule)
@@ -41,9 +51,9 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
               else
                 val clsOfType = escapeJavaArray(erasure(tp))
                 classTag.select(nme.apply).appliedToType(tp).appliedTo(clsOf(clsOfType))
-            tag.withSpan(span)
-          case tp => EmptyTree
-      case _ => EmptyTree
+            withNoErrors(tag.withSpan(span))
+          case tp => EmptyTreeNoError
+      case _ => EmptyTreeNoError
   end synthesizedClassTag
 
   val synthesizedTypeTest: SpecialHandler =
@@ -54,9 +64,9 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
         val sym2 = tp2.typeSymbol
         if tp1 <:< tp2 then
           // optimization when we know the typetest will always succeed
-          ref(defn.TypeTestModule_identity).appliedToType(tp2).withSpan(span)
+          withNoErrors(ref(defn.TypeTestModule_identity).appliedToType(tp2).withSpan(span))
         else if sym2 == defn.AnyValClass || sym2 == defn.AnyRefAlias || sym2 == defn.ObjectClass then
-          EmptyTree
+          EmptyTreeNoError
         else
           // Generate SAM: (s: <tp1>) => if s.isInstanceOf[<tp2>] then Some(s.asInstanceOf[s.type & <tp2>]) else None
           def body(args: List[Tree]): Tree = {
@@ -72,9 +82,9 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
           val tpe = MethodType(List(nme.s))(_ => List(tp1), mth => defn.OptionClass.typeRef.appliedTo(mth.newParamRef(0) & tp2))
           val meth = newAnonFun(ctx.owner, tpe, coord = span)
           val typeTestType = defn.TypeTestClass.typeRef.appliedTo(List(tp1, tp2))
-          Closure(meth, tss => body(tss.head).changeOwner(ctx.owner, meth), targetType = typeTestType).withSpan(span)
+          withNoErrors(Closure(meth, tss => body(tss.head).changeOwner(ctx.owner, meth), targetType = typeTestType).withSpan(span))
       case _ =>
-        EmptyTree
+        EmptyTreeNoError
     }
   end synthesizedTypeTest
 
@@ -109,17 +119,17 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
             // TupledFunction[?, ?]
             -1
         if arity == -1 then
-          EmptyTree
+          EmptyTreeNoError
         else if arity <= Definitions.MaxImplementedFunctionArity then
-          ref(defn.RuntimeTupleFunctionsModule)
+          withNoErrors(ref(defn.RuntimeTupleFunctionsModule)
             .select(s"tupledFunction$arity".toTermName)
-            .appliedToTypes(funArgs)
+            .appliedToTypes(funArgs))
         else
-          ref(defn.RuntimeTupleFunctionsModule)
+          withNoErrors(ref(defn.RuntimeTupleFunctionsModule)
             .select("tupledFunctionXXL".toTermName)
-            .appliedToTypes(funArgs)
+            .appliedToTypes(funArgs))
       case _ =>
-        EmptyTree
+        EmptyTreeNoError
   end synthesizedTupleFunction
 
   /** If `formal` is of the form CanEqual[T, U], try to synthesize an
@@ -191,13 +201,13 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
         List(arg1, arg2).foreach(fullyDefinedType(_, "eq argument", span))
         if canComparePredefined(arg1, arg2)
             || !Implicits.strictEquality && explore(validEqAnyArgs(arg1, arg2))
-        then ref(defn.CanEqual_canEqualAny).appliedToTypes(args).withSpan(span)
-        else EmptyTree
-      case _ => EmptyTree
+        then withNoErrors(ref(defn.CanEqual_canEqualAny).appliedToTypes(args).withSpan(span))
+        else EmptyTreeNoError
+      case _ => EmptyTreeNoError
   end synthesizedCanEqual
 
   /** Creates a tree that will produce a ValueOf instance for the requested type.
-   * An EmptyTree is returned if materialization fails.
+   * An EmptyTreeNoError is returned if materialization fails.
    */
   val synthesizedValueOf: SpecialHandler = (formal, span) =>
 
@@ -207,15 +217,15 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       case arg :: Nil =>
         fullyDefinedType(arg, "ValueOf argument", span).normalized.dealias match
           case ConstantType(c: Constant) =>
-            success(Literal(c))
+            withNoErrors(success(Literal(c)))
           case tp: TypeRef if tp.isRef(defn.UnitClass) =>
-            success(Literal(Constant(())))
+            withNoErrors(success(Literal(Constant(()))))
           case n: TermRef =>
-            success(ref(n))
+            withNoErrors(success(ref(n)))
           case tp =>
-            EmptyTree
+            EmptyTreeNoError
       case _ =>
-        EmptyTree
+        EmptyTreeNoError
   end synthesizedValueOf
 
   /** Create an anonymous class `new Object { type MirroredMonoType = ... }`
@@ -274,7 +284,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
         case t => mapOver(t)
     monoMap(mirroredType.resultType)
 
-  private def productMirror(mirroredType: Type, formal: Type, span: Span)(using Context): Tree =
+  private def productMirror(mirroredType: Type, formal: Type, span: Span)(using Context): TreeWithErrors =
 
     /** do all parts match the class symbol? */
     def acceptable(tp: Type, cls: Symbol): Boolean = tp match
@@ -299,7 +309,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
     def genAnonyousMirror(cls: Symbol): Boolean =
       cls.is(Scala2x) || cls.linkedClass.is(Case)
 
-    def makeProductMirror(cls: Symbol): Tree =
+    def makeProductMirror(cls: Symbol): TreeWithErrors =
       val accessors = cls.caseAccessors.filterNot(_.isAllOf(PrivateLocal))
       val elemLabels = accessors.map(acc => ConstantType(Constant(acc.name.toString)))
       val nestedPairs = TypeOps.nestedPairs(accessors.map(mirroredType.resultType.memberInfo(_).widenExpr))
@@ -318,12 +328,21 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       val mirrorRef =
         if (genAnonyousMirror(cls)) anonymousMirror(monoType, ExtendsProductMirror, span)
         else companionPath(mirroredType, span)
-      mirrorRef.cast(mirrorType)
+      withNoErrors(mirrorRef.cast(mirrorType))
     end makeProductMirror
+
+    def getErrors(cls: Symbol): List[String] = 
+      if !cls.isGenericProduct then
+        List(cls.whyNotGenericProduct)
+      else if !canAccessCtor(cls) then
+        List(i"Constructor of $cls is unnaccessible from the calling scope.")
+      else 
+        List.empty
+    end getErrors
 
     mirroredType match
       case AndType(tp1, tp2) =>
-        productMirror(tp1, formal, span).orElse(productMirror(tp2, formal, span))
+        orElse(productMirror(tp1, formal, span), productMirror(tp2, formal, span))
       case _ =>
         if mirroredType.termSymbol.is(CaseVal) then
           val module = mirroredType.termSymbol
@@ -331,10 +350,10 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
           if module.info.classSymbol.is(Scala2x) then
             val mirrorType = mirrorCore(defn.Mirror_SingletonProxyClass, mirroredType, mirroredType, module.name, formal)
             val mirrorRef = New(defn.Mirror_SingletonProxyClass.typeRef, modulePath :: Nil)
-            mirrorRef.cast(mirrorType)
+            withNoErrors(mirrorRef.cast(mirrorType))
           else
             val mirrorType = mirrorCore(defn.Mirror_SingletonClass, mirroredType, mirroredType, module.name, formal)
-            modulePath.cast(mirrorType)
+            withNoErrors(modulePath.cast(mirrorType))
         else
           val cls = mirroredType.classSymbol
           if acceptable(mirroredType, cls)
@@ -343,12 +362,15 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
           then
             makeProductMirror(cls)
           else
-            EmptyTree
+            (EmptyTree, getErrors(cls))
   end productMirror
 
-  private def sumMirror(mirroredType: Type, formal: Type, span: Span)(using Context): Tree =
+  private def sumMirror(mirroredType: Type, formal: Type, span: Span)(using Context): TreeWithErrors =
+
     val cls = mirroredType.classSymbol
     val useCompanion = cls.useCompanionAsSumMirror
+    val declScope = if useCompanion then cls.linkedClass else ctx.owner
+    val clsIsGenericSum = cls.isGenericSum(declScope)
 
     def acceptable(tp: Type): Boolean = tp match
       case tp: TermRef => false
@@ -357,7 +379,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       case OrType(tp1, tp2) => acceptable(tp1) && acceptable(tp2)
       case _            => tp.classSymbol eq cls
 
-    if acceptable(mirroredType) && cls.isGenericSum(if useCompanion then cls.linkedClass else ctx.owner) then
+    if acceptable(mirroredType) && clsIsGenericSum then
       val elemLabels = cls.children.map(c => ConstantType(Constant(c.name.toString)))
 
       def solve(sym: Symbol): Type = sym match
@@ -410,18 +432,21 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       val mirrorRef =
         if useCompanion then companionPath(mirroredType, span)
         else anonymousMirror(monoType, ExtendsSumMirror, span)
-      mirrorRef.cast(mirrorType)
-    else EmptyTree
+      withNoErrors(mirrorRef.cast(mirrorType))
+    else if !clsIsGenericSum then
+      (EmptyTree, List(cls.whyNotGenericSum(declScope)))
+    else 
+      EmptyTreeNoError
   end sumMirror
 
   def makeMirror
-      (synth: (Type, Type, Span) => Context ?=> Tree, formal: Type, span: Span)
-      (using Context): Tree =
+      (synth: (Type, Type, Span) => Context ?=> TreeWithErrors, formal: Type, span: Span)
+      (using Context): TreeWithErrors =
     if checkFormal(formal) then
       formal.member(tpnme.MirroredType).info match
         case TypeBounds(mirroredType, _) => synth(TypeOps.stripTypeVars(mirroredType), formal, span)
-        case other => EmptyTree
-    else EmptyTree
+        case other => EmptyTreeNoError
+    else EmptyTreeNoError
 
   /** An implied instance for a type of the form `Mirror.Product { type MirroredType = T }`
    *  where `T` is a generic product type or a case object or an enum case.
@@ -447,7 +472,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
           synthesizedProductMirror(formal, span)
         else
           synthesizedSumMirror(formal, span)
-      case _ => EmptyTree
+      case _ => EmptyTreeNoError
 
   private def escapeJavaArray(tp: Type)(using Context): Type = tp match
     case JavaArrayType(elemTp) => defn.ArrayOf(escapeJavaArray(elemTp))
@@ -553,9 +578,9 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
                |replace with the type `scala.reflect.ClassTag[$arg]`.
                |Alternatively, consider using the new metaprogramming features of Scala 3,
                |see https://docs.scala-lang.org/scala3/reference/metaprogramming.html""", ctx.source.atSpan(span))
-        manifest
+        withNoErrors(manifest)
       case _ =>
-        EmptyTree
+        EmptyTreeNoError
 
   end manifestFactoryOf
 
@@ -575,8 +600,8 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
     defn.OptManifestClass     -> synthesizedOptManifest,
   )
 
-  def tryAll(formal: Type, span: Span)(using Context): Tree =
-    def recur(handlers: SpecialHandlers): Tree = handlers match
+  def tryAll(formal: Type, span: Span)(using Context): TreeWithErrors =
+    def recur(handlers: SpecialHandlers): TreeWithErrors = handlers match
       case (cls, handler) :: rest =>
         def baseWithRefinements(tp: Type): Type = tp.dealias match
           case tp @ RefinedType(parent, rname, rinfo) =>
@@ -585,13 +610,13 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
             tp.baseType(cls)
         val base = baseWithRefinements(formal)
         val result =
-          if (base <:< formal.widenExpr)
+          if (base <:< formal.widenExpr)  
             // With the subtype test we enforce that the searched type `formal` is of the right form
             handler(base, span)
-          else EmptyTree
-        result.orElse(recur(rest))
+          else EmptyTreeNoError
+        orElse(result, recur(rest))
       case Nil =>
-        EmptyTree
+        EmptyTreeNoError
     recur(specialHandlers)
 
 end Synthesizer

--- a/docs/_docs/reference/contextual/derivation.md
+++ b/docs/_docs/reference/contextual/derivation.md
@@ -119,6 +119,16 @@ new Mirror.Product:
     new Leaf(...)
 ```
 
+If a Mirror cannot be generated automatically for a given type, an error will appear explaining why it is neither a supported 
+sum type nor a product type. For example, if `A` is a trait that is not sealed,
+
+```
+No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[A]: 
+     * trait A is not a generic product because it is not a case class
+     * trait A is not a generic sum because it is not a sealed trait
+```
+
+
 Note the following properties of `Mirror` types,
 
 + Properties are encoded using types rather than terms. This means that they have no runtime footprint unless used and

--- a/tests/neg-custom-args/i13838.check
+++ b/tests/neg-custom-args/i13838.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg-custom-args/i13838.scala:10:5 ----------------------------------------------------------------------
 10 |  foo  // error
    |     ^
-   |no given instance of type Order[X] was found for parameter x$1 of method foo in object FooT
+   |No given instance of type Order[X] was found for parameter x$1 of method foo in object FooT
    |
    |where:    X is a type variable
    |.

--- a/tests/neg-macros/i6436.check
+++ b/tests/neg-macros/i6436.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg-macros/i6436.scala:5:9 -----------------------------------------------------------------------------
 5 |    case '{ StringContext(${Varargs(parts)}*) } => // error
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |         no given instance of type scala.quoted.Quotes was found
+  |         No given instance of type scala.quoted.Quotes was found
 -- [E006] Not Found Error: tests/neg-macros/i6436.scala:6:34 -----------------------------------------------------------
 6 |      val ps: Seq[Expr[String]] = parts // error
   |                                  ^^^^^

--- a/tests/neg-macros/i9014b.check
+++ b/tests/neg-macros/i9014b.check
@@ -2,7 +2,7 @@
 -- Error: tests/neg-macros/i9014b/Test_2.scala:1:23 --------------------------------------------------------------------
 1 |val tests = summon[Bar] // error
   |                       ^
-  |                       no given instance of type Bar was found for parameter x of method summon in object Predef.
+  |                       No given instance of type Bar was found for parameter x of method summon in object Predef.
   |                       I found:
   |
   |                           given_Bar

--- a/tests/neg-scalajs/jsconstructortag-error-in-typer.check
+++ b/tests/neg-scalajs/jsconstructortag-error-in-typer.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-typer.scala:9:39 -------------------------------------------------
 9 |  val a = js.constructorTag[ScalaClass] // error
   |                                       ^
-  |no given instance of type scala.scalajs.js.ConstructorTag[ScalaClass] was found for parameter tag of method constructorTag in package scala.scalajs.js.
+  |No given instance of type scala.scalajs.js.ConstructorTag[ScalaClass] was found for parameter tag of method constructorTag in package scala.scalajs.js.
   |I found:
   |
   |    scala.scalajs.js.ConstructorTag.materialize[T]
@@ -10,7 +10,7 @@
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-typer.scala:10:39 ------------------------------------------------
 10 |  val b = js.constructorTag[ScalaTrait] // error
    |                                       ^
-   |no given instance of type scala.scalajs.js.ConstructorTag[ScalaTrait] was found for parameter tag of method constructorTag in package scala.scalajs.js.
+   |No given instance of type scala.scalajs.js.ConstructorTag[ScalaTrait] was found for parameter tag of method constructorTag in package scala.scalajs.js.
    |I found:
    |
    |    scala.scalajs.js.ConstructorTag.materialize[T]
@@ -19,7 +19,7 @@
 -- Error: tests/neg-scalajs/jsconstructortag-error-in-typer.scala:11:45 ------------------------------------------------
 11 |  val c = js.constructorTag[ScalaObject.type] // error
    |                                             ^
-   |no given instance of type scala.scalajs.js.ConstructorTag[ScalaObject.type] was found for parameter tag of method constructorTag in package scala.scalajs.js.
+   |No given instance of type scala.scalajs.js.ConstructorTag[ScalaObject.type] was found for parameter tag of method constructorTag in package scala.scalajs.js.
    |I found:
    |
    |    scala.scalajs.js.ConstructorTag.materialize[T]

--- a/tests/neg/i10603a.check
+++ b/tests/neg/i10603a.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i10603a.scala:2:35 ---------------------------------------------------------------------------------
 2 |  val x = implicitly[List[Boolean]] // error
   |                                   ^
-  |           no given instance of type List[Boolean] was found for parameter e of method implicitly in object Predef
+  |           No given instance of type List[Boolean] was found for parameter e of method implicitly in object Predef

--- a/tests/neg/i10901.check
+++ b/tests/neg/i10901.check
@@ -38,4 +38,4 @@
    |
    |              Test.foo("abc")(/* missing */summon[C])    failed with
    |
-   |                  no given instance of type C was found for parameter x$2 of method foo in object Test
+   |                  No given instance of type C was found for parameter x$2 of method foo in object Test

--- a/tests/neg/i11066.check
+++ b/tests/neg/i11066.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i11066.scala:15:37 ---------------------------------------------------------------------------------
 15 |val x = Greeter.greet("Who's there?") // error
    |                                     ^
-   |ambiguous given instances: both given instance joesPrompt in object JoesPrefs and given instance jillsPrompt in object JillsPrefs match type PreferredPrompt of parameter prompt of method greet in object Greeter
+   |Ambiguous given instances: both given instance joesPrompt in object JoesPrefs and given instance jillsPrompt in object JillsPrefs match type PreferredPrompt of parameter prompt of method greet in object Greeter

--- a/tests/neg/i11897.check
+++ b/tests/neg/i11897.check
@@ -26,20 +26,20 @@
 -- Error: tests/neg/i11897.scala:16:18 ---------------------------------------------------------------------------------
 16 |  assert(summon[A] == A(23)) // error
    |                  ^
-   |                  no given instance of type A was found for parameter x of method summon in object Predef
+   |                  No given instance of type A was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i11897.scala:17:18 ---------------------------------------------------------------------------------
 17 |  assert(summon[B] == B(false)) // error
    |                  ^
-   |                  no given instance of type B was found for parameter x of method summon in object Predef
+   |                  No given instance of type B was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i11897.scala:18:18 ---------------------------------------------------------------------------------
 18 |  assert(summon[C] == C("c")) // error
    |                  ^
-   |                  no given instance of type C was found for parameter x of method summon in object Predef
+   |                  No given instance of type C was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i11897.scala:19:18 ---------------------------------------------------------------------------------
 19 |  assert(summon[E] == E(93)) // error
    |                  ^
-   |                  no given instance of type E was found for parameter x of method summon in object Predef
+   |                  No given instance of type E was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i11897.scala:20:18 ---------------------------------------------------------------------------------
 20 |  assert(summon[G] == G(101)) // error
    |                  ^
-   |                  no given instance of type G was found for parameter x of method summon in object Predef
+   |                  No given instance of type G was found for parameter x of method summon in object Predef

--- a/tests/neg/i12049.check
+++ b/tests/neg/i12049.check
@@ -34,7 +34,7 @@
 -- Error: tests/neg/i12049.scala:24:20 ---------------------------------------------------------------------------------
 24 |val _ = summon[M[B]]  // error
    |                    ^
-   |                    no given instance of type M[B] was found for parameter x of method summon in object Predef
+   |                    No given instance of type M[B] was found for parameter x of method summon in object Predef
    |
    |                    Note: a match type could not be fully reduced:
    |

--- a/tests/neg/i12232.check
+++ b/tests/neg/i12232.check
@@ -1,12 +1,12 @@
 -- Error: tests/neg/i12232.scala:17:15 ---------------------------------------------------------------------------------
 17 |  foo(min(3, 4)) // error: works in Scala 2, not in 3
    |               ^
-   |               no given instance of type Op[Int, Int, V] was found for parameter op of method min in object Foo
+   |               No given instance of type Op[Int, Int, V] was found for parameter op of method min in object Foo
    |
    |               where:    V is a type variable with constraint <: Double
 -- Error: tests/neg/i12232.scala:19:16 ---------------------------------------------------------------------------------
 19 |  foo(minR(3, 4)) // error: works in Scala 2, not in 3
    |                ^
-   |               no given instance of type Op[Int, Int, R] was found for parameter op of method minR in object Foo
+   |               No given instance of type Op[Int, Int, R] was found for parameter op of method minR in object Foo
    |
    |               where:    R is a type variable with constraint <: Double

--- a/tests/neg/i12591.check
+++ b/tests/neg/i12591.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i12591/Inner.scala:12:31 ---------------------------------------------------------------------------
 12 |val badSummon = summon[TC[Bar]] // error here
    |                               ^
-   |ambiguous given instances: both outer.inner.Foo.ofFoo and outer.Foo.ofFoo match type outer.inner.Foo.TC[outer.Bar] of parameter x of method summon in object Predef
+   |Ambiguous given instances: both outer.inner.Foo.ofFoo and outer.Foo.ofFoo match type outer.inner.Foo.TC[outer.Bar] of parameter x of method summon in object Predef

--- a/tests/neg/i13991.check
+++ b/tests/neg/i13991.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/i13991.scala:5:7 -----------------------------------------------------------------------------------
  5 |  first[String] // error // before line 10 to test alignment of the error message `|`
    |  ^^^^^^^^^^^^^
-   |  no given instance of type Foo[String] was found
+   |  No given instance of type Foo[String] was found
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/neg/i14025.check
+++ b/tests/neg/i14025.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/i14025.scala:1:88 ----------------------------------------------------------------------------------
 1 |val foo = summon[deriving.Mirror.Product { type MirroredType = [X] =>> [Y] =>> (X, Y) }] // error
   |                                                                                        ^
-  |No given instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)} was found for parameter x of method summon in object Predef
+  |No given instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)} was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)}: class Tuple2 is not a generic product 
 -- Error: tests/neg/i14025.scala:2:90 ----------------------------------------------------------------------------------
 2 |val bar = summon[deriving.Mirror.Sum { type MirroredType = [X] =>> [Y] =>> List[(X, Y)] }] // error
   |                                                                                          ^

--- a/tests/neg/i14025.check
+++ b/tests/neg/i14025.check
@@ -1,8 +1,8 @@
 -- Error: tests/neg/i14025.scala:1:88 ----------------------------------------------------------------------------------
 1 |val foo = summon[deriving.Mirror.Product { type MirroredType = [X] =>> [Y] =>> (X, Y) }] // error
   |                                                                                        ^
-  |no given instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)} was found for parameter x of method summon in object Predef
+  |No given instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)} was found for parameter x of method summon in object Predef
 -- Error: tests/neg/i14025.scala:2:90 ----------------------------------------------------------------------------------
 2 |val bar = summon[deriving.Mirror.Sum { type MirroredType = [X] =>> [Y] =>> List[(X, Y)] }] // error
   |                                                                                          ^
-  |no given instance of type deriving.Mirror.Sum{MirroredType[X] = [Y] =>> List[(X, Y)]} was found for parameter x of method summon in object Predef
+  |No given instance of type deriving.Mirror.Sum{MirroredType[X] = [Y] =>> List[(X, Y)]} was found for parameter x of method summon in object Predef

--- a/tests/neg/i14432.check
+++ b/tests/neg/i14432.check
@@ -1,4 +1,6 @@
 -- Error: tests/neg/i14432.scala:13:33 ---------------------------------------------------------------------------------
 13 |val mFoo = summon[Mirror.Of[Foo]] // error: no mirror found
    |                                 ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic sum because it is not a sealed class
+   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432.check
+++ b/tests/neg/i14432.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14432.scala:13:33 ---------------------------------------------------------------------------------
 13 |val mFoo = summon[Mirror.Of[Foo]] // error: no mirror found
    |                                 ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432.check
+++ b/tests/neg/i14432.check
@@ -2,5 +2,5 @@
 13 |val mFoo = summon[Mirror.Of[Foo]] // error: no mirror found
    |                                 ^
    |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class
-   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432.check
+++ b/tests/neg/i14432.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14432.scala:13:33 ---------------------------------------------------------------------------------
 13 |val mFoo = summon[Mirror.Of[Foo]] // error: no mirror found
    |                                 ^
-   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432a.check
+++ b/tests/neg/i14432a.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14432a.scala:14:43 --------------------------------------------------------------------------------
 14 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
-   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432a.check
+++ b/tests/neg/i14432a.check
@@ -1,4 +1,6 @@
 -- Error: tests/neg/i14432a.scala:14:43 --------------------------------------------------------------------------------
 14 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic sum because it is not a sealed class
+   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432a.check
+++ b/tests/neg/i14432a.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14432a.scala:14:43 --------------------------------------------------------------------------------
 14 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432a.check
+++ b/tests/neg/i14432a.check
@@ -2,5 +2,5 @@
 14 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
    |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class
-   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432b.check
+++ b/tests/neg/i14432b.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14432b.scala:15:43 --------------------------------------------------------------------------------
 15 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
-   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432b.check
+++ b/tests/neg/i14432b.check
@@ -1,4 +1,6 @@
 -- Error: tests/neg/i14432b.scala:15:43 --------------------------------------------------------------------------------
 15 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic sum because it is not a sealed class
+   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432b.check
+++ b/tests/neg/i14432b.check
@@ -2,5 +2,5 @@
 15 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
    |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class
-   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432b.check
+++ b/tests/neg/i14432b.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14432b.scala:15:43 --------------------------------------------------------------------------------
 15 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432c.check
+++ b/tests/neg/i14432c.check
@@ -9,4 +9,6 @@
 -- Error: tests/neg/i14432c.scala:16:43 --------------------------------------------------------------------------------
 16 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic sum because it is not a sealed class
+   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432c.check
+++ b/tests/neg/i14432c.check
@@ -9,4 +9,4 @@
 -- Error: tests/neg/i14432c.scala:16:43 --------------------------------------------------------------------------------
 16 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror
    |                                           ^
-   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432c.check
+++ b/tests/neg/i14432c.check
@@ -10,5 +10,5 @@
 16 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror
    |                                           ^
    |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class
-   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432c.check
+++ b/tests/neg/i14432c.check
@@ -9,4 +9,4 @@
 -- Error: tests/neg/i14432c.scala:16:43 --------------------------------------------------------------------------------
 16 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432d.check
+++ b/tests/neg/i14432d.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14432d.scala:17:45 --------------------------------------------------------------------------------
 17 |    val mFoo = summon[Mirror.Of[example.Foo]] // error
    |                                             ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432d.check
+++ b/tests/neg/i14432d.check
@@ -1,4 +1,6 @@
 -- Error: tests/neg/i14432d.scala:17:45 --------------------------------------------------------------------------------
 17 |    val mFoo = summon[Mirror.Of[example.Foo]] // error
    |                                             ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic sum because it is not a sealed class
+   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432d.check
+++ b/tests/neg/i14432d.check
@@ -2,5 +2,5 @@
 17 |    val mFoo = summon[Mirror.Of[example.Foo]] // error
    |                                             ^
    |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class
-   |	* class Foo is not a generic product because constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14432d.check
+++ b/tests/neg/i14432d.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14432d.scala:17:45 --------------------------------------------------------------------------------
 17 |    val mFoo = summon[Mirror.Of[example.Foo]] // error
    |                                             ^
-   |no given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[example.Foo]: Constructor of class Foo is unnaccessible from the calling scope.

--- a/tests/neg/i14823.check
+++ b/tests/neg/i14823.check
@@ -1,4 +1,6 @@
 -- Error: tests/neg/i14823.scala:8:50 ----------------------------------------------------------------------------------
 8 |val baz = summon[Mirror.Of[SubA[Int] | SubB[Int]]] // error
   |                                                  ^
-  |No given instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]] was found for parameter x of method summon in object Predef
+  |No given instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]]: 
+  |	* class Cov is not a generic sum because it is not a sealed class
+  |	* class Cov is not a generic product 

--- a/tests/neg/i14823.check
+++ b/tests/neg/i14823.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i14823.scala:8:50 ----------------------------------------------------------------------------------
 8 |val baz = summon[Mirror.Of[SubA[Int] | SubB[Int]]] // error
   |                                                  ^
-  |no given instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]] was found for parameter x of method summon in object Predef
+  |No given instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]] was found for parameter x of method summon in object Predef

--- a/tests/neg/i14823.check
+++ b/tests/neg/i14823.check
@@ -2,5 +2,5 @@
 8 |val baz = summon[Mirror.Of[SubA[Int] | SubB[Int]]] // error
   |                                                  ^
   |No given instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]]: 
-  |	* class Cov is not a generic sum because it is not a sealed class
   |	* class Cov is not a generic product 
+  |	* class Cov is not a generic sum because it is not a sealed class

--- a/tests/neg/i5498-postfixOps.check
+++ b/tests/neg/i5498-postfixOps.check
@@ -13,4 +13,4 @@
 -- Error: tests/neg/i5498-postfixOps.scala:6:0 -------------------------------------------------------------------------
 6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error
   |^
-  |no given instance of type scala.concurrent.duration.DurationConversions.Classifier[Null] was found for parameter ev of method second in trait DurationConversions
+  |No given instance of type scala.concurrent.duration.DurationConversions.Classifier[Null] was found for parameter ev of method second in trait DurationConversions

--- a/tests/neg/i7613.check
+++ b/tests/neg/i7613.check
@@ -1,8 +1,8 @@
 -- Error: tests/neg/i7613.scala:10:16 ----------------------------------------------------------------------------------
 10 |  new BazLaws[A] {}  // error // error
    |                ^
-   |            no given instance of type Baz[A] was found for parameter x$1 of constructor BazLaws in trait BazLaws
+   |            No given instance of type Baz[A] was found for parameter x$1 of constructor BazLaws in trait BazLaws
 -- Error: tests/neg/i7613.scala:10:2 -----------------------------------------------------------------------------------
 10 |  new BazLaws[A] {}  // error // error
    |  ^
-   |  no given instance of type Bar[A] was found for parameter x$1 of constructor BarLaws in trait BarLaws
+   |  No given instance of type Bar[A] was found for parameter x$1 of constructor BarLaws in trait BarLaws

--- a/tests/neg/i9185.check
+++ b/tests/neg/i9185.check
@@ -8,11 +8,11 @@
   |      /* ambiguous: both object listMonad in object M and object optionMonad in object M match type M[F] */summon[M[F]]
   |    )    failed with
   |
-  |        ambiguous given instances: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
+  |        Ambiguous given instances: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
 -- Error: tests/neg/i9185.scala:8:28 -----------------------------------------------------------------------------------
 8 |  val value3 = M.pure("ola") // error
   |                            ^
-  |ambiguous given instances: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
+  |Ambiguous given instances: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
 -- [E008] Not Found Error: tests/neg/i9185.scala:11:16 -----------------------------------------------------------------
 11 |  val l = "abc".len  // error
    |          ^^^^^^^^^

--- a/tests/neg/i9568.check
+++ b/tests/neg/i9568.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/i9568.scala:13:10 ----------------------------------------------------------------------------------
 13 |  blaMonad.foo(bla) // error: diverges
    |          ^
-   |          no given instance of type => Monad[F] was found for parameter ev of method blaMonad in object Test
+   |          No given instance of type => Monad[F] was found for parameter ev of method blaMonad in object Test
    |
    |          where:    F is a type variable with constraint <: [_] =>> Any
    |          .

--- a/tests/neg/i9958.check
+++ b/tests/neg/i9958.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/i9958.scala:1:30 -----------------------------------------------------------------------------------
 1 |val x = summon[[X] =>> (X, X)] // error
   |                              ^
-  |              no given instance of type [X] =>> (X, X) was found for parameter x of method summon in object Predef
+  |              No given instance of type [X] =>> (X, X) was found for parameter x of method summon in object Predef
 -- [E007] Type Mismatch Error: tests/neg/i9958.scala:8:10 --------------------------------------------------------------
 8 |def b = f(a) // error
   |          ^

--- a/tests/neg/implicitSearch.check
+++ b/tests/neg/implicitSearch.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/implicitSearch.scala:13:12 -------------------------------------------------------------------------
 13 |    sort(xs)  // error (with a partially constructed implicit argument shown)
    |            ^
-   |      no given instance of type Test.Ord[List[List[T]]] was found for parameter o of method sort in object Test.
+   |      No given instance of type Test.Ord[List[List[T]]] was found for parameter o of method sort in object Test.
    |      I found:
    |
    |          Test.listOrd[List[T]](Test.listOrd[T](/* missing */summon[Test.Ord[T]]))
@@ -10,4 +10,4 @@
 -- Error: tests/neg/implicitSearch.scala:15:38 -------------------------------------------------------------------------
 15 |    listOrd(listOrd(implicitly[Ord[T]] /*not found*/)) // error
    |                                      ^
-   |           no given instance of type Test.Ord[T] was found for parameter e of method implicitly in object Predef
+   |           No given instance of type Test.Ord[T] was found for parameter e of method implicitly in object Predef

--- a/tests/neg/mirror-synthesis-errors.check
+++ b/tests/neg/mirror-synthesis-errors.check
@@ -1,0 +1,28 @@
+-- Error: tests/neg/mirror-synthesis-errors.scala:21:32 ----------------------------------------------------------------
+21 |val testA = summon[Mirror.Of[A]] // error: Not a sealed trait
+   |                                ^
+   |No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[A]: trait A is not a sealed trait
+-- Error: tests/neg/mirror-synthesis-errors.scala:22:32 ----------------------------------------------------------------
+22 |val testC = summon[Mirror.Of[C]] // error: Does not have subclasses
+   |                                ^
+   |No given instance of type deriving.Mirror.Of[C] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[C]: trait C does not have subclasses
+-- Error: tests/neg/mirror-synthesis-errors.scala:23:32 ----------------------------------------------------------------
+23 |val testD = summon[Mirror.Of[D]] // error: child SubD takes more than one parameter list
+   |                                ^
+   |No given instance of type deriving.Mirror.Of[D] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[D]: class D's child class SubD is not a generic product because class SubD takes more than one parameter list
+-- Error: tests/neg/mirror-synthesis-errors.scala:24:38 ----------------------------------------------------------------
+24 |val testSubD = summon[Mirror.Of[SubD]] // error: takes more than one parameter list
+   |                                      ^
+   |No given instance of type deriving.Mirror.Of[SubD] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[SubD]: class SubD is not a sealed class
+-- Error: tests/neg/mirror-synthesis-errors.scala:25:32 ----------------------------------------------------------------
+25 |val testE = summon[Mirror.Of[E]] // error: Not an abstract class
+   |                                ^
+   |No given instance of type deriving.Mirror.Of[E] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[E]: class E is not an abstract class
+-- Error: tests/neg/mirror-synthesis-errors.scala:26:32 ----------------------------------------------------------------
+26 |val testF = summon[Mirror.Of[F]] // error: No children
+   |                                ^
+   |No given instance of type deriving.Mirror.Of[F] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[F]: trait F does not have subclasses
+-- Error: tests/neg/mirror-synthesis-errors.scala:27:36 ----------------------------------------------------------------
+27 |val testG = summon[Mirror.Of[Foo.G]] // error: Has anonymous subclasses
+   |                                    ^
+   |No given instance of type deriving.Mirror.Of[Foo.G] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[Foo.G]: trait G has anonymous or inaccessible subclasses

--- a/tests/neg/mirror-synthesis-errors.check
+++ b/tests/neg/mirror-synthesis-errors.check
@@ -1,28 +1,42 @@
 -- Error: tests/neg/mirror-synthesis-errors.scala:21:32 ----------------------------------------------------------------
 21 |val testA = summon[Mirror.Of[A]] // error: Not a sealed trait
    |                                ^
-   |No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[A]: trait A is not a sealed trait
+   |No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[A]: 
+   |	* trait A is not a generic sum because it is not a sealed trait
+   |	* trait A is not a generic product because it is not a case class
 -- Error: tests/neg/mirror-synthesis-errors.scala:22:32 ----------------------------------------------------------------
 22 |val testC = summon[Mirror.Of[C]] // error: Does not have subclasses
    |                                ^
-   |No given instance of type deriving.Mirror.Of[C] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[C]: trait C does not have subclasses
+   |No given instance of type deriving.Mirror.Of[C] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[C]: 
+   |	* trait C is not a generic sum because it does not have subclasses
+   |	* trait C is not a generic product because it is not a case class
 -- Error: tests/neg/mirror-synthesis-errors.scala:23:32 ----------------------------------------------------------------
 23 |val testD = summon[Mirror.Of[D]] // error: child SubD takes more than one parameter list
    |                                ^
-   |No given instance of type deriving.Mirror.Of[D] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[D]: class D's child class SubD is not a generic product because class SubD takes more than one parameter list
+   |No given instance of type deriving.Mirror.Of[D] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[D]: 
+   |	* class D is not a generic sum because its child class SubD is not a generic product because it takes more than one parameter list
+   |	* class D is not a generic product because it is not a case class
 -- Error: tests/neg/mirror-synthesis-errors.scala:24:38 ----------------------------------------------------------------
 24 |val testSubD = summon[Mirror.Of[SubD]] // error: takes more than one parameter list
    |                                      ^
-   |No given instance of type deriving.Mirror.Of[SubD] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubD]: class SubD is not a sealed class
+   |No given instance of type deriving.Mirror.Of[SubD] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubD]: 
+   |	* class SubD is not a generic sum because it is not a sealed class
+   |	* class SubD is not a generic product because it takes more than one parameter list
 -- Error: tests/neg/mirror-synthesis-errors.scala:25:32 ----------------------------------------------------------------
 25 |val testE = summon[Mirror.Of[E]] // error: Not an abstract class
    |                                ^
-   |No given instance of type deriving.Mirror.Of[E] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[E]: class E is not an abstract class
+   |No given instance of type deriving.Mirror.Of[E] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[E]: 
+   |	* class E is not a generic sum because it is not an abstract class
+   |	* class E is not a generic product because it is not a case class
 -- Error: tests/neg/mirror-synthesis-errors.scala:26:32 ----------------------------------------------------------------
 26 |val testF = summon[Mirror.Of[F]] // error: No children
    |                                ^
-   |No given instance of type deriving.Mirror.Of[F] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[F]: trait F does not have subclasses
+   |No given instance of type deriving.Mirror.Of[F] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[F]: 
+   |	* trait F is not a generic sum because it does not have subclasses
+   |	* trait F is not a generic product because it is not a case class
 -- Error: tests/neg/mirror-synthesis-errors.scala:27:36 ----------------------------------------------------------------
 27 |val testG = summon[Mirror.Of[Foo.G]] // error: Has anonymous subclasses
    |                                    ^
-   |No given instance of type deriving.Mirror.Of[Foo.G] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Foo.G]: trait G has anonymous or inaccessible subclasses
+   |No given instance of type deriving.Mirror.Of[Foo.G] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Foo.G]: 
+   |	* trait G is not a generic sum because it has anonymous or inaccessible subclasses
+   |	* trait G is not a generic product because it is not a case class

--- a/tests/neg/mirror-synthesis-errors.check
+++ b/tests/neg/mirror-synthesis-errors.check
@@ -1,28 +1,28 @@
 -- Error: tests/neg/mirror-synthesis-errors.scala:21:32 ----------------------------------------------------------------
 21 |val testA = summon[Mirror.Of[A]] // error: Not a sealed trait
    |                                ^
-   |No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[A]: trait A is not a sealed trait
+   |No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[A]: trait A is not a sealed trait
 -- Error: tests/neg/mirror-synthesis-errors.scala:22:32 ----------------------------------------------------------------
 22 |val testC = summon[Mirror.Of[C]] // error: Does not have subclasses
    |                                ^
-   |No given instance of type deriving.Mirror.Of[C] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[C]: trait C does not have subclasses
+   |No given instance of type deriving.Mirror.Of[C] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[C]: trait C does not have subclasses
 -- Error: tests/neg/mirror-synthesis-errors.scala:23:32 ----------------------------------------------------------------
 23 |val testD = summon[Mirror.Of[D]] // error: child SubD takes more than one parameter list
    |                                ^
-   |No given instance of type deriving.Mirror.Of[D] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[D]: class D's child class SubD is not a generic product because class SubD takes more than one parameter list
+   |No given instance of type deriving.Mirror.Of[D] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[D]: class D's child class SubD is not a generic product because class SubD takes more than one parameter list
 -- Error: tests/neg/mirror-synthesis-errors.scala:24:38 ----------------------------------------------------------------
 24 |val testSubD = summon[Mirror.Of[SubD]] // error: takes more than one parameter list
    |                                      ^
-   |No given instance of type deriving.Mirror.Of[SubD] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[SubD]: class SubD is not a sealed class
+   |No given instance of type deriving.Mirror.Of[SubD] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubD]: class SubD is not a sealed class
 -- Error: tests/neg/mirror-synthesis-errors.scala:25:32 ----------------------------------------------------------------
 25 |val testE = summon[Mirror.Of[E]] // error: Not an abstract class
    |                                ^
-   |No given instance of type deriving.Mirror.Of[E] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[E]: class E is not an abstract class
+   |No given instance of type deriving.Mirror.Of[E] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[E]: class E is not an abstract class
 -- Error: tests/neg/mirror-synthesis-errors.scala:26:32 ----------------------------------------------------------------
 26 |val testF = summon[Mirror.Of[F]] // error: No children
    |                                ^
-   |No given instance of type deriving.Mirror.Of[F] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[F]: trait F does not have subclasses
+   |No given instance of type deriving.Mirror.Of[F] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[F]: trait F does not have subclasses
 -- Error: tests/neg/mirror-synthesis-errors.scala:27:36 ----------------------------------------------------------------
 27 |val testG = summon[Mirror.Of[Foo.G]] // error: Has anonymous subclasses
    |                                    ^
-   |No given instance of type deriving.Mirror.Of[Foo.G] was found for parameter x of method summon in object Predef. Failed to synthesize implicit of type deriving.Mirror.Of[Foo.G]: trait G has anonymous or inaccessible subclasses
+   |No given instance of type deriving.Mirror.Of[Foo.G] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Foo.G]: trait G has anonymous or inaccessible subclasses

--- a/tests/neg/mirror-synthesis-errors.check
+++ b/tests/neg/mirror-synthesis-errors.check
@@ -2,41 +2,41 @@
 21 |val testA = summon[Mirror.Of[A]] // error: Not a sealed trait
    |                                ^
    |No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[A]: 
-   |	* trait A is not a generic sum because it is not a sealed trait
    |	* trait A is not a generic product because it is not a case class
+   |	* trait A is not a generic sum because it is not a sealed trait
 -- Error: tests/neg/mirror-synthesis-errors.scala:22:32 ----------------------------------------------------------------
 22 |val testC = summon[Mirror.Of[C]] // error: Does not have subclasses
    |                                ^
    |No given instance of type deriving.Mirror.Of[C] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[C]: 
-   |	* trait C is not a generic sum because it does not have subclasses
    |	* trait C is not a generic product because it is not a case class
+   |	* trait C is not a generic sum because it does not have subclasses
 -- Error: tests/neg/mirror-synthesis-errors.scala:23:32 ----------------------------------------------------------------
 23 |val testD = summon[Mirror.Of[D]] // error: child SubD takes more than one parameter list
    |                                ^
    |No given instance of type deriving.Mirror.Of[D] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[D]: 
-   |	* class D is not a generic sum because its child class SubD is not a generic product because it takes more than one parameter list
    |	* class D is not a generic product because it is not a case class
+   |	* class D is not a generic sum because its child class SubD is not a generic product because it takes more than one parameter list
 -- Error: tests/neg/mirror-synthesis-errors.scala:24:38 ----------------------------------------------------------------
 24 |val testSubD = summon[Mirror.Of[SubD]] // error: takes more than one parameter list
    |                                      ^
    |No given instance of type deriving.Mirror.Of[SubD] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubD]: 
-   |	* class SubD is not a generic sum because it is not a sealed class
    |	* class SubD is not a generic product because it takes more than one parameter list
+   |	* class SubD is not a generic sum because it is not a sealed class
 -- Error: tests/neg/mirror-synthesis-errors.scala:25:32 ----------------------------------------------------------------
 25 |val testE = summon[Mirror.Of[E]] // error: Not an abstract class
    |                                ^
    |No given instance of type deriving.Mirror.Of[E] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[E]: 
-   |	* class E is not a generic sum because it is not an abstract class
    |	* class E is not a generic product because it is not a case class
+   |	* class E is not a generic sum because it is not an abstract class
 -- Error: tests/neg/mirror-synthesis-errors.scala:26:32 ----------------------------------------------------------------
 26 |val testF = summon[Mirror.Of[F]] // error: No children
    |                                ^
    |No given instance of type deriving.Mirror.Of[F] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[F]: 
-   |	* trait F is not a generic sum because it does not have subclasses
    |	* trait F is not a generic product because it is not a case class
+   |	* trait F is not a generic sum because it does not have subclasses
 -- Error: tests/neg/mirror-synthesis-errors.scala:27:36 ----------------------------------------------------------------
 27 |val testG = summon[Mirror.Of[Foo.G]] // error: Has anonymous subclasses
    |                                    ^
    |No given instance of type deriving.Mirror.Of[Foo.G] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Foo.G]: 
-   |	* trait G is not a generic sum because it has anonymous or inaccessible subclasses
    |	* trait G is not a generic product because it is not a case class
+   |	* trait G is not a generic sum because it has anonymous or inaccessible subclasses

--- a/tests/neg/mirror-synthesis-errors.scala
+++ b/tests/neg/mirror-synthesis-errors.scala
@@ -1,0 +1,27 @@
+import scala.deriving.Mirror
+
+trait A
+class B extends A
+
+sealed trait C
+
+sealed abstract class D(i: Int)(s: String)
+case class SubD(i: Int)(s: String) extends D(i)(s)
+
+sealed class E
+
+sealed trait F
+
+object Foo {
+    sealed trait G
+    case class H() extends G
+    val J = new G { }
+}
+
+val testA = summon[Mirror.Of[A]] // error: Not a sealed trait
+val testC = summon[Mirror.Of[C]] // error: Does not have subclasses
+val testD = summon[Mirror.Of[D]] // error: child SubD takes more than one parameter list
+val testSubD = summon[Mirror.Of[SubD]] // error: takes more than one parameter list
+val testE = summon[Mirror.Of[E]] // error: Not an abstract class
+val testF = summon[Mirror.Of[F]] // error: No children
+val testG = summon[Mirror.Of[Foo.G]] // error: Has anonymous subclasses

--- a/tests/neg/missing-implicit1.check
+++ b/tests/neg/missing-implicit1.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/missing-implicit1.scala:17:4 -----------------------------------------------------------------------
 17 |  ff // error
    |    ^
-   |no given instance of type testObjectInstance.Zip[Option] was found for parameter xs of method ff in object testObjectInstance
+   |No given instance of type testObjectInstance.Zip[Option] was found for parameter xs of method ff in object testObjectInstance
    |
    |The following import might fix the problem:
    |
@@ -19,7 +19,7 @@
 -- Error: tests/neg/missing-implicit1.scala:23:42 ----------------------------------------------------------------------
 23 |    List(1, 2, 3).traverse(x => Option(x)) // error
    |                                          ^
-   |no given instance of type testObjectInstance.Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
+   |No given instance of type testObjectInstance.Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
    |
    |The following import might fix the problem:
    |

--- a/tests/neg/missing-implicit2.check
+++ b/tests/neg/missing-implicit2.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/missing-implicit2.scala:10:18 ----------------------------------------------------------------------
 10 |    f(using xFromY) // error
    |                  ^
-   |                  no given instance of type Y was found for parameter y of given instance xFromY
+   |                  No given instance of type Y was found for parameter y of given instance xFromY
    |
    |                  The following import might fix the problem:
    |
@@ -10,7 +10,7 @@
 -- Error: tests/neg/missing-implicit2.scala:16:5 -----------------------------------------------------------------------
 16 |    f // error
    |     ^
-   |     no given instance of type X was found for parameter x of method f in object test
+   |     No given instance of type X was found for parameter x of method f in object test
    |
    |     The following import might make progress towards fixing the problem:
    |

--- a/tests/neg/missing-implicit3.check
+++ b/tests/neg/missing-implicit3.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/missing-implicit3.scala:13:36 ----------------------------------------------------------------------
 13 |val sortedFoos = sort(List(new Foo)) // error
    |                                    ^
-   |   no given instance of type ord.Ord[ord.Foo] was found for an implicit parameter of method sort in package ord.
+   |   No given instance of type ord.Ord[ord.Foo] was found for an implicit parameter of method sort in package ord.
    |   I found:
    |
    |       ord.Ord.ordered[ord.Foo](/* missing */summon[ord.Foo => Comparable[? >: ord.Foo]])

--- a/tests/neg/missing-implicit4.check
+++ b/tests/neg/missing-implicit4.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg/missing-implicit4.scala:14:4 -----------------------------------------------------------------------
 14 |  ff // error
    |    ^
-   |    no given instance of type Zip[Option] was found for parameter xs of method ff
+   |    No given instance of type Zip[Option] was found for parameter xs of method ff
    |
    |    The following import might fix the problem:
    |
@@ -19,7 +19,7 @@
 -- Error: tests/neg/missing-implicit4.scala:20:42 ----------------------------------------------------------------------
 20 |    List(1, 2, 3).traverse(x => Option(x)) // error
    |                                          ^
-   |  no given instance of type Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
+   |  No given instance of type Zip[Option] was found for an implicit parameter of method traverse in trait Traverse
    |
    |  The following import might fix the problem:
    |

--- a/tests/neg/summon-function.check
+++ b/tests/neg/summon-function.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/summon-function.scala:2:23 -------------------------------------------------------------------------
 2 |  summon[Int => String] // error
   |                       ^
-  |               no given instance of type Int => String was found for parameter x of method summon in object Predef
+  |               No given instance of type Int => String was found for parameter x of method summon in object Predef


### PR DESCRIPTION
Fixes #15128 
Added reporting for errors on mirror synthesis and modified the Synthesizer so adding errors for synthesis of another terms is also straightforward. Modified the error messages. 