### PR TITLE
Fix documentation regressions

### DIFF
--- a/docs/_docs/internals/syntax-3.1.md
+++ b/docs/_docs/internals/syntax-3.1.md
@@ -10,8 +10,8 @@ _Unicode escapes_ are used to represent the Unicode character with the given
 hexadecimal code:
 
 ```ebnf
-UnicodeEscape ::= ‘\’ ‘u’ {‘u’} hexDigit hexDigit hexDigit hexDigit ;
-hexDigit      ::= ‘0’ | … | ‘9’ | ‘A’ | … | ‘F’ | ‘a’ | … | ‘f’ ;
+UnicodeEscape ::= ‘\’ ‘u’ {‘u’} hexDigit hexDigit hexDigit hexDigit
+hexDigit      ::= ‘0’ | … | ‘9’ | ‘A’ | … | ‘F’ | ‘a’ | … | ‘f’
 ```
 
 Informal descriptions are typeset as `“some comment”`.
@@ -21,69 +21,69 @@ The lexical syntax of Scala is given by the following grammar in EBNF
 form.
 
 ```ebnf
-whiteSpace       ::=  ‘\u0020’ | ‘\u0009’ | ‘\u000D’ | ‘\u000A’ ;
-upper            ::=  ‘A’ | … | ‘Z’ | ‘\$’ | ‘_’  “… and Unicode category Lu” ;
-lower            ::=  ‘a’ | … | ‘z’ “… and Unicode category Ll” ;
-letter           ::=  upper | lower “… and Unicode categories Lo, Lt, Lm, Nl” ;
-digit            ::=  ‘0’ | … | ‘9’ ;
-paren            ::=  ‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’ | ‘'(’ | ‘'[’ | ‘'{’ ;
-delim            ::=  ‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’ ;
+whiteSpace       ::=  ‘\u0020’ | ‘\u0009’ | ‘\u000D’ | ‘\u000A’
+upper            ::=  ‘A’ | … | ‘Z’ | ‘\$’ | ‘_’  “… and Unicode category Lu”
+lower            ::=  ‘a’ | … | ‘z’ “… and Unicode category Ll”
+letter           ::=  upper | lower “… and Unicode categories Lo, Lt, Lm, Nl”
+digit            ::=  ‘0’ | … | ‘9’
+paren            ::=  ‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’ | ‘'(’ | ‘'[’ | ‘'{’
+delim            ::=  ‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’
 opchar           ::=  ‘!’ | ‘#’ | ‘%’ | ‘&’ | ‘*’ | ‘+’ | ‘-’ | ‘/’ | ‘:’ |
                       ‘<’ | ‘=’ | ‘>’ | ‘?’ | ‘@’ | ‘\’ | ‘^’ | ‘|’ | ‘~’
-                      “… and Unicode categories Sm, So” ;
-printableChar    ::=  “all characters in [\u0020, \u007E] inclusive” ;
-charEscapeSeq    ::=  ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘"’ | ‘'’ | ‘\’) ;
+                      “… and Unicode categories Sm, So”
+printableChar    ::=  “all characters in [\u0020, \u007E] inclusive”
+charEscapeSeq    ::=  ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘"’ | ‘'’ | ‘\’)
 
-op               ::=  opchar {opchar} ;
-varid            ::=  lower idrest ;
+op               ::=  opchar {opchar}
+varid            ::=  lower idrest
 alphaid          ::=  upper idrest
-                   |  varid ;
+                   |  varid
 plainid          ::=  alphaid
-                   |  op ;
+                   |  op
 id               ::=  plainid
-                   |  ‘`’ { charNoBackQuoteOrNewline | UnicodeEscape | charEscapeSeq } ‘`’ ;
-idrest           ::=  {letter | digit} [‘_’ op] ;
-quoteId          ::=  ‘'’ alphaid ;
+                   |  ‘`’ { charNoBackQuoteOrNewline | UnicodeEscape | charEscapeSeq } ‘`’
+idrest           ::=  {letter | digit} [‘_’ op]
+quoteId          ::=  ‘'’ alphaid
 
-integerLiteral   ::=  (decimalNumeral | hexNumeral) [‘L’ | ‘l’] ;
-decimalNumeral   ::=  ‘0’ | nonZeroDigit {digit} ;
-hexNumeral       ::=  ‘0’ (‘x’ | ‘X’) hexDigit {hexDigit} ;
-digit            ::=  ‘0’ | nonZeroDigit ;
-nonZeroDigit     ::=  ‘1’ | … | ‘9’ ;
+integerLiteral   ::=  (decimalNumeral | hexNumeral) [‘L’ | ‘l’]
+decimalNumeral   ::=  ‘0’ | nonZeroDigit {digit}
+hexNumeral       ::=  ‘0’ (‘x’ | ‘X’) hexDigit {hexDigit}
+digit            ::=  ‘0’ | nonZeroDigit
+nonZeroDigit     ::=  ‘1’ | … | ‘9’
 
 floatingPointLiteral
                  ::=  digit {digit} ‘.’ {digit} [exponentPart] [floatType]
                    |  ‘.’ digit {digit} [exponentPart] [floatType]
                    |  digit {digit} exponentPart [floatType]
-                   |  digit {digit} [exponentPart] floatType ;
-exponentPart     ::=  (‘E’ | ‘e’) [‘+’ | ‘-’] digit {digit} ;
-floatType        ::=  ‘F’ | ‘f’ | ‘D’ | ‘d’ ;
+                   |  digit {digit} [exponentPart] floatType
+exponentPart     ::=  (‘E’ | ‘e’) [‘+’ | ‘-’] digit {digit}
+floatType        ::=  ‘F’ | ‘f’ | ‘D’ | ‘d’
 
-booleanLiteral   ::=  ‘true’ | ‘false’ ;
+booleanLiteral   ::=  ‘true’ | ‘false’
 
-characterLiteral ::=  ‘'’ (printableChar | charEscapeSeq) ‘'’ ;
+characterLiteral ::=  ‘'’ (printableChar | charEscapeSeq) ‘'’
 
 stringLiteral    ::=  ‘"’ {stringElement} ‘"’
-                   |  ‘"""’ multiLineChars ‘"""’ ;
+                   |  ‘"""’ multiLineChars ‘"""’
 stringElement    ::=  printableChar \ (‘"’ | ‘\’)
                    |  UnicodeEscape
-                   |  charEscapeSeq ;
-multiLineChars   ::=  {[‘"’] [‘"’] char \ ‘"’} {‘"’} ;
+                   |  charEscapeSeq
+multiLineChars   ::=  {[‘"’] [‘"’] char \ ‘"’} {‘"’}
 processedStringLiteral
                  ::=  alphaid ‘"’ {[‘\’] processedStringPart | ‘\\’ | ‘\"’} ‘"’
-                   |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘$’) | escape} {‘"’} ‘"""’ ;
+                   |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘$’) | escape} {‘"’} ‘"""’
 processedStringPart
-                 ::= printableChar \ (‘"’ | ‘$’ | ‘\’) | escape ;
+                 ::= printableChar \ (‘"’ | ‘$’ | ‘\’) | escape
 escape           ::=  ‘$$’
                    |  ‘$’ letter { letter | digit }
-                   |  ‘{’ Block  [‘;’ whiteSpace stringFormat whiteSpace] ‘}’ ;
-stringFormat     ::=  {printableChar \ (‘"’ | ‘}’ | ‘ ’ | ‘\t’ | ‘\n’)} ;
+                   |  ‘{’ Block  [‘;’ whiteSpace stringFormat whiteSpace] ‘}’
+stringFormat     ::=  {printableChar \ (‘"’ | ‘}’ | ‘ ’ | ‘\t’ | ‘\n’)}
 
 comment          ::=  ‘/*’ “any sequence of characters; nested comments are allowed” ‘*/’
-                   |  ‘//’ “any sequence of characters up to end of line” ;
+                   |  ‘//’ “any sequence of characters up to end of line”
 
-nl               ::=  “new line character” ;
-semi             ::=  ‘;’ |  nl {nl} ;
+nl               ::=  “new line character”
+semi             ::=  ‘;’ |  nl {nl}
 ```
 
 ## Keywords
@@ -117,20 +117,20 @@ SimpleLiteral     ::=  [‘-’] integerLiteral
                     |  [‘-’] floatingPointLiteral
                     |  booleanLiteral
                     |  characterLiteral
-                    |  stringLiteral ;
+                    |  stringLiteral
 Literal           ::=  SimpleLiteral
                     |  processedStringLiteral
-                    |  ‘null’ ;
+                    |  ‘null’
 
-QualId            ::=  id {‘.’ id} ;
-ids               ::=  id {‘,’ id} ;
+QualId            ::=  id {‘.’ id}
+ids               ::=  id {‘,’ id}
 
 Path              ::=  StableId
-                    |  [id ‘.’] ‘this’ ;
+                    |  [id ‘.’] ‘this’
 StableId          ::=  id
                     |  Path ‘.’ id
-                    |  [id ‘.’] ‘super’ [ClassQualifier] ‘.’ id ;
-ClassQualifier    ::=  ‘[’ id ‘]’ ;
+                    |  [id ‘.’] ‘super’ [ClassQualifier] ‘.’ id
+ClassQualifier    ::=  ‘[’ id ‘]’
 ```
 
 ### Types
@@ -138,15 +138,15 @@ ClassQualifier    ::=  ‘[’ id ‘]’ ;
 Type              ::=  { ‘erased’ | ‘given’} FunArgTypes ‘=>’ Type
                     |  HkTypeParamClause ‘=>’ Type
                     |  MatchType
-                    |  InfixType ;
+                    |  InfixType
 FunArgTypes       ::=  InfixType
                     |  ‘(’ [ FunArgType {‘,’ FunArgType } ] ‘)’
-                    |  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’ ;
-TypedFunParam     ::=  id ‘:’ Type ;
-MatchType         ::=  InfixType `match` TypeCaseClauses ;
-InfixType         ::=  RefinedType {id [nl] RefinedType} ;
-RefinedType       ::=  AnnotType {[nl] Refinement} ;
-AnnotType         ::=  SimpleType {Annotation} ;
+                    |  ‘(’ TypedFunParam {‘,’ TypedFunParam } ‘)’
+TypedFunParam     ::=  id ‘:’ Type
+MatchType         ::=  InfixType `match` TypeCaseClauses
+InfixType         ::=  RefinedType {id [nl] RefinedType}
+RefinedType       ::=  AnnotType {[nl] Refinement}
+AnnotType         ::=  SimpleType {Annotation}
 SimpleType        ::=  SimpleType TypeArgs
                     |  SimpleType ‘#’ id
                     |  StableId
@@ -155,25 +155,25 @@ SimpleType        ::=  SimpleType TypeArgs
                     |  ‘_’ SubtypeBounds
                     |  Refinement
                     |  SimpleLiteral
-                    |  ‘$’ ‘{’ Block ‘}’ ;
-ArgTypes          ::=  Type {‘,’ Type} ;
+                    |  ‘$’ ‘{’ Block ‘}’
+ArgTypes          ::=  Type {‘,’ Type}
 FunArgType        ::=  Type
-                    |  ‘=>’ Type ;
-ParamType         ::=  [‘=>’] ParamValueType ;
-ParamValueType    ::=  Type [‘*’] ;
-TypeArgs          ::=  ‘[’ ArgTypes ‘]’ ;
-Refinement        ::=  ‘{’ [RefineDcl] {semi [RefineDcl]} ‘}’ ;
-SubtypeBounds     ::=  [‘>:’ Type] [‘<:’ Type] ;
-TypeParamBounds   ::=  SubtypeBounds {‘:’ Type} ;
+                    |  ‘=>’ Type
+ParamType         ::=  [‘=>’] ParamValueType
+ParamValueType    ::=  Type [‘*’]
+TypeArgs          ::=  ‘[’ ArgTypes ‘]’
+Refinement        ::=  ‘{’ [RefineDcl] {semi [RefineDcl]} ‘}’
+SubtypeBounds     ::=  [‘>:’ Type] [‘<:’ Type]
+TypeParamBounds   ::=  SubtypeBounds {‘:’ Type}
 ```
 
 ### Expressions
 ```ebnf
 Expr              ::=  [‘given’] [‘erased’] FunParams ‘=>’ Expr
-                    |  Expr1 ;
+                    |  Expr1
 FunParams         ::=  Bindings
                     |  id
-                    |  ‘_’ ;
+                    |  ‘_’
 Expr1             ::=  ‘if’ Expr ‘then’ Expr [[semi] ‘else’ Expr]
                     |  ‘while’ Expr ‘do’ Expr
                     |  ‘try’ Expr ‘catch’ Expr [‘finally’ Expr]
@@ -185,19 +185,19 @@ Expr1             ::=  ‘if’ Expr ‘then’ Expr [[semi] ‘else’ Expr]
                     |  SimpleExpr1 ArgumentExprs ‘=’ Expr
                     |  InfixExpr [Ascription]
                     |  [‘inline’] InfixExpr ‘match’ ‘{’ CaseClauses ‘}’
-                    |  ‘implied’ ‘match’ ‘{’ ImpliedCaseClauses ‘}’ ;
+                    |  ‘implied’ ‘match’ ‘{’ ImpliedCaseClauses ‘}’
 Ascription        ::=  ‘:’ InfixType
-                    |  ‘:’ Annotation {Annotation} ;
+                    |  ‘:’ Annotation {Annotation}
 InfixExpr         ::=  PrefixExpr
                     |  InfixExpr id [nl] InfixExpr
-                    |  InfixExpr ‘given’ (InfixExpr | ParArgumentExprs) ;
-PrefixExpr        ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr ;
+                    |  InfixExpr ‘given’ (InfixExpr | ParArgumentExprs)
+PrefixExpr        ::=  [‘-’ | ‘+’ | ‘~’ | ‘!’] SimpleExpr
 SimpleExpr        ::=  ‘new’ (ConstrApp [TemplateBody] | TemplateBody)
                     |  BlockExpr
                     |  ‘$’ ‘{’ Block ‘}’
                     |  Quoted
                     |  quoteId     // only inside splices
-                    |  SimpleExpr1 ;
+                    |  SimpleExpr1
 SimpleExpr1       ::=  Literal
                     |  Path
                     |  ‘_’
@@ -205,122 +205,122 @@ SimpleExpr1       ::=  Literal
                     |  SimpleExpr ‘.’ id
                     |  SimpleExpr TypeArgs
                     |  SimpleExpr1 ArgumentExprs
-                    |  XmlExpr ;
+                    |  XmlExpr
 Quoted            ::=  ‘'’ ‘{’ Block ‘}’
-                    |  ‘'’ ‘[’ Type ‘]’ ;
-ExprsInParens     ::=  ExprInParens {‘,’ ExprInParens} ;
+                    |  ‘'’ ‘[’ Type ‘]’
+ExprsInParens     ::=  ExprInParens {‘,’ ExprInParens}
 ExprInParens      ::=  InfixExpr ‘:’ Type
-                    |  Expr ;
+                    |  Expr
 ParArgumentExprs  ::=  ‘(’ ExprsInParens ‘)’
-                    |  ‘(’ [ExprsInParens ‘,’] InfixExpr ‘:’ ‘_’ ‘*’ ‘)’ ;
+                    |  ‘(’ [ExprsInParens ‘,’] InfixExpr ‘:’ ‘_’ ‘*’ ‘)’
 ArgumentExprs     ::=  ParArgumentExprs
-                    |  [nl] BlockExpr ;
-BlockExpr         ::=  ‘{’ CaseClauses | Block ‘}’ ;
-Block             ::=  {BlockStat semi} [Expr] ;
+                    |  [nl] BlockExpr
+BlockExpr         ::=  ‘{’ CaseClauses | Block ‘}’
+Block             ::=  {BlockStat semi} [Expr]
 BlockStat         ::=  Import
                     |  {Annotation [nl]} {LocalModifier} Def
-                    |  Expr1 ;
+                    |  Expr1
 
-Enumerators       ::=  Generator {semi Enumerator | Guard} ;
+Enumerators       ::=  Generator {semi Enumerator | Guard}
 Enumerator        ::=  Generator
                     |  Guard
-                    |  Pattern1 ‘=’ Expr ;
-Generator         ::=  Pattern1 ‘<-’ Expr ;
-Guard             ::=  ‘if’ PostfixExpr ;
+                    |  Pattern1 ‘=’ Expr
+Generator         ::=  Pattern1 ‘<-’ Expr
+Guard             ::=  ‘if’ PostfixExpr
 
-CaseClauses       ::=  CaseClause { CaseClause } ;
-CaseClause        ::=  ‘case’ Pattern [Guard] ‘=>’ Block ;
-ImpliedCaseClauses::=  ImpliedCaseClause { ImpliedCaseClause } ;
-ImpliedCaseClause ::=  ‘case’ PatVar [‘:’ RefinedType] [Guard] ‘=>’ Block ;
-TypeCaseClauses   ::=  TypeCaseClause { TypeCaseClause } ;
-TypeCaseClause    ::=  ‘case’ InfixType ‘=>’ Type [nl] ;
+CaseClauses       ::=  CaseClause { CaseClause }
+CaseClause        ::=  ‘case’ Pattern [Guard] ‘=>’ Block
+ImpliedCaseClauses::=  ImpliedCaseClause { ImpliedCaseClause }
+ImpliedCaseClause ::=  ‘case’ PatVar [‘:’ RefinedType] [Guard] ‘=>’ Block
+TypeCaseClauses   ::=  TypeCaseClause { TypeCaseClause }
+TypeCaseClause    ::=  ‘case’ InfixType ‘=>’ Type [nl]
 
-Pattern           ::=  Pattern1 { ‘|’ Pattern1 } ;
+Pattern           ::=  Pattern1 { ‘|’ Pattern1 }
 Pattern1          ::=  PatVar ‘:’ RefinedType
-                    |  Pattern2 ;
-Pattern2          ::=  [id ‘@’] InfixPattern ;
-InfixPattern      ::=  SimplePattern { id [nl] SimplePattern } ;
+                    |  Pattern2
+Pattern2          ::=  [id ‘@’] InfixPattern
+InfixPattern      ::=  SimplePattern { id [nl] SimplePattern }
 SimplePattern     ::=  PatVar
                     |  Literal
                     |  ‘(’ [Patterns] ‘)’
                     |  Quoted
                     |  XmlPattern
-                    |  SimplePattern1 [TypeArgs] [ArgumentPatterns] ;
+                    |  SimplePattern1 [TypeArgs] [ArgumentPatterns]
 SimplePattern1    ::=  Path
-                    |  SimplePattern1 ‘.’ id ;
+                    |  SimplePattern1 ‘.’ id
 PatVar            ::=  varid
-                    |  ‘_’ ;
-Patterns          ::=  Pattern {‘,’ Pattern} ;
+                    |  ‘_’
+Patterns          ::=  Pattern {‘,’ Pattern}
 ArgumentPatterns  ::=  ‘(’ [Patterns] ‘)’
-                    |  ‘(’ [Patterns ‘,’] Pattern2 ‘:’ ‘_’ ‘*’ ‘)’ ;
+                    |  ‘(’ [Patterns ‘,’] Pattern2 ‘:’ ‘_’ ‘*’ ‘)’
 ```
 
 ### Type and Value Parameters
 ```ebnf
-ClsTypeParamClause::=  ‘[’ ClsTypeParam {‘,’ ClsTypeParam} ‘]’ ;
-ClsTypeParam      ::=  {Annotation} [‘+’ | ‘-’] id [HkTypeParamClause] TypeParamBounds ;
+ClsTypeParamClause::=  ‘[’ ClsTypeParam {‘,’ ClsTypeParam} ‘]’
+ClsTypeParam      ::=  {Annotation} [‘+’ | ‘-’] id [HkTypeParamClause] TypeParamBounds
 
-DefTypeParamClause::=  ‘[’ DefTypeParam {‘,’ DefTypeParam} ‘]’ ;
-DefTypeParam      ::=  {Annotation} id [HkTypeParamClause] TypeParamBounds ;
+DefTypeParamClause::=  ‘[’ DefTypeParam {‘,’ DefTypeParam} ‘]’
+DefTypeParam      ::=  {Annotation} id [HkTypeParamClause] TypeParamBounds
 
-TypTypeParamClause::=  ‘[’ TypTypeParam {‘,’ TypTypeParam} ‘]’ ;
-TypTypeParam      ::=  {Annotation} id [HkTypeParamClause] SubtypeBounds ;
+TypTypeParamClause::=  ‘[’ TypTypeParam {‘,’ TypTypeParam} ‘]’
+TypTypeParam      ::=  {Annotation} id [HkTypeParamClause] SubtypeBounds
 
-HkTypeParamClause ::=  ‘[’ HkTypeParam {‘,’ HkTypeParam} ‘]’ ;
-HkTypeParam       ::=  {Annotation} [‘+’ | ‘-’] (Id[HkTypeParamClause] | ‘_’) SubtypeBounds ;
+HkTypeParamClause ::=  ‘[’ HkTypeParam {‘,’ HkTypeParam} ‘]’
+HkTypeParam       ::=  {Annotation} [‘+’ | ‘-’] (Id[HkTypeParamClause] | ‘_’) SubtypeBounds
 
 ClsParamClause    ::=  [nl] [‘erased’] ‘(’ [ClsParams] ‘)’
-                    |  ‘given’ [‘erased’] (‘(’ ClsParams ‘)’ | GivenTypes) ;
-ClsParams         ::=  ClsParam {‘,’ ClsParam} ;
-ClsParam          ::=  {Annotation} [{Modifier} (‘val’ | ‘var’) | ‘inline’] Param ;
-Param             ::=  id ‘:’ ParamType [‘=’ Expr] ;
+                    |  ‘given’ [‘erased’] (‘(’ ClsParams ‘)’ | GivenTypes)
+ClsParams         ::=  ClsParam {‘,’ ClsParam}
+ClsParam          ::=  {Annotation} [{Modifier} (‘val’ | ‘var’) | ‘inline’] Param
+Param             ::=  id ‘:’ ParamType [‘=’ Expr]
 
-DefParamClause    ::=  [nl] [‘erased’] ‘(’ [DefParams] ‘)’ | GivenParamClause ;
-GivenParamClause  ::=  ‘given’ [‘erased’] (‘(’ DefParams ‘)’ | GivenTypes) ;
-DefParams         ::=  DefParam {‘,’ DefParam} ;
-DefParam          ::=  {Annotation} [‘inline’] Param ;
-GivenTypes        ::=  AnnotType {‘,’ AnnotType} ;
+DefParamClause    ::=  [nl] [‘erased’] ‘(’ [DefParams] ‘)’ | GivenParamClause
+GivenParamClause  ::=  ‘given’ [‘erased’] (‘(’ DefParams ‘)’ | GivenTypes)
+DefParams         ::=  DefParam {‘,’ DefParam}
+DefParam          ::=  {Annotation} [‘inline’] Param
+GivenTypes        ::=  AnnotType {‘,’ AnnotType}
 ```
 
 ### Bindings, Imports, and Exports
 ```ebnf
-Bindings          ::=  ‘(’ Binding {‘,’ Binding} ‘)’ ;
-Binding           ::=  (id | ‘_’) [‘:’ Type] ;
+Bindings          ::=  ‘(’ Binding {‘,’ Binding} ‘)’
+Binding           ::=  (id | ‘_’) [‘:’ Type]
 
 Modifier          ::=  LocalModifier
                     |  AccessModifier
-                    |  ‘override’ ;
+                    |  ‘override’
 LocalModifier     ::=  ‘abstract’
                     |  ‘final’
                     |  ‘sealed’
                     |  ‘lazy’
                     |  ‘opaque’
                     |  ‘inline’
-                    |  ‘erased’ ;
-AccessModifier    ::=  (‘private’ | ‘protected’) [AccessQualifier] ;
-AccessQualifier   ::=  ‘[’ (id | ‘this’) ‘]’ ;
+                    |  ‘erased’
+AccessModifier    ::=  (‘private’ | ‘protected’) [AccessQualifier]
+AccessQualifier   ::=  ‘[’ (id | ‘this’) ‘]’
 
-Annotation        ::=  ‘@’ SimpleType {ParArgumentExprs} ;
+Annotation        ::=  ‘@’ SimpleType {ParArgumentExprs}
 
-Import            ::=  ‘import’ [‘implied’] ImportExpr {‘,’ ImportExpr} ;
-ImportExpr        ::=  StableId ‘.’ (id | ‘_’ | ImportSelectors) ;
-ImportSelectors   ::=  ‘{’ {ImportSelector ‘,’} (ImportSelector | ‘_’) ‘}’ ;
-ImportSelector    ::=  id [‘=>’ id | ‘=>’ ‘_’] ;
-Export            ::=  ‘export’ [‘implied’] ImportExpr {‘,’ ImportExpr} ;
+Import            ::=  ‘import’ [‘implied’] ImportExpr {‘,’ ImportExpr}
+ImportExpr        ::=  StableId ‘.’ (id | ‘_’ | ImportSelectors)
+ImportSelectors   ::=  ‘{’ {ImportSelector ‘,’} (ImportSelector | ‘_’) ‘}’
+ImportSelector    ::=  id [‘=>’ id | ‘=>’ ‘_’]
+Export            ::=  ‘export’ [‘implied’] ImportExpr {‘,’ ImportExpr}
 ```
 
 ### Declarations and Definitions
 ```ebnf
 RefineDcl         ::=  ‘val’ ValDcl
                     |  ‘def’ DefDcl
-                    |  ‘type’ {nl} TypeDcl ;
+                    |  ‘type’ {nl} TypeDcl
 Dcl               ::=  RefineDcl
-                    |  ‘var’ ValDcl ;
-ValDcl            ::=  ids ‘:’ Type ;
-DefDcl            ::=  DefSig [‘:’ Type] ;
-DefSig            ::=  ‘(’ DefParam ‘)’ [nl] id [DefTypeParamClause] {DefParamClause} ;
+                    |  ‘var’ ValDcl
+ValDcl            ::=  ids ‘:’ Type
+DefDcl            ::=  DefSig [‘:’ Type]
+DefSig            ::=  ‘(’ DefParam ‘)’ [nl] id [DefTypeParamClause] {DefParamClause}
 TypeDcl           ::=  id [TypeParamClause] (SubtypeBounds | ‘=’ Type)
-                    |  id [TypeParamClause] <: Type = MatchType ;
+                    |  id [TypeParamClause] <: Type = MatchType
 
 Def               ::=  ‘val’ PatDef
                     |  ‘var’ VarDef
@@ -329,52 +329,52 @@ Def               ::=  ‘val’ PatDef
                     |  ([‘case’] ‘class’ | ‘trait’) ClassDef
                     |  [‘case’] ‘object’ ObjectDef
                     |  ‘enum’ EnumDef
-                    |  ‘implied’ InstanceDef ;
+                    |  ‘implied’ InstanceDef
 
-PatDef            ::=  Pattern2 {‘,’ Pattern2} [‘:’ Type] ‘=’ Expr ;
+PatDef            ::=  Pattern2 {‘,’ Pattern2} [‘:’ Type] ‘=’ Expr
 VarDef            ::=  PatDef
-                    |  ids ‘:’ Type ‘=’ ‘_’ ;
+                    |  ids ‘:’ Type ‘=’ ‘_’
 DefDef            ::=  DefSig [(‘:’ | ‘<:’) Type] ‘=’ Expr
-                    |  ‘this’ DefParamClause {DefParamClause} ‘=’ ConstrExpr ;
-ClassDef          ::=  id ClassConstr [Template]= ;
-ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] {ClsParamClause} ;
-ConstrMods        ::=  {Annotation} [AccessModifier] ;
-ObjectDef         ::=  id [Template] ;
-EnumDef           ::=  id ClassConstr InheritClauses EnumBody ;
-InstanceDef       ::=  [id] InstanceParams InstanceBody ;
-InstanceParams    ::=  [DefTypeParamClause] {GivenParamClause} ;
+                    |  ‘this’ DefParamClause {DefParamClause} ‘=’ ConstrExpr
+ClassDef          ::=  id ClassConstr [Template]=
+ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] {ClsParamClause}
+ConstrMods        ::=  {Annotation} [AccessModifier]
+ObjectDef         ::=  id [Template]
+EnumDef           ::=  id ClassConstr InheritClauses EnumBody
+InstanceDef       ::=  [id] InstanceParams InstanceBody
+InstanceParams    ::=  [DefTypeParamClause] {GivenParamClause}
 InstanceBody      ::=  [‘for’ ConstrApp {‘,’ ConstrApp }] [TemplateBody]
-                    |  ‘for’ Type ‘=’ Expr ;
-Template          ::=  InheritClauses [TemplateBody] ;
-InheritClauses    ::=  [‘extends’ ConstrApps] [‘derives’ QualId {‘,’ QualId}] ;
-ConstrApps        ::=  ConstrApp {‘,’ ConstrApp} ;
-ConstrApp         ::=  AnnotType {ArgumentExprs} ;
+                    |  ‘for’ Type ‘=’ Expr
+Template          ::=  InheritClauses [TemplateBody]
+InheritClauses    ::=  [‘extends’ ConstrApps] [‘derives’ QualId {‘,’ QualId}]
+ConstrApps        ::=  ConstrApp {‘,’ ConstrApp}
+ConstrApp         ::=  AnnotType {ArgumentExprs}
 ConstrExpr        ::=  SelfInvocation
-                    |  {’ SelfInvocation {semi BlockStat} ‘}’ ;
-SelfInvocation    ::=  ‘this’ ArgumentExprs {ArgumentExprs} ;
+                    |  {’ SelfInvocation {semi BlockStat} ‘}’
+SelfInvocation    ::=  ‘this’ ArgumentExprs {ArgumentExprs}
 
-TemplateBody      ::=  [nl] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’ ;
+TemplateBody      ::=  [nl] ‘{’ [SelfType] TemplateStat {semi TemplateStat} ‘}’
 TemplateStat      ::=  Import
                     |  Export
                     |  {Annotation [nl]} {Modifier} Def
                     |  {Annotation [nl]} {Modifier} Dcl
                     |  Expr1
-                    | ;
+                    |
 SelfType          ::=  id [‘:’ InfixType] ‘=>’
-                    |  ‘this’ ‘:’ InfixType ‘=>’ ;
+                    |  ‘this’ ‘:’ InfixType ‘=>’
 
-EnumBody          ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’ ;
+EnumBody          ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
 EnumStat          ::=  TemplateStat
-                    |  {Annotation [nl]} {Modifier} EnumCase ;
-EnumCase          ::=  ‘case’ (id ClassConstr [‘extends’ ConstrApps]] | ids) ;
+                    |  {Annotation [nl]} {Modifier} EnumCase
+EnumCase          ::=  ‘case’ (id ClassConstr [‘extends’ ConstrApps]] | ids)
 
-TopStatSeq        ::=  TopStat {semi TopStat} ;
+TopStatSeq        ::=  TopStat {semi TopStat}
 TopStat           ::=  Import
                     |  Export
                     |  {Annotation [nl]} {Modifier} Def
                     |  Packaging
-                    | ;
-Packaging         ::=  ‘package’ QualId [nl] ‘{’ TopStatSeq ‘}’ ;
+                    |
+Packaging         ::=  ‘package’ QualId [nl] ‘{’ TopStatSeq ‘}’
 
-CompilationUnit   ::=  {‘package’ QualId semi} TopStatSeq ;
+CompilationUnit   ::=  {‘package’ QualId semi} TopStatSeq
 ```

--- a/docs/_docs/reference/experimental/explicit-nulls.md
+++ b/docs/_docs/reference/experimental/explicit-nulls.md
@@ -86,7 +86,7 @@ val c = new C()
 ```
 
 The unsoundness above can be caught by the compiler with the option `-Ysafe-init`.
-More details can be found in [safe initialization](./safe-initialization.md).
+More details can be found in [safe initialization](../other-new-features/safe-initialization.md).
 
 ## Equality
 

--- a/docs/_docs/reference/experimental/fewer-braces.md
+++ b/docs/_docs/reference/experimental/fewer-braces.md
@@ -1,7 +1,7 @@
 ---
 layout: doc-page
 title: "Fewer Braces"
-movedTo: https://docs.scala-lang.org/scala3/reference/other-new-features/indentation-experimental.html
+movedTo: https://docs.scala-lang.org/scala3/reference/experimental/fewer-braces.html
 ---
 
 By and large, the possible indentation regions coincide with those regions where braces `{...}` are also legal, no matter whether the braces enclose an expression or a set of definitions. There is one exception, though: Arguments to function can be enclosed in braces but they cannot be simply indented instead. Making indentation always significant for function arguments would be too restrictive and fragile.

--- a/docs/_docs/release-notes-0.1.2.md
+++ b/docs/_docs/release-notes-0.1.2.md
@@ -77,11 +77,11 @@ This release ships with the following features:
 
 [1]: https://docs.google.com/document/d/1h3KUMxsSSjyze05VecJGQ5H2yh7fNADtIf3chD3_wr0/edit
 [2]: https://infoscience.epfl.ch/record/222780?ln=en
-[3]: ../reference/new-types/intersection-types.html
-[4]: ../reference/new-types/union-types.html
-[5]: ../reference/enums/adts.html
-[6]: ../reference/enums/desugarEnums.html
-[7]: ../reference/contextual/by-name-context-parameters.html
+[3]: reference/new-types/intersection-types.html
+[4]: reference/new-types/union-types.html
+[5]: reference/enums/adts.html
+[6]: reference/enums/desugarEnums.html
+[7]: reference/contextual/by-name-context-parameters.html
 [8]: https://infoscience.epfl.ch/record/228518
 [9]: http://docs.scala-lang.org/sips/pending/static-members.html
 [10]: http://docs.scala-lang.org/sips/pending/improved-lazy-val-initialization.html
@@ -89,7 +89,7 @@ This release ships with the following features:
 [12]: https://github.com/lampepfl/dotty/commit/b2215ed23311b2c99ea638f9d7fcad9737dba588
 [13]: https://github.com/lampepfl/dotty/pull/187
 [14]: https://github.com/lampepfl/dotty/pull/217
-[15]: ../reference/other-new-features/trait-parameters.html
+[15]: reference/other-new-features/trait-parameters.html
 [16]: https://github.com/lampepfl/dotty/commit/89540268e6c49fb92b9ca61249e46bb59981bf5a
 [17]: https://github.com/lampepfl/dotty/pull/174
 [18]: https://github.com/lampepfl/dotty/pull/488
@@ -104,10 +104,10 @@ This release ships with the following features:
 [27]: https://github.com/lampepfl/dotty/pull/2513
 [28]: https://github.com/lampepfl/dotty/pull/2361
 [29]: https://github.com/lampepfl/dotty/pull/1453
-[30]: ../reference/contextual/context-functions.html
+[30]: reference/contextual/context-functions.html
 [31]: https://github.com/lampepfl/dotty/pull/2136
 [32]: https://github.com/lampepfl/dotty/pull/1758
-[33]: ../reference/metaprogramming/inline.html
+[33]: reference/metaprogramming/inline.html
 
 # Contributors
 The Dotty team and contributors have closed 750 issues and have merged a total of 1258 pull requests.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -208,7 +208,6 @@ subsection:
       - page: internals/explicit-nulls.md
       - page: internals/periods.md
       - page: internals/syntax.md
-      - page: internals/syntax-3.1.md
       - page: internals/type-system.md
       - page: internals/dotty-internals-1-notes.md
       - page: internals/debug-macros.md

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -25,13 +25,17 @@ subsection:
         subsection:
           - page: reference/new-types/intersection-types.md
           - page: reference/new-types/intersection-types-spec.md
+            hidden: true
           - page: reference/new-types/union-types.md
           - page: reference/new-types/union-types-spec.md
+            hidden: true
           - page: reference/new-types/type-lambdas.md
           - page: reference/new-types/type-lambdas-spec.md
+            hidden: true
           - page: reference/new-types/match-types.md
           - page: reference/new-types/dependent-function-types.md
           - page: reference/new-types/dependent-function-types-spec.md
+            hidden: true
           - page: reference/new-types/polymorphic-function-types.md
       - title: Enums
         index: reference/enums/enums-index.md
@@ -55,6 +59,7 @@ subsection:
           - page: reference/contextual/multiversal-equality.md
           - page: reference/contextual/context-functions.md
           - page: reference/contextual/context-functions-spec.md
+            hidden: true
           - page: reference/contextual/conversions.md
           - page: reference/contextual/by-name-context-parameters.md
           - page: reference/contextual/relationship-implicits.md
@@ -65,6 +70,7 @@ subsection:
           - page: reference/metaprogramming/compiletime-ops.md
           - page: reference/metaprogramming/macros.md
           - page: reference/metaprogramming/macros-spec.md
+            hidden: true
           - page: reference/metaprogramming/staging.md
           - page: reference/metaprogramming/reflection.md
           - page: reference/metaprogramming/tasty-inspect.md
@@ -80,6 +86,7 @@ subsection:
           - page: reference/other-new-features/open-classes.md
           - page: reference/other-new-features/parameter-untupling.md
           - page: reference/other-new-features/parameter-untupling-spec.md
+            hidden: true
           - page: reference/other-new-features/kind-polymorphism.md
           - page: reference/other-new-features/matchable.md
           - page: reference/other-new-features/threadUnsafe-annotation.md
@@ -96,6 +103,7 @@ subsection:
           - page: reference/changed-features/numeric-literals.md
           - page: reference/changed-features/structural-types.md
           - page: reference/changed-features/structural-types-spec.md
+            hidden: true
           - page: reference/changed-features/operators.md
           - page: reference/changed-features/wildcards.md
           - page: reference/changed-features/imports.md
@@ -104,6 +112,7 @@ subsection:
           - page: reference/changed-features/implicit-resolution.md
           - page: reference/changed-features/implicit-conversions.md
           - page: reference/changed-features/implicit-conversions-spec.md
+            hidden: true
           - page: reference/changed-features/overload-resolution.md
           - page: reference/changed-features/match-syntax.md
           - page: reference/changed-features/vararg-splices.md
@@ -111,6 +120,7 @@ subsection:
           - page: reference/changed-features/pattern-matching.md
           - page: reference/changed-features/eta-expansion.md
           - page: reference/changed-features/eta-expansion-spec.md
+            hidden: true
           - page: reference/changed-features/compiler-plugins.md
           - page: reference/changed-features/lazy-vals-init.md
           - page: reference/changed-features/main-functions.md
@@ -127,12 +137,14 @@ subsection:
           - page: reference/dropped-features/early-initializers.md
           - page: reference/dropped-features/class-shadowing.md
           - page: reference/dropped-features/class-shadowing-spec.md
+            hidden: true
           - page: reference/dropped-features/limit22.md
           - page: reference/dropped-features/xml.md
           - page: reference/dropped-features/symlits.md
           - page: reference/dropped-features/auto-apply.md
           - page: reference/dropped-features/weak-conformance.md
           - page: reference/dropped-features/weak-conformance-spec.md
+            hidden: true
           - page: reference/dropped-features/nonlocal-returns.md
           - page: reference/dropped-features/this-qualifier.md
           - page: reference/dropped-features/wildcard-init.md
@@ -143,8 +155,10 @@ subsection:
           - page: reference/experimental/canthrow.md
           - page: reference/experimental/erased-defs.md
           - page: reference/experimental/erased-defs-spec.md
+            hidden: true
           - page: reference/experimental/named-typeargs.md
           - page: reference/experimental/named-typeargs-spec.md
+            hidden: true
           - page: reference/experimental/numeric-literals.md
           - page: reference/experimental/explicit-nulls.md
           - page: reference/experimental/main-annotation.md

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -74,6 +74,7 @@ subsection:
           - page: reference/metaprogramming/staging.md
           - page: reference/metaprogramming/reflection.md
           - page: reference/metaprogramming/tasty-inspect.md
+          - page: reference/metaprogramming/simple-smp.md
       - title: Other New Features
         index: reference/other-new-features/other-new-features.md
         subsection:
@@ -93,6 +94,7 @@ subsection:
           - page: reference/other-new-features/targetName.md
           - page: reference/other-new-features/control-syntax.md
           - page: reference/other-new-features/indentation.md
+          - page: reference/other-new-features/indentation-experimental.md
           - page: reference/other-new-features/safe-initialization.md
           - page: reference/other-new-features/type-test.md
           - page: reference/other-new-features/experimental-defs.md
@@ -124,6 +126,7 @@ subsection:
           - page: reference/changed-features/compiler-plugins.md
           - page: reference/changed-features/lazy-vals-init.md
           - page: reference/changed-features/main-functions.md
+          - page: reference/changed-features/interpolation-escapes.md
       - title: Dropped Features
         index: reference/dropped-features/dropped-features.md
         subsection:
@@ -202,8 +205,10 @@ subsection:
       - page: internals/dotc-scalac.md
       - page: internals/higher-kinded-v2.md
       - page: internals/overall-structure.md
+      - page: internals/explicit-nulls.md
       - page: internals/periods.md
       - page: internals/syntax.md
+      - page: internals/syntax-3.1.md
       - page: internals/type-system.md
       - page: internals/dotty-internals-1-notes.md
       - page: internals/debug-macros.md

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -94,7 +94,6 @@ subsection:
           - page: reference/other-new-features/targetName.md
           - page: reference/other-new-features/control-syntax.md
           - page: reference/other-new-features/indentation.md
-          - page: reference/other-new-features/indentation-experimental.md
           - page: reference/other-new-features/safe-initialization.md
           - page: reference/other-new-features/type-test.md
           - page: reference/other-new-features/experimental-defs.md
@@ -155,6 +154,7 @@ subsection:
         directory: experimental
         index: reference/experimental/overview.md
         subsection:
+          - page: reference/experimental/fewer-braces.md
           - page: reference/experimental/canthrow.md
           - page: reference/experimental/erased-defs.md
           - page: reference/experimental/erased-defs-spec.md

--- a/project/resources/referenceReplacements/sidebar.yml
+++ b/project/resources/referenceReplacements/sidebar.yml
@@ -5,13 +5,17 @@ subsection:
     subsection:
       - page: reference/new-types/intersection-types.md
       - page: reference/new-types/intersection-types-spec.md
+        hidden: true
       - page: reference/new-types/union-types.md
       - page: reference/new-types/union-types-spec.md
+        hidden: true
       - page: reference/new-types/type-lambdas.md
       - page: reference/new-types/type-lambdas-spec.md
+        hidden: true
       - page: reference/new-types/match-types.md
       - page: reference/new-types/dependent-function-types.md
       - page: reference/new-types/dependent-function-types-spec.md
+        hidden: true
       - page: reference/new-types/polymorphic-function-types.md
   - title: Enums
     index: reference/enums/enums-index.md
@@ -35,6 +39,7 @@ subsection:
       - page: reference/contextual/multiversal-equality.md
       - page: reference/contextual/context-functions.md
       - page: reference/contextual/context-functions-spec.md
+        hidden: true
       - page: reference/contextual/conversions.md
       - page: reference/contextual/by-name-context-parameters.md
       - page: reference/contextual/relationship-implicits.md
@@ -45,9 +50,11 @@ subsection:
       - page: reference/metaprogramming/compiletime-ops.md
       - page: reference/metaprogramming/macros.md
       - page: reference/metaprogramming/macros-spec.md
+        hidden: true
       - page: reference/metaprogramming/staging.md
       - page: reference/metaprogramming/reflection.md
       - page: reference/metaprogramming/tasty-inspect.md
+      - page: reference/metaprogramming/simple-smp.md
   - title: Other New Features
     index: reference/other-new-features/other-new-features.md
     subsection:
@@ -60,6 +67,7 @@ subsection:
       - page: reference/other-new-features/open-classes.md
       - page: reference/other-new-features/parameter-untupling.md
       - page: reference/other-new-features/parameter-untupling-spec.md
+        hidden: true
       - page: reference/other-new-features/kind-polymorphism.md
       - page: reference/other-new-features/matchable.md
       - page: reference/other-new-features/threadUnsafe-annotation.md
@@ -76,6 +84,7 @@ subsection:
       - page: reference/changed-features/numeric-literals.md
       - page: reference/changed-features/structural-types.md
       - page: reference/changed-features/structural-types-spec.md
+        hidden: true
       - page: reference/changed-features/operators.md
       - page: reference/changed-features/wildcards.md
       - page: reference/changed-features/imports.md
@@ -84,6 +93,7 @@ subsection:
       - page: reference/changed-features/implicit-resolution.md
       - page: reference/changed-features/implicit-conversions.md
       - page: reference/changed-features/implicit-conversions-spec.md
+        hidden: true
       - page: reference/changed-features/overload-resolution.md
       - page: reference/changed-features/match-syntax.md
       - page: reference/changed-features/vararg-splices.md
@@ -91,9 +101,11 @@ subsection:
       - page: reference/changed-features/pattern-matching.md
       - page: reference/changed-features/eta-expansion.md
       - page: reference/changed-features/eta-expansion-spec.md
+        hidden: true
       - page: reference/changed-features/compiler-plugins.md
       - page: reference/changed-features/lazy-vals-init.md
       - page: reference/changed-features/main-functions.md
+      - page: reference/changed-features/interpolation-escapes.md
   - title: Dropped Features
     index: reference/dropped-features/dropped-features.md
     subsection:
@@ -107,12 +119,14 @@ subsection:
       - page: reference/dropped-features/early-initializers.md
       - page: reference/dropped-features/class-shadowing.md
       - page: reference/dropped-features/class-shadowing-spec.md
+        hidden: true
       - page: reference/dropped-features/limit22.md
       - page: reference/dropped-features/xml.md
       - page: reference/dropped-features/symlits.md
       - page: reference/dropped-features/auto-apply.md
       - page: reference/dropped-features/weak-conformance.md
       - page: reference/dropped-features/weak-conformance-spec.md
+        hidden: true
       - page: reference/dropped-features/nonlocal-returns.md
       - page: reference/dropped-features/this-qualifier.md
       - page: reference/dropped-features/wildcard-init.md
@@ -120,15 +134,19 @@ subsection:
     directory: experimental
     index: reference/experimental/overview.md
     subsection:
+      - page: reference/experimental/fewer-braces.md
       - page: reference/experimental/canthrow.md
       - page: reference/experimental/erased-defs.md
       - page: reference/experimental/erased-defs-spec.md
+        hidden: true
       - page: reference/experimental/named-typeargs.md
       - page: reference/experimental/named-typeargs-spec.md
+        hidden: true
       - page: reference/experimental/numeric-literals.md
       - page: reference/experimental/explicit-nulls.md
       - page: reference/experimental/main-annotation.md
       - page: reference/experimental/cc.md
+      - page: reference/experimental/tupled-function.md
   - page: reference/syntax.md
   - title: Language Versions
     index: reference/language-versions/language-versions.md

--- a/project/scripts/expected-links/reference-expected-links.txt
+++ b/project/scripts/expected-links/reference-expected-links.txt
@@ -7,6 +7,7 @@
 ./changed-features/implicit-resolution.html
 ./changed-features/imports.html
 ./changed-features/index.html
+./changed-features/interpolation-escapes.html
 ./changed-features/lazy-vals-init.html
 ./changed-features/main-functions.html
 ./changed-features/match-syntax.html
@@ -70,12 +71,14 @@
 ./experimental/erased-defs-spec.html
 ./experimental/erased-defs.html
 ./experimental/explicit-nulls.html
+./experimental/fewer-braces.html
 ./experimental/index.html
 ./experimental/main-annotation.html
 ./experimental/named-typeargs-spec.html
 ./experimental/named-typeargs.html
 ./experimental/numeric-literals.html
 ./experimental/overview.html
+./experimental/tupled-function.html
 ./features-classification.html
 ./index.html
 ./language-versions/binary-compatibility.html
@@ -88,6 +91,7 @@
 ./metaprogramming/macros-spec.html
 ./metaprogramming/macros.html
 ./metaprogramming/reflection.html
+./metaprogramming/simple-smp.html
 ./metaprogramming/staging.html
 ./metaprogramming/tasty-inspect.html
 ./new-types/dependent-function-types-spec.html


### PR DESCRIPTION
This pull request addresses change requests mentioned in: #15099

List of changes:
 - Restored documents that were present in docs directory but weren't rendered in documentation
 - Reverted semicolons at the end of lines in syntax-3.1.md
 - Fixed broken links
 - Hide "More details" pages from sidebar

The best option to review this PR is to go commit-by-commit since one commit addresses one issue from the list above.

I'm going to paste there a link to documentation as soon as the CI uploads it.

EDIT: I'll change the target branch to stable docs - it will be then backported to main after merge