### PR TITLE
Try `either` when compare an intersection against an applied type in GADT mode

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1198,6 +1198,14 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
             case _ => false
         } && { GADTused = true; true }
 
+      def tryGadtAnd1: Boolean =
+        ctx.mode.is(Mode.GadtConstraintInference) && {
+          tp1 match
+            case AndType(tp11, tp12) =>
+              either(recur(tp11, tp2), recur(tp12, tp2))
+            case _ => false
+        }
+
       tycon2 match {
         case param2: TypeParamRef =>
           isMatchingApply(tp1) ||
@@ -1213,6 +1221,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
               case info2: ClassInfo =>
                 tycon2.name.startsWith("Tuple") &&
                   defn.isTupleNType(tp2) && recur(tp1, tp2.toNestedPairs) ||
+                tryGadtAnd1 ||
                 tryBaseType(info2.cls)
               case _ =>
                 fourthTry

--- a/tests/neg/i11545.scala
+++ b/tests/neg/i11545.scala
@@ -1,0 +1,21 @@
+// Taken from
+// https://github.com/lampepfl/dotty/issues/11545#issuecomment-787609144
+class test0 {
+  type AA
+  trait S[A]
+  trait Inv[A]
+
+  class P[X] extends S[Inv[X] & AA]
+
+}
+
+@main def test: Unit =
+  new test0:
+    type AA = Inv[String]
+
+    def patmat[A, Y](s: S[Inv[A] & Y]): A = s match {
+      case p: P[x] =>
+        "Hello"  // error
+    }
+
+    val got: Int = patmat[Int, AA](new P)


### PR DESCRIPTION
This PR fixes #11545 by trying `either` before approximating LHS with `tryBaseType` when comparing an intersection type against an applied type in GADT inference mode.

The unsoundness of #11545 comes from the following steps taken by `TypeComparer`:
```
// the following comparison happens when typing the pattern matching
==> isSubType Inv[A] & Y <:< Inv[String]?
  ==> isSubType Inv[A] <:< Inv[String] (left is approximated)?
    ==> isSubType String <:< A?  // approx is reset here
```
In the above trace, when comparing an intersection type `Inv[A] & Y` against `Inv[String]`, the type comparer approximate LHS to `Inv[A]` directly and compare `Inv[A] <:< Inv[String]`. Since the approximation state gets reset when comparing the arguments of applied types, this comparison results in unsound GADT constraints.

In this PR, when comparing `S ∧ T <:< F[A]`, instead of trying to approximate LHS type to the base type `F`, we will try both `S <:< F[A]` and `T <:< F[A]` and merge GADT constraints from the two branches. This fixes the unsoundness brought by approximating the intersection (and forgetting the approximation afterwards as shown in the trace) by trying to inference GADT constraints in a more precise way.