### PR TITLE
Special case inline unapply seq

### DIFF
--- a/tests/pos-macros/i8577a/Macro_1.scala
+++ b/tests/pos-macros/i8577a/Macro_1.scala
@@ -1,0 +1,11 @@
+package i8577
+
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+def implUnapply(sc: Expr[Macro.StrCtx], input: Expr[Int])(using Quotes): Expr[Option[Seq[Int]]] =
+  '{ Some(Seq(${input})) }

--- a/tests/pos-macros/i8577a/Main_2.scala
+++ b/tests/pos-macros/i8577a/Main_2.scala
@@ -1,0 +1,9 @@
+package i8577
+
+def main: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension (inline ctx: Macro.StrCtx) inline def unapplySeq(inline input: Int): Option[Seq[Int]] =
+    ${ implUnapply('ctx, 'input) }
+
+  val mac"$x" = 1
+  assert(x == 1)

--- a/tests/pos-macros/i8577b/Macro_1.scala
+++ b/tests/pos-macros/i8577b/Macro_1.scala
@@ -1,0 +1,11 @@
+package i8577
+
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+def implUnapply[U](sc: Expr[Macro.StrCtx], input: Expr[U])(using Type[U])(using Quotes): Expr[Option[Seq[U]]] =
+  '{ Some(Seq(${input})) }

--- a/tests/pos-macros/i8577b/Main_2.scala
+++ b/tests/pos-macros/i8577b/Main_2.scala
@@ -1,0 +1,9 @@
+package i8577
+
+def main: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: U): Option[Seq[U]] =
+    ${ implUnapply('ctx, 'input) }
+
+  val mac"$x" = 1
+  assert(x == 1)

--- a/tests/pos-macros/i8577c/Macro_1.scala
+++ b/tests/pos-macros/i8577c/Macro_1.scala
@@ -1,0 +1,11 @@
+package i8577
+
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+def implUnapply[T](sc: Expr[Macro.StrCtx], input: Expr[T])(using Type[T])(using Quotes): Expr[Option[Seq[T]]] =
+  '{ Some(Seq(${input})) }

--- a/tests/pos-macros/i8577c/Main_2.scala
+++ b/tests/pos-macros/i8577c/Main_2.scala
@@ -1,0 +1,9 @@
+package i8577
+
+def main: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq(inline input: T): Option[Seq[T]] =
+    ${ implUnapply('ctx, 'input) }
+
+  val mac"$x" = 1
+  assert(x == 1)

--- a/tests/pos-macros/i8577d/Macro_1.scala
+++ b/tests/pos-macros/i8577d/Macro_1.scala
@@ -1,0 +1,11 @@
+package i8577
+
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+def implUnapply[T](sc: Expr[Macro.StrCtx], input: Expr[T])(using Type[T])(using Quotes): Expr[Option[Seq[T]]] =
+  '{ Some(Seq(${input})) }

--- a/tests/pos-macros/i8577d/Main_2.scala
+++ b/tests/pos-macros/i8577d/Main_2.scala
@@ -1,0 +1,9 @@
+package i8577
+
+def main: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: T): Option[Seq[T]] =
+    ${ implUnapply('ctx, 'input) }
+
+  val mac"$x" = 1
+  assert(x == 1)

--- a/tests/pos-macros/i8577e/Macro_1.scala
+++ b/tests/pos-macros/i8577e/Macro_1.scala
@@ -1,0 +1,11 @@
+package i8577
+
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+def implUnapply[T, U](sc: Expr[Macro.StrCtx], input: Expr[U])(using Type[U])(using Quotes): Expr[Option[Seq[U]]] =
+  '{ Some(Seq(${input})) }

--- a/tests/pos-macros/i8577e/Main_2.scala
+++ b/tests/pos-macros/i8577e/Main_2.scala
@@ -1,0 +1,9 @@
+package i8577
+
+def main: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: U): Option[Seq[U]] =
+    ${ implUnapply('ctx, 'input) }
+
+  val mac"$x" = 1
+  assert(x == 1)

--- a/tests/pos-macros/i8577f/Macro_1.scala
+++ b/tests/pos-macros/i8577f/Macro_1.scala
@@ -1,0 +1,11 @@
+package i8577
+
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+def implUnapply[T, U](sc: Expr[Macro.StrCtx], input: Expr[(T, U)])(using Type[T], Type[U])(using Quotes): Expr[Option[Seq[(T, U)]]] =
+  '{ Some(Seq(${input})) }

--- a/tests/pos-macros/i8577f/Main_2.scala
+++ b/tests/pos-macros/i8577f/Main_2.scala
@@ -1,0 +1,12 @@
+package i8577
+
+def main: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: (T, U)): Option[Seq[(T, U)]] =
+    ${ implUnapply('ctx, 'input) }
+
+  val mac"$x" = (1, 2)
+  assert(x == (1, 2))
+
+  val mac"$y" = (1, "a")
+  assert(y == (1, "a"))

--- a/tests/pos-macros/i8577g/Macro_1.scala
+++ b/tests/pos-macros/i8577g/Macro_1.scala
@@ -1,0 +1,11 @@
+package i8577
+
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+def implUnapply[T, U](sc: Expr[Macro.StrCtx], input: Expr[T | U])(using Type[T], Type[U])(using Quotes): Expr[Option[Seq[T | U]]] =
+  '{ Some(Seq(${input})) }

--- a/tests/pos-macros/i8577g/Main_2.scala
+++ b/tests/pos-macros/i8577g/Main_2.scala
@@ -1,0 +1,9 @@
+package i8577
+
+def main: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: T | U): Option[Seq[T | U]] =
+    ${ implUnapply('ctx, 'input) }
+
+  val mac"$x" = 1
+  assert(x == 1)

--- a/tests/pos-macros/i8577h/Macro_1.scala
+++ b/tests/pos-macros/i8577h/Macro_1.scala
@@ -1,0 +1,11 @@
+package i8577
+
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+def implUnapply[T, U](sc: Expr[Macro.StrCtx], input: Expr[T | U])(using Type[T], Type[U])(using Quotes): Expr[Option[Seq[T | U]]] =
+  '{ Some(Seq(${input})) }

--- a/tests/pos-macros/i8577h/Main_2.scala
+++ b/tests/pos-macros/i8577h/Main_2.scala
@@ -1,0 +1,9 @@
+package i8577
+
+def main: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: U | T): Option[Seq[T | U]] =
+    ${ implUnapply('ctx, 'input) }
+
+  val mac"$x" = 1
+  assert(x == 1)

--- a/tests/run/i8577a.scala
+++ b/tests/run/i8577a.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+extension (inline ctx: Macro.StrCtx) inline def unapplySeq(inline input: Int): Option[Seq[Int]] =
+  Some(Seq(input))
+
+@main def Test: Unit =
+  val mac"$x" = 1
+  val y: Int = x
+  assert(x == 1)

--- a/tests/run/i8577b.scala
+++ b/tests/run/i8577b.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+extension (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: U): Option[Seq[U]] =
+  Some(Seq(input))
+
+@main def Test: Unit =
+  val mac"$x" = 1
+  val y: Int = x
+  assert(x == 1)

--- a/tests/run/i8577c.scala
+++ b/tests/run/i8577c.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq(inline input: T): Option[Seq[T]] =
+  Some(Seq(input))
+
+@main def Test: Unit =
+  val mac"$x" = 1
+  val y: Int = x
+  assert(x == 1)

--- a/tests/run/i8577d.scala
+++ b/tests/run/i8577d.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: T): Option[Seq[T]] =
+  Some(Seq(input))
+
+@main def Test: Unit =
+  val mac"$x" = 1
+  val y: Int = x
+  assert(x == 1)

--- a/tests/run/i8577e.scala
+++ b/tests/run/i8577e.scala
@@ -1,0 +1,19 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: (T, U)): Option[Seq[(T, U)]] =
+  Some(Seq(input))
+
+@main def Test: Unit =
+  val mac"$x" = (1, 2)
+  val x2: (Int, Int) = x
+  assert(x == (1, 2))
+
+  val mac"$y" = (1, "a")
+  val y2: (Int, String) = y
+  assert(y == (1, "a"))

--- a/tests/run/i8577f.scala
+++ b/tests/run/i8577f.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+@main def Test: Unit =
+  extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+  extension (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: U): Option[Seq[U]] =
+    Some(Seq(input))
+
+  val mac"$x" = 1
+  val y: Int = x
+  assert(x == 1)

--- a/tests/run/i8577g.scala
+++ b/tests/run/i8577g.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: T | U): Option[Seq[T | U]] =
+  Some(Seq(input))
+
+@main def Test: Unit =
+  val mac"$x" = 1
+  val y: Int = x
+  assert(x == 1)

--- a/tests/run/i8577h.scala
+++ b/tests/run/i8577h.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+extension [T] (inline ctx: Macro.StrCtx) inline def unapplySeq[U](inline input: U | T): Option[Seq[T | U]] =
+  Some(Seq(input))
+
+@main def Test: Unit =
+  val mac"$x" = 1
+  val y: Int = x
+  assert(x == 1)

--- a/tests/run/i8577i.scala
+++ b/tests/run/i8577i.scala
@@ -1,0 +1,16 @@
+import scala.quoted._
+
+object Macro:
+  opaque type StrCtx = StringContext
+  def apply(ctx: StringContext): StrCtx = ctx
+  def unapply(ctx: StrCtx): Option[StringContext] = Some(ctx)
+
+extension (ctx: StringContext) def mac: Macro.StrCtx = Macro(ctx)
+extension (inline ctx: Macro.StrCtx) transparent inline def unapplySeq(inline input: String): Option[Seq[Any]] =
+  Some(Seq(123))
+
+@main def Test: Unit =
+  "abc" match
+    case mac"$x" =>
+      val y: Int = x
+      assert(x == 123)


### PR DESCRIPTION
Replacement for lampepfl/dotty#15053

Resolves #8577 

Fixed a bug where extension inline unapplySeq would fail to type by adding a few special cases in Inliner.scala