### PR TITLE
support intersection types in mirrorCompanionRef

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -87,11 +87,6 @@ object TypeUtils {
      *  of this type, while keeping the same prefix.
      */
     def mirrorCompanionRef(using Context): TermRef = self match {
-      case OrType(tp1, tp2) =>
-        val r1 = tp1.mirrorCompanionRef
-        val r2 = tp2.mirrorCompanionRef
-        assert(r1.symbol == r2.symbol, em"mirrorCompanionRef mismatch for $self: $r1, $r2 did not have the same symbol")
-        r1
       case AndType(tp1, tp2) =>
         val c1 = tp1.classSymbol
         val c2 = tp2.classSymbol

--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -92,6 +92,11 @@ object TypeUtils {
         val r2 = tp2.mirrorCompanionRef
         assert(r1.symbol == r2.symbol, em"mirrorCompanionRef mismatch for $self: $r1, $r2 did not have the same symbol")
         r1
+      case AndType(tp1, tp2) =>
+        val c1 = tp1.classSymbol
+        val c2 = tp2.classSymbol
+        if c1.isSubClass(c2) then tp1.mirrorCompanionRef
+        else tp2.mirrorCompanionRef // precondition: the parts of the AndType have already been checked to be non-overlapping
       case self @ TypeRef(prefix, _) if self.symbol.isClass =>
         prefix.select(self.symbol.companionModule).asInstanceOf[TermRef]
       case self: TypeProxy =>

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -290,14 +290,14 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
         case (Singleton(src1, _), Singleton(src2, _)) => src1 eq src2
         case (_: ClassSymbol, _: Singleton) => false
 
-    def debug(using Context): String = this match
+    def show(using Context): String = this match
       case ClassSymbol(cls) => i"$cls"
       case Singleton(src, _) => i"$src"
 
-  object MirrorSource:
+  private[Synthesizer] object MirrorSource:
 
     /** Reduces a mirroredType to either its most specific ClassSymbol,
-     *  or a TermRef to a singleton value, these are
+     *  or a TermRef to a singleton value. These are
      *  the base elements required to generate a mirror.
      */
     def reduce(mirroredType: Type)(using Context): Either[String, MirrorSource] = mirroredType match
@@ -341,7 +341,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
           res <- locally {
             if lsrc.isSub(rsrc) then Right(lsrc)
             else if rsrc.isSub(lsrc) then Right(rsrc)
-            else Left(i"its subpart `$tp` is an intersection of unrelated symbols ${lsrc.debug} and ${rsrc.debug}.")
+            else Left(i"its subpart `$tp` is an intersection of unrelated definitions ${lsrc.show} and ${rsrc.show}.")
           }
         yield
           res

--- a/tests/neg/i15190.scala
+++ b/tests/neg/i15190.scala
@@ -1,0 +1,17 @@
+import scala.deriving.Mirror
+
+trait Mixin
+object Mixin
+
+trait Parent
+object Parent
+
+sealed trait Fruit extends Parent
+object Fruit {
+  case object Apple extends Fruit
+  case object Orange extends Fruit
+}
+
+@main def Test = {
+  summon[Mirror.SumOf[Fruit & Mixin]] // error: not a sum type
+}

--- a/tests/neg/mirror-synthesis-errors-b.check
+++ b/tests/neg/mirror-synthesis-errors-b.check
@@ -1,0 +1,28 @@
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:11:56 --------------------------------------------------------------
+11 |val testA = summon[Mirror.ProductOf[Cns[Int] & Sm[Int]]] // error: unreleated
+   |                                                        ^
+   |No given instance of type deriving.Mirror.ProductOf[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Cns[Int] & Sm[Int]]: type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:12:56 --------------------------------------------------------------
+12 |val testB = summon[Mirror.ProductOf[Sm[Int] & Cns[Int]]] // error: unreleated
+   |                                                        ^
+   |No given instance of type deriving.Mirror.ProductOf[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Sm[Int] & Cns[Int]]: type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:13:49 --------------------------------------------------------------
+13 |val testC = summon[Mirror.Of[Cns[Int] & Sm[Int]]] // error: unreleated
+   |                                                 ^
+   |No given instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]]: 
+   |	* type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
+   |	* type `Cns[Int] & Sm[Int]` is not a generic sum because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:14:49 --------------------------------------------------------------
+14 |val testD = summon[Mirror.Of[Sm[Int] & Cns[Int]]] // error: unreleated
+   |                                                 ^
+   |No given instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]]: 
+   |	* type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
+   |	* type `Sm[Int] & Cns[Int]` is not a generic sum because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:15:55 --------------------------------------------------------------
+15 |val testE = summon[Mirror.ProductOf[Sm[Int] & Nn.type]] // error: unreleated
+   |                                                       ^
+   |No given instance of type deriving.Mirror.ProductOf[Sm[Int] & Nn.type] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Sm[Int] & Nn.type]: type `Sm[Int] & Nn.type` is not a generic product because its subpart `Sm[Int] & Nn.type` is an intersection of unrelated symbols class Sm and object Nn.
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:16:55 --------------------------------------------------------------
+16 |val testF = summon[Mirror.ProductOf[Nn.type & Sm[Int]]] // error: unreleated
+   |                                                       ^
+   |No given instance of type deriving.Mirror.ProductOf[Nn.type & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Nn.type & Sm[Int]]: type `Nn.type & Sm[Int]` is not a generic product because its subpart `Nn.type & Sm[Int]` is an intersection of unrelated symbols object Nn and class Sm.

--- a/tests/neg/mirror-synthesis-errors-b.check
+++ b/tests/neg/mirror-synthesis-errors-b.check
@@ -1,40 +1,40 @@
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:21:56 --------------------------------------------------------------
 21 |val testA = summon[Mirror.ProductOf[Cns[Int] & Sm[Int]]] // error: unreleated
    |                                                        ^
-   |No given instance of type deriving.Mirror.ProductOf[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Cns[Int] & Sm[Int]]: type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
+   |No given instance of type deriving.Mirror.ProductOf[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Cns[Int] & Sm[Int]]: type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated definitions class Cns and class Sm.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:22:56 --------------------------------------------------------------
 22 |val testB = summon[Mirror.ProductOf[Sm[Int] & Cns[Int]]] // error: unreleated
    |                                                        ^
-   |No given instance of type deriving.Mirror.ProductOf[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Sm[Int] & Cns[Int]]: type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
+   |No given instance of type deriving.Mirror.ProductOf[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Sm[Int] & Cns[Int]]: type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated definitions class Sm and class Cns.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:23:49 --------------------------------------------------------------
 23 |val testC = summon[Mirror.Of[Cns[Int] & Sm[Int]]] // error: unreleated
    |                                                 ^
    |No given instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]]: 
-   |	* type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
-   |	* type `Cns[Int] & Sm[Int]` is not a generic sum because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
+   |	* type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated definitions class Cns and class Sm.
+   |	* type `Cns[Int] & Sm[Int]` is not a generic sum because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated definitions class Cns and class Sm.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:24:49 --------------------------------------------------------------
 24 |val testD = summon[Mirror.Of[Sm[Int] & Cns[Int]]] // error: unreleated
    |                                                 ^
    |No given instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]]: 
-   |	* type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
-   |	* type `Sm[Int] & Cns[Int]` is not a generic sum because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
+   |	* type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated definitions class Sm and class Cns.
+   |	* type `Sm[Int] & Cns[Int]` is not a generic sum because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated definitions class Sm and class Cns.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:25:55 --------------------------------------------------------------
 25 |val testE = summon[Mirror.ProductOf[Sm[Int] & Nn.type]] // error: unreleated
    |                                                       ^
-   |No given instance of type deriving.Mirror.ProductOf[Sm[Int] & Nn.type] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Sm[Int] & Nn.type]: type `Sm[Int] & Nn.type` is not a generic product because its subpart `Sm[Int] & Nn.type` is an intersection of unrelated symbols class Sm and object Nn.
+   |No given instance of type deriving.Mirror.ProductOf[Sm[Int] & Nn.type] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Sm[Int] & Nn.type]: type `Sm[Int] & Nn.type` is not a generic product because its subpart `Sm[Int] & Nn.type` is an intersection of unrelated definitions class Sm and object Nn.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:26:55 --------------------------------------------------------------
 26 |val testF = summon[Mirror.ProductOf[Nn.type & Sm[Int]]] // error: unreleated
    |                                                       ^
-   |No given instance of type deriving.Mirror.ProductOf[Nn.type & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Nn.type & Sm[Int]]: type `Nn.type & Sm[Int]` is not a generic product because its subpart `Nn.type & Sm[Int]` is an intersection of unrelated symbols object Nn and class Sm.
+   |No given instance of type deriving.Mirror.ProductOf[Nn.type & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Nn.type & Sm[Int]]: type `Nn.type & Sm[Int]` is not a generic product because its subpart `Nn.type & Sm[Int]` is an intersection of unrelated definitions object Nn and class Sm.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:27:54 --------------------------------------------------------------
 27 |val testG = summon[Mirror.Of[Foo.A.type & Foo.B.type]] // error: unreleated
    |                                                      ^
    |No given instance of type deriving.Mirror.Of[(Foo.A : Foo) & (Foo.B : Foo)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Foo.A : Foo) & (Foo.B : Foo)]: 
-   |	* type `(Foo.A : Foo) & (Foo.B : Foo)` is not a generic product because its subpart `(Foo.A : Foo) & (Foo.B : Foo)` is an intersection of unrelated symbols value A and value B.
-   |	* type `(Foo.A : Foo) & (Foo.B : Foo)` is not a generic sum because its subpart `(Foo.A : Foo) & (Foo.B : Foo)` is an intersection of unrelated symbols value A and value B.
+   |	* type `(Foo.A : Foo) & (Foo.B : Foo)` is not a generic product because its subpart `(Foo.A : Foo) & (Foo.B : Foo)` is an intersection of unrelated definitions value A and value B.
+   |	* type `(Foo.A : Foo) & (Foo.B : Foo)` is not a generic sum because its subpart `(Foo.A : Foo) & (Foo.B : Foo)` is an intersection of unrelated definitions value A and value B.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:28:54 --------------------------------------------------------------
 28 |val testH = summon[Mirror.Of[Foo.B.type & Foo.A.type]] // error: unreleated
    |                                                      ^
    |No given instance of type deriving.Mirror.Of[(Foo.B : Foo) & (Foo.A : Foo)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Foo.B : Foo) & (Foo.A : Foo)]: 
-   |	* type `(Foo.B : Foo) & (Foo.A : Foo)` is not a generic product because its subpart `(Foo.B : Foo) & (Foo.A : Foo)` is an intersection of unrelated symbols value B and value A.
-   |	* type `(Foo.B : Foo) & (Foo.A : Foo)` is not a generic sum because its subpart `(Foo.B : Foo) & (Foo.A : Foo)` is an intersection of unrelated symbols value B and value A.
+   |	* type `(Foo.B : Foo) & (Foo.A : Foo)` is not a generic product because its subpart `(Foo.B : Foo) & (Foo.A : Foo)` is an intersection of unrelated definitions value B and value A.
+   |	* type `(Foo.B : Foo) & (Foo.A : Foo)` is not a generic sum because its subpart `(Foo.B : Foo) & (Foo.A : Foo)` is an intersection of unrelated definitions value B and value A.

--- a/tests/neg/mirror-synthesis-errors-b.check
+++ b/tests/neg/mirror-synthesis-errors-b.check
@@ -1,28 +1,40 @@
--- Error: tests/neg/mirror-synthesis-errors-b.scala:11:56 --------------------------------------------------------------
-11 |val testA = summon[Mirror.ProductOf[Cns[Int] & Sm[Int]]] // error: unreleated
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:21:56 --------------------------------------------------------------
+21 |val testA = summon[Mirror.ProductOf[Cns[Int] & Sm[Int]]] // error: unreleated
    |                                                        ^
    |No given instance of type deriving.Mirror.ProductOf[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Cns[Int] & Sm[Int]]: type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
--- Error: tests/neg/mirror-synthesis-errors-b.scala:12:56 --------------------------------------------------------------
-12 |val testB = summon[Mirror.ProductOf[Sm[Int] & Cns[Int]]] // error: unreleated
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:22:56 --------------------------------------------------------------
+22 |val testB = summon[Mirror.ProductOf[Sm[Int] & Cns[Int]]] // error: unreleated
    |                                                        ^
    |No given instance of type deriving.Mirror.ProductOf[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Sm[Int] & Cns[Int]]: type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
--- Error: tests/neg/mirror-synthesis-errors-b.scala:13:49 --------------------------------------------------------------
-13 |val testC = summon[Mirror.Of[Cns[Int] & Sm[Int]]] // error: unreleated
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:23:49 --------------------------------------------------------------
+23 |val testC = summon[Mirror.Of[Cns[Int] & Sm[Int]]] // error: unreleated
    |                                                 ^
    |No given instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]]: 
    |	* type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
    |	* type `Cns[Int] & Sm[Int]` is not a generic sum because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated symbols class Cns and class Sm.
--- Error: tests/neg/mirror-synthesis-errors-b.scala:14:49 --------------------------------------------------------------
-14 |val testD = summon[Mirror.Of[Sm[Int] & Cns[Int]]] // error: unreleated
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:24:49 --------------------------------------------------------------
+24 |val testD = summon[Mirror.Of[Sm[Int] & Cns[Int]]] // error: unreleated
    |                                                 ^
    |No given instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]]: 
    |	* type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
    |	* type `Sm[Int] & Cns[Int]` is not a generic sum because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated symbols class Sm and class Cns.
--- Error: tests/neg/mirror-synthesis-errors-b.scala:15:55 --------------------------------------------------------------
-15 |val testE = summon[Mirror.ProductOf[Sm[Int] & Nn.type]] // error: unreleated
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:25:55 --------------------------------------------------------------
+25 |val testE = summon[Mirror.ProductOf[Sm[Int] & Nn.type]] // error: unreleated
    |                                                       ^
    |No given instance of type deriving.Mirror.ProductOf[Sm[Int] & Nn.type] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Sm[Int] & Nn.type]: type `Sm[Int] & Nn.type` is not a generic product because its subpart `Sm[Int] & Nn.type` is an intersection of unrelated symbols class Sm and object Nn.
--- Error: tests/neg/mirror-synthesis-errors-b.scala:16:55 --------------------------------------------------------------
-16 |val testF = summon[Mirror.ProductOf[Nn.type & Sm[Int]]] // error: unreleated
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:26:55 --------------------------------------------------------------
+26 |val testF = summon[Mirror.ProductOf[Nn.type & Sm[Int]]] // error: unreleated
    |                                                       ^
    |No given instance of type deriving.Mirror.ProductOf[Nn.type & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.ProductOf[Nn.type & Sm[Int]]: type `Nn.type & Sm[Int]` is not a generic product because its subpart `Nn.type & Sm[Int]` is an intersection of unrelated symbols object Nn and class Sm.
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:27:54 --------------------------------------------------------------
+27 |val testG = summon[Mirror.Of[Foo.A.type & Foo.B.type]] // error: unreleated
+   |                                                      ^
+   |No given instance of type deriving.Mirror.Of[(Foo.A : Foo) & (Foo.B : Foo)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Foo.A : Foo) & (Foo.B : Foo)]: 
+   |	* type `(Foo.A : Foo) & (Foo.B : Foo)` is not a generic product because its subpart `(Foo.A : Foo) & (Foo.B : Foo)` is an intersection of unrelated symbols value A and value B.
+   |	* type `(Foo.A : Foo) & (Foo.B : Foo)` is not a generic sum because its subpart `(Foo.A : Foo) & (Foo.B : Foo)` is an intersection of unrelated symbols value A and value B.
+-- Error: tests/neg/mirror-synthesis-errors-b.scala:28:54 --------------------------------------------------------------
+28 |val testH = summon[Mirror.Of[Foo.B.type & Foo.A.type]] // error: unreleated
+   |                                                      ^
+   |No given instance of type deriving.Mirror.Of[(Foo.B : Foo) & (Foo.A : Foo)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Foo.B : Foo) & (Foo.A : Foo)]: 
+   |	* type `(Foo.B : Foo) & (Foo.A : Foo)` is not a generic product because its subpart `(Foo.B : Foo) & (Foo.A : Foo)` is an intersection of unrelated symbols value B and value A.
+   |	* type `(Foo.B : Foo) & (Foo.A : Foo)` is not a generic sum because its subpart `(Foo.B : Foo) & (Foo.A : Foo)` is an intersection of unrelated symbols value B and value A.

--- a/tests/neg/mirror-synthesis-errors-b.scala
+++ b/tests/neg/mirror-synthesis-errors-b.scala
@@ -1,0 +1,16 @@
+import scala.deriving.Mirror
+
+sealed trait Lst[+A] // AKA: scala.collection.immutable.List
+case class Cns[+A](head: A, tail: Lst[A]) extends Lst[A]
+case object Nl extends Lst[Nothing]
+
+sealed trait Opt[+A] // AKA: scala.Option
+case class Sm[+A](value: A) extends Opt[A]
+case object Nn extends Opt[Nothing]
+
+val testA = summon[Mirror.ProductOf[Cns[Int] & Sm[Int]]] // error: unreleated
+val testB = summon[Mirror.ProductOf[Sm[Int] & Cns[Int]]] // error: unreleated
+val testC = summon[Mirror.Of[Cns[Int] & Sm[Int]]] // error: unreleated
+val testD = summon[Mirror.Of[Sm[Int] & Cns[Int]]] // error: unreleated
+val testE = summon[Mirror.ProductOf[Sm[Int] & Nn.type]] // error: unreleated
+val testF = summon[Mirror.ProductOf[Nn.type & Sm[Int]]] // error: unreleated

--- a/tests/neg/mirror-synthesis-errors-b.scala
+++ b/tests/neg/mirror-synthesis-errors-b.scala
@@ -8,9 +8,25 @@ sealed trait Opt[+A] // AKA: scala.Option
 case class Sm[+A](value: A) extends Opt[A]
 case object Nn extends Opt[Nothing]
 
+enum Foo:
+  case A, B
+
+object Bar:
+  val A: Foo.A.type = Foo.A // alias of Foo.A
+  type A = Foo.A.type // type alias
+
+case object Baz
+type Baz = Baz.type
+
 val testA = summon[Mirror.ProductOf[Cns[Int] & Sm[Int]]] // error: unreleated
 val testB = summon[Mirror.ProductOf[Sm[Int] & Cns[Int]]] // error: unreleated
 val testC = summon[Mirror.Of[Cns[Int] & Sm[Int]]] // error: unreleated
 val testD = summon[Mirror.Of[Sm[Int] & Cns[Int]]] // error: unreleated
 val testE = summon[Mirror.ProductOf[Sm[Int] & Nn.type]] // error: unreleated
 val testF = summon[Mirror.ProductOf[Nn.type & Sm[Int]]] // error: unreleated
+val testG = summon[Mirror.Of[Foo.A.type & Foo.B.type]] // error: unreleated
+val testH = summon[Mirror.Of[Foo.B.type & Foo.A.type]] // error: unreleated
+val testI = summon[Mirror.Of[Foo.A.type & Bar.A.type]] // ok
+val testJ = summon[Mirror.Of[Bar.A.type & Foo.A.type]] // ok
+val testK = summon[Mirror.Of[Foo.A.type & Bar.A.type & Bar.A]] // ok
+val testL = summon[Mirror.Of[Baz & Baz.type]] // ok

--- a/tests/run/i15190.scala
+++ b/tests/run/i15190.scala
@@ -1,0 +1,19 @@
+import scala.deriving.Mirror
+
+trait Mixin
+object Mixin
+
+trait Parent
+object Parent
+
+sealed trait Fruit extends Parent
+object Fruit {
+  case object Apple extends Fruit
+  case object Orange extends Fruit
+}
+
+@main def Test = {
+  val mFruit = summon[Mirror.SumOf[Fruit & Parent]]
+  assert(mFruit.ordinal(Fruit.Apple) == 0)
+  assert(mFruit.ordinal(Fruit.Orange) == 1)
+}

--- a/tests/run/i15234.scala
+++ b/tests/run/i15234.scala
@@ -13,7 +13,6 @@ package app {
   val Bar: lib.Bar.type = lib.Bar
 }
 
-
 @main def Test =
   assert(summon[Mirror.Of[scala.Nil.type]].fromProduct(EmptyTuple) == Nil) // alias scala 2 defined
   assert(summon[Mirror.Of[lib.Foo.A.type]].fromProduct(EmptyTuple) == lib.Foo.A) // real mirror

--- a/tests/run/i15234.scala
+++ b/tests/run/i15234.scala
@@ -13,6 +13,7 @@ package app {
   val Bar: lib.Bar.type = lib.Bar
 }
 
+
 @main def Test =
   assert(summon[Mirror.Of[scala.Nil.type]].fromProduct(EmptyTuple) == Nil) // alias scala 2 defined
   assert(summon[Mirror.Of[lib.Foo.A.type]].fromProduct(EmptyTuple) == lib.Foo.A) // real mirror


### PR DESCRIPTION
Introduces `MirrorSource` - i.e. an abstract representation of what is used to create the mirror. This means only one traversal of types compared to using `whyNotAcceptableType`. It also is extensible, i.e. allowing us to add new kinds of types supporting mirrors, such as generic tuple types.

This also fixes an uncaught bug where we could summon a mirror for `::[Int] & Some[Int]`, which would only fail at runtime

closes https://github.com/lampepfl/dotty/issues/15190