### PR TITLE
Parse unary operators as regular identifiers when backquoted

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2293,10 +2293,10 @@ object Parsers {
         isOperator = !(location.inArgs && followingIsVararg()))
 
     /** PrefixExpr       ::= [PrefixOperator'] SimpleExpr
-     *  PrefixOperator   ::=  ‘-’ | ‘+’ | ‘~’ | ‘!’
+     *  PrefixOperator   ::=  ‘-’ | ‘+’ | ‘~’ | ‘!’ (if not backquoted)
      */
     val prefixExpr: Location => Tree = location =>
-      if isIdent && nme.raw.isUnary(in.name)
+      if in.token == IDENTIFIER && nme.raw.isUnary(in.name)
          && in.canStartExprTokens.contains(in.lookahead.token)
       then
         val start = in.offset

--- a/docs/_docs/internals/syntax.md
+++ b/docs/_docs/internals/syntax.md
@@ -254,7 +254,7 @@ InfixExpr         ::=  PrefixExpr
                     |  InfixExpr MatchClause
 MatchClause       ::=  ‘match’ <<< CaseClauses >>>                              Match(expr, cases)
 PrefixExpr        ::=  [PrefixOperator] SimpleExpr                              PrefixOp(expr, op)
-PrefixOperator    ::=  ‘-’ | ‘+’ | ‘~’ | ‘!’
+PrefixOperator    ::=  ‘-’ | ‘+’ | ‘~’ | ‘!’                                    -- unless backquoted
 SimpleExpr        ::=  SimpleRef
                     |  Literal
                     |  ‘_’

--- a/docs/_docs/reference/syntax.md
+++ b/docs/_docs/reference/syntax.md
@@ -252,7 +252,7 @@ InfixExpr         ::=  PrefixExpr
                     |  InfixExpr MatchClause
 MatchClause       ::=  ‘match’ <<< CaseClauses >>>
 PrefixExpr        ::=  [PrefixOperator] SimpleExpr
-PrefixOperator    ::=  ‘-’ | ‘+’ | ‘~’ | ‘!’
+PrefixOperator    ::=  ‘-’ | ‘+’ | ‘~’ | ‘!’                                    -- unless backquoted
 SimpleExpr        ::=  SimpleRef
                     |  Literal
                     |  ‘_’

--- a/tests/neg/unary-with-type-params.scala
+++ b/tests/neg/unary-with-type-params.scala
@@ -1,0 +1,4 @@
+object Test {
+  def +[T](x: T): String = "x"
+  +[Int](6): String // error: expression expected but '[' found
+}

--- a/tests/pos/unary-with-type-params.scala
+++ b/tests/pos/unary-with-type-params.scala
@@ -1,0 +1,6 @@
+object Test {
+  def +[T](x: T): String = "x"
+  `+`[Int](6): String // Parser can treat + as identifier when backquoted and followed by a type argument
+  `+`(6): String // Parser can treat + as identifier when backquoted and followed by a parenthesized argument
+  +(6): Int // Parser prioritizes + as unary when possible
+}


### PR DESCRIPTION
A sheepish attempt at retrying https://github.com/lampepfl/dotty/pull/14299. In that PR, I suggested allowing unaries like `+` to be interpreted as regular `Apply` nodes when followed by type parameters. @odersky commented that

> What is the reason for the change? I guess we all agree that a + operation as in the test is very bad style. Why encourage it with the change to the parsing rules?

>I find it also concerning that
```scala
+(6)
//and
+[Int](6)
```
> now are parsed differently. This goes counter to the intuition that type arguments are optional.

@som-snytt pointed out that 
> There is an historically very consistent expectation that backticks should do something here.

I strongly agree with that last statement -- it makes sense to me that anything in backticks is "just some identifier" and never receives syntactic privilege. This is already the case for keywords and in pattern matching. I was rather surprised to learn that backquotes don't suppress special unary operator parsing as it is. 

I suspect this PR will not be accepted because it is technically a breaking change, although I suspect it will affect no one, and I would gladly guard it behind a setting it if that's the path to acceptance. I thought I'd try anyways!

(This can be made non-breaking by allowing 

```scala
`+`[Int](6) // parses as apply 
`+`(6) // parses as unary
```

but I suspect that is a non-starter because of the surprise). 