### PR TITLE
Add proper signatureHelp for unapply methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -7,6 +7,7 @@ import core.Constants.Constant
 import core.Contexts._
 import core.Denotations.SingleDenotation
 import core.Flags
+import core.NameOps.isUnapplyName
 import core.Names._
 import core.Types._
 import util.Spans.Span
@@ -159,14 +160,6 @@ object Signatures {
       params :: rest
     }
 
-    /**
-     * This function is a hack which allows Signatures API to remain unchanged
-     *
-     * @return true if denot is "unapply" or "unapplySeq", false otherwise
-     */
-    def isUnapplyDenotation: Boolean =
-      List(core.Names.termName("unapply"), core.Names.termName("unapplySeq")) contains denot.name
-
     def extractParamNamess(resultType: Type): List[List[Name]] =
       if resultType.typeSymbol.flags.is(Flags.CaseClass) && symbol.flags.is(Flags.Synthetic) then
         resultType.typeSymbol.primaryConstructor.paramInfo.paramNamess
@@ -189,7 +182,7 @@ object Signatures {
     }
 
     denot.info.stripPoly match {
-      case tpe if isUnapplyDenotation =>
+      case tpe if denot.name.isUnapplyName =>
         val params = toUnapplyParamss(tpe)
         if params.nonEmpty then
           Some(Signature("", Nil, List(params), None))

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -7,10 +7,10 @@ import core.Constants.Constant
 import core.Contexts._
 import core.Denotations.SingleDenotation
 import core.Flags
+import core.Names._
 import core.Types._
 import util.Spans.Span
 import reporting._
-import core.Names._
 
 
 object Signatures {
@@ -59,7 +59,8 @@ object Signatures {
       case Apply(fun, params) => callInfo(span, params, fun, Signatures.countParams(fun))
     }.getOrElse((0, 0, Nil))
 
-  def callInfo( span: Span,
+  def callInfo(
+    span: Span,
     params: List[tpd.Tree],
     fun: tpd.Tree,
     alreadyAppliedCount : Int

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -149,9 +149,9 @@ object Signatures {
       }
 
     def toUnapplyParamss(method: Type)(using Context): List[Param] = {
-      val resultTpe = method.finalResultType.widenDealias
-      val paramNames = extractParamNamess(resultTpe).flatten
-      val paramTypes = extractParamTypess(resultTpe).flatten
+      val resultType = method.finalResultType.widenDealias
+      val paramNames = extractParamNamess(resultType).flatten
+      val paramTypes = extractParamTypess(resultType).flatten
 
       if paramNames.length == paramTypes.length then
         (paramNames zip paramTypes).map((name, info) => Param(name.show, info.show))
@@ -228,7 +228,7 @@ object Signatures {
       err.msg match
         case msg: AmbiguousOverload  => msg.alternatives
         case msg: NoMatchingOverload => msg.alternatives
-        case _                                => Nil
+        case _                       => Nil
 
     // If the user writes `foo(bar, <cursor>)`, the typer will insert a synthetic
     // `null` parameter: `foo(bar, null)`. This may influence what's the "best"
@@ -245,8 +245,7 @@ object Signatures {
       alt.info.stripPoly match {
         case tpe: MethodType =>
           userParamsTypes.zip(tpe.paramInfos).takeWhile{ case (t0, t1) => t0 <:< t1 }.size
-        case _ =>
-          0
+        case _ => 0
       }
     }
     val bestAlternative =

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -154,6 +154,24 @@ class SignatureHelpTest {
       .signatureHelp(m2, List(signature), Some(0), 1)
   }
 
+  @Test def productTypeClassMatch: Unit = {
+    val signature = S("", Nil, List(List(P("", "String"), P("", "String"))), None)
+
+    code"""class FirstChars[A](s: A) extends Product:
+          |  def _1 = s
+          |  def _2 = s
+          |
+          |object FirstChars:
+          |  def unapply(s: String): FirstChars[String] = new FirstChars(s)
+          |
+          |object Test:
+          |  "Hi!" match
+          |    case FirstChars(ch${m1}, ch${m2}) => ???
+          """
+      .signatureHelp(m1, List(signature), Some(0), 0)
+      .signatureHelp(m2, List(signature), Some(0), 1)
+  }
+
   @Test def nameBasedMatch: Unit = {
     val signature = S("", Nil, List(List(P("", "Int"), P("", "String"))), None)
 
@@ -171,6 +189,22 @@ class SignatureHelpTest {
           """
       .signatureHelp(m1, List(signature), Some(0), 0)
       .signatureHelp(m2, List(signature), Some(0), 1)
+  }
+
+  @Test def getObjectMatch: Unit = {
+    val signature = S("", Nil, List(List(P("", "String"))), None)
+
+    code"""object ProdEmpty:
+          |  def isEmpty = true
+          |  def unapply(s: String): this.type = this
+          |  def get: String = ""
+          |
+          |object Test:
+          |  "" match
+          |    case ProdEmpty(${m1}) => ???
+          |    case _ => ()
+          """
+      .signatureHelp(m1, List(signature), Some(0), 0)
   }
 
   @Test def sequenceMatch: Unit = {
@@ -212,7 +246,7 @@ class SignatureHelpTest {
   }
 
   @Test def productSequenceMatchForCaseClass: Unit = {
-    val signature = S("", Nil, List(List(P("name", "String"), P("children", "Int*"))), None)
+    val signature = S("", Nil, List(List(P("name", "String"), P("children", "Seq[Int]"))), None)
 
     code"""case class Foo(val name: String, val children: Int*)
           |

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -146,15 +146,15 @@ class SignatureHelpTest {
           |      println("Expected *exactly* 7 characters!")
           """
       .signatureHelp(m1, List(signature), Some(0), 0)
-      .signatureHelp(m2, List(signature), Some(0), 1)
-      .signatureHelp(m3, List(signature), Some(0), 2)
-      .signatureHelp(m4, List(signature), Some(0), 6)
+      .signatureHelp(m2, List(signature), Some(0), 0)
+      .signatureHelp(m3, List(signature), Some(0), 0)
+      .signatureHelp(m4, List(signature), Some(0), 0)
   }
 
   @Test def productSequenceMatch: Unit = {
     val signature = S("", Nil, List(List(P("", "String"), P("", "Seq[Int]"))), None)
 
-    code"""class Foo(val name: String, val children: Int *)
+    code"""class Foo(val name: String, val children: Int*)
           |object Foo:
           |  def unapplySeq(f: Foo): Option[(String, Seq[Int])] =
           |    Some((f.name, f.children))
@@ -167,10 +167,26 @@ class SignatureHelpTest {
       .signatureHelp(m2, List(signature), Some(0), 1)
       .signatureHelp(m3, List(signature), Some(0), 0)
       .signatureHelp(m4, List(signature), Some(0), 1)
-      .signatureHelp(m5, List(signature), Some(0), 2)
-      .signatureHelp(m6, List(signature), Some(0), 3)
+      .signatureHelp(m5, List(signature), Some(0), 1)
+      .signatureHelp(m6, List(signature), Some(0), 1)
   }
 
+  @Test def productSequenceMatchForCaseClass: Unit = {
+    val signature = S("", Nil, List(List(P("name", "String"), P("children", "Int*"))), None)
+
+    code"""case class Foo(val name: String, val children: Int*)
+          |
+          |def foo(f: Foo) = f match
+          |  case Foo(na${m1}e, n${m2} : _*) =>
+          |  case Foo(nam${m3}e, ${m4}x, ${m5}y, n${m6}s : _*) =>
+          """
+      .signatureHelp(m1, List(signature), Some(0), 0)
+      .signatureHelp(m2, List(signature), Some(0), 1)
+      .signatureHelp(m3, List(signature), Some(0), 0)
+      .signatureHelp(m4, List(signature), Some(0), 1)
+      .signatureHelp(m5, List(signature), Some(0), 1)
+      .signatureHelp(m6, List(signature), Some(0), 1)
+  }
 
   @Test def unapplyManyType: Unit = {
     val signature = S("", Nil, List(List(P("", "Int"), P("", "String"))), None)
@@ -202,6 +218,15 @@ class SignatureHelpTest {
           |}"""
       .signatureHelp(m1, List(signature), Some(0), 0)
       .signatureHelp(m2, List(signature), Some(0), 1)
+  }
+
+  @Test def noUnapplyForTuple: Unit = {
+    code"""object Main {
+          |  (1, 2) match
+          |    case (x${m1}, ${m2}) =>
+          |}"""
+      .signatureHelp(m1, Nil, Some(0), 0)
+      .signatureHelp(m2, Nil, Some(0), 0)
   }
 
   @Test def unapplyCaseClass: Unit = {

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -38,9 +38,9 @@ class SignatureHelpTest {
           |object O:
           |  "even" match
           |    case s @ Even(${m1}) => println(s"s has an even number of characters")
-          |    case s          => println(s"s has an odd number of characters")
+          |    case s               => println(s"s has an odd number of characters")
           """
-      .signatureHelp(m1, List(), Some(0), 0)
+      .signatureHelp(m1, Nil, Some(0), 0)
 
   }
 

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -40,7 +40,6 @@ class SignatureHelpTest {
           |    case s @ Even(${m1}) => println(s"s has an even number of characters")
           |    case s          => println(s"s has an odd number of characters")
           """
-
       .signatureHelp(m1, List(), Some(0), 0)
 
   }
@@ -59,7 +58,6 @@ class SignatureHelpTest {
           |    case Nat(${m1}) => println(s"n is a natural number")
           |    case _      => ()
           """
-
       .signatureHelp(m1, List(signature), Some(0), 0)
 
   }


### PR DESCRIPTION
SignatureHelp is used in LSP to provide help when applying or unapplying.
The real value is displaying each parameter name, type and documentation to make it easier to understand and use given method.
Currently dotty signatureHelp allowed to easily show unapply signatures but with 2 problems:
- types were not inferred
- returned signature provided too much clutter and wasn't useful.

It was caused by returning signature of unapply method, not its return type.
This implementation makes signatureHelp useful.

Example:

```scala
case class Foo[A, B](a: A, b: B)

val x = Foo(1, "")
x match {
  case Foo(x, @@) => ???
  case _ => ???
}
```

Previously:
```scala
unapply[A,B](x$0: Foo[A,B]): Foo[A, B]
```

After changes:
```scala
(a: Int, b: String)
```

Provided tests checks all supported syntax for unapply available in Scala3. They were created according to https://docs.scala-lang.org/scala3/reference/changed-features/pattern-matching.html

Returned value contains parameter names only when result is a case class, only then we are certain that unapply patterns match its apply method ( there is also check if unapply is synthetic to check for possible overrides ).

SIgnature help for unapply doesn't show values for tuples as they act as clutter.

There are possible peformance optimizations to be made in places where i left comments in this PR, but I can't find better way to do it without changing existing API.

Fixes https://github.com/lampepfl/dotty/issues/15126