### PR TITLE
Fix `SourceFile.column` method.

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -75,9 +75,6 @@ class SourceFile(val file: AbstractFile, computeContent: => Array[Char]) extends
 
   def maybeIncomplete: Boolean = _maybeInComplete
 
-  /** Tab increment; can be overridden */
-  def tabInc: Int = 8
-
   override def name: String = file.name
   override def path: String = file.path
   override def jfile: Optional[JFile] = Optional.ofNullable(file.file)
@@ -197,12 +194,7 @@ class SourceFile(val file: AbstractFile, computeContent: => Array[Char]) extends
   /** The column corresponding to `offset`, starting at 0 */
   def column(offset: Int): Int = {
     var idx = startOfLine(offset)
-    var col = 0
-    while (idx != offset) {
-      col += (if (idx < content().length && content()(idx) == '\t') (tabInc - col) % tabInc else 1)
-      idx += 1
-    }
-    col
+    offset - idx
   }
 
   /** The padding of the column corresponding to `offset`, includes tabs */

--- a/tests/neg/doubleDefinition.check
+++ b/tests/neg/doubleDefinition.check
@@ -1,4 +1,4 @@
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:14:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:14:5 ----------------------------------------------------------
 14 |	def foo(x: List[B]): Function1[B, B] = ??? // error: same jvm signature
    |	    ^
    |	    Double definition:
@@ -8,38 +8,38 @@
    |
    |	    Consider adding a @targetName annotation to one of the conflicting definitions
    |	    for disambiguation.
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:21:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:21:5 ----------------------------------------------------------
 21 |	def foo(x: List[A]): Function2[B, B, B] = ??? // error
    |	    ^
    |	    Double definition:
    |	    def foo(x: List[A]): A => A in class Test3 at line 20 and
    |	    def foo(x: List[A]): (B, B) => B in class Test3 at line 21
    |	    have matching parameter types.
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:26:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:26:5 ----------------------------------------------------------
 26 |	def foo = 2 // error
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test4 at line 25 and
    |	    def foo: Int in class Test4 at line 26
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:31:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:31:5 ----------------------------------------------------------
 31 |	val foo = 1 // error
    |	    ^
    |	    Double definition:
    |	    def foo: Int in class Test4b at line 30 and
    |	    val foo: Int in class Test4b at line 31
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:36:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:36:5 ----------------------------------------------------------
 36 |	var foo = 1 // error
    |	    ^
    |	    Double definition:
    |	    def foo: Int in class Test4c at line 35 and
    |	    var foo: Int in class Test4c at line 36
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:41:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:41:5 ----------------------------------------------------------
 41 |	def foo = 2 // error
    |	    ^
    |	    Double definition:
    |	    var foo: Int in class Test4d at line 40 and
    |	    def foo: Int in class Test4d at line 41
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:55:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:55:5 ----------------------------------------------------------
 55 |	def foo(x: List[B]): Function1[B, B] = ??? // error: same jvm signature
    |	    ^
    |	    Double definition:
@@ -49,80 +49,80 @@
    |
    |	    Consider adding a @targetName annotation to one of the conflicting definitions
    |	    for disambiguation.
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:62:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:62:5 ----------------------------------------------------------
 62 |	def foo(x: List[A]): Function2[B, B, B] = ??? // error
    |	    ^
    |	    Double definition:
    |	    def foo(x: List[A]): A => A in trait Test7 at line 61 and
    |	    def foo(x: List[A]): (B, B) => B in trait Test7 at line 62
    |	    have matching parameter types.
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:67:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:67:5 ----------------------------------------------------------
 67 |	def foo = 2 // error
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test8 at line 66 and
    |	    def foo: Int in class Test8 at line 67
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:72:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:72:5 ----------------------------------------------------------
 72 |	val foo = 1 // error
    |	    ^
    |	    Double definition:
    |	    def foo: Int in class Test8b at line 71 and
    |	    val foo: Int in class Test8b at line 72
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:77:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:77:5 ----------------------------------------------------------
 77 |	var foo = 1 // error
    |	    ^
    |	    Double definition:
    |	    def foo: Int in class Test8c at line 76 and
    |	    var foo: Int in class Test8c at line 77
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:82:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:82:5 ----------------------------------------------------------
 82 |	def foo = 2 // error
    |	    ^
    |	    Double definition:
    |	    var foo: Int in class Test8d at line 81 and
    |	    def foo: Int in class Test8d at line 82
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:88:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:88:5 ----------------------------------------------------------
 88 |	def foo: String // error
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test9 at line 87 and
    |	    def foo: String in class Test9 at line 88
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:92:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:92:5 ----------------------------------------------------------
 92 |	def foo: Int // error
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test10 at line 91 and
    |	    def foo: Int in class Test10 at line 92
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:96:4 ----------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:96:5 ----------------------------------------------------------
 96 |	def foo: String // error
    |	    ^
    |	    Double definition:
    |	    val foo: Int in class Test11 at line 95 and
    |	    def foo: String in class Test11 at line 96
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:100:4 ---------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:100:5 ---------------------------------------------------------
 100 |	def foo: Int // error
     |	    ^
     |	    Double definition:
     |	    val foo: Int in class Test12 at line 99 and
     |	    def foo: Int in class Test12 at line 100
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:104:4 ---------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:104:5 ---------------------------------------------------------
 104 |	def foo: String // error
     |	    ^
     |	    Double definition:
     |	    var foo: Int in class Test13 at line 103 and
     |	    def foo: String in class Test13 at line 104
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:108:4 ---------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:108:5 ---------------------------------------------------------
 108 |	def foo: Int // error
     |	    ^
     |	    Double definition:
     |	    var foo: Int in class Test14 at line 107 and
     |	    def foo: Int in class Test14 at line 108
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:112:4 ---------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:112:5 ---------------------------------------------------------
 112 |	def foo: String // error
     |	    ^
     |	    Double definition:
     |	    var foo: Int in class Test15 at line 111 and
     |	    def foo: String in class Test15 at line 112
--- [E120] Naming Error: tests/neg/doubleDefinition.scala:116:4 ---------------------------------------------------------
+-- [E120] Naming Error: tests/neg/doubleDefinition.scala:116:5 ---------------------------------------------------------
 116 |	def foo: Int // error
     |	    ^
     |	    Double definition:

--- a/tests/neg/spaces-vs-tabs.check
+++ b/tests/neg/spaces-vs-tabs.check
@@ -4,13 +4,13 @@
   |    Incompatible combinations of tabs and spaces in indentation prefixes.
   |    Previous indent : 2 tabs
   |    Latest indent   : 4 spaces
--- Error: tests/neg/spaces-vs-tabs.scala:6:8 ---------------------------------------------------------------------------
+-- Error: tests/neg/spaces-vs-tabs.scala:6:3 ---------------------------------------------------------------------------
 6 |  	println(3)   // error
   |  	^
   |  	Incompatible combinations of tabs and spaces in indentation prefixes.
   |  	Previous indent : 2 tabs
   |  	Latest indent   : 2 spaces, 1 tab
--- Error: tests/neg/spaces-vs-tabs.scala:7:2 ---------------------------------------------------------------------------
+-- Error: tests/neg/spaces-vs-tabs.scala:7:3 ---------------------------------------------------------------------------
 7 |	  println(4)   // error
   |	  ^
   |	  Incompatible combinations of tabs and spaces in indentation prefixes.
@@ -22,13 +22,13 @@
   | Incompatible combinations of tabs and spaces in indentation prefixes.
   | Previous indent : 2 tabs
   | Latest indent   : 1 space
--- Error: tests/neg/spaces-vs-tabs.scala:14:2 --------------------------------------------------------------------------
+-- Error: tests/neg/spaces-vs-tabs.scala:14:3 --------------------------------------------------------------------------
 14 |	  else 2 // error
    |	  ^
    |	  The start of this line does not match any of the previous indentation widths.
    |	  Indentation width of current line : 1 tab, 2 spaces
    |	  This falls between previous widths: 1 tab and 1 tab, 4 spaces
--- [E129] Potential Issue Warning: tests/neg/spaces-vs-tabs.scala:13:6 -------------------------------------------------
+-- [E129] Potential Issue Warning: tests/neg/spaces-vs-tabs.scala:13:7 -------------------------------------------------
 13 |	      1
    |	      ^
    |	      A pure expression does nothing in statement position; you may be omitting necessary parentheses

--- a/tests/semanticdb/expect/Tabs.expect.scala
+++ b/tests/semanticdb/expect/Tabs.expect.scala
@@ -1,0 +1,5 @@
+package example
+
+val a/*<-example::Tabs$package.a.*/ =
+	List/*->scala::package.List.*/(1,2,3)
+		.map/*->scala::collection::immutable::List#map().*/(_ +/*->scala::Int#`+`(+4).*/ 1)

--- a/tests/semanticdb/expect/Tabs.scala
+++ b/tests/semanticdb/expect/Tabs.scala
@@ -1,0 +1,5 @@
+package example
+
+val a = 
+	List(1,2,3)
+		.map(_ + 1)

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3393,6 +3393,34 @@ Synthetics:
 [55:6..55:12):foo(x) => *(x)
 [58:6..58:12):foo(0) => *(given_Int)
 
+expect/Tabs.scala
+-----------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => Tabs.scala
+Text => empty
+Language => Scala
+Symbols => 2 entries
+Occurrences => 5 entries
+Synthetics => 2 entries
+
+Symbols:
+example/Tabs$package. => final package object example extends Object { self: example.type => +2 decls }
+example/Tabs$package.a. => val method a List[Int]
+
+Occurrences:
+[0:8..0:15): example <- example/
+[2:4..2:5): a <- example/Tabs$package.a.
+[3:1..3:5): List -> scala/package.List.
+[4:3..4:6): map -> scala/collection/immutable/List#map().
+[4:9..4:10): + -> scala/Int#`+`(+4).
+
+Synthetics:
+[3:1..4:6):List(1,2,3)
+		.map => *[Int]
+[3:1..3:5):List => *.apply[Int]
+
 expect/Traits.scala
 -------------------
 


### PR DESCRIPTION
In case if code is indented with tabs `column` was always retuning `0`.

Originally reported in scalameta/metals#3724