### PR TITLE
Fix issues related to types of synthetic methods, boxing, intersection

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureAnnotation.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureAnnotation.scala
@@ -12,7 +12,7 @@ import printing.Printer
 import printing.Texts.Text
 
 
-case class CaptureAnnotation(refs: CaptureSet, kind: CapturingKind) extends Annotation:
+case class CaptureAnnotation(refs: CaptureSet, boxed: Boolean)(cls: Symbol) extends Annotation:
   import CaptureAnnotation.*
   import tpd.*
 
@@ -25,19 +25,19 @@ case class CaptureAnnotation(refs: CaptureSet, kind: CapturingKind) extends Anno
     val arg = repeated(elems, TypeTree(defn.AnyType))
     New(symbol.typeRef, arg :: Nil)
 
-  override def symbol(using Context) =
-    if kind == CapturingKind.ByName then defn.RetainsByNameAnnot else defn.RetainsAnnot
+  override def symbol(using Context) = cls
 
   override def derivedAnnotation(tree: Tree)(using Context): Annotation =
     if refs == CaptureSet.universal then this
     else unsupported("derivedAnnotation(Tree)")
 
-  def derivedAnnotation(refs: CaptureSet, kind: CapturingKind)(using Context): Annotation =
-    if (this.refs eq refs) && (this.kind == kind) then this
-    else CaptureAnnotation(refs, kind)
+  def derivedAnnotation(refs: CaptureSet, boxed: Boolean)(using Context): Annotation =
+    if (this.refs eq refs) && (this.boxed == boxed) then this
+    else CaptureAnnotation(refs, boxed)(cls)
 
   override def sameAnnotation(that: Annotation)(using Context): Boolean = that match
-    case CaptureAnnotation(refs2, kind2) => refs == refs2 && kind == kind2
+    case CaptureAnnotation(refs, boxed) =>
+      this.refs == refs && this.boxed == boxed && this.symbol == that.symbol
     case _ => false
 
   override def mapWith(tp: TypeMap)(using Context) =
@@ -45,7 +45,7 @@ case class CaptureAnnotation(refs: CaptureSet, kind: CapturingKind) extends Anno
     val elems1 = elems.mapConserve(tp)
     if elems1 eq elems then this
     else if elems1.forall(_.isInstanceOf[CaptureRef])
-    then derivedAnnotation(CaptureSet(elems1.asInstanceOf[List[CaptureRef]]*), kind)
+    then derivedAnnotation(CaptureSet(elems1.asInstanceOf[List[CaptureRef]]*), boxed)
     else EmptyAnnotation
 
   override def refersToParamOf(tl: TermLambda)(using Context): Boolean =
@@ -57,10 +57,10 @@ case class CaptureAnnotation(refs: CaptureSet, kind: CapturingKind) extends Anno
   override def toText(printer: Printer): Text = refs.toText(printer)
 
   override def hash: Int =
-    (refs.hashCode << 1) | (if kind == CapturingKind.Regular then 0 else 1)
+    (refs.hashCode << 1) | (if boxed then 1 else 0)
 
   override def eql(that: Annotation) = that match
-    case that: CaptureAnnotation => (this.refs eq that.refs) && (this.kind == kind)
+    case that: CaptureAnnotation => (this.refs eq that.refs) && (this.boxed == that.boxed)
     case _ => false
 
 end CaptureAnnotation

--- a/compiler/src/dotty/tools/dotc/cc/CapturingKind.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CapturingKind.scala
@@ -1,9 +1,0 @@
-package dotty.tools
-package dotc
-package cc
-
-/** Possible kinds of captures */
-enum CapturingKind:
-  case Regular     // normal capture
-  case Boxed       // capture under box
-  case ByName      // capture applies to enclosing by-name type (only possible before ElimByName)

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -10,6 +10,7 @@ import config.Printers.capt
 import ast.tpd
 import transform.Recheck.*
 import CaptureSet.IdentityCaptRefMap
+import Synthetics.isExcluded
 
 class Setup(
   preRecheckPhase: DenotTransformer,
@@ -325,8 +326,10 @@ extends tpd.TreeTraverser:
       then transformInferredType(tree.tpe, boxed)
       else transformExplicitType(tree.tpe, boxed))
 
-  def traverse(tree: Tree)(using Context) =
+  def traverse(tree: Tree)(using Context): Unit =
     tree match
+      case tree: DefDef if isExcluded(tree.symbol) =>
+        return
       case tree @ ValDef(_, tpt: TypeTree, _) if tree.symbol.is(Mutable) =>
         transformTT(tpt, boxed = true)
         traverse(tree.rhs)

--- a/compiler/src/dotty/tools/dotc/cc/Synthetics.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Synthetics.scala
@@ -1,0 +1,161 @@
+package dotty.tools
+package dotc
+package cc
+
+import core.*
+import Symbols.*, SymDenotations.*, Contexts.*, Flags.*, Types.*, Decorators.*
+import StdNames.nme
+import NameKinds.DefaultGetterName
+
+/** Classification and transformation methods for synthetic
+ *  case class methods that need to be treated specially.
+ *  In particular, compute capturing types for some of these methods which
+ *  have inferred (result-)types that need to be established under separate
+ *  compilation.
+ */
+object Synthetics:
+  def isSyntheticCopyMethod(sym: SymDenotation)(using Context) =
+    sym.name == nme.copy && sym.is(Synthetic) && sym.owner.isClass && sym.owner.is(Case)
+
+  def isSyntheticApplyMethod(sym: SymDenotation)(using Context) =
+    sym.name == nme.apply && sym.is(Synthetic) && sym.owner.is(Module) && sym.owner.companionClass.is(Case)
+
+  def isSyntheticUnapplyMethod(sym: SymDenotation)(using Context) =
+    sym.name == nme.unapply && sym.is(Synthetic) && sym.owner.is(Module) && sym.owner.companionClass.is(Case)
+
+  def isSyntheticCopyDefaultGetterMethod(sym: SymDenotation)(using Context) = sym.name match
+    case DefaultGetterName(nme.copy, _) => sym.is(Synthetic)
+    case _ => false
+
+  /** Is `sym` a synthetic apply, copy, or copy default getter method? */
+  def needsTransform(sym: SymDenotation)(using Context): Boolean =
+    isSyntheticCopyMethod(sym)
+    || isSyntheticApplyMethod(sym)
+    || isSyntheticUnapplyMethod(sym)
+    || isSyntheticCopyDefaultGetterMethod(sym)
+
+  /** Method is excluded from regular capture checking */
+  def isExcluded(sym: Symbol)(using Context): Boolean =
+    sym.is(Synthetic)
+    && sym.owner.isClass
+    && ( defn.caseClassSynthesized.exists(
+             ccsym => sym.overriddenSymbol(ccsym.owner.asClass) == ccsym)
+        || sym.name == nme.fromProduct
+        || needsTransform(sym)
+      )
+
+  /** Add capture dependencies to the type of `apply` or `copy` method of a case class */
+  private def addCaptureDeps(info: Type)(using Context): Type = info match
+    case info: MethodType =>
+      val trackedParams = info.paramRefs.filter(atPhase(ctx.phase.next)(_.isTracked))
+      def augmentResult(tp: Type): Type = tp match
+        case tp: MethodOrPoly =>
+          tp.derivedLambdaType(resType = augmentResult(tp.resType))
+        case _ =>
+          val refined = trackedParams.foldLeft(tp) { (parent, pref) =>
+            RefinedType(parent, pref.paramName,
+              CapturingType(
+                atPhase(ctx.phase.next)(pref.underlying.stripCapturing),
+                CaptureSet(pref), CapturingKind.Regular))
+          }
+          CapturingType(refined, CaptureSet(trackedParams*), CapturingKind.Regular)
+      if trackedParams.isEmpty then info else augmentResult(info)
+    case info: PolyType =>
+      info.derivedLambdaType(resType = addCaptureDeps(info.resType))
+    case _ =>
+      info
+
+  /** Drop capture dependencies from the type of `apply` or `copy` method of a case class */
+  private def dropCaptureDeps(tp: Type)(using Context): Type = tp match
+    case tp: MethodOrPoly =>
+      tp.derivedLambdaType(resType = dropCaptureDeps(tp.resType))
+    case CapturingType(parent, _, _) =>
+      dropCaptureDeps(parent)
+    case RefinedType(parent, _, _) =>
+      dropCaptureDeps(parent)
+    case _ =>
+      tp
+
+  /** Add capture information to the type of the default getter of a case class copy method */
+  private def addDefaultGetterCapture(info: Type, owner: Symbol, idx: Int)(using Context): Type = info match
+    case info: MethodOrPoly =>
+      info.derivedLambdaType(resType = addDefaultGetterCapture(info.resType, owner, idx))
+    case info: ExprType =>
+      info.derivedExprType(addDefaultGetterCapture(info.resType, owner, idx))
+    case EventuallyCapturingType(parent, _, _) =>
+      addDefaultGetterCapture(parent, owner, idx)
+    case info @ AnnotatedType(parent, annot) =>
+      info.derivedAnnotatedType(addDefaultGetterCapture(parent, owner, idx), annot)
+    case _ if idx < owner.asClass.paramGetters.length =>
+      val param = owner.asClass.paramGetters(idx)
+      val pinfo = param.info
+      atPhase(ctx.phase.next) {
+        if pinfo.captureSet.isAlwaysEmpty then info
+        else CapturingType(pinfo.stripCapturing, CaptureSet(param.termRef), CapturingKind.Regular)
+      }
+    case _ =>
+      info
+
+  /** Drop capture information from the type of the default getter of a case class copy method */
+  private def dropDefaultGetterCapture(info: Type)(using Context): Type = info match
+    case info: MethodOrPoly =>
+      info.derivedLambdaType(resType = dropDefaultGetterCapture(info.resType))
+    case CapturingType(parent, _, _) =>
+      parent
+    case info @ AnnotatedType(parent, annot) =>
+      info.derivedAnnotatedType(dropDefaultGetterCapture(parent), annot)
+    case _ =>
+      info
+
+  private def addUnapplyCaptures(info: Type)(using Context): Type = info match
+    case info: MethodType =>
+      val paramInfo :: Nil = info.paramInfos: @unchecked
+      val newParamInfo =
+        CapturingType(paramInfo, CaptureSet.universal, CapturingKind.Regular)
+      val trackedParam = info.paramRefs.head
+      def newResult(tp: Type): Type = tp match
+        case tp: MethodOrPoly =>
+          tp.derivedLambdaType(resType = newResult(tp.resType))
+        case _ =>
+          CapturingType(tp, CaptureSet(trackedParam), CapturingKind.Regular)
+      info.derivedLambdaType(paramInfos = newParamInfo :: Nil, resType = newResult(info.resType))
+    case info: PolyType =>
+      info.derivedLambdaType(resType = addUnapplyCaptures(info.resType))
+
+  private def dropUnapplyCaptures(info: Type)(using Context): Type = info match
+    case info: MethodType =>
+      val CapturingType(oldParamInfo, _, _) :: Nil = info.paramInfos: @unchecked
+      def oldResult(tp: Type): Type = tp match
+        case tp: MethodOrPoly =>
+          tp.derivedLambdaType(resType = oldResult(tp.resType))
+        case CapturingType(tp, _, _) =>
+          tp
+      info.derivedLambdaType(paramInfos = oldParamInfo :: Nil, resType = oldResult(info.resType))
+    case info: PolyType =>
+      info.derivedLambdaType(resType = dropUnapplyCaptures(info.resType))
+
+  /** If `sym` refers to a synthetic apply, copy, or copy default getter method
+   *  of a case class, transform it to account for capture information.
+   *  @pre needsTransform(sym)
+   */
+  def transformToCC(sym: SymDenotation)(using Context): SymDenotation = sym.name match
+    case DefaultGetterName(nme.copy, n) if sym.is(Synthetic) && sym.owner.is(Case) =>
+      sym.copySymDenotation(info = addDefaultGetterCapture(sym.info, sym.owner, n))
+    case nme.unapply =>
+      sym.copySymDenotation(info = addUnapplyCaptures(sym.info))
+    case _ =>
+      sym.copySymDenotation(info = addCaptureDeps(sym.info))
+
+  /** If `sym` refers to a synthetic apply, copy, or copy default getter method
+   *  of a case class, transform it back to what it was before the CC phase.
+   *  @pre needsTransform(sym)
+   */
+  def transformFromCC(sym: SymDenotation)(using Context): SymDenotation =
+    if isSyntheticCopyDefaultGetterMethod(sym) then
+      sym.copySymDenotation(info = dropDefaultGetterCapture(sym.info))
+    else if sym.name == nme.unapply then
+      sym.copySymDenotation(info = dropUnapplyCaptures(sym.info))
+    else
+      sym.copySymDenotation(info = dropCaptureDeps(sym.info))
+
+end Synthetics

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -15,7 +15,7 @@ import Comments.CommentsContext
 import Comments.Comment
 import util.Spans.NoSpan
 import Symbols.requiredModuleRef
-import cc.{CapturingType, CaptureSet, CapturingKind, EventuallyCapturingType}
+import cc.{CapturingType, CaptureSet, EventuallyCapturingType}
 
 import scala.annotation.tailrec
 
@@ -136,7 +136,7 @@ class Definitions {
             HKTypeLambda(argParamNames :+ "R".toTypeName, argVariances :+ Covariant)(
               tl => List.fill(arity + 1)(TypeBounds.empty),
               tl => CapturingType(underlyingClass.typeRef.appliedTo(tl.paramRefs),
-                CaptureSet.universal, CapturingKind.Regular)
+                CaptureSet.universal)
             ))
         else
           val cls = denot.asClass.classSymbol
@@ -1157,8 +1157,8 @@ class Definitions {
    */
   object ByNameFunction:
     def apply(tp: Type)(using Context): Type = tp match
-      case EventuallyCapturingType(tp1, refs, CapturingKind.ByName) =>
-        CapturingType(apply(tp1), refs, CapturingKind.Regular)
+      case tp @ EventuallyCapturingType(tp1, refs) if tp.annot.symbol == RetainsByNameAnnot =>
+        CapturingType(apply(tp1), refs)
       case _ =>
         defn.ContextFunction0.typeRef.appliedTo(tp :: Nil)
     def unapply(tp: Type)(using Context): Option[Type] = tp match

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -332,7 +332,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
       case tp: TypeVar =>
         val underlying1 = recur(tp.underlying, fromBelow)
         if underlying1 ne tp.underlying then underlying1 else tp
-      case CapturingType(parent, refs, _) =>
+      case CapturingType(parent, refs) =>
         val parent1 = recur(parent, fromBelow)
         if parent1 ne parent then tp.derivedCapturingType(parent1, refs) else tp
       case tp: AnnotatedType =>

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2168,7 +2168,7 @@ object SymDenotations {
           case tp: TypeParamRef =>  // uncachable, since baseType depends on context bounds
             recur(TypeComparer.bounds(tp).hi)
 
-          case CapturingType(parent, refs, _) =>
+          case CapturingType(parent, refs) =>
             tp.derivedCapturingType(recur(parent), refs)
 
           case tp: TypeProxy =>

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -165,7 +165,7 @@ object TypeOps:
         // with Nulls (which have no base classes). Under -Yexplicit-nulls, we take
         // corrective steps, so no widening is wanted.
         simplify(l, theMap) | simplify(r, theMap)
-      case CapturingType(parent, refs, _) =>
+      case CapturingType(parent, refs) =>
         if !ctx.mode.is(Mode.Type)
             && refs.subCaptures(parent.captureSet, frozen = true).isOK then
           simplify(parent, theMap)
@@ -284,7 +284,7 @@ object TypeOps:
       tp1 match {
         case tp1: RecType =>
           return tp1.rebind(approximateOr(tp1.parent, tp2))
-        case CapturingType(parent1, refs1, _) =>
+        case CapturingType(parent1, refs1) =>
           return tp1.derivedCapturingType(approximateOr(parent1, tp2), refs1)
         case err: ErrorType =>
           return err
@@ -293,7 +293,7 @@ object TypeOps:
       tp2 match {
         case tp2: RecType =>
           return tp2.rebind(approximateOr(tp1, tp2.parent))
-        case CapturingType(parent2, refs2, _) =>
+        case CapturingType(parent2, refs2) =>
           return tp2.derivedCapturingType(approximateOr(tp1, parent2), refs2)
         case err: ErrorType =>
           return err

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -35,7 +35,7 @@ import scala.util.hashing.{ MurmurHash3 => hashing }
 import config.Printers.{core, typr, matchTypes}
 import reporting.{trace, Message}
 import java.lang.ref.WeakReference
-import cc.{CapturingType, CaptureSet, derivedCapturingType, retainedElems, isBoxedCapturing, CapturingKind, EventuallyCapturingType}
+import cc.{CapturingType, CaptureSet, derivedCapturingType, retainedElems, isBoxedCapturing, EventuallyCapturingType}
 import CaptureSet.{CompareResult, IdempotentCaptRefMap, IdentityCaptRefMap}
 
 import scala.annotation.internal.sharable
@@ -374,7 +374,7 @@ object Types {
       case tp: AndOrType => tp.tp1.unusableForInference || tp.tp2.unusableForInference
       case tp: LambdaType => tp.resultType.unusableForInference || tp.paramInfos.exists(_.unusableForInference)
       case WildcardType(optBounds) => optBounds.unusableForInference
-      case CapturingType(parent, refs, _) => parent.unusableForInference || refs.elems.exists(_.unusableForInference)
+      case CapturingType(parent, refs) => parent.unusableForInference || refs.elems.exists(_.unusableForInference)
       case _: ErrorType => true
       case _ => false
 
@@ -1397,7 +1397,7 @@ object Types {
       case tp: AnnotatedType =>
         val parent1 = tp.parent.dealias1(keep, keepOpaques)
         tp match
-          case tp @ CapturingType(parent, refs, _) =>
+          case tp @ CapturingType(parent, refs) =>
             tp.derivedCapturingType(parent1, refs)
           case _ =>
             if keep(tp) then tp.derivedAnnotatedType(parent1, tp.annot)
@@ -1875,15 +1875,13 @@ object Types {
 
     def capturing(ref: CaptureRef)(using Context): Type =
       if captureSet.accountsFor(ref) then this
-      else CapturingType(this, ref.singletonCaptureSet,
-        if this.isBoxedCapturing then CapturingKind.Boxed else CapturingKind.Regular)
+      else CapturingType(this, ref.singletonCaptureSet)
 
     def capturing(cs: CaptureSet)(using Context): Type =
       if cs.isConst && cs.subCaptures(captureSet, frozen = true).isOK then this
       else this match
-        case CapturingType(parent, cs1, boxed) => parent.capturing(cs1 ++ cs)
-        case _ => CapturingType(this, cs,
-          if this.isBoxedCapturing then CapturingKind.Boxed else CapturingKind.Regular)
+        case CapturingType(parent, cs1) => parent.capturing(cs1 ++ cs)
+        case _ => CapturingType(this, cs)
 
     /** The set of distinct symbols referred to by this type, after all aliases are expanded */
     def coveringSet(using Context): Set[Symbol] =
@@ -3731,7 +3729,7 @@ object Types {
           case tp: TermParamRef if tp.binder eq thisLambdaType => TrueDeps
           case tp: AnnotatedType =>
             tp match
-              case CapturingType(parent, refs, _) =>
+              case CapturingType(parent, refs) =>
                 (compute(status, parent, theAcc) /: refs.elems) {
                   (s, ref) => ref match
                     case tp: TermParamRef if tp.binder eq thisLambdaType => combine(s, CaptureDeps)
@@ -3803,15 +3801,14 @@ object Types {
           def apply(tp: Type) = tp match {
             case tp @ TermParamRef(`thisLambdaType`, _) =>
               range(defn.NothingType, atVariance(1)(apply(tp.underlying)))
-            case CapturingType(parent, refs, boxed) =>
+            case CapturingType(_, _) =>
               mapOver(tp)
             case AnnotatedType(parent, ann) if ann.refersToParamOf(thisLambdaType) =>
               val parent1 = mapOver(parent)
               if ann.symbol == defn.RetainsAnnot || ann.symbol == defn.RetainsByNameAnnot then
-                val byName = ann.symbol == defn.RetainsByNameAnnot
                 range(
-                  AnnotatedType(parent1, CaptureSet.empty.toRegularAnnotation(byName)),
-                  AnnotatedType(parent1, CaptureSet.universal.toRegularAnnotation(byName)))
+                  AnnotatedType(parent1, CaptureSet.empty.toRegularAnnotation(ann.symbol)),
+                  AnnotatedType(parent1, CaptureSet.universal.toRegularAnnotation(ann.symbol)))
               else
                 parent1
             case _ => mapOver(tp)
@@ -5050,7 +5047,7 @@ object Types {
           else if (clsd.is(Module)) givenSelf
           else if (ctx.erasedTypes) appliedRef
           else givenSelf match
-            case givenSelf @ EventuallyCapturingType(tp, refs, kind) =>
+            case givenSelf @ EventuallyCapturingType(tp, _) =>
               givenSelf.derivedAnnotatedType(tp & appliedRef, givenSelf.annot)
             case _ =>
               AndType(givenSelf, appliedRef)
@@ -5742,7 +5739,7 @@ object Types {
         case tp: ExprType =>
           derivedExprType(tp, this(tp.resultType))
 
-        case CapturingType(parent, refs, _) =>
+        case CapturingType(parent, refs) =>
           mapCapturingType(tp, parent, refs, variance)
 
         case tp @ AnnotatedType(underlying, annot) =>
@@ -6222,7 +6219,7 @@ object Types {
         val x2 = atVariance(0)(this(x1, tp.scrutinee))
         foldOver(x2, tp.cases)
 
-      case CapturingType(parent, refs, _) =>
+      case CapturingType(parent, refs) =>
         (this(x, parent) /: refs.elems)(this)
 
       case AnnotatedType(underlying, annot) =>

--- a/compiler/src/dotty/tools/dotc/core/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/core/Variances.scala
@@ -100,7 +100,7 @@ object Variances {
             v
         }
       varianceInArgs(varianceInType(tycon)(tparam), args, tycon.typeParams)
-    case CapturingType(tp, _, _) =>
+    case CapturingType(tp, _) =>
       varianceInType(tp)(tparam)
     case AnnotatedType(tp, annot) =>
       varianceInType(tp)(tparam) & varianceInAnnot(annot)(tparam)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -15,7 +15,7 @@ import util.SourcePosition
 import scala.util.control.NonFatal
 import scala.annotation.switch
 import config.Config
-import cc.{CapturingType, EventuallyCapturingType, CaptureSet, CapturingKind}
+import cc.{CapturingType, EventuallyCapturingType, CaptureSet, isBoxed}
 
 class PlainPrinter(_ctx: Context) extends Printer {
 
@@ -200,9 +200,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
           keywordStr(" match ") ~ "{" ~ casesText ~ "}" ~
           (" <: " ~ toText(bound) provided !bound.isAny)
         }.close
-      case EventuallyCapturingType(parent, refs, kind) =>
+      case tp @ EventuallyCapturingType(parent, refs) =>
         def box =
-          Str("box ") provided kind == CapturingKind.Boxed && ctx.settings.YccDebug.value
+          Str("box ") provided tp.isBoxed && ctx.settings.YccDebug.value
         if printDebug && !refs.isConst then
           changePrec(GlobalPrec)(box ~ s"$refs " ~ toText(parent))
         else if ctx.settings.YccDebug.value then
@@ -233,9 +233,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
           ~ (if tp.resultType.isInstanceOf[MethodType] then ")" else "): ")
           ~ toText(tp.resultType)
         }
-      case ExprType(ct @ EventuallyCapturingType(parent, refs, CapturingKind.ByName)) =>
+      case ExprType(ct @ EventuallyCapturingType(parent, refs))
+      if ct.annot.symbol == defn.RetainsByNameAnnot =>
         if refs.isUniversal then changePrec(GlobalPrec) { "=> " ~ toText(parent) }
-        else toText(CapturingType(ExprType(parent), refs, CapturingKind.Regular))
+        else toText(CapturingType(ExprType(parent), refs))
       case ExprType(restp) =>
         changePrec(GlobalPrec) {
           (if ctx.settings.Ycc.value then "-> " else "=> ") ~ toText(restp)

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -254,7 +254,12 @@ abstract class Recheck extends Phase, SymTransformer:
       recheck(tree.body, pt)
 
     def recheckReturn(tree: Return)(using Context): Type =
-      recheck(tree.expr, tree.from.symbol.returnProto)
+      val rawType = recheck(tree.expr)
+      def avoidMap = new TypeOps.AvoidMap:
+        def toAvoid(tp: NamedType) =
+          tp.symbol.is(Case) && tp.symbol.owner.isContainedIn(ctx.owner)
+      val ownType = avoidMap(rawType)
+      checkConforms(ownType, tree.from.symbol.returnProto, tree)
       defn.NothingType
 
     def recheckWhileDo(tree: WhileDo)(using Context): Type =

--- a/compiler/src/dotty/tools/dotc/typer/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CheckCaptures.scala
@@ -72,7 +72,7 @@ object CheckCaptures:
    *  This check is performed after capture sets are computed in phase cc.
    */
   def checkWellformedPost(tp: Type, pos: SrcPos)(using Context): Unit = tp match
-    case CapturingType(parent, refs, _) =>
+    case CapturingType(parent, refs) =>
       for ref <- refs.elems do
         if ref.captureSetOfInfo.elems.isEmpty then
           report.error(em"$ref cannot be tracked since its capture set is empty", pos)
@@ -131,7 +131,7 @@ class CheckCaptures extends Recheck, SymTransformer:
       variance = startingVariance
       override def traverse(t: Type) =
         t match
-          case CapturingType(parent, refs: CaptureSet.Var, _) =>
+          case CapturingType(parent, refs: CaptureSet.Var) =>
             if variance < 0 then
               capt.println(i"solving $t")
               refs.solve()
@@ -193,6 +193,34 @@ class CheckCaptures extends Recheck, SymTransformer:
           case _ => true
         }
         checkSubset(targetSet, curEnv.captured, pos)
+
+    /** If result type of a function type has toplevel boxed captures, propagate
+     *  them to the function type as a whole. Such boxed captures
+     *  can be created by substitution or as-seen-from. Propagating captures to the
+     *  left simulates an unbox operation on the result. I.e. if f has type `A -> box C B`
+     *  then in theory we need to unbox with
+     *
+     *      x => C o- f(x)
+     *
+     *   and that also propagates C into the type of the unboxing expression.
+     *   TODO: Generalize this to boxed captues in other parts of a function type.
+     */
+    def addResultBoxes(tp: Type)(using Context): Type =
+      def includeBoxed(res: Type) = tp.capturing(res.boxedCaptured)
+      val tpw = tp.widen
+      val boxedTpw = tpw.dealias match
+        case tp1 @ AppliedType(_, args) if defn.isNonRefinedFunction(tp1) =>
+          includeBoxed(args.last)
+        case tp1 @ RefinedType(_, _, rinfo) if defn.isFunctionType(tp1) =>
+          includeBoxed(rinfo.finalResultType)
+        case tp1 @ CapturingType(parent, refs) =>
+          val boxedParent = addResultBoxes(parent)
+          if boxedParent eq parent then tpw
+          else boxedParent.capturing(refs)
+        case _ =>
+          tpw
+      if boxedTpw eq tpw then tp else boxedTpw
+    end addResultBoxes
 
     def assertSub(cs1: CaptureSet, cs2: CaptureSet)(using Context) =
       assert(cs1.subCaptures(cs2, frozen = false).isOK, i"$cs1 is not a subset of $cs2")
@@ -327,7 +355,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         def augmentConstructorType(core: Type, initCs: CaptureSet): Type = core match
           case core: MethodType =>
             core.derivedLambdaType(resType = augmentConstructorType(core.resType, initCs))
-          case CapturingType(parent, refs, _) =>
+          case CapturingType(parent, refs) =>
             augmentConstructorType(parent, initCs ++ refs)
           case _ =>
             val (refined, cs) = addParamArgRefinements(core, initCs)
@@ -369,7 +397,7 @@ class CheckCaptures extends Recheck, SymTransformer:
     override def recheckApply(tree: Apply, pt: Type)(using Context): Type =
       includeCallCaptures(tree.symbol, tree.srcPos)
       super.recheckApply(tree, pt) match
-        case tp @ CapturingType(tp1, refs, kind) =>
+        case tp @ CapturingType(tp1, refs) =>
           tree.fun match
             case Select(qual, nme.apply)
             if defn.isFunctionType(qual.tpe.widen) =>
@@ -409,7 +437,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         case _ =>
           NoType
       def checkNotUniversal(tp: Type): Unit = tp.widenDealias match
-        case wtp @ CapturingType(parent, refs, _) =>
+        case wtp @ CapturingType(parent, refs) =>
           refs.disallowRootCapability { () =>
             val kind = if tree.isInstanceOf[ValDef] then "mutable variable" else "expression"
             report.error(
@@ -420,7 +448,8 @@ class CheckCaptures extends Recheck, SymTransformer:
           checkNotUniversal(parent)
         case _ =>
       checkNotUniversal(typeToCheck)
-      super.recheckFinish(tpe, tree, pt)
+      val tpe1 = if tree.isTerm then addResultBoxes(tpe) else tpe
+      super.recheckFinish(tpe1, tree, pt)
 
     /** This method implements the rule outlined in #14390:
      *  When checking an expression `e: T` against an expected type `Cx Tx`
@@ -453,7 +482,7 @@ class CheckCaptures extends Recheck, SymTransformer:
               erefs
         }
       val expected1 = expected match
-        case CapturingType(ecore, erefs, _) =>
+        case CapturingType(ecore, erefs) =>
           val erefs1 = augment(erefs, actual.captureSet)
           if erefs1 ne erefs then
             capt.println(i"augmented $expected from ${actual.captureSet} --> $erefs1")
@@ -508,7 +537,7 @@ class CheckCaptures extends Recheck, SymTransformer:
           interpolator(startingVariance = -1).traverse(selfType)
           if !root.isEffectivelySealed  then
             selfType match
-              case CapturingType(_, refs: CaptureSet.Var, _) if !refs.isUniversal =>
+              case CapturingType(_, refs: CaptureSet.Var) if !refs.isUniversal =>
                 report.error(
                   i"""$root needs an explicitly declared self type since its
                      |inferred self type $selfType
@@ -550,7 +579,7 @@ class CheckCaptures extends Recheck, SymTransformer:
           then
             val inferred = t.tpt.knownType
             def checkPure(tp: Type) = tp match
-              case CapturingType(_, refs, _) if !refs.elems.isEmpty =>
+              case CapturingType(_, refs) if !refs.elems.isEmpty =>
                 val resultStr = if t.isInstanceOf[DefDef] then " result" else ""
                 report.error(
                   em"""Non-local $sym cannot have an inferred$resultStr type

--- a/compiler/src/dotty/tools/dotc/typer/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CheckCaptures.scala
@@ -30,9 +30,12 @@ object CheckCaptures:
      *  in Setup if they have non-empty capture sets
      */
     def transformSym(sym: SymDenotation)(using Context): SymDenotation =
-      if sym.isAllOf(PrivateParamAccessor) && !sym.hasAnnotation(defn.ConstructorOnlyAnnot)
-      then sym.copySymDenotation(initFlags = sym.flags &~ Private | Recheck.ResetPrivate)
-      else sym
+      if sym.isAllOf(PrivateParamAccessor) && !sym.hasAnnotation(defn.ConstructorOnlyAnnot) then
+        sym.copySymDenotation(initFlags = sym.flags &~ Private | Recheck.ResetPrivate)
+      else if Synthetics.needsTransform(sym) then
+        Synthetics.transformToCC(sym)
+      else
+        sym
   end Pre
 
   case class Env(owner: Symbol, captured: CaptureSet, isBoxed: Boolean, outer0: Env | Null):
@@ -105,6 +108,10 @@ class CheckCaptures extends Recheck, SymTransformer:
   override def run(using Context): Unit =
     checkOverrides.traverse(ctx.compilationUnit.tpdTree)
     super.run
+
+  override def transformSym(sym: SymDenotation)(using Context): SymDenotation =
+    if Synthetics.needsTransform(sym) then Synthetics.transformFromCC(sym)
+    else super.transformSym(sym)
 
   def checkOverrides = new TreeTraverser:
     def traverse(t: Tree)(using Context) =
@@ -261,14 +268,7 @@ class CheckCaptures extends Recheck, SymTransformer:
           interpolateVarsIn(tree.tpt)
 
     override def recheckDefDef(tree: DefDef, sym: Symbol)(using Context): Unit =
-      val isExcluded =
-        sym.is(Synthetic)
-        && sym.owner.isClass
-        && ( defn.caseClassSynthesized.exists(
-                ccsym => sym.overriddenSymbol(ccsym.owner.asClass) == ccsym)
-            || sym.name == nme.fromProduct
-        )
-      if !isExcluded then
+      if !Synthetics.isExcluded(sym) then
         val saved = curEnv
         val localSet = capturedVars(sym)
         if !localSet.isAlwaysEmpty then curEnv = Env(sym, localSet, false, curEnv)
@@ -536,8 +536,8 @@ class CheckCaptures extends Recheck, SymTransformer:
               checkWellformedPost(annot.tree)
             case _ =>
           }
-        case t: ValOrDefDef if t.tpt.isInstanceOf[InferredTypeTree]
-            && !t.symbol.is(Synthetic) =>  // !!! needs to be refined
+        case t: ValOrDefDef
+        if t.tpt.isInstanceOf[InferredTypeTree] && !Synthetics.isExcluded(t.symbol) =>
           val sym = t.symbol
           val isLocal =
             sym.owner.ownersIterator.exists(_.isTerm)

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -537,7 +537,7 @@ object Inferencing {
     case tp: RefinedType => tp.derivedRefinedType(captureWildcards(tp.parent), tp.refinedName, tp.refinedInfo)
     case tp: RecType => tp.derivedRecType(captureWildcards(tp.parent))
     case tp: LazyRef => captureWildcards(tp.ref)
-    case CapturingType(parent, refs, _) => tp.derivedCapturingType(captureWildcards(parent), refs)
+    case CapturingType(parent, refs) => tp.derivedCapturingType(captureWildcards(parent), refs)
     case tp: AnnotatedType => tp.derivedAnnotatedType(captureWildcards(tp.parent), tp.annot)
     case _ => tp
   }

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -364,7 +364,7 @@ trait TypeAssigner {
             // reference to a polytype would have to be a fresh copy of that type,
             // but we want to avoid that because it would increase compilation cost.
             // See pos/i6682a.scala for a test case where the defensive copying matters.
-            val ensureFresh = new TypeMap:
+            val ensureFresh = new TypeMap with CaptureSet.IdempotentCaptRefMap:
               def apply(tp: Type) = mapOver(
                 if tp eq pt then pt.newLikeThis(pt.paramNames, pt.paramInfos, pt.resType)
                 else tp)

--- a/tests/neg-custom-args/captures/bounded.scala
+++ b/tests/neg-custom-args/captures/bounded.scala
@@ -12,3 +12,15 @@ def test(c: Cap) =
   val r1c: {c} Int -> Int = r1
   val r2 = b.lateElem
   val r2c: () -> {c} Int -> Int = r2 // error
+
+def test2(c: Cap) =
+  class B[X](x: X):
+    def elem = x
+    def lateElem = () => x
+
+  def f(x: Int): Int = if c == c then x else 0
+  val b = new B(f)
+  val r1 = b.elem
+  val r1c: {c} Int -> Int = r1
+  val r2 = b.lateElem
+  val r2c: () -> {c} Int -> Int = r2 // error

--- a/tests/neg-custom-args/captures/caseclass/Ref_1.scala
+++ b/tests/neg-custom-args/captures/caseclass/Ref_1.scala
@@ -1,0 +1,1 @@
+case class Ref(x: () => Unit)

--- a/tests/neg-custom-args/captures/caseclass/Test_2.scala
+++ b/tests/neg-custom-args/captures/caseclass/Test_2.scala
@@ -1,0 +1,30 @@
+@annotation.capability class C
+def test(c: C) =
+  val pure: () -> Unit = () => ()
+  val impure: () => Unit = pure
+  val mixed: {c} () -> Unit = pure
+  val x = Ref(impure)
+  val _: Ref = x // error
+  val y = x.copy()
+  val yc: Ref = y // error
+  val y0 = x.copy(pure)
+  val yc0: Ref = y0
+
+  val x2 = Ref(pure)
+  val _: Ref = x2
+  val y2 = x2.copy()
+  val yc2: Ref = y2
+
+  val x3 = Ref(mixed)
+  val _: {c} Ref = x3
+  val y3 = x3.copy()
+  val yc3: {c} Ref = y3
+
+  val y4 = y3 match
+    case Ref(xx) => xx
+  val y4c: {x3} () -> Unit = y4  // error (?) found: (y4 : {*} () -> Unit) required: {x3} () -> Unit. (But in fact it should work)
+
+
+
+
+

--- a/tests/pos-custom-args/captures/caseclass.scala
+++ b/tests/pos-custom-args/captures/caseclass.scala
@@ -1,0 +1,7 @@
+case class Ref(x: {*} String)
+
+@annotation.capability class C
+def test(c: C) =
+  val x1 = Ref("hello")
+  val y = x1 match
+    case Ref(z) => z


### PR DESCRIPTION
Synthetic apply and copy methods of case classes as well as copy default getters
have inferred types that do not correctly convey capture information before phase CC.
To allow for separate compilation, we have to fix the types of these methods
in a denotation transformer, and then fix them back after CC.

Also: Fix several issues related boxing. 

 - avoid side effects when adding boxes
 - handle unboxing in function type results

Also: Better implementation of intersection
