### PR TITLE
Fixed a typo in the documentation (reference/compiletime-ops.md)

### DIFF
--- a/docs/_docs/reference/metaprogramming/compiletime-ops.md
+++ b/docs/_docs/reference/metaprogramming/compiletime-ops.md
@@ -107,7 +107,7 @@ If an inline expansion results in a call `error(msgStr)` the compiler
 produces an error message containing the given `msgStr`.
 
 ```scala
-import scala.compiletime.{error, code}
+import scala.compiletime.{error, codeOf}
 
 inline def fail() =
   error("failed for a reason")
@@ -118,10 +118,10 @@ fail() // error: failed for a reason
 or
 
 ```scala
-inline def fail(p1: => Any) =
-  error(code"failed on: $p1")
+inline def fail(inline p1: Any) =
+  error("failed on: " + codeOf(p1))
 
-fail(identity("foo")) // error: failed on: identity("foo")
+fail(identity("foo")) // error: failed on: identity[String]("foo")
 ```
 
 ### The `scala.compiletime.ops` package


### PR DESCRIPTION
`code` was renamed to `codeOf` in this PR:
https://github.com/lampepfl/dotty/pull/10313/files

Example:
https://scastie.scala-lang.org/mWg37jZLS7SLBZCSSl0Tjg

May be it'll be good to change the documentation:
https://docs.scala-lang.org/scala3/reference/metaprogramming/compiletime-ops.html#error