### PR TITLE
fix #15222 recursively check for product ctor accessibility

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -82,11 +82,26 @@ object SymUtils:
     *  parameter section.
     */
     def whyNotGenericProduct(using Context): String =
+      /** for a case class, if it will have an anonymous mirror,
+       *  check that its constructor can be accessed
+       *  from the calling scope.
+       */
+      def canAccessCtor: Boolean =
+        def isAccessible(sym: Symbol): Boolean = ctx.owner.isContainedIn(sym)
+        def isSub(sym: Symbol): Boolean = ctx.owner.ownersIterator.exists(_.derivesFrom(sym))
+        val ctor = self.primaryConstructor
+        (!ctor.isOneOf(Private | Protected) || isSub(self)) // we cant access the ctor because we do not extend cls
+        && (!ctor.privateWithin.exists || isAccessible(ctor.privateWithin)) // check scope is compatible
+
+
+      val companionMirror = self.useCompanionAsProductMirror
       if (!self.is(CaseClass)) "it is not a case class"
       else if (self.is(Abstract)) "it is an abstract class"
       else if (self.primaryConstructor.info.paramInfoss.length != 1) "it takes more than one parameter list"
       else if (isDerivedValueClass(self)) "it is a value class"
+      else if (!(companionMirror || canAccessCtor)) s"the constructor of $self is innaccessible from the calling scope."
       else ""
+    end whyNotGenericProduct
 
     def isGenericProduct(using Context): Boolean = whyNotGenericProduct.isEmpty
 
@@ -120,6 +135,9 @@ object SymUtils:
       self.isOneOf(FinalOrInline, butNot = Mutable)
       && (!self.is(Method) || self.is(Accessor))
 
+    def useCompanionAsProductMirror(using Context): Boolean =
+      self.linkedClass.exists && !self.is(Scala2x) && !self.linkedClass.is(Case)
+
     def useCompanionAsSumMirror(using Context): Boolean =
       def companionExtendsSum(using Context): Boolean =
         self.linkedClass.isSubClass(defn.Mirror_SumClass)
@@ -145,7 +163,7 @@ object SymUtils:
     *     and also the location of the generated mirror.
     *   - all of its children are generic products, singletons, or generic sums themselves.
     */
-    def whyNotGenericSum(declScope: Symbol)(using Context): String =
+    def whyNotGenericSum(using Context): String =
       if (!self.is(Sealed))
         s"it is not a sealed ${self.kindString}"
       else if (!self.isOneOf(AbstractOrTrait))
@@ -153,31 +171,31 @@ object SymUtils:
       else {
         val children = self.children
         val companionMirror = self.useCompanionAsSumMirror
-        assert(!(companionMirror && (declScope ne self.linkedClass)))
         def problem(child: Symbol) = {
 
           def isAccessible(sym: Symbol): Boolean =
-            (self.isContainedIn(sym) && (companionMirror || declScope.isContainedIn(sym)))
+            (self.isContainedIn(sym) && (companionMirror || ctx.owner.isContainedIn(sym)))
             || sym.is(Module) && isAccessible(sym.owner)
 
           if (child == self) "it has anonymous or inaccessible subclasses"
           else if (!isAccessible(child.owner)) i"its child $child is not accessible"
-          else if (!child.isClass) ""
+          else if (!child.isClass) "" // its a singleton enum value
           else {
             val s = child.whyNotGenericProduct
-            if (s.isEmpty) s
-            else if (child.is(Sealed)) {
-              val s = child.whyNotGenericSum(if child.useCompanionAsSumMirror then child.linkedClass else ctx.owner)
-              if (s.isEmpty) s
+            if s.isEmpty then s
+            else if child.is(Sealed) then
+              val s = child.whyNotGenericSum
+              if s.isEmpty then s
               else i"its child $child is not a generic sum because $s"
-            } else i"its child $child is not a generic product because $s"
+            else
+              i"its child $child is not a generic product because $s"
           }
         }
         if (children.isEmpty) "it does not have subclasses"
         else children.map(problem).find(!_.isEmpty).getOrElse("")
       }
 
-    def isGenericSum(declScope: Symbol)(using Context): Boolean = whyNotGenericSum(declScope).isEmpty
+    def isGenericSum(using Context): Boolean = whyNotGenericSum.isEmpty
 
     /** If this is a constructor, its owner: otherwise this. */
     final def skipConstructor(using Context): Symbol =

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -94,7 +94,7 @@ object SymUtils:
         && (!ctor.privateWithin.exists || isAccessible(ctor.privateWithin)) // check scope is compatible
 
 
-      val companionMirror = self.useCompanionAsProductMirror
+      def companionMirror = self.useCompanionAsProductMirror
       if (!self.is(CaseClass)) "it is not a case class"
       else if (self.is(Abstract)) "it is an abstract class"
       else if (self.primaryConstructor.info.paramInfoss.length != 1) "it takes more than one parameter list"

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -594,9 +594,9 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     if (clazz.is(Module)) {
       if (clazz.is(Case)) makeSingletonMirror()
       else if (linked.isGenericProduct) makeProductMirror(linked)
-      else if (linked.isGenericSum(clazz)) makeSumMirror(linked)
+      else if (linked.isGenericSum) makeSumMirror(linked)
       else if (linked.is(Sealed))
-        derive.println(i"$linked is not a sum because ${linked.whyNotGenericSum(clazz)}")
+        derive.println(i"$linked is not a sum because ${linked.whyNotGenericSum}")
     }
     else if (impl.removeAttachment(ExtendsSingletonMirror).isDefined)
       makeSingletonMirror()

--- a/tests/neg/i14025.check
+++ b/tests/neg/i14025.check
@@ -1,8 +1,8 @@
 -- Error: tests/neg/i14025.scala:1:88 ----------------------------------------------------------------------------------
 1 |val foo = summon[deriving.Mirror.Product { type MirroredType = [X] =>> [Y] =>> (X, Y) }] // error
   |                                                                                        ^
-  |No given instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)} was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)}: class Tuple2 is not a generic product 
+  |No given instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)} was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Product{MirroredType[X] = [Y] =>> (X, Y)}: type [X] =>> [Y] =>> (X, Y) is not a generic product because its subpart [X] =>> [Y] =>> (X, Y) is not a supported kind (either `*` or `* -> *`)
 -- Error: tests/neg/i14025.scala:2:90 ----------------------------------------------------------------------------------
 2 |val bar = summon[deriving.Mirror.Sum { type MirroredType = [X] =>> [Y] =>> List[(X, Y)] }] // error
   |                                                                                          ^
-  |No given instance of type deriving.Mirror.Sum{MirroredType[X] = [Y] =>> List[(X, Y)]} was found for parameter x of method summon in object Predef
+  |No given instance of type deriving.Mirror.Sum{MirroredType[X] = [Y] =>> List[(X, Y)]} was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Sum{MirroredType[X] = [Y] =>> List[(X, Y)]}: type [X] =>> [Y] =>> List[(X, Y)] is not a generic sum because its subpart [X] =>> [Y] =>> List[(X, Y)] is not a supported kind (either `*` or `* -> *`)

--- a/tests/neg/i14823.check
+++ b/tests/neg/i14823.check
@@ -2,5 +2,5 @@
 8 |val baz = summon[Mirror.Of[SubA[Int] | SubB[Int]]] // error
   |                                                  ^
   |No given instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]]: 
-  |	* class Cov is not a generic product 
-  |	* class Cov is not a generic sum because it is not a sealed class
+  |	* type SubA[Int] | SubB[Int] is not a generic product because a subpart reduces to the more precise class SubA, expected class Cov
+  |	* type SubA[Int] | SubB[Int] is not a generic sum because a subpart reduces to the more precise class SubA, expected class Cov

--- a/tests/neg/prod-mirror-inacessible-ctor.scala
+++ b/tests/neg/prod-mirror-inacessible-ctor.scala
@@ -1,0 +1,26 @@
+import scala.deriving.Mirror
+
+package lib {
+  sealed trait Foo
+  object Foo // normally, would cache a mirror if one exists.
+  case class Bar private[lib] () extends Foo
+  case object Bar // force mirror for Bar to be anonymous.
+
+
+  object CallSiteSucceed {
+    val mFoo = summon[Mirror.SumOf[lib.Foo]] // ok
+    val mBar = summon[Mirror.ProductOf[lib.Bar]] // ok
+  }
+
+}
+
+package app {
+
+  object MustFail {
+    // we are outsite of accessible scope for Bar's ctor, so this should fail.
+
+    val mFoo = summon[Mirror.SumOf[lib.Foo]] // error
+    val mBar = summon[Mirror.ProductOf[lib.Bar]] // error
+  }
+
+}

--- a/tests/run/i15234.scala
+++ b/tests/run/i15234.scala
@@ -1,0 +1,22 @@
+import scala.deriving.Mirror
+
+package lib {
+  enum Foo:
+    case A
+
+  case object Bar
+}
+
+package app {
+  object Foo:
+    val A: lib.Foo.A.type = lib.Foo.A
+  val Bar: lib.Bar.type = lib.Bar
+}
+
+
+@main def Test =
+  assert(summon[Mirror.Of[scala.Nil.type]].fromProduct(EmptyTuple) == Nil) // alias scala 2 defined
+  assert(summon[Mirror.Of[lib.Foo.A.type]].fromProduct(EmptyTuple) == lib.Foo.A) // real mirror
+  assert(summon[Mirror.Of[lib.Bar.type]].fromProduct(EmptyTuple) == lib.Bar) // real mirror
+  assert(summon[Mirror.Of[app.Foo.A.type]].fromProduct(EmptyTuple) == lib.Foo.A) // alias mirror
+  assert(summon[Mirror.Of[app.Bar.type]].fromProduct(EmptyTuple) == lib.Bar) // alias mirror

--- a/tests/run/prod-mirror-inacessible-ctor/Lib_1.scala
+++ b/tests/run/prod-mirror-inacessible-ctor/Lib_1.scala
@@ -1,0 +1,15 @@
+package lib
+
+import scala.deriving.Mirror
+
+sealed trait Foo
+object Foo // normally, would cache a mirror if one exists.
+case class Bar private[lib] () extends Foo
+case object Bar // force mirror for Bar to be anonymous.
+
+
+object CallSiteSucceed {
+  val mFoo = summon[Mirror.SumOf[Foo]] // ok
+  val mBar = summon[Mirror.ProductOf[Bar]] // ok
+  val sampleBar = Bar()
+}

--- a/tests/run/prod-mirror-inacessible-ctor/Test_2.scala
+++ b/tests/run/prod-mirror-inacessible-ctor/Test_2.scala
@@ -1,0 +1,6 @@
+@main def Test =
+  assert(lib.CallSiteSucceed.mFoo eq lib.Foo) // binary compatibility with 3.1
+  assert(lib.CallSiteSucceed.mBar ne lib.Bar) // anonymous mirror
+
+  assert(lib.CallSiteSucceed.mFoo.ordinal(lib.CallSiteSucceed.sampleBar) == 0)
+  assert(lib.CallSiteSucceed.mBar.fromProduct(EmptyTuple) == lib.CallSiteSucceed.sampleBar)


### PR DESCRIPTION
mostly a refactoring, except now `whyNotGenericSum` will benefit by checking the constructor accessibility of child product types.

Removes the `declScope` parameter from `whyNotGenericSum` because it is not useful. In all cases it is populated by either the companion object of `self` when it is valid to use as the mirror, or it is the context owner when we should use an anonymous mirror. This is awkward because we end up calling `useCompanionAsSumMirror` twice in each recursive call.

Also fixes an inconsistency where `scala.Nil.type` would not get a singleton mirror, causing a runtime error (and extends it to aliases of singleton enum values)

fixes #15222
fixes #15234