### PR TITLE
shebang lines work on macos

### DIFF
--- a/compiler/test-resources/scripting/classpathReport.sc
+++ b/compiler/test-resources/scripting/classpathReport.sc
@@ -1,4 +1,4 @@
-#!bin/scala -classpath 'dist/target/pack/lib/*'
+#!/usr/bin/env -S bin/scala -classpath 'dist/target/pack/lib/*'
 
 import java.nio.file.Paths
 
@@ -9,4 +9,3 @@ def main(args: Array[String]): Unit =
 
 extension(s: String)
   def norm: String = s.replace('\\', '/')
-

--- a/compiler/test-resources/scripting/scriptPath.sc
+++ b/compiler/test-resources/scripting/scriptPath.sc
@@ -1,4 +1,4 @@
-#!dist/target/pack/bin/scala
+#!/usr/bin/env dist/target/pack/bin/scala
 
   def main(args: Array[String]): Unit =
     args.zipWithIndex.foreach { case (arg,i) => printf("arg %d: [%s]\n",i,arg) }

--- a/compiler/test-resources/scripting/sqlDateError.sc
+++ b/compiler/test-resources/scripting/sqlDateError.sc
@@ -1,4 +1,4 @@
-#!bin/scala
+#!/usr/bin/env -S bin/scala
 
 def main(args: Array[String]): Unit = {
   println(new java.sql.Date(100L))

--- a/compiler/test-resources/scripting/unglobClasspath.sc
+++ b/compiler/test-resources/scripting/unglobClasspath.sc
@@ -1,7 +1,7 @@
-#!bin/scala -classpath 'dist/target/pack/lib/*'
+#!/usr/bin/env -S bin/scala -classpath 'dist/target/pack/lib/*'
 
 // won't compile unless the hashbang line sets classpath
-import org.jline.terminal.Terminal
+import org.jsoup.Jsoup
 
 def main(args: Array[String]) =
   val cp = sys.props("java.class.path")


### PR DESCRIPTION
update `import jline.terminal.Terminal` to `import jsoup.Jsoup`, this is because jline was already part of the classpath (added by the `dist/bin/common` script).

I hope that this is still testing the bug with globbing arguments on jvm on windows.