### PR TITLE
synthesize mirrors for small generic tuples

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -689,7 +689,9 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
   }
 
   private def erasePair(tp: Type)(using Context): Type = {
-    val arity = tp.tupleArity
+    // NOTE: `tupleArity` does not consider TypeRef(EmptyTuple$) equivalent to EmptyTuple.type,
+    // we fix this for printers, but type erasure should be preserved.
+    val arity = tp.tupleArity()
     if (arity < 0) defn.ProductClass.typeRef
     else if (arity <= Definitions.MaxTupleArity) defn.TupleType(arity).nn
     else defn.TupleXXLClass.typeRef

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -218,7 +218,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         val cls = tycon.typeSymbol
         if tycon.isRepeatedParam then toTextLocal(args.head) ~ "*"
         else if defn.isFunctionClass(cls) then toTextFunction(args, cls.name.isContextFunction, cls.name.isErasedFunction)
-        else if tp.tupleArity >= 2 && !printDebug then toTextTuple(tp.tupleElementTypes)
+        else if tp.tupleArity(relaxEmptyTuple = true) >= 2 && !printDebug then toTextTuple(tp.tupleElementTypes)
         else if isInfixType(tp) then
           val l :: r :: Nil = args: @unchecked
           val opName = tyconName(tycon)

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -248,7 +248,7 @@ object GenericSignatures {
               case _ => jsig(elemtp)
 
         case RefOrAppliedType(sym, pre, args) =>
-          if (sym == defn.PairClass && tp.tupleArity > Definitions.MaxTupleArity)
+          if (sym == defn.PairClass && tp.tupleArity() > Definitions.MaxTupleArity)
             jsig(defn.TupleXXLClass.typeRef)
           else if (isTypeParameterInSig(sym, sym0)) {
             assert(!sym.isAliasType, "Unexpected alias type: " + sym)

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -26,6 +26,9 @@ object SyntheticMembers {
 
   /** Attachment recording that an anonymous class should extend Mirror.Sum */
   val ExtendsSumMirror: Property.StickyKey[Unit] = new Property.StickyKey
+
+  /** Attachment recording that an anonymous class should extend Mirror.Sum */
+  val GenericTupleArity: Property.StickyKey[Int] = new Property.StickyKey
 }
 
 /** Synthetic method implementations for case classes, case objects,
@@ -601,7 +604,11 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     else if (impl.removeAttachment(ExtendsSingletonMirror).isDefined)
       makeSingletonMirror()
     else if (impl.removeAttachment(ExtendsProductMirror).isDefined)
-      makeProductMirror(monoType.typeRef.dealias.classSymbol)
+      val tupleArity = impl.removeAttachment(GenericTupleArity)
+      val cls = tupleArity match
+        case Some(n) => defn.TupleType(n).nn.classSymbol
+        case _ => monoType.typeRef.dealias.classSymbol
+      makeProductMirror(cls)
     else if (impl.removeAttachment(ExtendsSumMirror).isDefined)
       makeSumMirror(monoType.typeRef.dealias.classSymbol)
 

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -27,7 +27,10 @@ object SyntheticMembers {
   /** Attachment recording that an anonymous class should extend Mirror.Sum */
   val ExtendsSumMirror: Property.StickyKey[Unit] = new Property.StickyKey
 
-  /** Attachment recording that an anonymous class should extend Mirror.Sum */
+  /** Attachment recording that an anonymous class (with the ExtendsProductMirror attachment)
+   *  should implement its `fromProduct` method in terms of the runtime class corresponding
+   *  to a tuple with that arity.
+   */
   val GenericTupleArity: Property.StickyKey[Int] = new Property.StickyKey
 }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2767,7 +2767,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       typed(desugar.smallTuple(tree).withSpan(tree.span), pt)
     else {
       val pts =
-        if (arity == pt.tupleArity) pt.tupleElementTypes
+        if (arity == pt.tupleArity()) pt.tupleElementTypes
         else List.fill(arity)(defn.AnyType)
       val elems = tree.trees.lazyZip(pts).map(
         if ctx.mode.is(Mode.Type) then typedType(_, _, mapPatternBounds = true)

--- a/tests/neg/i14127.check
+++ b/tests/neg/i14127.check
@@ -1,0 +1,10 @@
+-- Error: tests/neg/i14127.scala:6:55 ----------------------------------------------------------------------------------
+6 |    *: Int *: Int *: Int *: Int *: Int *: EmptyTuple)]] // error
+  |                                                       ^
+  |No given instance of type deriving.Mirror.Of[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, 
+  |  Int
+  |, Int, Int)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, 
+  |  Int
+  |, Int, Int)]: 
+  |	* class *: is not a generic product because it reduces to a tuple with arity 23, expected arity <= 22
+  |	* class *: is not a generic sum because it does not have subclasses

--- a/tests/neg/i14127.scala
+++ b/tests/neg/i14127.scala
@@ -1,0 +1,6 @@
+import scala.deriving.Mirror
+
+val mT23 = summon[Mirror.Of[(
+  Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int
+    *: Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int
+    *: Int *: Int *: Int *: Int *: Int *: EmptyTuple)]] // error

--- a/tests/pos/i13859.scala
+++ b/tests/pos/i13859.scala
@@ -29,3 +29,10 @@ object Test:
       type MirroredElemTypes[X, Y] = (Y, X)
     }
   }
+
+  locally {
+    val x = summon[Kind2[Mirror.Product, [X, Y] =>> (Y, X) & (Y *: X *: EmptyTuple)]]
+    x: Mirror.Product {
+      type MirroredElemTypes[X, Y] = (Y, X)
+    }
+  }

--- a/tests/run/i14127.scala
+++ b/tests/run/i14127.scala
@@ -1,0 +1,14 @@
+import scala.deriving.Mirror
+
+@main def Test =
+  val mISB = summon[Mirror.Of[Int *: String *: Boolean *: EmptyTuple]]
+  assert(mISB.fromProduct((1, "foo", true)) == (1, "foo", true))
+
+  val mT22 = summon[Mirror.Of[(
+    Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int
+      *: Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int
+      *: Int *: Int *: Int *: Int *: EmptyTuple)]]
+
+  // tuple of 22 elements
+  val t22 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
+  assert(mT22.fromProduct(t22) == t22)

--- a/tests/run/i7049.scala
+++ b/tests/run/i7049.scala
@@ -1,0 +1,18 @@
+import scala.deriving._
+
+case class Foo(x: Int, y: String)
+
+def toTuple[T <: Product](x: T)(using m: Mirror.ProductOf[T], mt: Mirror.ProductOf[m.MirroredElemTypes]) =
+  mt.fromProduct(x)
+
+@main def Test = {
+  val m = summon[Mirror.ProductOf[Foo]]
+  val mt1 = summon[Mirror.ProductOf[(Int, String)]]
+  type R = (Int, String)
+  val mt2 = summon[Mirror.ProductOf[R]]
+  val mt3 = summon[Mirror.ProductOf[m.MirroredElemTypes]]
+
+  val f = Foo(1, "foo")
+  val g: (Int, String) = toTuple(f)// (using m, mt1)
+  assert(g == (1, "foo"))
+}


### PR DESCRIPTION
finally, `summon[Mirror.Of[Int *: String *: EmptyTuple]]`,

has the nice benefit of also being possible to summon a mirror that is derived from the `MirroredElemTypes` of another mirror

fixes #14127 
fixes #7049