### PR TITLE
Extract unapply types like typedUnApply

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -556,7 +556,7 @@ class SpaceEngine(using Context) extends SpaceLogic {
     // Case unapplySeq:
     // 1. return the type `List[T]` where `T` is the element type of the unapplySeq return type `Seq[T]`
 
-    val resTp = mt.instantiate(scrutineeTp :: Nil).finalResultType
+    val resTp = ctx.typeAssigner.safeSubstMethodParams(mt, scrutineeTp :: Nil).finalResultType
 
     val sig =
       if (resTp.isRef(defn.BooleanClass))

--- a/tests/pos/i15226.scala
+++ b/tests/pos/i15226.scala
@@ -1,0 +1,12 @@
+// scalac: -Werror
+class Proj { type State = String }
+
+sealed trait ProjState:
+  val a: Proj
+  val b: a.State
+
+object ProjState:
+  def unapply(pj: ProjState): Some[(pj.a.type, pj.b.type)] = Some((pj.a, pj.b))
+
+def test(pj: ProjState) = pj match
+  case ProjState(p, s) =>


### PR DESCRIPTION
Inside typedUnApply, argTypes depend on the result of applying the
unapply function (unapplyFn) on a "dummy arg", which results in calling
"safeSubstParams" (while constructing the tpd.Apply) instead of just
calling MethodType#instantiate.

Not doing the same thing in SpaceEngine#signature results in different
types that don't cancel each other, so we make SpaceEngine follow
Typer/Applications/TypeAssigner.
