### PR TITLE
Revert "BashScriptTests: shebang lines work on macos"

### DIFF
--- a/compiler/test-resources/scripting/classpathReport.sc
+++ b/compiler/test-resources/scripting/classpathReport.sc
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bin/scala -classpath 'dist/target/pack/lib/*'
+#!bin/scala -classpath 'dist/target/pack/lib/*'
 
 import java.nio.file.Paths
 
@@ -9,3 +9,4 @@ def main(args: Array[String]): Unit =
 
 extension(s: String)
   def norm: String = s.replace('\\', '/')
+

--- a/compiler/test-resources/scripting/scriptPath.sc
+++ b/compiler/test-resources/scripting/scriptPath.sc
@@ -1,4 +1,4 @@
-#!/usr/bin/env dist/target/pack/bin/scala
+#!dist/target/pack/bin/scala
 
   def main(args: Array[String]): Unit =
     args.zipWithIndex.foreach { case (arg,i) => printf("arg %d: [%s]\n",i,arg) }

--- a/compiler/test-resources/scripting/sqlDateError.sc
+++ b/compiler/test-resources/scripting/sqlDateError.sc
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bin/scala
+#!bin/scala
 
 def main(args: Array[String]): Unit = {
   println(new java.sql.Date(100L))

--- a/compiler/test-resources/scripting/unglobClasspath.sc
+++ b/compiler/test-resources/scripting/unglobClasspath.sc
@@ -1,7 +1,7 @@
-#!/usr/bin/env -S bin/scala -classpath 'dist/target/pack/lib/*'
+#!bin/scala -classpath 'dist/target/pack/lib/*'
 
 // won't compile unless the hashbang line sets classpath
-import org.jsoup.Jsoup
+import org.jline.terminal.Terminal
 
 def main(args: Array[String]) =
   val cp = sys.props("java.class.path")


### PR DESCRIPTION
Reverts lampepfl/dotty#15241

Windows CI environment does not support the `-S` flag for env

fixes #15257 