### PR TITLE
[backport] Avoid overeager completion of Java annotations in classfile parser

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -920,8 +920,6 @@ class Definitions {
   @tu lazy val ScalaStrictFPAnnot: ClassSymbol = requiredClass("scala.annotation.strictfp")
   @tu lazy val ScalaStaticAnnot: ClassSymbol = requiredClass("scala.annotation.static")
   @tu lazy val SerialVersionUIDAnnot: ClassSymbol = requiredClass("scala.SerialVersionUID")
-  @tu lazy val TASTYSignatureAnnot: ClassSymbol = requiredClass("scala.annotation.internal.TASTYSignature")
-  @tu lazy val TASTYLongSignatureAnnot: ClassSymbol = requiredClass("scala.annotation.internal.TASTYLongSignature")
   @tu lazy val TailrecAnnot: ClassSymbol = requiredClass("scala.annotation.tailrec")
   @tu lazy val ThreadUnsafeAnnot: ClassSymbol = requiredClass("scala.annotation.threadUnsafe")
   @tu lazy val ConstructorOnlyAnnot: ClassSymbol = requiredClass("scala.annotation.constructorOnly")

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -871,7 +871,7 @@ class ClassfileParser(
 
   /** Parse inner classes. Expects `in.bp` to point to the superclass entry.
    *  Restores the old `bp`.
-   *  @return true iff classfile is from Scala, so no Java info needs to be read.
+   *  @return Some(unpickler) iff classfile is from Scala, so no Java info needs to be read.
    */
   def unpickleOrParseInnerClasses()(using ctx: Context, in: DataReader): Option[Embedded] = {
     val oldbp = in.bp
@@ -1028,7 +1028,7 @@ class ClassfileParser(
         // attribute isn't, this classfile is a compilation artifact.
         return Some(NoEmbedded)
 
-      if (scan(tpnme.RuntimeVisibleAnnotationATTR) || scan(tpnme.RuntimeInvisibleAnnotationATTR)) {
+      if (scan(tpnme.ScalaSignatureATTR) && scan(tpnme.RuntimeVisibleAnnotationATTR)) {
         val attrLen = in.nextInt
         val nAnnots = in.nextChar
         var i = 0
@@ -1039,14 +1039,10 @@ class ClassfileParser(
           while (j < nArgs) {
             val argName = pool.getName(in.nextChar)
             if (argName.name == nme.bytes) {
-              if (attrClass == defn.ScalaSignatureAnnot)
+              if attrClass == defn.ScalaSignatureAnnot then
                 return unpickleScala(parseScalaSigBytes)
-              else if (attrClass == defn.ScalaLongSignatureAnnot)
+              else if attrClass == defn.ScalaLongSignatureAnnot then
                 return unpickleScala(parseScalaLongSigBytes)
-              else if (attrClass == defn.TASTYSignatureAnnot)
-                return unpickleTASTY(parseScalaSigBytes)
-              else if (attrClass == defn.TASTYLongSignatureAnnot)
-                return unpickleTASTY(parseScalaLongSigBytes)
             }
             parseAnnotArg(skip = true)
             j += 1

--- a/library/src/scala/annotation/internal/TASTYLongSignature.java
+++ b/library/src/scala/annotation/internal/TASTYLongSignature.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Deprecated
 public @interface TASTYLongSignature {
     public String[] bytes();
 }

--- a/library/src/scala/annotation/internal/TASTYSignature.java
+++ b/library/src/scala/annotation/internal/TASTYSignature.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Deprecated
 public @interface TASTYSignature {
     public String bytes();
 }

--- a/tests/pos/i15166/InterfaceAudience_JAVA_ONLY_1.java
+++ b/tests/pos/i15166/InterfaceAudience_JAVA_ONLY_1.java
@@ -1,0 +1,8 @@
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@InterfaceStability_JAVA_ONLY_1.Evolving(bytes="no")
+public class InterfaceAudience_JAVA_ONLY_1 {
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Public { String bytes(); }
+}

--- a/tests/pos/i15166/InterfaceStability_JAVA_ONLY_1.java
+++ b/tests/pos/i15166/InterfaceStability_JAVA_ONLY_1.java
@@ -1,0 +1,8 @@
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@InterfaceAudience_JAVA_ONLY_1.Public(bytes="yes")
+public class InterfaceStability_JAVA_ONLY_1 {
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Evolving { String bytes(); }
+}

--- a/tests/pos/i15166/Test_2.scala
+++ b/tests/pos/i15166/Test_2.scala
@@ -1,0 +1,4 @@
+// scalac: -Xfatal-warnings
+object Test {
+  val x: InterfaceAudience_JAVA_ONLY_1.Public = ???
+}


### PR DESCRIPTION
This backports #15185 to 3.1.3 which fixes a regression introduced in 3.1.3-RC1.