### PR TITLE
Signature help fixes for exposed bugs and refactor after signature change

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -146,13 +146,16 @@ object Signatures {
         val alternativeIndex = alternatives.map(_.symbol).indexOf(funSymbol) max 0
         (alternativeIndex, alternatives)
 
-    val curriedArguments = countParams(fun, alternatives(alternativeIndex))
-    val paramIndex = params.indexWhere(_.span.contains(span)) match {
-      case -1 => (params.length - 1 max 0) + curriedArguments
-      case n => n + curriedArguments
-    }
-    val alternativeSignatures = alternatives.flatMap(toApplySignature)
-    (paramIndex, alternativeIndex, alternativeSignatures)
+    if alternativeIndex < alternatives.length then
+      val curriedArguments = countParams(fun, alternatives(alternativeIndex))
+      val paramIndex = params.indexWhere(_.span.contains(span)) match {
+        case -1 => (params.length - 1 max 0) + curriedArguments
+        case n => n + curriedArguments
+      }
+      val alternativeSignatures = alternatives.flatMap(toApplySignature)
+      (paramIndex, alternativeIndex, alternativeSignatures)
+    else
+      (0, 0, Nil)
 
   /**
    * Extracts call informatioin for function in unapply context.

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -52,14 +52,13 @@ object Signatures {
   /**
    * Extract (current parameter index, function index, functions) method call for given position.
    *
-   * @param pos Position for which call should be returned
+   * @param path The path to the function application
+   * @param span The position of the cursor
    * @return A triple containing the index of the parameter being edited, the index of functeon
    *         being called, the list of overloads of this function).
    */
-  def signatureHelp(pos: SourcePosition)(using Context): (Int, Int, List[Signature]) = {
-    val path = Interactive.pathTo(ctx.compilationUnit.tpdTree, pos.span)
-    computeSignatureHelp(path, pos.span)(using Interactive.contextOfPath(path))
-  }
+  def signatureHelp(path: List[tpd.Tree], pos: Span)(using Context): (Int, Int, List[Signature]) =
+    computeSignatureHelp(path, pos)
 
   /**
    * Extract (current parameter index, function index, functions) out of a method call.

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -106,7 +106,14 @@ object Signatures {
     val (alternativeIndex, alternatives) = fun.tpe match
       case err: ErrorType =>
         val (alternativeIndex, alternatives) = alternativesFromError(err, params) match
-          case (_, Nil) => (0, fun.denot.alternatives)
+          // if we have no alternatives from error, we have to fallback to function denotation
+          // Check `partialyFailedCurriedFunctions` test for example
+          case (_, Nil) =>
+            val denot = fun.denot
+            if denot.exists then
+              (0, List(denot.asSingleDenotation))
+            else
+              (0, Nil)
           case other => other
         (alternativeIndex, alternatives)
       case _ =>

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -554,13 +554,10 @@ class DottyLanguageServer extends LanguageServer
     implicit def ctx: Context = driver.currentCtx
 
     val pos = sourcePosition(driver, uri, params.getPosition)
-    driver.compilationUnits.get(uri) match {
-      case Some(unit) =>
-        val freshCtx = ctx.fresh.setCompilationUnit(unit)
-        val (paramN, callableN, signatures) = Signatures.signatureHelp(pos)(using freshCtx)
-        new SignatureHelp(signatures.map(signatureToSignatureInformation).asJava, callableN, paramN)
-      case None => new SignatureHelp(Nil.asJava, 0, 0)
-    }
+    val trees = driver.openedTrees(uri)
+    val path = Interactive.pathTo(trees, pos)
+    val (paramN, callableN, signatures) = Signatures.signatureHelp(path, pos.span)
+    new SignatureHelp(signatures.map(signatureToSignatureInformation).asJava, callableN, paramN)
 
   }
 

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -253,23 +253,19 @@ class SignatureHelpTest {
 
   @Test def sequenceMatchUnapply: Unit = {
     val signatureSeq = S("", Nil, List(List(P("", "Seq[Int]"))), None)
-    // FIXME `Any` should be `Int`
-    val signatureList = S("", Nil, List(List(P("", "Seq[Any]"))), None)
     val signatureVariadicExtractor = S("", Nil, List(List(P("", "Int"), P("","List[Int]"))), None)
 
     code"""case class Two[A, B](a: A, b: B)
           |object Main {
           |  Seq(1,2,3) match {
-          |    case Seq($m2) =>
-          |    case List($m3) =>
-          |    case h$m4 :: t$m5 =>
+          |    case Seq($m1) =>
+          |    case h$m2 :: t$m3 =>
           |  }
           |}
           """
-      .signatureHelp(m2, List(signatureSeq), Some(0), 0)
-      .signatureHelp(m3, List(signatureList), Some(0), 0)
-      .signatureHelp(m4, List(signatureVariadicExtractor), Some(0), 0)
-      .signatureHelp(m5, List(signatureVariadicExtractor), Some(0), 1)
+      .signatureHelp(m1, List(signatureSeq), Some(0), 0)
+      .signatureHelp(m2, List(signatureVariadicExtractor), Some(0), 0)
+      .signatureHelp(m3, List(signatureVariadicExtractor), Some(0), 1)
   }
 
   @Test def productTypeClassMatch: Unit = {

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -18,10 +18,8 @@ class SignatureHelpTest {
   }
 
   @Test def properFunctionReturnWithoutParenthesis: Unit = {
-    val listSignature =
-      S("apply", List("A"), List(List(P("elems", "A*"))), Some("CC[A]"))
-    val optionSignature =
-      S("apply", List("A"), List(List(P("x", "A"))), Some("Option[A]"))
+    val listSignature = S("apply", List("A"), List(List(P("elems", "A*"))), Some("List[A]"))
+    val optionSignature = S("apply", List("A"), List(List(P("x", "A"))), Some("Option[A]"))
     code"""object O {
           |  List(1, 2$m1
           |}
@@ -37,8 +35,7 @@ class SignatureHelpTest {
   }
 
   @Test def partialyFailedCurriedFunctions: Unit = {
-    val listSignature =
-      S("curry", Nil, List(List(P("a", "Int"), P("b", "Int")), List(P("c", "Int"))), Some("Int"))
+    val listSignature = S("curry", Nil, List(List(P("a", "Int"), P("b", "Int")), List(P("c", "Int"))), Some("Int"))
     code"""object O {
           |def curry(a: Int, b: Int)(c: Int) = a
           |  curry(1$m1)(3$m2)
@@ -48,8 +45,7 @@ class SignatureHelpTest {
   }
 
   @Test def optionProperSignature: Unit = {
-    val listSignature =
-      S("apply", List("A"), List(List(P("x", "A"))), Some("Option[A]"))
+    val listSignature = S("apply", List("A"), List(List(P("x", "A"))), Some("Option[A]"))
     code"""object O {
           |  Option(1, 2, 3, $m1)
           |}"""
@@ -65,17 +61,25 @@ class SignatureHelpTest {
   }
 
   @Test def fromScala2: Unit = {
-    val applySig =
-      // TODO: Ideally this should say `List[A]`, not `CC[A]`
-      S("apply", List("A"), List(List(P("elems", "A*"))), Some("CC[A]"))
-    val mapSig =
-      S("map[B]", Nil, List(List(P("f", "A => B"))), Some("List[B]"))
+    val applySig = S("apply", List("A"), List(List(P("elems", "A*"))), Some("List[A]"))
+    val mapSig = S("map[B]", Nil, List(List(P("f", "Int => B"))), Some("List[B]"))
     code"""object O {
              List($m1)
              List(1, 2, 3).map($m2)
            }"""
       .signatureHelp(m1, List(applySig), Some(0), 0)
       .signatureHelp(m2, List(mapSig), Some(0), 0)
+  }
+
+  @Test def typeParameterMethodApply: Unit = {
+    val testSig = S("method", Nil, List(List()), Some("Int"))
+    code"""case class Foo[A](test: A) {
+          |  def method(): A = ???
+          |}
+          |object O {
+          |  Foo(5).method($m1)
+          |}"""
+      .signatureHelp(m1, List(testSig), Some(0), 0)
   }
 
   @Test def unapplyBooleanReturn: Unit = {

--- a/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
+++ b/language-server/test/dotty/tools/languageserver/SignatureHelpTest.scala
@@ -38,18 +38,19 @@ class SignatureHelpTest {
     val listSignature = S("curry", Nil, List(List(P("a", "Int"), P("b", "Int")), List(P("c", "Int"))), Some("Int"))
     code"""object O {
           |def curry(a: Int, b: Int)(c: Int) = a
-          |  curry(1$m1)(3$m2)
+          |  curry(1$m1)$m2(3$m3)
           |}"""
       .signatureHelp(m1, List(listSignature), Some(0), 0)
-      .signatureHelp(m2, List(listSignature), Some(0), 2)
+      .signatureHelp(m2, List(listSignature), Some(0), 0)
+      .signatureHelp(m3, List(listSignature), Some(0), 2)
   }
 
   @Test def optionProperSignature: Unit = {
-    val listSignature = S("apply", List("A"), List(List(P("x", "A"))), Some("Option[A]"))
+    val signature = S("apply", List("A"), List(List(P("x", "A"))), Some("Option[A]"))
     code"""object O {
           |  Option(1, 2, 3, $m1)
           |}"""
-      .signatureHelp(m1, List(listSignature), Some(0), 0)
+      .signatureHelp(m1, List(signature), Some(0), 0)
   }
 
   @Test def noSignaturesForTuple: Unit = {


### PR DESCRIPTION
Fixes https://github.com/lampepfl/dotty/issues/15248
Fixes https://github.com/lampepfl/dotty/issues/15244
Fixes https://github.com/lampepfl/dotty/issues/15284

For all found bugs i created tests.
This pull request changes almost whole file, as in previous implementation I tried to leave function signature the way it was.
It required few hacks to achieve that but now I've hit the wall and to fix:
```scala
object And {
  def unapply[A](a: A): Some[(A, A)] = Some((a, a))
}
object a {
  And.unapply(@@)
}
```
I had to change function signature as I discussed it with @tgodzik. As i changed signature, many places became unreadable and I had to refactor it a bit thus so many lines are changed. I could try split it into multiple pull requests but effect would be almost the same as it changed almost all file. I will pinpoint locations which caused each bug to where it was fixed.

I also wrote documentation for new functions to better explain the idea.