### PR TITLE
Gradual warning for deprecated nonlocal return

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -262,9 +262,9 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case tp: ClassInfo =>
         if tp.cls.derivesFrom(defn.PolyFunctionClass) then
           tp.member(nme.apply).info match
-            case info: PolyType => return toTextMethodAsFunction(info)
-            case _ =>
-        toTextParents(tp.parents) ~~ "{...}"
+            case info: PolyType => toTextMethodAsFunction(info)
+            case _ => toTextParents(tp.parents) ~~ "{...}"
+        else toTextParents(tp.parents) ~~ "{...}"
       case JavaArrayType(elemtp) =>
         toText(elemtp) ~ "[]"
       case tp: LazyRef if !printDebug =>

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -5,7 +5,7 @@ import core._
 import Contexts._, Symbols._, Types._, Flags._, StdNames._
 import MegaPhase._
 import NameKinds.NonLocalReturnKeyName
-import config.SourceVersion._
+import config.SourceVersion.*
 
 object NonLocalReturns {
   import ast.tpd._
@@ -95,10 +95,11 @@ class NonLocalReturns extends MiniPhase {
 
   override def transformReturn(tree: Return)(using Context): Tree =
     if isNonLocalReturn(tree) then
-      report.errorOrMigrationWarning(
+      report.gradualErrorOrMigrationWarning(
           "Non local returns are no longer supported; use scala.util.control.NonLocalReturns instead",
           tree.srcPos,
-          from = future)
+          warnFrom = `3.2`,
+          errorFrom = future)
       nonLocalReturnThrow(tree.expr, tree.from.symbol).withSpan(tree.span)
     else tree
 }

--- a/docs/_docs/reference/dropped-features/nonlocal-returns.md
+++ b/docs/_docs/reference/dropped-features/nonlocal-returns.md
@@ -5,7 +5,7 @@ title: "Deprecated: Nonlocal Returns"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html
 ---
 
-Returning from nested anonymous functions has been deprecated.
+Returning from nested anonymous functions has been deprecated, and will produce a warning from version `3.2`.
 
 Nonlocal returns are implemented by throwing and catching `scala.runtime.NonLocalReturnException`-s. This is rarely what is intended by the programmer. It can be problematic because of the hidden performance cost of throwing and catching exceptions. Furthermore, it is a leaky implementation: a catch-all exception handler can intercept a `NonLocalReturnException`.
 

--- a/docs/_docs/reference/language-versions/source-compatibility.md
+++ b/docs/_docs/reference/language-versions/source-compatibility.md
@@ -17,7 +17,9 @@ The default Scala language syntax version currently supported by the Dotty compi
     - in conjunction with `-rewrite`, offer code rewrites from Scala 2.13 to 3.0.
 
 - [`3.0`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/0$.html), [`3.1`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/1$.html): the default set of features included in scala versions `3.0.0` to `3.1.3`.
-- [`3.2`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/2$.html): the same as `3.0` and `3.1`, but [stricter pattern bindings](https://docs.scala-lang.org/scala3/reference/changed-features/pattern-bindings.html) are now enabled (part of `future` in earlier `3.x` releases), producing warnings for refutable patterns. These warnings can be silenced to achieve the same runtime behavior, but in `future` they become errors and refutable patterns will not compile.
+- [`3.2`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/2$.html): the same as `3.0` and `3.1`, but in addition:
+- [stricter pattern bindings](https://docs.scala-lang.org/scala3/reference/changed-features/pattern-bindings.html) are now enabled (part of `future` in earlier `3.x` releases), producing warnings for refutable patterns. These warnings can be silenced to achieve the same runtime behavior, but in `future` they become errors and refutable patterns will not compile.
+- [Nonlocal returns](https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html) now produce a warning upon usage (they are still an error under `future`).
 - [`3.2-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/2-migration$.html): the same as `3.2`, but in conjunction with `-rewrite`, offer code rewrites from Scala `3.0/3.1` to `3.2`.
 - [`future`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future$.html): A preview of changes that will be introduced in `3.x` versions after `3.2`.
 Some Scala 2 specific idioms are dropped in this version. The feature set supported by this version may grow over time as features become stabilised for preview.

--- a/library/src/scala/util/control/NonLocalReturns.scala
+++ b/library/src/scala/util/control/NonLocalReturns.scala
@@ -4,7 +4,7 @@ package scala.util.control
  *
  *  Usage:
  *
- *     import scala.util.control.NonLocalReturns._
+ *     import scala.util.control.NonLocalReturns.*
  *
  *     returning { ... throwReturn(x) ... }
  */


### PR DESCRIPTION
Follow up https://github.com/lampepfl/dotty/pull/15298

warns for nonlocal returns from `-source:3.2`
It's still true that it errors only on `-source:future`.