### PR TITLE
Update imports.md

### DIFF
--- a/docs/_docs/reference/changed-features/imports.md
+++ b/docs/_docs/reference/changed-features/imports.md
@@ -48,7 +48,7 @@ are offered under settings `-source 3.1-migration -rewrite`.
 
 ```
 Import            ::=  ‘import’ ImportExpr {‘,’ ImportExpr}
-ImportExpr        ::=  SimpleRef {‘.’ id} ‘.’ ImportSpec
+ImportExpr        ::=  { SimpleRef {‘.’ id} ‘.’ } ImportSpec
 ImportSpec        ::=  NamedSelector
                     |  WildcardSelector
                     | ‘{’ ImportSelectors) ‘}’


### PR DESCRIPTION
Without the additional braces making the `SimpleRef.` optional in `ImportExpr`, an expression such as `import java as j` wouldn't technically be accepted by the grammar specification.

Co-authored-by: @keynmol