### PR TITLE
Example showing alias is preserved in anon given name

### DIFF
--- a/docs/_docs/reference/contextual/givens.md
+++ b/docs/_docs/reference/contextual/givens.md
@@ -18,7 +18,6 @@ given intOrd: Ord[Int] with
     if x < y then -1 else if x > y then +1 else 0
 
 given listOrd[T](using ord: Ord[T]): Ord[List[T]] with
-
   def compare(xs: List[T], ys: List[T]): Int = (xs, ys) match
     case (Nil, Nil) => 0
     case (Nil, _) => -1
@@ -63,6 +62,16 @@ given instances of types that are "too similar". To avoid conflicts one can
 use named instances.
 
 **Note** To ensure robust binary compatibility, publicly available libraries should prefer named instances.
+
+**Note** Conflicts between synthetic names can also be resolved by the judicious use of type aliases:
+
+```scala
+given Ord[List[Int]] = ???     // given_Ord_List (overloaded with previous parameterized definition)
+given Ord[List[String]] = ???  // double definition
+
+type StringList = List[String]
+given Ord[StringList] = ???    // given_Ord_StringList
+```
 
 ## Alias Givens
 


### PR DESCRIPTION
Add mildly clever aliasing trick from https://github.com/lampepfl/dotty/issues/15316#issuecomment-1140847190

The hard part is avoiding the pun on "given name" in English.

Also, in a double def, the name is "already taken", so that is a "taken name".