### PR TITLE
fix nightlyOf links in docs

### DIFF
--- a/docs/_docs/reference/enums/enums-index.md
+++ b/docs/_docs/reference/enums/enums-index.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: "Enums"
-nightlyOf: https://docs.scala-lang.org/scala3/reference/enums.html
+nightlyOf: https://docs.scala-lang.org/scala3/reference/enums/index.html
 ---
 
 This chapter documents enums in Scala 3.

--- a/docs/_docs/reference/language-versions/binary-compatibility.md
+++ b/docs/_docs/reference/language-versions/binary-compatibility.md
@@ -1,6 +1,7 @@
 ---
 layout: doc-page
 title: "Binary Compatibility"
+nightlyOf: https://docs.scala-lang.org/scala3/reference/language-versions/binary-compatibility.html
 ---
 
 In Scala 2 different minor versions of the compiler were free to change the way how they encode different language features in JVM bytecode so each bump of the compiler's minor version resulted in breaking binary compatibility and if a project had any Scala dependencies they all needed to be (cross-)compiled to the same minor Scala version that was used in that project itself. On the contrary, Scala 3 has a stable encoding into JVM bytecode.

--- a/docs/_docs/reference/language-versions/language-versions.md
+++ b/docs/_docs/reference/language-versions/language-versions.md
@@ -1,6 +1,7 @@
 ---
 layout: index
 title: "Language Versions"
+nightlyOf: https://docs.scala-lang.org/scala3/reference/language-versions/index.html
 ---
 
 Additional information on interoperability and migration between Scala 2 and 3 can be found [here](https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html).

--- a/docs/_docs/reference/language-versions/source-compatibility.md
+++ b/docs/_docs/reference/language-versions/source-compatibility.md
@@ -1,7 +1,7 @@
 ---
 layout: doc-page
 title: "Source Compatibility"
-nightlyOf: https://docs.scala-lang.org/scala3/reference/language-versions.html
+nightlyOf: https://docs.scala-lang.org/scala3/reference/language-versions/source-compatibility.html
 ---
 
 Scala 3 does NOT guarantee source compatibility between different minor language versions (e.g. some syntax valid in 3.x might get deprecated and then phased out in 3.y for y > x). There are also some syntax structures that were valid in Scala 2 but are not anymore in Scala 3. However the compiler provides a possibility to specify the desired version of syntax used in a particular file or globally for a run of the compiler to make migration between versions easier.

--- a/docs/_docs/reference/new-types/new-types.md
+++ b/docs/_docs/reference/new-types/new-types.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: "New Types"
-nightlyOf: https://docs.scala-lang.org/scala3/reference/new-types.html
+nightlyOf: https://docs.scala-lang.org/scala3/reference/new-types/index.html
 ---
 
 This chapter documents the new types introduced in Scala 3.


### PR DESCRIPTION
the nightlyOf links for the language-versions subsection were removed when the pages were moved around, so I restored them, also the links for the index pages of enums and new-types were broken