### PR TITLE
Consider GADT upper bounds when upcasting the scrutinee type

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -138,13 +138,28 @@ trait PatternTypeConstrainer { self: TypeComparer =>
           val andType = buildAndType(baseClasses)
           !andType.exists || constrainPatternType(pat, andType)
         case _ =>
-          val upcasted: Type = scrut match {
-            case scrut: TypeProxy => scrut.superType
-            case _ => NoType
+          def tryGadtBounds = scrut match {
+            case scrut: TypeRef =>
+              ctx.gadt.bounds(scrut.symbol) match {
+                case tb: TypeBounds =>
+                  val hi = tb.hi
+                  constrainPatternType(pat, hi)
+                case null => false
+              }
+            case _ => false
           }
-          if (upcasted.exists)
-            tryConstrainSimplePatternType(pat, upcasted) || constrainUpcasted(upcasted)
-          else true
+
+          def trySuperType =
+            val upcasted: Type = scrut match {
+              case scrut: TypeProxy =>
+                scrut.superType
+              case _ => NoType
+            }
+            if (upcasted.exists)
+              tryConstrainSimplePatternType(pat, upcasted) || constrainUpcasted(upcasted)
+            else true
+
+          tryGadtBounds || trySuperType
       }
     }
 

--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -144,9 +144,9 @@ trait PatternTypeConstrainer { self: TypeComparer =>
                 case tb: TypeBounds =>
                   val hi = tb.hi
                   constrainPatternType(pat, hi)
-                case null => false
+                case null => true
               }
-            case _ => false
+            case _ => true
           }
 
           def trySuperType =
@@ -159,7 +159,7 @@ trait PatternTypeConstrainer { self: TypeComparer =>
               tryConstrainSimplePatternType(pat, upcasted) || constrainUpcasted(upcasted)
             else true
 
-          tryGadtBounds || trySuperType
+          tryGadtBounds && trySuperType
       }
     }
 

--- a/tests/pos/i15274.orig.scala
+++ b/tests/pos/i15274.orig.scala
@@ -1,0 +1,21 @@
+enum Format[A]:
+  case Str[Next](next: Format[Next]) extends Format[(String, Next)]
+  case Num[Next](next: Format[Next]) extends Format[(Int, Next)]
+  case Constant[Next](value: String, next: Format[Next]) extends Format[Next]
+  case Done extends Format[Unit]
+
+def printf[A](format: Format[A], params: A): Unit = (format, params) match
+  case (Format.Done, ()) =>
+    ()
+
+  case (Format.Constant(value, next), params) =>
+    println(value)
+    printf(next, params)
+
+  case (Format.Str(next), (str, rest)) =>
+    println(str)
+    printf(next, rest)
+
+  case (Format.Num(next), (i, rest)) =>
+    println(i)
+    printf(next, rest)

--- a/tests/pos/i15274.scala
+++ b/tests/pos/i15274.scala
@@ -1,0 +1,6 @@
+enum Format[A]:
+  case Str[Next](next: Format[Next]) extends Format[(String, Next)]
+
+def printf[A](format: Format[A], params: A): Unit = (format, params) match
+  case (Format.Str(next), (str, rest)) =>
+    val s: String = str


### PR DESCRIPTION
(cherry picked from commit 172e957422f31ab0b5305e5127a52203cc9ea409)

[test_non_bootstrapped]