### PR TITLE
Update imports.md to match reference syntax

### DIFF
--- a/docs/_docs/reference/changed-features/imports.md
+++ b/docs/_docs/reference/changed-features/imports.md
@@ -48,7 +48,8 @@ are offered under settings `-source 3.1-migration -rewrite`.
 
 ```
 Import            ::=  ‘import’ ImportExpr {‘,’ ImportExpr}
-ImportExpr        ::=  { SimpleRef {‘.’ id} ‘.’ } ImportSpec
+ImportExpr        ::= SimpleRef {‘.’ id} ‘.’ ImportSpec
+                    | SimpleRef `as` id
 ImportSpec        ::=  NamedSelector
                     |  WildcardSelector
                     | ‘{’ ImportSelectors) ‘}’


### PR DESCRIPTION
Looks like the change in #15321 remained a [suggestion](https://github.com/lampepfl/dotty/pull/15321#discussion_r886874887) and didn't get merged correctly, unfortunately.