### PR TITLE
Better handling of type parameters in constructor pattern

### DIFF
--- a/tests/run/unapply-tparam.scala
+++ b/tests/run/unapply-tparam.scala
@@ -1,0 +1,36 @@
+class Foo[T] {
+  def unapply(x: Int): Option[Int] = Some(4)
+}
+
+object Foo {
+  def unapply[T](x: T): Option[Int] = Some(5)
+}
+
+object Bar {
+  def unapply[T](x: T): Option[Int] = Some(5)
+}
+
+class Baz[T] {
+  def unapply(x: Int): Option[Int] = Some(4)
+}
+
+object Baz
+
+
+object Test extends App {
+  1 match {
+    case Foo(x) => assert(x == 5)
+  }
+
+  1 match {
+    case Foo[Int](x) => assert(x == 5)  // Type params on object takes precedence
+  }
+
+  1 match {
+    case Bar[Int](x) => assert(x == 5)
+  }
+
+  1 match {
+    case Baz[Int](x) => assert(x == 4)  // Otherwise type params are for the class
+  }
+}


### PR DESCRIPTION
In a constructor pattern `C[T](x)` with some type parameter(s), we have two choices.

 1. Interpret it as `C[T].unapply(selector)`
 2. Interpret it as `C.unapply[T](selector)`.

So far we always picked the first choice, which means that usually it will fail with a
message such as "`C` does not take type parameters".

In this PR, we pick the second choice if it can be typechecked without errors and
fall back to the first choice otherwise.