### PR TITLE
Scaladoc annotations rework

### DIFF
--- a/scaladoc-testcases/src/tests/annotations.scala
+++ b/scaladoc-testcases/src/tests/annotations.scala
@@ -8,15 +8,22 @@ import scala.reflect.Enum
 
 class SomeObject(val s: String)
 
-class MyAnnotation extends StaticAnnotation
+@java.lang.annotation.Documented
+class MyAnnotation extends StaticAnnotation //expected: @Documented class MyAnnotation extends StaticAnnotation
 
-class AnnotationWithArg(val s: String, val o: SomeObject) extends StaticAnnotation
+@java.lang.annotation.Documented
+class AnnotationWithArg(val s: String, val o: SomeObject) extends StaticAnnotation //expected: @Documented class AnnotationWithArg(val s: String, val o: SomeObject) extends StaticAnnotation
 
-class AnnotationWithMultiArg(val i: Int, val s: String, val c: Char*) extends StaticAnnotation
+@java.lang.annotation.Documented
+class AnnotationWithMultiArg(val i: Int, val s: String, val c: Char*) extends StaticAnnotation //expected: @Documented class AnnotationWithMultiArg(val i: Int, val s: String, val c: Char*) extends StaticAnnotation
 
-class EnumAnnotation(val e: Enum) extends StaticAnnotation
+@java.lang.annotation.Documented
+class EnumAnnotation(val e: Enum) extends StaticAnnotation //expected: @Documented class EnumAnnotation(val e: Enum) extends StaticAnnotation
 
-class ClassAnnotation[T](val c: Class[T]) extends StaticAnnotation
+@java.lang.annotation.Documented
+class ClassAnnotation[T](val c: Class[T]) extends StaticAnnotation //expected: @Documented class ClassAnnotation[T](val c: Class[T]) extends StaticAnnotation
+
+class NotDocumentedAnnotation extends StaticAnnotation
 
 @AnnotationWithMultiArg(2, "cda", 'a', 'b', 'c') @MyAnnotation class AnnotatedClass
 
@@ -28,3 +35,5 @@ class AnnotatedMethods
   @MyAnnotation @AnnotationWithMultiArg(2, "cda", 'a', 'b', 'c') def a: String
   = ???
 }
+
+/*<-*/@NotDocumentedAnnotation/*->*/class ClassWithoutAnnotation(/*<-*/@NotDocumentedAnnotation/*->*/val a: String)

--- a/scaladoc-testcases/src/tests/specializedSignature.scala
+++ b/scaladoc-testcases/src/tests/specializedSignature.scala
@@ -4,11 +4,11 @@ package specializedSignature
 
 import scala.{specialized}
 
-trait AdditiveMonoid[@specialized(Int, Long, Float, Double) A]
+trait AdditiveMonoid[@specialized(Int, Long, Float, Double) A] //expected: trait AdditiveMonoid[A]
 {
   def a: A
    = ???
 
-  def b[@specialized(Int, Float) B]: B
+  def b[@specialized(Int, Float) B]: B //expected: def b[B]: B
    = ???
 }


### PR DESCRIPTION
This PR refactors the way Scaladoc picks annotations to show:

- All annotations are hidden by default
- Only annotations annotated with @java.lang.annotation.Documented are shown
- There's a whitelist of annotations from stdlib that should be shown

I would like to ask about which annotations should be whitelisted? I created some rough set but I don't know if it's exhaustive
@odersky @smarter 
