### PR TITLE
Refine criterion when to skip identifiers in pattern constructors

### DIFF
--- a/tests/pos/i15347.scala
+++ b/tests/pos/i15347.scala
@@ -1,0 +1,8 @@
+object Test:
+  enum E[T]:
+    case A(i: Int)
+
+  export E.*
+
+  def f(x: E[Int]) = x match
+    case A(i) => i


### PR DESCRIPTION
There's a strange and almost forgotten rule that disqualifies method symbols
from direct lookup when the identifier is the constructor of a pattern. This
is done to make code like this work:
```
class List[T]:
  def :: (that: T): List[T]
  def f(...) = this match
    case x :: xs => ...
object `::`:
  def unapply...
```
Without the rule, the `::` in the pattern would resolve to the `::` method
in `List` which does not have an `unapply`. We need to skip that method to get
to the outer `::` object.

The rule plays badly with export forwarders, which are methods, and therefore
were ineligible for pattern constructurs. We now change the rule so that methods
are also accepted as unqualified `unapply` prefixes as long as they are parameterless.

Fixes #15347