### PR TITLE
allow forEach as an alternative to foreach

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -474,6 +474,7 @@ object StdNames {
     val flatMap: N              = "flatMap"
     val floatHash: N            = "floatHash"
     val foreach: N              = "foreach"
+    val forEach: N              = "forEach"
     val format: N               = "format"
     val fromDigits: N           = "fromDigits"
     val fromProduct: N          = "fromProduct"

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -629,6 +629,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           assignType(tree2, TryDynamicCallType)
         else
           typedDynamicSelect(tree2, Nil, pt)
+      else if tree0.name == nme.foreach then
+        typedSelect(cpy.Select(tree0)(tree0.qualifier, nme.forEach), pt, qual)
       else
         assignType(tree,
           rawType match

--- a/tests/pos/forEach-desugar.scala
+++ b/tests/pos/forEach-desugar.scala
@@ -1,0 +1,18 @@
+import java.util.{List, ArrayList}
+
+object ForEachDesugar {
+
+  val listA = scala.List(1, 2, 3)
+  val listB = List.of(1, 2, 3)
+  val listC = ArrayList[Int]()
+
+  for i <- listB do listB.add(i)
+
+  for
+    x <- listA
+    y <- listB
+    z <- listC
+  do
+    listB.add(x + y)
+
+}


### PR DESCRIPTION
We have some problems with `foreach` in Scala:

**1. Compatibility with Java libraries**

```scala
import java.util.List

for x <- List.of(1,2,3) do println(x)
```
This doesn't work, since Java uses `forEach` on its collections. It's annoying that Java collections work in `for-yield` loops, but not `for-do`.

**2. Developer Expectations**

Developers expect `forEach`, not `foreach`, because the former is camel cased just like `flatMap` and every other method. Java, [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach), [C++](https://en.cppreference.com/w/cpp/algorithm/for_each), [Kotlin](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/for-each.html), and the majority of popular languages case `foreach` according to the language's regular style.


I propose that in cases where `foreach` is required but not resolved, we try `forEach` as an alternative.

This fixes the compatibility issue, while also allowing developers to use the case they prefer.

Questions:
1. Should this behavior be limited to non-Scala sources?
2. Should this behavior be limited to `for-do` loop desugaring?
3. Are there binary compatibility issues to consider?