### PR TITLE
Implement `provablyDisjoint` for refined types and type aliases

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2659,6 +2659,10 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         fullyInstantiated(tp2) && !tp1.classSymbols.exists(_.derivesFrom(tp2.symbol))
       case (tp1: TypeRef, tp2: TermRef) if isEnumValue(tp2) =>
         fullyInstantiated(tp1) && !tp2.classSymbols.exists(_.derivesFrom(tp1.symbol))
+      case (tp1: RefinedType, tp2: RefinedType) if tp1.refinedName == tp2.refinedName =>
+        provablyDisjoint(tp1.parent, tp2.parent) || provablyDisjoint(tp1.refinedInfo, tp2.refinedInfo)
+      case (tp1: TypeAlias, tp2: TypeAlias) =>
+        provablyDisjoint(tp1.alias, tp2.alias)
       case (tp1: Type, tp2: Type) if defn.isTupleNType(tp1) =>
         provablyDisjoint(tp1.toNestedPairs, tp2)
       case (tp1: Type, tp2: Type) if defn.isTupleNType(tp2) =>

--- a/docs/_docs/reference/experimental/numeric-literals.md
+++ b/docs/_docs/reference/experimental/numeric-literals.md
@@ -73,7 +73,7 @@ trait FromDigits[T]:
   def fromDigits(digits: String): T
 ```
 
-Implementations of the `fromDigits` convert strings of digits to the values of the
+Implementations of `fromDigits` convert strings of digits to the values of the
 implementation type `T`.
 The `digits` string consists of digits between `0` and `9`, possibly preceded by a
 sign ("+" or "-"). Number separator characters `_` are filtered out before

--- a/tests/pos/i15312.scala
+++ b/tests/pos/i15312.scala
@@ -1,0 +1,7 @@
+type F[t] =
+  t match
+    case {type A = Float} => Int
+    case {type A = Int} => String
+
+val a: F[{type A = Float}] = 10
+val b: F[{type A = Int}] = "asd" // Found:("asd" : String) Required: F[Object{A = Int}]


### PR DESCRIPTION
Fixes #15312