### PR TITLE
Support java collections & streams in for-do loops

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -60,4 +60,12 @@ object Predef:
     inline def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
 
+  extension [T](it: java.lang.Iterable[T])
+    def foreach(f: java.util.function.Consumer[T]): Unit =
+      it.forEach(f)
+
+  extension [T](s: java.util.stream.Stream[T])
+    def foreach(f: java.util.function.Consumer[T]): Unit =
+      s.forEach(f)
+
 end Predef

--- a/tests/pos/java-collection-for-do.scala
+++ b/tests/pos/java-collection-for-do.scala
@@ -1,0 +1,13 @@
+import java.util.{List, ArrayList}
+import java.util.stream.Stream
+
+object JavaCollectionForDo {
+
+  for
+    x <- scala.List(1, 2, 3)
+    y <- List.of(1, 2, 3)
+    z <- Stream.of(1, 2, 3)
+  do
+    println(x + y + z)
+
+}


### PR DESCRIPTION
Support java collections & streams in for-do loops by defining foreach extension methods in scala.Predef

Alternative to https://github.com/lampepfl/dotty/pull/15368