### PR TITLE
Case class must have at least one *leading* non-implicit parameter list

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2344,10 +2344,10 @@ import transform.SymUtils._
   class CaseClassMissingNonImplicitParamList(cdef: untpd.TypeDef)(using Context)
     extends SyntaxMsg(CaseClassMissingNonImplicitParamListID) {
     def msg =
-      em"""|A ${hl("case class")} must have at least one non-implicit parameter list"""
+      em"""|A ${hl("case class")} must have at least one leading non-implicit parameter list"""
 
     def explain =
-      em"""|${cdef.name} must have at least one non-implicit parameter list,
+      em"""|${cdef.name} must have at least one leading non-implicit parameter list,
            | if you're aiming to have a case class parametrized only by implicit ones, you should
            | add an explicit ${hl("()")} as a parameter list to ${cdef.name}.""".stripMargin
   }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2349,7 +2349,7 @@ import transform.SymUtils._
     def explain =
       em"""|${cdef.name} must have at least one leading non-implicit parameter list,
            | if you're aiming to have a case class parametrized only by implicit ones, you should
-           | add an explicit ${hl("()")} as a parameter list to ${cdef.name}.""".stripMargin
+           | add an explicit ${hl("()")} as the first parameter list to ${cdef.name}.""".stripMargin
   }
 
   class EnumerationsShouldNotBeEmpty(cdef: untpd.TypeDef)(using Context)


### PR DESCRIPTION
Closes #15202. Changes the message for case classes like `case class Foo(using Bar)(x: Baz)` from `Foo must have at least one non-implicit parameter list` to `must have at least one leading non-implicit parameter list`.