### PR TITLE
Preserve modifiers when desugaring for-comps

### DIFF
--- a/tests/run/fors.check
+++ b/tests/run/fors.check
@@ -44,3 +44,8 @@ hello  world
 hello  world 
 hello/1~2 hello/3~4 /1~2 /3~4 world/1~2 world/3~4 
 (2,1) (4,3) 
+
+testGivens
+123
+456
+0

--- a/tests/run/fors.scala
+++ b/tests/run/fors.scala
@@ -74,7 +74,6 @@ object Test extends App {
 
     // arrays
     for (x <- ar) print(x + " "); println()
-
   }
 
   /////////////////// filtering with case ///////////////////
@@ -109,9 +108,38 @@ object Test extends App {
     for case (x, y) <- xs do print(s"${(y, x)} "); println()
   }
 
+  def testGivens(): Unit = {
+    println("\ntestGivens")
+
+    // bound given that is summoned in subsequent bind
+    for
+      a <- List(123)
+      given Int = a
+      b = summon[Int]
+    do
+      println(b)
+
+    // generated given that is summoned in subsequent bind
+    for
+      given Int <- List(456)
+      x = summon[Int]
+    do
+      println(x)
+
+    // pick the correct given
+    for
+      a <- List(789)
+      given Int = a
+      given Int <- List(0)
+      x = summon[Int]
+    do
+      println(x)
+  }
+
   ////////////////////////////////////////////////////
 
   testOld()
   testNew()
   testFiltering()
+  testGivens()
 }


### PR DESCRIPTION
When `Bind` trees are copied, `Modifiers` are not copied along with them, causing generated vals and pattern matches to lose given modifiers.

fixes https://github.com/lampepfl/dotty/issues/12646