### PR TITLE
Add runtime.TupleMirror to avoid anonymous classes for mirrors of tuples

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -915,6 +915,8 @@ class Definitions {
 
     def TupleXXL_fromIterator(using Context): Symbol = TupleXXLModule.requiredMethod("fromIterator")
 
+  @tu lazy val RuntimeTupleMirrorTypeRef: TypeRef = requiredClassRef("scala.runtime.TupleMirror")
+
   @tu lazy val RuntimeTuplesModule: Symbol = requiredModule("scala.runtime.Tuples")
   @tu lazy val RuntimeTuplesModuleClass: Symbol = RuntimeTuplesModule.moduleClass
     lazy val RuntimeTuples_consIterator: Symbol = RuntimeTuplesModule.requiredMethod("consIterator")

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -26,12 +26,6 @@ object SyntheticMembers {
 
   /** Attachment recording that an anonymous class should extend Mirror.Sum */
   val ExtendsSumMirror: Property.StickyKey[Unit] = new Property.StickyKey
-
-  /** Attachment recording that an anonymous class (with the ExtendsProductMirror attachment)
-   *  should implement its `fromProduct` method in terms of the runtime class corresponding
-   *  to a tuple with that arity.
-   */
-  val GenericTupleArity: Property.StickyKey[Int] = new Property.StickyKey
 }
 
 /** Synthetic method implementations for case classes, case objects,
@@ -607,11 +601,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     else if (impl.removeAttachment(ExtendsSingletonMirror).isDefined)
       makeSingletonMirror()
     else if (impl.removeAttachment(ExtendsProductMirror).isDefined)
-      val tupleArity = impl.removeAttachment(GenericTupleArity)
-      val cls = tupleArity match
-        case Some(n) => defn.TupleType(n).nn.classSymbol
-        case _ => monoType.typeRef.dealias.classSymbol
-      makeProductMirror(cls)
+      makeProductMirror(monoType.typeRef.dealias.classSymbol)
     else if (impl.removeAttachment(ExtendsSumMirror).isDefined)
       makeSumMirror(monoType.typeRef.dealias.classSymbol)
 

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -408,11 +408,8 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       }
       val mirrorRef =
         if cls.useCompanionAsProductMirror then companionPath(mirroredType, span)
-        else
-          if defn.isTupleClass(cls) then // add `|| cls == defn.PairClass` when we support TupleXXL
-            newTupleMirror(arity = typeElems.size)
-          else
-            anonymousMirror(monoType, ExtendsProductMirror, span)
+        else if defn.isTupleClass(cls) then newTupleMirror(typeElems.size) // TODO: cls == defn.PairClass when > 22
+        else anonymousMirror(monoType, ExtendsProductMirror, span)
       withNoErrors(mirrorRef.cast(mirrorType))
     end makeProductMirror
 

--- a/library/src/scala/runtime/TupleMirror.scala
+++ b/library/src/scala/runtime/TupleMirror.scala
@@ -4,13 +4,11 @@ package scala.runtime
  *  as we do not need to synthesize an anonymous Mirror class at every callsite.
  */
 final class TupleMirror(arity: Int) extends scala.deriving.Mirror.Product with Serializable:
-  assert(arity > 0) // EmptyTuple is not a valid `MirroredType` for TupleMirror
+  assert(arity >= 0) // technically could be used for EmptyTuple also, but it has its own singleton mirror.
 
-  override type MirroredMonoType <: NonEmptyTuple
+  override type MirroredMonoType <: Tuple
 
   final def fromProduct(product: Product): MirroredMonoType =
     if product.productArity != arity then
       throw IllegalArgumentException(s"expected Product with $arity elements, got ${product.productArity}")
     runtime.Tuples.fromProduct(product).asInstanceOf[MirroredMonoType]
-
-  override final def toString: String = s"<tuple-mirror@${Integer.toHexString(hashCode).nn.take(6)}>"

--- a/library/src/scala/runtime/TupleMirror.scala
+++ b/library/src/scala/runtime/TupleMirror.scala
@@ -1,0 +1,16 @@
+package scala.runtime
+
+/** A concrete subclass of `scala.deriving.Mirror.Product`, enabling reduction of bytecode size.
+ *  as we do not need to synthesize an anonymous Mirror class at every callsite.
+ */
+final class TupleMirror(arity: Int) extends scala.deriving.Mirror.Product with Serializable:
+  assert(arity > 0) // EmptyTuple is not a valid `MirroredType` for TupleMirror
+
+  override type MirroredMonoType <: NonEmptyTuple
+
+  final def fromProduct(product: Product): MirroredMonoType =
+    if product.productArity != arity then
+      throw IllegalArgumentException(s"expected Product with $arity elements, got ${product.productArity}")
+    runtime.Tuples.fromProduct(product).asInstanceOf[MirroredMonoType]
+
+  override final def toString: String = s"<tuple-mirror@${Integer.toHexString(hashCode).nn.take(6)}>"

--- a/tests/run/i15399.check
+++ b/tests/run/i15399.check
@@ -1,0 +1,4 @@
+Expected failure when pass Tuple3 to TupleMirror(2):
+-  expected Product with 2 elements, got 3
+Expected failure when pass Tuple1 to TupleMirror(2):
+-  expected Product with 2 elements, got 1

--- a/tests/run/i15399.scala
+++ b/tests/run/i15399.scala
@@ -1,0 +1,15 @@
+@main def Test =
+  val tup2Mirror = summon[scala.deriving.Mirror.Of[(Int, Int)]]
+  try
+    val tup2a: (Int, Int) = tup2Mirror.fromProduct((1, 2, 3)) // fails silently and creates (1, 2)
+    println(tup2a)  // should be unreachable
+  catch case err: IllegalArgumentException =>
+    println("Expected failure when pass Tuple3 to TupleMirror(2):")
+    println(s"-  ${err.getMessage}")
+
+  try
+    val tup2b: (Int, Int) = tup2Mirror.fromProduct(Tuple(1)) // crashes with index out of bounds
+    println(tup2b) // should be unreachable
+  catch case err: IllegalArgumentException =>
+    println("Expected failure when pass Tuple1 to TupleMirror(2):")
+    println(s"-  ${err.getMessage}")


### PR DESCRIPTION
adds the `runtime.TupleMirror` class as a way to decrease bytecode generation for mirrors of Tuples. Also adapts mirror synthesis to use TupleMirror for mirrors of tuples.

Follow up work is to enable Synthesizer to accept tuples of arity > 22

fixes #15399