### PR TITLE
Add -Vprofile option

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -206,8 +206,10 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     compiling = true
 
     profile =
-      if ctx.settings.Yprofile.value || !ctx.settings.YprofileSortedBy.value.isEmpty
-      then ActiveProfile()
+      if ctx.settings.Vprofile.value
+        || !ctx.settings.VprofileSortedBy.value.isEmpty
+        || ctx.settings.VprofileDetails.value != 0
+      then ActiveProfile(ctx.settings.VprofileDetails.value.max(0).min(1000))
       else NoProfile
 
     // If testing pickler, make sure to stop after pickling phase:

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -333,4 +333,8 @@ private sealed trait YSettings:
   val YinstrumentDefs: Setting[Boolean] = BooleanSetting("-Yinstrument-defs", "Add instrumentation code that counts method calls; needs -Yinstrument to be set, too.")
 
   val YforceInlineWhileTyping: Setting[Boolean] = BooleanSetting("-Yforce-inline-while-typing", "Make non-transparent inline methods inline when typing. Emulates the old inlining behavior of 3.0.0-M3.")
+
+  val Yprofile: Setting[Boolean] = BooleanSetting("-Yprofile", "Show information about sizes and compiletime complexity.")
+  val YprofileSortedBy = ChoiceSetting("-Yprofile-sorted-by", "key", "Show information about sizes and compiletime complexity sorted by given column name", List("name", "path", "lines", "tokens", "tasty", "complexity"), "")
 end YSettings
+

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -146,6 +146,10 @@ private sealed trait VerboseSettings:
   val Xprint: Setting[List[String]] = PhasesSetting("-Vprint", "Print out program after", aliases = List("-Xprint"))
   val XshowPhases: Setting[Boolean] = BooleanSetting("-Vphases", "List compiler phases.", aliases = List("-Xshow-phases"))
 
+  val Vprofile: Setting[Boolean] = BooleanSetting("-Vprofile", "Show information about sizes and compiletime complexity.")
+  val VprofileSortedBy = ChoiceSetting("-Vprofile-sorted-by", "key", "Show information about sizes and compiletime complexity sorted by given column name", List("name", "path", "lines", "tokens", "tasty", "complexity"), "")
+  val VprofileDetails = IntSetting("-Vprofile-details", "List tasty sizes of a given number of most complex methods", 0)
+
 /** -W "Warnings" settings
  */
 private sealed trait WarningSettings:
@@ -333,8 +337,5 @@ private sealed trait YSettings:
   val YinstrumentDefs: Setting[Boolean] = BooleanSetting("-Yinstrument-defs", "Add instrumentation code that counts method calls; needs -Yinstrument to be set, too.")
 
   val YforceInlineWhileTyping: Setting[Boolean] = BooleanSetting("-Yforce-inline-while-typing", "Make non-transparent inline methods inline when typing. Emulates the old inlining behavior of 3.0.0-M3.")
-
-  val Yprofile: Setting[Boolean] = BooleanSetting("-Yprofile", "Show information about sizes and compiletime complexity.")
-  val YprofileSortedBy = ChoiceSetting("-Yprofile-sorted-by", "key", "Show information about sizes and compiletime complexity sorted by given column name", List("name", "path", "lines", "tokens", "tasty", "complexity"), "")
 end YSettings
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -146,9 +146,9 @@ private sealed trait VerboseSettings:
   val Xprint: Setting[List[String]] = PhasesSetting("-Vprint", "Print out program after", aliases = List("-Xprint"))
   val XshowPhases: Setting[Boolean] = BooleanSetting("-Vphases", "List compiler phases.", aliases = List("-Xshow-phases"))
 
-  val Vprofile: Setting[Boolean] = BooleanSetting("-Vprofile", "Show information about sizes and compiletime complexity.")
-  val VprofileSortedBy = ChoiceSetting("-Vprofile-sorted-by", "key", "Show information about sizes and compiletime complexity sorted by given column name", List("name", "path", "lines", "tokens", "tasty", "complexity"), "")
-  val VprofileDetails = IntSetting("-Vprofile-details", "List tasty sizes of a given number of most complex methods", 0)
+  val Vprofile: Setting[Boolean] = BooleanSetting("-Vprofile", "Show metrics about sources and internal representations to estimate compile-time complexity.")
+  val VprofileSortedBy = ChoiceSetting("-Vprofile-sorted-by", "key", "Show metrics about sources and internal representations sorted by given column name", List("name", "path", "lines", "tokens", "tasty", "complexity"), "")
+  val VprofileDetails = IntSetting("-Vprofile-details", "Show metrics about sources and internal representations of the most complex methods", 0)
 
 /** -W "Warnings" settings
  */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -172,7 +172,7 @@ object Parsers {
 
   class Parser(source: SourceFile)(using Context) extends ParserCommon(source) {
 
-    val in: Scanner = new Scanner(source)
+    val in: Scanner = new Scanner(source, profile = Profile.current)
     // in.debugTokenStream = true    // uncomment to see the token stream of the standard scanner, but not syntax highlighting
 
     /** This is the general parse entry point.

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -162,7 +162,7 @@ object Scanners {
         errorButContinue("trailing separator is not allowed", offset + litBuf.length - 1)
   }
 
-  class Scanner(source: SourceFile, override val startFrom: Offset = 0)(using Context) extends ScannerCommon(source) {
+  class Scanner(source: SourceFile, override val startFrom: Offset = 0, profile: Profile = NoProfile)(using Context) extends ScannerCommon(source) {
     val keepComments = !ctx.settings.YdropComments.value
 
     /** A switch whether operators at the start of lines can be infix operators */
@@ -189,8 +189,6 @@ object Scanners {
         case self: LookaheadScanner => self.allowIndent
         case _ => true
       }
-
-    private val profile = if this.isInstanceOf[LookaheadScanner] then NoProfile else Profile.current
 
     if (rewrite) {
       val s = ctx.settings

--- a/compiler/src/dotty/tools/dotc/reporting/Profile.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Profile.scala
@@ -4,14 +4,20 @@ package reporting
 
 import core.*
 import Contexts.{Context, ctx}
+import Symbols.{Symbol, NoSymbol}
 import collection.mutable
 import util.{EqHashMap, NoSourcePosition}
+import util.Spans.{Span, NoSpan}
+import Decorators.i
+import parsing.Scanners.Scanner
+import io.AbstractFile
 
 abstract class Profile:
   def unitProfile(unit: CompilationUnit): Profile.Info
   def recordNewLine()(using Context): Unit
   def recordNewToken()(using Context): Unit
   def recordTasty(size: Int)(using Context): Unit
+  def recordMethodSize(meth: Symbol, size: Int, span: Span)(using Context): Unit
   def printSummary()(using Context): Unit
 
 object Profile:
@@ -19,27 +25,40 @@ object Profile:
     val run = ctx.run
     if run == null then NoProfile else run.profile
 
-  private val TastyFactor = 50
+  inline val TastyChunkSize = 50
 
-  class Info:
+  case class MethodInfo(meth: Symbol, size: Int, span: Span)
+  object NoInfo extends MethodInfo(NoSymbol, 0, NoSpan)
+
+  class Info(details: Int):
     var lineCount: Int = 0
     var tokenCount: Int = 0
     var tastySize: Int = 0
-    def complexity: Float = tastySize.toFloat/lineCount/TastyFactor
+    def complexity: Float = (tastySize/TastyChunkSize).toFloat/lineCount
+    val leading: Array[MethodInfo] = Array.fill[MethodInfo](details)(NoInfo)
+
+    def recordMethodSize(meth: Symbol, size: Int, span: Span): Unit =
+      var i = leading.length
+      while i > 0 && leading(i - 1).size < size do
+        if i < leading.length then leading(i) = leading(i - 1)
+        i -= 1
+      if i < leading.length then
+        leading(i) = MethodInfo(meth, size, span)
+  end Info
 end Profile
 
-class ActiveProfile extends Profile:
+class ActiveProfile(details: Int) extends Profile:
 
   private val pinfo = new EqHashMap[CompilationUnit, Profile.Info]
 
-  private val junkInfo = new Profile.Info
+  private val junkInfo = new Profile.Info(0)
 
   private def curInfo(using Context): Profile.Info =
     val unit: CompilationUnit | Null = ctx.compilationUnit
     if unit == null then junkInfo else unitProfile(unit)
 
   def unitProfile(unit: CompilationUnit): Profile.Info =
-    pinfo.getOrElseUpdate(unit, new Profile.Info)
+    pinfo.getOrElseUpdate(unit, new Profile.Info(details))
 
   def recordNewLine()(using Context): Unit =
     curInfo.lineCount += 1
@@ -47,11 +66,13 @@ class ActiveProfile extends Profile:
     curInfo.tokenCount += 1
   def recordTasty(size: Int)(using Context): Unit =
     curInfo.tastySize += size
+  def recordMethodSize(meth: Symbol, size: Int, span: Span)(using Context): Unit =
+    curInfo.recordMethodSize(meth, size, span)
 
   def printSummary()(using Context): Unit =
     val units =
       val rawUnits = pinfo.keysIterator.toArray
-      ctx.settings.YprofileSortedBy.value match
+      ctx.settings.VprofileSortedBy.value match
         case "name"       => rawUnits.sortBy(_.source.file.name)
         case "path"       => rawUnits.sortBy(_.source.file.path)
         case "lines"      => rawUnits.sortBy(unitProfile(_).lineCount)
@@ -59,32 +80,67 @@ class ActiveProfile extends Profile:
         case "complexity" => rawUnits.sortBy(unitProfile(_).complexity)
         case _            => rawUnits.sortBy(unitProfile(_).tastySize)
 
-    val nameWidth = units.map(_.source.file.name.length).max.max(10).min(50)
-    val layout = s"%-${nameWidth}s %6s %8s %8s %s     %s"
-    report.echo(layout.format("Source file", "Lines", "Tokens", "Tasty", " Complexity/Line", "Directory"))
+    def printHeader(sourceNameWidth: Int, methNameWidth: Int = 0): String =
+      val prefix =
+        if methNameWidth > 0
+        then s"%-${sourceNameWidth}s %-${methNameWidth}s".format("Sourcefile", "Method")
+        else s"%-${sourceNameWidth}s".format("Sourcefile")
+      val layout = s"%-${prefix.length}s %6s %8s %7s %s    %s"
+      report.echo(layout.format(prefix, "Lines", "Tokens", "Tasty", " Complexity/Line", "Directory"))
+      layout
 
-    def printInfo(name: String, info: Profile.Info, path: String) =
+    def printInfo(layout: String, name: String, info: Profile.Info, path: String) =
       val complexity = info.complexity
       val explanation =
         if complexity < 1       then "low     "
         else if complexity < 5  then "moderate"
         else if complexity < 25 then "high    "
         else                         "extreme "
-      val complexityStr = s"${"%6.2f".format(info.complexity)}  $explanation"
       report.echo(layout.format(
-        name, info.lineCount, info.tokenCount, info.tastySize, complexityStr, path))
+        name, info.lineCount, info.tokenCount, info.tastySize/Profile.TastyChunkSize,
+        s"${"%6.2f".format(complexity)}  $explanation", path))
 
-    val agg = new Profile.Info
-    for unit <- units do
-      val info = unitProfile(unit)
-      val file = unit.source.file
-      printInfo(file.name, info, file.container.path)
-      agg.lineCount += info.lineCount
-      agg.tokenCount += info.tokenCount
-      agg.tastySize += info.tastySize
-    if units.length > 1 then
-      report.echo(s"${"-"*nameWidth}------------------------------------------")
-      printInfo("Total", agg, "")
+    def safeMax(xs: Array[Int]) = xs.max.max(10).min(50)
+
+    def printAndAggregateSourceInfos(): Profile.Info =
+      val sourceNameWidth = safeMax(units.map(_.source.file.name.length))
+      val layout = printHeader(sourceNameWidth)
+      val agg = new Profile.Info(details)
+      for unit <- units do
+        val file = unit.source.file
+        val info = unitProfile(unit)
+        printInfo(layout, file.name, info, file.container.path)
+        agg.lineCount += info.lineCount
+        agg.tokenCount += info.tokenCount
+        agg.tastySize += info.tastySize
+        for Profile.MethodInfo(meth, size, span) <- info.leading do
+          agg.recordMethodSize(meth, size, span)
+      if units.length > 1 then
+        report.echo(s"${"-" * sourceNameWidth}------------------------------------------")
+        printInfo(layout, "Total", agg, "")
+      agg
+
+    def printDetails(agg: Profile.Info): Unit =
+      val sourceNameWidth = safeMax(agg.leading.map(_.meth.source.name.length))
+      val methNameWidth = safeMax(agg.leading.map(_.meth.name.toString.length))
+      report.echo("\nMost complex methods:")
+      val layout = printHeader(sourceNameWidth, methNameWidth)
+      for
+        Profile.MethodInfo(meth, size, span) <- agg.leading.reverse
+        unit <- units.find(_.source.eq(meth.source))
+      do
+        val methProfile = new ActiveProfile(0)
+        val methCtx = ctx.fresh.setCompilationUnit(unit)
+        val s = Scanner(meth.source, span.start, methProfile)(using methCtx)
+        while s.offset < span.end do s.nextToken()
+        val info = methProfile.unitProfile(unit)
+        info.tastySize = size
+        val file = meth.source.file
+        val header = s"%-${sourceNameWidth}s %-${methNameWidth}s".format(file.name, meth.name)
+        printInfo(layout, header, info, file.container.path)
+
+    val agg = printAndAggregateSourceInfos()
+    if details > 0 then printDetails(agg)
   end printSummary
 end ActiveProfile
 
@@ -93,4 +149,5 @@ object NoProfile extends Profile:
   def recordNewLine()(using Context): Unit = ()
   def recordNewToken()(using Context): Unit = ()
   def recordTasty(size: Int)(using Context): Unit = ()
+  def recordMethodSize(meth: Symbol, size: Int, span: Span)(using Context): Unit = ()
   def printSummary()(using Context): Unit = ()

--- a/compiler/src/dotty/tools/dotc/reporting/Profile.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Profile.scala
@@ -11,6 +11,7 @@ import util.Spans.{Span, NoSpan}
 import Decorators.i
 import parsing.Scanners.Scanner
 import io.AbstractFile
+import annotation.internal.sharable
 
 abstract class Profile:
   def unitProfile(unit: CompilationUnit): Profile.Info
@@ -28,7 +29,7 @@ object Profile:
   inline val TastyChunkSize = 50
 
   case class MethodInfo(meth: Symbol, size: Int, span: Span)
-  object NoInfo extends MethodInfo(NoSymbol, 0, NoSpan)
+  @sharable object NoInfo extends MethodInfo(NoSymbol, 0, NoSpan)
 
   class Info(details: Int):
     var lineCount: Int = 0

--- a/compiler/src/dotty/tools/dotc/reporting/Profile.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Profile.scala
@@ -16,9 +16,10 @@ abstract class Profile:
 
 object Profile:
   def current(using Context): Profile =
-    if ctx.run == null then NoProfile else ctx.run.profile
+    val run = ctx.run
+    if run == null then NoProfile else run.profile
 
-  private val TastyFactor = 40
+  private val TastyFactor = 50
 
   class Info:
     var lineCount: Int = 0
@@ -34,7 +35,7 @@ class ActiveProfile extends Profile:
   private val junkInfo = new Profile.Info
 
   private def curInfo(using Context): Profile.Info =
-    val unit = ctx.compilationUnit
+    val unit: CompilationUnit | Null = ctx.compilationUnit
     if unit == null then junkInfo else unitProfile(unit)
 
   def unitProfile(unit: CompilationUnit): Profile.Info =

--- a/compiler/src/dotty/tools/dotc/reporting/Profile.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Profile.scala
@@ -1,0 +1,95 @@
+package dotty.tools
+package dotc
+package reporting
+
+import core.*
+import Contexts.{Context, ctx}
+import collection.mutable
+import util.{EqHashMap, NoSourcePosition}
+
+abstract class Profile:
+  def unitProfile(unit: CompilationUnit): Profile.Info
+  def recordNewLine()(using Context): Unit
+  def recordNewToken()(using Context): Unit
+  def recordTasty(size: Int)(using Context): Unit
+  def printSummary()(using Context): Unit
+
+object Profile:
+  def current(using Context): Profile =
+    if ctx.run == null then NoProfile else ctx.run.profile
+
+  private val TastyFactor = 40
+
+  class Info:
+    var lineCount: Int = 0
+    var tokenCount: Int = 0
+    var tastySize: Int = 0
+    def complexity: Float = tastySize.toFloat/lineCount/TastyFactor
+end Profile
+
+class ActiveProfile extends Profile:
+
+  private val pinfo = new EqHashMap[CompilationUnit, Profile.Info]
+
+  private val junkInfo = new Profile.Info
+
+  private def curInfo(using Context): Profile.Info =
+    val unit = ctx.compilationUnit
+    if unit == null then junkInfo else unitProfile(unit)
+
+  def unitProfile(unit: CompilationUnit): Profile.Info =
+    pinfo.getOrElseUpdate(unit, new Profile.Info)
+
+  def recordNewLine()(using Context): Unit =
+    curInfo.lineCount += 1
+  def recordNewToken()(using Context): Unit =
+    curInfo.tokenCount += 1
+  def recordTasty(size: Int)(using Context): Unit =
+    curInfo.tastySize += size
+
+  def printSummary()(using Context): Unit =
+    val units =
+      val rawUnits = pinfo.keysIterator.toArray
+      ctx.settings.YprofileSortedBy.value match
+        case "name"       => rawUnits.sortBy(_.source.file.name)
+        case "path"       => rawUnits.sortBy(_.source.file.path)
+        case "lines"      => rawUnits.sortBy(unitProfile(_).lineCount)
+        case "tokens"     => rawUnits.sortBy(unitProfile(_).tokenCount)
+        case "complexity" => rawUnits.sortBy(unitProfile(_).complexity)
+        case _            => rawUnits.sortBy(unitProfile(_).tastySize)
+
+    val nameWidth = units.map(_.source.file.name.length).max.max(10).min(50)
+    val layout = s"%-${nameWidth}s %6s %8s %8s %s     %s"
+    report.echo(layout.format("Source file", "Lines", "Tokens", "Tasty", " Complexity/Line", "Directory"))
+
+    def printInfo(name: String, info: Profile.Info, path: String) =
+      val complexity = info.complexity
+      val explanation =
+        if complexity < 1       then "low     "
+        else if complexity < 5  then "moderate"
+        else if complexity < 25 then "high    "
+        else                         "extreme "
+      val complexityStr = s"${"%6.2f".format(info.complexity)}  $explanation"
+      report.echo(layout.format(
+        name, info.lineCount, info.tokenCount, info.tastySize, complexityStr, path))
+
+    val agg = new Profile.Info
+    for unit <- units do
+      val info = unitProfile(unit)
+      val file = unit.source.file
+      printInfo(file.name, info, file.container.path)
+      agg.lineCount += info.lineCount
+      agg.tokenCount += info.tokenCount
+      agg.tastySize += info.tastySize
+    if units.length > 1 then
+      report.echo(s"${"-"*nameWidth}------------------------------------------")
+      printInfo("Total", agg, "")
+  end printSummary
+end ActiveProfile
+
+object NoProfile extends Profile:
+  def unitProfile(unit: CompilationUnit) = unsupported("NoProfile.info")
+  def recordNewLine()(using Context): Unit = ()
+  def recordNewToken()(using Context): Unit = ()
+  def recordTasty(size: Int)(using Context): Unit = ()
+  def printSummary()(using Context): Unit = ()

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -214,14 +214,14 @@ abstract class Reporter extends interfaces.ReporterResult {
     b.mkString("\n")
   }
 
-  def summarizeUnreportedWarnings(using Context): Unit =
+  def summarizeUnreportedWarnings()(using Context): Unit =
     for (settingName, count) <- unreportedWarnings do
       val were = if count == 1 then "was" else "were"
       val msg = s"there $were ${countString(count, settingName.tail + " warning")}; re-run with $settingName for details"
       report(Warning(msg, NoSourcePosition))
 
   /** Print the summary of warnings and errors */
-  def printSummary(using Context): Unit = {
+  def printSummary()(using Context): Unit = {
     val s = summary
     if (s != "") report(new Info(s, NoSourcePosition))
   }

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -11,7 +11,7 @@ import Periods._
 import Phases._
 import Symbols._
 import Flags.Module
-import reporting.ThrowingReporter
+import reporting.{ThrowingReporter, Profile}
 import collection.mutable
 import scala.concurrent.{Future, Await, ExecutionContext}
 import scala.concurrent.duration.Duration
@@ -70,6 +70,7 @@ class Pickler extends Phase {
         picklers(cls) = pickler
       val treePkl = new TreePickler(pickler)
       treePkl.pickle(tree :: Nil)
+      Profile.current.recordTasty(treePkl.buf.length)
       val positionWarnings = new mutable.ListBuffer[String]()
       val pickledF = inContext(ctx.fresh) {
         Future {

--- a/compiler/test/dotty/tools/dotc/parsing/desugarPackage.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/desugarPackage.scala
@@ -16,7 +16,7 @@ object desugarPackage extends DeSugarTest {
     val buf = parsedTrees map desugarTree
     val ms2 = (System.nanoTime() - start)/1000000
     println(s"$parsed files parsed in ${ms1}ms, ${nodes - startNodes} nodes desugared in ${ms2-ms1}ms, total trees created = ${Trees.ntrees - startNodes}")
-    ctx.reporter.printSummary
+    ctx.reporter.printSummary()
   }
 
   def main(args: Array[String]): Unit = {

--- a/compiler/test/dotty/tools/dotc/parsing/parsePackage.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/parsePackage.scala
@@ -70,7 +70,7 @@ object parsePackage extends ParserTest {
     val buf = parsedTrees map transformer.transform
     val ms2 = (System.nanoTime() - start)/1000000
     println(s"$parsed files parsed in ${ms1}ms, $nodes nodes transformed in ${ms2-ms1}ms, total trees created = ${Trees.ntrees}")
-    ctx.reporter.printSummary
+    ctx.reporter.printSummary()
   }
 
   def main(args: Array[String]): Unit = {

--- a/tests/pos/profile-test.scala
+++ b/tests/pos/profile-test.scala
@@ -1,0 +1,29 @@
+// When compiling this with -Yprofile, this should output
+//
+// Source file         Lines   Tokens    Tasty  Complexity/Line     Directory
+// profile-test.scala     16       50      316   0.49  low          tests/pos
+object ProfileTest:
+
+  def test = ???
+
+  def bar: Boolean = ??? ;
+  def baz = ???
+
+  /** doc comment
+   */
+  def bam = ???
+
+  if bar then
+    // comment
+    baz
+  else
+    bam
+
+  if bar then {
+    baz
+  }
+  else {
+    // comment
+    bam
+  }
+


### PR DESCRIPTION
Add `-Vprofile` and `-Vprofile-sorted-by` options.

This prints for each source file

 - the number of code lines
 - the number of tokens
 - the size of serialized tasty trees (just the trees, not the name table, nor the positions)
 - the complexity per line, computed by the formula (tasty-size/lines/50). That is, we
   assume 50 tasty-bytes/line as standard. 

Using `-Vprofile-sorted-by` one can sort by a column name.