### PR TITLE
Fix TupleXXL.productPrefix

### DIFF
--- a/library/src/scala/runtime/TupleXXL.scala
+++ b/library/src/scala/runtime/TupleXXL.scala
@@ -5,7 +5,7 @@ final class TupleXXL private (es: IArray[Object]) extends Product {
 
   def productElement(n: Int): Any = es(n)
   def productArity: Int = es.length
-  override def productPrefix: String = "TupleXXL"
+  override def productPrefix: String = "Tuple"
 
   override def toString: String =
     elems.asInstanceOf[Array[Object]].mkString("(", ",", ")")


### PR DESCRIPTION
The current version returns `"TupleXXL"` which leaks erasure details.
From the user perspective, any tuple lager than 2 is of type `Tuple`
which is a `Product`. Therefore the `productPrefix` should be `Tuple`.