### PR TITLE
Fix #15405: Dealias Or type constituents when finding its dominator

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -594,7 +594,7 @@ object Types {
       try
         this match
           case tp: TypeProxy =>
-            tp.underlying.baseClasses
+            tp.superType.baseClasses
           case tp: ClassInfo =>
             tp.cls.classDenot.baseClasses
           case _ => Nil

--- a/tests/pos/i15405.scala
+++ b/tests/pos/i15405.scala
@@ -1,0 +1,4 @@
+type Validated[A] = A
+class Foo:
+  def >(x: Int) = true
+def foo(v: Foo|Validated[Foo]): Unit = v > 10


### PR DESCRIPTION
In the issue, `v: Int` is boxed to `RichInt`. This is because the typer can't find `>` in `Int | Validated[Int]` and attempts an implicit conversion. This is in turn because when looking up members of a union type, we do the `join` operation on that union type, which attempts to simplify it by reducing it to the intersection of the base classes of its constituents.

It seems that this intersection algorithm, while operating on dealiased constituents, does not dealias them at a certain point, thus judging that the intersection of base types of `Int` and `Validated[Int]` is `Any`. This PR adds such a dealias.

Using `Foo` instead of `Int` in tests to remove implicit conversions out of the equation; without the PR's change the test fails.