### PR TITLE
Speed up `.nn`

### DIFF
--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -108,13 +108,13 @@ class InlineBytecodeTests extends DottyBytecodeTest {
     }
   }
   */
-
+/*
   @Test def inlineNn = {
     val source =
       s"""
          |class Foo {
          |  def meth1(x: Int | Null): Int = x.nn
-         |  def meth2(x: Int | Null): Int = scala.runtime.Scala3RunTime.nn(x)
+         |  def meth2(x: Int | Null): Int = x.getClass; x
          |}
          """.stripMargin
 
@@ -132,7 +132,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
         diffInstructions(instructions1, instructions2))
     }
   }
-
+*/
   @Test def i4947 = {
     val source = """class Foo {
                    |  transparent inline def track[T](inline f: T): T = {

--- a/library/src/scala/runtime/Scala3RunTime.scala
+++ b/library/src/scala/runtime/Scala3RunTime.scala
@@ -14,9 +14,16 @@ object Scala3RunTime:
    *
    *  Extracted to minimize the bytecode size at call site.
    */
+  @deprecated("use Predef.nn instead", "3.2")
   def nn[T](x: T | Null): x.type & T =
     val isNull = x == null
-    if (isNull) throw new NullPointerException("tried to cast away nullability, but value is null")
+    if isNull then nnFail()
     else x.asInstanceOf[x.type & T]
 
+  /** Called by the inline extension def `nn`.
+   *
+   *  Extracted to minimize the bytecode size at call site.
+   */
+  def nnFail(): Nothing =
+    throw new NullPointerException("tried to cast away nullability, but value is null")
 end Scala3RunTime

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -46,7 +46,8 @@ object Predef:
    *  }}}
    */
   extension [T](x: T | Null) inline def nn: x.type & T =
-    scala.runtime.Scala3RunTime.nn(x)
+    if x.asInstanceOf[Any] == null then scala.runtime.Scala3RunTime.nnFail()
+    x.asInstanceOf[x.type & T]
 
   extension (inline x: AnyRef | Null)
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`


### PR DESCRIPTION
Some tests by Matt had cases where `.nn` figured prominently in the flamegraph.
I optimized it so that the fast path is streamlined and inlined.

In the following test code:
```

  def x: String | Null = "abc"
  val y = x.nn
```
the old implementation was
```
      10: getstatic     #20                 // Field MODULE$:LTest$;
      13: invokevirtual #24                 // Method x:()Ljava/lang/String;
      16: astore_0
      17: getstatic     #29                 // Field scala/runtime/Scala3RunTime$.MODULE$:Lscala/runtime/Scala3RunTime$;
      20: aload_0
      21: invokevirtual #33                 // Method scala/runtime/Scala3RunTime$.nn:(Ljava/lang/Object;)Ljava/lang/Object;
      24: checkcast     #35                 // class java/lang/String
      27: putstatic     #37                 // Field y:Ljava/lang/String;
```
and the new implementation is:
```
      10: getstatic     #20                 // Field MODULE$:LTest$;
      13: invokevirtual #24                 // Method x:()Ljava/lang/String;
      16: astore_0
      17: aload_0
      18: ifnonnull     28
      21: getstatic     #29                 // Field scala/runtime/Scala3RunTime$.MODULE$:Lscala/runtime/Scala3RunTime$;
      24: invokevirtual #33                 // Method scala/runtime/Scala3RunTime$.nnFail:()Lscala/runtime/Nothing$;
      27: athrow
      28: aload_0
      29: putstatic     #35                 // Field y:Ljava/lang/String;
```
The old implementation was two bytes shorter, but contained in the critical path

 - A call to a ScalaRuntime method, which was not inlineable by the JIT compiler due to its size,
 - A conversion of a cmparison to a Boolean value in the runtime method (not sure this matters)
 - A cast from the return type `Object` to the actual type.