### PR TITLE
docs: Add a comment to `pathTo` mentioning that it might return `errorTermTree`

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -247,6 +247,11 @@ object Interactive {
   /** The reverse path to the node that closest encloses position `pos`,
    *  or `Nil` if no such path exists. If a non-empty path is returned it starts with
    *  the tree closest enclosing `pos` and ends with an element of `trees`.
+   *
+   *  Note that if the given `pos` points out places for incomplete parses,
+   *  this method returns `errorTermTree` (`Literal(Consotant(null)`).
+   *
+   *  @see https://github.com/lampepfl/dotty/issues/15294
    */
   def pathTo(trees: List[SourceTree], pos: SourcePosition)(using Context): List[Tree] =
     pathTo(trees.map(_.tree), pos.span)


### PR DESCRIPTION
Closes https://github.com/lampepfl/dotty/issues/15294

We agreed that we could close the issue by adding a comment mentioning `Interactive.pathTo` might return `errorTermTree` if `pos` points out the places for incomplete parse.