### PR TITLE
Fix loop in parser

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2745,14 +2745,13 @@ object Parsers {
     def pattern3(): Tree =
       val p = infixPattern()
       if followingIsVararg() then
-        atSpan(in.skipToken()) {
-          p match
-            case p @ Ident(name) if name.isVarPattern =>
-              Typed(p, Ident(tpnme.WILDCARD_STAR))
-            case _ =>
-              syntaxError(em"`*` must follow pattern variable")
-              p
-        }
+        val start = in.skipToken()
+        p match
+          case p @ Ident(name) if name.isVarPattern =>
+            Typed(p, atSpan(start) { Ident(tpnme.WILDCARD_STAR) })
+          case _ =>
+            syntaxError(em"`*` must follow pattern variable", start)
+            p
       else p
 
     /**  Pattern2    ::=  [id `@'] Pattern3

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -313,8 +313,13 @@ object Scanners {
           // when skipping and therefore might erroneously end up syncing on a nested OUTDENT.
       if debugTokenStream then
         println(s"\nSTART SKIP AT ${sourcePos().line + 1}, $this in $currentRegion")
-      while !atStop do
+      var noProgress = 0
+        // Defensive measure to ensure we always get out of the following while loop
+        // even if source file is weirly formatted (i.e. we never reach EOF
+      while !atStop && noProgress < 3 do
+        val prevOffset = offset
         nextToken()
+        if offset == prevOffset then noProgress += 1 else noProgress = 0
       if debugTokenStream then
         println(s"\nSTOP SKIP AT ${sourcePos().line + 1}, $this in $currentRegion")
       if token == OUTDENT then dropUntil(_.isInstanceOf[Indented])


### PR DESCRIPTION
I noted a case in Metals where the compiler would keep running at 100+ % until the process was killed.

Using jstack I tracked it down to an infinite `skip` caused by a `syntaxError` in `pattern3`. In fact,
the syntaxError should not skip at this point since the offending expression was already fully parsed.
I fixed this in this commit.

The parser was invoked from the `signatureHelp` method. It seems it parsed something that was not
syntactically correct (specifically, a postfix `*` appeared in a pattern where none was allowed).

`