### PR TITLE
Handle recursions in isFullyDefined

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1118,7 +1118,7 @@ trait Applications extends Compatibility {
    */
   def convertNewGenericArray(tree: Tree)(using Context): Tree = tree match {
     case Apply(TypeApply(tycon, targs@(targ :: Nil)), args) if tycon.symbol == defn.ArrayConstructor =>
-      fullyDefinedType(tree.tpe, "array", tree.span)
+      fullyDefinedType(tree.tpe, "array", tree.srcPos)
 
       def newGenericArrayCall =
         ref(defn.DottyArraysModule)
@@ -1333,7 +1333,7 @@ trait Applications extends Compatibility {
         val ownType =
           if (selType <:< unapplyArgType) {
             unapp.println(i"case 1 $unapplyArgType ${ctx.typerState.constraint}")
-            fullyDefinedType(unapplyArgType, "pattern selector", tree.span)
+            fullyDefinedType(unapplyArgType, "pattern selector", tree.srcPos)
             selType.dropAnnot(defn.UncheckedAnnot) // need to drop @unchecked. Just because the selector is @unchecked, the pattern isn't.
           }
           else {
@@ -1564,7 +1564,7 @@ trait Applications extends Compatibility {
             // `isSubType` as a TypeVar might get constrained by a TypeRef it's
             // part of.
             val tp1Params = tp1.newLikeThis(tp1.paramNames, tp1.paramInfos, defn.AnyType)
-            fullyDefinedType(tp1Params, "type parameters of alternative", alt1.symbol.span)
+            fullyDefinedType(tp1Params, "type parameters of alternative", alt1.symbol.srcPos)
 
             val tparams = newTypeParams(alt1.symbol, tp1.paramNames, EmptyFlags, tp1.instantiateParamInfos(_))
             isAsSpecific(alt1, tp1.instantiate(tparams.map(_.typeRef)), alt2, tp2)

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -257,7 +257,7 @@ class ImplicitSearchError(
       ++ ErrorReporting.matchReductionAddendum(pt)
   }
 
-  private def formatMsg(shortForm: String)(headline: String = shortForm) = arg match 
+  private def formatMsg(shortForm: String)(headline: String = shortForm) = arg match
     case arg: Trees.SearchFailureIdent[?] =>
       arg.tpe match
         case _: NoMatchingImplicits => headline
@@ -318,7 +318,7 @@ class ImplicitSearchError(
       case _           => Nil
     }
     def resolveTypes(targs: List[tpd.Tree])(using Context) =
-      targs.map(a => Inferencing.fullyDefinedType(a.tpe, "type argument", a.span))
+      targs.map(a => Inferencing.fullyDefinedType(a.tpe, "type argument", a.srcPos))
 
     // We can extract type arguments from:
     //   - a function call:

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1467,7 +1467,7 @@ class Namer { typer: Typer =>
               else {
                 if (denot.is(ModuleClass) && denot.sourceModule.isOneOf(GivenOrImplicit))
                   missingType(denot.symbol, "parent ")(using creationContext)
-                fullyDefinedType(typedAheadExpr(parent).tpe, "class parent", parent.span)
+                fullyDefinedType(typedAheadExpr(parent).tpe, "class parent", parent.srcPos)
               }
             case _ =>
               UnspecifiedErrorType.assertingErrorsReported
@@ -1890,7 +1890,7 @@ class Namer { typer: Typer =>
     def dealiasIfUnit(tp: Type) = if (tp.isRef(defn.UnitClass)) defn.UnitType else tp
 
     def cookedRhsType = dealiasIfUnit(rhsType).deskolemized
-    def lhsType = fullyDefinedType(cookedRhsType, "right-hand side", mdef.span)
+    def lhsType = fullyDefinedType(cookedRhsType, "right-hand side", mdef.srcPos)
     //if (sym.name.toString == "y") println(i"rhs = $rhsType, cooked = $cookedRhsType")
     if (inherited.exists)
       if sym.isInlineVal then lhsType else inherited

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1101,7 +1101,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     def noLeaks(t: Tree): Boolean = escapingRefs(t, localSyms).isEmpty
     if (noLeaks(tree)) tree
     else {
-      fullyDefinedType(tree.tpe, "block", tree.span)
+      fullyDefinedType(tree.tpe, "block", tree.srcPos)
       var avoidingType = TypeOps.avoid(tree.tpe, localSyms)
       val ptDefined = isFullyDefined(pt, ForceDegree.none)
       if (ptDefined && !(avoidingType.widenExpr <:< pt)) avoidingType = pt
@@ -1534,7 +1534,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       case _ =>
         if tree.isInline then checkInInlineContext("inline match", tree.srcPos)
         val sel1 = typedExpr(tree.selector)
-        val rawSelectorTpe = fullyDefinedType(sel1.tpe, "pattern selector", tree.span)
+        val rawSelectorTpe = fullyDefinedType(sel1.tpe, "pattern selector", tree.srcPos)
         val selType = rawSelectorTpe match
           case c: ConstantType if tree.isInline => c
           case otherTpe => otherTpe.widen

--- a/tests/neg/i15311.check
+++ b/tests/neg/i15311.check
@@ -1,0 +1,32 @@
+-- Error: tests/neg/i15311.scala:16:4 ----------------------------------------------------------------------------------
+16 |def test =  // error
+   |^
+   |Recursion limit exceeded.
+   |Maybe there is an illegal cyclic reference?
+   |If that's not the case, you could also try to increase the stacksize using the -Xss JVM option.
+   |A recurring operation is (inner to outer):
+   |
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  ...
+   |
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined food.T
+   |  check fully defined Template[food.T]
+17 |  eat(ham)
+18 |  eat(food.self)

--- a/tests/neg/i15311.scala
+++ b/tests/neg/i15311.scala
@@ -1,0 +1,18 @@
+trait Template[+T <: Template[T]]:
+   type Clone <: T { type Clone = Template.this.Clone }
+   val self :Clone
+
+type Food = Template[_]
+
+class Ham extends Template[Ham]:
+   type Clone = Ham
+   val self = this
+
+def eat[F <: Template[F]](food :F) :F = food.self.self
+
+val ham = new Ham
+val food :Food = ham
+
+def test =  // error
+  eat(ham)
+  eat(food.self)


### PR DESCRIPTION
If one indulges in cycles too heavily it can happen that we run into
an infinite recursion in `fullyDefinedType` even before we had a chance
to run `checkNonCyclic`. In this case we now diagnose the stack overflow
as an error message instead of failing with an internal error.

Fixes #15311