### PR TITLE
Remove obsolete note on escapes in interpolations

### DIFF
--- a/docs/_docs/reference/changed-features/interpolation-escapes.md
+++ b/docs/_docs/reference/changed-features/interpolation-escapes.md
@@ -4,11 +4,17 @@ title: "Escapes in interpolations"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/changed-features/interpolation-escapes.html
 ---
 
-In Scala 2 there is no straightforward way to represent a single quote character `"` in a single quoted interpolation. A `\` character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether the `"` character should be escaped or used as a terminator.
+Scala 3 allows `"` (Unicode Quotation Mark) in an interpolation that uses `"` as a delimiter.
 
-In Scala 3, we can use the `$` meta character of interpolations to escape a `"` character. Example:
+The quotation mark must be escaped by either `$` (Dollar Sign) or `\` (Reverse Solidus or "backslash").
+
+Note that `\` may also escape `"` in an ordinary string. This behavior is consistent with Scala 2.
 
 ```scala
   val inventor = "Thomas Edison"
-  val interpolation = s"as $inventor said: $"The three great essentials to achieve anything worth while are: Hard work, Stick-to-itiveness, and Common sense.$""
+  val essentials =
+    s"As $inventor said: $"The three great essentials to achieve anything worthwhile are, first, hard work; second, stick-to-itiveness; third, common sense.$""
+  val perspiration = "interpolation"
+  val attribution =
+    s"As $inventor wrote in a letter in 1927: \"It is quite true I once made the statement that genius is one percent inspiration and 99 percent $perspiration, and I am still of the same opinion.\""
 ```


### PR DESCRIPTION
Scala 2/3 have parity on "how to escape double quote in an interpolated string with single-double quotes" since https://github.com/lampepfl/dotty/pull/11751

This commit fixes the Edison quotation (though I did not track down a source) and also adds a second bon mot which everyone knows from childhood, to illustrate both forms of escape. Google cites a source which cites the letter.

No links were harmed in the production of this PR.