### PR TITLE
Fix isStructuralTermSelectOrApply

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -869,7 +869,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
         case RefinedType(parent, rname, rinfo) =>
           rname == tree.name || hasRefinement(parent)
         case tp: TypeProxy =>
-          hasRefinement(tp.underlying)
+          hasRefinement(tp.superType)
         case tp: AndType =>
           hasRefinement(tp.tp1) || hasRefinement(tp.tp2)
         case tp: OrType =>

--- a/tests/neg/i15448.scala
+++ b/tests/neg/i15448.scala
@@ -1,0 +1,11 @@
+object Minimized:
+  type Pointer[S <: Int] <: S
+
+  type Break = Int {
+    def boom: Unit
+  }
+
+  def test = {
+    val ptrBreak: Pointer[Break] = ???
+    ptrBreak.boom // error Required: Selectable, was boom crashes the compiler
+  }

--- a/tests/pos/i15448.scala
+++ b/tests/pos/i15448.scala
@@ -1,0 +1,21 @@
+object SelectableBreaks1 {
+  object opaques {
+    opaque type Pointer[S] <: S = S
+    object Pointer {
+      implicit class PointerSelectable[S](private val f: Pointer[S]) extends Selectable {
+        def selectDynamic(name: String): Any = ???
+        def applyDynamic(name: String)(): Any = ???
+      }
+    }
+  }
+  import opaques.*
+
+  type Break = AnyRef {
+    def boom(): Nothing
+  }
+
+  def makeBreak(): Pointer[Break] = ???
+
+  makeBreak().boom()
+}
+


### PR DESCRIPTION
When looking at AppliedTypes, we want to go to the supertype (which is the dealiased type or upper bound),
not the underlying type (which is the type constructor).

This is the second bug in a week caused by a confusion of underlying and supertype for AppliedTypes. We
should do an audit of the codebase to see whether there are more cases like this.

Fixes #15448