### PR TITLE
Fix MiMa filters for base version 3.2.1-RC1

### DIFF
--- a/library/src/scala/annotation/MainAnnotation.scala
+++ b/library/src/scala/annotation/MainAnnotation.scala
@@ -91,6 +91,7 @@ object MainAnnotation:
    *  @param documentation The documentation of the main method without the `@param` documentation (see Parameter.documentaion)
    *  @param parameters Information about the parameters of the main method
    */
+  @experimental // MiMa does not check scope inherited @experimental
   final class Info(
     val name: String,
     val documentation: String,
@@ -111,6 +112,7 @@ object MainAnnotation:
    *  @param documentation The documentation of the parameter (from `@param` documentation in the main method)
    *  @param annotations The annotations of the parameter that extend `ParameterAnnotation`
    */
+  @experimental // MiMa does not check scope inherited @experimental
   final class Parameter(
     val name: String,
     val typeName: String,
@@ -121,6 +123,7 @@ object MainAnnotation:
   )
 
   /** Marker trait for annotations that will be included in the Parameter annotations. */
+  @experimental // MiMa does not check scope inherited @experimental
   trait ParameterAnnotation extends StaticAnnotation
 
 end MainAnnotation

--- a/library/src/scala/annotation/newMain.scala
+++ b/library/src/scala/annotation/newMain.scala
@@ -217,7 +217,7 @@ final class newMain extends MainAnnotation[FromString, Any]:
         hasParseErrors = true
         () => throw new AssertionError("trying to get invalid argument")
 
-
+  @experimental // MiMa does not check scope inherited @experimental
   private object Help:
 
     /** The name of the special argument to display the method's help.
@@ -321,6 +321,7 @@ final class newMain extends MainAnnotation[FromString, Any]:
 
   end Help
 
+  @experimental // MiMa does not check scope inherited @experimental
   private class Names(info: Info):
 
     checkNames()

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -8,14 +8,27 @@ object MiMaFilters {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.runtime.QuoteUnpickler.unpickleExprV2"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.runtime.QuoteUnpickler.unpickleTypeV2"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.runtime.QuoteUnpickler.unpickleTypeV2"),
-
-    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.since"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.TupleMirror"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.Tuple$package$EmptyTuple$"), // we made the empty tuple a case object
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Scala3RunTime.nnFail"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Scala3RunTime.nnFail"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.LazyVals.getOffsetStatic"), // Added for #14780
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.LazyVals.getOffsetStatic"), // Added for #14780
+    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.2-migration"),
+    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.2"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E2$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E2$minusmigration$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.coverage.Invoker"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.coverage.Invoker$"),
 
     // APIs will be added in 3.2.0
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#AppliedTypeModule.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#AppliedTypeModule.apply"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.asQuotes"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.typeRef"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.termRef"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TypeTreeModule.ref"),
+
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.since"),
   )
 }

--- a/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -31,6 +31,10 @@ val experimentalDefinitionInLibrary = Set(
   // Should we have better support for main annotation macros?
   "scala.annotation.MainAnnotation",
   "scala.annotation.MainAnnotation$",
+  "scala.annotation.MainAnnotation$.Info",
+  "scala.annotation.MainAnnotation$.Parameter",
+  "scala.annotation.MainAnnotation$.ParameterAnnotation",
+
 
   //// New feature: prototype of new version of @main
   // This will never be stabilized. When it is ready it should replace the old @main annotation (requires scala.annotation.MainAnnotation).
@@ -38,6 +42,9 @@ val experimentalDefinitionInLibrary = Set(
   "scala.annotation.newMain",
   "scala.annotation.newMain$",
   "scala.annotation.newMain$.alias",
+  "scala.annotation.newMain.Help",
+  "scala.annotation.newMain.Help$",
+  "scala.annotation.newMain.Names",
 
   //// New APIs: Mirror
   // Can be stabilized in 3.3.0 or later.


### PR DESCRIPTION
This issue was introduced in https://github.com/lampepfl/dotty/pull/15454. This PR should have added these filters but did not. It also failed the MiMa tests as expected but was accidentally merged.