### PR TITLE
Generate anonymous class for SAMs defining narrowed overrides

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -53,7 +53,7 @@ class ExpandSAMs extends MiniPhase:
         case tpe @ SAMType(_) if tpe.isRef(defn.PartialFunctionClass) =>
           val tpe1 = checkRefinements(tpe, fn)
           toPartialFunction(tree, tpe1)
-        case tpe @ SAMType(_) if ExpandSAMs.isPlatformSam(tpe.classSymbol.asClass) =>
+        case tpe @ SAMType(_) if ExpandSAMs.isPlatformSam(tpe.classSymbol.asClass) && !definesNarrowedOverrides(tpe) =>
           checkRefinements(tpe, fn)
           tree
         case tpe =>
@@ -65,6 +65,12 @@ class ExpandSAMs extends MiniPhase:
     case _ =>
       tree
   }
+
+  private def definesNarrowedOverrides(tpe: Type)(using Context): Boolean = 
+    tpe.decls.exists { sym => 
+      val resultType = sym.info.resultType
+      sym.allOverriddenSymbols.exists(resultType <:< _.info.resultType)  
+    }
 
   /** A partial function literal:
    *

--- a/tests/run/i15402.scala
+++ b/tests/run/i15402.scala
@@ -1,0 +1,15 @@
+trait Named:
+  def me: Named
+
+trait Foo extends Named:
+  def me: Foo = this
+  def foo(x: String): String
+
+class Names(xs: List[Named]):
+  def mkString = xs.map(_.me).mkString(",")
+
+object Names:
+  def single[T <: Named](t: T): Names = Names(List(t))
+
+@main def Test() =
+  Names.single[Foo](x => x).mkString


### PR DESCRIPTION
Fixes #15402 

Invocation of method on SAM using overridden narrowed method was leading to `java.lang.AbstractMethodError: Receiver class i15402$package$$$Lambda$1/0x0000000100085840 does not define or inherit an implementation of the resolved method X in Y. `. To mitigate this issue we make sure that for each SAM which defines a narrowed member override we would generate an anonymous class. 