### PR TITLE
Fix `throwReturn` of `NonLocalReturns` to allow wider usage

### DIFF
--- a/library/src/scala/util/control/NonLocalReturns.scala
+++ b/library/src/scala/util/control/NonLocalReturns.scala
@@ -19,7 +19,7 @@ object NonLocalReturns {
   }
 
   /** Performs a nonlocal return by throwing an exception. */
-  def throwReturn[T](result: T)(using returner: ReturnThrowable[T]): Nothing =
+  def throwReturn[T](result: T)(using returner: ReturnThrowable[? >: T]): Nothing =
     returner.throwReturn(result)
 
   /** Enable nonlocal returns in `op`. */

--- a/tests/run/nonlocal-return.scala
+++ b/tests/run/nonlocal-return.scala
@@ -8,9 +8,20 @@ object Test {
       false
     }
 
+  trait Animal
+  object Dog extends Animal
+  object Cat extends Animal
+
+  def animal(arg: Int): Animal = returning {
+    if (arg < 0) throwReturn(Dog) 
+    Cat
+  }
+
   def main(arg: Array[String]): Unit = {
     assert(has(1 :: 2 :: Nil, 1))
     assert(has(1 :: 2 :: Nil, 2))
     assert(!has(1 :: 2 :: Nil, 3))
+    assert(animal(1) == Cat)
+    assert(animal(-1) == Dog)
   }
 }


### PR DESCRIPTION
See https://contributors.scala-lang.org/t/scala-nonlocalreturns-ergonomics-are-problematic/5767