### PR TITLE
Fix #15494: Handle non-specialized functions in EtaReduce.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
@@ -48,6 +48,10 @@ class EtaReduce extends MiniPhase:
         fn
       case TypeApply(Select(qual, _), _) if rhs.symbol.isTypeCast && rhs.span.isSynthetic =>
         tryReduce(mdef, qual)
+      case Apply(_, arg :: Nil) if Erasure.Boxing.isUnbox(rhs.symbol) && rhs.span.isSynthetic =>
+        tryReduce(mdef, arg)
+      case Block(call :: Nil, unit @ Literal(Constants.Constant(()))) if unit.span.isSynthetic =>
+        tryReduce(mdef, call)
       case _ =>
         tree
 

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -59,6 +59,25 @@ class RegressionTestScala3 {
     assertEquals(0L, Foo.bar().x)
     assertEquals(5L, Foo.bar(5L).x)
   }
+
+  @Test def etaReduceIssue15494(): Unit = {
+    // Also known as tests/run/i14623.scala for Scala/JVM
+
+    object Thunk {
+      private[this] val impl =
+        ((x: Any) => x).asInstanceOf[(=> Any) => Function0[Any]]
+
+      def asFunction0[A](thunk: => A): Function0[A] = impl(thunk).asInstanceOf[Function0[A]]
+    }
+
+    var i = 0
+    val f1 = { () => i += 1; "" }
+    assertSame(f1, Thunk.asFunction0(f1()))
+    val f2 = { () => i += 1; i }
+    assertSame(f2, Thunk.asFunction0(f2()))
+    val f3 = { () => i += 1 }
+    assertSame(f3, Thunk.asFunction0(f3()))
+  }
 }
 
 object RegressionTestScala3 {


### PR DESCRIPTION
In Scala.js, function specialization is disabled. This means that non-specialized functions can reach `EtaReduce`. Previously, it did not handle the shape of right-hand-side for non-specialized functions returning primitives. We fix the issue by handling those, like we already handled `.asInstanceOf`s.

### How I fixed it

First, I took the reproduction from the issue and put it in `sandbox/scalajs/src/hello.scala`. I verified that I could reproduce with
```
> sjsSandbox/run
```
Next, I looked at the Scala.js IR produced for this code:
```
> sjsSandbox/scalajsp Thunk$
```
showed nothing wrong, but
```
> sjsSandbox/scalajsp hello$package$
```
showed, sure enough, an extra wrapping when calling `asFunction0` for `f2` and `f3`, which is not present for `f1`:
```scala
  def Test;V() {
    val i: scala.runtime.IntRef = scala.runtime.IntRef::create;I;Lscala.runtime.IntRef(0);
    val f1: scala.Function0 = <redacted>;
    if ((!(mod:hello.Thunk$.asFunction0;Lscala.Function0;Lscala.Function0(f1) === f1))) {
      mod:scala.runtime.Scala3RunTime$.assertFailed;E()
    };
    val f2: scala.Function0 = <redacted>;
    if ((!(mod:hello.Thunk$.asFunction0;Lscala.Function0;Lscala.Function0(new scala.scalajs.runtime.AnonFunction0().<init>;Lscala.scalajs.js.Function0;V((arrow-lambda<this$3{this}: hello.hello$package$ = this, f2$2{f2}: scala.Function0 = f2>(): any = {
      this$3.hello.hello$package$::private::Test$$anonfun$1;Lscala.Function0;I(f2$2)
    }))) === f2))) {
      mod:scala.runtime.Scala3RunTime$.assertFailed;E()
    };
    val f3: scala.Function0 = <redacted>;
    if ((!(mod:hello.Thunk$.asFunction0;Lscala.Function0;Lscala.Function0(new scala.scalajs.runtime.AnonFunction0().<init>;Lscala.scalajs.js.Function0;V((arrow-lambda<this$5{this}: hello.hello$package$ = this, f3$2{f3}: scala.Function0 = f3>(): any = {
      this$5.hello.hello$package$::private::Test$$anonfun$adapted$1;Lscala.Function0;Ljava.lang.Object(f3$2)
    }))) === f3))) {
      mod:scala.runtime.Scala3RunTime$.assertFailed;E()
    }
  }
```
Now I needed to diagnose what phase within the compiler caused the issue. I do that with
```
> set sjsSandbox / scalacOptions += "-Xprint:flatten"
> sjsSandbox/compile
```
`flatten` is always a good first candidate when working on Scala.js issues, as it shows the dotc trees right before the back-end.

`flatten` shows that the wrappings are already there, so the issue must come earlier. There's not supposed to be major differences in transformations in earlier phases for Scala.js versus Scala/JVM, especially when no Scala.js-specific code is involved.

So I started investigating the difference in `-Xprint` between Scala/JVM and Scala.js for the same snippet.

I reached the conclusion that the group of `etaReduce` received as input something worse on Scala.js than Scala/JVM. And for good reason: the input on Scala/JVM uses specialized function types, which don't exist on Scala.js.

I then tried reproducing on Scala/JVM by manually deactivating the `SpecializeFunctions` phase. Sure enough, the issue was triggered.

From there, it was a matter of looking at the shape of trees received by `EtaReduce` when `SpecializeFunctions` is disabled, and adding cases in `EtaReduce` to handle those shapes.