### PR TITLE
Fix #15199: Exclude JavaDefined Modules from bridge generation.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -37,7 +37,7 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
     override def parents = Array(root.superClass)
 
     override def exclude(sym: Symbol) =
-      !sym.isOneOf(MethodOrModule) || super.exclude(sym)
+      !sym.isOneOf(MethodOrModule) || sym.isAllOf(Module | JavaDefined) || super.exclude(sym)
 
     override def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parent: Symbol): Boolean =
       OverridingPairs.isOverridingPair(sym1, sym2, parent.thisType)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -527,7 +527,7 @@ object Checking {
       fail("Traits cannot have secondary constructors" + addendum)
     checkApplicable(Inline, sym.isTerm && !sym.isOneOf(Mutable | Module))
     checkApplicable(Lazy, !sym.isOneOf(Method | Mutable))
-    if (sym.isType && !sym.is(Deferred))
+    if (sym.isType && !sym.isOneOf(Deferred | JavaDefined))
       for (cls <- sym.allOverriddenSymbols.filter(_.isClass)) {
         fail(CannotHaveSameNameAs(sym, cls, CannotHaveSameNameAs.CannotBeOverridden))
         sym.setFlag(Private) // break the overriding relationship by making sym Private

--- a/tests/run/i15199/Child_1.java
+++ b/tests/run/i15199/Child_1.java
@@ -1,0 +1,4 @@
+public class Child_1 extends Parent_1 {
+  public class Inner {
+  }
+}

--- a/tests/run/i15199/Parent_1.java
+++ b/tests/run/i15199/Parent_1.java
@@ -1,0 +1,4 @@
+public class Parent_1 {
+  public class Inner {
+  }
+}

--- a/tests/run/i15199/Test_2.scala
+++ b/tests/run/i15199/Test_2.scala
@@ -1,0 +1,5 @@
+class ScalaChild extends Child_1
+
+@main def Test(): Unit =
+  val methods = classOf[ScalaChild].getDeclaredMethods()
+  assert(methods.length == 0, methods.mkString(", "))


### PR DESCRIPTION
JavaDefined modules are imaginary symbols that dotc uses to refer to static methods of Java classes. They have no reification, and therefore it makes no sense for them to participate in bridge generation.

### How I fixed it

First, I happen to know that bridges are generated in Erasure, so that's one thing to look at.

I looked at the JavaDoc of `javax.swing.plaf.metal.MetalTabbedPaneUI` to find out what `TabbedPaneLayout`. I discovered that it is an inner class, and that it shadows an inner class of the same name in `basic.BasicTabbedPaneUI`. Java inner classes should never have bridges, as they are types. But they also implicitly declare companion objects, which dotc uses to refer to static members.

Apparently, dotc gets confused about those imaginary objects, and tries to create bridges for them. It shouldn't even consider them.

I reproduced the issue with my own Java-defined classes, to get rid of the dependency on the JDK Swing APIs, which is a beast.

I search for "Bridge" in `Erasure.scala`, which leads me to the `class Bridges`. I did not know that class, but it's not very big. A quick look at `BridgesCursor` and its relationship to `OverridingPairs.Cursor` (the latter is the thing that enumerates pairs of members where one overrides the other) tells me that I should exclude JavaDefined modules from `BridgesCursor`. Lucky me: there is a `def exclude` in it, so I amend it to also exclude `sym.isAllOf(Module | JavaDefined)`.