### PR TITLE
Backport #15498: Fix #15494: Handle non-specialized functions in EtaReduce.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
@@ -48,6 +48,10 @@ class EtaReduce extends MiniPhase:
         fn
       case TypeApply(Select(qual, _), _) if rhs.symbol.isTypeCast && rhs.span.isSynthetic =>
         tryReduce(mdef, qual)
+      case Apply(_, arg :: Nil) if Erasure.Boxing.isUnbox(rhs.symbol) && rhs.span.isSynthetic =>
+        tryReduce(mdef, arg)
+      case Block(call :: Nil, unit @ Literal(Constants.Constant(()))) if unit.span.isSynthetic =>
+        tryReduce(mdef, call)
       case _ =>
         tree
 

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -59,6 +59,25 @@ class RegressionTestScala3 {
     assertEquals(0L, Foo.bar().x)
     assertEquals(5L, Foo.bar(5L).x)
   }
+
+  @Test def etaReduceIssue15494(): Unit = {
+    // Also known as tests/run/i14623.scala for Scala/JVM
+
+    object Thunk {
+      private[this] val impl =
+        ((x: Any) => x).asInstanceOf[(=> Any) => Function0[Any]]
+
+      def asFunction0[A](thunk: => A): Function0[A] = impl(thunk).asInstanceOf[Function0[A]]
+    }
+
+    var i = 0
+    val f1 = { () => i += 1; "" }
+    assertSame(f1, Thunk.asFunction0(f1()))
+    val f2 = { () => i += 1; i }
+    assertSame(f2, Thunk.asFunction0(f2()))
+    val f3 = { () => i += 1 }
+    assertSame(f3, Thunk.asFunction0(f3()))
+  }
 }
 
 object RegressionTestScala3 {


### PR DESCRIPTION
Backports #15498