### PR TITLE
Don't unsoundly maximise types to Any/Nothing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,13 @@ jobs:
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
       - name: Test
+        # DON'T add dist/pack!
+        # Adding dist/pack bootstraps the compiler
+        # which undermines the point of these tests:
+        # to quickly run the tests without the cost of bootstrapping
+        # and also to run tests when the compiler doesn't bootstrap
         run: |
-          ./project/scripts/sbt ";dist/pack; compile ;test"
+          ./project/scripts/sbt ";compile ;test"
           ./project/scripts/cmdTests
 
   test:

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1341,7 +1341,7 @@ trait Applications extends Compatibility {
             // Constraining only fails if the pattern cannot possibly match,
             // but useless pattern checks detect more such cases, so we simply rely on them instead.
             withMode(Mode.GadtConstraintInference)(TypeComparer.constrainPatternType(unapplyArgType, selType))
-            val patternBound = maximizeType(unapplyArgType, tree.span)
+            val patternBound = maximizeType(unapplyArgType, unapplyFn.span.endPos)
             if (patternBound.nonEmpty) unapplyFn = addBinders(unapplyFn, patternBound)
             unapp.println(i"case 2 $unapplyArgType ${ctx.typerState.constraint}")
             unapplyArgType

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -405,8 +405,8 @@ object Inferencing {
     val patternBindings = new mutable.ListBuffer[(Symbol, TypeParamRef)]
     vs foreachBinding { (tvar, v) =>
       if !tvar.isInstantiated then
-        if (v == 1) tvar.instantiate(fromBelow = false)
-        else if (v == -1) tvar.instantiate(fromBelow = true)
+        if (v == 1 && tvar.hasUpperBound) tvar.instantiate(fromBelow = false)
+        else if (v == -1 && tvar.hasLowerBound) tvar.instantiate(fromBelow = true)
         else {
           val bounds = TypeComparer.fullBounds(tvar.origin)
           if bounds.hi <:< bounds.lo || bounds.hi.classSymbol.is(Final) then

--- a/compiler/test/dotty/tools/scripting/BashScriptsTests.scala
+++ b/compiler/test/dotty/tools/scripting/BashScriptsTests.scala
@@ -7,6 +7,7 @@ import scala.language.unsafeNulls
 import java.nio.file.Paths
 import org.junit.{Test, AfterClass}
 import org.junit.Assert.assertEquals
+import org.junit.experimental.categories.Category
 
 import vulpix.TestConfiguration
 
@@ -156,6 +157,7 @@ class BashScriptsTests:
    * verify that scriptPath.sc sees a valid script.path property,
    * and that it's value is the path to "scriptPath.sc".
    */
+  @Category(Array(classOf[BootstrappedOnlyTests]))
   @Test def verifyScriptPathProperty =
     val scriptFile = testFiles.find(_.getName == "scriptPath.sc").get
     val expected = s"${scriptFile.getName}"

--- a/compiler/test/dotty/tools/scripting/ExpressionTest.scala
+++ b/compiler/test/dotty/tools/scripting/ExpressionTest.scala
@@ -7,6 +7,7 @@ import scala.language.unsafeNulls
 import java.nio.file.Paths
 import org.junit.{Test, AfterClass}
 import org.junit.Assert.assertEquals
+import org.junit.experimental.categories.Category
 
 import vulpix.TestConfiguration
 
@@ -15,6 +16,7 @@ import ScriptTestEnv.*
 /**
  *   +. test scala -e <expression>
  */
+@Category(Array(classOf[BootstrappedOnlyTests]))
 class ExpressionTest:
   /*
    * verify -e <expression> works.

--- a/tests/neg/i14983.scala
+++ b/tests/neg/i14983.scala
@@ -1,0 +1,13 @@
+sealed trait Tree[+A]
+final case class Leaf[+B](v: B)        extends Tree[B]
+final case class Node[+C](xs: List[C]) extends Tree[List[C]]
+
+object Test:
+  def meth[X](tree: Tree[X]): X = tree match
+    case Leaf(v) => v
+    case Node(x) => List("boom") // error
+
+  def main(args: Array[String]): Unit =
+    val tree = Node(List(42))
+    val res = meth(tree)
+    assert(res.head == 42) // was: ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer

--- a/tests/run/i14983.scala
+++ b/tests/run/i14983.scala
@@ -1,0 +1,13 @@
+sealed trait Tree[+A]
+final case class Leaf[+B](v: B)        extends Tree[B]
+final case class Node[+C](xs: List[C]) extends Tree[List[C]]
+
+object Test:
+  def meth[X](tree: Tree[X]): X = tree match
+    case Leaf(v) => v
+    case Node(x) => x // ok
+
+  def main(args: Array[String]): Unit =
+    val tree = Node(List(42))
+    val res = meth(tree)
+    assert(res.head == 42) // ok


### PR DESCRIPTION
Also fix the span of the new pattern bound symbol,
which was failing pickling tests.

[test_non_bootstrapped]