### PR TITLE
Avoid lookahead into interpolation

### DIFF
--- a/tests/pos/i15514.scala
+++ b/tests/pos/i15514.scala
@@ -1,0 +1,4 @@
+
+object Main { s"Hello $Main.toStr!" }
+
+object Alt { s"Hello ${Alt}.toStr!" }


### PR DESCRIPTION
Since an interpolation is really two tokens deep, for the literal
part and the interpolated expression, one-char lookahead does not
preserve the second token on reset.

Make lookahead itself more robust by falling back to a LookaheadScanner
for this case.

Also add an internal error for the bad reset.

Fixes #15514 