### PR TITLE
Post-process STRINGPART

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -695,10 +695,10 @@ object Scanners {
       getNextToken(token)
       if token == END && !isEndMarker then token = IDENTIFIER
 
-    def reset() = {
+    def reset() =
+      assert(next.token == EMPTY || isInstanceOf[LookaheadScanner], s"lookAhead/reset would erase next token ${tokenString(next.token)} after ${tokenString(token)}")
       next.copyFrom(this)
       this.copyFrom(prev)
-    }
 
     def closeIndented() = currentRegion match
       case r: Indented if !r.isOutermost => insert(OUTDENT, offset)

--- a/tests/pos/i15514.scala
+++ b/tests/pos/i15514.scala
@@ -1,0 +1,4 @@
+
+object Main { s"Hello $Main.toStr!" }
+
+object Alt { s"Hello ${Alt}.toStr!" }


### PR DESCRIPTION
When getting the next part of an interpolation,
consisting of the literal part followed by the interpolated
identifier or expression, defer fetching the identifier
to postProcessToken. This ensures that lookahead at an
interpolation looks ahead only one token.

Fixes #15514 