### PR TITLE
Fix #15514 in Parser

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3957,8 +3957,8 @@ object Parsers {
      */
     def selfType(): ValDef =
       if (in.isIdent || in.token == THIS)
-            && in.lookahead.isColon && followingIsSelfType()
-            || in.lookahead.token == ARROW
+        && (in.lookahead.isColon && followingIsSelfType()
+            || in.lookahead.token == ARROW)
       then
         atSpan(in.offset) {
           val selfName =

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1281,7 +1281,6 @@ object Scanners {
               putChar(ch) ; nextRawChar()
               loopRest()
             else
-              assert(next.token == EMPTY)
               finishNamedToken(IDENTIFIER, target = next)
           end loopRest
           setStrVal()

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -662,7 +662,7 @@ object Scanners {
           true
         else token == COLONfollow && (inTemplate || fewerBracesEnabled)
       if enabled then
-        lookAhead()
+        peekAhead()
         val atEOL = isAfterLineEnd || token == EOF
         reset()
         if atEOL then token = COLONeol
@@ -690,15 +690,14 @@ object Scanners {
         insert(OUTDENT, offset)
       case _ =>
 
-    def lookAhead() =
+    def peekAhead() =
       prev.copyFrom(this)
       getNextToken(token)
       if token == END && !isEndMarker then token = IDENTIFIER
 
-    def reset() = {
+    def reset() =
       next.copyFrom(this)
       this.copyFrom(prev)
-    }
 
     def closeIndented() = currentRegion match
       case r: Indented if !r.isOutermost => insert(OUTDENT, offset)
@@ -717,12 +716,12 @@ object Scanners {
       }
       (token: @switch) match {
         case CASE =>
-          lookAhead()
+          peekAhead()
           if (token == CLASS) fuse(CASECLASS)
           else if (token == OBJECT) fuse(CASEOBJECT)
           else reset()
         case SEMI =>
-          lookAhead()
+          peekAhead()
           if (token != ELSE) reset()
         case COMMA =>
           def isEnclosedInParens(r: Region): Boolean = r match
@@ -733,7 +732,7 @@ object Scanners {
             case r: Indented if isEnclosedInParens(r.outer) =>
               insert(OUTDENT, offset)
             case _ =>
-              lookAhead()
+              peekAhead()
               if isAfterLineEnd
                  && currentRegion.commasExpected
                  && (token == RPAREN || token == RBRACKET || token == RBRACE || token == OUTDENT)
@@ -1083,11 +1082,14 @@ object Scanners {
      *  The token is computed via fetchToken, so complex two word
      *  tokens such as CASECLASS are not recognized.
      *  Newlines and indent/unindent tokens are skipped.
-     *
+     *  Restriction: `lookahead` is illegal if the current token is INTERPOLATIONID
      */
-     def lookahead: TokenData =
+    def lookahead: TokenData =
       if next.token == EMPTY then
-        lookAhead()
+        assert(token != INTERPOLATIONID)
+          // INTERPOLATONIDs are followed by a string literal, which can set next
+          // in peekAhead(). In that case, the following reset() would forget that token.
+        peekAhead()
         reset()
       next
 
@@ -1279,6 +1281,7 @@ object Scanners {
               putChar(ch) ; nextRawChar()
               loopRest()
             else
+              assert(next.token == EMPTY)
               finishNamedToken(IDENTIFIER, target = next)
           end loopRest
           setStrVal()

--- a/tests/pos/i15514.scala
+++ b/tests/pos/i15514.scala
@@ -1,0 +1,4 @@
+
+object Main { s"Hello $Main.toStr!" }
+
+object Alt { s"Hello ${Alt}.toStr!" }


### PR DESCRIPTION
There was a missing set of parentheses in parser which caused a lookahead
from INTERPOLATIONID, which should be illegal, since the lookahead then
might set the next TokenData which is subsequently overwritten by reset.

We now demand that lookahead cannot be called if the current token is
a INTERPOLATIONID.

There were two variants of `lookahead` in the Scanner, which only differed
in camelCase or not. Rename one to`peekAhead` to make the code clearer.

Alternative for #15518 and #15519.