### PR TITLE
Ignore types in macro runtime dependencies

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1046,9 +1046,9 @@ class Inliner(val call: tpd.Tree)(using Context):
     new TreeAccumulator[List[Symbol]] {
       private var level = -1
       override def apply(syms: List[Symbol], tree: tpd.Tree)(using Context): List[Symbol] =
-        if (level != -1) foldOver(syms, tree)
+        if level != -1 then foldOver(syms, tree)
         else tree match {
-          case tree: RefTree if level == -1 && tree.symbol.isDefinedInCurrentRun && !tree.symbol.isLocal =>
+          case tree: RefTree if tree.isTerm && tree.symbol.isDefinedInCurrentRun && !tree.symbol.isLocal =>
             foldOver(tree.symbol :: syms, tree)
           case Quoted(body) =>
             level += 1
@@ -1062,6 +1062,8 @@ class Inliner(val call: tpd.Tree)(using Context):
             level -= 1
             try apply(syms, body)
             finally level += 1
+          case _: TypTree =>
+            syms
           case _ =>
             foldOver(syms, tree)
         }

--- a/tests/pos-macros/i12498/Macro_1.scala
+++ b/tests/pos-macros/i12498/Macro_1.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+class Wrapper[T](t: T):
+  inline def showType: String = ${ Wrapper.showTypeImpl[T]}
+
+object Wrapper:
+  def showTypeImpl[U](using Quotes): Expr[String] = Expr("foo")

--- a/tests/pos-macros/i12498/Test_2.scala
+++ b/tests/pos-macros/i12498/Test_2.scala
@@ -1,0 +1,3 @@
+class Person
+
+def test =  Wrapper(new Person).showType

--- a/tests/pos-macros/i12498a/Macro_1.scala
+++ b/tests/pos-macros/i12498a/Macro_1.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+class Wrapper[T](t: T):
+  inline def showType: String = ${ Wrapper.showTypeImpl[T]}
+
+object Wrapper:
+  def showTypeImpl[U](using Quotes): Expr[String] = Expr("foo")

--- a/tests/pos-macros/i12498a/Test_2.scala
+++ b/tests/pos-macros/i12498a/Test_2.scala
@@ -1,0 +1,3 @@
+class Person
+
+def test =  Wrapper(new Person).showType

--- a/tests/pos-macros/i12498b/Macro_1.scala
+++ b/tests/pos-macros/i12498b/Macro_1.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+
+class Wrapper[T](t: T):
+  inline def nothing: T = ${ Wrapper.nothing : Expr[T] }
+
+object Wrapper:
+  def nothing(using Quotes): Expr[Nothing] = '{???}

--- a/tests/pos-macros/i12498b/Test_2.scala
+++ b/tests/pos-macros/i12498b/Test_2.scala
@@ -1,0 +1,3 @@
+class Person
+
+def test =  Wrapper(new Person).nothing

--- a/tests/pos-macros/i12498c/Macro_1.scala
+++ b/tests/pos-macros/i12498c/Macro_1.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+
+class Wrapper[T](t: T):
+  inline def emptyList: List[T] = ${ Wrapper.emptyListImpl : Expr[List[T]] }
+
+object Wrapper:
+  def emptyListImpl(using Quotes): Expr[List[Nothing]] = Expr(Nil)

--- a/tests/pos-macros/i12498c/Test_2.scala
+++ b/tests/pos-macros/i12498c/Test_2.scala
@@ -1,0 +1,3 @@
+class Person
+
+def test =  Wrapper(new Person).emptyList


### PR DESCRIPTION
 We can have different kinds of type references in the contents of a
splice. We do not care about types because those are erased and the
interpreter emulates erased semantics. These types are in `Tree`s that
extend `TypeTree` or `RefTree` referring to type.

Fixes #12498