### PR TITLE
Refine GADT casts with GADT approximation of singleton types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -209,7 +209,15 @@ final class ProperGadtConstraint private(
   def isNarrowing: Boolean = wasConstrained
 
   override def approximation(sym: Symbol, fromBelow: Boolean)(using Context): Type = {
-    val res = approximation(tvarOrError(sym).origin, fromBelow = fromBelow)
+    val res =
+      approximation(tvarOrError(sym).origin, fromBelow = fromBelow) match
+        case tpr: TypeParamRef =>
+          // Here we do externalization when the returned type is a TypeParamRef,
+          //  b/c ConstraintHandling.approximation may return internal types when
+          //  the type variable is instantiated. See #15531.
+          externalize(tpr)
+        case tp => tp
+
     gadts.println(i"approximating $sym ~> $res")
     res
   }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3767,7 +3767,13 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             // up with a test case for this.
             val target =
               if tree.tpe.isSingleton then
-                val conj = AndType(tree.tpe, pt)
+                // In the target type, when the singleton type is intersected, we also intersect
+                //   the GADT-approximated type of the singleton to avoid the loss of 
+                //   information. See #14776.
+                val gadtApprox = Inferencing.approximateGADT(tree.tpe.widen)
+                gadts.println(i"gadt approx $wtp ~~~ $gadtApprox")
+                val conj =
+                  AndType(AndType(tree.tpe, gadtApprox), pt)
                 if tree.tpe.isStable && !conj.isStable then
                   // this is needed for -Ycheck. Without the annotation Ycheck will
                   // skolemize the result type which will lead to different types before

--- a/tests/pos/gadt-cast-singleton.scala
+++ b/tests/pos/gadt-cast-singleton.scala
@@ -1,0 +1,13 @@
+enum SUB[-A, +B]:
+  case Refl[S]() extends SUB[S, S]
+
+trait R {
+  type Data
+}
+trait L extends R
+
+def f(x: L): x.Data = ???
+
+def g[T <: R](x: T, ev: T SUB L): x.Data = ev match
+  case SUB.Refl() =>
+    f(x)

--- a/tests/pos/i14776-patmat.scala
+++ b/tests/pos/i14776-patmat.scala
@@ -1,0 +1,15 @@
+trait T1
+trait T2 extends T1
+
+trait Expr[T] { val data: T = ??? }
+case class Tag2() extends Expr[T2]
+
+def flag: Boolean = ???
+
+def foo[T](e: Expr[T]): T1 = e match {
+  case Tag2() =>
+    flag match
+      case true => new T2 {}
+      case false => e.data
+}
+

--- a/tests/pos/i14776.scala
+++ b/tests/pos/i14776.scala
@@ -1,0 +1,16 @@
+trait T1
+trait T2 extends T1
+
+trait Expr[T] { val data: T = ??? }
+case class Tag2() extends Expr[T2]
+
+def flag: Boolean = ???
+
+def foo[T](e: Expr[T]): T1 = e match {
+  case Tag2() =>
+      if flag then
+        new T2 {}
+      else
+        e.data
+}
+

--- a/tests/pos/i15531.scala
+++ b/tests/pos/i15531.scala
@@ -1,0 +1,9 @@
+trait Tag { val data: Int }
+
+enum EQ[A, B]:
+  case Refl[C]() extends EQ[C, C]
+
+def foo[T, B <: Tag](ev: EQ[T, B], x: T) = ev match
+  case EQ.Refl() =>
+    val i: Int = x.data
+


### PR DESCRIPTION
Fixes #14776.
Fixes #15531.

#12159 refines GADT casts with singleton types to retain the identity of casted stable references.

This causes #14776, where we find that the checker fails when checking some if expressions with GADT constraints. Briefly, the reason why the code snippet in the #14776 crashes:
- The then-branch is typed as `T2`, the else-body, after GADT casting, is typed as `e.data.type & T1`.
- When typing the if tree, the assigned type is computed as the union type of `T2` and `e.data.type & T1`, which is `T2`, with GADT knowledge.
- When checking the if tree, we do not have GADT knowledge any more, and will find the re-computed type `T2 | (e.data.type & T1)` mismatches with the assigned type `T2`.
- The checker fails.

It turns out that, the target type in the cast of the then-body, `e.data.type & T1`, does not contain enough typing information to recover the (simplified) union type of the entire if expression. To fix this issue, we intersect the GADT approximation of the singleton type to preserve as much GADT information as possible. Specifically, now we cast `e.data: T` to `e.data.type & T2 & T1`.

This PR also fixes a bug (see #15531) where the typer leaks the internal type parameters in GADT casts, which will break the pickler.