### PR TITLE
Change ValDefs generated from tuples to have proper span

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1191,7 +1191,7 @@ object desugar {
             mods & Lazy | Synthetic | (if (ctx.owner.isClass) PrivateLocal else EmptyFlags)
           val firstDef =
             ValDef(tmpName, TypeTree(), matchExpr)
-              .withSpan(pat.span.startPos).withMods(patMods)
+              .withSpan(pat.span.union(rhs.span)).withMods(patMods)
           val useSelectors = vars.length <= 22
           def selector(n: Int) =
             if useSelectors then Select(Ident(tmpName), nme.selectorName(n))

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1441,4 +1441,20 @@ class CompletionTest {
     )
     withProjects(p1, p2).completion(m1, Set(("name", Method, "=> String")))
   }
+
+  @Test def generatedValDefCompletions: Unit = {
+    val expected = ("testMethod", Method, "=> Unit")
+    code"""case class Test(x: Int, y: Int)
+          |def testMethod: Unit = ???
+          |object M:
+          |  val (x, y) =
+          |    testMet$m1
+          |    (1, 2)
+          |  val Test(x, y) =
+          |    testMet$m2
+          |    Test(1, 2)
+          """
+            .completion(m1, expected)
+            .completion(m2, expected)
+  }
 }


### PR DESCRIPTION
Reverts probably leftover changes from Desugar for PatDef.
It resulted in incorrect tree returned from `Interactive.pathTo` for given position which lead to e.g no completions for RHS of ValDefs with pattern:

```scala
val (x, y) = List(1,2,3).ma@@ // no completions
```