### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -608,6 +608,8 @@ jobs:
         run: .github/workflows/scripts/triggerUnmanagedCommunityBuild.sh "${{ secrets.BUILD_TOKEN }}" "$THISBUILD_VERSION"
 
   publish_release:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2021-03-22

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - 'language-reference-backport'
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -9,8 +9,14 @@ on:
       - 'language-reference-stable'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
+    permissions:
+      contents: write  # for Git to git push
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     steps:
       - name: Get current date

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -2,6 +2,9 @@ name: Releases
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish_release:
     runs-on: [self-hosted, Linux]

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches-ignore:
       - 'language-reference-stable'
+permissions:
+  contents: read
+
 jobs:
   build:
     env:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
