### PR TITLE
fill out .mailmap, to improve credits in release notes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,13 @@
+Martin Odersky <odersky@gmail.com>
 Lionel Parreaux <lionel.parreaux@gmail.com>
+Som Snytt <som.snytt@gmail.com>
+Fengyun Liu <liu@fengy.me>
+Fengyun Liu <liufengyunchina@gmail.com>
+Anatolii Kmetiuk <anatoliykmetyuk@gmail.com>
+Jamie Thompson <bishbashboshjt@gmail.com>
+Krzysztof Romanowski <kromanowski@virtuslab.com>
+Oron Port <oron.port@cornell.edu>
+Oron Port <soronpo@tx.technion.ac.il>
+Ólafur Páll Geirsson <lgeirsson@twitter.com>
+Kenji Yoshida <6b656e6a69@gmail.com>
+Dmitry Petrashko <darkdimius@gmail.com>


### PR DESCRIPTION
improves the output of `git shortlog -sn`, which is what the credits at e.g. https://github.com/lampepfl/dotty/releases/tag/3.1.3 are made with, by consolidating multiple entries for the same person