### PR TITLE
Add a guard against empty ident

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -416,7 +416,7 @@ object Scala3:
         unicodeEscape.replaceAllIn(symbol, m => String.valueOf(Integer.parseInt(m.group(1), 16).toChar).nn)
 
       def isJavaIdent =
-        isJavaIdentifierStart(symbol.head) && symbol.tail.forall(isJavaIdentifierPart)
+        symbol.nonEmpty && isJavaIdentifierStart(symbol.head) && symbol.tail.forall(isJavaIdentifierPart)
   end StringOps
 
   given InfoOps: AnyRef with


### PR DESCRIPTION
Got this in a stack trace why working with Metals:
```
Exception in thread "pool-5-thread-2" java.util.NoSuchElementException: head of empty String
        at scala.collection.StringOps$.head$extension(StringOps.scala:1129)
        at dotty.tools.dotc.semanticdb.Scala3$StringOps$.isJavaIdent(Scala3.scala:419)
        at dotty.tools.dotc.semanticdb.SemanticSymbolBuilder.addName(SemanticSymbolBuilder.scala:63)
        at dotty.tools.dotc.semanticdb.SemanticSymbolBuilder.addDescriptor$1(SemanticSymbolBuilder.scala:109)
        at dotty.tools.dotc.semanticdb.SemanticSymbolBuilder.addSymName(SemanticSymbolBuilder.scala:146)
        at dotty.tools.dotc.semanticdb.SemanticSymbolBuilder.symbolName(SemanticSymbolBuilder.scala:29)
        at dotty.tools.dotc.semanticdb.Scala3$SymbolOps$.symbolName(Scala3.scala:266)
        at dotty.tools.dotc.semanticdb.ExtractSemanticDB$Extractor.registerUse(ExtractSemanticDB.scala:344)
        at dotty.tools.dotc.semanticdb.ExtractSemanticDB$Extractor.registerUseGuarded(ExtractSemanticDB.scala:341)
        at dotty.tools.dotc.semanticdb.ExtractSemanticDB$Extractor.traverse$$anonfun$15$$anonfun$1(ExtractSemanticDB.scala:250)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:333)
        at dotty.tools.dotc.semanticdb.ExtractSemanticDB$Extractor.traverse$$anonfun$15(ExtractSemanticDB.scala:256)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:333)
        at dotty.tools.dotc.semanticdb.ExtractSemanticDB$Extractor.traverse(ExtractSemanticDB.scala:256)
        at dotty.tools.dotc.semanticdb.ExtractSemanticDB$Extractor.traverse$$anonfun$1(ExtractSemanticDB.scala:140)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:333)
        at dotty.tools.dotc.semanticdb.ExtractSemanticDB$Extractor.traverse(ExtractSemanticDB.scala:140)
        at scala.meta.internal.pc.SemanticdbTextDocumentProvider.textDocument(SemanticdbTextDocumentProvider.scala:39)
        at scala.meta.internal.pc.ScalaPresentationCompiler.semanticdbTextDocument$$anonfun$1(ScalaPresentationCompiler.scala:138)
        at scala.meta.internal.pc.CompilerAccess.withSharedCompiler(CompilerAccess.scala:137)
        at scala.meta.internal.pc.CompilerAccess.withNonInterruptableCompiler$$anonfun$1(CompilerAccess.scala:125)
        at scala.meta.internal.pc.CompilerAccess.onCompilerJobQueue$$anonfun$1(CompilerAccess.scala:197)
        at scala.meta.internal.pc.CompilerJobQueue$Job.run(CompilerJobQueue.scala:139)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```