### PR TITLE
Try to avoid static symbols if leaving them would make a leak

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -512,7 +512,7 @@ object TypeOps:
       @threadUnsafe lazy val forbidden = symsToAvoid.toSet
       def toAvoid(tp: NamedType) =
         val sym = tp.symbol
-        !sym.isStatic && forbidden.contains(sym)
+        forbidden.contains(sym)
 
       override def apply(tp: Type): Type = tp match
         case tp: TypeVar if mapCtx.typerState.constraint.contains(tp) =>

--- a/tests/pos/i9314.scala
+++ b/tests/pos/i9314.scala
@@ -1,0 +1,4 @@
+final class fooAnnot[T](member: T) extends scala.annotation.StaticAnnotation // must have type parameter
+
+@fooAnnot(new RecAnnotated {}) // must pass instance of anonymous subclass
+trait RecAnnotated


### PR DESCRIPTION
Possible fix for #9314

Typer.ensureNoLocalRefs doesn't avoid local static refs like anonymous
class instances to allow typing more specific expected types with e.g. refinements.
Unfortunately this can cause leaks when expected types have to be
inferred. This PR tries to fix this problem by adding a fallback that
avoids all local symbols if this leak were to happen.