### PR TITLE
Avoid leaking internal types in GadtConstraint.approximation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -209,7 +209,15 @@ final class ProperGadtConstraint private(
   def isNarrowing: Boolean = wasConstrained
 
   override def approximation(sym: Symbol, fromBelow: Boolean)(using Context): Type = {
-    val res = approximation(tvarOrError(sym).origin, fromBelow = fromBelow)
+    val res =
+      approximation(tvarOrError(sym).origin, fromBelow = fromBelow) match
+        case tpr: TypeParamRef =>
+          // Here we do externalization when the returned type is a TypeParamRef,
+          //  b/c ConstraintHandling.approximation may return internal types when
+          //  the type variable is instantiated. See #15531.
+          externalize(tpr)
+        case tp => tp
+
     gadts.println(i"approximating $sym ~> $res")
     res
   }

--- a/tests/pos/i15531.scala
+++ b/tests/pos/i15531.scala
@@ -1,0 +1,9 @@
+trait Tag { val data: Int }
+
+enum EQ[A, B]:
+  case Refl[C]() extends EQ[C, C]
+
+def foo[T, B <: Tag](ev: EQ[T, B], x: T) = ev match
+  case EQ.Refl() =>
+    val i: Int = x.data
+


### PR DESCRIPTION
This PR fixes #15531, where internal type parameters in the GADT solver are leaked by `GadtConstraint.approximation`.

Now we apply `externalize` on the result when it is a `TypeParamRef` to avoid the leaking.

*Picked from #15533*