### PR TITLE
Suppress initialization warnings

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -32,9 +32,9 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
     if ids != null then
       val ownId = nextId
       nextId += 1
-      ids.nn.put(this, ownId)
+      ids.nn.put(this: @unchecked, ownId)
       if ownId == debugId then
-        println(s"Debug tree (id=$debugId) creation \n$this\n")
+        println(s"Debug tree (id=$debugId) creation \n${this: @unchecked}\n")
         Thread.dumpStack()
 
   allocateId()
@@ -83,7 +83,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
    *  the left, or, if that one does not exist, to the start position of the envelope
    *  of all children to the right.
    */
-  def envelope(src: SourceFile, startSpan: Span = NoSpan): Span = this match {
+  def envelope(src: SourceFile, startSpan: Span = NoSpan): Span = (this: @unchecked) match {
     case Trees.Inlined(call, _, _) =>
       call.span
     case _ =>
@@ -106,7 +106,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
       }
       val limit = productArity
       def includeChildren(span: Span, n: Int): Span =
-        if (n < limit) includeChildren(include(span, productElement(n)), n + 1)
+        if (n < limit) includeChildren(include(span, productElement(n): @unchecked), n + 1)
         else span
       val span1 = includeChildren(startSpan, 0)
       val span2 =

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -819,7 +819,7 @@ object Contexts {
 
   @sharable object NoContext extends Context((null: ContextBase | Null).uncheckedNN) {
     source = NoSource
-    override val implicits: ContextualImplicits = new ContextualImplicits(Nil, null, false)(this)
+    override val implicits: ContextualImplicits = new ContextualImplicits(Nil, null, false)(this: @unchecked)
   }
 
   /** A context base defines state and associated methods that exist once per

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -85,7 +85,7 @@ object NameKinds {
       case _ => None
     }
 
-    simpleNameKinds(tag) = this
+    simpleNameKinds(tag) = this: @unchecked
   }
 
   /** The kind of names that get formed by adding a prefix to an underlying name */
@@ -152,7 +152,7 @@ object NameKinds {
 
     def infoString: String = s"Qualified $separator"
 
-    qualifiedNameKinds(tag) = this
+    qualifiedNameKinds(tag) = this: @unchecked
   }
 
   /** An extractor for qualified names of an arbitrary kind */
@@ -190,7 +190,7 @@ object NameKinds {
       else -1
     }
 
-    numberedNameKinds(tag) = this
+    numberedNameKinds(tag) = this: @unchecked
   }
 
   /** An extractor for numbered names of arbitrary kind */
@@ -225,7 +225,7 @@ object NameKinds {
     def fresh(prefix: TypeName)(using Context): TypeName =
       fresh(prefix.toTermName).toTypeName
 
-    uniqueNameKinds(separator) = this
+    uniqueNameKinds(separator) = this: @unchecked
   }
 
   /** An extractor for unique names of arbitrary kind */

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -568,7 +568,7 @@ object Names {
           enterIfNew(cs, offset, len)
       }
 
-    addEntryAt(0, EmptyTermName)
+    addEntryAt(0, EmptyTermName: @unchecked)
   end NameTable
 
   /** Hashtable for finding term names quickly. */

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -162,7 +162,7 @@ object Scanners {
         errorButContinue("trailing separator is not allowed", offset + litBuf.length - 1)
   }
 
-  class Scanner(source: SourceFile, override val startFrom: Offset = 0, profile: Profile = NoProfile)(using Context) extends ScannerCommon(source) {
+  class Scanner(source: SourceFile, override val startFrom: Offset = 0, profile: Profile = NoProfile, allowIndent: Boolean = true)(using Context) extends ScannerCommon(source) {
     val keepComments = !ctx.settings.YdropComments.value
 
     /** A switch whether operators at the start of lines can be infix operators */
@@ -185,10 +185,7 @@ object Scanners {
     val indentSyntax =
       ((if (Config.defaultIndent) !noindentSyntax else ctx.settings.indent.value)
        || rewriteNoIndent)
-      && { this match
-        case self: LookaheadScanner => self.allowIndent
-        case _ => true
-      }
+      && allowIndent
 
     if (rewrite) {
       val s = ctx.settings
@@ -1093,7 +1090,7 @@ object Scanners {
         reset()
       next
 
-    class LookaheadScanner(val allowIndent: Boolean = false) extends Scanner(source, offset) {
+    class LookaheadScanner(val allowIndent: Boolean = false) extends Scanner(source, offset, allowIndent = allowIndent) {
       override def languageImportContext = Scanner.this.languageImportContext
     }
 

--- a/compiler/src/dotty/tools/dotc/profile/Profiler.scala
+++ b/compiler/src/dotty/tools/dotc/profile/Profiler.scala
@@ -100,10 +100,6 @@ private [profile] class RealProfiler(reporter : ProfileReporter)(using Context) 
   def outDir: AbstractFile = ctx.settings.outputDir.value
 
   val id: Int = RealProfiler.idGen.incrementAndGet()
-  RealProfiler.gcMx foreach {
-    case emitter: NotificationEmitter => emitter.addNotificationListener(this, null, null)
-    case gc => println(s"Cant connect gcListener to ${gc.getClass}")
-  }
 
   private val mainThread = Thread.currentThread()
 
@@ -128,6 +124,11 @@ private [profile] class RealProfiler(reporter : ProfileReporter)(using Context) 
   private def doGC: Unit = {
     System.gc()
     System.runFinalization()
+  }
+
+  RealProfiler.gcMx foreach {
+    case emitter: NotificationEmitter => emitter.addNotificationListener(this, null, null)
+    case gc => println(s"Cant connect gcListener to ${gc.getClass}")
   }
 
   reporter.header(this)

--- a/compiler/src/dotty/tools/dotc/transform/ForwardDepChecks.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ForwardDepChecks.scala
@@ -31,7 +31,7 @@ object ForwardDepChecks:
       stats.foldLeft(outer.levelAndIndex, 0) {(mi, stat) =>
         val (m, idx) = mi
         val m1 = stat match {
-          case stat: MemberDef => m.updated(stat.symbol, (this, idx))
+          case stat: MemberDef => m.updated(stat.symbol, (this: @unchecked, idx))
           case _ => m
         }
         (m1, idx + 1)

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1029,8 +1029,8 @@ object PatternMatcher {
     end checkSwitch
 
     val optimizations: List[(String, Plan => Plan)] = List(
-      "mergeTests" -> mergeTests: @unchecked,
-      "inlineVars" -> inlineVars: @unchecked
+      "mergeTests" -> mergeTests,
+      "inlineVars" -> inlineVars
     )
 
     /** Translate pattern match to sequence of tests. */

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1029,8 +1029,8 @@ object PatternMatcher {
     end checkSwitch
 
     val optimizations: List[(String, Plan => Plan)] = List(
-      "mergeTests" -> mergeTests,
-      "inlineVars" -> inlineVars
+      "mergeTests" -> mergeTests: @unchecked,
+      "inlineVars" -> inlineVars: @unchecked
     )
 
     /** Translate pattern match to sequence of tests. */


### PR DESCRIPTION
Suppress initialization warnings

If simple code refactoring suppresses the warning, it's preferred as long as the code change is an improvement.
Otherwise, we avoid big code changes with the usage of `@unchecked`.