### PR TITLE
bump compiler-interface and capture the diagnosticCode

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,6 +25,6 @@ object Dependencies {
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % flexmarkVersion,
   )
 
-  val newCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.4.3"
+  val newCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.7.1"
   val oldCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.3.5"
 }

--- a/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
@@ -39,12 +39,13 @@ final public class DelegatingReporter extends AbstractReporter {
     StringBuilder rendered = new StringBuilder();
     rendered.append(messageAndPos(dia, ctx));
     Message message = dia.msg();
+    String diagnosticCode = String.valueOf(message.errorId().errorNumber());
     boolean shouldExplain = Diagnostic.shouldExplain(dia, ctx);
     if (shouldExplain && !message.explanation().isEmpty()) {
       rendered.append(explanation(message, ctx));
     }
 
-    delegate.log(new Problem(position, message.msg(), severity, rendered.toString()));
+    delegate.log(new Problem(position, message.msg(), severity, rendered.toString(), diagnosticCode));
   }
 
   private static Severity severityOf(int level) {

--- a/sbt-bridge/src/dotty/tools/xsbt/DiagnosticCode.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/DiagnosticCode.java
@@ -1,0 +1,23 @@
+package dotty.tools.xsbt;
+
+import java.util.Optional;
+
+final public class DiagnosticCode implements xsbti.DiagnosticCode {
+	private final String _code;
+	private final Optional<String> _explanation;
+
+	public DiagnosticCode(String code, Optional<String> explanation) {
+		super();
+		this._code = code;
+		this._explanation = explanation;
+	}
+
+	public String code() {
+		return _code;
+	}
+
+	public Optional<String> explanation() {
+		return _explanation;
+	}
+
+}

--- a/sbt-bridge/src/dotty/tools/xsbt/Problem.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/Problem.java
@@ -9,13 +9,15 @@ final public class Problem implements xsbti.Problem {
   private final String _message;
   private final Severity _severity;
   private final Optional<String> _rendered;
+  private final String _diagnosticCode;
 
-  public Problem(Position position, String message, Severity severity, String rendered) {
+  public Problem(Position position, String message, Severity severity, String rendered, String diagnosticCode) {
     super();
     this._position = position;
     this._message = message;
     this._severity = severity;
     this._rendered = Optional.of(rendered);
+    this._diagnosticCode = diagnosticCode;
   }
 
   public String category() {
@@ -38,8 +40,17 @@ final public class Problem implements xsbti.Problem {
     return _rendered;
   }
 
+  public Optional<xsbti.DiagnosticCode> diagnosticCode() {
+    // NOTE: It's important for compatibility that we only construct a
+    // DiagnosticCode here to maintain compatibility with older versions of
+    // zinc while using this newer version of the compiler. If we would
+    // contstruct it earlier, you'd end up with ClassNotFoundExceptions for
+    // DiagnosticCode.
+    return Optional.of(new DiagnosticCode(_diagnosticCode, Optional.empty()));
+  }
+
   @Override
   public String toString() {
-    return "Problem(" + _position + ", " + _message + ", " + _severity + ", " + _rendered + ")";
+    return "Problem(" + _position + ", " + _message + ", " + _severity + ", " + _rendered + ", " + _diagnosticCode + ")";
   }
 }

--- a/sbt-test/compilerReporter/simple/project/Reporter.scala
+++ b/sbt-test/compilerReporter/simple/project/Reporter.scala
@@ -36,6 +36,11 @@ object Reporter {
       assert(line.isPresent() == true)
       assert(line.get() == 9)
 
+      val diagnosticCode = mainProblem.diagnosticCode()
+      assert(diagnosticCode.isPresent() == true)
+      val code = diagnosticCode.get()
+      assert(diagnosticCode.get().code() == "6")
+
       val pointer = mainProblem.position().pointer()
       assert(pointer.isPresent() == true)
       assert(pointer.get() == 10)


### PR DESCRIPTION
NOTE: It's important that in `Problem` we don't construct the actual
`DiagnosticCode` _unless_ the method is called to get it. By doing this we
keep compatibility ensuring that older build tools can still use the
bridge just fine. That's what the `sbt-test/sbt-bridge` tests ensuring
that this is still usable by an older tool using the old `Problem`. This
then unlocks forwarding the diagnostic code on for tools to use.

refs: https://github.com/lampepfl/dotty/issues/14904