### PR TITLE
Check is inline unapply has leading implicits

### DIFF
--- a/tests/neg/i12991.scala
+++ b/tests/neg/i12991.scala
@@ -1,0 +1,7 @@
+object Foo:
+  inline def unapply(using String)(i: Int): Some[Int] = Some(i)
+
+given String = ""
+
+val i = 10 match
+  case Foo(x) => x // error


### PR DESCRIPTION
We patch the crash in the compiler but do not support this feature yet.

To support it see https://github.com/lampepfl/dotty/pull/13158

Fixes #12991