### PR TITLE
Don't report warnings in migration when performing rewrites

### DIFF
--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -82,7 +82,8 @@ object report:
 
   def errorOrMigrationWarning(msg: Message, pos: SrcPos, from: SourceVersion)(using Context): Unit =
     if sourceVersion.isAtLeast(from) then
-      if sourceVersion.isMigrating && sourceVersion.ordinal <= from.ordinal then migrationWarning(msg, pos)
+      if sourceVersion.isMigrating && sourceVersion.ordinal <= from.ordinal then
+        if ctx.settings.rewrite.value.isEmpty then migrationWarning(msg, pos)
       else error(msg, pos)
 
   def gradualErrorOrMigrationWarning(msg: Message, pos: SrcPos, warnFrom: SourceVersion, errorFrom: SourceVersion)(using Context): Unit =

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -75,6 +75,7 @@ class CompilationTests {
     aggregateTests(
       compileFile("tests/rewrites/rewrites.scala", scala2CompatMode.and("-rewrite", "-indent")),
       compileFile("tests/rewrites/rewrites3x.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
+      compileFile("tests/rewrites/rewrites3x.scala", defaultOptions.and("-rewrite", "-source", "future-migration", "-Xfatal-warnings")),
       compileFile("tests/rewrites/filtering-fors.scala", defaultOptions.and("-rewrite", "-source", "3.2-migration")),
       compileFile("tests/rewrites/refutable-pattern-bindings.scala", defaultOptions.and("-rewrite", "-source", "3.2-migration")),
       compileFile("tests/rewrites/i8982.scala", defaultOptions.and("-indent", "-rewrite")),


### PR DESCRIPTION
This PR stops reporting migration warnings when the given code snippet is also being rewritten. It fixes terrible development experience when combining `-rewrite -source .*-migration` with `-Xfatal-warnings`. In the mentioned case compilation would never succeed, since migration warnings elevated to errors, would always roll back generated rewrites.  
Since the warning message is not being shown in all paths I've changed the function arguments to be passed by name

Sidenote:
I've spent literally too much time wondering why -rewrites do not work as they should. I belive that typical Scala users would have the same problems.