### PR TITLE
Fix #15374: Make sure prefix of outer select has the correct class symbol

### DIFF
--- a/tests/run/i15374.scala
+++ b/tests/run/i15374.scala
@@ -1,0 +1,18 @@
+class A(val x: Int):
+  class X:
+    inline def foo() = A.this.foo()
+
+  private def foo(): Int = x
+
+class B extends A(20):
+  val a = new A(10)
+  val y: Y = new Y
+
+  class Y extends a.X
+
+class C:
+  var b = new B
+  assert(b.y.foo() == 10)
+
+@main
+def Test = new C()


### PR DESCRIPTION
Fix #15374: Make sure prefix of outer select has the correct class symbol

If we have an outer select `e.outer_<hops>`, we must make sure that the class symbol
of `e` is the class where the outer this is located in. Otherwise, the phase
`ElimOuterSelect` would get confused.

Co-authored-by: Dale Wijnand <dale.wijnand@gmail.com>