### PR TITLE
Irrefutable for generators don't require `withFilter` under `-source:future`

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2574,8 +2574,8 @@ object Parsers {
       atSpan(startOffset(pat), accept(LARROW)) {
         val checkMode =
           if casePat then GenCheckMode.FilterAlways
-          else if sourceVersion.isAtLeast(`3.2`) then GenCheckMode.CheckAndFilter
           else if sourceVersion.isAtLeast(`future`) then GenCheckMode.Check
+          else if sourceVersion.isAtLeast(`3.2`) then GenCheckMode.CheckAndFilter
           else GenCheckMode.FilterNow  // filter on source version < 3.2, for backward compat
         GenFrom(pat, subExpr(), checkMode)
       }

--- a/tests/pos/i15579.scala
+++ b/tests/pos/i15579.scala
@@ -1,0 +1,10 @@
+// scalac: -source:future
+
+trait Foo[A]:
+  def map[B](f: A => B): Foo[B] = ???
+
+def baz: Foo[(Int, String)] = ???
+
+@main def main =
+  for (x, y) <- baz
+  yield ()


### PR DESCRIPTION
Fixes #15579