### PR TITLE
Fix #15465: Use resolveThis for outer this resolution

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -1515,8 +1515,7 @@ object Semantic:
             resolveThis(target, thisV, cur)
 
           case None =>
-            // TODO: use error once we fix https://github.com/lampepfl/dotty/issues/15465
-            report.warning("[Internal error] unexpected outerSelect, thisV = " + thisV + ", target = " + target.show + ", hops = " + hops, trace.toVector.last.srcPos)
+            report.error("[Internal error] unexpected outerSelect, thisV = " + thisV + ", target = " + target.show + ", hops = " + hops, trace.toVector.last.srcPos)
             Cold
 
       case RefSet(refs) =>

--- a/tests/init/pos/i15465.scala
+++ b/tests/init/pos/i15465.scala
@@ -1,0 +1,17 @@
+class TestSuite:
+  protected val it = new ItWord
+
+  protected final class ItWord:
+    def should(string: String) = new ItVerbString("should", string)
+
+  private def registerTestToRun(fun: => Any): Unit = ()
+
+  protected final class ItVerbString(verb: String, name: String):
+    inline def in(testFun: => Any): Unit = registerTestToRun(testFun)
+
+class MyTest extends TestSuite:
+  it should "not cause outer select errors" in {
+    assert(1 + 1 == 2)
+  }
+
+  val n = 10


### PR DESCRIPTION
Fix #15465: Use `resolveThis` for outer this resolution

This shows that `hops` is redundant after https://github.com/lampepfl/dotty/pull/15592. The refactoring can be addressed in another PR.