### PR TITLE
Rewrites are UTF-8

### DIFF
--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -8,6 +8,7 @@ import collection.mutable
 import scala.annotation.tailrec
 import dotty.tools.dotc.reporting.Reporter
 
+import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets.UTF_8
 
 /** Handles rewriting of Scala2 files to Dotty */
@@ -56,13 +57,11 @@ object Rewrites {
       ds
     }
 
-    def writeBack(): Unit = {
+    def writeBack(): Unit =
       val chars = apply(source.underlying.content)
-      val bytes = new String(chars).getBytes(UTF_8)
-      val out = source.file.output
-      out.write(bytes)
-      out.close()
-    }
+      val osw = OutputStreamWriter(source.file.output, UTF_8)
+      try osw.write(chars, 0, chars.length)
+      finally osw.close()
   }
 
   /** If -rewrite is set, record a patch that replaces the range

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -8,6 +8,8 @@ import collection.mutable
 import scala.annotation.tailrec
 import dotty.tools.dotc.reporting.Reporter
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 /** Handles rewriting of Scala2 files to Dotty */
 object Rewrites {
   private class PatchedFiles extends mutable.HashMap[SourceFile, Patches]
@@ -56,7 +58,7 @@ object Rewrites {
 
     def writeBack(): Unit = {
       val chars = apply(source.underlying.content)
-      val bytes = new String(chars).getBytes
+      val bytes = new String(chars).getBytes(UTF_8)
       val out = source.file.output
       out.write(bytes)
       out.close()


### PR DESCRIPTION
Don't use platform default, as UTF-8 is specified everywhere. `getBytes` is the dangerous API.

Instead of getting the byte array, just write through the underlying encoder (which buffers). The stream writer closes the encoder which closes the underlying stream, as I verified not for the first time in my life.
