### PR TITLE
Fix Vulpix progress vs sbt supershell (CR)

### DIFF
--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -8,8 +8,8 @@ import java.nio.file._
 object Properties {
 
   /** If property is unset or "TRUE" we consider it `true` */
-  private def propIsNullOrTrue(prop: String): Boolean = {
-    val prop = System.getProperty("dotty.tests.interactive")
+  private def propIsNullOrTrue(name: String): Boolean = {
+    val prop = System.getProperty(name)
     prop == null || prop == "TRUE"
   }
 


### PR DESCRIPTION
It seems how things are done by putting a carriage return at the end
doesn't play nicely with sbt's super shell.  And I couldn't find a way
to disable supershell during test execution.  So instead I found that
carriage returning at the start seems to work as desired.

Other that that I just cleaned up the area a bit (subjectively).

[test_non_bootstrapped]