### PR TITLE
community build: Cats Effect: use 3.3.x branch, enable JS tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,7 +100,7 @@
 [submodule "community-build/community-projects/cats-effect-3"]
 	path = community-build/community-projects/cats-effect-3
 	url = https://github.com/dotty-staging/cats-effect.git
-	branch = series/3.x
+	branch = series/3.3.x
 [submodule "community-build/community-projects/scala-parallel-collections"]
 	path = community-build/community-projects/scala-parallel-collections
 	url = https://github.com/dotty-staging/scala-parallel-collections.git

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -485,7 +485,7 @@ object projects:
 
   lazy val catsEffect3 = SbtCommunityProject(
     project        = "cats-effect-3",
-    sbtTestCommand = "ciJVM",
+    sbtTestCommand = "ci",
     sbtPublishCommand = "publishLocal",
     sbtDocCommand  = ";coreJVM/doc ;lawsJVM/doc ;kernelJVM/doc",
     dependencies   = List(cats, coop, disciplineSpecs2, scalacheck)


### PR DESCRIPTION
I don't really remember why I volunteered for this, but I did :-)

@armanbilge told me:

> btw, we had a regression in 3.1.3 b/c the JS tests are not being run in the CB I'm not sure if that's just not a thing, or nobody enabled it for some reason

it looks to me like that happened in 1092b356e6f032978e04963ad8e76cd2b905d803 (`ci` was replaced with `ciJVM`), @griggt wdyt?  (there is some discussion about the JS tests at #10639 but it isn't clear to me if it's still relevant)

as for `series/3.3.x` being the right branch, I think it was also Arman who told me:

> series/3.3.x is the branch you want for the latest stable release

Sounds plausible that we don't need to track latest series/3.x development until it stabilizes.