### PR TITLE
Merge nested polytypes in more cases in resolveOverloaded

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1466,7 +1466,7 @@ trait Applications extends Compatibility {
     case mt: MethodType if mt.isImplicitMethod =>
       stripImplicit(resultTypeApprox(mt))
     case pt: PolyType =>
-      pt.derivedLambdaType(pt.paramNames, pt.paramInfos, stripImplicit(pt.resultType))
+      pt.derivedLambdaType(pt.paramNames, pt.paramInfos, stripImplicit(pt.resultType)).asInstanceOf[PolyType].flatten
     case _ =>
       tp
   }
@@ -1520,7 +1520,7 @@ trait Applications extends Compatibility {
       else compareOwner(cls1, sym2)
     else 0
 
-  /** Compare to alternatives of an overloaded call or an implicit search.
+  /** Compare two alternatives of an overloaded call or an implicit search.
    *
    *  @param  alt1, alt2      Non-overloaded references indicating the two choices
    *  @return  1   if 1st alternative is preferred over 2nd

--- a/tests/pos/i11713.scala
+++ b/tests/pos/i11713.scala
@@ -1,0 +1,5 @@
+extension [T1](x: T1)(using Numeric[T1])
+  def combine[T2](y: T2)(using Numeric[T2]) = ???
+  def combine(y: String) = ???
+
+val res = 100.combine(200)

--- a/tests/pos/i13668.scala
+++ b/tests/pos/i13668.scala
@@ -1,0 +1,15 @@
+class MyType()
+trait Candidate[R]
+given Candidate[MyType] with {}
+class Fuzzy[W]()
+class Fuzzy1()
+class Bear()
+
+extension [L](lhs: L)(using Candidate[L])
+  def +[RW](rhs: Fuzzy[RW]): Unit = {}
+  def +(rhs: Bear): Unit = {}
+  def -(rhs: Fuzzy1): Unit = {}
+  def -(rhs: Bear): Unit = {}
+
+val works = MyType() - Fuzzy1()
+val fails = MyType() + Fuzzy[1]()


### PR DESCRIPTION
In some cases while going deeper into alternatives during overload resolution,
we may end up with a nested polytype after dropping contextual parameters.

In particular this can happen for an extension with a `using` clause, as seen
in tests/pos/i11713.scala and tests/pos/i13668.scala.

The overload applicability test fails here unless the type parameter lists
are merged.

Co-authored-by: Gagandeep Kalra <gagandeepkalra1994@gmail.com>
Co-authored-by: Mark T. Kennedy <mtk@acm.org>

Fixes #11713
Fixes #13668