### PR TITLE
deprecate ToString type which should be deprecated at 3.2.0

### DIFF
--- a/library/src/scala/compiletime/ops/int.scala
+++ b/library/src/scala/compiletime/ops/int.scala
@@ -244,7 +244,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  //@deprecated("Use compiletime.ops.any.ToString instead.","3.2.0") // uncomment when reaching 3.2.0
+  @deprecated("Use compiletime.ops.any.ToString instead.","3.2.0")
   type ToString[X <: Int] <: String
 
   /** Long conversion of an `Int` singleton type.


### PR DESCRIPTION
ToString from compile time ops for int should be deprecated at 3.2.0 according to comment.
If it is deprecated from 3.2.0 we must backport it.