### PR TITLE
Fix GADT casting when typing if expressions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3779,7 +3779,13 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             // The check "safeToInstantiate" in `maximizeType` works to prevent unsound GADT casts.
             val target =
               if tree.tpe.isSingleton then
-                val conj = AndType(tree.tpe, pt)
+                // In the target type, when the singleton type is intersected, we also intersect
+                //   the GADT-approximated type of the singleton to avoid the loss of 
+                //   information. See #14776.
+                val gadtApprox = Inferencing.approximateGADT(tree.tpe.widen)
+                gadts.println(i"gadt approx $wtp ~~~ $gadtApprox")
+                val conj =
+                  AndType(AndType(tree.tpe, gadtApprox), pt)
                 if tree.tpe.isStable && !conj.isStable then
                   // this is needed for -Ycheck. Without the annotation Ycheck will
                   // skolemize the result type which will lead to different types before

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1137,7 +1137,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
     def gadtAdaptBranch(tree: Tree, branchPt: Type): Tree =
       TypeComparer.testSubType(tree.tpe.widenExpr, branchPt) match {
-        case CompareResult.OKwithGADTUsed => tree.cast(branchPt)
+        case CompareResult.OKwithGADTUsed =>
+          insertGadtCast(tree, tree.tpe.widen, branchPt)
         case _ => tree
       }
 
@@ -1157,8 +1158,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
         val resType = thenp1.tpe | elsep1.tpe
 
-        val thenp2 = gadtAdaptBranch(thenp1, resType)
-        val elsep2 = gadtAdaptBranch(elsep1, resType)
+        val thenp2 :: elsep2 :: Nil =
+          (thenp1 :: elsep1 :: Nil) map { t =>
+            gadtAdaptBranch(t, resType)
+          }: @unchecked
 
         cpy.If(tree)(cond1, thenp2, elsep2).withType(resType)
 
@@ -3775,26 +3778,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                  gadts.println(i"unnecessary GADTused for $tree: ${tree.tpe.widenExpr} vs $pt in ${ctx.source}")
                res
               } =>
-            // Insert an explicit cast, so that -Ycheck in later phases succeeds.
-            // The check "safeToInstantiate" in `maximizeType` works to prevent unsound GADT casts.
-            val target =
-              if tree.tpe.isSingleton then
-                // In the target type, when the singleton type is intersected, we also intersect
-                //   the GADT-approximated type of the singleton to avoid the loss of 
-                //   information. See #14776.
-                val gadtApprox = Inferencing.approximateGADT(tree.tpe.widen)
-                gadts.println(i"gadt approx $wtp ~~~ $gadtApprox")
-                val conj =
-                  AndType(AndType(tree.tpe, gadtApprox), pt)
-                if tree.tpe.isStable && !conj.isStable then
-                  // this is needed for -Ycheck. Without the annotation Ycheck will
-                  // skolemize the result type which will lead to different types before
-                  // and after checking. See i11955.scala.
-                  AnnotatedType(conj, Annotation(defn.UncheckedStableAnnot))
-                else conj
-              else pt
-            gadts.println(i"insert GADT cast from $tree to $target")
-            tree.cast(target)
+            insertGadtCast(tree, wtp, pt)
           case _ =>
             //typr.println(i"OK ${tree.tpe}\n${TypeComparer.explained(_.isSubType(tree.tpe, pt))}") // uncomment for unexpected successes
             tree
@@ -4225,4 +4209,36 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           EmptyTree
     else typedExpr(call, defn.AnyType)
 
+  /** Insert GADT cast to target type `pt` on the `tree`
+    *   so that -Ycheck in later phases succeeds.
+    *  The check "safeToInstantiate" in `maximizeType` works to prevent unsound GADT casts.
+    */
+  private def insertGadtCast(tree: Tree, wtp: Type, pt: Type)(using Context): Tree =
+    val target =
+      if tree.tpe.isSingleton then
+        // In the target type, when the singleton type is intersected, we also intersect
+        //   the GADT-approximated type of the singleton to avoid the loss of
+        //   information. See #14776.
+        val gadtApprox = Inferencing.approximateGADT(wtp)
+        gadts.println(i"gadt approx $wtp ~~~ $gadtApprox")
+        val conj =
+          TypeComparer.testSubType(gadtApprox, pt) match {
+            case CompareResult.OK =>
+              // GADT approximation of the tree type is a subtype of expected type under empty GADT
+              //   constraints, so it is enough to only have the GADT approximation.
+              AndType(tree.tpe, gadtApprox)
+            case _ =>
+              // In other cases, we intersect both the approximated type and the expected type.
+              AndType(AndType(tree.tpe, gadtApprox), pt)
+          }
+        if tree.tpe.isStable && !conj.isStable then
+          // this is needed for -Ycheck. Without the annotation Ycheck will
+          // skolemize the result type which will lead to different types before
+          // and after checking. See i11955.scala.
+          AnnotatedType(conj, Annotation(defn.UncheckedStableAnnot))
+        else conj
+      else pt
+    gadts.println(i"insert GADT cast from $tree to $target")
+    tree.cast(target)
+  end insertGadtCast
 }

--- a/tests/pos/gadt-cast-if.scala
+++ b/tests/pos/gadt-cast-if.scala
@@ -1,0 +1,12 @@
+trait Expr[T]
+  case class IntExpr() extends Expr[Int]
+
+  def flag: Boolean = ???
+
+  def foo[T](ev: Expr[T]): Int | T = ev match
+    case IntExpr() =>
+      if flag then
+        val i: T = ???
+        i
+      else
+        (??? : Int)

--- a/tests/pos/gadt-cast-singleton.scala
+++ b/tests/pos/gadt-cast-singleton.scala
@@ -1,0 +1,13 @@
+enum SUB[-A, +B]:
+  case Refl[S]() extends SUB[S, S]
+
+trait R {
+  type Data
+}
+trait L extends R
+
+def f(x: L): x.Data = ???
+
+def g[T <: R](x: T, ev: T SUB L): x.Data = ev match
+  case SUB.Refl() =>
+    f(x)

--- a/tests/pos/i14776-patmat.scala
+++ b/tests/pos/i14776-patmat.scala
@@ -1,0 +1,15 @@
+trait T1
+trait T2 extends T1
+
+trait Expr[T] { val data: T = ??? }
+case class Tag2() extends Expr[T2]
+
+def flag: Boolean = ???
+
+def foo[T](e: Expr[T]): T1 = e match {
+  case Tag2() =>
+    flag match
+      case true => new T2 {}
+      case false => e.data
+}
+

--- a/tests/pos/i14776.scala
+++ b/tests/pos/i14776.scala
@@ -1,0 +1,16 @@
+trait T1
+trait T2 extends T1
+
+trait Expr[T] { val data: T = ??? }
+case class Tag2() extends Expr[T2]
+
+def flag: Boolean = ???
+
+def foo[T](e: Expr[T]): T1 = e match {
+  case Tag2() =>
+      if flag then
+        new T2 {}
+      else
+        e.data
+}
+


### PR DESCRIPTION
Fixes #14776.

Currently, when typing if expressions the compiler computes the union type of the two branches, during which GADT constraints may be implicitly used. This cause `-Ycheck` to fail due to the missing of proper GADT casts. The problems caused by this can be classified into two cases:

- In the first case, GADT casts are inserted in the branches, but the cast does not contain enough typing information to recover the type of the if tree when checking the tree. Details of this case are discussed in #15533.

- In the second case, no GADT cast is inserted. The tree fails the checker due to the lack of GADT casts. For example:
  ```scala
  trait Expr[T]
  case class IntExpr() extends Expr[Int]

  def flag: Boolean = ???

  def foo[T](ev: Expr[T]): Int | T = ev match
    case IntExpr() =>
      if flag then
        val i: T = ???
        i
      else
        (??? : Int)
  ```
  The if tree is typed as `T | Int` which get simplified to `T` with GADT constraints, with no GADT cast inserted. Later the checker finds that `T | Int` does not confirm to `T` (w/o GADT constr) and fails.

This PR fixes this issue by doing two things:

- Change 1: When typing an if expression `if cond then thenp else elsep`, we will compare `thenp.tpe` and `elsep.tpe` to the type assigned to the if tree, which is `thenp.tpe | elsep.tpe`. If `thenp/elsep.tpe` is a subtype of `thenp.tpe | elsep.tpe` only when GADT constraint is used, we will insert a GADT cast to ensure `-Ycheck` passes in future phases. With this change, when typing the above example we will insert a cast `(??? : Int).$asInstanceOf[T]`.

- Change 2: We cherry-pick the related commit in #15533 to refine the cast with GADT approximated type when the casted tree is a singleton. For the example in #14776:
  ```scala
  trait T1
  trait T2 extends T1

  trait Expr[T] { val data: T = ??? }
  case class Tag2() extends Expr[T2]

  def flag: Boolean = ???

  def foo[T](e: Expr[T]): T1 = e match {
    case Tag2() =>
      if flag then
        new T2 {}
      else
        e.data
  }
  ```
  We will insert a cast `e.data.$asInstanceOf[e.data.type & T2]` (instead of `e.data.$asInstanceOf[e.data.type & T1]`). With only change 1, we will insert two GADT casts like `e.data.$asInstanceOf[e.data.type & T1].$asInstanceOf[T2]` for this example, which is wordy and loses the identity of `e.data`. So change 2 makes sure the cases involving GADT casts will be solved, and change 1 takes care of the rest.

