### PR TITLE
Harden erasure of TermRefs

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -602,7 +602,9 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
       else if (tp.isRepeatedParam) apply(tp.translateFromRepeated(toArray = sourceLanguage.isJava))
       else if (semiEraseVCs && isDerivedValueClass(tycon.classSymbol)) eraseDerivedValueClass(tp)
       else apply(tp.translucentSuperType)
-    case _: TermRef | _: ThisType =>
+    case tp: TermRef =>
+      this(underlyingOfTermRef(tp))
+    case _: ThisType =>
       this(tp.widen)
     case SuperType(thistpe, supertpe) =>
       SuperType(this(thistpe), this(supertpe))
@@ -686,6 +688,10 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
     case tp if (tp `eq` NoType) || (tp `eq` NoPrefix) =>
       tp
   }
+
+  private def underlyingOfTermRef(tp: TermRef)(using Context) = tp.widen match
+    case tpw @ MethodType(Nil) if tp.symbol.isGetter => tpw.resultType
+    case tpw => tpw
 
   private def eraseArray(tp: Type)(using Context) = {
     val defn.ArrayOf(elemtp) = tp: @unchecked
@@ -832,7 +838,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
       case JavaArrayType(elem) =>
         sigName(elem) ++ "[]"
       case tp: TermRef =>
-        sigName(tp.widen)
+        sigName(underlyingOfTermRef(tp))
       case ExprType(rt) =>
         sigName(defn.FunctionOf(Nil, rt))
       case tp: TypeVar =>

--- a/tests/pos/i15649.scala
+++ b/tests/pos/i15649.scala
@@ -1,0 +1,11 @@
+trait ConfigSourceModule:
+  object ConfigSource:
+    class R
+
+object M extends ConfigSourceModule
+
+object Foo:
+  implicit class FromConfigSource(c: M.ConfigSource.type)
+
+object FooBar:                                      // problem disappears if we rename as `Bar`
+  def foo: M.ConfigSource.R = new M.ConfigSource.R  // problem disappears if we use `???` as rhs


### PR DESCRIPTION
If a getter TermRef has a MethodType, erase it to the erasure of the method
result type.

Fixes #15649

Since the fault in #15649 is highly non-deterministic, I can only guess what the reason
was. I think what happened was that the TermRef was created very late, when the TermRef
was already a getter. I.e. after phase `Getters`, which is itself after `Erasure`. The
whole thing was launched from the code that generates static forwarders in the backend.

Type erasure is run at erasure phase, but if there is no previous denotation of the `TermRef`,
it will keep the first one it read, which would have the `MethodType` as underlying type.
The end result was that the `TermRef` was erased to a method type, where it should have
been erased to the result type. Consequently, we ended up with a MethodType as the
parameter type of another method, which is unexpected.

But all that is just a guess. I am not even sure this PR will fix the problem since it
comes up so rarely.