### PR TITLE
test the use of `@unchecked` in a type pattern

### DIFF
--- a/tests/pos/type-pattern-unchecked.scala
+++ b/tests/pos/type-pattern-unchecked.scala
@@ -1,0 +1,8 @@
+// scalac: -Werror
+
+def foo =
+  Seq(List(1))
+    .filter {
+      case Seq(x): Seq[Int] @unchecked =>
+        true
+    }


### PR DESCRIPTION
this is a question, couched in the form of a draft pull request with a failing pos test:

```scala
// scalac: -Werror

def foo =
  Seq(List(1))
    .filter {
      case Seq(x): Seq[Int] @unchecked =>
        true
    }
```

in Scala 3.0.2 and 3.1.3, the test compiles, because the use of `@unchecked` suppresses the exhaustivity warning that would otherwise occur:

    case Seq(x): Seq[Int] =>
    ^
    match may not be exhaustive.

    It would fail on pattern case: List(_, _, _*), Nil

in Scala 3.2.0-RC2 and on HEAD, the exhaustivity warning occurs anyway.

is this a 3.2 progression, or regression? if it's a regression, the pos test I've added needs fixing. if y'all tell me that it's actually intended behavior, then I can change it to a neg test.