### PR TITLE
Better infos for dependent class parameter references

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1118,6 +1118,10 @@ object Denotations {
       if !owner.membersNeedAsSeenFrom(pre) && (!ownerIsPrefix || hasOriginalInfo)
          || symbol.is(NonMember)
       then this
+      else if symbol.isAllOf(ClassTypeParam) then
+        val arg = symbol.typeRef.argForParam(pre, widenAbstract = true)
+        if arg.exists then derivedSingleDenotation(symbol, arg.bounds, pre)
+        else derived(symbol.info)
       else derived(symbol.info)
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -432,8 +432,7 @@ object TypeOps:
     override def apply(tp: Type): Type =
       try
         tp match
-          case tp: TermRef
-          if toAvoid(tp) =>
+          case tp: TermRef if toAvoid(tp) =>
             tp.info.widenExpr.dealias match {
               case info: SingletonType => apply(info)
               case info => range(defn.NothingType, apply(info))

--- a/tests/pos/i15652.scala
+++ b/tests/pos/i15652.scala
@@ -1,0 +1,12 @@
+trait Node
+type NodeParser[T] = Node => T
+
+def child(key: String): Option[Node] = ???
+
+def optionalOneOf[T](in: Map[String, NodeParser[? <: T]]): Option[T] =
+  val mappings = in flatMap { (key, parser) =>
+    child(key) map { node =>
+      key -> (() => parser(node))
+    }
+  }
+  mappings.headOption map (_._2())


### PR DESCRIPTION
We sometimes create a dependent parameter reference p.X where
`p` is a path with a type that has a wildcard argument, e.g. `P[X >: L <: H].`
So far the denotation of `p.X` had as info the bounds with which `X` was
declared in `P`. Now it gets the actual parameter bounds `>: L <: H` instead.

Fixes #15652

#15652 started failing when tuple unpackings started to use `val`s instead of `def`s
in #14816. That caused dependent class parameter references to be created and uncovered
the problem.