### PR TITLE
Don't trust case class extractors with explicit type arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -121,6 +121,12 @@ trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
     case _ => Nil
   }
 
+  /** Is tree explicitly parameterized with type arguments? */
+  def hasExplicitTypeArgs(tree: Tree): Boolean = tree match
+    case TypeApply(tycon, args) =>
+      args.exists(arg => !arg.span.isZeroExtent && !tycon.span.contains(arg.span))
+    case _ => false
+
   /** Is tree a path? */
   def isPath(tree: Tree): Boolean = unsplice(tree) match {
     case Ident(_) | This(_) | Super(_, _) => true

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1,4 +1,5 @@
-package dotty.tools.dotc
+package dotty.tools
+package dotc
 package transform
 
 import scala.annotation.tailrec
@@ -388,7 +389,9 @@ object PatternMatcher {
         case Typed(pat, tpt) =>
           val isTrusted = pat match {
             case UnApply(extractor, _, _) =>
-              extractor.symbol.is(Synthetic) && extractor.symbol.owner.linkedClass.is(Case)
+              extractor.symbol.is(Synthetic)
+              && extractor.symbol.owner.linkedClass.is(Case)
+              && !hasExplicitTypeArgs(extractor)
             case _ => false
           }
           TestPlan(TypeTest(tpt, isTrusted), scrutinee, tree.span,

--- a/tests/neg-custom-args/fatal-warnings/i15662.scala
+++ b/tests/neg-custom-args/fatal-warnings/i15662.scala
@@ -1,0 +1,15 @@
+case class Composite[T](v: T)
+
+def m(composite: Composite[_]): Unit =
+  composite match {
+    case Composite[Int](v) => println(v)  // error: cannot be checked at runtime
+    case _ => println("OTHER")
+  }
+
+def m2(composite: Composite[_]): Unit =
+  composite match {
+    case Composite(v) => println(v)  // ok
+  }
+
+@main def Test =
+  m(Composite("This is String"))


### PR DESCRIPTION
#6551 introduced an exception where type tests of parameterized case classes were not flagged
as "type test cannot be checked at runtime". The idea was that the parameters would be inferred
by GADT reasoning and would therefore be correct.

But with #15356 we now also allow explicit type arguments in extractors. If these are given
we cannot guarantee that a type test for a case class in an unapply will always succeed.
So we need an unchecked warning.

Fixes #15662 