### PR TITLE
[backport] Refutable extractor may be an Apply tree

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -816,10 +816,13 @@ trait Checking {
         case RefutableExtractor =>
           val extractor =
             val UnApply(fn, _, _) = pat: @unchecked
-            fn match
+            tpd.funPart(fn) match
               case Select(id, _) => id
-              case TypeApply(Select(id, _), _) => id
-          em"pattern binding uses refutable extractor `$extractor`"
+              case _ => EmptyTree
+          if extractor.isEmpty then
+            em"pattern binding uses refutable extractor"
+          else
+            em"pattern binding uses refutable extractor `$extractor`"
 
       val fix =
         if isPatDef then "adding `: @unchecked` after the expression"

--- a/tests/pos/i15650.scala
+++ b/tests/pos/i15650.scala
@@ -1,0 +1,18 @@
+class Rational
+
+import scala.quoted.*
+
+class TC
+
+object meta:
+  object rationalTE:
+    def unapply(using Quotes)(tr: quotes.reflect.TypeRepr): Option[Rational] = ???
+
+  object rationalTC:
+    def unapply(using Quotes)(using TC)(tr: quotes.reflect.TypeRepr): Option[Rational] = ???
+
+  def foo(using Quotes)(p: quotes.reflect.TypeRepr): Unit =
+    val rationalTE(e) = p  // warn: pattern binding uses refutable extractor `meta.rationalTE`
+
+  def bar(using Quotes)(using TC)(p: quotes.reflect.TypeRepr): Unit =
+    val rationalTC(c) = p  // warn: pattern binding uses refutable extractor `meta.rationalTC`


### PR DESCRIPTION
Backport of #15651, which fixes a regression in 3.2.0-RC1.