### PR TITLE
Allow refineUsingParent to infer GADT bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1945,8 +1945,11 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       val tparam = tr.symbol
       gadts.println(i"narrow gadt bound of $tparam: ${tparam.info} from ${if (isUpper) "above" else "below"} to $bound ${bound.toString} ${bound.isRef(tparam)}")
       if (bound.isRef(tparam)) false
-      else if (isUpper) gadtAddUpperBound(tparam, bound)
-      else gadtAddLowerBound(tparam, bound)
+      else
+        val savedGadt = ctx.gadt.fresh
+        val success = if isUpper then gadtAddUpperBound(tparam, bound) else gadtAddLowerBound(tparam, bound)
+        if !success then ctx.gadt.restore(savedGadt)
+        success
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -712,16 +712,7 @@ object TypeOps:
 
     val childTp = if (child.isTerm) child.termRef else child.typeRef
 
-    val ctx1 = ctx.fresh.setExploreTyperState().setFreshGADTBounds
-    val ctx2 = parent match
-      case _: RefinedType =>
-        ctx1
-        // patmat/t9657
-        // When running Bicycle.type <:< Vehicle { A = P }
-        // TypeComparer is happy to infer GADT bounds P >: Pedal.type <: Petrol.type & Pedal.type
-        // Despite the fact that Bicycle is an object, and thus final, so its type A can only be Pedal.type.
-      case _              => ctx1.addMode(Mode.GadtConstraintInference)
-    inContext(ctx2) {
+    inContext(ctx.fresh.setExploreTyperState().setFreshGADTBounds.addMode(Mode.GadtConstraintInference)) {
       instantiateToSubType(childTp, parent).dealias
     }
   }

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -168,7 +168,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
   ) extends TestSource {
     def sourceFiles: Array[JFile] = files.filter(isSourceFile)
 
-    override def toString() = outDir.toString
+    override def toString() = sourceFiles match { case Array(f) => f.getPath case _ => outDir.getPath }
   }
 
   /** A test source whose files will be compiled separately according to their

--- a/tests/neg-custom-args/fatal-warnings/suppressed-type-test-warnings.scala
+++ b/tests/neg-custom-args/fatal-warnings/suppressed-type-test-warnings.scala
@@ -18,10 +18,12 @@ object Test {
   def err2[A, B](value: Foo[A, B], a: A => Int): B = value match {
     case b: Bar[B] => // spurious // error
       b.x
+    case _ => ??? // avoid fatal inexhaustivity warnings suppressing the uncheckable warning
   }
 
   def fail[A, B](value: Foo[A, B], a: A => Int): B = value match {
     case b: Bar[Int] => // error
       b.x
+    case _ => ??? // avoid fatal inexhaustivity warnings suppressing the uncheckable warning
   }
 }

--- a/tests/pos/i13548.scala
+++ b/tests/pos/i13548.scala
@@ -1,0 +1,6 @@
+// scalac: -Werror
+sealed abstract class Foo[N, A]
+final case class Bar[B](foo: Foo[B, B]) extends Foo[B, B]
+class Test:
+  def pmat[P, C](scr: Foo[P, C]): C = scr match
+    case Bar(foo) => pmat(foo)

--- a/tests/pos/i15289.scala
+++ b/tests/pos/i15289.scala
@@ -1,0 +1,6 @@
+// scalac: -Werror
+sealed abstract class Foo[A, B]
+final case class Bar[C](baz: C) extends Foo[C, C]
+
+class Test:
+  def m1[X](f1: Foo[X, String]): String = f1 match { case Bar(_) => "" }


### PR DESCRIPTION
Not doing so makes the type var interpolation between typer and the match space analysis different, which can result in false positive and negative exhaustivity and reachability warnings.