### PR TITLE
Upgrade to Scala.js 1.10.1.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1220,6 +1220,7 @@ object Build {
           ++ (dir / "js/src/test/require-2.12" ** "*.scala").get
           ++ (dir / "js/src/test/require-sam" ** "*.scala").get
           ++ (dir / "js/src/test/scala-new-collections" ** "*.scala").get
+          ++ (dir / "js/src/test/require-no-modules" ** "*.scala").get
         )
       },
     )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 //
 // e.g. addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.9.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 


### PR DESCRIPTION
It is fine to do this in a patch version, because

* The IR version was not changed in 1.10.x.
* There was no change in the scalajs-library API.

---

I'm not sure who's available for reviews, these days. Anyone up for it?