### PR TITLE
Keep 'fun' and 'args' together when instrumenting TypeApply for coverage

### DIFF
--- a/tests/coverage/pos/PolymorphicExtensions.scala
+++ b/tests/coverage/pos/PolymorphicExtensions.scala
@@ -1,0 +1,11 @@
+package covtest
+
+object PolyExt:
+  extension (s: String)
+    def foo[A](x: A): A = x
+
+  extension [A](i: Int)
+    def get(x: A): A = x
+
+  "str".foo(0) // ({foo("str")}[type])(0) i.e. Apply(TypeApply( Apply(foo, "str"), type ), List(0))
+  123.get(0) // {(get[type])(123)}(0) i.e. Apply(Apply(TypeApply(...), List(123)), List(0))

--- a/tests/coverage/pos/PolymorphicExtensions.scoverage.check
+++ b/tests/coverage/pos/PolymorphicExtensions.scoverage.check
@@ -1,0 +1,105 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+PolymorphicExtensions.scala
+covtest
+PolyExt$
+Object
+covtest.PolyExt$
+foo
+61
+68
+4
+foo
+DefDef
+false
+0
+false
+def foo
+
+1
+PolymorphicExtensions.scala
+covtest
+PolyExt$
+Object
+covtest.PolyExt$
+get
+114
+121
+7
+get
+DefDef
+false
+0
+false
+def get
+
+2
+PolymorphicExtensions.scala
+covtest
+PolyExt$
+Object
+covtest.PolyExt$
+<init>
+138
+147
+9
+foo
+Apply
+false
+0
+false
+"str".foo
+
+3
+PolymorphicExtensions.scala
+covtest
+PolyExt$
+Object
+covtest.PolyExt$
+<init>
+138
+150
+9
+<none>
+Apply
+false
+0
+false
+"str".foo(0)
+
+4
+PolymorphicExtensions.scala
+covtest
+PolyExt$
+Object
+covtest.PolyExt$
+<init>
+238
+248
+10
+get
+Apply
+false
+0
+false
+123.get(0)
+

--- a/tests/coverage/pos/PolymorphicMethods.scala
+++ b/tests/coverage/pos/PolymorphicMethods.scala
@@ -1,0 +1,10 @@
+package covtest
+
+object PolyMeth:
+  def f[A](x: A): A = x
+  this.f(0) // (this.f[type])(0) i.e. Apply(TypeApply(Select(this,f), type), List(0))
+
+  C[String]().f("str", 0)
+
+class C[T1]:
+  def f[T2](p1: T1, p2: T2): Unit = ()

--- a/tests/coverage/pos/PolymorphicMethods.scoverage.check
+++ b/tests/coverage/pos/PolymorphicMethods.scoverage.check
@@ -1,0 +1,105 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+PolymorphicMethods.scala
+covtest
+PolyMeth$
+Object
+covtest.PolyMeth$
+f
+36
+41
+3
+f
+DefDef
+false
+0
+false
+def f
+
+1
+PolymorphicMethods.scala
+covtest
+PolyMeth$
+Object
+covtest.PolyMeth$
+<init>
+60
+69
+4
+f
+Apply
+false
+0
+false
+this.f(0)
+
+2
+PolymorphicMethods.scala
+covtest
+PolyMeth$
+Object
+covtest.PolyMeth$
+<init>
+147
+158
+6
+<init>
+Apply
+false
+0
+false
+C[String]()
+
+3
+PolymorphicMethods.scala
+covtest
+PolyMeth$
+Object
+covtest.PolyMeth$
+<init>
+147
+170
+6
+f
+Apply
+false
+0
+false
+C[String]().f("str", 0)
+
+4
+PolymorphicMethods.scala
+covtest
+C
+Class
+covtest.C
+f
+187
+192
+9
+f
+DefDef
+false
+0
+false
+def f
+


### PR DESCRIPTION
~~Based on PR #15648.~~ edit: rebased on main because #15648 has been merged

Fixes #15705 :)

Note: most of the changes in #15648 (and thus in this PR) are tests, the interesting code is in `InstrumentCoverage.scala`.