### PR TITLE
Avoid null types when reducing match types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2988,7 +2988,7 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
       def redux(canApprox: Boolean): MatchResult =
         caseLambda match
           case caseLambda: HKTypeLambda =>
-            val instances = paramInstances(canApprox)(new Array(caseLambda.paramNames.length), pat)
+            val instances = paramInstances(canApprox)(Array.fill(caseLambda.paramNames.length)(NoType), pat)
             instantiateParams(instances)(body) match
               case Range(lo, hi) =>
                 MatchResult.NoInstance {

--- a/tests/neg/i15687.scala
+++ b/tests/neg/i15687.scala
@@ -1,0 +1,2 @@
+val _ = summon[Tuple.IsMappedBy[[X] =>> Int][(4, 2)]] // error
+


### PR DESCRIPTION
Fixes #15687

Interestingly that one escaped null checking even under -Yexplicit-nulls.
