### PR TITLE
Do not fold IsConst applied to dependent parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeEval.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeEval.scala
@@ -64,7 +64,12 @@ object TypeEval:
         // currently not a concrete known type
         case _: TypeParamRef => None
         // constant if the term is constant
-        case t: TermRef => isConst(t.underlying)
+        case t: TermRef =>
+          if t.denot.symbol.flagsUNSAFE.is(Flags.Param) then
+            // might be substituted later
+            None
+          else
+            isConst(t.underlying)
         // an operation type => recursively check all argument compositions
         case applied: AppliedType if defn.isCompiletimeAppliedType(applied.typeSymbol) =>
           val argsConst = applied.args.map(isConst)

--- a/tests/neg/singleton-ops-any.scala
+++ b/tests/neg/singleton-ops-any.scala
@@ -37,4 +37,9 @@ object Test {
   val t51 : true = isConst2[1, 1]
   val t52 : false = isConst2[1, one.type]
   val t53 : true = isConst2[1, two.type]
+
+  val t54: 2 = 2
+  summon[IsConst[t54.type] =:= true]
+  def isConst(arg: Int)(using IsConst[arg.type] =:= true): Unit = ???
+  isConst(t54)
 }


### PR DESCRIPTION
`IsConst` is currently folded too early when applied to dependent parameters, before they have a chance to be substituted. Here is an example of the problem:

```scala
val x: 2 = 2

summon[IsConst[x.type] =:= true] // works

def isConst(arg: Int)(using IsConst[arg.type] =:= true): Unit = ???
isConst(x) // error; IsConst[(arg: Int)] =:= false
```

This PR fixes this issue, so that the second case also works.