### PR TITLE
Fix #14488: Scala.js: Add compiler support for scala.Enumeration.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -5,6 +5,7 @@ import scala.language.unsafeNulls
 import scala.annotation.threadUnsafe
 
 import dotty.tools.dotc.core._
+import Names._
 import Types._
 import Contexts._
 import Symbols._
@@ -255,6 +256,45 @@ final class JSDefinitions()(using Context) {
       allRefClassesCache = fullNames.map(name => requiredClass(name)).toSet
     }
     allRefClassesCache
+  }
+
+  /** Definitions related to scala.Enumeration. */
+  object scalaEnumeration {
+    val nmeValue = termName("Value")
+    val nmeVal = termName("Val")
+    val hasNext = termName("hasNext")
+    val next = termName("next")
+
+    @threadUnsafe lazy val EnumerationClass = requiredClass("scala.Enumeration")
+      @threadUnsafe lazy val Enumeration_Value_NoArg = EnumerationClass.requiredValue(nmeValue)
+      @threadUnsafe lazy val Enumeration_Value_IntArg = EnumerationClass.requiredMethod(nmeValue, List(defn.IntType))
+      @threadUnsafe lazy val Enumeration_Value_StringArg = EnumerationClass.requiredMethod(nmeValue, List(defn.StringType))
+      @threadUnsafe lazy val Enumeration_Value_IntStringArg = EnumerationClass.requiredMethod(nmeValue, List(defn.IntType, defn.StringType))
+      @threadUnsafe lazy val Enumeration_nextName = EnumerationClass.requiredMethod(termName("nextName"))
+
+    @threadUnsafe lazy val EnumerationValClass = EnumerationClass.requiredClass("Val")
+      @threadUnsafe lazy val Enumeration_Val_NoArg = EnumerationValClass.requiredMethod(nme.CONSTRUCTOR, Nil)
+      @threadUnsafe lazy val Enumeration_Val_IntArg = EnumerationValClass.requiredMethod(nme.CONSTRUCTOR, List(defn.IntType))
+      @threadUnsafe lazy val Enumeration_Val_StringArg = EnumerationValClass.requiredMethod(nme.CONSTRUCTOR, List(defn.StringType))
+      @threadUnsafe lazy val Enumeration_Val_IntStringArg = EnumerationValClass.requiredMethod(nme.CONSTRUCTOR, List(defn.IntType, defn.StringType))
+
+    def isValueMethod(sym: Symbol)(using Context): Boolean =
+      sym.name == nmeValue && sym.owner == EnumerationClass
+
+    def isValueMethodNoName(sym: Symbol)(using Context): Boolean =
+      isValueMethod(sym) && (sym == Enumeration_Value_NoArg || sym == Enumeration_Value_IntArg)
+
+    def isValueMethodName(sym: Symbol)(using Context): Boolean =
+      isValueMethod(sym) && (sym == Enumeration_Value_StringArg || sym == Enumeration_Value_IntStringArg)
+
+    def isValCtor(sym: Symbol)(using Context): Boolean =
+      sym.isClassConstructor && sym.owner == EnumerationValClass
+
+    def isValCtorNoName(sym: Symbol)(using Context): Boolean =
+      isValCtor(sym) && (sym == Enumeration_Val_NoArg || sym == Enumeration_Val_IntArg)
+
+    def isValCtorName(sym: Symbol)(using Context): Boolean =
+      isValCtor(sym) && (sym == Enumeration_Val_StringArg || sym == Enumeration_Val_IntStringArg)
   }
 
   /** Definitions related to the treatment of JUnit bootstrappers. */

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1241,7 +1241,6 @@ object Build {
         (
           (dir / "shared/src/test/scala" ** (("*.scala": FileFilter)
             -- "ReflectiveCallTest.scala" // uses many forms of structural calls that are not allowed in Scala 3 anymore
-            -- "EnumerationTest.scala" // scala.Enumeration support for Scala.js is not implemented in scalac (yet)
             )).get
 
           ++ (dir / "shared/src/test/require-sam" ** "*.scala").get

--- a/tests/neg-scalajs/enumeration-warnings.check
+++ b/tests/neg-scalajs/enumeration-warnings.check
@@ -1,0 +1,60 @@
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:6:4 -------------------------------------------------------------
+6 |    Value // error
+  |    ^^^^^
+  |    Could not transform call to scala.Enumeration.Value.
+  |    The resulting program is unlikely to function properly as this operation requires reflection.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:10:9 ------------------------------------------------------------
+10 |    Value(4) // error
+   |    ^^^^^^^^
+   |    Could not transform call to scala.Enumeration.Value.
+   |    The resulting program is unlikely to function properly as this operation requires reflection.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:15:15 -----------------------------------------------------------
+15 |  val a = Value(null) // error
+   |          ^^^^^^^^^^^
+   |          Passing null as name to scala.Enumeration.Value requires reflection at run-time.
+   |          The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:16:15 -----------------------------------------------------------
+16 |  val b = Value(10, null) // error
+   |          ^^^^^^^^^^^^^^^
+   |          Passing null as name to scala.Enumeration.Value requires reflection at run-time.
+   |          The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:20:10 -----------------------------------------------------------
+20 |  val a = new Val // error
+   |          ^^^^^^^
+   |          Calls to the non-string constructors of scala.Enumeration.Val require reflection at run-time.
+   |          The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:21:10 -----------------------------------------------------------
+21 |  val b = new Val(10) // error
+   |          ^^^^^^^^^^^
+   |          Calls to the non-string constructors of scala.Enumeration.Val require reflection at run-time.
+   |          The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:25:10 -----------------------------------------------------------
+25 |  val a = new Val(null) // error
+   |          ^^^^^^^^^^^^^
+   |          Passing null as name to a constructor of scala.Enumeration.Val requires reflection at run-time.
+   |          The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:26:10 -----------------------------------------------------------
+26 |  val b = new Val(10, null) // error
+   |          ^^^^^^^^^^^^^^^^^
+   |          Passing null as name to a constructor of scala.Enumeration.Val requires reflection at run-time.
+   |          The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:30:31 -----------------------------------------------------------
+30 |  protected class Val1 extends Val // error
+   |                               ^^^
+   |                   Calls to the non-string constructors of scala.Enumeration.Val require reflection at run-time.
+   |                   The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:31:31 -----------------------------------------------------------
+31 |  protected class Val2 extends Val(1) // error
+   |                               ^^^^^^
+   |                   Calls to the non-string constructors of scala.Enumeration.Val require reflection at run-time.
+   |                   The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:35:31 -----------------------------------------------------------
+35 |  protected class Val1 extends Val(null) // error
+   |                               ^^^^^^^^^
+   |                 Passing null as name to a constructor of scala.Enumeration.Val requires reflection at run-time.
+   |                 The resulting program is unlikely to function properly.
+-- Error: tests/neg-scalajs/enumeration-warnings.scala:36:31 -----------------------------------------------------------
+36 |  protected class Val2 extends Val(1, null) // error
+   |                               ^^^^^^^^^^^^
+   |                 Passing null as name to a constructor of scala.Enumeration.Val requires reflection at run-time.
+   |                 The resulting program is unlikely to function properly.

--- a/tests/neg-scalajs/enumeration-warnings.scala
+++ b/tests/neg-scalajs/enumeration-warnings.scala
@@ -1,0 +1,37 @@
+// scalac: -Xfatal-warnings
+
+class UnableToTransformValue extends Enumeration {
+  val a = {
+    println("oh, oh!")
+    Value // error
+  }
+  val b = {
+    println("oh, oh!")
+    Value(4) // error
+  }
+}
+
+class ValueWithNullName extends Enumeration {
+  val a = Value(null) // error
+  val b = Value(10, null) // error
+}
+
+class NewValWithNoName extends Enumeration {
+  val a = new Val // error
+  val b = new Val(10) // error
+}
+
+class NewValWithNullName extends Enumeration {
+  val a = new Val(null) // error
+  val b = new Val(10, null) // error
+}
+
+class ExtendsValWithNoName extends Enumeration {
+  protected class Val1 extends Val // error
+  protected class Val2 extends Val(1) // error
+}
+
+class ExtendsValWithNullName extends Enumeration {
+  protected class Val1 extends Val(null) // error
+  protected class Val2 extends Val(1, null) // error
+}

--- a/tests/run/t1505.scala
+++ b/tests/run/t1505.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip --pending
-
 object Q extends Enumeration {
   val A = Value("A")
   val B = Value("B")

--- a/tests/run/t2111.scala
+++ b/tests/run/t2111.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip --pending
-
 object Test extends App {
 
   object Color extends Enumeration {

--- a/tests/run/t3616.scala
+++ b/tests/run/t3616.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip --pending
-
 object X extends Enumeration {
     val Y = Value
 }

--- a/tests/run/t3687.scala
+++ b/tests/run/t3687.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip --pending
-
 object t extends Enumeration { val a, b = Value }
 
 object Test extends App {

--- a/tests/run/t3719.scala
+++ b/tests/run/t3719.scala
@@ -1,4 +1,4 @@
-// scalajs: --skip --pending
+// scalajs: --skip
 
 object Days extends Enumeration {
   type Day = DayValue

--- a/tests/run/t4570.scala
+++ b/tests/run/t4570.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip --pending
-
 object Test extends Enumeration {
   val foo = Value
   def bar = withName("foo")

--- a/tests/run/t5612.scala
+++ b/tests/run/t5612.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip --pending
-
 object L extends Enumeration {
   val One, Two, Three = Value
 }


### PR DESCRIPTION
This is the same logic that is used in the Scala.js compiler plugin for Scala 2.

We catch ValDefs of the forms
```scala
  val SomeField = Value
  val SomeOtherField = Value(5)
```
and rewrite them as
```scala
  val SomeField = Value("SomeField")
  val SomeOtherField = Value(5, "SomeOtherField")
```
For calls to `Value` and `new Val` without name that we cannot rewrite, we emit warnings.