### PR TITLE
chore(ci): enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
After #15778 and #15777 the actions should all be up to date. By adding this end, this will ensure that they stay up to date by sending in automated PRs for updates to github actions.