### PR TITLE
Fix ValDef span assignment in PatternMatcher

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -932,7 +932,8 @@ object PatternMatcher {
           }
           emitWithMashedConditions(plan :: Nil)
         case LetPlan(sym, body) =>
-          seq(ValDef(sym, initializer(sym).ensureConforms(sym.info)) :: Nil, emit(body))
+          val valDef = ValDef(sym, initializer(sym).ensureConforms(sym.info)).withSpan(sym.span)
+          seq(valDef :: Nil, emit(body))
         case LabeledPlan(label, expr) =>
           Labeled(label, emit(expr))
         case ReturnPlan(label) =>

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -1577,6 +1577,90 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       testSig("bar", "()I")
     }
   }
+
+  @Test def i15535 = {
+    // primary goal of this test is to check that `LineNumber` have correct numbers
+    val source =
+      """object Main {
+        |  def m(x: Int): Unit = {
+        |    x match {
+        |      case y =>
+        |        println(y)
+        |        println(y)
+        |    }
+        |  }
+        |}
+        """.stripMargin
+
+    checkBCode(source) { dir =>
+      val clsIn   = dir.lookupName("Main$.class", directory = false).input
+      val clsNode = loadClassNode(clsIn, skipDebugInfo = false)
+      val method  = getMethod(clsNode, "m")
+      val instructions = instructionsFromMethod(method).filter(_.isInstanceOf[LineNumber])
+
+      val expected = List(
+        LineNumber(2, Label(0)),
+        LineNumber(3, Label(0)),
+        LineNumber(4, Label(5)), // case y =>
+        LineNumber(5, Label(9)),
+        LineNumber(6, Label(15)),
+      )
+
+      assertSameCode(instructions, expected)
+    }
+  }
+
+  @Test def i15535_2 = {
+    // primary goal of this test is to check that `LineNumber` have correct numbers
+    val source =
+      """object Main {
+        |  def m(x: Matchable): Unit = {
+        |    x match {
+        |      case a if a == 3 =>
+        |        println(a)
+        |        println(a)
+        |      case b: Int =>
+        |        println(b)
+        |        println(b)
+        |      case c @ Left(l) =>
+        |        println(l)
+        |        println(c)
+        |      case d =>
+        |        println(d)
+        |        println(d)
+        |        println(d)
+        |    }
+        |  }
+        |}
+        """.stripMargin
+
+    checkBCode(source) { dir =>
+      val clsIn   = dir.lookupName("Main$.class", directory = false).input
+      val clsNode = loadClassNode(clsIn, skipDebugInfo = false)
+      val method  = getMethod(clsNode, "m")
+      val instructions = instructionsFromMethod(method).filter(_.isInstanceOf[LineNumber])
+
+      val expected = List(
+        LineNumber(2, Label(0)),
+        LineNumber(3, Label(0)),
+        LineNumber(4, Label(5)), // case a if a == 3 =>
+        LineNumber(5, Label(15)),
+        LineNumber(6, Label(20)),
+        LineNumber(7, Label(26)), // case b: Int =>
+        LineNumber(8, Label(35)),
+        LineNumber(9, Label(41)),
+        LineNumber(10, Label(48)), // case c @ Left(l) =>
+        LineNumber(11, Label(63)),
+        LineNumber(12, Label(68)),
+        LineNumber(13, Label(74)), // case d =>
+        LineNumber(14, Label(79)),
+        LineNumber(15, Label(84)),
+        LineNumber(16, Label(89)),
+      )
+
+      assertSameCode(instructions, expected)
+    }
+  }
 }
 
 object invocationReceiversTestCode {


### PR DESCRIPTION
Fixes #15535 

Problem was in `ValDef` creation in `PatternMatcher`.
When the following code
```scala
def m(x: Int): Unit = 
  {
    x match 
      {
        case y @ _ => 
          println(y)
          println(y)
      }
  }
```
gets transformed to
```scala
def m(x: Int): Unit = 
  {
    matchResult1[Unit]: 
      {
        case val x1: (x : Int) = x
        case val y: Int = x1
        return[matchResult1] 
          {
            println(y)
            println(y)
          }
      }
  }
```
there are new `ValDef`s created for `x1` and `y`. Their `span`s are assigned by `Positioned.envelope` based on spans of `ValDef`'s fields. Those spans not always exist. In that case, span is assigned in `seq` function based on span of the block, which is usually incorrect.

Solution is to set `ValDef`'s `span` to the `span` of original `TermSymbol` from which current val is being created.