### PR TITLE
Allow for dottyCompileBisect to take multiple files

### DIFF
--- a/project/scripts/dottyCompileBisect.sh
+++ b/project/scripts/dottyCompileBisect.sh
@@ -6,11 +6,11 @@
 #
 # Note: Use dottyCompileBisect.scala for faster bisection over commits that spans several days
 
-file="$1"
+files=$@
 shift
 
 rm -r out
 mkdir out
 mkdir out/bisect
 
-sbt "clean; scalac -d out/bisect $file"
+sbt "clean; scalac -d out/bisect $files"


### PR DESCRIPTION
Allow for `dottyCompileBisect` to be used with multiple files