### PR TITLE
Add dependency-graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,12 @@
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main # default branch of the project
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2


### PR DESCRIPTION
The worflow will submit all dependencies of the dotty build to the Github Dependency API to receive reports of vulnerabilities from Dependabot.

Before merging, an admin must enable the `Dependency graph` feature in https://github.com/lampepfl/dotty/settings/security_analysis
![image](https://user-images.githubusercontent.com/13123162/182406473-8cda2bf6-5065-4dcd-87fc-607e8279d7d8.png)
