### PR TITLE
dep: bump to latest jackson 2.13.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
  *  to ensure the same version of the dependency is used in all projects
  */
 object Dependencies {
-  private val jacksonVersion = "2.12.1"
+  private val jacksonVersion = "2.13.3"
   val `jackson-databind` =
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   val `jackson-dataformat-yaml` =


### PR DESCRIPTION
There are some security vulnerabilities associated with older jackson
versions. People mentioned starting to see this in their projects
after adding sbt-dependency-submission in their Scala 3 projects.

ref: https://github.com/scalacenter/sbt-dependency-submission/issues/49