### PR TITLE
update syntax.md: `final` is not a local modifier

### DIFF
--- a/docs/_docs/reference/syntax.md
+++ b/docs/_docs/reference/syntax.md
@@ -341,9 +341,9 @@ Binding           ::=  (id | ‘_’) [‘:’ Type] ;
 Modifier          ::=  LocalModifier
                     |  AccessModifier
                     |  ‘override’
+                    |  ‘final’
                     |  ‘opaque’ ;
 LocalModifier     ::=  ‘abstract’
-                    |  ‘final’
                     |  ‘sealed’
                     |  ‘open’
                     |  ‘implicit’


### PR DESCRIPTION
>The final modifier applies to class member definitions and to class definitions