### PR TITLE
Handle colons in file names when producing SemanticDB

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/Tools.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Tools.scala
@@ -12,8 +12,10 @@ object Tools:
   def mkURIstring(path: Path): String =
     // Calling `.toUri` on a relative path will convert it to absolute. Iteration through its parts instead preserves
     // the resulting URI as relative.
-    val uriParts = for part <- path.asScala yield new java.net.URI(null, null, part.toString, null)
-    uriParts.mkString("/")
+    // To prevent colon `:` from being treated as a scheme separator, prepend a slash `/` to each part to trick the URI
+    // parser into treating it as an absolute path, and then strip the spurious leading slash from the final result.
+    val uriParts = for part <- path.asScala yield new java.net.URI(null, null, "/" + part.toString, null)
+    uriParts.mkString.stripPrefix("/")
 
   /** Load SemanticDB TextDocument for a single Scala source file
    *

--- a/tests/semanticdb/expect/example-dir/FileInDir.expect.scala
+++ b/tests/semanticdb/expect/example-dir/FileInDir.expect.scala
@@ -1,0 +1,3 @@
+package example
+
+class FileInDir/*<-example::FileInDir#*/

--- a/tests/semanticdb/expect/example-dir/FileInDir.scala
+++ b/tests/semanticdb/expect/example-dir/FileInDir.scala
@@ -1,0 +1,3 @@
+package example
+
+class FileInDir

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3811,6 +3811,25 @@ Occurrences:
 [6:19..6:20): U -> local0
 [6:24..6:27): ??? -> scala/Predef.`???`().
 
+expect/example-dir/FileInDir.scala
+----------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example-dir/FileInDir.scala
+Text => empty
+Language => Scala
+Symbols => 2 entries
+Occurrences => 2 entries
+
+Symbols:
+example/FileInDir# => class FileInDir extends Object { self: FileInDir => +1 decls }
+example/FileInDir#`<init>`(). => primary ctor <init> (): FileInDir
+
+Occurrences:
+[0:8..0:15): example <- example/
+[2:6..2:15): FileInDir <- example/FileInDir#
+
 expect/exports-example-Codec.scala
 ----------------------------------
 


### PR DESCRIPTION
Fixes #15860

This solution feels pretty hacky to me, but it passes all existing tests... :shrug: