### PR TITLE
Improve GADT usage tracing for MatchType reduction

### DIFF
--- a/tests/pos/i15743.moregadt.scala
+++ b/tests/pos/i15743.moregadt.scala
@@ -1,0 +1,16 @@
+enum SUB[-A, +B]:
+  case Refl[C]() extends SUB[C, C]
+import SUB._
+
+type <:<[A, B] = SUB[A, B]
+
+def foo[A, T](ev: T <:< Tuple) = ev.match { case Refl() =>
+  val t1: Int *: T = ???
+  val t2: Int = t1.head  // works
+
+  val t3: A *: T = ???
+  val t4: A = t3.head    // boom
+
+  val t5: Tuple.Head[Int *: T] = 0  // boom
+  val t6: Tuple.Head[A *: T] = t4  // boom
+}


### PR DESCRIPTION
#15851 merges a nice fix for issue #15743. However, in some cases the usage of GADT constraints is not recorded so the GADT cast is not inserted. This PR tries to cover more cases where `GADTused` should be set.