### PR TITLE
CommandLineParser strips escaping backslash

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/CommandLineParser.scala
+++ b/compiler/src/dotty/tools/dotc/config/CommandLineParser.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.config
 import java.lang.Character.isWhitespace
 import java.nio.file.{Files, Paths}
 import scala.annotation.tailrec
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.*
 
 /** Split a line of text using shell conventions.
@@ -21,86 +21,54 @@ object CommandLineParser:
    *  `""" echo hello,' 'world! """`   => "echo" :: "hello, world!" :: Nil
    *  `""" echo \"hello, world!\" """` => "echo" :: "\"hello," :: "world!\"" :: Nil
    *
-   *  The embedded quotes are stripped. Escaping backslash is not stripped.
+   *  The embedded quotes are stripped. Escaping backslash is stripped.
    *
    *  Invoke `errorFn` with a descriptive message if an end quote is missing.
    */
   def tokenize(line: String, errorFn: String => Unit): List[String] =
-
-    var accum: List[String] = Nil
-
+    val accum = ListBuffer.empty[String]
+    val buf   = new java.lang.StringBuilder
     var pos   = 0
-    var start = 0
-    val qpos  = new ArrayBuffer[Int](16)    // positions of paired quotes in current token
 
     inline def cur    = if done then EOF else line.charAt(pos): Int
     inline def bump() = pos += 1
+    inline def put()  = { buf.append(cur.toChar); bump() }
     inline def done   = pos >= line.length
-
-    // Skip to the given unescaped end quote; false on no more input.
-    def skipToEndQuote(q: Int): Boolean =
-      var escaped = false
-      def terminal = cur match
-        case _ if escaped => escaped = false ; false
-        case '\\'         => escaped = true ; false
-        case `q` | EOF    => true
-        case _            => false
-      while !terminal do bump()
-      !done
-
-    // Skip to the next whitespace word boundary; record unescaped embedded quotes; false on missing quote.
-    def skipToDelim(): Boolean =
-      var escaped = false
-      inline def quote() = { qpos += pos ; bump() }
-      @tailrec def advance(): Boolean = cur match
-        case _ if escaped         => escaped = false ; bump() ; advance()
-        case '\\'                 => escaped = true ; bump() ; advance()
-        case q @ (DQ | SQ)        => { quote() ; skipToEndQuote(q) } && { quote() ; advance() }
-        case EOF                  => true
-        case c if isWhitespace(c) => true
-        case _                    => bump(); advance()
-      advance()
-
-    def copyText(): String =
-      val buf = new java.lang.StringBuilder
-      var p = start
-      var i = 0
-      while p < pos do
-        if i >= qpos.size then
-          buf.append(line, p, pos)
-          p = pos
-        else if p == qpos(i) then
-          buf.append(line, qpos(i)+1, qpos(i+1))
-          p = qpos(i+1)+1
-          i += 2
-        else
-          buf.append(line, p, qpos(i))
-          p = qpos(i)
-      buf.toString
-
-    // the current token, stripped of any embedded quotes.
-    def text(): String =
-      val res =
-        if qpos.isEmpty then line.substring(start, pos)
-        else if qpos(0) == start && qpos(1) == pos then line.substring(start+1, pos-1)
-        else copyText()
-      qpos.clear()
-      res.nn
-
-    inline def badquote() = errorFn(s"Unmatched quote [${qpos.last}](${line.charAt(qpos.last)})")
 
     inline def skipWhitespace() = while isWhitespace(cur) do bump()
 
+    // Collect to end of word, handling quotes. False for missing end quote.
+    def word(): Boolean =
+      var escaped = false
+      var Q = EOF
+      var lastQ = 0
+      def badquote() = errorFn(s"Unmatched quote [${lastQ}](${line.charAt(lastQ)})")
+      inline def inQuote = Q != EOF
+      inline def finish(): Boolean = if (!inQuote) !escaped else { badquote(); false }
+      @tailrec def advance(): Boolean = cur match
+        case EOF                              => finish()
+        case _ if escaped                     => escaped = false; put(); advance()
+        case '\\'                             => escaped = true; bump(); advance()
+        case q if q == Q                      => Q = EOF; bump(); advance()
+        case q @ (DQ | SQ) if !inQuote        => Q = q; lastQ = pos; bump(); advance()
+        case c if isWhitespace(c) && !inQuote => finish()
+        case _                                => put(); advance()
+      advance()
+
+    // the current token, stripped of any embedded quotes.
+    def text(): String =
+      val res = buf.toString
+      buf.setLength(0)
+      res.nn
+
     @tailrec def loop(): List[String] =
       skipWhitespace()
-      start = pos
       if done then
-        accum.reverse
-      else if !skipToDelim() then
-        badquote()
+        accum.toList
+      else if !word() then
         Nil
       else
-        accum ::= text()
+        accum += text()
         loop()
     end loop
 

--- a/compiler/test/dotty/tools/dotc/config/CommandLineParserTest.scala
+++ b/compiler/test/dotty/tools/dotc/config/CommandLineParserTest.scala
@@ -48,7 +48,7 @@ class CommandLineParserTest:
   @Test def `leading quote is escaped`: Unit =
     check("echo", "hello, world!")("""echo "hello, world!" """)
     check("echo", "hello, world!")("""echo hello,' 'world! """)
-    check("echo", """\"hello,""", """world!\"""")("""echo \"hello, world!\" """)
-    check("""a\"b\"c""")("""a\"b\"c""")
-    check("a", "\\'b", "\\'", "c")("""a \'b \' c""")
-    check("a", "\\\\b ", "c")("""a \\'b ' c""")
+    check("echo", """"hello,""", """world!"""")("""echo \"hello, world!\" """)
+    check("""a"b"c""")("""a\"b\"c""")
+    check("a", "'b", "'", "c")("""a \'b \' c""")
+    check("a", """\b """, "c")("""a \\'b ' c""")


### PR DESCRIPTION
ports https://github.com/scala/scala/pull/10114

`"""echo \"hello world\" """.!!` should behave like
`echo \"hello world\"` in the shell, with result
`"hello world"`. The two arguments are `"hello`
and `world"`.