### PR TITLE
Provide better info on compiler crashes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -308,7 +308,10 @@ object Phases {
     def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
       units.map { unit =>
         val unitCtx = ctx.fresh.setPhase(this.start).setCompilationUnit(unit).withRootImports
-        run(using unitCtx)
+        try run(using unitCtx)
+        catch case ex: Throwable =>
+          println(s"$ex while running $phaseName on $unit")
+          throw ex
         unitCtx.compilationUnit
       }
 

--- a/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
@@ -38,8 +38,8 @@ class TyperPhase(addRootImports: Boolean = true) extends Phase {
   }
 
   def typeCheck(using Context): Unit = monitor("typechecking") {
+    val unit = ctx.compilationUnit
     try
-      val unit = ctx.compilationUnit
       if !unit.suspended then
         unit.tpdTree = ctx.typer.typedExpr(unit.untpdTree)
         typr.println("typed: " + unit.source)
@@ -48,6 +48,9 @@ class TyperPhase(addRootImports: Boolean = true) extends Phase {
         ctx.run.nn.suppressions.reportSuspendedMessages(unit.source)
     catch
       case ex: CompilationUnit.SuspendException =>
+      case ex: Throwable =>
+        println(s"$ex while typechecking $unit")
+        throw ex
   }
 
   def javaCheck(using Context): Unit = monitor("checking java") {


### PR DESCRIPTION
When encountering a compiler crash, show the current phase and the currently compiled unit.