### PR TITLE
Better output under -Ydetailed-stats

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
@@ -13,9 +13,11 @@ trait ConstraintRunInfo { self: Run =>
       maxConstraint = c
     }
   def printMaxConstraint()(using Context): Unit =
-    val printer = if (ctx.settings.YdetailedStats.value) default else typr
     if maxSize > 0 then
-      printer.println(s"max constraint = ${maxConstraint.nn.show}\nsize = $maxSize")
+      val printer = if ctx.settings.YdetailedStats.value then default else typr
+      printer.println(s"max constraint size: $maxSize")
+      try printer.println(s"max constraint = ${maxConstraint.nn.show}")
+      catch case ex: StackOverflowError => printer.println("max constraint cannot be printed due to stack overflow")
 
   protected def reset(): Unit = maxConstraint = null
 }

--- a/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintRunInfo.scala
@@ -12,9 +12,10 @@ trait ConstraintRunInfo { self: Run =>
       maxSize = size
       maxConstraint = c
     }
-  def printMaxConstraint()(using Context): Unit = {
+  def printMaxConstraint()(using Context): Unit =
     val printer = if (ctx.settings.YdetailedStats.value) default else typr
-    if (maxSize > 0) printer.println(s"max constraint = ${maxConstraint.nn.show}")
-  }
+    if maxSize > 0 then
+      printer.println(s"max constraint = ${maxConstraint.nn.show}\nsize = $maxSize")
+
   protected def reset(): Unit = maxConstraint = null
 }

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -55,7 +55,7 @@ import collection.mutable
   }
 
   def maybeMonitored[T](op: => T)(using Context): T =
-    if (ctx.settings.YdetailedStats.value) {
+    if (ctx.settings.YdetailedStats.value && hits.nonEmpty) {
       monitored = true
       try op
       finally {


### PR DESCRIPTION
 - Don't print empty lines if Stats.enabled is false
 - Print constraint size