### PR TITLE
Align implementation with spec of soft modifiers

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -247,7 +247,7 @@ object Tokens extends TokensCommon {
 
   final val modifierTokensOrCase: TokenSet = modifierTokens | BitSet(CASE)
 
-  final val modifierFollowers = modifierTokensOrCase | defIntroTokens
+  final val modifierFollowers = modifierTokens | defIntroTokens
 
   /** Is token only legal as start of statement (eof also included)? */
   final val mustStartStatTokens: TokenSet = defIntroTokens | modifierTokens | BitSet(IMPORT, EXPORT, PACKAGE)

--- a/tests/neg-custom-args/erased/i5525.scala
+++ b/tests/neg-custom-args/erased/i5525.scala
@@ -1,10 +1,9 @@
-
 erased   enum Foo6 {} // error: only access modifiers allowed
 
-enum Foo10 {
-  erased    case C6()  // error: only access modifiers allowed
+enum Foo10 { // error: Enumerations must contain at least one case
+  erased    case C6()  // error // error
 }
 
-enum Foo11 {
-  erased    case C6  // error: only access modifiers allowed
+enum Foo11 { // error: Enumerations must contain at least one case
+  erased    case C6  // error // error
 }

--- a/tests/neg/i5525.scala
+++ b/tests/neg/i5525.scala
@@ -29,6 +29,6 @@ enum Foo11 {
   protected case C9  // ok
 }
 
-enum Foo12 {
+enum Foo12 {  // error: Enumerations must contain at least one case
   inline    case C10() // error: only access modifiers allowed
 }

--- a/tests/pos/i15960.scala
+++ b/tests/pos/i15960.scala
@@ -1,0 +1,9 @@
+class Foo(open: String) {
+  def bar(n: Int) = n match {
+    case 0 => open
+    case _ => throw new IndexOutOfBoundsException()
+  }
+  def baz() = open
+}
+
+


### PR DESCRIPTION
The spec in https://dotty.epfl.ch/docs/reference/soft-modifier.html says:

> A soft modifier is treated as potential modifier of a definition if it is followed by a hard modifier or a keyword combination starting a definition (def, val, var, type, given, class, trait, object, enum, case class, case object). Between the two words there may be a sequence of newline tokens and soft modifiers.

But the implementation recognized also soft modifiers in front of just `case`, not followed by `class` or `object`.
The change caused some breakage for enum cases, where we have `case` alone, but that one cannot be preceded by any
soft modifiers anyway. So only neg tests were affected.

Fixes #15960