### PR TITLE
Refine estimation of default arguments in overloading resolution

### DIFF
--- a/tests/neg/i15898.scala
+++ b/tests/neg/i15898.scala
@@ -1,0 +1,22 @@
+object O {
+  class AC(code: => Unit) {
+    def apply() = code
+
+    def this(code: => Unit, key: Int = 1, modifiers: Int = 0) = {
+      this(code)
+    }
+  }
+
+  class Doc {
+    def method: Boolean = true
+  }
+
+  val doc = new Doc
+
+  val ac = new AC(doc.method) // error
+
+  def foo[T](code: => Unit): Unit = ()
+  def foo[T](code: => Unit, key: Int = 1, modifiers: Int = 0): Unit = foo(code)
+  foo(doc.method) // error
+  foo[Int](doc.method) // error
+}

--- a/tests/pending/pos/i15915.scala
+++ b/tests/pending/pos/i15915.scala
@@ -1,0 +1,24 @@
+class _Monoid[A]
+object _Monoid {
+  implicit val Monoid: _Monoid[Int] = new _Monoid[Int]
+}
+
+class Lifecycle[A]
+object Lifecycle {
+
+  implicit def monoidForLifecycle[Monoid[_], A](
+    implicit
+    monoidType: GetMonoidType[Monoid],
+    monoidA: Monoid[A]
+  ): Monoid[Lifecycle[A]] = new _Monoid().asInstanceOf[Monoid[Lifecycle[A]]]
+
+}
+
+sealed class GetMonoidType[C[_]]
+object GetMonoidType {
+  implicit val getMonoid: GetMonoidType[_Monoid] = new GetMonoidType[_Monoid]
+}
+
+object App extends App {
+  println(implicitly[_Monoid[Lifecycle[Int]]])
+}

--- a/tests/pending/pos/i15926.scala
+++ b/tests/pending/pos/i15926.scala
@@ -1,0 +1,31 @@
+//@main def main(): Unit =
+//  println(summon[Sum[Minus[Succ[Zero]], Minus[Succ[Zero]]] =:= Minus[Succ[Succ[Zero]]]])
+
+sealed trait IntT
+sealed trait NatT extends IntT
+final case class Zero() extends NatT
+final case class Succ[+N <: NatT](n: N) extends NatT
+final case class Minus[+N <: Succ[NatT]](n: N) extends IntT
+
+type NatSum[X <: NatT, Y <: NatT] <: NatT = Y match
+  case Zero => X
+  case Succ[y] => NatSum[Succ[X], y]
+
+type NatDif[X <: NatT, Y <: NatT] <: IntT = Y match
+  case Zero => X
+  case Succ[y] => X match
+    case Zero => Minus[Y]
+    case Succ[x] => NatDif[x, y]
+
+type Sum[X <: IntT, Y <: IntT] <: IntT = Y match
+  case Zero => X
+  case Minus[y] => X match
+    case Minus[x] => Minus[NatSum[x, y]]
+    case _ => NatDif[X, y]
+    case _ => X match
+      case Minus[x] => NatDif[Y, x]
+      case _ => NatSum[X, Y]
+
+def test =
+  val x: Sum[Minus[Succ[Zero]], Minus[Succ[Zero]]] = ???
+  val y = x

--- a/tests/pending/run/i15893.scala
+++ b/tests/pending/run/i15893.scala
@@ -1,0 +1,65 @@
+sealed trait NatT
+case class Zero() extends NatT
+case class Succ[+N <: NatT](n: N) extends NatT
+
+type Mod2[N <: NatT] <: NatT = N match
+  case Zero => Zero
+  case Succ[Zero] => Succ[Zero]
+  case Succ[Succ[predPredN]] => Mod2[predPredN]
+
+
+def mod2(n: NatT):  NatT = n match
+  case Zero() => Zero()
+  case Succ(Zero()) => Succ(Zero())
+  case Succ(Succ(predPredN)) => mod2(predPredN)
+
+/*
+inline def inlineMod2(inline n: NatT):  NatT = inline n match
+  case Zero() => Zero()
+  case Succ(Zero()) => Succ(Zero())
+  case Succ(Succ(predPredN)) => inlineMod2(predPredN)
+
+transparent inline def transparentInlineMod2(inline n: NatT):  NatT = inline n match
+  case Zero() => Zero()
+  case Succ(Zero()) => Succ(Zero())
+  case Succ(Succ(predPredN)) => transparentInlineMod2(predPredN)
+*/
+def dependentlyTypedMod2[N <: NatT](n: N): Mod2[N] = n match // exhaustivity warning; unexpected
+  case Zero(): Zero => Zero()
+  case Succ(Zero()): Succ[Zero] => Succ(Zero())
+  case Succ(Succ(predPredN)): Succ[Succ[_]] => dependentlyTypedMod2(predPredN)
+/*
+inline def inlineDependentlyTypedMod2[N <: NatT](inline n: N): Mod2[N] = inline n match
+  case Zero(): Zero => Zero()
+  case Succ(Zero()): Succ[Zero] => Succ(Zero())
+  case Succ(Succ(predPredN)): Succ[Succ[_]] => inlineDependentlyTypedMod2(predPredN)
+
+transparent inline def transparentInlineDependentlyTypedMod2[N <: NatT](inline n: N): Mod2[N] = inline n match
+  case Zero(): Zero => Zero()
+  case Succ(Zero()): Succ[Zero] => Succ(Zero())
+  case Succ(Succ(predPredN)): Succ[Succ[_]] => transparentInlineDependentlyTypedMod2(predPredN)
+
+def foo(n: NatT): NatT = mod2(n) match
+  case Succ(Zero()) => Zero()
+  case _ => n
+
+inline def inlineFoo(inline n: NatT): NatT = inline inlineMod2(n) match
+  case Succ(Zero()) => Zero()
+  case _ => n
+
+inline def transparentInlineFoo(inline n: NatT): NatT = inline transparentInlineMod2(n) match
+  case Succ(Zero()) => Zero()
+  case _ => n
+*/
+@main def main(): Unit =
+/*
+  println(mod2(Succ(Succ(Succ(Zero()))))) // prints Succ(Zero()), as expected
+  println(foo(Succ(Succ(Succ(Zero()))))) // prints Zero(), as expected
+  println(inlineMod2(Succ(Succ(Succ(Zero()))))) // prints Succ(Zero()), as expected
+  println(inlineFoo(Succ(Succ(Succ(Zero()))))) // prints Succ(Succ(Succ(Zero()))); unexpected
+  println(transparentInlineMod2(Succ(Succ(Succ(Zero()))))) // prints Succ(Zero()), as expected
+  println(transparentInlineFoo(Succ(Succ(Succ(Zero()))))) // prints Zero(), as expected
+*/
+  println(dependentlyTypedMod2(Succ(Succ(Succ(Zero()))))) // runtime error; unexpected
+//  println(inlineDependentlyTypedMod2(Succ(Succ(Succ(Zero()))))) // doesn't compile; unexpected
+//  println(transparentInlineDependentlyTypedMod2(Succ(Succ(Succ(Zero()))))) // doesn't compile; unexpected

--- a/tests/pos/i15898.scala
+++ b/tests/pos/i15898.scala
@@ -1,0 +1,22 @@
+object O {
+  class AC(code: => Unit) {
+    def apply() = code
+
+    def this(code: => Unit, key: Int, modifiers: Int = 0) = {
+      this(code)
+    }
+  }
+
+  class Doc {
+    def method: Boolean = true
+  }
+
+  val doc = new Doc
+
+  val ac = new AC(doc.method)
+
+  def foo[T](code: => Unit): Unit = ()
+  def foo[T](code: => Unit, key: Int, modifiers: Int = 0): Unit = foo(code)
+  foo(doc.method)
+  foo[Int](doc.method)
+}


### PR DESCRIPTION
When doing a "size-fits" check, we previously only worked with the fact
whether the given alternative had default parameters or not. We know count
the number of default parameters in the applied parameter section, which
gives us a better estimate.

Fixes #15898