### PR TITLE
Avoid adding NoSymbol to gadt constraints in TypeOps.instantiateToSubType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -852,7 +852,7 @@ object TypeOps:
 
     val getAbstractSymbols = new TypeAccumulator[List[Symbol]]:
       def apply(xs: List[Symbol], tp: Type) = tp.dealias match
-        case tp: TypeRef if !tp.symbol.isClass => foldOver(tp.symbol :: xs, tp)
+        case tp: TypeRef if tp.symbol.exists && !tp.symbol.isClass => foldOver(tp.symbol :: xs, tp)
         case tp                                => foldOver(xs, tp)
     val syms2 = getAbstractSymbols(Nil, tp2).reverse
     if syms2.nonEmpty then ctx.gadt.addToConstraint(syms2)

--- a/tests/pos/i15964.scala
+++ b/tests/pos/i15964.scala
@@ -1,0 +1,16 @@
+// scalac: -Werror
+sealed trait T
+class C extends T
+
+class AClass
+type AType = AClass {
+  type TypeMember <: T
+}
+
+def list2Product(
+  atype: AType,
+  opt: atype.TypeMember
+): Unit =
+  opt match {
+    case _: C => ()
+  }


### PR DESCRIPTION
fixes lampepfl#15964