### PR TITLE
Refactor class parent handling

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -107,6 +107,11 @@ object TypeUtils {
         self.superType.mirrorCompanionRef
     }
 
+    /** Is this type a methodic type that takes at least one parameter? */
+    def takesParams(using Context): Boolean = self.stripPoly match
+      case mt: MethodType => mt.paramNames.nonEmpty || mt.resType.takesParams
+      case _ => false
+
     /** Is this type a methodic type that takes implicit parameters (both old and new) at some point? */
     def takesImplicitParams(using Context): Boolean = self.stripPoly match
       case mt: MethodType => mt.isImplicitMethod || mt.resType.takesImplicitParams

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -108,7 +108,7 @@ class ReTyper(nestingLevel: Int = 0) extends Typer(nestingLevel) with ReChecking
 
   override def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(using Context): Unit = ()
 
-  override def ensureConstrCall(cls: ClassSymbol, parent: Tree)(using Context): Tree =
+  override def ensureConstrCall(cls: ClassSymbol, parent: Tree, psym: Symbol)(using Context): Tree =
     parent
 
   override def handleUnexpectedFunType(tree: untpd.Apply, fun: Tree)(using Context): Tree = fun.tpe match {

--- a/tests/neg/i14432c.check
+++ b/tests/neg/i14432c.check
@@ -1,11 +1,7 @@
 -- Error: tests/neg/i14432c.scala:12:18 --------------------------------------------------------------------------------
-12 |class Bar extends example.Foo(23) { // error // error: cant access private[example] ctor
+12 |class Bar extends example.Foo(23) { // error: cant access private[example] ctor
    |                  ^^^^^^^^^^^
    |                  constructor Foo cannot be accessed as a member of example.Foo from class Bar.
--- Error: tests/neg/i14432c.scala:12:6 ---------------------------------------------------------------------------------
-12 |class Bar extends example.Foo(23) { // error // error: cant access private[example] ctor
-   |      ^
-   |      constructor Foo cannot be accessed as a member of example.Foo from class Bar.
 -- Error: tests/neg/i14432c.scala:16:43 --------------------------------------------------------------------------------
 16 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror
    |                                           ^

--- a/tests/neg/i14432c.scala
+++ b/tests/neg/i14432c.scala
@@ -9,7 +9,7 @@ package example {
 
 }
 
-class Bar extends example.Foo(23) { // error // error: cant access private[example] ctor
+class Bar extends example.Foo(23) { // error: cant access private[example] ctor
 
   // however we can not provide an anonymous mirror
   // at this call site because the constructor is not accessible.

--- a/tests/neg/i6778.check
+++ b/tests/neg/i6778.check
@@ -1,6 +1,10 @@
 -- [E104] Syntax Error: tests/neg/i6778.scala:3:27 ---------------------------------------------------------------------
-3 |class Bar extends Foo with A(10) // error
+3 |class Bar extends Foo with A(10) // error // error
   |                           ^^^^^
   |                           class A is not a trait
   |
   | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/i6778.scala:3:6 ------------------------------------------------------------------------------------
+3 |class Bar extends Foo with A(10) // error // error
+  |      ^
+  |      missing argument for parameter x of constructor A in class A: (x: Int): A

--- a/tests/neg/i6778.scala
+++ b/tests/neg/i6778.scala
@@ -1,3 +1,3 @@
 trait Foo
 class A(x: Int)
-class Bar extends Foo with A(10) // error
+class Bar extends Foo with A(10) // error // error

--- a/tests/neg/i7613.check
+++ b/tests/neg/i7613.check
@@ -1,8 +1,4 @@
 -- Error: tests/neg/i7613.scala:10:16 ----------------------------------------------------------------------------------
-10 |  new BazLaws[A] {}  // error // error
+10 |  new BazLaws[A] {}  // error
    |                ^
    |            No given instance of type Baz[A] was found for parameter x$1 of constructor BazLaws in trait BazLaws
--- Error: tests/neg/i7613.scala:10:2 -----------------------------------------------------------------------------------
-10 |  new BazLaws[A] {}  // error // error
-   |  ^
-   |  No given instance of type Bar[A] was found for parameter x$1 of constructor BarLaws in trait BarLaws

--- a/tests/neg/i7613.scala
+++ b/tests/neg/i7613.scala
@@ -7,5 +7,4 @@ trait BarLaws[A](using Bar[A]) extends FooLaws[A]
 trait BazLaws[A](using Baz[A]) extends BarLaws[A]
 
 def instance[A](using Foo[A]): BazLaws[A] =
-  new BazLaws[A] {}  // error // error
-
+  new BazLaws[A] {}  // error

--- a/tests/pos/i15976.scala
+++ b/tests/pos/i15976.scala
@@ -1,0 +1,16 @@
+final abstract class ForcedRecompilationToken[T]
+object ForcedRecompilationToken {
+  implicit def default: ForcedRecompilationToken["abc"] = null
+}
+
+class BadNoParens[T](implicit ev: ForcedRecompilationToken[T])
+
+// error
+object X extends BadNoParens
+
+// ok
+object Y extends BadNoParens()
+
+object App extends App {
+  println("compiled")
+}


### PR DESCRIPTION
Class parent handling was hard to understand because it consisted of interacting parts that each worked under intricate but separate conditions. It's more centralized now.

Fixes #15976 