### PR TITLE
Fix i14451

### DIFF
--- a/tests/pos/i14451.scala
+++ b/tests/pos/i14451.scala
@@ -1,0 +1,27 @@
+
+class Foo
+
+extension (dfVal: Foo)
+  def f0(step: Int): Foo = ???
+  def f0: Foo = ???
+val v0 = (new Foo).f0
+
+extension (dfVal: Foo)
+  def f1[T](step: Int): Foo = ???
+  def f1: Foo = ???
+val v1 = (new Foo).f1
+
+extension (dfVal: Foo)
+  def f2[T](step: Int): Foo = ???
+  def f2[T]: Foo = ???
+val v2 = (new Foo).f2
+
+extension [A](dfVal: Foo)
+  def f3[T](step: Int): Foo = ???
+  def f3: Foo = ???
+val v3 = (new Foo).f3
+
+extension [A](dfVal: Foo)
+  def f4[T](step: Int): Foo = ???
+  def f4[T]: Foo = ???
+val v4 = (new Foo).f4


### PR DESCRIPTION
Fixes #14451

Implicitly assumed type clauses could only be at the beginning, which is wrong since:
```scala
extension (x: Int) def foo[T](y: T) = ???
```
de-sugars to something like:
```scala
def foo(x: Int)[T](y: T) = ???
```

To fix it, I implement `stripInferrable`, a variant of `stripImplicit` which also drops type clauses, and use it in `resultIsMethod`
I suspect the other uses of `stripImplicit` could be simplified, or even fixed (assuming they make the same mistake as `resultIsMethod`), by using `stripInferrable`