### PR TITLE
fix InlineMatch pos for `summonFrom`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -994,7 +994,7 @@ trait Applications extends Compatibility {
                   case CaseDef(pat, _, _) =>
                     report.error(UnexpectedPatternForSummonFrom(pat), pat.srcPos)
                 }
-                typed(untpd.InlineMatch(EmptyTree, cases).withSpan(arg.span), pt)
+                typed(untpd.InlineMatch(EmptyTree, cases).withSpan(tree.span), pt)
               case _ =>
                 errorTree(tree, em"argument to summonFrom must be a pattern matching closure")
             }


### PR DESCRIPTION
Use the span of all tree instead of only cases.
This is needed for Metals: https://github.com/scalameta/metals/issues/4366