### PR TITLE
[SemanticDB] fix regression in type apply synthetics

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -222,6 +222,12 @@ object Scala3:
           case NameKinds.AnyNumberedName(nme.EMPTY, _) => true
           case _                                       => false
         }
+
+      def isDynamic(using Context): Boolean =
+        name == nme.applyDynamic ||
+        name == nme.selectDynamic ||
+        name == nme.updateDynamic ||
+        name == nme.applyDynamicNamed
   end NameOps
 
   given SymbolOps: AnyRef with

--- a/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
@@ -26,7 +26,7 @@ class SyntheticsExtractor:
       tree match
         case tree: TypeApply
           if tree.span.isSynthetic &&
-            tree.args.forall(arg => !arg.symbol.is(Scala2x)) &&
+            tree.args.forall(arg => !arg.symbol.isDefinedInSource) &&
             !tree.span.isZeroExtent =>
           visited.add(tree)
           val fnTree = tree.fun match

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -50,7 +50,7 @@ Text => empty
 Language => Scala
 Symbols => 60 entries
 Occurrences => 132 entries
-Synthetics => 7 entries
+Synthetics => 3 entries
 
 Symbols:
 advanced/C# => class C [typeparam T ] extends Object { self: C[T] => +3 decls }
@@ -249,13 +249,9 @@ Occurrences:
 [53:39..53:47): toString -> scala/Tuple2#toString().
 
 Synthetics:
-[27:12..27:18):s.s1.x => *[Int]
 [27:12..27:16):s.s1 => reflectiveSelectable(*)
-[29:12..29:18):s.s2.x => *[Int]
 [29:12..29:16):s.s2 => reflectiveSelectable(*)
-[31:12..31:22):s.s3.m(??? => *[Int]
 [31:12..31:16):s.s3 => reflectiveSelectable(*)
-[47:19..47:24):foo.a => *[foo.A]
 
 expect/Annotations.scala
 ------------------------
@@ -267,7 +263,6 @@ Text => empty
 Language => Scala
 Symbols => 23 entries
 Occurrences => 52 entries
-Synthetics => 2 entries
 
 Symbols:
 annot/Alias. => final object Alias extends Object { self: Alias.type => +2 decls }
@@ -347,10 +342,6 @@ Occurrences:
 [39:7..39:8): A <- annot/Alias.A#
 [39:11..39:26): ClassAnnotation -> com/javacp/annot/ClassAnnotation#
 [39:28..39:33): param -> scala/annotation/meta/param#
-
-Synthetics:
-[25:2..25:20):@throws[Exception] => *[Exception]
-[25:2..25:20):@throws[Exception] => *[Exception]
 
 expect/Anonymous.scala
 ----------------------
@@ -899,7 +890,7 @@ Text => empty
 Language => Scala
 Symbols => 181 entries
 Occurrences => 148 entries
-Synthetics => 8 entries
+Synthetics => 6 entries
 
 Symbols:
 _empty_/Enums. => final object Enums extends Object { self: Enums.type => +30 decls }
@@ -1235,8 +1226,6 @@ Occurrences:
 [68:25..68:31): Planet -> _empty_/Enums.Planet#
 
 Synthetics:
-[42:24..42:32):Tag[Int] => *[Int]
-[43:28..43:40):Tag[Boolean] => *[Boolean]
 [52:9..52:13):Refl => *.unapply[Option[B]]
 [52:31..52:50):identity[Option[B]] => *[Function1[A, Option[B]]]
 [54:14..54:18):Some => *.apply[Some[Int]]
@@ -1288,7 +1277,6 @@ Text => empty
 Language => Scala
 Symbols => 5 entries
 Occurrences => 23 entries
-Synthetics => 2 entries
 
 Symbols:
 example/Example. => final object Example extends Object { self: Example.type => +3 decls }
@@ -1321,10 +1309,6 @@ Occurrences:
 [9:16..9:23): reflect -> scala/reflect/
 [9:24..9:32): classTag -> scala/reflect/package.classTag().
 [9:33..9:36): Int -> scala/Int#
-
-Synthetics:
-[5:6..5:41):scala.collection.mutable.Stack[Int] => *[Int]
-[5:6..5:41):scala.collection.mutable.Stack[Int] => *[Int]
 
 expect/Extension.scala
 ----------------------
@@ -2228,7 +2212,7 @@ Text => empty
 Language => Scala
 Symbols => 3 entries
 Occurrences => 80 entries
-Synthetics => 5 entries
+Synthetics => 2 entries
 
 Symbols:
 example/MethodUsages# => class MethodUsages extends Object { self: MethodUsages => +2 decls }
@@ -2318,11 +2302,8 @@ Occurrences:
 [34:8..34:9): m -> example/Methods#m17.m().
 
 Synthetics:
-[3:14..3:26):Methods[Int] => *[Int]
-[11:11..11:22):m.List[Int] => *[Int]
 [13:2..13:6):m.m7 => *[Int]
 [13:2..13:26):m.m7(m, new m.List[Int]) => *(Int)
-[13:14..13:25):m.List[Int] => *[Int]
 
 expect/Methods.scala
 --------------------
@@ -4215,7 +4196,7 @@ Text => empty
 Language => Scala
 Symbols => 17 entries
 Occurrences => 29 entries
-Synthetics => 2 entries
+Synthetics => 1 entries
 
 Symbols:
 _empty_/Concrete# => class Concrete extends NullaryTest[Int, List] { self: Concrete => +3 decls }
@@ -4268,7 +4249,6 @@ Occurrences:
 [18:17..18:25): nullary3 -> _empty_/Concrete#nullary3().
 
 Synthetics:
-[11:23..11:45):NullaryTest[Int, List] => *[Int, List]
 [13:17..13:21):List => *.apply[Int]
 
 expect/recursion.scala

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -50,7 +50,7 @@ Text => empty
 Language => Scala
 Symbols => 60 entries
 Occurrences => 132 entries
-Synthetics => 4 entries
+Synthetics => 7 entries
 
 Symbols:
 advanced/C# => class C [typeparam T ] extends Object { self: C[T] => +3 decls }
@@ -249,8 +249,11 @@ Occurrences:
 [53:39..53:47): toString -> scala/Tuple2#toString().
 
 Synthetics:
+[27:12..27:18):s.s1.x => *[Int]
 [27:12..27:16):s.s1 => reflectiveSelectable(*)
+[29:12..29:18):s.s2.x => *[Int]
 [29:12..29:16):s.s2 => reflectiveSelectable(*)
+[31:12..31:22):s.s3.m(??? => *[Int]
 [31:12..31:16):s.s3 => reflectiveSelectable(*)
 [47:19..47:24):foo.a => *[foo.A]
 
@@ -359,6 +362,7 @@ Text => empty
 Language => Scala
 Symbols => 14 entries
 Occurrences => 30 entries
+Synthetics => 2 entries
 
 Symbols:
 example/Anonymous# => class Anonymous extends Object { self: Anonymous & Anonymous => +6 decls }
@@ -408,6 +412,10 @@ Occurrences:
 [18:6..18:9): foo <- example/Anonymous#foo.
 [18:16..18:19): Foo -> example/Anonymous#Foo#
 
+Synthetics:
+[10:2..10:9):locally => *[Unit]
+[13:2..13:9):locally => *[Unit]
+
 expect/AnonymousGiven.scala
 ---------------------------
 
@@ -442,6 +450,7 @@ Text => empty
 Language => Scala
 Symbols => 109 entries
 Occurrences => 113 entries
+Synthetics => 2 entries
 
 Symbols:
 classes/C1# => final class C1 extends AnyVal { self: C1 => +2 decls }
@@ -668,6 +677,10 @@ Occurrences:
 [52:8..52:13): local <- local4
 [53:4..53:9): local -> local4
 [53:10..53:11): + -> scala/Int#`+`(+4).
+
+Synthetics:
+[51:16..51:27):List(1).map => *[Int]
+[51:16..51:20):List => *.apply[Int]
 
 expect/Empty.scala
 ------------------
@@ -1222,14 +1235,14 @@ Occurrences:
 [68:25..68:31): Planet -> _empty_/Enums.Planet#
 
 Synthetics:
-[46:28..46:35):C <:< C => *[C, C]
-[49:27..49:31):Refl => *.apply[T]
+[42:24..42:32):Tag[Int] => *[Int]
+[43:28..43:40):Tag[Boolean] => *[Boolean]
 [52:9..52:13):Refl => *.unapply[Option[B]]
-[52:19..52:30):opt.flatMap => *[B]
 [52:31..52:50):identity[Option[B]] => *[Function1[A, Option[B]]]
 [54:14..54:18):Some => *.apply[Some[Int]]
 [54:14..54:34):Some(Some(1)).unwrap => *(given_<:<_T_T[Option[Int]])
-[56:52..56:64):Enum[Planet] => *[Planet]
+[54:19..54:23):Some => *.apply[Int]
+[54:28..54:34):unwrap => *[Some[Int], Int]
 
 expect/EtaExpansion.scala
 -------------------------
@@ -1241,7 +1254,7 @@ Text => empty
 Language => Scala
 Symbols => 3 entries
 Occurrences => 8 entries
-Synthetics => 1 entries
+Synthetics => 5 entries
 
 Symbols:
 example/EtaExpansion# => class EtaExpansion extends Object { self: EtaExpansion => +1 decls }
@@ -1259,7 +1272,11 @@ Occurrences:
 [4:25..4:26): + -> java/lang/String#`+`().
 
 Synthetics:
+[3:2..3:13):Some(1).map => *[Int]
+[3:2..3:6):Some => *.apply[Int]
+[3:14..3:22):identity => *[Int]
 [4:2..4:18):List(1).foldLeft => *[String]
+[4:2..4:6):List => *.apply[Int]
 
 expect/Example.scala
 --------------------
@@ -1271,6 +1288,7 @@ Text => empty
 Language => Scala
 Symbols => 5 entries
 Occurrences => 23 entries
+Synthetics => 2 entries
 
 Symbols:
 example/Example. => final object Example extends Object { self: Example.type => +3 decls }
@@ -1303,6 +1321,10 @@ Occurrences:
 [9:16..9:23): reflect -> scala/reflect/
 [9:24..9:32): classTag -> scala/reflect/package.classTag().
 [9:33..9:36): Int -> scala/Int#
+
+Synthetics:
+[5:6..5:41):scala.collection.mutable.Stack[Int] => *[Int]
+[5:6..5:41):scala.collection.mutable.Stack[Int] => *[Int]
 
 expect/Extension.scala
 ----------------------
@@ -1409,7 +1431,7 @@ Text => empty
 Language => Scala
 Symbols => 13 entries
 Occurrences => 52 entries
-Synthetics => 2 entries
+Synthetics => 6 entries
 
 Symbols:
 example/ForComprehension# => class ForComprehension extends Object { self: ForComprehension => +1 decls }
@@ -1481,6 +1503,10 @@ Occurrences:
 [41:6..41:7): f -> local10
 
 Synthetics:
+[4:9..4:13):List => *.apply[Int]
+[5:9..5:13):List => *.apply[Int]
+[10:9..10:13):List => *.apply[Int]
+[11:9..11:13):List => *.apply[Int]
 [19:9..19:13):List => *.apply[Tuple2[Int, Int]]
 [33:9..33:13):List => *.apply[Tuple4[Int, Int, Int, Int]]
 
@@ -1494,6 +1520,7 @@ Text => empty
 Language => Scala
 Symbols => 29 entries
 Occurrences => 65 entries
+Synthetics => 3 entries
 
 Symbols:
 a/b/Givens. => final object Givens extends Object { self: Givens.type => +12 decls }
@@ -1592,6 +1619,11 @@ Occurrences:
 [26:50..26:55): empty -> a/b/Givens.Monoid#empty().
 [26:57..26:58): A -> a/b/Givens.foo().(A)
 [26:59..26:64): empty -> a/b/Givens.Monoid#empty().
+
+Synthetics:
+[12:17..12:25):sayHello => *[Int]
+[13:19..13:29):sayGoodbye => *[Int]
+[14:18..14:27):saySoLong => *[Int]
 
 expect/ImplicitConversion.scala
 -------------------------------
@@ -1992,6 +2024,7 @@ Text => empty
 Language => Scala
 Symbols => 6 entries
 Occurrences => 10 entries
+Synthetics => 1 entries
 
 Symbols:
 example/Local# => class Local extends Object { self: Local => +2 decls }
@@ -2013,6 +2046,9 @@ Occurrences:
 [4:25..4:26): a -> local1
 [5:4..5:6): id -> local2
 
+Synthetics:
+[5:4..5:6):id => *[Int]
+
 expect/Locals.scala
 -------------------
 
@@ -2023,6 +2059,7 @@ Text => empty
 Language => Scala
 Symbols => 3 entries
 Occurrences => 6 entries
+Synthetics => 1 entries
 
 Symbols:
 local0 => val local x: Int
@@ -2036,6 +2073,9 @@ Occurrences:
 [4:8..4:9): x <- local0
 [5:4..5:8): List -> scala/package.List.
 [5:9..5:10): x -> local0
+
+Synthetics:
+[5:4..5:8):List => *.apply[Int]
 
 expect/MatchType.scala
 ----------------------
@@ -2188,7 +2228,7 @@ Text => empty
 Language => Scala
 Symbols => 3 entries
 Occurrences => 80 entries
-Synthetics => 1 entries
+Synthetics => 5 entries
 
 Symbols:
 example/MethodUsages# => class MethodUsages extends Object { self: MethodUsages => +2 decls }
@@ -2278,7 +2318,11 @@ Occurrences:
 [34:8..34:9): m -> example/Methods#m17.m().
 
 Synthetics:
+[3:14..3:26):Methods[Int] => *[Int]
+[11:11..11:22):m.List[Int] => *[Int]
+[13:2..13:6):m.m7 => *[Int]
 [13:2..13:26):m.m7(m, new m.List[Int]) => *(Int)
+[13:14..13:25):m.List[Int] => *[Int]
 
 expect/Methods.scala
 --------------------
@@ -3130,7 +3174,7 @@ Text => empty
 Language => Scala
 Symbols => 52 entries
 Occurrences => 132 entries
-Synthetics => 23 entries
+Synthetics => 39 entries
 
 Symbols:
 example/Synthetic# => class Synthetic extends Object { self: Synthetic => +23 decls }
@@ -3321,17 +3365,29 @@ Occurrences:
 [58:6..58:9): foo -> example/Synthetic#Contexts.foo().
 
 Synthetics:
+[5:2..5:13):List(1).map => *[Int]
+[5:2..5:6):List => *.apply[Int]
 [6:2..6:18):Array.empty[Int] => intArrayOps(*)
 [7:2..7:8):"fooo" => augmentString(*)
 [10:13..10:24):"name:(.*)" => augmentString(*)
+[11:8..11:11):#:: => *.unapply[Int]
+[11:17..11:25):LazyList => *.apply[Int]
+[13:4..13:28):#:: 2 #:: LazyList.empty => *[Int]
 [13:8..13:28):2 #:: LazyList.empty => toDeferrer[Int](*)
+[13:10..13:28):#:: LazyList.empty => *[Int]
 [13:14..13:28):LazyList.empty => toDeferrer[Nothing](*)
 [13:14..13:28):LazyList.empty => *[Nothing]
+[15:9..15:12):#:: => *.unapply[Int]
+[15:16..15:19):#:: => *.unapply[Int]
+[15:25..15:33):LazyList => *.apply[Int]
+[17:14..17:38):#:: 2 #:: LazyList.empty => *[Int]
 [17:18..17:38):2 #:: LazyList.empty => toDeferrer[Int](*)
+[17:20..17:38):#:: LazyList.empty => *[Int]
 [17:24..17:38):LazyList.empty => toDeferrer[Nothing](*)
 [17:24..17:38):LazyList.empty => *[Nothing]
 [19:12..19:13):1 => intWrapper(*)
 [19:26..19:27):0 => intWrapper(*)
+[19:46..19:50):x -> => *[Int]
 [19:46..19:47):x => ArrowAssoc[Int](*)
 [20:12..20:13):1 => intWrapper(*)
 [20:26..20:27):0 => intWrapper(*)
@@ -3340,6 +3396,10 @@ Synthetics:
 [32:35..32:49):Array.empty[T] => *(evidence$1)
 [36:22..36:27):new F => orderingToOrdered[F](*)
 [36:22..36:27):new F => *(ordering)
+[40:9..40:43):scala.concurrent.Future.successful => *[Int]
+[41:9..41:43):scala.concurrent.Future.successful => *[Int]
+[44:9..44:43):scala.concurrent.Future.successful => *[Int]
+[45:9..45:43):scala.concurrent.Future.successful => *[Int]
 [51:24..51:30):foo(0) => *(x$1)
 [52:27..52:33):foo(0) => *(x)
 [55:6..55:12):foo(x) => *(x)
@@ -3355,6 +3415,7 @@ Text => empty
 Language => Scala
 Symbols => 2 entries
 Occurrences => 5 entries
+Synthetics => 2 entries
 
 Symbols:
 example/Tabs$package. => final package object example extends Object { self: example.type => +2 decls }
@@ -3366,6 +3427,11 @@ Occurrences:
 [3:1..3:5): List -> scala/package.List.
 [4:3..4:6): map -> scala/collection/immutable/List#map().
 [4:9..4:10): + -> scala/Int#`+`(+4).
+
+Synthetics:
+[3:1..4:6):List(1,2,3)
+		.map => *[Int]
+[3:1..3:5):List => *.apply[Int]
 
 expect/Traits.scala
 -------------------
@@ -3417,7 +3483,7 @@ Text => empty
 Language => Scala
 Symbols => 22 entries
 Occurrences => 46 entries
-Synthetics => 2 entries
+Synthetics => 11 entries
 
 Symbols:
 example/ValPattern# => class ValPattern extends Object { self: ValPattern => +14 decls }
@@ -3492,8 +3558,17 @@ Occurrences:
 [40:10..40:18): rightVar -> local4
 
 Synthetics:
+[5:6..5:10):Some => *.unapply[Int]
+[6:4..6:8):Some => *.apply[Int]
 [8:6..8:10):List => *.unapplySeq[Nothing]
 [8:11..8:15):Some => *.unapply[Nothing]
+[11:6..11:10):Some => *.unapply[Int]
+[12:4..12:8):Some => *.apply[Int]
+[25:4..25:11):locally => *[Unit]
+[27:10..27:14):Some => *.unapply[Int]
+[28:8..28:12):Some => *.apply[Int]
+[31:10..31:14):Some => *.unapply[Int]
+[32:8..32:12):Some => *.apply[Int]
 
 expect/Vals.scala
 -----------------
@@ -4112,6 +4187,7 @@ Text => empty
 Language => Scala
 Symbols => 3 entries
 Occurrences => 6 entries
+Synthetics => 1 entries
 
 Symbols:
 example/`local-file`# => class local-file extends Object { self: local-file => +1 decls }
@@ -4126,6 +4202,9 @@ Occurrences:
 [5:4..5:9): local -> local0
 [5:10..5:11): + -> scala/Int#`+`(+4).
 
+Synthetics:
+[3:2..3:9):locally => *[Int]
+
 expect/nullary.scala
 --------------------
 
@@ -4136,6 +4215,7 @@ Text => empty
 Language => Scala
 Symbols => 17 entries
 Occurrences => 29 entries
+Synthetics => 2 entries
 
 Symbols:
 _empty_/Concrete# => class Concrete extends NullaryTest[Int, List] { self: Concrete => +3 decls }
@@ -4187,6 +4267,10 @@ Occurrences:
 [18:7..18:15): Concrete -> _empty_/Concrete#
 [18:17..18:25): nullary3 -> _empty_/Concrete#nullary3().
 
+Synthetics:
+[11:23..11:45):NullaryTest[Int, List] => *[Int, List]
+[13:17..13:21):List => *.apply[Int]
+
 expect/recursion.scala
 ----------------------
 
@@ -4197,7 +4281,6 @@ Text => empty
 Language => Scala
 Symbols => 36 entries
 Occurrences => 46 entries
-Synthetics => 3 entries
 
 Symbols:
 local0 => type N$1  <: Nat
@@ -4284,11 +4367,6 @@ Occurrences:
 [23:33..23:34): + -> recursion/Nats.Nat#`+`().
 [23:35..23:39): Zero -> recursion/Nats.Zero.
 [23:40..23:42): ++ -> recursion/Nats.Nat#`++`().
-
-Synthetics:
-[5:50..5:54):Succ => *.apply[Nat.this.type]
-[10:13..10:17):Succ => *.unapply[N$1]
-[20:11..20:15):Succ => *.unapply[N$2]
 
 expect/semanticdb-Definitions.scala
 -----------------------------------
@@ -4475,6 +4553,7 @@ Text => empty
 Language => Scala
 Symbols => 144 entries
 Occurrences => 225 entries
+Synthetics => 1 entries
 
 Symbols:
 local0 => abstract method k => Int
@@ -4849,6 +4928,9 @@ Occurrences:
 [119:32..119:38): Option -> scala/Option#
 [119:39..119:42): Int -> scala/Int#
 
+Synthetics:
+[68:20..68:24):@ann => *[Int]
+
 expect/semanticdb-extract.scala
 -------------------------------
 
@@ -4859,7 +4941,7 @@ Text => empty
 Language => Scala
 Symbols => 18 entries
 Occurrences => 20 entries
-Synthetics => 2 entries
+Synthetics => 3 entries
 
 Symbols:
 _empty_/AnObject. => final object AnObject extends Object { self: AnObject.type => +6 decls }
@@ -4904,6 +4986,7 @@ Occurrences:
 [16:20..16:23): Int -> scala/Int#
 
 Synthetics:
+[11:2..11:6):List => *.apply[Int]
 [12:2..12:12):List.apply => *[Nothing]
 [13:2..13:14):List.`apply` => *[Nothing]
 
@@ -4917,7 +5000,7 @@ Text => empty
 Language => Scala
 Symbols => 18 entries
 Occurrences => 43 entries
-Synthetics => 1 entries
+Synthetics => 2 entries
 
 Symbols:
 _empty_/MyProgram# => final class MyProgram extends Object { self: MyProgram => +2 decls }
@@ -4985,5 +5068,6 @@ Occurrences:
 [7:30..7:33): foo -> _empty_/toplevel$package.foo().
 
 Synthetics:
+[5:40..5:60):(1 to times) foreach => *[Unit]
 [5:41..5:42):1 => intWrapper(*)
 


### PR DESCRIPTION
This PR fixes the regressions in SemanticDB's TypeApply synthetics introduced by https://github.com/lampepfl/dotty/pull/15877

- https://github.com/lampepfl/dotty/commit/e835dc0a6fb3de39ea4f072fda51207652e0048b
- https://github.com/lampepfl/dotty/commit/097b179755fd664f29243308dc5691f48f845633
- https://github.com/lampepfl/dotty/commit/097b179755fd664f29243308dc5691f48f845633

Previously, we relies on `Scala2` flag for filtering out some synthetics, which isn't reliable for SemanticDB (that's why the capture checking made a change in how the compiler put flags to symbols and the regression occurred).
This PR fixes the regression by re-implements TypeApply synthetics without using `Scala2` flag.

(also fix https://github.com/scalameta/metals/issues/4372)

Probably, it makes more sense to compare the `metac.expect`'s diff from 53e1adc783fbe1bdc0636b19c24244617cbb2552 which was something before the regression.

<details>
<summary>diff from 53e1adc783fbe1bdc0636b19c24244617cbb2552</summary>

`git diff 53e1adc783fbe1bdc0636b19c24244617cbb2552 HEAD tests/semanticdb/metac.expect`

```diff
diff --git a/tests/semanticdb/metac.expect b/tests/semanticdb/metac.expect
index 5e20650513..2c7f720937 100644
--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -50,7 +50,7 @@ Text => empty
 Language => Scala
 Symbols => 60 entries
 Occurrences => 132 entries
-Synthetics => 4 entries
+Synthetics => 3 entries
 
 Symbols:
 advanced/C# => class C [typeparam T ] extends Object { self: C[T] => +3 decls }
@@ -252,7 +252,6 @@ Synthetics:
 [27:12..27:16):s.s1 => reflectiveSelectable(*)
 [29:12..29:16):s.s2 => reflectiveSelectable(*)
 [31:12..31:16):s.s3 => reflectiveSelectable(*)
-[47:19..47:24):foo.a => *[foo.A]
 
 expect/Annotations.scala
 ------------------------
@@ -264,7 +263,6 @@ Text => empty
 Language => Scala
 Symbols => 23 entries
 Occurrences => 52 entries
-Synthetics => 2 entries
 
 Symbols:
 annot/Alias. => final object Alias extends Object { self: Alias.type => +2 decls }
@@ -345,10 +343,6 @@ Occurrences:
 [39:11..39:26): ClassAnnotation -> com/javacp/annot/ClassAnnotation#
 [39:28..39:33): param -> scala/annotation/meta/param#
 
-Synthetics:
-[25:2..25:20):@throws[Exception] => *[Exception]
-[25:2..25:20):@throws[Exception] => *[Exception]
-
 expect/Anonymous.scala
 ----------------------
 
@@ -896,7 +890,7 @@ Text => empty
 Language => Scala
 Symbols => 181 entries
 Occurrences => 148 entries
-Synthetics => 10 entries
+Synthetics => 6 entries
 
 Symbols:
 _empty_/Enums. => final object Enums extends Object { self: Enums.type => +30 decls }
@@ -1232,16 +1226,12 @@ Occurrences:
 [68:25..68:31): Planet -> _empty_/Enums.Planet#
 
 Synthetics:
-[46:28..46:35):C <:< C => *[C, C]
-[49:27..49:31):Refl => *.apply[T]
 [52:9..52:13):Refl => *.unapply[Option[B]]
-[52:19..52:30):opt.flatMap => *[B]
 [52:31..52:50):identity[Option[B]] => *[Function1[A, Option[B]]]
 [54:14..54:18):Some => *.apply[Some[Int]]
 [54:14..54:34):Some(Some(1)).unwrap => *(given_<:<_T_T[Option[Int]])
 [54:19..54:23):Some => *.apply[Int]
 [54:28..54:34):unwrap => *[Some[Int], Int]
-[56:52..56:64):Enum[Planet] => *[Planet]
 
 expect/EtaExpansion.scala
 -------------------------
@@ -3165,7 +3155,7 @@ Text => empty
 Language => Scala
 Symbols => 52 entries
 Occurrences => 132 entries
-Synthetics => 36 entries
+Synthetics => 39 entries
 
 Symbols:
 example/Synthetic# => class Synthetic extends Object { self: Synthetic => +23 decls }
@@ -3361,12 +3351,15 @@ Synthetics:
 [6:2..6:18):Array.empty[Int] => intArrayOps(*)
 [7:2..7:8):"fooo" => augmentString(*)
 [10:13..10:24):"name:(.*)" => augmentString(*)
+[11:8..11:11):#:: => *.unapply[Int]
 [11:17..11:25):LazyList => *.apply[Int]
 [13:4..13:28):#:: 2 #:: LazyList.empty => *[Int]
 [13:8..13:28):2 #:: LazyList.empty => toDeferrer[Int](*)
 [13:10..13:28):#:: LazyList.empty => *[Int]
 [13:14..13:28):LazyList.empty => toDeferrer[Nothing](*)
 [13:14..13:28):LazyList.empty => *[Nothing]
+[15:9..15:12):#:: => *.unapply[Int]
+[15:16..15:19):#:: => *.unapply[Int]
 [15:25..15:33):LazyList => *.apply[Int]
 [17:14..17:38):#:: 2 #:: LazyList.empty => *[Int]
 [17:18..17:38):2 #:: LazyList.empty => toDeferrer[Int](*)
@@ -3471,7 +3464,7 @@ Text => empty
 Language => Scala
 Symbols => 22 entries
 Occurrences => 46 entries
-Synthetics => 7 entries
+Synthetics => 11 entries
 
 Symbols:
 example/ValPattern# => class ValPattern extends Object { self: ValPattern => +14 decls }
@@ -3546,12 +3539,16 @@ Occurrences:
 [40:10..40:18): rightVar -> local4
 
 Synthetics:
+[5:6..5:10):Some => *.unapply[Int]
 [6:4..6:8):Some => *.apply[Int]
 [8:6..8:10):List => *.unapplySeq[Nothing]
 [8:11..8:15):Some => *.unapply[Nothing]
+[11:6..11:10):Some => *.unapply[Int]
 [12:4..12:8):Some => *.apply[Int]
 [25:4..25:11):locally => *[Unit]
+[27:10..27:14):Some => *.unapply[Int]
 [28:8..28:12):Some => *.apply[Int]
+[31:10..31:14):Some => *.unapply[Int]
 [32:8..32:12):Some => *.apply[Int]
 
 expect/Vals.scala
@@ -4264,7 +4261,6 @@ Text => empty
 Language => Scala
 Symbols => 36 entries
 Occurrences => 46 entries
-Synthetics => 3 entries
 
 Symbols:
 local0 => type N$1  <: Nat
@@ -4352,11 +4348,6 @@ Occurrences:
 [23:35..23:39): Zero -> recursion/Nats.Zero.
 [23:40..23:42): ++ -> recursion/Nats.Nat#`++`().
 
-Synthetics:
-[5:50..5:54):Succ => *.apply[Nat.this.type]
-[10:13..10:17):Succ => *.unapply[N$1]
-[20:11..20:15):Succ => *.unapply[N$2]
-
 expect/semanticdb-Definitions.scala
 -----------------------------------
 
```

</details>