### PR TITLE
Track type variable dependencies to guide instantiation decisions

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -22,7 +22,7 @@ object Config {
    */
   inline val checkConstraintsNonCyclic = false
 
-  inline val checkConstraintDeps = true
+  inline val checkConstraintDeps = false
 
   /** Check that each constraint resulting from a subtype test
    *  is satisfiable. Also check that a type variable instantiation

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -22,6 +22,8 @@ object Config {
    */
   inline val checkConstraintsNonCyclic = false
 
+  inline val checkConstraintDeps = false
+
   /** Check that each constraint resulting from a subtype test
    *  is satisfiable. Also check that a type variable instantiation
    *  satisfies its constraints.

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -189,7 +189,7 @@ object Config {
   /** If set, prints a trace of all symbol completions */
   inline val showCompletions = false
 
-  /** If set, show variable/variable reverse dependencoes when printing constraints. */
+  /** If set, show variable/variable reverse dependencies when printing constraints. */
   inline val showConstraintDeps = true
 
   /** If set, method results that are context functions are flattened by adding

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -184,6 +184,9 @@ object Config {
   /** If set, prints a trace of all symbol completions */
   inline val showCompletions = false
 
+  /** If set, show variable/variable reverse dependencoes when printing constraints. */
+  inline val showConstraintDeps = true
+
   /** If set, method results that are context functions are flattened by adding
    *  the parameters of the context function results to the methods themselves.
    *  This is an optimization that reduces closure allocations.

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -22,6 +22,9 @@ object Config {
    */
   inline val checkConstraintsNonCyclic = false
 
+  /** Check that reverse dependencies in constraints are correct and complete.
+   *  Can also be enabled using -Ycheck-constraint-deps.
+   */
   inline val checkConstraintDeps = false
 
   /** Check that each constraint resulting from a subtype test

--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -22,7 +22,7 @@ object Config {
    */
   inline val checkConstraintsNonCyclic = false
 
-  inline val checkConstraintDeps = false
+  inline val checkConstraintDeps = true
 
   /** Check that each constraint resulting from a subtype test
    *  is satisfiable. Also check that a type variable instantiation

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -309,6 +309,7 @@ private sealed trait YSettings:
   val YforceSbtPhases: Setting[Boolean] = BooleanSetting("-Yforce-sbt-phases", "Run the phases used by sbt for incremental compilation (ExtractDependencies and ExtractAPI) even if the compiler is ran outside of sbt, for debugging.")
   val YdumpSbtInc: Setting[Boolean] = BooleanSetting("-Ydump-sbt-inc", "For every compiled foo.scala, output the API representation and dependencies used for sbt incremental compilation in foo.inc, implies -Yforce-sbt-phases.")
   val YcheckAllPatmat: Setting[Boolean] = BooleanSetting("-Ycheck-all-patmat", "Check exhaustivity and redundancy of all pattern matching (used for testing the algorithm).")
+  val YcheckConstraintDeps: Setting[Boolean] = BooleanSetting("-Ycheck-constraint-deps", "Check dependency tracking in constraints (used for testing the algorithm).")
   val YretainTrees: Setting[Boolean] = BooleanSetting("-Yretain-trees", "Retain trees for top-level classes, accessible from ClassSymbol#tree")
   val YshowTreeIds: Setting[Boolean] = BooleanSetting("-Yshow-tree-ids", "Uniquely tag all tree nodes in debugging output.")
   val YfromTastyIgnoreList: Setting[List[String]] = MultiStringSetting("-Yfrom-tasty-ignore-list", "file", "List of `tasty` files in jar files that will not be loaded when using -from-tasty")

--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -172,19 +172,9 @@ abstract class Constraint extends Showable {
    */
   def occursAtToplevel(param: TypeParamRef, tp: Type)(using Context): Boolean
 
-  /** A map that associates type parameters of this constraint with all other type
-   *  parameters that refer to them in their bounds covariantly, such that, if the
-   *  type parameter is instantiated to a larger type, the constraint would be narrowed.
+  /** A string that shows the reverse dependencies maintained by this constraint
+   *  (coDeps and contraDeps for OrderingConstraints).
    */
-  def coDeps: Constraint.ReverseDeps
-
-  /** A map that associates type parameters of this constraint with all other type
-   *  parameters that refer to them in their bounds covariantly, such that, if the
-   *  type parameter is instantiated to a smaller type, the constraint would be narrowed.
-   */
-  def contraDeps: Constraint.ReverseDeps
-
-  /** A string showing the `coDeps` and `contraDeps` maps */
   def depsToString(using Context): String
 
   /** Does the constraint restricted to variables outside `except` depend on `tv`
@@ -194,7 +184,12 @@ abstract class Constraint extends Showable {
    */
   def dependsOn(tv: TypeVar, except: TypeVars, co: Boolean)(using Context): Boolean
 
-  /** Check that no constrained parameter contains itself as a bound */
+  /** Depending on Config settngs:
+   *   - Under `checkConstraintsNonCyclic`, check that no constrained
+   *     parameter contains itself as a bound.
+   *   - Under `checkConstraintDeps`, check hat reverse dependencies in
+   *     constraints are correct and complete.
+   */
   def checkWellFormed()(using Context): this.type
 
   /** Check that constraint only refers to TypeParamRefs bound by itself */
@@ -205,9 +200,6 @@ abstract class Constraint extends Showable {
    */
   def checkConsistentVars()(using Context): Unit
 }
-
-object Constraint:
-  type ReverseDeps = SimpleIdentityMap[TypeParamRef, SimpleIdentitySet[TypeParamRef]]
 
 /** When calling `Constraint#addLess(p1, p2, ...)`, the caller might end up
  *  unifying one parameter with the other, this enum lets `addLess` know which

--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -166,6 +166,12 @@ abstract class Constraint extends Showable {
    */
   def hasConflictingTypeVarsFor(tl: TypeLambda, that: Constraint): Boolean
 
+  /** Does `param` occur at the toplevel in `tp` ?
+   *  Toplevel means: the type itself or a factor in some
+   *  combination of `&` or `|` types.
+   */
+  def occursAtToplevel(param: TypeParamRef, tp: Type)(using Context): Boolean
+
   /** A map that associates type parameters of this constraint with all other type
    *  parameters that refer to them in their bounds covariantly, such that, if the
    *  type parameter is instantiated to a larger type, the constraint would be narrowed.
@@ -190,12 +196,6 @@ abstract class Constraint extends Showable {
 
   /** Check that no constrained parameter contains itself as a bound */
   def checkWellFormed()(using Context): this.type
-
-  /** Does `param` occur at the toplevel in `tp` ?
-   *  Toplevel means: the type itself or a factor in some
-   *  combination of `&` or `|` types.
-   */
-  def occursAtToplevel(param: TypeParamRef, tp: Type)(using Context): Boolean
 
   /** Check that constraint only refers to TypeParamRefs bound by itself */
   def checkClosed()(using Context): Unit

--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -4,7 +4,7 @@ package core
 
 import Types._, Contexts._
 import printing.Showable
-import util.SimpleIdentityMap
+import util.{SimpleIdentitySet, SimpleIdentityMap}
 
 /** Constraint over undetermined type parameters. Constraints are built
  *  over values of the following types:
@@ -166,17 +166,17 @@ abstract class Constraint extends Showable {
    */
   def hasConflictingTypeVarsFor(tl: TypeLambda, that: Constraint): Boolean
 
-  /** A map that associates type variables with all other type variables that
-   *  refer to them in their bounds covariantly, such that, if the type variable
-   *  is isntantiated to a larger type, the constraint would be narrowed.
+  /** A map that associates type parameters of this constraint with all other type
+   *  parameters that refer to them in their bounds covariantly, such that, if the
+   *  type parameter is instantiated to a larger type, the constraint would be narrowed.
    */
-  def coDeps: Constraint.TypeVarDeps
+  def coDeps: Constraint.ReverseDeps
 
-  /** A map that associates type variables with all other type variables that
-   *  refer to them in their bounds covariantly, such that, if the type variable
-   *  is isntantiated to a smaller type, the constraint would be narrowed.
+  /** A map that associates type parameters of this constraint with all other type
+   *  parameters that refer to them in their bounds covariantly, such that, if the
+   *  type parameter is instantiated to a smaller type, the constraint would be narrowed.
    */
-  def contraDeps: Constraint.TypeVarDeps
+  def contraDeps: Constraint.ReverseDeps
 
   /** A string showing the `coDeps` and `contraDeps` maps */
   def depsToString(using Context): String
@@ -207,8 +207,7 @@ abstract class Constraint extends Showable {
 }
 
 object Constraint:
-  type TypeVarDeps = SimpleIdentityMap[TypeVar, TypeVars]
-
+  type ReverseDeps = SimpleIdentityMap[TypeParamRef, SimpleIdentitySet[TypeParamRef]]
 
 /** When calling `Constraint#addLess(p1, p2, ...)`, the caller might end up
  *  unifying one parameter with the other, this enum lets `addLess` know which

--- a/compiler/src/dotty/tools/dotc/core/Constraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/Constraint.scala
@@ -189,7 +189,7 @@ abstract class Constraint extends Showable {
   def dependsOn(tv: TypeVar, except: TypeVars, co: Boolean)(using Context): Boolean
 
   /** Check that no constrained parameter contains itself as a bound */
-  def checkNonCyclic()(using Context): this.type
+  def checkWellFormed()(using Context): this.type
 
   /** Does `param` occur at the toplevel in `tp` ?
    *  Toplevel means: the type itself or a factor in some

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -245,6 +245,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
 
   private class Adjuster(srcParam: TypeParamRef)(using Context) extends TypeTraverser:
     var add: Boolean = compiletime.uninitialized
+    val seen = util.HashSet[LazyRef]()
 
     def update(deps: ReverseDeps, referenced: TypeParamRef): ReverseDeps =
       val prev = deps.at(referenced)
@@ -255,7 +256,10 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         if contains(param) then
           if variance >= 0 then coDeps = update(coDeps, param)
           if variance <= 0 then contraDeps = update(contraDeps, param)
-      case tp: LazyRef if !tp.completed =>
+      case tp: LazyRef =>
+        if !seen.contains(tp) then
+          seen += tp
+          traverse(tp.ref)
       case _ => traverseChildren(t)
   end Adjuster
 

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -267,7 +267,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
 
   override def dependsOn(tv: TypeVar, except: TypeVars, co: Boolean)(using Context): Boolean =
     def origin(tv: TypeVar) =
-      assert(!tv.isInstantiated)
+      assert(!instType(tv).exists)
       tv.origin
     val param = origin(tv)
     val excluded = except.map(origin)
@@ -694,7 +694,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         var newDepEntry = newEntry
         replacedTypeVar match
           case tvar: TypeVar =>
-            if tvar.isInstantiated
+            if tvar.inst.exists // `isInstantiated` would use ctx.typerState.constraint rather than the current constraint
             then
               // If the type variable has been instantiated, we need to forget about
               // the instantiation for old dependencies.

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -427,7 +427,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
       val param = poly.paramRefs(i)
       val bounds = dropWildcards(nonParamBounds(param))
       val stripped = stripParams(bounds, todos, isUpper = true)
-      current = updateEntry(current, param, stripped)
+      current = boundsLens.update(this, current, param, stripped)
       while todos.nonEmpty do
         current = todos.head(current, param)
         todos.dropInPlace(1)

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -595,14 +595,17 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         adjustDeps(newEntry, entry, pref)
         newEntry
 
+      for lo <- lower(param) do
+        current = upperLens.map(this, current, lo, removeParam)
+      for hi <- upper(param) do
+        current = lowerLens.map(this, current, hi, removeParam)
+
       current.foreachParam { (p, i) =>
         current = boundsLens.map(this, current, p, i,
           entry =>
             val newEntry = replaceParam(entry, p, i)
             adjustDeps(newEntry, entry, p.paramRefs(i))
             newEntry)
-        current = lowerLens.map(this, current, p, i, removeParam)
-        current = upperLens.map(this, current, p, i, removeParam)
       }
       current.dropDeps(param)
       current.checkWellFormed()

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -284,7 +284,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
    *     arguments Ts. That can make a difference for the variance in which an argument
    *     is traversed. Example constraint:
    *
-   *         constrainded types: C[X], A
+   *         constrained types: C[X], A
    *         A >: C[B]
    *         C := Option
    *
@@ -696,14 +696,14 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
           case tvar: TypeVar =>
             if tvar.isInstantiated
             then
-              // If the type variuable has been instantiated, we need to forget about
+              // If the type variable has been instantiated, we need to forget about
               // the instantiation for old dependencies.
               // I.e. to find out what the old entry was, we should not follow
               // the newly instantiated type variable but assume the type variable's origin `param`.
               // An example where this happens is if `replace` is called from TypeVar's `instantiateWith`.
               oldDepEntry = mapReplacedTypeVarTo(param)(oldDepEntry)
             else
-              // If the type variuable has not been instantiated, we need to replace references to it
+              // If the type variable has not been instantiated, we need to replace references to it
               // in the new entry by `replacement`. Otherwise we would get stuck in an uninstantiated
               // type variable.
               // An example where this happens is if `replace` is called from unify.

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -299,7 +299,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
 
     override def tyconTypeParams(tp: AppliedType)(using Context): List[ParamInfo] =
       def tparams(tycon: Type): List[ParamInfo] = tycon match
-        case tycon: TypeVar if !tycon.isInstantiated => tparams(tycon.origin)
+        case tycon: TypeVar if !tycon.inst.exists => tparams(tycon.origin)
         case tycon: TypeParamRef =>
           entry(tycon) match
             case _: TypeBounds => tp.tyconTypeParams

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -193,7 +193,7 @@ object Substituters:
     def apply(tp: Type): Type = substRecThis(tp, from, to, this)(using mapCtx)
   }
 
-  class SubstParamMap(from: ParamRef, to: Type)(using Context) extends DeepTypeMap, IdempotentCaptRefMap {
+  final class SubstParamMap(from: ParamRef, to: Type)(using Context) extends DeepTypeMap, IdempotentCaptRefMap {
     def apply(tp: Type): Type = substParam(tp, from, to, this)(using mapCtx)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -193,7 +193,7 @@ object Substituters:
     def apply(tp: Type): Type = substRecThis(tp, from, to, this)(using mapCtx)
   }
 
-  final class SubstParamMap(from: ParamRef, to: Type)(using Context) extends DeepTypeMap, IdempotentCaptRefMap {
+  class SubstParamMap(from: ParamRef, to: Type)(using Context) extends DeepTypeMap, IdempotentCaptRefMap {
     def apply(tp: Type): Type = substParam(tp, from, to, this)(using mapCtx)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5498,6 +5498,11 @@ object Types {
         || stop == StopAt.Package && tp.currentSymbol.is(Package)
       }
 
+    /** The type parameters of the constructor of this applied type.
+     *  Overridden in OrderingConstraint's ConstraintAwareTraversal to take account
+     *  of instantiations in the constraint that are not yet propagated to the
+     *  instance types of type variables.
+     */
     protected def tyconTypeParams(tp: AppliedType)(using Context): List[ParamInfo] =
       tp.tyconTypeParams
   end VariantTraversal
@@ -6066,11 +6071,11 @@ object Types {
      *  By contrast, covariance does translate to the prefix, since we have that
      *  if `p <: q` then `p.A <: q.A`, and well-formedness requires that `A` is a member
      *  of `p`'s upper bound.
-     *  Overridden in traversers that compute or check reverse dependencies in OrderingConstraint,
-     *  where we use a more relaxed scheme.
+     *  Overridden in OrderingConstraint's ConstraintAwareTraversal, where a
+     *  more relaxed scheme is used.
      */
     protected def applyToPrefix(x: T, tp: NamedType): T =
-      atVariance(variance max 0)(this(x, tp.prefix)) // see remark on NamedType case in TypeMap
+      atVariance(variance max 0)(this(x, tp.prefix))
 
     def foldOver(x: T, tp: Type): T = {
       record(s"foldOver $getClass")

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -689,8 +689,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
                 Text(ups.map(toText), ", ")
           Text(deps, "\n")
         }
+      val depsText = if Config.showConstraintDeps then c.depsToString else ""
       //Printer.debugPrintUnique = false
-      Text.lines(List(uninstVarsText, constrainedText, boundsText, orderingText))
+      Text.lines(List(uninstVarsText, constrainedText, boundsText, orderingText, depsText))
     finally
       ctx.typerState.constraint = savedConstraint
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1502,11 +1502,17 @@ trait Applications extends Compatibility {
   }
 
   /** Drop any leading implicit parameter sections */
-  def stripImplicit(tp: Type)(using Context): Type = tp match {
+  def stripImplicit(tp: Type, wildcardOnly: Boolean = false)(using Context): Type = tp match {
     case mt: MethodType if mt.isImplicitMethod =>
-      stripImplicit(resultTypeApprox(mt))
+      stripImplicit(resultTypeApprox(mt, wildcardOnly))
     case pt: PolyType =>
-      pt.derivedLambdaType(pt.paramNames, pt.paramInfos, stripImplicit(pt.resultType)).asInstanceOf[PolyType].flatten
+      pt.derivedLambdaType(pt.paramNames, pt.paramInfos,
+          stripImplicit(pt.resultType, wildcardOnly = true))
+            // can't use TypeParamRefs for parameter references in `resultTypeApprox`
+            // since their bounds can refer to type parameters in `pt` that are not
+            // bound by the constraint. This can lead to hygiene violations if subsequently
+            // `pt` itself is added to the constraint. Test case is run/enrich-gentraversable.scala.
+        .asInstanceOf[PolyType].flatten
     case _ =>
       tp
   }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -44,7 +44,7 @@ class CompilationTests {
       compileFilesInDir("tests/pos-custom-args/erased", defaultOptions.and("-language:experimental.erasedDefinitions")),
       compileFilesInDir("tests/pos", defaultOptions.and("-Ysafe-init")),
       // Run tests for experimental lightweight lazy vals
-      compileFilesInDir("tests/pos", defaultOptions.and("-Ysafe-init", "-Ylightweight-lazy-vals"), FileFilter.include(TestSources.posLazyValsAllowlist)),
+      compileFilesInDir("tests/pos", defaultOptions.and("-Ysafe-init", "-Ylightweight-lazy-vals", "-Ycheck-constraint-deps"), FileFilter.include(TestSources.posLazyValsAllowlist)),
       compileFilesInDir("tests/pos-deep-subtype", allowDeepSubtypes),
       compileFilesInDir("tests/pos-custom-args/no-experimental", defaultOptions.and("-Yno-experimental")),
       compileDir("tests/pos-special/java-param-names", defaultOptions.withJavacOnlyOptions("-parameters")),
@@ -219,7 +219,7 @@ class CompilationTests {
       compileFilesInDir("tests/run-deep-subtype", allowDeepSubtypes),
       compileFilesInDir("tests/run", defaultOptions.and("-Ysafe-init"), FileFilter.exclude("serialization-new.scala")),
       // Run tests for experimental lightweight lazy vals and stable lazy vals.
-      compileFilesInDir("tests/run", defaultOptions.and("-Ysafe-init", "-Ylightweight-lazy-vals"), FileFilter.include(TestSources.runLazyValsAllowlist)),
+      compileFilesInDir("tests/run", defaultOptions.and("-Ysafe-init", "-Ylightweight-lazy-vals", "-Ycheck-constraint-deps"), FileFilter.include(TestSources.runLazyValsAllowlist)),
     ).checkRuns()
   }
 

--- a/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
@@ -20,7 +20,7 @@ class PatmatExhaustivityTest {
   val testsDir = "tests/patmat"
   // pagewidth/color: for a stable diff as the defaults are based on the terminal (e.g size)
   // stop-after: patmatexhaust-huge.scala crash compiler (but also hides other warnings..)
-  val options = List("-pagewidth", "80", "-color:never", "-Ystop-after:explicitSelf", "-classpath", TestConfiguration.basicClasspath)
+  val options = List("-pagewidth", "80", "-color:never", "-Ystop-after:explicitSelf", "-Ycheck-constraint-deps", "-classpath", TestConfiguration.basicClasspath)
 
   private def compile(files: List[JPath]): Seq[String] = {
     val opts         = toolArgsFor(files).get(ToolName.Scalac).getOrElse(Nil)

--- a/tests/pos/i15864.scala
+++ b/tests/pos/i15864.scala
@@ -1,0 +1,22 @@
+object Test:
+  def op[O, P](ta: List[O], tb: List[P]): List[P] = ???
+
+  class Graph { class Node }
+
+  def outsQ(using g: Graph): List[List[g.Node]] = ???
+
+  object aGraph extends Graph
+  given implA: aGraph.type = aGraph
+
+  val q1: List[List[aGraph.Node]] = op(outsQ, op(outsQ, outsQ))
+  implicitly[q1.type <:< List[List[aGraph.Node]]]
+
+  val a1 = outsQ
+  val a2 = op(outsQ, outsQ)
+  val a3 = op(a1, a2)
+
+  val q2 = op(outsQ, op(outsQ, outsQ))
+  val q3: List[List[aGraph.Node]] = q2
+  implicitly[q2.type <:< List[List[aGraph.Node]]]
+
+


### PR DESCRIPTION
We now keep track of reverse type variable dependencies in constraints. 
E.g. if a constraint contains a clause like

    A >: List[B]

We associate with `B` info that `A` depends co-variantly on it. Or, if 

    A <: B => C

we associate with `B` that `A` depends co-variantly on it and with `C`
that `A` depends contra-variantly on it. Here, co-variant means that
the allowable range of `A` narrows if the referred-to variable `B` grows, and 
contra-variant means that the allowable range of `A` narrows if the referred-to 
variable `C` shrinks. If there's an invariant reference such as

    A <: Array[B]

Then `A` depends both co- and contra-variantly on `B`.

These dependencies are then used to guide type variable instantiation. 
If an eligible type variable does not appear in the type of a typed expression,
we interpolate it to one of its bounds. Previously this was done in an ad-hoc
manner where we minimized the type variable if it had a lower bound and maximized
it otherwise. We now take reverse dependencies into account. If maximizing a type
variable would narrow the remaining constraint we minimize, and if minimizing
a type variable would narrow the remaining constraint we maximize. Only if
the type variable is not referred to from the remaining constraint we resort
to the old heuristic based on the lower bound. 

Fixes #15864

Todo: This could be generalized in several directions:

 - We could base the dependency tracking on type param refs instead of type variables.
   That could make the `replace` operation in a constraint more efficient. 
 - We could base more interpolation decisions on dependencies. E.g. we could
   interpolate a type variable only if both the type of an expression and the enclosing
   constraint agree in which direction this should be done.
 