### PR TITLE
feat: [SemanticDB] support LambdaType (convert from HKTypeLambda)

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
@@ -196,6 +196,10 @@ class SymbolInformationPrinter (symtab: PrinterSymtab):
             s"${pprint(caseType.key)} => ${pprint(caseType.body)}"
           }.mkString(", ")
           s"${pprint(scrutinee)} match { ${casesStr} }"
+        case LambdaType(tparams, res) =>
+          val params = tparams.infos.map(_.displayName).mkString("[", ", ", "]")
+          val resType = normal(res)
+          s"$params =>> $resType"
         case x =>
           "<?>"
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Type.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Type.scala
@@ -39,6 +39,7 @@ object Type {
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType => __v.value
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType => __v.value
       case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType => __v.value
+      case __v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType => __v.value
       case dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty => Empty
     }
     override def toBase(__custom: dotty.tools.dotc.semanticdb.Type): dotty.tools.dotc.semanticdb.TypeMessage = dotty.tools.dotc.semanticdb.TypeMessage(__custom match {
@@ -57,6 +58,7 @@ object Type {
       case __v: dotty.tools.dotc.semanticdb.ByNameType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.ByNameType(__v)
       case __v: dotty.tools.dotc.semanticdb.RepeatedType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__v)
       case __v: dotty.tools.dotc.semanticdb.MatchType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__v)
+      case __v: dotty.tools.dotc.semanticdb.LambdaType => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__v)
       case Empty => dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty
     })
   }
@@ -127,6 +129,10 @@ final case class TypeMessage(
       };
       if (sealedValue.matchType.isDefined) {
         val __value = sealedValue.matchType.get
+        __size += 2 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      };
+      if (sealedValue.lambdaType.isDefined) {
+        val __value = sealedValue.lambdaType.get
         __size += 2 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       };
       __size
@@ -231,6 +237,12 @@ final case class TypeMessage(
         _output__.writeUInt32NoTag(__m.serializedSize)
         __m.writeTo(_output__)
       };
+      sealedValue.lambdaType.foreach { __v =>
+        val __m = __v
+        _output__.writeTag(26, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      };
     }
     def getTypeRef: dotty.tools.dotc.semanticdb.TypeRef = sealedValue.typeRef.getOrElse(dotty.tools.dotc.semanticdb.TypeRef.defaultInstance)
     def withTypeRef(__v: dotty.tools.dotc.semanticdb.TypeRef): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.TypeRef(__v))
@@ -262,6 +274,8 @@ final case class TypeMessage(
     def withRepeatedType(__v: dotty.tools.dotc.semanticdb.RepeatedType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__v))
     def getMatchType: dotty.tools.dotc.semanticdb.MatchType = sealedValue.matchType.getOrElse(dotty.tools.dotc.semanticdb.MatchType.defaultInstance)
     def withMatchType(__v: dotty.tools.dotc.semanticdb.MatchType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__v))
+    def getLambdaType: dotty.tools.dotc.semanticdb.LambdaType = sealedValue.lambdaType.getOrElse(dotty.tools.dotc.semanticdb.LambdaType.defaultInstance)
+    def withLambdaType(__v: dotty.tools.dotc.semanticdb.LambdaType): TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__v))
     def clearSealedValue: TypeMessage = copy(sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty)
     def withSealedValue(__v: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue): TypeMessage = copy(sealedValue = __v)
     
@@ -311,6 +325,8 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
           __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.RepeatedType(__sealedValue.repeatedType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.RepeatedType](_input__))(LiteParser.readMessage(_input__, _)))
         case 202 =>
           __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.MatchType(__sealedValue.matchType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.MatchType](_input__))(LiteParser.readMessage(_input__, _)))
+        case 210 =>
+          __sealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.LambdaType(__sealedValue.lambdaType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.LambdaType](_input__))(LiteParser.readMessage(_input__, _)))
         case tag => _input__.skipField(tag)
       }
     }
@@ -345,6 +361,7 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
     def isByNameType: _root_.scala.Boolean = false
     def isRepeatedType: _root_.scala.Boolean = false
     def isMatchType: _root_.scala.Boolean = false
+    def isLambdaType: _root_.scala.Boolean = false
     def typeRef: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeRef] = _root_.scala.None
     def singleType: _root_.scala.Option[dotty.tools.dotc.semanticdb.SingleType] = _root_.scala.None
     def thisType: _root_.scala.Option[dotty.tools.dotc.semanticdb.ThisType] = _root_.scala.None
@@ -360,6 +377,7 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
     def byNameType: _root_.scala.Option[dotty.tools.dotc.semanticdb.ByNameType] = _root_.scala.None
     def repeatedType: _root_.scala.Option[dotty.tools.dotc.semanticdb.RepeatedType] = _root_.scala.None
     def matchType: _root_.scala.Option[dotty.tools.dotc.semanticdb.MatchType] = _root_.scala.None
+    def lambdaType: _root_.scala.Option[dotty.tools.dotc.semanticdb.LambdaType] = _root_.scala.None
   }
   object SealedValue {
     @SerialVersionUID(0L)
@@ -476,6 +494,13 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
       override def matchType: _root_.scala.Option[dotty.tools.dotc.semanticdb.MatchType] = Some(value)
       override def number: _root_.scala.Int = 25
     }
+    @SerialVersionUID(0L)
+    final case class LambdaType(value: dotty.tools.dotc.semanticdb.LambdaType) extends dotty.tools.dotc.semanticdb.TypeMessage.SealedValue  derives CanEqual {
+      type ValueType = dotty.tools.dotc.semanticdb.LambdaType
+      override def isLambdaType: _root_.scala.Boolean = true
+      override def lambdaType: _root_.scala.Option[dotty.tools.dotc.semanticdb.LambdaType] = Some(value)
+      override def number: _root_.scala.Int = 26
+    }
   }
   final val TYPE_REF_FIELD_NUMBER = 2
   final val SINGLE_TYPE_FIELD_NUMBER = 20
@@ -492,6 +517,7 @@ object TypeMessage  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc
   final val BY_NAME_TYPE_FIELD_NUMBER = 13
   final val REPEATED_TYPE_FIELD_NUMBER = 14
   final val MATCH_TYPE_FIELD_NUMBER = 25
+  final val LAMBDA_TYPE_FIELD_NUMBER = 26
   def of(
     sealedValue: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue
   ): _root_.dotty.tools.dotc.semanticdb.TypeMessage = _root_.dotty.tools.dotc.semanticdb.TypeMessage(
@@ -2033,4 +2059,108 @@ object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
     cases
   )
   // @@protoc_insertion_point(GeneratedMessageCompanion[dotty.tools.dotc.semanticdb.MatchType])
+}
+
+@SerialVersionUID(0L)
+final case class LambdaType(
+    parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None,
+    returnType: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
+    )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
+    @transient @sharable
+    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
+    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+      var __size = 0
+      if (parameters.isDefined) {
+        val __value = parameters.get
+        __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      };
+      
+      {
+        val __value = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toBase(returnType)
+        if (__value.serializedSize != 0) {
+          __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+        }
+      };
+      __size
+    }
+    override def serializedSize: _root_.scala.Int = {
+      var __size = __serializedSizeMemoized
+      if (__size == 0) {
+        __size = __computeSerializedSize() + 1
+        __serializedSizeMemoized = __size
+      }
+      __size - 1
+      
+    }
+    def writeTo(`_output__`: SemanticdbOutputStream): _root_.scala.Unit = {
+      parameters.foreach { __v =>
+        val __m = __v
+        _output__.writeTag(1, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      };
+      {
+        val __v = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toBase(returnType)
+        if (__v.serializedSize != 0) {
+          _output__.writeTag(2, 2)
+          _output__.writeUInt32NoTag(__v.serializedSize)
+          __v.writeTo(_output__)
+        }
+      };
+    }
+    def getParameters: dotty.tools.dotc.semanticdb.Scope = parameters.getOrElse(dotty.tools.dotc.semanticdb.Scope.defaultInstance)
+    def clearParameters: LambdaType = copy(parameters = _root_.scala.None)
+    def withParameters(__v: dotty.tools.dotc.semanticdb.Scope): LambdaType = copy(parameters = Option(__v))
+    def withReturnType(__v: dotty.tools.dotc.semanticdb.Type): LambdaType = copy(returnType = __v)
+    
+    
+    
+    
+    // @@protoc_insertion_point(GeneratedMessage[dotty.tools.dotc.semanticdb.LambdaType])
+}
+
+object LambdaType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType] {
+  implicit def messageCompanion: SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType] = this
+  def parseFrom(`_input__`: SemanticdbInputStream): dotty.tools.dotc.semanticdb.LambdaType = {
+    var __parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None
+    var __returnType: _root_.scala.Option[dotty.tools.dotc.semanticdb.TypeMessage] = _root_.scala.None
+    var _done__ = false
+    while (!_done__) {
+      val _tag__ = _input__.readTag()
+      _tag__ match {
+        case 0 => _done__ = true
+        case 10 =>
+          __parameters = Option(__parameters.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.Scope](_input__))(LiteParser.readMessage(_input__, _)))
+        case 18 =>
+          __returnType = _root_.scala.Some(__returnType.fold(LiteParser.readMessage[dotty.tools.dotc.semanticdb.TypeMessage](_input__))(LiteParser.readMessage(_input__, _)))
+        case tag => _input__.skipField(tag)
+      }
+    }
+    dotty.tools.dotc.semanticdb.LambdaType(
+        parameters = __parameters,
+        returnType = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(__returnType.getOrElse(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance))
+    )
+  }
+  
+  
+  
+  
+  
+  
+  lazy val defaultInstance = dotty.tools.dotc.semanticdb.LambdaType(
+    parameters = _root_.scala.None,
+    returnType = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
+  )
+  final val PARAMETERS_FIELD_NUMBER = 1
+  final val RETURN_TYPE_FIELD_NUMBER = 2
+  @transient @sharable
+  private[semanticdb] val _typemapper_returnType: SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type] = implicitly[SemanticdbTypeMapper[dotty.tools.dotc.semanticdb.TypeMessage, dotty.tools.dotc.semanticdb.Type]]
+  def of(
+    parameters: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope],
+    returnType: dotty.tools.dotc.semanticdb.Type
+  ): _root_.dotty.tools.dotc.semanticdb.LambdaType = _root_.dotty.tools.dotc.semanticdb.LambdaType(
+    parameters,
+    returnType
+  )
+  // @@protoc_insertion_point(GeneratedMessageCompanion[dotty.tools.dotc.semanticdb.LambdaType])
 }

--- a/tests/semanticdb/expect/hk.expect.scala
+++ b/tests/semanticdb/expect/hk.expect.scala
@@ -1,0 +1,17 @@
+package hk
+
+trait Monad/*<-hk::Monad#*/[M/*<-hk::Monad#[M]*/[_]] {
+  def pure/*<-hk::Monad#pure().*/[A/*<-hk::Monad#pure().[A]*/](a/*<-hk::Monad#pure().(a)*/: A/*->hk::Monad#pure().[A]*/): M/*->hk::Monad#[M]*/[A/*->hk::Monad#pure().[A]*/] = ???/*->scala::Predef.`???`().*/
+  def flatMap/*<-hk::Monad#flatMap().*/[A/*<-hk::Monad#flatMap().[A]*/, B/*<-hk::Monad#flatMap().[B]*/](m/*<-hk::Monad#flatMap().(m)*/: M/*->hk::Monad#[M]*/[A/*->hk::Monad#flatMap().[A]*/])(f/*<-hk::Monad#flatMap().(f)*/: A/*->hk::Monad#flatMap().[A]*/ => M/*->hk::Monad#[M]*/[B/*->hk::Monad#flatMap().[B]*/]): M/*->hk::Monad#[M]*/[B/*->hk::Monad#flatMap().[B]*/] = ???/*->scala::Predef.`???`().*/
+}
+
+class EitherMonad/*<-hk::EitherMonad#*/[T/*<-hk::EitherMonad#[T]*/] extends Monad/*->hk::Monad#*/[[E/*<-hk::EitherMonad#`<init>`().[E]*/] =>> Either/*->scala::package.Either#*/[T/*->hk::EitherMonad#[T]*/, E]] {
+}
+
+type MapKV/*<-hk::hk$package.MapKV#*/ = [K/*<-hk::hk$package.MapKV#[K]*/] =>> [V/*<-hk::hk$package.MapKV#[V]*/] =>> Map/*->scala::Predef.Map#*/[K/*->hk::hk$package.MapKV#[K]*/,V/*->hk::hk$package.MapKV#[V]*/]
+
+type MapV/*<-hk::hk$package.MapV#*/ = [_] =>> [V/*<-hk::hk$package.MapV#[V]*/] =>> Map/*->scala::Predef.Map#*/[String/*->scala::Predef.String#*/, V/*->hk::hk$package.MapV#[V]*/]
+
+type MapEither/*<-hk::hk$package.MapEither#*/ = [K/*<-hk::hk$package.MapEither#[K]*/] =>> [L/*<-hk::hk$package.MapEither#[L]*/] =>> [R/*<-hk::hk$package.MapEither#[R]*/] =>> Map/*->scala::Predef.Map#*/[K/*->hk::hk$package.MapEither#[K]*/, Either/*->scala::package.Either#*/[L/*->hk::hk$package.MapEither#[L]*/, R/*->hk::hk$package.MapEither#[R]*/]]
+
+type Id/*<-hk::hk$package.Id#*/[A/*<-hk::hk$package.Id#[A]*/] = A/*->hk::hk$package.Id#[A]*/

--- a/tests/semanticdb/expect/hk.scala
+++ b/tests/semanticdb/expect/hk.scala
@@ -1,0 +1,17 @@
+package hk
+
+trait Monad[M[_]] {
+  def pure[A](a: A): M[A] = ???
+  def flatMap[A, B](m: M[A])(f: A => M[B]): M[B] = ???
+}
+
+class EitherMonad[T] extends Monad[[E] =>> Either[T, E]] {
+}
+
+type MapKV = [K] =>> [V] =>> Map[K,V]
+
+type MapV = [_] =>> [V] =>> Map[String, V]
+
+type MapEither = [K] =>> [L] =>> [R] =>> Map[K, Either[L, R]]
+
+type Id[A] = A

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -48,7 +48,7 @@ Schema => SemanticDB v4
 Uri => Advanced.scala
 Text => empty
 Language => Scala
-Symbols => 60 entries
+Symbols => 61 entries
 Occurrences => 138 entries
 Synthetics => 3 entries
 
@@ -57,10 +57,11 @@ advanced/C# => class C [typeparam T ] extends Object { self: C[T] => +3 decls }
 advanced/C#[T] => typeparam T 
 advanced/C#`<init>`(). => primary ctor <init> [typeparam T ](): C[T]
 advanced/C#t(). => method t => T
-advanced/HKClass# => class HKClass [typeparam F [typeparam T ] <: <?>] extends Object { self: HKClass[F] => +3 decls }
-advanced/HKClass#[F] => typeparam F [typeparam T ] <: <?>
+advanced/HKClass# => class HKClass [typeparam F [typeparam T ] <: [U] =>> Tuple2[U, T]] extends Object { self: HKClass[F] => +3 decls }
+advanced/HKClass#[F] => typeparam F [typeparam T ] <: [U] =>> Tuple2[U, T]
 advanced/HKClass#[F][T] => typeparam T 
-advanced/HKClass#`<init>`(). => primary ctor <init> [typeparam F [typeparam T ] <: <?>](): HKClass[F]
+advanced/HKClass#[F][U] => typeparam U 
+advanced/HKClass#`<init>`(). => primary ctor <init> [typeparam F [typeparam T ] <: [U] =>> Tuple2[U, T]](): HKClass[F]
 advanced/HKClass#`<init>`().[F][T] => typeparam T 
 advanced/HKClass#`<init>`().[F][U] => typeparam U 
 advanced/HKClass#foo(). => method foo [typeparam T , typeparam U ](param x: F[T, U]): String
@@ -3969,6 +3970,103 @@ example/FilenameWithSpaces#`<init>`(). => primary ctor <init> (): FilenameWithSp
 Occurrences:
 [0:8..0:15): example <- example/
 [2:6..2:24): FilenameWithSpaces <- example/FilenameWithSpaces#
+
+expect/hk.scala
+---------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => hk.scala
+Text => empty
+Language => Scala
+Symbols => 30 entries
+Occurrences => 52 entries
+
+Symbols:
+hk/EitherMonad# => class EitherMonad [typeparam T ] extends Object with Monad[[E] =>> Either[T, E]] { self: EitherMonad[T] => +2 decls }
+hk/EitherMonad#[E] => typeparam E 
+hk/EitherMonad#[T] => typeparam T 
+hk/EitherMonad#`<init>`(). => primary ctor <init> [typeparam T ](): EitherMonad[T]
+hk/EitherMonad#`<init>`().[E] => typeparam E 
+hk/Monad# => trait Monad [typeparam M [type _ ]] extends Object { self: Monad[M] => +4 decls }
+hk/Monad#[M] => typeparam M [type _ ]
+hk/Monad#[M][_] => type _ 
+hk/Monad#`<init>`(). => primary ctor <init> [typeparam M [type _ ]](): Monad[M]
+hk/Monad#flatMap(). => method flatMap [typeparam A , typeparam B ](param m: M[A])(param f: Function1[A, M[B]]): M[B]
+hk/Monad#flatMap().(f) => param f: Function1[A, M[B]]
+hk/Monad#flatMap().(m) => param m: M[A]
+hk/Monad#flatMap().[A] => typeparam A 
+hk/Monad#flatMap().[B] => typeparam B 
+hk/Monad#pure(). => method pure [typeparam A ](param a: A): M[A]
+hk/Monad#pure().(a) => param a: A
+hk/Monad#pure().[A] => typeparam A 
+hk/hk$package. => final package object hk extends Object { self: hk.type => +5 decls }
+hk/hk$package.Id# => type Id [typeparam A ] = A
+hk/hk$package.Id#[A] => typeparam A 
+hk/hk$package.MapEither# => type MapEither [typeparam K ] = [L] =>> [R] =>> Map[K, Either[L, R]]
+hk/hk$package.MapEither#[K] => typeparam K 
+hk/hk$package.MapEither#[L] => typeparam L 
+hk/hk$package.MapEither#[R] => typeparam R 
+hk/hk$package.MapKV# => type MapKV [typeparam K ] = [V] =>> Map[K, V]
+hk/hk$package.MapKV#[K] => typeparam K 
+hk/hk$package.MapKV#[V] => typeparam V 
+hk/hk$package.MapV# => type MapV [type _ ] = [V] =>> Map[String, V]
+hk/hk$package.MapV#[V] => typeparam V 
+hk/hk$package.MapV#[_] => type _ 
+
+Occurrences:
+[0:8..0:10): hk <- hk/
+[2:6..2:11): Monad <- hk/Monad#
+[2:12..2:13): M <- hk/Monad#[M]
+[3:6..3:10): pure <- hk/Monad#pure().
+[3:11..3:12): A <- hk/Monad#pure().[A]
+[3:14..3:15): a <- hk/Monad#pure().(a)
+[3:17..3:18): A -> hk/Monad#pure().[A]
+[3:21..3:22): M -> hk/Monad#[M]
+[3:23..3:24): A -> hk/Monad#pure().[A]
+[3:28..3:31): ??? -> scala/Predef.`???`().
+[4:6..4:13): flatMap <- hk/Monad#flatMap().
+[4:14..4:15): A <- hk/Monad#flatMap().[A]
+[4:17..4:18): B <- hk/Monad#flatMap().[B]
+[4:20..4:21): m <- hk/Monad#flatMap().(m)
+[4:23..4:24): M -> hk/Monad#[M]
+[4:25..4:26): A -> hk/Monad#flatMap().[A]
+[4:29..4:30): f <- hk/Monad#flatMap().(f)
+[4:32..4:33): A -> hk/Monad#flatMap().[A]
+[4:37..4:38): M -> hk/Monad#[M]
+[4:39..4:40): B -> hk/Monad#flatMap().[B]
+[4:44..4:45): M -> hk/Monad#[M]
+[4:46..4:47): B -> hk/Monad#flatMap().[B]
+[4:51..4:54): ??? -> scala/Predef.`???`().
+[7:6..7:17): EitherMonad <- hk/EitherMonad#
+[7:18..7:19): T <- hk/EitherMonad#[T]
+[7:29..7:34): Monad -> hk/Monad#
+[7:36..7:37): E <- hk/EitherMonad#`<init>`().[E]
+[7:43..7:49): Either -> scala/package.Either#
+[7:50..7:51): T -> hk/EitherMonad#[T]
+[10:5..10:10): MapKV <- hk/hk$package.MapKV#
+[10:14..10:15): K <- hk/hk$package.MapKV#[K]
+[10:22..10:23): V <- hk/hk$package.MapKV#[V]
+[10:29..10:32): Map -> scala/Predef.Map#
+[10:33..10:34): K -> hk/hk$package.MapKV#[K]
+[10:35..10:36): V -> hk/hk$package.MapKV#[V]
+[12:5..12:9): MapV <- hk/hk$package.MapV#
+[12:21..12:22): V <- hk/hk$package.MapV#[V]
+[12:28..12:31): Map -> scala/Predef.Map#
+[12:32..12:38): String -> scala/Predef.String#
+[12:40..12:41): V -> hk/hk$package.MapV#[V]
+[14:5..14:14): MapEither <- hk/hk$package.MapEither#
+[14:18..14:19): K <- hk/hk$package.MapEither#[K]
+[14:26..14:27): L <- hk/hk$package.MapEither#[L]
+[14:34..14:35): R <- hk/hk$package.MapEither#[R]
+[14:41..14:44): Map -> scala/Predef.Map#
+[14:45..14:46): K -> hk/hk$package.MapEither#[K]
+[14:48..14:54): Either -> scala/package.Either#
+[14:55..14:56): L -> hk/hk$package.MapEither#[L]
+[14:58..14:59): R -> hk/hk$package.MapEither#[R]
+[16:5..16:7): Id <- hk/hk$package.Id#
+[16:8..16:9): A <- hk/hk$package.Id#[A]
+[16:13..16:14): A -> hk/hk$package.Id#[A]
 
 expect/i5854.scala
 ------------------


### PR DESCRIPTION
based on the new semanticdb schema
https://github.com/scalameta/scalameta/pull/2867
https://github.com/tanishiking/semanticdb-for-scala3/commit/3981424f2eee9b03e6114b21026572f877185638

This commit adds support for LambdaType that is converted from HKTypeLambda in Scala3.

For example, the following type signature 
`[A, B] =>> [C] =>> A | B | C`

will be

```scala
LambdaType(
  parameters = Some(
    value = Scope(hardlinks =
      List(
        "....Union#[A]"
        "....Union#[B]"
      ), symlinks = List()
    )
  ),
  returnType = LambdaType(
    parameters = Some(
      value = Scope(hardlinks = List("....Union#[C]"), symlinks = List())
    ),
    returnType = UnionType(
      types = List(
        TypeRef(
          prefix = Empty,
          symbol = "....Union#[A]",
          typeArguments = List()
        ),
        TypeRef(
          prefix = Empty,
          symbol = "....Union#[B]",
          typeArguments = List()
        ),
        TypeRef(
          prefix = Empty,
          symbol = "....Union#[C]",
          typeArguments = List()
        )
      )
    )
  )
)
```

## I'm wondering...

Previously, we embed `type Id = [A] =>> A` which is equivalent to `type Id[A] = A`
https://github.com/lampepfl/dotty/blob/afc6ce4d2135e3532bf28146a7700d2cc4338e90/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala#L218-L231
because we didn't have a way to express `[A] =>> A` in SemanticDB.

Now we support `LambdaType` in SemanticDB, maybe we can save `type Id[A] = A` as `type Id = [A] =>> A` instead of converting it to `type Id[A] = A` when converting the signature into SemanticDB. 🤔 