### PR TITLE
End marker for last invocation

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1398,6 +1398,8 @@ object Parsers {
         case _: Match => in.token == MATCH
         case _: New => in.token == NEW
         case _: (ForYield | ForDo) => in.token == FOR
+        case InfixOp(_, Ident(opname), _) => opname == in.name
+        case Apply(Select(_, opname), _) => opname == in.name
         case _ => false
 
       def endName = if in.token == IDENTIFIER then in.name.toString else tokenString(in.token)

--- a/tests/pos/end-arg.scala
+++ b/tests/pos/end-arg.scala
@@ -1,0 +1,16 @@
+
+def f =
+  Option("hello, world") orElse {
+    val text = "goodbyte"
+    val res = Some(text)
+    res
+  }
+  end orElse
+
+def g =
+  Option("hello, world").orElse {
+    val text = "goodbyte"
+    val res = Some(text)
+    res
+  }
+  end orElse


### PR DESCRIPTION
It's natural to rewrite
```
if b.exists then
  b
else
  x
end if // b.exists (label is not checked against condition)
```
to
```
opt orElse {
  x
}
end orElse  // easy to check against method name
```