### PR TITLE
Add scaladoc typography fallback fonts

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/typography.css
+++ b/scaladoc/resources/dotty_res/styles/theme/typography.css
@@ -26,85 +26,85 @@
 .h700 {
   font-size: 40px;
   line-height: 40px;
-  font-family: "Inter-Bold";
+  font-family: "Inter-Bold", sans-serif;
 }
 
 .h600 {
   font-size: 32px;
   line-height: 40px;
-  font-family: "Inter-SemiBold";
+  font-family: "Inter-SemiBold", sans-serif;
 }
 
 .h500 {
   font-size: 28px;
   line-height: 32px;
-  font-family: "Inter-Medium";
+  font-family: "Inter-Medium", sans-serif;
 }
 
 .h400 {
   font-size: 24px;
   line-height: 32px;
-  font-family: "Inter-Medium";
+  font-family: "Inter-Medium", sans-serif;
 }
 
 .h300 {
   font-size: 20px;
   line-height: 24px;
-  font-family: "Inter-Bold";
+  font-family: "Inter-Bold", sans-serif;
 }
 
 .h200 {
   font-size: 16px;
   line-height: 24px;
-  font-family: "Inter-SemiBold";
+  font-family: "Inter-SemiBold", sans-serif;
 }
 
 .h100 {
   font-size: 13px;
   line-height: 16px;
-  font-family: "Inter-SemiBold";
+  font-family: "Inter-SemiBold", sans-serif;
 }
 
 .h50 {
   font-size: 9px;
   line-height: 12px;
-  font-family: "Inter-SemiBold";
+  font-family: "Inter-SemiBold", sans-serif;
 }
 
 .body-large {
   font-size: 20px;
   line-height: 24px;
-  font-family: "Inter-Regular";
+  font-family: "Inter-Regular", sans-serif;
 }
 
 .body-medium {
   font-size: 16px;
   line-height: 24px;
-  font-family: "Inter-Regular";
+  font-family: "Inter-Regular", sans-serif;
 }
 
 .body-small {
   font-size: 13px;
   line-height: 16px;
-  font-family: "Inter-Regular";
+  font-family: "Inter-Regular", sans-serif;
 }
 
 .mono-medium {
   font-size: 16px;
   line-height: 24px;
-  font-family: "FiraCode-Regular";
+  font-family: "FiraCode-Regular", monospace;
 }
 
 .mono-small-inline {
   font-size: 13px;
   line-height: 16px;
-  font-family: "FiraCode-Regular";
+  font-family: "FiraCode-Regular", monospace;
 }
 
 .mono-small-block {
   font-size: 15px;
   line-height: 20px;
-  font-family: "FiraCode-Regular";
+  font-family: "FiraCode-Regular", monospace;
 }
 
 :root {


### PR DESCRIPTION
Adds the correct fallback fonts to the `typography.css`.
This improves readibility for users who for some reason can't load the fonts (e.g. disabled JS/custom fonts on their browsers). WIthout this change, inline code would not use a monospace font on such cases.

<details><summary>Before</summary>
  <img src ="https://user-images.githubusercontent.com/1187242/190891202-738b984c-8a06-47d0-84cf-b42c36f3b150.png">
</details>

<details><summary>After</summary>
  <img src ="https://user-images.githubusercontent.com/1187242/190891317-a4290c2a-6add-4b61-87e5-7e110131f6a3.png">
</details>

