### PR TITLE
Make the scaladoc footer text configurable

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -201,12 +201,8 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
 
     val (apiNavOpt, docsNavOpt): (Option[(Boolean, Seq[AppliedTag])], Option[(Boolean, Seq[AppliedTag])]) = buildNavigation(link)
 
-    def textFooter: String | AppliedTag =
-      args.projectFooter.fold("") { f =>
-        span(id := "footer-text")(
-          raw(f)
-        )
-      }
+    def textFooter: String =
+      args.projectFooter.getOrElse("")
 
     def quickLinks(mobile: Boolean = false): TagArg =
       val className = if mobile then "mobile-menu-item" else "text-button"
@@ -277,13 +273,9 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
         ),
         div(cls := "right-container")(
           socialLinks,
-          div(cls := "text")(
-            "© 2002-2021 · LAMP/EPFL"
-          )
+          div(cls := "text")(textFooter)
         ),
-        div(cls := "text-mobile")(
-          "© 2002-2021 · LAMP/EPFL"
-        )
+        div(cls := "text-mobile")(textFooter)
       ),
       div(id := "scaladoc-searchBar"),
       div(id := "main")(
@@ -316,13 +308,9 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
             a(href := "https://gitter.im/scala/scala") (
               button(cls := "icon-button gitter"),
             ),
-            div(cls := "text")(
-              "© 2002-2021 · LAMP/EPFL"
-            )
+            div(cls := "text")(textFooter)
           ),
-          div(cls := "text-mobile")(
-            "© 2002-2021 · LAMP/EPFL"
-          )
+          div(cls := "text-mobile")(textFooter)
         ),
       ),
     )


### PR DESCRIPTION
Among the multiple changes in #15697 the footer text stoped being configurable (defaulting to an EPFL copyright).

This PR makes the footer text configurable again.

Incidentally, this will also fix the copyright message to show 2022 (notice that the current message says 2021, while [the message defined in the build](https://github.com/lampepfl/dotty/blob/afc6ce4d2135e3532bf28146a7700d2cc4338e90/project/Build.scala#L1887) uses `$currentYear`).