### PR TITLE
Unimportant import rewrites

### DIFF
--- a/compiler/src/dotty/tools/MainGenericCompiler.scala
+++ b/compiler/src/dotty/tools/MainGenericCompiler.scala
@@ -6,16 +6,7 @@ import scala.annotation.tailrec
 import scala.io.Source
 import scala.util.Try
 import java.io.File
-import java.lang.Thread
 import scala.annotation.internal.sharable
-import dotty.tools.dotc.util.ClasspathFromClassloader
-import dotty.tools.runner.ObjectRunner
-import dotty.tools.dotc.config.Properties.envOrNone
-import dotty.tools.io.Jar
-import dotty.tools.runner.ScalaClassLoader
-import java.nio.file.Paths
-import dotty.tools.dotc.config.CommandLineParser
-import dotty.tools.scripting.StringDriver
 
 enum CompileMode:
   case Guess

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -8,7 +8,7 @@ import scala.annotation.switch
 import scala.collection.mutable.SortedMap
 
 import scala.tools.asm
-import scala.tools.asm.{Handle, Opcodes}
+import scala.tools.asm.Opcodes
 import BCodeHelpers.InvokeStyle
 
 import dotty.tools.dotc.ast.tpd

--- a/compiler/src/dotty/tools/backend/jvm/CoreBTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CoreBTypes.scala
@@ -6,7 +6,6 @@ package jvm
 import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.transform.Erasure
 import scala.tools.asm.{Handle, Opcodes}
-import dotty.tools.dotc.core.StdNames
 
 /**
  * Core BTypes and some other definitions. The initialization of these definitions requies access

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
@@ -2,7 +2,7 @@ package dotty.tools.backend.jvm
 
 import scala.language.unsafeNulls
 
-import scala.tools.asm.{ClassReader, Type, Handle }
+import scala.tools.asm.{Type, Handle}
 import scala.tools.asm.tree._
 
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -20,17 +20,13 @@ import reporting.Diagnostic
 import reporting.Diagnostic.Warning
 import rewrites.Rewrites
 import profile.Profiler
-import printing.XprintMode
 import typer.ImplicitRunInfo
 import config.Feature
 import StdNames.nme
 
-import java.io.{BufferedWriter, OutputStreamWriter}
-import java.nio.charset.StandardCharsets
 
 import scala.collection.mutable
 import scala.util.control.NonFatal
-import scala.io.Codec
 
 /** A compiler run. Exports various methods to compile source files */
 class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with ConstraintRunInfo {

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -9,7 +9,7 @@ import Decorators._, transform.SymUtils._
 import NameKinds.{UniqueName, EvidenceParamName, DefaultGetterName, WildcardParamName}
 import typer.{Namer, Checking}
 import util.{Property, SourceFile, SourcePosition, Chars}
-import config.Feature.{sourceVersion, migrateTo3, enabled}
+import config.Feature.{sourceVersion, migrateTo3}
 import config.SourceVersion._
 import collection.mutable.ListBuffer
 import reporting._

--- a/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
+++ b/compiler/src/dotty/tools/dotc/ast/DesugarEnums.scala
@@ -10,7 +10,6 @@ import util.{Property, SourceFile}
 import typer.ErrorReporting._
 import transform.SyntheticMembers.ExtendsSingletonMirror
 
-import scala.annotation.internal.sharable
 
 /** Helper methods to desugar enums */
 object DesugarEnums {

--- a/compiler/src/dotty/tools/dotc/ast/MainProxies.scala
+++ b/compiler/src/dotty/tools/dotc/ast/MainProxies.scala
@@ -2,10 +2,8 @@ package dotty.tools.dotc
 package ast
 
 import core._
-import Symbols._, Types._, Contexts._, Decorators._, util.Spans._, Flags._, Constants._
-import StdNames.{nme, tpnme}
-import ast.Trees._
-import Names.Name
+import Symbols.*, Types.*, Contexts.*, Flags.*, Constants.*
+import StdNames.nme
 import Comments.Comment
 import NameKinds.DefaultGetterName
 import Annotations.Annotation

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -7,7 +7,6 @@ import typer.ProtoTypes
 import transform.SymUtils._
 import transform.TypeUtils._
 import core._
-import Scopes.newScope
 import util.Spans._, Types._, Contexts._, Constants._, Names._, Flags._, NameOps._
 import Symbols._, StdNames._, Annotations._, Trees._, Symbols._
 import Decorators._, DenotTransformers._

--- a/compiler/src/dotty/tools/dotc/cc/BoxedTypeCache.scala
+++ b/compiler/src/dotty/tools/dotc/cc/BoxedTypeCache.scala
@@ -3,7 +3,7 @@ package dotc
 package cc
 
 import core.*
-import Types.*, Symbols.*, Contexts.*
+import Types.*, Contexts.*
 
 /** A one-element cache for the boxed version of an unboxed capturing type */
 class BoxedTypeCache:

--- a/compiler/src/dotty/tools/dotc/cc/CaptureAnnotation.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureAnnotation.scala
@@ -4,10 +4,8 @@ package cc
 
 import core.*
 import Types.*, Symbols.*, Contexts.*, Annotations.*
-import ast.Trees.*
 import ast.{tpd, untpd}
 import Decorators.*
-import config.Printers.capt
 import printing.Printer
 import printing.Texts.Text
 
@@ -21,7 +19,6 @@ import printing.Texts.Text
  *  @param cls     the underlying class (either annotation.retains or annotation.retainsByName)
  */
 case class CaptureAnnotation(refs: CaptureSet, boxed: Boolean)(cls: Symbol) extends Annotation:
-  import CaptureAnnotation.*
   import tpd.*
 
   /** A cache for boxed version of a capturing type with this annotation */

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -3,8 +3,8 @@ package dotc
 package cc
 
 import core.*
-import Types.*, Symbols.*, Contexts.*, Annotations.*, Flags.*
-import ast.{tpd, untpd}
+import Types.*, Symbols.*, Contexts.*, Flags.*
+import ast.tpd
 import Decorators.*, NameOps.*
 import config.Printers.capt
 import util.Property.Key

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -3,17 +3,14 @@ package dotc
 package cc
 
 import core.*
-import Types.*, Symbols.*, Flags.*, Contexts.*, Decorators.*
+import Types.*, Symbols.*, Contexts.*, Decorators.*
 import config.Printers.capt
 import Annotations.Annotation
-import annotation.threadUnsafe
 import annotation.constructorOnly
 import annotation.internal.sharable
-import reporting.trace
 import printing.{Showable, Printer}
 import printing.Texts.*
 import util.{SimpleIdentitySet, Property}
-import util.common.alwaysTrue
 import scala.collection.mutable
 import config.Config.ccAllowUnsoundMaps
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -3,22 +3,19 @@ package dotc
 package cc
 
 import core.*
-import Phases.*, DenotTransformers.*, SymDenotations.*
+import DenotTransformers.*, SymDenotations.*
 import Contexts.*, Names.*, Flags.*, Symbols.*, Decorators.*
-import Types.*, StdNames.*
-import config.Printers.{capt, recheckr}
-import config.Config
-import ast.{tpd, untpd, Trees}
-import Trees.*
+import Types.*
+import config.Printers.capt
+import ast.{tpd, Trees}
 import typer.RefChecks.{checkAllOverrides, checkParents}
-import util.{SimpleIdentitySet, EqHashMap, SrcPos}
+import util.{EqHashMap, SrcPos}
 import transform.SymUtils.*
 import transform.{Recheck, PreRecheck}
 import Recheck.*
 import scala.collection.mutable
 import CaptureSet.{withCaptureSetsExplained, IdempotentCaptRefMap}
 import StdNames.nme
-import reporting.trace
 
 /** The capture checker */
 object CheckCaptures:

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -3,13 +3,12 @@ package dotc
 package cc
 
 import core._
-import Phases.*, DenotTransformers.*, SymDenotations.*
-import Contexts.*, Names.*, Flags.*, Symbols.*, Decorators.*
+import DenotTransformers.*, SymDenotations.*
+import Contexts.*, Flags.*, Symbols.*, Decorators.*
 import Types.*, StdNames.*
 import config.Printers.capt
 import ast.tpd
 import transform.Recheck.*
-import CaptureSet.IdentityCaptRefMap
 import Synthetics.isExcluded
 
 /** A tree traverser that prepares a compilation unit to be capture checked.

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -12,7 +12,6 @@ import config.Printers.typr
 import typer.ProtoTypes.{newTypeVar, representedParamRef}
 import UnificationDirection.*
 import NameKinds.AvoidNameKind
-import util.SimpleIdentitySet
 import NullOpsDecorator.stripNull
 
 /** Methods for adding constraints and solving them.

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -13,7 +13,7 @@ import Scopes._
 import Uniques._
 import ast.Trees._
 import ast.untpd
-import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet, ReusableInstance}
+import util.{NoSource, SimpleIdentityMap, SourceFile, ReusableInstance}
 import typer.{Implicits, ImportInfo, SearchHistory, SearchRoot, TypeAssigner, Typer, Nullables}
 import inlines.Inliner
 import Nullables._
@@ -37,7 +37,6 @@ import util.Property.Key
 import util.Store
 import xsbti.AnalysisCallback
 import plugins._
-import java.util.concurrent.atomic.AtomicInteger
 import java.nio.file.InvalidPathException
 
 object Contexts {

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
 import Contexts._, Names._, Phases._, Symbols._
-import printing.{ Printer, Showable }, printing.Formatting._, printing.Texts._
+import printing.Showable, printing.Formatting.*, printing.Texts.*
 import transform.MegaPhase
 
 /** This object provides useful implicit decorators for types defined elsewhere */

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -8,13 +8,12 @@ import Flags._, Scopes._, Decorators._, NameOps._, Periods._, NullOpsDecorator._
 import unpickleScala2.Scala2Unpickler.ensureConstructor
 import scala.collection.mutable
 import collection.mutable
-import Denotations.{SingleDenotation, staticRef}
+import Denotations.staticRef
 import util.{SimpleIdentityMap, SourceFile, NoSource}
 import typer.ImportInfo.RootRef
 import Comments.CommentsContext
 import Comments.Comment
 import util.Spans.NoSpan
-import Symbols.requiredModuleRef
 import cc.{CapturingType, CaptureSet, EventuallyCapturingType}
 
 import scala.annotation.tailrec

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -8,7 +8,6 @@ import scala.io.Codec
 import Int.MaxValue
 import Names._, StdNames._, Contexts._, Symbols._, Flags._, NameKinds._, Types._
 import util.Chars.{isOperatorPart, digit2int}
-import Decorators.*
 import Definitions._
 import nme._
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -23,7 +23,6 @@ import scala.util.control.NonFatal
 import config.Config
 import reporting._
 import collection.mutable
-import transform.TypeUtils._
 import cc.{CapturingType, derivedCapturingType}
 
 import scala.annotation.internal.sharable

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -9,7 +9,7 @@ import SymDenotations.LazyType
 import Decorators._
 import util.Stats._
 import Names._
-import Flags.{Module, Provisional}
+import Flags.Module
 import dotty.tools.dotc.config.Config
 import cc.boxedUnlessFun
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2,13 +2,13 @@ package dotty.tools
 package dotc
 package core
 
-import Types._, Contexts._, Symbols._, Flags._, Names._, NameOps._, Denotations._
+import Types.*, Contexts.*, Symbols.*, Flags.*, Names.*, Denotations.*
 import Decorators._
 import Phases.{gettersPhase, elimByNamePhase}
 import StdNames.nme
 import TypeOps.refineUsingParent
 import collection.mutable
-import util.{Stats, NoSourcePosition, EqHashMap}
+import util.{Stats, NoSourcePosition}
 import config.Config
 import config.Feature.migrateTo3
 import config.Printers.{subtyping, gadts, matchTypes, noPrinter}

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package core
 
-import Contexts._, Types._, Symbols._, Names._, Flags._
+import Contexts.*, Types.*, Symbols.*, Flags.*
 import SymDenotations._
 import util.Spans._
 import util.Stats
@@ -16,10 +16,8 @@ import config.Feature
 import typer.ProtoTypes._
 import typer.ForceDegree
 import typer.Inferencing._
-import typer.IfBottom
-import reporting.TestingReporter
 import cc.{CapturingType, derivedCapturingType, CaptureSet, isBoxed, isBoxedCapturing}
-import CaptureSet.{CompareResult, IdempotentCaptRefMap, IdentityCaptRefMap}
+import CaptureSet.{IdempotentCaptRefMap, IdentityCaptRefMap}
 
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5,7 +5,7 @@ package core
 import Symbols._
 import Flags._
 import Names._
-import StdNames._, NameOps._
+import StdNames.*
 import NullOpsDecorator._
 import NameKinds.SkolemName
 import Scopes._
@@ -36,8 +36,8 @@ import config.Printers.{core, typr, matchTypes}
 import reporting.{trace, Message}
 import java.lang.ref.WeakReference
 import compiletime.uninitialized
-import cc.{CapturingType, CaptureSet, derivedCapturingType, isBoxedCapturing, EventuallyCapturingType, boxedUnlessFun}
-import CaptureSet.{CompareResult, IdempotentCaptRefMap, IdentityCaptRefMap}
+import cc.{CapturingType, CaptureSet, derivedCapturingType, EventuallyCapturingType, boxedUnlessFun}
+import CaptureSet.{IdempotentCaptRefMap, IdentityCaptRefMap}
 
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe

--- a/compiler/src/dotty/tools/dotc/core/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/core/Variances.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc
 package core
 
-import Types._, Contexts._, Flags._, Symbols._, Annotations._
+import Types.*, Contexts.*, Flags.*, Symbols.*
 import TypeApplications.TypeParamInfo
 import Decorators._
 

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable
 import scala.collection.mutable.{ ListBuffer, ArrayBuffer }
 import scala.annotation.switch
 import typer.Checking.checkNonCyclic
-import io.{AbstractFile, ZipArchive}
+import io.AbstractFile
 import scala.util.control.NonFatal
 
 object ClassfileParser {

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -11,7 +11,7 @@ import ast._
 import Trees.WithLazyField
 import util.{SourceFile, NoSource}
 import core._
-import Annotations._, Decorators._
+import Decorators.*
 import collection.mutable
 import util.Spans._
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyClassName.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyClassName.scala
@@ -5,7 +5,6 @@ package tasty
 import dotty.tools.tasty.{TastyBuffer, TastyReader}
 import TastyBuffer.NameRef
 
-import Contexts._, Decorators._
 import Names.TermName
 import StdNames.nme
 import TastyUnpickler._

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -5,7 +5,6 @@ package tasty
 import dotty.tools.tasty.{TastyBuffer, TastyReader}
 import TastyBuffer.NameRef
 
-import Contexts._, Decorators._
 import Names.Name
 import TastyUnpickler._
 import util.Spans.offsetToInt

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -8,7 +8,6 @@ import scala.language.unsafeNulls
 import dotty.tools.tasty.TastyFormat._
 import dotty.tools.tasty.TastyBuffer._
 
-import ast.Trees._
 import ast.{untpd, tpd}
 import Contexts._, Symbols._, Types._, Names._, Constants._, Decorators._, Annotations._, Flags._
 import Comments.{Comment, CommentsContext}

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -31,7 +31,6 @@ import util.{SourceFile, Property}
 import ast.{Trees, tpd, untpd}
 import Trees._
 import Decorators._
-import transform.SymUtils._
 import cc.adaptFunctionTypeUnderCC
 
 import dotty.tools.tasty.{TastyBuffer, TastyReader}

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Erasure.scala
@@ -3,7 +3,7 @@ package dotc
 package core
 package unpickleScala2
 
-import Symbols._, Types._, Contexts._, Flags._, Names._, StdNames._, Phases._
+import Symbols.*, Types.*, Contexts.*, Flags.*
 import Decorators._
 import scala.collection.mutable.ListBuffer
 

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -10,10 +10,10 @@ import java.lang.Float.intBitsToFloat
 import java.lang.Double.longBitsToDouble
 
 import Contexts._, Symbols._, Types._, Scopes._, SymDenotations._, Names._, NameOps._
-import StdNames._, Denotations._, NameOps._, Flags._, Constants._, Annotations._, Phases._
+import StdNames.*, Denotations.*, NameOps.*, Flags.*, Constants.*, Annotations.*
 import NameKinds.{Scala2MethodNameKinds, SuperAccessorName, ExpandedName}
 import util.Spans._
-import dotty.tools.dotc.ast.{tpd, untpd}, ast.tpd._
+import dotty.tools.dotc.ast.untpd, ast.tpd.*
 import ast.untpd.Modifiers
 import backend.sjs.JSDefinitions
 import printing.Texts._

--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -18,7 +18,7 @@ import collection.mutable
 class InlineReducer(inliner: Inliner)(using Context):
   import tpd.*
   import Inliner.{isElideableExpr, DefBuffer}
-  import inliner.{call, newSym, tryInlineArg, paramBindingDef}
+  import inliner.{call, newSym, paramBindingDef}
 
   extension (tp: Type)
     /** same as widenTermRefExpr, but preserves modules and singleton enum values */

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -10,7 +10,6 @@ import typer.*
 import Names.Name
 import NameKinds.InlineBinderName
 import ProtoTypes.shallowSelectionProto
-import SymDenotations.SymDenotation
 import Inferencing.isFullyDefined
 import config.Printers.inlining
 import ErrorReporting.errorTree

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -4,7 +4,6 @@ package inlines
 
 import ast.*, core.*
 import Flags.*, Symbols.*, Types.*, Decorators.*, Constants.*, Contexts.*
-import StdNames.tpnme
 import transform.SymUtils._
 import typer.*
 import NameKinds.BodyRetainerName
@@ -16,7 +15,6 @@ import parsing.Parsers.Parser
 import transform.{PostTyper, Inlining, CrossVersionChecks}
 
 import collection.mutable
-import reporting.trace
 import util.Spans.Span
 
 /** Support for querying inlineable methods and for inlining calls to such methods */

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -8,7 +8,7 @@ import scala.collection._
 
 import ast.{NavigateAST, Trees, tpd, untpd}
 import core._
-import Decorators._, ContextOps._
+import ContextOps.*
 import Contexts._, Flags._, Names._, NameOps._, Symbols._, Trees._, Types._
 import transform.SymUtils._
 import util.Spans._, util.SourceFile, util.SourcePosition

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -8,17 +8,15 @@ import java.net.URI
 import java.io._
 import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
-import java.nio.charset.StandardCharsets
 import java.util.zip._
 
 import scala.collection._
-import scala.io.Codec
 
 import dotty.tools.io.AbstractFile
 
 import ast.{Trees, tpd}
 import core._, core.Decorators._
-import Contexts._, Names._, NameOps._, Symbols._, SymDenotations._, Trees._, Types._
+import Contexts.*, Names.*, NameOps.*, Symbols.*, SymDenotations.*, Types.*
 import Denotations.staticRef
 import classpath._
 import reporting._

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -4,7 +4,6 @@ package parsing
 
 import scala.language.unsafeNulls
 
-import scala.annotation.internal.sharable
 import scala.collection.mutable.ListBuffer
 import scala.collection.immutable.BitSet
 import util.{ SourceFile, SourcePosition, NoSourcePosition }

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -4,7 +4,7 @@ package parsing
 
 import scala.language.unsafeNulls
 
-import core.Names._, core.Contexts._, core.Decorators._, util.Spans._
+import core.Names.*, core.Contexts.*, core.Decorators.*
 import core.StdNames._, core.Comments._
 import util.SourceFile
 import util.Chars._

--- a/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 import core._
 import Decorators._
 import Flags.Mutable
-import Names._, StdNames._, ast.Trees._, ast.{tpd, untpd}
+import Names.*, StdNames.*, ast.{tpd, untpd}
 import Symbols._, Contexts._
 import util.Spans._
 import Parsers.Parser

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -11,7 +11,6 @@ import Texts._, Types._, Flags._, Symbols._, Contexts._
 import Decorators._
 import reporting.Message
 import util.DiffUtil
-import Highlighting._
 
 object Formatting {
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -16,7 +16,7 @@ import Denotations._
 import SymDenotations._
 import StdNames.{nme, tpnme}
 import ast.{Trees, tpd, untpd}
-import typer.{Implicits, Namer, Applications}
+import typer.{Implicits, Namer}
 import typer.ProtoTypes._
 import Trees._
 import TypeApplications._
@@ -28,7 +28,7 @@ import config.Config
 
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.ast.untpd.{MemberDef, Modifiers, PackageDef, RefTree, Template, TypeDef, ValOrDefDef}
-import cc.{CaptureSet, toCaptureSet, IllegalCaptureRef}
+import cc.{toCaptureSet, IllegalCaptureRef}
 
 class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 

--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -1,6 +1,5 @@
 package dotty.tools.dotc.quoted
 
-import dotty.tools.dotc.ast.Trees._
 import dotty.tools.dotc.ast.{TreeTypeMap, tpd}
 import dotty.tools.dotc.config.Printers._
 import dotty.tools.dotc.core.Contexts._

--- a/compiler/src/dotty/tools/dotc/reporting/Profile.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Profile.scala
@@ -5,12 +5,9 @@ package reporting
 import core.*
 import Contexts.{Context, ctx}
 import Symbols.{Symbol, NoSymbol}
-import collection.mutable
-import util.{EqHashMap, NoSourcePosition}
+import util.EqHashMap
 import util.Spans.{Span, NoSpan}
-import Decorators.i
 import parsing.Scanners.Scanner
-import io.AbstractFile
 import annotation.internal.sharable
 
 abstract class Profile:

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -15,7 +15,6 @@ import collection.mutable
 
 import dotty.tools.dotc.{semanticdb => s}
 import Scala3.{FakeSymbol, SemanticSymbol, WildcardTypeSymbol, TypeParamRefSymbol, TermParamRefSymbol, RefinementSymbol}
-import dotty.tools.dotc.core.Names.Designator
 
 class TypeOps:
   import SymbolScopeOps._

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Language.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Language.scala
@@ -6,7 +6,6 @@
 
 package dotty.tools.dotc.semanticdb
 import dotty.tools.dotc.semanticdb.internal._
-import scala.annotation.internal.sharable
 
 sealed abstract class Language(val value: _root_.scala.Int)  extends SemanticdbGeneratedEnum  derives CanEqual {
   type EnumType = Language

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Schema.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Schema.scala
@@ -6,7 +6,6 @@
 
 package dotty.tools.dotc.semanticdb
 import dotty.tools.dotc.semanticdb.internal._
-import scala.annotation.internal.sharable
 
 sealed abstract class Schema(val value: _root_.scala.Int)  extends SemanticdbGeneratedEnum  derives CanEqual {
   type EnumType = Schema

--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -11,7 +11,6 @@ import NameOps._
 import Decorators._
 import TypeUtils._
 import Types._
-import util.Spans.Span
 import config.Printers.transforms
 
 /** A utility class for generating access proxies. Currently used for

--- a/compiler/src/dotty/tools/dotc/transform/CheckLoopingImplicits.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckLoopingImplicits.scala
@@ -3,7 +3,7 @@ package transform
 
 import core.*
 import MegaPhase.MiniPhase
-import Contexts.*, Types.*, Symbols.*, SymDenotations.*, Flags.*
+import Contexts.*, Types.*, Symbols.*, Flags.*
 import ast.*
 import Decorators.*
 import StdNames.*

--- a/compiler/src/dotty/tools/dotc/transform/CheckNoSuperThis.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckNoSuperThis.scala
@@ -3,7 +3,7 @@ package transform
 
 import core.*
 import MegaPhase.MiniPhase
-import Contexts.*, Types.*, Symbols.*, SymDenotations.*, Flags.*
+import Contexts.*, Types.*, Symbols.*, Flags.*
 import ast.*
 import Decorators.*
 

--- a/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
@@ -3,10 +3,10 @@ package dotc
 package transform
 
 import ast.{Trees, tpd}
-import core._, core.Decorators._
+import core.*
 import MegaPhase._
 import Types._, Contexts._, Flags._, DenotTransformers._, Phases._
-import Symbols._, StdNames._, Trees._
+import Symbols.*, StdNames.*
 import TypeErasure.ErasedValueType, ValueClasses._
 import reporting._
 import NameKinds.SuperAccessorName

--- a/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimPolyFunction.scala
@@ -3,10 +3,9 @@ package transform
 
 import ast.{Trees, tpd}
 import core._, core.Decorators._
-import MegaPhase._, Phases.Phase
-import Types._, Contexts._, Constants._, Names._, NameOps._, Flags._, DenotTransformers._
-import SymDenotations._, Symbols._, StdNames._, Annotations._, Trees._, Scopes._, Denotations._
-import TypeErasure.ErasedValueType, ValueClasses._
+import MegaPhase.*
+import Types.*, Contexts.*, DenotTransformers.*
+import SymDenotations.*, Symbols.*, StdNames.*, Denotations.*
 
 /** This phase rewrite PolyFunction subclasses to FunctionN subclasses
  *

--- a/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
@@ -4,7 +4,7 @@ package transform
 
 import MegaPhase.MiniPhase
 import core.*
-import Symbols.*, Contexts.*, Types.*, Decorators.*
+import Symbols.*, Contexts.*, Decorators.*
 import StdNames.nme
 import SymUtils.*
 import NameKinds.AdaptedClosureName

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -3,7 +3,6 @@ package dotc
 package transform
 
 import core._
-import Scopes.newScope
 import Contexts._, Symbols._, Types._, Flags._, Decorators._, StdNames._, Constants._
 import MegaPhase._
 import SymUtils._

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc
 package transform
 
 import core._
-import Contexts._, Types._, MegaPhase._, ast.Trees._, Symbols._, Decorators._, Flags._
+import Contexts.*, Types.*, MegaPhase.*, Symbols.*, Decorators.*, Flags.*
 import SymUtils.*
 
 /** Transform references of the form

--- a/compiler/src/dotty/tools/dotc/transform/ForwardDepChecks.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ForwardDepChecks.scala
@@ -3,7 +3,7 @@ package dotc
 package transform
 
 import core.*
-import Symbols.*, Types.*, Contexts.*, Flags.*, Decorators.*, reporting.*
+import Symbols.*, Types.*, Contexts.*, Flags.*, reporting.*
 import util.Spans.Span
 import util.Store
 import collection.immutable

--- a/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
@@ -4,7 +4,7 @@ package transform
 
 import core._
 import MegaPhase._
-import Symbols._, Contexts._, Types._, Decorators._
+import Contexts.*, Types.*, Decorators.*
 import NameOps._
 import Names._
 

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -8,7 +8,6 @@ import Symbols._
 import SymUtils._
 import dotty.tools.dotc.ast.tpd
 
-import dotty.tools.dotc.core.StagingContext._
 import dotty.tools.dotc.inlines.Inlines
 import dotty.tools.dotc.ast.TreeMapWithImplicits
 

--- a/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LetOverApply.scala
@@ -3,7 +3,7 @@ package dotc
 package transform
 
 import core._
-import Contexts._, Symbols._, Decorators._
+import Contexts.*
 import MegaPhase._
 
 /** Rewrite `{ stats; expr}.f(args)` to `{ stats; expr.f(args) }` and

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -3,7 +3,7 @@ package dotc
 package transform
 
 import core._
-import Contexts._, Phases._, Symbols._, Decorators._
+import Contexts.*, Phases.*, Symbols.*
 import Flags.PackageVal
 
 /** A MegaPhase combines a number of mini-phases which are all executed in

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -3,9 +3,8 @@ package dotc
 package transform
 
 import core._
-import Flags._, Symbols._, Contexts._, Scopes._, Decorators._, Types.Type
+import Flags.*, Symbols.*, Contexts.*, Scopes.*, Types.Type
 import NameKinds.DefaultGetterName
-import NullOpsDecorator._
 import collection.immutable.BitSet
 import scala.annotation.tailrec
 

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -3,7 +3,7 @@ package dotc
 package transform
 
 import core._
-import Contexts._, Types._, Symbols._, Flags._, TypeUtils._, DenotTransformers._, StdNames._
+import Contexts.*, Symbols.*, Flags.*, TypeUtils.*, DenotTransformers.*, StdNames.*
 import Decorators._
 import MegaPhase._
 import NameKinds.ParamAccessorName

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -10,7 +10,6 @@ import Symbols._, Contexts._, Types._, StdNames._, NameOps._
 import util.Spans._
 import typer.Applications.*
 import SymUtils._
-import TypeUtils.*
 import Flags._, Constants._
 import Decorators._
 import NameKinds.{PatMatStdBinderName, PatMatAltsName, PatMatResultName}

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -8,21 +8,15 @@ import Types._
 import Contexts._
 import Symbols._
 import Constants._
-import ast.Trees._
-import ast.TreeTypeMap
 import SymUtils._
 import NameKinds._
 import dotty.tools.dotc.ast.tpd
-import dotty.tools.dotc.config.ScalaRelease.*
 
-import scala.collection.mutable
-import dotty.tools.dotc.core.Annotations._
 import dotty.tools.dotc.core.StdNames._
 import dotty.tools.dotc.quoted._
 import dotty.tools.dotc.transform.TreeMapWithStages._
 import dotty.tools.dotc.inlines.Inlines
 
-import scala.annotation.constructorOnly
 
 /** Translates quoted terms and types to `unpickleExprV2` or `unpickleType` method calls.
  *
@@ -73,7 +67,6 @@ import scala.annotation.constructorOnly
  *
  */
 class PickleQuotes extends MacroTransform {
-  import PickleQuotes._
   import tpd._
 
   override def phaseName: String = PickleQuotes.name

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -1,21 +1,18 @@
 package dotty.tools.dotc
 package transform
 
-import dotty.tools.dotc.ast.{Trees, tpd, untpd, desugar}
-import scala.collection.mutable
+import dotty.tools.dotc.ast.{Trees, tpd, desugar}
 import core._
 import dotty.tools.dotc.typer.Checking
 import dotty.tools.dotc.inlines.Inlines
 import dotty.tools.dotc.typer.VarianceChecker
 import typer.ErrorReporting.errorTree
 import Types._, Contexts._, Names._, Flags._, DenotTransformers._, Phases._
-import SymDenotations._, StdNames._, Annotations._, Trees._, Scopes._
+import SymDenotations.*, StdNames.*, Annotations.*, Scopes.*
 import Decorators._
-import Symbols._, SymUtils._, NameOps._
+import Symbols.*, SymUtils.*
 import ContextFunctionResults.annotateContextResults
 import config.Printers.typr
-import util.SrcPos
-import reporting._
 import NameKinds.WildcardParamName
 
 object PostTyper {

--- a/compiler/src/dotty/tools/dotc/transform/PreRecheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PreRecheck.scala
@@ -3,7 +3,7 @@ package transform
 
 import core.Phases.Phase
 import core.DenotTransformers.DenotTransformer
-import core.Contexts.{Context, ctx}
+import core.Contexts.Context
 
 /** A base class for a phase that precedes a rechecker and that allows installing
  *  new types for local symbols.

--- a/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
@@ -12,7 +12,6 @@ import MegaPhase.MiniPhase
 import ast.tpd
 import SymUtils._
 import config.Feature
-import Decorators.*
 
 /** This phase makes all erased term members of classes private so that they cannot
  *  conflict with non-erased members. This is needed so that subsequent phases like

--- a/compiler/src/dotty/tools/dotc/transform/PureStats.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PureStats.scala
@@ -2,10 +2,10 @@ package dotty.tools.dotc
 package transform
 
 import ast.{Trees, tpd}
-import core._, core.Decorators._
+import core.*
 import MegaPhase._
-import Types._, Contexts._, Flags._, DenotTransformers._
-import Symbols._, StdNames._, Trees._
+import Contexts.*
+import Symbols.*
 
 object PureStats {
   val name: String = "pureStats"

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -9,16 +9,13 @@ import ast.*
 import Names.Name
 import Phases.Phase
 import DenotTransformers.{DenotTransformer, IdentityDenotTransformer, SymTransformer}
-import NamerOps.{methodType, linkConstructorParams}
+import NamerOps.linkConstructorParams
 import NullOpsDecorator.stripNull
 import typer.ErrorReporting.err
-import typer.ProtoTypes.*
 import typer.TypeAssigner.seqLitType
 import typer.ConstFold
-import NamerOps.methodType
 import config.Printers.recheckr
 import util.Property
-import StdNames.nme
 import reporting.trace
 import annotation.constructorOnly
 

--- a/compiler/src/dotty/tools/dotc/transform/ReifiedReflect.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifiedReflect.scala
@@ -2,24 +2,13 @@ package dotty.tools.dotc
 package transform
 
 import core._
-import Decorators._
-import Flags._
 import Types._
 import Contexts._
 import Symbols._
-import SymUtils._
-import NameKinds._
 import dotty.tools.dotc.ast.tpd
 import tpd._
 
-import scala.collection.mutable
-import dotty.tools.dotc.core.Annotations._
-import dotty.tools.dotc.core.Names._
-import dotty.tools.dotc.core.StdNames._
-import dotty.tools.dotc.quoted._
-import dotty.tools.dotc.transform.TreeMapWithStages._
 
-import scala.annotation.constructorOnly
 
 /** Helper methods to construct trees calling methods in `Quotes.reflect` based on the current `quotes` tree */
 trait ReifiedReflect:

--- a/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
@@ -12,7 +12,6 @@ import DenotTransformers._
 import Names._
 import NameOps._
 import NameKinds._
-import NullOpsDecorator._
 import ResolveSuper._
 import reporting.IllegalSuperAccessor
 

--- a/compiler/src/dotty/tools/dotc/transform/SpecializeApplyMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeApplyMethods.scala
@@ -1,9 +1,9 @@
 package dotty.tools.dotc
 package transform
 
-import ast.Trees._, ast.tpd, core._
-import Contexts._, Types._, Decorators._, Symbols._, DenotTransformers._
-import SymDenotations._, Scopes._, StdNames._, NameOps._, Names._
+import core.*
+import Contexts.*, Types.*, Symbols.*, DenotTransformers.*
+import StdNames.*, NameOps.*, Names.*
 import MegaPhase.MiniPhase
 
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/transform/SpecializeFunctions.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeFunctions.scala
@@ -1,9 +1,9 @@
 package dotty.tools.dotc
 package transform
 
-import ast.Trees._, ast.tpd, core._
-import Contexts._, Types._, Decorators._, Symbols._, DenotTransformers._
-import SymDenotations._, Scopes._, StdNames._, NameOps._, Names._
+import ast.tpd, core.*
+import Contexts.*, Types.*, Symbols.*
+import StdNames.*, NameOps.*, Names.*
 import MegaPhase.MiniPhase
 
 

--- a/compiler/src/dotty/tools/dotc/transform/SpecializeTuples.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeTuples.scala
@@ -2,9 +2,9 @@ package dotty.tools
 package dotc
 package transform
 
-import ast.Trees.*, ast.tpd, core.*
-import Contexts.*, Types.*, Decorators.*, Symbols.*, DenotTransformers.*
-import SymDenotations.*, Scopes.*, StdNames.*, NameOps.*, Names.*
+import ast.tpd, core.*
+import Contexts.*, Types.*, Symbols.*
+import StdNames.*, NameOps.*
 import MegaPhase.MiniPhase
 import inlines.Inliner.isElideableExpr
 

--- a/compiler/src/dotty/tools/dotc/transform/Splicing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicing.scala
@@ -9,22 +9,15 @@ import Contexts._
 import Symbols._
 import Constants._
 import ast.Trees._
-import ast.{TreeTypeMap, untpd}
-import util.Spans._
-import SymUtils._
 import NameKinds._
 import dotty.tools.dotc.ast.tpd
 import StagingContext._
 
 import scala.collection.mutable
 import dotty.tools.dotc.core.Annotations._
-import dotty.tools.dotc.core.Names._
 import dotty.tools.dotc.core.StdNames._
-import dotty.tools.dotc.quoted._
 import dotty.tools.dotc.transform.TreeMapWithStages._
-import dotty.tools.dotc.config.ScalaRelease.*
 
-import scala.annotation.constructorOnly
 
 object Splicing:
   val name: String = "splicing"

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -6,7 +6,7 @@ import dotty.tools.dotc.ast.{Trees, tpd}
 import scala.collection.mutable
 import ValueClasses.isMethodWithExtension
 import core._
-import Contexts._, Flags._, Symbols._, Names._, StdNames._, NameOps._, Trees._
+import Contexts.*, Flags.*, Symbols.*, Names.*, StdNames.*, NameOps.*
 import TypeUtils._, SymUtils._
 import DenotTransformers.DenotTransformer
 import Symbols._

--- a/compiler/src/dotty/tools/dotc/transform/TreeExtractors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeExtractors.scala
@@ -3,7 +3,7 @@ package transform
 
 import ast.{Trees, tpd}
 import core._
-import Contexts._, Trees._, Types._, StdNames._, Symbols._
+import Contexts.*, Types.*, StdNames.*, Symbols.*
 import ValueClasses._
 
 object TreeExtractors {

--- a/compiler/src/dotty/tools/dotc/transform/VCInlineMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/VCInlineMethods.scala
@@ -4,7 +4,7 @@ package transform
 
 import ast.{Trees, tpd}
 import core._
-import Contexts._, Trees._, Types._
+import Contexts.*, Types.*
 import DenotTransformers._, MegaPhase._
 import ExtensionMethods._, ValueClasses._
 

--- a/compiler/src/dotty/tools/dotc/transform/init/Errors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Errors.scala
@@ -8,7 +8,7 @@ import core._
 import util.SourcePosition
 import util.Property
 import Decorators._, printing.SyntaxHighlighting
-import Types._, Symbols._, Contexts._
+import Symbols.*, Contexts.*
 
 import scala.collection.mutable
 

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
@@ -14,7 +14,7 @@ import Contexts._
 import Decorators._
 import DenotTransformers._
 import Flags._
-import NameKinds.{DefaultGetterName, ModuleClassName}
+import NameKinds.DefaultGetterName
 import NameOps._
 import StdNames._
 import Symbols._

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -26,7 +26,7 @@ import inlines.Inlines
 import transform.SymUtils._
 import transform.ValueClasses._
 import Decorators._
-import ErrorReporting.{err, errorType}
+import ErrorReporting.errorType
 import config.Printers.{typr, patmatch}
 import NameKinds.DefaultGetterName
 import NameOps._

--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -5,7 +5,7 @@ package transform
 import core.*
 import Symbols.*, Types.*, Contexts.*, Flags.*, SymUtils.*, Decorators.*, reporting.*
 import util.SrcPos
-import config.{ScalaVersion, NoScalaVersion, Feature, ScalaRelease}
+import config.{ScalaVersion, NoScalaVersion, Feature}
 import MegaPhase.MiniPhase
 import scala.util.{Failure, Success}
 import ast.tpd

--- a/compiler/src/dotty/tools/dotc/typer/Deriving.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Deriving.scala
@@ -6,7 +6,7 @@ import core._
 import ast._
 import ast.Trees._
 import StdNames._
-import Contexts._, Symbols._, Types._, SymDenotations._, Names._, NameOps._, Flags._, Decorators._
+import Contexts.*, Symbols.*, Types.*, Names.*, Flags.*, Decorators.*
 import ProtoTypes._, ContextOps._
 import util.Spans._
 import util.SrcPos

--- a/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
@@ -3,7 +3,7 @@ package dotc
 package typer
 
 import core._
-import Contexts._, Symbols._, Decorators._, Comments.{_, given}
+import Contexts.*, Symbols.*, Comments.{*, given}
 import ast.tpd
 
 object Docstrings {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -22,7 +22,6 @@ import StdNames._
 import ProtoTypes._
 import ErrorReporting._
 import Inferencing.{fullyDefinedType, isFullyDefined}
-import Scopes.newScope
 import transform.TypeUtils._
 import Hashable._
 import util.{EqHashMap, Stats}

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -6,7 +6,7 @@ import ast.{tpd, untpd}
 import core._
 import printing.{Printer, Showable}
 import util.SimpleIdentityMap
-import Symbols._, Names._, Types._, Contexts._, StdNames._, Flags._
+import Symbols.*, Names.*, Types.*, Contexts.*, Flags.*
 import Implicits.RenamedImplicitRef
 import StdNames.nme
 import printing.Texts.Text

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -12,7 +12,6 @@ import util.{Stats, SimpleIdentityMap, SrcPos}
 import Decorators._
 import config.Printers.{gadts, typr}
 import annotation.tailrec
-import reporting._
 import collection.mutable
 
 import scala.annotation.internal.sharable

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -6,7 +6,7 @@ import core._
 import ast._
 import Trees._, StdNames._, Scopes._, Denotations._, NamerOps._, ContextOps._
 import Contexts._, Symbols._, Types._, SymDenotations._, Names._, NameOps._, Flags._
-import Decorators._, Comments.{_, given}
+import Decorators.*, Comments.given
 import NameKinds.DefaultGetterName
 import ast.desugar, ast.desugar._
 import ProtoTypes._

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -2,8 +2,6 @@ package dotty.tools.dotc
 package typer
 
 import dotty.tools.dotc.ast._
-import dotty.tools.dotc.config.Feature._
-import dotty.tools.dotc.config.SourceVersion._
 import dotty.tools.dotc.core._
 import dotty.tools.dotc.core.Annotations._
 import dotty.tools.dotc.core.Contexts._

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -5,7 +5,7 @@ package typer
 import transform._
 import core._
 import Symbols._, Types._, Contexts._, Flags._, Names._, NameOps._, NameKinds._
-import StdNames._, Denotations._, SymUtils._, Phases._, SymDenotations._
+import StdNames.*, SymUtils.*, Phases.*, SymDenotations.*
 import NameKinds.DefaultGetterName
 import util.Spans._
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -14,7 +14,6 @@ import ast.untpd
 import transform.SymUtils._
 import transform.TypeUtils._
 import transform.SyntheticMembers._
-import util.Property
 import ast.Trees.genericEmptyTree
 import annotation.{tailrec, constructorOnly}
 import ast.tpd._

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -10,7 +10,7 @@ import util.SrcPos
 import NameOps._
 import collection.mutable
 import reporting._
-import Checking.{checkNoPrivateLeaks, checkNoWildcard}
+import Checking.checkNoPrivateLeaks
 import cc.CaptureSet
 
 trait TypeAssigner {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -50,7 +50,6 @@ import reporting._
 import Nullables._
 import NullOpsDecorator._
 import cc.CheckCaptures
-import config.Config
 
 import scala.annotation.constructorOnly
 

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -3,7 +3,7 @@ package typer
 
 import dotty.tools.dotc.ast.{ Trees, tpd }
 import core._
-import Types._, Contexts._, Flags._, Symbols._, Trees._
+import Types.*, Contexts.*, Flags.*, Symbols.*
 import Decorators._
 import Variances._
 import NameKinds._

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -11,8 +11,6 @@ import core.NameOps.isUnapplyName
 import core.Names._
 import core.NameKinds
 import core.Types._
-import core.Symbols.NoSymbol
-import interactive.Interactive
 import util.Spans.Span
 import reporting._
 

--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -11,7 +11,6 @@ import core.Contexts._
 import scala.io.Codec
 import Chars._
 import scala.annotation.internal.sharable
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.chaining.given
 
@@ -19,7 +18,6 @@ import java.io.File.separator
 import java.nio.charset.StandardCharsets
 import java.nio.file.{FileSystemException, NoSuchFileException}
 import java.util.Optional
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 
 object ScriptSourceFile {
@@ -60,7 +58,6 @@ object ScriptSourceFile {
 }
 
 class SourceFile(val file: AbstractFile, computeContent: => Array[Char]) extends interfaces.SourceFile {
-  import SourceFile._
 
   private var myContent: Array[Char] | Null = null
 

--- a/compiler/src/dotty/tools/dotc/util/Spans.scala
+++ b/compiler/src/dotty/tools/dotc/util/Spans.scala
@@ -1,7 +1,6 @@
 package dotty.tools.dotc
 package util
 
-import language.implicitConversions
 
 /** The offsets part of a full position, consisting of 2 or 3 entries:
  *    - start:  the start offset of the span, in characters from start of file

--- a/compiler/src/dotty/tools/runner/ScalaClassLoader.scala
+++ b/compiler/src/dotty/tools/runner/ScalaClassLoader.scala
@@ -4,7 +4,6 @@ package runner
 import scala.language.unsafeNulls
 
 import java.lang.ClassLoader
-import java.lang.invoke.{MethodHandles, MethodType}
 import java.lang.reflect.Modifier
 import java.net.{ URL, URLClassLoader }
 import java.lang.reflect.{ InvocationTargetException, UndeclaredThrowableException }

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -1,7 +1,6 @@
 package scala
 
 import annotation.showAsInfix
-import compiletime._
 import compiletime.ops.int._
 
 /** Tuple of arbitrary arity */

--- a/library/src/scala/annotation/newMain.scala
+++ b/library/src/scala/annotation/newMain.scala
@@ -10,7 +10,6 @@ package scala.annotation
 
 import scala.collection.mutable
 import scala.util.CommandLineParser.FromString
-import scala.annotation.meta.param
 
 /**
  * The annotation that designates a main function.

--- a/library/src/scala/quoted/Type.scala
+++ b/library/src/scala/quoted/Type.scala
@@ -1,6 +1,6 @@
 package scala.quoted
 
-import scala.annotation.{compileTimeOnly, experimental}
+import scala.annotation.compileTimeOnly
 
 /** Type (or type constructor) `T` needed contextually when using `T` in a quoted expression `'{... T ...}` */
 abstract class Type[T <: AnyKind] private[scala]:

--- a/library/src/scala/quoted/runtime/Expr.scala
+++ b/library/src/scala/quoted/runtime/Expr.scala
@@ -1,7 +1,7 @@
 package scala.quoted
 package runtime
 
-import scala.annotation.{Annotation, compileTimeOnly}
+import scala.annotation.compileTimeOnly
 
 @compileTimeOnly("Illegal reference to `scala.quoted.runtime.Expr`")
 object Expr:

--- a/library/src/scala/runtime/coverage/Invoker.scala
+++ b/library/src/scala/runtime/coverage/Invoker.scala
@@ -2,7 +2,6 @@ package scala.runtime.coverage
 
 import scala.collection.mutable.{BitSet, AnyRefMap}
 import scala.collection.concurrent.TrieMap
-import java.nio.file.Files
 import java.io.FileWriter
 import java.io.File
 import scala.annotation.internal.sharable

--- a/library/src/scala/util/FromDigits.scala
+++ b/library/src/scala/util/FromDigits.scala
@@ -1,6 +1,5 @@
 package scala.util
 import scala.math.{BigInt}
-import quoted._
 import annotation.internal.sharable
 
 


### PR DESCRIPTION
It's not fun without the converse, rewriting to supply missing imports from well-known locations, such as `Decorators`.