### PR TITLE
Correctly render codeblock in experimental-defs.md

### DIFF
--- a/docs/_docs/reference/other-new-features/experimental-defs.md
+++ b/docs/_docs/reference/other-new-features/experimental-defs.md
@@ -216,6 +216,7 @@ Experimental definitions can only be referenced in an experimental scope. Experi
 
    <details>
    <summary>Example 1</summary>
+   
    ```scala
    import scala.annotation.experimental
 
@@ -241,6 +242,7 @@ Experimental definitions can only be referenced in an experimental scope. Experi
      }
    }
    ```
+   
    </details>
 
 5. Annotations of an experimental definition are in experimental scopes. Examples:


### PR DESCRIPTION
Because of the missing newlines I think 
<img width="723" alt="image" src="https://user-images.githubusercontent.com/1052965/190992410-f8a69215-212e-4781-86b2-3426b1dd7478.png">
