### PR TITLE
bugfix: Traverse annotations in NavigateAST

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
+++ b/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
@@ -111,7 +111,12 @@ object NavigateAST {
             p.forceIfLazy
           case _ =>
         }
-        childPath(p.productIterator, p :: path)
+        val iterator = p match
+          case defdef: DefTree[?] =>
+            p.productIterator ++ defdef.mods.productIterator
+          case _ =>
+            p.productIterator 
+        childPath(iterator, p :: path)
       }
       else {
         p match {

--- a/language-server/test/dotty/tools/languageserver/HoverTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HoverTest.scala
@@ -244,4 +244,10 @@ class HoverTest {
       .hover(m1 to m2, hoverContent("Double"))
       .hover(m3 to m4, hoverContent("Double"))
   }
+
+  @Test def annotation: Unit = {
+    code"""|@${m1}deprecated${m2} def ${m3}x${m4} = 42.0"""
+      .hover(m1 to m2, hoverContent("deprecated"))
+      .hover(m3 to m4, hoverContent("Double"))
+  }
 }


### PR DESCRIPTION
Previously, we wouldn't find any symbols inside annotations. Now we do find them correctly.

I wonder if this should also be done in some other places such as TreeAccumulator, I can follow up later with that since it might be a bit more dangerous change