### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,9 @@ env:
 # `java` (we could use the `_JAVA_OPTIONS` environment variable, but this prints
 # text on stderr and so can break tests which check the output of a program).
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test_non_bootstrapped:
     runs-on: [self-hosted, Linux]
@@ -528,6 +531,9 @@ jobs:
           ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
 
   nightly_documentation:
+    permissions:
+      contents: write # to push pages branch (peaceiris/actions-gh-pages)
+
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2021-03-22
@@ -706,6 +712,10 @@ jobs:
 
 
   open_issue_on_failure:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      issues: write # to create new issues (jasonetco/create-an-issue)
+
     runs-on: [self-hosted, Linux]
     container:
       image: lampepfl/dotty:2021-03-22

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main # default branch of the project
+permissions:
+  contents: read # to fetch code (actions/checkout)
 jobs:
   dependency-graph:
     name: Update Dependency Graph


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.