### PR TITLE
Change Show Tuple2 instance to generic tuple

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -58,9 +58,9 @@ object Formatting {
         def show(x: Seq[X]) = new CtxShow:
           def run(using Context) = x.map(show1)
 
-      given [A: Show, B: Show]: Show[(A, B)] with
-        def show(x: (A, B)) = new CtxShow:
-          def run(using Context) = (show1(x._1), show1(x._2))
+      given [H: Show, T <: Tuple: Show]: Show[H *: T] with
+        def show(x: H *: T) = new CtxShow:
+          def run(using Context) = show1(x.head) *: Show[T].show(x.tail).ctxShow.asInstanceOf[Tuple]
 
       given [X: Show]: Show[X | Null] with
         def show(x: X | Null) = if x == null then "null" else Show[X].show(x.nn)

--- a/compiler/test/dotty/tools/dotc/StringFormatterTest.scala
+++ b/compiler/test/dotty/tools/dotc/StringFormatterTest.scala
@@ -22,6 +22,7 @@ class StringFormatterTest extends AbstractStringFormatterTest:
   @Test def flagsSeq   = check("<static>, final", i"${Seq(JavaStatic, Final)}%, %")
   @Test def flagsTup   = check("(<static>,final)", i"${(JavaStatic, Final)}")
   @Test def seqOfTup2  = check("(final,given), (private,lazy)", i"${Seq((Final, Given), (Private, Lazy))}%, %")
+  @Test def seqOfTup3  = check("(Foo,given, (right is approximated))", i"${Seq((Foo, Given, TypeComparer.ApproxState.None.addHigh))}%, %")
 
   class StorePrinter extends Printer:
     var string: String = "<never set>"
@@ -76,6 +77,11 @@ class ExStringFormatterTest extends AbstractStringFormatterTest:
                                   |where:    Foo  is a type
                                   |          Foo² is a type
                                   |""".stripMargin, ex"${(Foo, Foo)}")
+  @Test def seqOfTup3Amb = check("""[(Foo,Foo²,<nonsensical>type Err</nonsensical>)]
+                                   |
+                                   |where:    Foo  is a type
+                                   |          Foo² is a type
+                                   |""".stripMargin, ex"${Seq((Foo, Foo, Err))}")
 end ExStringFormatterTest
 
 abstract class AbstractStringFormatterTest extends DottyTest:


### PR DESCRIPTION
I tried to show a Tuple3 and it fell back to Show[Product]
(which then calls toString).

So let's use our generic tuples - don't even need a macro!
