### PR TITLE
Let accesors inherit @experimental annotations from accessed symvbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -80,6 +80,8 @@ abstract class AccessProxies {
       val sym = newSymbol(owner, name, Synthetic | Method, info, coord = accessed.span).entered
       if accessed.is(Private) then sym.setFlag(Final)
       else if sym.allOverriddenSymbols.exists(!_.is(Deferred)) then sym.setFlag(Override)
+      if accessed.hasAnnotation(defn.ExperimentalAnnot) then
+        sym.addAnnotation(defn.ExperimentalAnnot)
       sym
     }
 

--- a/tests/pos-custom-args/no-experimental/i16091.scala
+++ b/tests/pos-custom-args/no-experimental/i16091.scala
@@ -1,0 +1,9 @@
+import scala.annotation.experimental
+
+object Macro {
+  @experimental
+  inline def foo() = fooImpl
+
+  @experimental
+  private def fooImpl = ()
+}


### PR DESCRIPTION
Fixes #16091