### PR TITLE
Refine checking for outer references

### DIFF
--- a/tests/pos/i16119.scala
+++ b/tests/pos/i16119.scala
@@ -1,0 +1,16 @@
+class Foo:
+  self =>
+  type T = this.type
+  val foo: T = ???
+  object bar:
+    inline def baz(): Any =
+      ??? : T
+
+  bar.baz()
+
+class Foo2:
+  self =>
+  object bar:
+    inline def baz(): Any = ??? : self.type
+
+  bar.baz()

--- a/tests/pos/i16119.scala
+++ b/tests/pos/i16119.scala
@@ -14,3 +14,22 @@ class Foo2:
     inline def baz(): Any = ??? : self.type
 
   bar.baz()
+
+class Foo3:
+
+  type T
+  object bar:
+    inline def baz(): Any = ??? : List[T]
+
+  bar.baz()
+
+class Foo4:
+  self =>
+
+  type T
+  object bar:
+    inline def baz(): Any =
+      val xs: Foo4 { type T = self.T } = ???
+      xs
+
+  bar.baz()


### PR DESCRIPTION
Outer references should also count anywhere in a type if we are in the scope of an inline method. Expansions of calls to these methods will have to reference these types using outer accessors.

Fixes #16119