### PR TITLE
Create boxed environments only for references and function values

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -520,7 +520,8 @@ class CheckCaptures extends Recheck, SymTransformer:
         case _: RefTree => true
         case _          => false
 
-    /** If expected type `pt` is boxed, don't propagate free variables.
+    /** If expected type `pt` is boxed and the tree is a function or a reference,
+     *  don't propagate free variables.
      *  Otherwise, if the result type is boxed, simulate an unboxing by
      *  adding all references in the boxed capture set to the current environment.
      */
@@ -528,7 +529,6 @@ class CheckCaptures extends Recheck, SymTransformer:
       if tree.isTerm && pt.isBoxedCapturing then
         val saved = curEnv
         if tree.isRefTree || tree.isFunctionLiteral then
-          curEnv = Env(curEnv.owner, CaptureSet.Var(), isBoxed = true, curEnv)
           curEnv = Env(curEnv.owner, nestedInOwner = false, CaptureSet.Var(), isBoxed = true, curEnv)
         try super.recheck(tree, pt)
         finally curEnv = saved

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -516,9 +516,9 @@ class CheckCaptures extends Recheck, SymTransformer:
         case _ =>
           false
 
-      private def isIdent: Boolean = tree match
-        case Ident(_) => true
-        case _        => false
+      private def isRefTree: Boolean = tree match
+        case _: RefTree => true
+        case _          => false
 
     /** If expected type `pt` is boxed, don't propagate free variables.
      *  Otherwise, if the result type is boxed, simulate an unboxing by
@@ -527,7 +527,8 @@ class CheckCaptures extends Recheck, SymTransformer:
     override def recheck(tree: Tree, pt: Type = WildcardType)(using Context): Type =
       if tree.isTerm && pt.isBoxedCapturing then
         val saved = curEnv
-        if tree.isIdent || tree.isFunctionLiteral then
+        if tree.isRefTree || tree.isFunctionLiteral then
+          curEnv = Env(curEnv.owner, CaptureSet.Var(), isBoxed = true, curEnv)
           curEnv = Env(curEnv.owner, nestedInOwner = false, CaptureSet.Var(), isBoxed = true, curEnv)
         try super.recheck(tree, pt)
         finally curEnv = saved

--- a/tests/pos-custom-args/captures/boxmap.scala
+++ b/tests/pos-custom-args/captures/boxmap.scala
@@ -9,7 +9,7 @@ def box[T <: Top](x: T): Box[T] =
 def map[A <: Top, B <: Top](b: Box[A])(f: A => B): Box[B] =
   b[Box[B]]((x: A) => box(f(x)))
 
-def lazymap[A <: Top, B <: Top](b: Box[A])(f: A => B): (() -> Box[B]) =
+def lazymap[A <: Top, B <: Top](b: Box[A])(f: A => B): {f} (() -> Box[B]) =
   () => b[Box[B]]((x: A) => box(f(x)))
 
 def test[A <: Top, B <: Top] =


### PR DESCRIPTION
Fixes #16114.

According to the [comment](https://github.com/lampepfl/dotty/issues/16114#issuecomment-1259691904) in the issue, only create boxed environment when the rechecked tree is a reference or a function value.

This PR also fixes a testcase, as explained in this [commit](https://github.com/lampepfl/dotty/commit/25daaa8cf171b255709bb1cb930eeff20365a347).