### PR TITLE
Update asm to 9.4

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
@@ -54,6 +54,7 @@ trait BCodeIdiomatic {
     case "17" => asm.Opcodes.V17
     case "18" => asm.Opcodes.V18
     case "19" => asm.Opcodes.V19
+    case "20" => asm.Opcodes.V20
   }
 
   lazy val majorVersion: Int = (classfileVersion & 0xFF)

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -17,7 +17,7 @@ class ScalaSettings extends SettingGroup with AllScalaSettings
 object ScalaSettings:
   // Keep synchronized with `classfileVersion` in `BCodeIdiomatic`
   private val minTargetVersion = 8
-  private val maxTargetVersion = 19
+  private val maxTargetVersion = 20
 
   def supportedTargetVersions: List[String] =
     (minTargetVersion to maxTargetVersion).toList.map(_.toString)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -545,7 +545,7 @@ object Build {
 
       // get libraries onboard
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" % "scala-asm" % "9.3.0-scala-1", // used by the backend
+        "org.scala-lang.modules" % "scala-asm" % "9.4.0-scala-1", // used by the backend
         Dependencies.oldCompilerInterface, // we stick to the old version to avoid deprecation warnings
         "org.jline" % "jline-reader" % "3.19.0",   // used by the REPL
         "org.jline" % "jline-terminal" % "3.19.0",


### PR DESCRIPTION
There's first some work to be done in https://github.com/scala/scala-asm.

scala 2.12.x PR: https://github.com/scala/scala/pull/10185
scala 2.13.x PR: https://github.com/scala/scala/pull/10184