### PR TITLE
Handle copies of constrained type lambdas when determining an implicit scope

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -627,6 +627,9 @@ trait ImplicitRunInfo:
               traverse(t.underlying)
             case t: TermParamRef =>
               traverse(t.underlying)
+            case t: TypeLambda =>
+              for p <- t.paramRefs do partSeen += p
+              traverseChildren(t)
             case t =>
               traverseChildren(t)
 

--- a/tests/neg/i16146.scala
+++ b/tests/neg/i16146.scala
@@ -1,0 +1,3 @@
+
+type N = [X] => (X => X) => X => X
+val exp = (a: N) => (b: N) => b(a) // error


### PR DESCRIPTION

Fixes #16146