### PR TITLE
Don't propagate imports into inlined code

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -596,6 +596,9 @@ class Inliner(val call: tpd.Tree)(using Context):
           // reference to a private method is kept at runtime.
           cpy.Select(tree)(qual.asInstance(qual.tpe.widen), name)
 
+        case tree: ImportOrExport =>
+          EmptyTree
+
         case tree => tree
       },
       oldOwners = inlinedMethod :: Nil,

--- a/tests/neg/i16156/Defs_1.scala
+++ b/tests/neg/i16156/Defs_1.scala
@@ -1,0 +1,25 @@
+//import quotes.reflect._
+
+trait MyEncoder[T]:
+  def encode: String
+class Context:
+  inline def summonMyEncoder[T]: String =
+    ${ SummonEncoder.impl[T] }
+  implicit val encoderInstance: MyEncoder[String] =
+    new MyEncoder[String] { def encode = "blah" }
+end Context
+
+import scala.quoted._
+
+object SummonEncoder:
+  def impl[T: Type](using Quotes) =
+    import quotes.reflect._
+    Expr.summon[MyEncoder[T]] match
+      case Some(enc) => '{ $enc.encode }
+      case None      => report.throwError("can't do it")
+
+class Repo[T]:
+  val ctx = new Context
+  inline def summonEncoder = { import ctx._ // change to: import ctx.{given, _} for the given example
+    ctx.summonMyEncoder[T]
+  }

--- a/tests/neg/i16156/Use_2.scala
+++ b/tests/neg/i16156/Use_2.scala
@@ -1,0 +1,4 @@
+
+object Use:
+  val repo = new Repo[String]
+  val v = repo.summonEncoder // error happens here!


### PR DESCRIPTION
Imports are supposed to be resolved already, so they need not and should not be copied into inlined code.

Fixes #16156, unfortuntely in the sense that it will not work.