### PR TITLE
Implement an internal "assertShort" utility

### DIFF
--- a/compiler/src/dotty/tools/package.scala
+++ b/compiler/src/dotty/tools/package.scala
@@ -42,4 +42,11 @@ package object tools {
 
   def unreachable(x: Any = "<< this case was declared unreachable >>"): Nothing =
     throw new MatchError(x)
+
+  transparent inline def assertShort(inline assertion: Boolean, inline message: Any = null): Unit =
+    if !assertion then
+      val msg = message
+      val e = if msg == null then AssertionError() else AssertionError("assertion failed: " + msg)
+      e.setStackTrace(Array())
+      throw e
 }


### PR DESCRIPTION
I'm often implementing against an assertion, for instance in TreeChecker.  While implementing a fix I add some extra output.  So it's useful for me to suppress the full page of stacktrace that that assert typically emits, so I can roundtrip without having to scroll back up.