### PR TITLE
Add a utility "className" on Type

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -274,6 +274,9 @@ object Decorators {
             s"[cannot display due to $msg, raw string = $x]"
       case _ => String.valueOf(x).nn
 
+    /** Returns the simple class name of `x`. */
+    def className: String = getClass.getSimpleName.nn
+
   extension [T](x: T)
     def assertingErrorsReported(using Context): T = {
       assert(ctx.reporter.errorsReported)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1906,14 +1906,6 @@ object Types {
       case _ => show
     }
 
-    /** Returns the shortened and slightly prettified name of the class of the type. */
-    def className: String =
-      def go(s: String): String =
-        import Predef.augmentString // "import Texts._" imports the conversion to Text, which has a stripPrefix
-        val s2 = s.stripPrefix("Cached").stripPrefix("Real").stripSuffix("Impl").stripSuffix("$")
-        if s == s2 then s2 else go(s2)
-      go(getClass.getSimpleName.nn)
-
     /** A simplified version of this type which is equivalent wrt =:= to this type.
      *  This applies a typemap to the type which (as all typemaps) follows type
      *  variable instances and reduces typerefs over refined types. It also

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1906,6 +1906,14 @@ object Types {
       case _ => show
     }
 
+    /** Returns the shortened and slightly prettified name of the class of the type. */
+    def className: String =
+      def go(s: String): String =
+        import Predef.augmentString // "import Texts._" imports the conversion to Text, which has a stripPrefix
+        val s2 = s.stripPrefix("Cached").stripPrefix("Real").stripSuffix("Impl").stripSuffix("$")
+        if s == s2 then s2 else go(s2)
+      go(getClass.getSimpleName.nn)
+
     /** A simplified version of this type which is equivalent wrt =:= to this type.
      *  This applies a typemap to the type which (as all typemaps) follows type
      *  variable instances and reduces typerefs over refined types. It also


### PR DESCRIPTION
Working with LazyRef, TypeVars and so forth, it's often unclear from
RefinedPrinter's show what classes types are.  So I often want to see
the implementing class.  But the fully-qualified name is extreme, and
even the simple name can be trimmed down a touch.  So I'd love to have
this implemented once so I can reuse it.
