### PR TITLE
bugfix: Also accumulate inlined call

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1579,7 +1579,7 @@ object Trees {
             case SeqLiteral(elems, elemtpt) =>
               this(this(x, elems), elemtpt)
             case Inlined(call, bindings, expansion) =>
-              this(this(x, bindings), expansion)(using inlineContext(call))
+              this(this(this(x, call), bindings), expansion)(using inlineContext(call))
             case TypeTree() =>
               x
             case SingletonTypeTree(ref) =>


### PR DESCRIPTION
We started using DeepFolder in metals as a handy way of gathering all symbols we are interested in within the tree:

https://github.com/scalameta/metals/blob/main/mtags/src/main/scala-3/scala/meta/internal/pc/PcDocumentHighlightProvider.scala#L275

However, I noticed some limitations (which might be intentional). I am rasing this PR to see if the changes upstream would make sense,

The other thing ommited is  annotations trees, but if this make sense I can raise a PR separately.