### PR TITLE
Avoid cyclic references due to experimental check when inlining

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -85,7 +85,10 @@ object Inlines:
       if (tree.symbol == defn.CompiletimeTesting_typeChecks) return Intrinsics.typeChecks(tree)
       if (tree.symbol == defn.CompiletimeTesting_typeCheckErrors) return Intrinsics.typeCheckErrors(tree)
 
-    CrossVersionChecks.checkExperimentalRef(tree.symbol, tree.srcPos)
+    if ctx.isAfterTyper then
+      // During typer we wait with cross version checks until PostTyper, in order
+      // not to provoke cyclic references. See i16116 for a test case.
+      CrossVersionChecks.checkExperimentalRef(tree.symbol, tree.srcPos)
 
     if tree.symbol.isConstructor then return tree // error already reported for the inline constructor definition
 

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -359,6 +359,7 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
           }
         case Inlined(call, bindings, expansion) if !call.isEmpty =>
           val pos = call.sourcePos
+          CrossVersionChecks.checkExperimentalRef(call.symbol, pos)
           val callTrace = Inlines.inlineCallTrace(call.symbol, pos)(using ctx.withSource(pos.source))
           cpy.Inlined(tree)(callTrace, transformSub(bindings), transform(expansion)(using inlineContext(call)))
         case templ: Template =>

--- a/tests/neg-custom-args/no-experimental/experimentalInline2.scala
+++ b/tests/neg-custom-args/no-experimental/experimentalInline2.scala
@@ -1,7 +1,7 @@
 import scala.annotation.experimental
 
 @experimental
-inline def g() = ()
+transparent inline def g() = ()
 
 def test: Unit =
   g() // error

--- a/tests/pos-custom-args/captures/i16116.scala
+++ b/tests/pos-custom-args/captures/i16116.scala
@@ -1,0 +1,39 @@
+package x
+
+import scala.annotation.*
+import scala.concurrent.*
+
+trait CpsMonad[F[_]] {
+  type Context
+}
+
+object CpsMonad {
+  type Aux[F[_],C] = CpsMonad[F] { type Context = C }
+  given CpsMonad[Future] with {}
+}
+
+@experimental
+object Test {
+
+  @capability
+  class CpsTransform[F[_]] {
+     def await[T](ft: F[T]): { this } T = ???
+  }
+
+  transparent inline def cpsAsync[F[_]](using m:CpsMonad[F]) =
+    new Test.InfernAsyncArg
+
+  class InfernAsyncArg[F[_],C](using am:CpsMonad.Aux[F,C]) {
+      def apply[A](expr: (CpsTransform[F], C) ?=> A): F[A] = ???
+  }
+
+  def asyncPlus[F[_]](a:Int, b:F[Int])(using cps: CpsTransform[F]): { cps } Int =
+    a + (cps.await(b).asInstanceOf[Int])
+
+  def testExample1Future(): Unit =
+     val fr = cpsAsync[Future] {
+        val y = asyncPlus(1,Future successful 2).asInstanceOf[Int]
+        y+1
+     }
+
+}


### PR DESCRIPTION
Fixes #16116