### PR TITLE
Fix incorrect wrong staging level error for Singleton type

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -115,7 +115,7 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
     if body.isTerm then
       // `quoted.runtime.Expr.quote[T](<body>)`  --> `quoted.runtime.Expr.quote[T2](<body2>)`
       val TypeApply(fun, targs) = quote.fun: @unchecked
-      val targs2 = targs.map(targ => TypeTree(healTypeOfTerm(quote.fun.srcPos)(targ.tpe)))
+      val targs2 = targs.map(targ => TypeTree(healType(quote.fun.srcPos)(targ.tpe)))
       cpy.Apply(quote)(cpy.TypeApply(quote.fun)(fun, targs2), body2 :: Nil)
     else
       val quotes = quote.args.mapConserve(transform)
@@ -209,8 +209,7 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
         case tp: ThisType if level != -1 && level != levelOf(tp.cls) =>
           levelError(tp.cls, tp, pos)
         case tp: AnnotatedType =>
-          val newAnnotTree = transform(tp.annot.tree)
-          derivedAnnotatedType(tp, apply(tp.parent), tp.annot.derivedAnnotation(newAnnotTree))
+          derivedAnnotatedType(tp, apply(tp.parent), tp.annot)
         case _ =>
           mapOver(tp)
   }

--- a/tests/pos-macros/i15709.scala
+++ b/tests/pos-macros/i15709.scala
@@ -1,0 +1,4 @@
+import quoted.*
+
+inline def foo(s: Singleton): Unit = ${ fooImpl('s) }
+def fooImpl(s: Expr[Singleton])(using Quotes) = '{}


### PR DESCRIPTION
FIxes #15709.
Initially, when I started working on this I thought that it was interesting that `'s` was transformed into `Apply(TypeApply(Ident(quote),List(TypeTree[TypeVar(TypeParamRef(T) -> TermRef(NoPrefix,val s))])),List(Ident(s)))`during the Typer phase, with the interesting part being the typetree `TypeTree[TypeVar(TypeParamRef(T) -> TermRef(NoPrefix,val s))]`. Directly inside a TypeVar a TermRef can be found, which was the direct cause of errors thrown via PCPCheckAndHeal. Initially I wanted to see if it was possible to somehow painlessly wrap the TermRef into a TypeRef, however after spending too much time fruitlessly exploring Typer I decided to adjust checks in PCPCheckAndHeal instead.

There I changed it so that type arguments were healed via healType instead of healTypeOfTerm, as that seems more applicable there just by name alone. Next, after encountering an error with an annotation I changed things so that annotation contents are not recursively visited by PCPCheckAndHeal, like it was previously done in healTypeOfTerm. This lead to no failed tests, and I was not able to find any examples that would break the above changes.