### PR TITLE
Make definitions used in capture checking again @experimental

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -445,6 +445,7 @@ object StdNames {
     val derived: N              = "derived"
     val derives: N              = "derives"
     val doubleHash: N           = "doubleHash"
+    val dotty: N                = "dotty"
     val drop: N                 = "drop"
     val dynamics: N             = "dynamics"
     val elem: N                 = "elem"

--- a/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SymUtils.scala
@@ -363,6 +363,8 @@ object SymUtils:
       self.hasAnnotation(defn.ExperimentalAnnot)
       || isDefaultArgumentOfExperimentalMethod
       || (!self.is(Package) && self.owner.isInExperimentalScope)
+      || self.topLevelClass.ownersIterator.exists(p =>
+          p.is(Package) && p.owner.isRoot && p.name == tpnme.dotty)
 
     /** The declared self type of this class, as seen from `site`, stripping
     *  all refinements for opaque types.

--- a/library/src/scala/annotation/retains.scala
+++ b/library/src/scala/annotation/retains.scala
@@ -11,8 +11,8 @@ package scala.annotation
  *  The annotation can also be written explicitly if one wants to avoid the
  *  non-standard capturing type syntax.
  */
-// @experimental // suppressed so we can use in compiler
+@experimental
 class retains(xs: Any*) extends annotation.StaticAnnotation
 
-// @experimental // suppressed so we can use in compiler
+@experimental
 class retainsUniversal extends annotation.StaticAnnotation

--- a/library/src/scala/caps.scala
+++ b/library/src/scala/caps.scala
@@ -2,7 +2,7 @@ package scala
 
 import annotation.experimental
 
-// @experimental , suppress @experimental so we can use in compiler itself
+@experimental
 object caps:
 
   /** If argument is of type `cs T`, converts to type `box cs T`. This

--- a/library/src/scala/caps.scala
+++ b/library/src/scala/caps.scala
@@ -2,8 +2,7 @@ package scala
 
 import annotation.experimental
 
-@experimental
-object caps:
+@experimental object caps:
 
   /** If argument is of type `cs T`, converts to type `box cs T`. This
    *  avoids the error that would be raised when boxing `*`.

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -4,5 +4,6 @@ import com.typesafe.tools.mima.core._
 object MiMaFilters {
   val Library: Seq[ProblemFilter] = Seq(
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.internal.MappedAlternative"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.caps"),
   )
 }

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -4,9 +4,5 @@ import com.typesafe.tools.mima.core._
 object MiMaFilters {
   val Library: Seq[ProblemFilter] = Seq(
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.internal.MappedAlternative"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.caps"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.caps$"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.retains"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.retainsUniversal"),
   )
 }

--- a/tests/pos-custom-args/no-experimental/dotty-experimental.scala
+++ b/tests/pos-custom-args/no-experimental/dotty-experimental.scala
@@ -1,0 +1,6 @@
+package dotty.tools
+object test {
+
+  val x = caps.unsafeBox
+
+}

--- a/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -50,8 +50,11 @@ val experimentalDefinitionInLibrary = Set(
   "scala.annotation.capability",
   "scala.annotation.internal.CaptureChecked",
   "scala.annotation.internal.requiresCapability",
-  //"scala.annotation.retains",
+  "scala.annotation.retains",
+  "scala.annotation.retainsUniversal",
   "scala.annotation.retainsByName",
+  "scala.caps",
+  "scala.caps$",
 
   //// New APIs: Mirror
   // Can be stabilized in 3.3.0 or later.


### PR DESCRIPTION
#16199 dropped their experimental status to allow experimenting with compiling the compiler under -Ycc, but that was meant as a local change that should not have been propagated to main.