### PR TITLE
Fix coverage tests on windows

### DIFF
--- a/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
+++ b/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
@@ -33,11 +33,12 @@ class CoverageTests:
     checkCoverageIn(rootSrc.resolve("run"), true)
 
   def checkCoverageIn(dir: Path, run: Boolean)(using TestGroup): Unit =
-    /** Converts \ to / on windows, to make the tests pass without changing the serialization. */
+    /** Converts \\ (escaped \) to / on windows, to make the tests pass without changing the serialization. */
     def fixWindowsPaths(lines: Buffer[String]): Buffer[String] =
       val separator = java.io.File.separatorChar
-      if separator != '/' then
-        lines.map(_.replace(separator, '/'))
+      if separator == '\\' then
+        val escapedSep = "\\\\"
+        lines.map(_.replace(escapedSep, "/"))
       else
         lines
     end fixWindowsPaths


### PR DESCRIPTION
[test_windows_full failed](https://github.com/lampepfl/dotty/actions/runs/3313981586/jobs/5472673283)

Coverage tests replaced all `\` by `/`, but the paths are now escaped, which turns `C:\folder\file` into `C:\\folder\\file`. Thus we need to replace `\\` by `/`!

Note: this fix is better than removing `.escaped` from paths, because paths are allowed to contains problematic characters such as newlines, which would break the coverage report.
