### PR TITLE
Fix errors in explicit type annotations in inline match cases

### DIFF
--- a/tests/pos-macros/i15971.scala
+++ b/tests/pos-macros/i15971.scala
@@ -1,0 +1,12 @@
+sealed trait A
+case class B[T](x: T) extends A
+
+object Test {
+  inline def fun(x: A): Int = inline x match {
+    case B(x1): B[t] => 0
+  }
+
+  @main def main() = 
+    val x = B(0)
+    fun(x)
+}


### PR DESCRIPTION
Previously, Unapply trees would have type bindings generated inside their body and this was the only case handled in InlineReducer. However, this mainly happened for inferred type parameters, and Unapply with an explicit binding inside a type annotation was not handled, leading to a "cannot reduce match" error. This case is now handled and a related comment was added as well.

Fixes #15971
For context, a more concise minimization then the one proposed in the issue above would be something like:
```scala
sealed trait A
case class B[T](x: T) extends A

object Test {
  inline def fun(x: A): Int = inline x match {
    case B(x1): B[t] => 0
  }

  @main def main() = 
    val x = B(0)
    fun(x)
}
```
And the issue itself ended up being unrelated to macros. I tried submitting this PR with the original minimization, however checker (-Ycheck) returned an exception, failing the tests. I tried to debug that as well, however I honestly spent an excessive amount of time on that, so for now I would like to at the very least, submit this fix for now, and reattempt fixing the checker later. For that reason I created a separate issue for the check failures, with a new minimization, in #16331.

