### PR TITLE
Attempt to fix completion crash

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -644,15 +644,19 @@ object Denotations {
 
     def atSignature(sig: Signature, targetName: Name, site: Type, relaxed: Boolean)(using Context): SingleDenotation =
       val situated = if site == NoPrefix then this else asSeenFrom(site)
-      val sigMatches = sig.matchDegree(situated.signature) match
-        case FullMatch =>
-          true
-        case MethodNotAMethodMatch =>
-          // See comment in `matches`
-          relaxed && !symbol.is(JavaDefined)
-        case ParamMatch =>
-          relaxed
-        case noMatch =>
+      val sigMatches =
+        try
+          sig.matchDegree(situated.signature) match
+            case FullMatch =>
+              true
+            case MethodNotAMethodMatch =>
+              // See comment in `matches`
+              relaxed && !symbol.is(JavaDefined)
+            case ParamMatch =>
+              relaxed
+            case noMatch =>
+              false
+        catch case ex: MissingType =>
           false
       if sigMatches && symbol.hasTargetName(targetName) then this else NoDenotation
 


### PR DESCRIPTION
Fixes #16228 (hopefully)

Note: I could not test this. Maybe somebody else take can this over.  

Looking at the stack trace in #16228:
```
at dotty.tools.dotc.core.TypeErasure.dotty$tools$dotc$core$TypeErasure$$sigName(TypeErasure.scala:815)
	at dotty.tools.dotc.core.TypeErasure$.sigName(TypeErasure.scala:204)
	at dotty.tools.dotc.core.Signature.$anonfun$2(Signature.scala:111)
	at scala.collection.immutable.List.map(List.scala:246)
	at dotty.tools.dotc.core.Signature.prependTermParams(Signature.scala:111)
	at dotty.tools.dotc.core.Types$MethodOrPoly.computeSignature$2(Types.scala:3565)
	at dotty.tools.dotc.core.Types$MethodOrPoly.signature(Types.scala:3582)
	at dotty.tools.dotc.core.Types$MethodOrPoly.computeSignature$2(Types.scala:3557)
	at dotty.tools.dotc.core.Types$MethodOrPoly.signature(Types.scala:3582)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.signature(Denotations.scala:615)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.signature(Denotations.scala:605)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.atSignature(Denotations.scala:647)
	at dotty.tools.dotc.core.Denotations$SingleDenotation.atSignature(Denotations.scala:645)
	at dotty.tools.dotc.core.tasty.TreeUnpickler$TreeReader.readLengthTerm$1(TreeUnpickler.scala:1299)
```
I think what happens is that we need to disambiguate an overloaded reference by looking at the signature of each overloaded alternative. But one of the signatures refers to a type that's not on the classpath, which causes the `MissingType` exception. The fix is to catch the exception and declare the alternative that caused it to be non-matching.

About the regression: I have no idea what previous fix could have caused this. 