### PR TITLE
REPL: open up for extensibility

### DIFF
--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -16,7 +16,7 @@ import org.jline.reader.impl.history.DefaultHistory
 import org.jline.terminal.TerminalBuilder
 import org.jline.utils.AttributedString
 
-final class JLineTerminal extends java.io.Closeable {
+class JLineTerminal extends java.io.Closeable {
   // import java.util.logging.{Logger, Level}
   // Logger.getLogger("org.jline").setLevel(Level.FINEST)
 
@@ -30,7 +30,8 @@ final class JLineTerminal extends java.io.Closeable {
   private def blue(str: String)(using Context) =
     if (ctx.settings.color.value != "never") Console.BLUE + str + Console.RESET
     else str
-  private def prompt(using Context)        = blue("\nscala> ")
+  protected def promptStr = "scala"
+  private def prompt(using Context)        = blue(s"\n$promptStr> ")
   private def newLinePrompt(using Context) = blue("     | ")
 
   /** Blockingly read line from `System.in`

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -28,10 +28,10 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
 
   import Rendering._
 
-  private var myClassLoader: AbstractFileClassLoader = _
+  var myClassLoader: AbstractFileClassLoader = _
 
   /** (value, maxElements, maxCharacters) => String */
-  private var myReplStringOf: (Object, Int, Int) => String = _
+  var myReplStringOf: (Object, Int, Int) => String = _
 
   /** Class loader used to load compiled code */
   private[repl] def classLoader()(using Context) =

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -138,7 +138,7 @@ class ReplDriver(settings: Array[String],
    *  observable outside of the CLI, for this reason, most helper methods are
    *  `protected final` to facilitate testing.
    */
-  final def runUntilQuit(using initialState: State = initialState)(): State = {
+  def runUntilQuit(using initialState: State = initialState)(): State = {
     val terminal = new JLineTerminal
 
     out.println(
@@ -181,7 +181,7 @@ class ReplDriver(settings: Array[String],
     interpret(parsed, quiet = true)
   }
 
-  private def runBody(body: => State): State = rendering.classLoader()(using rootCtx).asContext(withRedirectedOutput(body))
+  protected def runBody(body: => State): State = rendering.classLoader()(using rootCtx).asContext(withRedirectedOutput(body))
 
   // TODO: i5069
   final def bind(name: String, value: Any)(using state: State): State = state
@@ -247,7 +247,7 @@ class ReplDriver(settings: Array[String],
         .getOrElse(Nil)
   end completions
 
-  private def interpret(res: ParseResult, quiet: Boolean = false)(using state: State): State = {
+  protected def interpret(res: ParseResult, quiet: Boolean = false)(using state: State): State = {
     res match {
       case parsed: Parsed if parsed.trees.nonEmpty =>
         compile(parsed, state, quiet)

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -118,7 +118,7 @@ class ReplDriver(settings: Array[String],
   private var rootCtx: Context = _
   private var shouldStart: Boolean = _
   private var compiler: ReplCompiler = _
-  private var rendering: Rendering = _
+  protected var rendering: Rendering = _
 
   // initialize the REPL session as part of the constructor so that once `run`
   // is called, we're in business


### PR DESCRIPTION
The Scala ecosystem has two major REPLs: the regular Scala REPL and Ammonite. 
The former is intentionally kept low-key and simple: a concise and readable codebase, no bells and whistles, focusing on core Scala features. 
Ammonite has a ton of features, but also a very complex build, leading to [dependency tree issues](https://github.com/com-lihaoyi/Ammonite/pull/1301) and has many shortcomings in it's Scala 3 support, e.g. re [extension methods](https://github.com/com-lihaoyi/Ammonite/issues/1297).
Scala-CLI wraps up both and provides some additions, mostly via scripting, but doesn't add another REPL implementation.

IMO there is a gap in the middle, and we can fill it fairly easily: if we open up selected fields in the standard REPL implementation, we allow downstream builds to inherit the complete Scala support and build more features on top. This PR and the corresponding [scala-repl-pp](https://github.com/mpollmeier/scala-repl-pp/tree/dotty-nightly) demonstrate that: runtime dependencies via maven coordinates, pretty printing, customized prompt and shutdown code, scripting with multiple `@main`, predef code, server mode, ... 

It's heavily inspired by Ammonite and scala-cli, but is fundamentally simpler: the above features are implemented in only 700 lines of code. It's straightforward dependency tree allows users to embed it in their own builds, making their domains available in a customised REPL, while inheriting the full Scala REPL feature set.

The scala-repl-pp readme has more details and use cases. I published a custom scala3-compiler to maven central, so you can easily try it out.
