### PR TITLE
Fix Text wrapping

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -111,7 +111,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def refinementNameString(tp: RefinedType): String = nameString(tp.refinedName)
 
   /** String representation of a refinement */
-  protected def toTextRefinement(rt: RefinedType): Closed =
+  protected def toTextRefinement(rt: RefinedType): Text =
     (refinementNameString(rt) ~ toTextRHS(rt.refinedInfo)).close
 
   protected def argText(arg: Type): Text = homogenizeArg(arg) match {

--- a/compiler/src/dotty/tools/dotc/printing/Texts.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Texts.scala
@@ -15,12 +15,17 @@ object Texts {
       case Vertical(relems) => relems.isEmpty
     }
 
+    //                 Str Ver Clo Flu
+    // isVertical       F   T   F   F
+    // isClosed         F   T   T   F
+    // isFluid          F   F   T   T
+    // isSplittable     F   F   F   T
     def isVertical: Boolean = isInstanceOf[Vertical]
     def isClosed: Boolean = isVertical || isInstanceOf[Closed]
     def isFluid: Boolean = isInstanceOf[Fluid]
     def isSplittable: Boolean = isFluid && !isClosed
 
-    def close: Closed = new Closed(relems)
+    def close: Text = if isSplittable then Closed(relems) else this
 
     def remaining(width: Int): Int = this match {
       case Str(s, _) =>
@@ -53,7 +58,7 @@ object Texts {
     }
 
     private def appendIndented(that: Text)(width: Int): Text =
-      Vertical(that.layout(width - indentMargin).indented :: this.relems)
+      Fluid(that.layout(width - indentMargin).indented :: this.relems)
 
     private def append(width: Int)(that: Text): Text =
       if (this.isEmpty) that.layout(width)
@@ -113,7 +118,7 @@ object Texts {
             sb.append("|")
           }
         }
-        sb.append(s)
+        sb.append(s.replaceAll("[ ]+$", ""))
       case _ =>
         var follow = false
         for (elem <- relems.reverse) {
@@ -138,7 +143,13 @@ object Texts {
     def ~ (that: Text): Text =
       if (this.isEmpty) that
       else if (that.isEmpty) this
-      else Fluid(that :: this :: Nil)
+      else this match
+        case Fluid(relems1) if !isClosed => that match
+          case Fluid(relems2) if !that.isClosed => Fluid(relems2 ++ relems1)
+          case _                                => Fluid(that +: relems1)
+        case _             => that match
+          case Fluid(relems2) if !that.isClosed => Fluid(relems2 :+ this)
+          case _                                => Fluid(that :: this :: Nil)
 
     def ~~ (that: Text): Text =
       if (this.isEmpty) that
@@ -161,9 +172,9 @@ object Texts {
     def apply(xs: Traversable[Text], sep: String = " "): Text =
       if (sep == "\n") lines(xs)
       else {
-        val ys = xs filterNot (_.isEmpty)
+        val ys = xs.filterNot(_.isEmpty)
         if (ys.isEmpty) Str("")
-        else ys reduce (_ ~ sep ~ _)
+        else ys.reduceRight((a, b) => (a ~ sep).close ~ b)
       }
 
     /** The given texts `xs`, each on a separate line */
@@ -176,12 +187,16 @@ object Texts {
 
   case class Str(s: String, lineRange: LineRange = EmptyLineRange) extends Text {
     override def relems: List[Text] = List(this)
+    override def toString = this match
+      case Str(s, EmptyLineRange) => s"Str($s)"
+      case Str(s, lineRange)      => s"Str($s, $lineRange)"
   }
 
   case class Vertical(relems: List[Text]) extends Text
   case class Fluid(relems: List[Text]) extends Text
 
-  class Closed(relems: List[Text]) extends Fluid(relems)
+  class Closed(relems: List[Text]) extends Fluid(relems):
+    override def productPrefix = "Closed"
 
   implicit def stringToText(s: String): Text = Str(s)
 

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -187,7 +187,9 @@ object ErrorReporting {
          |The tests were made under $constraintText"""
 
     def whyFailedStr(fail: FailedExtension) =
-      i"""    failed with
+      i"""
+         |
+         |    failed with:
          |
          |${fail.whyFailed.message.indented(8)}"""
 

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -568,9 +568,9 @@ object Implicits:
       if reasons.length > 1 then
         reasons.mkString("\n\t* ", "\n\t* ", "")
       else
-        reasons.mkString
+        reasons.mkString(" ", "", "")
 
-    def explanation(using Context) = em"Failed to synthesize an instance of type ${clarify(expectedType)}: ${formatReasons}"
+    def explanation(using Context) = em"Failed to synthesize an instance of type ${clarify(expectedType)}:${formatReasons}"
 
 end Implicits
 

--- a/compiler/test/dotty/tools/dotc/TupleShowTests.scala
+++ b/compiler/test/dotty/tools/dotc/TupleShowTests.scala
@@ -1,0 +1,90 @@
+package dotty.tools
+package dotc
+
+import core.*, Decorators.*, Symbols.*
+import printing.Texts.*
+
+import org.junit.Test
+
+class TupleShowTests extends DottyTest:
+  def IntType = defn.IntType
+  def LongType = defn.LongType
+  def ShortType = defn.ShortType
+  def Types_10 = List.fill(5)(IntType) ::: List.fill(5)(LongType)
+  def Types_20 = Types_10 ::: Types_10
+
+  val tup0  = defn.tupleType(Nil)
+  val tup1  = defn.tupleType(IntType :: Nil)
+  val tup2  = defn.tupleType(IntType :: LongType :: Nil)
+  val tup3  = defn.tupleType(IntType :: LongType :: ShortType :: Nil)
+  val tup21 = defn.tupleType(Types_20 ::: IntType :: Nil)
+  val tup22 = defn.tupleType(Types_20 ::: IntType :: LongType :: Nil)
+  val tup23 = defn.tupleType(Types_20 ::: IntType :: LongType :: ShortType :: Nil)
+  val tup24 = defn.tupleType(Types_20 ::: IntType :: LongType :: ShortType :: ShortType :: Nil)
+
+  @Test def tup0_show  = chkEq("EmptyTuple.type", i"$tup0")
+  @Test def tup1_show  = chkEq("Tuple1[Int]", i"$tup1")
+  @Test def tup2_show  = chkEq("(Int, Long)", i"$tup2")
+  @Test def tup3_show  = chkEq("(Int, Long, Short)", i"$tup3")
+  @Test def tup21_show = chkEq(res21, i"$tup21")
+  @Test def tup22_show = chkEq(res22, i"$tup22")
+  @Test def tup23_show = chkEq(res23, i"$tup23")
+  @Test def tup24_show = chkEq(res24, i"$tup24")
+
+  @Test def tup3_text =
+    val obt = tup3.toText(ctx.printer)
+    val exp = Fluid(List(
+      Str(")"),
+      Str("Short"),
+      Closed(List(Str(", "), Str("Long"))),
+      Closed(List(Str(", "), Str("Int"))),
+      Str("("),
+    ))
+    chkEq(exp, obt)
+
+  @Test def tup3_layout10 =
+    val obt = tup3.toText(ctx.printer).layout(10)
+    val exp = Fluid(List(
+      Str("  Short)"),
+      Str("  Long, "),
+      Str("(Int, "),
+    ))
+    chkEq(exp, obt)
+
+  @Test def tup3_show10 = chkEq("(Int,\n  Long,\n  Short)", tup3.toText(ctx.printer).mkString(10, false))
+
+  val res21 = """|(Int, Int, Int, Int, Int, Long, Long, Long, Long, Long, Int, Int, Int, Int,
+                 |  Int, Long, Long, Long, Long, Long, Int)""".stripMargin
+
+  val res22 = """|(Int, Int, Int, Int, Int, Long, Long, Long, Long, Long, Int, Int, Int, Int,
+                 |  Int, Long, Long, Long, Long, Long, Int, Long)""".stripMargin
+
+  val res23 = """|(Int, Int, Int, Int, Int, Long, Long, Long, Long, Long, Int, Int, Int, Int,
+                 |  Int, Long, Long, Long, Long, Long, Int, Long, Short)""".stripMargin
+
+  val res24 = """|(Int, Int, Int, Int, Int, Long, Long, Long, Long, Long, Int, Int, Int, Int,
+                 |  Int, Long, Long, Long, Long, Long, Int, Long, Short, Short)""".stripMargin
+
+  def chkEq[A](expected: A, obtained: A) = assert(expected == obtained, diff(s"$expected", s"$obtained"))
+
+  def diff(exp: String, obt: String) =
+    val min = math.min(exp.length, obt.length)
+    val pre =
+      var i = 0
+      while i < min && exp(i) == obt(i) do i += 1
+      exp.take(i)
+    val suf =
+      val max = min - pre.length - 1
+      var i = 0
+      while i <= max && exp(exp.length - 1 - i) == obt(obt.length - 1 - i) do i += 1
+      exp.drop(exp.length - 1)
+
+    import scala.io.AnsiColor.*
+    val ellip = BLACK + BOLD + "..." + RESET
+    val compactPre = if pre.length <= 20 then pre else ellip + pre.drop(pre.length - 20)
+    val compactSuf = if suf.length <= 20 then suf else suf.take(20) + ellip
+    def extractDiff(s: String) = s.slice(pre.length, s.length - suf.length)
+    s"""|Comparison Failure:
+        |  expected: $compactPre${CYAN }${extractDiff(exp)}$RESET$compactSuf
+        |  obtained: $compactPre$MAGENTA${extractDiff(obt)}$RESET$compactSuf
+        |""".stripMargin

--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -21,6 +21,7 @@ import scala.io.Source
 import org.junit.Test
 import scala.util.Using
 import java.io.File
+
 class PrintingTest {
 
   def options(phase: String, flags: List[String]) =
@@ -45,7 +46,7 @@ class PrintingTest {
     }
 
     val actualLines = byteStream.toString(StandardCharsets.UTF_8.name).linesIterator
-    FileDiff.checkAndDump(path.toString, actualLines.toIndexedSeq, checkFilePath)
+    FileDiff.checkAndDumpOrUpdate(path.toString, actualLines.toIndexedSeq, checkFilePath)
   }
 
   def testIn(testsDir: String, phase: String) =

--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -50,21 +50,6 @@ object FileDiff {
     outFile.writeAll(content.mkString("", EOL, EOL))
   }
 
-  def checkAndDump(sourceTitle: String, actualLines: Seq[String], checkFilePath: String): Boolean = {
-    val outFilePath = checkFilePath + ".out"
-    FileDiff.check(sourceTitle, actualLines, checkFilePath) match {
-      case Some(msg) =>
-        FileDiff.dump(outFilePath, actualLines)
-        println(msg)
-        println(FileDiff.diffMessage(checkFilePath, outFilePath))
-        false
-      case _ =>
-        val jOutFilePath = Paths.get(outFilePath)
-        Files.deleteIfExists(jOutFilePath)
-        true
-    }
-  }
-
   def checkAndDumpOrUpdate(sourceTitle: String, actualLines: Seq[String], checkFilePath: String): Boolean = {
     val outFilePath = checkFilePath + ".out"
     FileDiff.check(sourceTitle, actualLines, checkFilePath) match {

--- a/tests/neg/enum-values.check
+++ b/tests/neg/enum-values.check
@@ -6,7 +6,9 @@
    |                                         meaning a values array is not defined.
    |                                         An extension method was tried, but could not be fully constructed:
    |
-   |                                             example.Extensions.values(Tag)    failed with
+   |                                             example.Extensions.values(Tag)
+   |
+   |                                             failed with:
    |
    |                                                 Found:    example.Tag.type
    |                                                 Required: Nothing
@@ -18,7 +20,9 @@
    |                                         meaning a values array is not defined.
    |                                         An extension method was tried, but could not be fully constructed:
    |
-   |                                             example.Extensions.values(ListLike)    failed with
+   |                                             example.Extensions.values(ListLike)
+   |
+   |                                             failed with:
    |
    |                                                 Found:    Array[example.Tag[?]]
    |                                                 Required: Array[example.ListLike[?]]
@@ -30,7 +34,9 @@
    |                                         meaning a values array is not defined.
    |                                         An extension method was tried, but could not be fully constructed:
    |
-   |                                             example.Extensions.values(TypeCtorsK)    failed with
+   |                                             example.Extensions.values(TypeCtorsK)
+   |
+   |                                             failed with:
    |
    |                                                 Found:    Array[example.Tag[?]]
    |                                                 Required: Array[example.TypeCtorsK[?[_$1]]]
@@ -63,7 +69,9 @@
    |  value values is not a member of object example.NotAnEnum.
    |  An extension method was tried, but could not be fully constructed:
    |
-   |      example.Extensions.values(NotAnEnum)    failed with
+   |      example.Extensions.values(NotAnEnum)
+   |
+   |      failed with:
    |
    |          Found:    example.NotAnEnum.type
    |          Required: Nothing

--- a/tests/neg/i10901.check
+++ b/tests/neg/i10901.check
@@ -4,7 +4,9 @@
    |       value º is not a member of object BugExp4Point2D.IntT.
    |       An extension method was tried, but could not be fully constructed:
    |
-   |           º(x)    failed with
+   |           º(x)
+   |
+   |           failed with:
    |
    |               Ambiguous overload. The overloaded alternatives of method º in object dsl with types
    |                [T1, T2]
@@ -22,7 +24,9 @@
    |value º is not a member of object BugExp4Point2D.IntT.
    |An extension method was tried, but could not be fully constructed:
    |
-   |    º(x)    failed with
+   |    º(x)
+   |
+   |    failed with:
    |
    |        Ambiguous overload. The overloaded alternatives of method º in object dsl with types
    |         [T1, T2]
@@ -36,6 +40,8 @@
    |          value foo is not a member of String.
    |          An extension method was tried, but could not be fully constructed:
    |
-   |              Test.foo("abc")(/* missing */summon[C])    failed with
+   |              Test.foo("abc")(/* missing */summon[C])
+   |
+   |              failed with:
    |
    |                  No given instance of type C was found for parameter x$2 of method foo in object Test

--- a/tests/neg/i13558.check
+++ b/tests/neg/i13558.check
@@ -4,7 +4,9 @@
    |            value id is not a member of testcode.A.
    |            An extension method was tried, but could not be fully constructed:
    |
-   |                testcode.ExtensionA.id(a)    failed with
+   |                testcode.ExtensionA.id(a)
+   |
+   |                failed with:
    |
    |                    Reference to id is ambiguous,
    |                    it is both imported by import testcode.ExtensionB._
@@ -15,7 +17,9 @@
    |            value id is not a member of testcode.A.
    |            An extension method was tried, but could not be fully constructed:
    |
-   |                testcode.ExtensionB.id(a)    failed with
+   |                testcode.ExtensionB.id(a)
+   |
+   |                failed with:
    |
    |                    Reference to id is ambiguous,
    |                    it is both imported by import testcode.ExtensionA._

--- a/tests/neg/i14127.check
+++ b/tests/neg/i14127.check
@@ -1,10 +1,8 @@
 -- Error: tests/neg/i14127.scala:6:55 ----------------------------------------------------------------------------------
 6 |    *: Int *: Int *: Int *: Int *: Int *: EmptyTuple)]] // error
   |                                                       ^
-  |No given instance of type deriving.Mirror.Of[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, 
-  |  Int
-  |, Int, Int)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, 
-  |  Int
-  |, Int, Int)]: 
+  |No given instance of type deriving.Mirror.Of[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+  |  Int, Int, Int)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+  |  Int, Int, Int)]:
   |	* class *: is not a generic product because it reduces to a tuple with arity 23, expected arity <= 22
   |	* class *: is not a generic sum because it does not have subclasses

--- a/tests/neg/i14432.check
+++ b/tests/neg/i14432.check
@@ -1,6 +1,6 @@
 -- Error: tests/neg/i14432.scala:13:33 ---------------------------------------------------------------------------------
 13 |val mFoo = summon[Mirror.Of[Foo]] // error: no mirror found
    |                                 ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]:
    |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class

--- a/tests/neg/i14432a.check
+++ b/tests/neg/i14432a.check
@@ -1,6 +1,6 @@
 -- Error: tests/neg/i14432a.scala:14:43 --------------------------------------------------------------------------------
 14 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]:
    |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class

--- a/tests/neg/i14432b.check
+++ b/tests/neg/i14432b.check
@@ -1,6 +1,6 @@
 -- Error: tests/neg/i14432b.scala:15:43 --------------------------------------------------------------------------------
 15 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror found
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]:
    |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class

--- a/tests/neg/i14432c.check
+++ b/tests/neg/i14432c.check
@@ -5,6 +5,6 @@
 -- Error: tests/neg/i14432c.scala:16:43 --------------------------------------------------------------------------------
 16 |  val mFoo = summon[Mirror.Of[example.Foo]] // error: no mirror
    |                                           ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]:
    |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class

--- a/tests/neg/i14432d.check
+++ b/tests/neg/i14432d.check
@@ -1,6 +1,6 @@
 -- Error: tests/neg/i14432d.scala:17:45 --------------------------------------------------------------------------------
 17 |    val mFoo = summon[Mirror.Of[example.Foo]] // error
    |                                             ^
-   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]: 
+   |No given instance of type deriving.Mirror.Of[example.Foo] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[example.Foo]:
    |	* class Foo is not a generic product because the constructor of class Foo is innaccessible from the calling scope.
    |	* class Foo is not a generic sum because it is not a sealed class

--- a/tests/neg/i14823.check
+++ b/tests/neg/i14823.check
@@ -1,6 +1,6 @@
 -- Error: tests/neg/i14823.scala:8:50 ----------------------------------------------------------------------------------
 8 |val baz = summon[Mirror.Of[SubA[Int] | SubB[Int]]] // error
   |                                                  ^
-  |No given instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]]: 
+  |No given instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubA[Int] | SubB[Int]]:
   |	* type `SubA[Int] | SubB[Int]` is not a generic product because its subpart `SubA[Int] | SubB[Int]` is a top-level union type.
   |	* type `SubA[Int] | SubB[Int]` is not a generic sum because its subpart `SubA[Int] | SubB[Int]` is a top-level union type.

--- a/tests/neg/i14823a.check
+++ b/tests/neg/i14823a.check
@@ -1,24 +1,24 @@
 -- Error: tests/neg/i14823a.scala:16:48 --------------------------------------------------------------------------------
 16 |val foo = summon[Mirror.Of[Box[Int] | Box[Int]]] // error
    |                                                ^
-   |No given instance of type deriving.Mirror.Of[Box[Int] | Box[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Box[Int] | Box[Int]]: 
+   |No given instance of type deriving.Mirror.Of[Box[Int] | Box[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Box[Int] | Box[Int]]:
    |	* type `Box[Int] | Box[Int]` is not a generic product because its subpart `Box[Int] | Box[Int]` is a top-level union type.
    |	* type `Box[Int] | Box[Int]` is not a generic sum because its subpart `Box[Int] | Box[Int]` is a top-level union type.
 -- Error: tests/neg/i14823a.scala:17:58 --------------------------------------------------------------------------------
 17 |val bar = summon[MirrorK1.Of[[X] =>> Box[Int] | Box[Int]]] // error
    |                                                          ^
-   |No given instance of type MirrorK1.Of[[X] =>> Box[Int] | Box[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type MirrorK1.Of[[X] =>> Box[Int] | Box[Int]]: 
+   |No given instance of type MirrorK1.Of[[X] =>> Box[Int] | Box[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type MirrorK1.Of[[X] =>> Box[Int] | Box[Int]]:
    |	* type `[A] =>> Box[Int] | Box[Int]` is not a generic product because its subpart `Box[Int] | Box[Int]` is a top-level union type.
    |	* type `[A] =>> Box[Int] | Box[Int]` is not a generic sum because its subpart `Box[Int] | Box[Int]` is a top-level union type.
 -- Error: tests/neg/i14823a.scala:18:63 --------------------------------------------------------------------------------
 18 |def baz = summon[deriving.Mirror.Of[Foo[String] | Foo[String]]] // error
    |                                                               ^
-   |No given instance of type deriving.Mirror.Of[Foo[String] | Foo[String]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Foo[String] | Foo[String]]: 
+   |No given instance of type deriving.Mirror.Of[Foo[String] | Foo[String]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Foo[String] | Foo[String]]:
    |	* type `Foo[String] | Foo[String]` is not a generic product because its subpart `Foo[String] | Foo[String]` is a top-level union type.
    |	* type `Foo[String] | Foo[String]` is not a generic sum because its subpart `Foo[String] | Foo[String]` is a top-level union type.
 -- Error: tests/neg/i14823a.scala:20:66 --------------------------------------------------------------------------------
 20 |def qux = summon[deriving.Mirror.Of[Option[Int] | Option[String]]] // error
    |                                                                  ^
-   |No given instance of type deriving.Mirror.Of[Option[Int] | Option[String]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Option[Int] | Option[String]]: 
+   |No given instance of type deriving.Mirror.Of[Option[Int] | Option[String]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Option[Int] | Option[String]]:
    |	* type `Option[Int] | Option[String]` is not a generic product because its subpart `Option[Int] | Option[String]` is a top-level union type.
    |	* type `Option[Int] | Option[String]` is not a generic sum because its subpart `Option[Int] | Option[String]` is a top-level union type.

--- a/tests/neg/i15000.check
+++ b/tests/neg/i15000.check
@@ -16,7 +16,9 @@
    |value apply is not a member of object ExtensionMethodReproduction.c.
    |An extension method was tried, but could not be fully constructed:
    |
-   |    apply(ExtensionMethodReproduction.c)    failed with
+   |    apply(ExtensionMethodReproduction.c)
+   |
+   |    failed with:
    |
    |        Ambiguous overload. The overloaded alternatives of method apply in object ExtensionMethodReproduction with types
    |         (c: ExtensionMethodReproduction.C)(x: Int, y: Int): String

--- a/tests/neg/i6183.check
+++ b/tests/neg/i6183.check
@@ -4,7 +4,9 @@
   |    value render is not a member of Int.
   |    An extension method was tried, but could not be fully constructed:
   |
-  |        render(42)    failed with
+  |        render(42)
+  |
+  |        failed with:
   |
   |            Ambiguous overload. The overloaded alternatives of method render in object Test with types
   |             [B](b: B)(using x$2: DummyImplicit): Char

--- a/tests/neg/i6779.check
+++ b/tests/neg/i6779.check
@@ -11,7 +11,9 @@
    |                             value f is not a member of T.
    |                             An extension method was tried, but could not be fully constructed:
    |
-   |                                 Test.f[G[T]](x)(given_Stuff)    failed with
+   |                                 Test.f[G[T]](x)(given_Stuff)
+   |
+   |                                 failed with:
    |
    |                                     Found:    (x : T)
    |                                     Required: G[T]

--- a/tests/neg/i9185.check
+++ b/tests/neg/i9185.check
@@ -5,8 +5,9 @@
   |An extension method was tried, but could not be fully constructed:
   |
   |    M.pure[A, F]("ola")(
-  |      /* ambiguous: both object listMonad in object M and object optionMonad in object M match type M[F] */summon[M[F]]
-  |    )    failed with
+  |      /* ambiguous: both object listMonad in object M and object optionMonad in object M match type M[F] */summon[M[F]])
+  |
+  |    failed with:
   |
   |        Ambiguous given instances: both object listMonad in object M and object optionMonad in object M match type M[F] of parameter m of method pure in object M
 -- Error: tests/neg/i9185.scala:8:28 -----------------------------------------------------------------------------------
@@ -19,7 +20,9 @@
    |          value len is not a member of String.
    |          An extension method was tried, but could not be fully constructed:
    |
-   |              M.len("abc")    failed with
+   |              M.len("abc")
+   |
+   |              failed with:
    |
    |                  Found:    ("abc" : String)
    |                  Required: Int

--- a/tests/neg/mirror-synthesis-errors-b.check
+++ b/tests/neg/mirror-synthesis-errors-b.check
@@ -9,13 +9,13 @@
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:23:49 --------------------------------------------------------------
 23 |val testC = summon[Mirror.Of[Cns[Int] & Sm[Int]]] // error: unreleated
    |                                                 ^
-   |No given instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]]: 
+   |No given instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Cns[Int] & Sm[Int]]:
    |	* type `Cns[Int] & Sm[Int]` is not a generic product because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated definitions class Cns and class Sm.
    |	* type `Cns[Int] & Sm[Int]` is not a generic sum because its subpart `Cns[Int] & Sm[Int]` is an intersection of unrelated definitions class Cns and class Sm.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:24:49 --------------------------------------------------------------
 24 |val testD = summon[Mirror.Of[Sm[Int] & Cns[Int]]] // error: unreleated
    |                                                 ^
-   |No given instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]]: 
+   |No given instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Sm[Int] & Cns[Int]]:
    |	* type `Sm[Int] & Cns[Int]` is not a generic product because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated definitions class Sm and class Cns.
    |	* type `Sm[Int] & Cns[Int]` is not a generic sum because its subpart `Sm[Int] & Cns[Int]` is an intersection of unrelated definitions class Sm and class Cns.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:25:55 --------------------------------------------------------------
@@ -29,12 +29,12 @@
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:27:54 --------------------------------------------------------------
 27 |val testG = summon[Mirror.Of[Foo.A.type & Foo.B.type]] // error: unreleated
    |                                                      ^
-   |No given instance of type deriving.Mirror.Of[(Foo.A : Foo) & (Foo.B : Foo)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Foo.A : Foo) & (Foo.B : Foo)]: 
+   |No given instance of type deriving.Mirror.Of[(Foo.A : Foo) & (Foo.B : Foo)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Foo.A : Foo) & (Foo.B : Foo)]:
    |	* type `(Foo.A : Foo) & (Foo.B : Foo)` is not a generic product because its subpart `(Foo.A : Foo) & (Foo.B : Foo)` is an intersection of unrelated definitions value A and value B.
    |	* type `(Foo.A : Foo) & (Foo.B : Foo)` is not a generic sum because its subpart `(Foo.A : Foo) & (Foo.B : Foo)` is an intersection of unrelated definitions value A and value B.
 -- Error: tests/neg/mirror-synthesis-errors-b.scala:28:54 --------------------------------------------------------------
 28 |val testH = summon[Mirror.Of[Foo.B.type & Foo.A.type]] // error: unreleated
    |                                                      ^
-   |No given instance of type deriving.Mirror.Of[(Foo.B : Foo) & (Foo.A : Foo)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Foo.B : Foo) & (Foo.A : Foo)]: 
+   |No given instance of type deriving.Mirror.Of[(Foo.B : Foo) & (Foo.A : Foo)] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[(Foo.B : Foo) & (Foo.A : Foo)]:
    |	* type `(Foo.B : Foo) & (Foo.A : Foo)` is not a generic product because its subpart `(Foo.B : Foo) & (Foo.A : Foo)` is an intersection of unrelated definitions value B and value A.
    |	* type `(Foo.B : Foo) & (Foo.A : Foo)` is not a generic sum because its subpart `(Foo.B : Foo) & (Foo.A : Foo)` is an intersection of unrelated definitions value B and value A.

--- a/tests/neg/mirror-synthesis-errors.check
+++ b/tests/neg/mirror-synthesis-errors.check
@@ -1,42 +1,42 @@
 -- Error: tests/neg/mirror-synthesis-errors.scala:21:32 ----------------------------------------------------------------
 21 |val testA = summon[Mirror.Of[A]] // error: Not a sealed trait
    |                                ^
-   |No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[A]: 
+   |No given instance of type deriving.Mirror.Of[A] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[A]:
    |	* trait A is not a generic product because it is not a case class
    |	* trait A is not a generic sum because it is not a sealed trait
 -- Error: tests/neg/mirror-synthesis-errors.scala:22:32 ----------------------------------------------------------------
 22 |val testC = summon[Mirror.Of[C]] // error: Does not have subclasses
    |                                ^
-   |No given instance of type deriving.Mirror.Of[C] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[C]: 
+   |No given instance of type deriving.Mirror.Of[C] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[C]:
    |	* trait C is not a generic product because it is not a case class
    |	* trait C is not a generic sum because it does not have subclasses
 -- Error: tests/neg/mirror-synthesis-errors.scala:23:32 ----------------------------------------------------------------
 23 |val testD = summon[Mirror.Of[D]] // error: child SubD takes more than one parameter list
    |                                ^
-   |No given instance of type deriving.Mirror.Of[D] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[D]: 
+   |No given instance of type deriving.Mirror.Of[D] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[D]:
    |	* class D is not a generic product because it is not a case class
    |	* class D is not a generic sum because its child class SubD is not a generic product because it takes more than one parameter list
 -- Error: tests/neg/mirror-synthesis-errors.scala:24:38 ----------------------------------------------------------------
 24 |val testSubD = summon[Mirror.Of[SubD]] // error: takes more than one parameter list
    |                                      ^
-   |No given instance of type deriving.Mirror.Of[SubD] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubD]: 
+   |No given instance of type deriving.Mirror.Of[SubD] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[SubD]:
    |	* class SubD is not a generic product because it takes more than one parameter list
    |	* class SubD is not a generic sum because it is not a sealed class
 -- Error: tests/neg/mirror-synthesis-errors.scala:25:32 ----------------------------------------------------------------
 25 |val testE = summon[Mirror.Of[E]] // error: Not an abstract class
    |                                ^
-   |No given instance of type deriving.Mirror.Of[E] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[E]: 
+   |No given instance of type deriving.Mirror.Of[E] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[E]:
    |	* class E is not a generic product because it is not a case class
    |	* class E is not a generic sum because it is not an abstract class
 -- Error: tests/neg/mirror-synthesis-errors.scala:26:32 ----------------------------------------------------------------
 26 |val testF = summon[Mirror.Of[F]] // error: No children
    |                                ^
-   |No given instance of type deriving.Mirror.Of[F] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[F]: 
+   |No given instance of type deriving.Mirror.Of[F] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[F]:
    |	* trait F is not a generic product because it is not a case class
    |	* trait F is not a generic sum because it does not have subclasses
 -- Error: tests/neg/mirror-synthesis-errors.scala:27:36 ----------------------------------------------------------------
 27 |val testG = summon[Mirror.Of[Foo.G]] // error: Has anonymous subclasses
    |                                    ^
-   |No given instance of type deriving.Mirror.Of[Foo.G] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Foo.G]: 
+   |No given instance of type deriving.Mirror.Of[Foo.G] was found for parameter x of method summon in object Predef. Failed to synthesize an instance of type deriving.Mirror.Of[Foo.G]:
    |	* trait G is not a generic product because it is not a case class
    |	* trait G is not a generic sum because it has anonymous or inaccessible subclasses

--- a/tests/printing/annot-printing.check
+++ b/tests/printing/annot-printing.check
@@ -12,9 +12,9 @@ package <empty> {
   final module class Xyz() extends AnyRef() { this: Xyz.type =>
     def $lessinit$greater$default$1: Int @uncheckedVariance = 23
   }
-  final lazy module val annot-printing$package: annot-printing$package = 
+  final lazy module val annot-printing$package: annot-printing$package =
     new annot-printing$package()
-  final module class annot-printing$package() extends Object() { 
+  final module class annot-printing$package() extends Object() {
     this: annot-printing$package.type =>
     def x: Int @nowarn() @main @Xyz() @Foo @Bar("hello") = ???
   }

--- a/tests/printing/dependent-annot.check
+++ b/tests/printing/dependent-annot.check
@@ -4,15 +4,15 @@ package <empty> {
   class ann(x: Seq[Any] @Repeated) extends annotation.Annotation() {
     private[this] val x: Seq[Any] @Repeated
   }
-  final lazy module val dependent-annot$package: dependent-annot$package = 
+  final lazy module val dependent-annot$package: dependent-annot$package =
     new dependent-annot$package()
-  final module class dependent-annot$package() extends Object() { 
+  final module class dependent-annot$package() extends Object() {
     this: dependent-annot$package.type =>
-    def f(y: C, z: C): Unit = 
+    def f(y: C, z: C): Unit =
       {
         def g(): C @ann([y,z : Any]*) = ???
-        val ac: 
-          (C => Array[String]) 
+        val ac:
+          (C => Array[String])
             {
               def apply(x: C): Array[String @ann([x : Any]*)]
             }

--- a/tests/printing/transformed/lazy-vals-legacy.check
+++ b/tests/printing/transformed/lazy-vals-legacy.check
@@ -1,57 +1,52 @@
 [[syntax trees at end of MegaPhase{dropOuterAccessors, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, Collect entry points, collectSuperCalls, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-legacy.scala
 package <empty> {
-  @SourceFile("tests/printing/transformed/lazy-vals-legacy.scala") final module 
-    class
-   A extends Object {
-    def <init>(): Unit = 
+  @SourceFile("tests/printing/transformed/lazy-vals-legacy.scala") final module
+    class A extends Object {
+    def <init>(): Unit =
       {
         super()
         ()
       }
-    @static private def <clinit>(): Unit = 
+    @static private def <clinit>(): Unit =
       {
-        A.OFFSET$_m_0 = 
+        A.OFFSET$_m_0 =
           scala.runtime.LazyVals.getOffsetStatic(
-            classOf[Object {...}].getDeclaredField("0bitmap$1")
-          )
+            classOf[Object {...}].getDeclaredField("0bitmap$1"))
         ()
       }
-    @static @static val OFFSET$_m_0: Long = 
+    @static @static val OFFSET$_m_0: Long =
       scala.runtime.LazyVals.getOffsetStatic(
-        classOf[Object {...}].getDeclaredField("0bitmap$1")
-      )
+        classOf[Object {...}].getDeclaredField("0bitmap$1"))
     lazy var 0bitmap$1: Long = 0L
-    private def writeReplace(): Object = 
+    private def writeReplace(): Object =
       new scala.runtime.ModuleSerializationProxy(classOf[A])
     lazy var x$lzy1: Int = 0
-    lazy def x(): Int = 
-      while <empty> do 
+    lazy def x(): Int =
+      while <empty> do
         {
           val flag: Long = scala.runtime.LazyVals.get(this, A.OFFSET$_m_0)
           val state: Long = scala.runtime.LazyVals.STATE(flag, 0)
-          if state.==(3) then return A.x$lzy1 else 
-            if state.==(0) then 
+          if state.==(3) then return A.x$lzy1 else
+            if state.==(0) then
               if scala.runtime.LazyVals.CAS(this, A.OFFSET$_m_0, flag, 1, 0)
                  then
-               
-                try 
+                try
                   {
                     val result: Int = 2
                     A.x$lzy1 = result
                     scala.runtime.LazyVals.setFlag(this, A.OFFSET$_m_0, 3, 0)
                     return result
                   }
-                 catch 
+                 catch
                   {
-                    case ex @ ex => 
+                    case ex @ ex =>
                       scala.runtime.LazyVals.setFlag(this, A.OFFSET$_m_0, 0, 0)
                       throw ex
                   }
                else ()
-             else 
-              scala.runtime.LazyVals.wait4Notification(this, A.OFFSET$_m_0, flag
-                , 
-              0)
+             else
+              scala.runtime.LazyVals.wait4Notification(this, A.OFFSET$_m_0,
+                flag, 0)
         }
   }
   final lazy module val A: A = new A()

--- a/tests/printing/transformed/lazy-vals-new.check
+++ b/tests/printing/transformed/lazy-vals-new.check
@@ -1,97 +1,85 @@
 [[syntax trees at end of MegaPhase{dropOuterAccessors, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, Collect entry points, collectSuperCalls, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-new.scala
 package <empty> {
-  @SourceFile("tests/printing/transformed/lazy-vals-new.scala") final module 
-    class
-   A extends Object {
-    def <init>(): Unit = 
+  @SourceFile("tests/printing/transformed/lazy-vals-new.scala") final module
+    class A extends Object {
+    def <init>(): Unit =
       {
         super()
         ()
       }
-    @static private def <clinit>(): Unit = 
+    @static private def <clinit>(): Unit =
       {
-        A.OFFSET$_m_0 = 
+        A.OFFSET$_m_0 =
           scala.runtime.LazyVals.getStaticFieldOffset(
-            classOf[Object {...}].getDeclaredField("x$lzy1")
-          )
+            classOf[Object {...}].getDeclaredField("x$lzy1"))
         ()
       }
-    @static @static val OFFSET$_m_0: Long = 
+    @static @static val OFFSET$_m_0: Long =
       scala.runtime.LazyVals.getStaticFieldOffset(
-        classOf[Object {...}].getDeclaredField("x$lzy1")
-      )
-    private def writeReplace(): Object = 
+        classOf[Object {...}].getDeclaredField("x$lzy1"))
+    private def writeReplace(): Object =
       new scala.runtime.ModuleSerializationProxy(classOf[A])
     @volatile private lazy <static> var x$lzy1: Object = null
-    lazy def x(): Int = 
+    lazy def x(): Int =
       {
         val result: Object = A#x$lzy1
-        if result.isInstanceOf[Int] then scala.Int.unbox(result) else 
-          if result.eq(scala.runtime.LazyVals.NullValue) then 
-            scala.Int.unbox(null)
-           else scala.Int.unbox(A.x$lzyINIT1())
+        if result.isInstanceOf[Int] then scala.Int.unbox(result) else
+          if result.eq(scala.runtime.LazyVals.NullValue) then
+            scala.Int.unbox(null) else scala.Int.unbox(A.x$lzyINIT1())
       }
-    private def x$lzyINIT1(): Object = 
-      while <empty> do 
+    private def x$lzyINIT1(): Object =
+      while <empty> do
         {
           val current: Object = A#x$lzy1
-          if current.eq(null) then 
-            if 
-              scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0, null, 
-                scala.runtime.LazyVals.Evaluating
-              )
-             then 
+          if current.eq(null) then
+            if
+              scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0, null,
+                scala.runtime.LazyVals.Evaluating)
+             then
               {
                 var result: Object = null
                 var resultNullable: Object = null
-                try 
+                try
                   {
                     resultNullable = scala.Int.box(2)
-                    if resultNullable.eq(null) then 
-                      result = scala.runtime.LazyVals.NullValue
-                     else result = resultNullable
+                    if resultNullable.eq(null) then
+                      result = scala.runtime.LazyVals.NullValue else
+                      result = resultNullable
                     ()
                   }
-                 finally 
-                  if 
-                    scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0, 
-                      scala.runtime.LazyVals.Evaluating
-                    , result).unary_!()
-                   then 
+                 finally
+                  if
+                    scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0,
+                      scala.runtime.LazyVals.Evaluating, result).unary_!()
+                   then
                     {
-                      val lock: scala.runtime.LazyVals.LazyVals$Waiting = 
+                      val lock: scala.runtime.LazyVals.LazyVals$Waiting =
                         A#x$lzy1.asInstanceOf[
-                          scala.runtime.LazyVals.LazyVals$Waiting
-                        ]
-                      scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0, 
-                        lock
-                      , result)
+                          scala.runtime.LazyVals.LazyVals$Waiting]
+                      scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0,
+                        lock, result)
                       lock.countDown()
                     }
                    else ()
                 return resultNullable
               }
              else ()
-           else 
-            if 
+           else
+            if
               current.isInstanceOf[
-                scala.runtime.LazyVals.LazyVals$LazyValControlState
-              ]
-             then 
-              if current.eq(scala.runtime.LazyVals.Evaluating) then 
+                scala.runtime.LazyVals.LazyVals$LazyValControlState]
+             then
+              if current.eq(scala.runtime.LazyVals.Evaluating) then
                 {
-                  scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0, 
-                    current
-                  , new scala.runtime.LazyVals.LazyVals$Waiting())
+                  scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0,
+                    current, new scala.runtime.LazyVals.LazyVals$Waiting())
                   ()
                 }
-               else 
+               else
                 if current.isInstanceOf[scala.runtime.LazyVals.LazyVals$Waiting]
                    then
-                 
                   current.asInstanceOf[scala.runtime.LazyVals.LazyVals$Waiting].
-                    await
-                  ()
+                    await()
                  else return null
              else return current
         }

--- a/tests/printing/untyped/dependent-annot.check
+++ b/tests/printing/untyped/dependent-annot.check
@@ -2,7 +2,7 @@
 package <empty> {
   class C {}
   class ann(private[this] val x: Any *) extends annotation.Annotation {}
-  def f(y: C, z: C) = 
+  def f(y: C, z: C) =
     {
       def g(): C @ann(y, z) = ???
       val ac: ((x: C) => Array[String @ann(x)]) = ???


### PR DESCRIPTION
There was a problem with how some text wrapped.  I noticed it in the
printing of big tuple types and I started to write unit tests for those,
but there turned out to also be a checkfile that demonstrates the fix:
tests/neg/i14127.check:

    -  |  Int
    -  |, Int, Int)] was found for parameter x [...]
    -  |  Int
    -  |, Int, Int)]:
    +  |  Int, Int, Int)] was found for parameter [...]
    +  |  Int, Int, Int)]:

The fix is to make appendIndented, which is used by append, use Fluid
instead of switching to Vertical.  It seems to me that, pre-layout,
Vertical means "I want my elements to be vertical", i.e. wrap every one,
and it's layout that takes that into account.  Fluid instead means "wrap
where necessary, pack where possible".  Post-layout, instead, it looks
like Fluid means one-per-line, as it's consumed by print.  So the fix is
to switch appendIndented from Vertical to Fluid.

Following that I made some improvements like not needless boxing Str
into Closed and merging non-closed Fluid text during concat (`~`).
Also, I changed close to preserve the Vertical wrapping, but didn't
investigate that more.

That fixed the extra wrapping, but it meant that the ", " separator
could be the text that is wrapped and indented, which didn't look nice.
So I changed Text.apply to close the separator to the previous element.
That encouraged lines ending with ", ", that is with a trailing space,
so I made print strip trailing spaces.

The change from Vertical to Fluid made the last parenthesis in
tests/neg/i9185.check not wrap, which is fine, but that pulled the
trailing "failed with" up to the previous line.  As that's not code, I
decided to move it down and a line away from the code.
