### PR TITLE
Help givens return refined types

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3807,7 +3807,7 @@ object Parsers {
         if !(name.isEmpty && noParams) then acceptColon()
         val parents =
           if isSimpleLiteral then rejectWildcardType(annotType()) :: Nil
-          else constrApp() :: withConstrApps()
+          else refinedTypeRest(constrApp()) :: withConstrApps()
         val parentsIsType = parents.length == 1 && parents.head.isType
         if in.token == EQUALS && parentsIsType then
           accept(EQUALS)

--- a/tests/pos/i7045.scala
+++ b/tests/pos/i7045.scala
@@ -1,0 +1,9 @@
+trait Bar { type Y }
+trait Foo { type X }
+
+class Test:
+  given a1(using b: Bar): Foo = new Foo { type X = b.Y }
+
+  given a2(using b: Bar): Foo { type X = b.Y } = new Foo { type X = b.Y }
+
+  given a3(using b: Bar): (Foo { type X = b.Y }) = new Foo { type X = b.Y }


### PR DESCRIPTION
Previously parens were required (example "a3" vs "a2").
