### PR TITLE
Skip caching provisional OrType atoms

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3423,25 +3423,29 @@ object Types {
     private var myAtoms: Atoms = _
     private var myWidened: Type = _
 
+    private def computeAtoms()(using Context): Atoms =
+      if tp1.hasClassSymbol(defn.NothingClass) then tp2.atoms
+      else if tp2.hasClassSymbol(defn.NothingClass) then tp1.atoms
+      else tp1.atoms | tp2.atoms
+
+    private def computeWidenSingletons()(using Context): Type =
+      val tp1w = tp1.widenSingletons
+      val tp2w = tp2.widenSingletons
+      if ((tp1 eq tp1w) && (tp2 eq tp2w)) this else TypeComparer.lub(tp1w, tp2w, isSoft = isSoft)
+
     private def ensureAtomsComputed()(using Context): Unit =
-      if atomsRunId != ctx.runId then
-        myAtoms =
-          if tp1.hasClassSymbol(defn.NothingClass) then tp2.atoms
-          else if tp2.hasClassSymbol(defn.NothingClass) then tp1.atoms
-          else tp1.atoms | tp2.atoms
-        val tp1w = tp1.widenSingletons
-        val tp2w = tp2.widenSingletons
-        myWidened = if ((tp1 eq tp1w) && (tp2 eq tp2w)) this else TypeComparer.lub(tp1w, tp2w, isSoft = isSoft)
+      if atomsRunId != ctx.runId && !isProvisional then
+        myAtoms = computeAtoms()
+        myWidened = computeWidenSingletons()
         atomsRunId = ctx.runId
 
     override def atoms(using Context): Atoms =
       ensureAtomsComputed()
-      myAtoms
+      if isProvisional then computeAtoms() else myAtoms
 
-    override def widenSingletons(using Context): Type = {
+    override def widenSingletons(using Context): Type =
       ensureAtomsComputed()
-      myWidened
-    }
+      if isProvisional then computeWidenSingletons() else myWidened
 
     def derivedOrType(tp1: Type, tp2: Type, soft: Boolean = isSoft)(using Context): Type =
       if ((tp1 eq this.tp1) && (tp2 eq this.tp2) && soft == isSoft) this

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -258,8 +258,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
         if annot.symbol == defn.InlineParamAnnot || annot.symbol == defn.ErasedParamAnnot then toText(tpe)
         else toTextLocal(tpe) ~ " " ~ toText(annot)
       case tp: TypeVar =>
+        def toTextCaret(tp: Type) = if printDebug then toTextLocal(tp) ~ Str("^") else toText(tp)
         if (tp.isInstantiated)
-          toTextLocal(tp.instanceOpt) ~ (Str("^") provided printDebug)
+          toTextCaret(tp.instanceOpt)
         else {
           val constr = ctx.typerState.constraint
           val bounds =
@@ -267,7 +268,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
               withMode(Mode.Printing)(TypeComparer.fullBounds(tp.origin))
             else
               TypeBounds.empty
-          if (bounds.isTypeAlias) toText(bounds.lo) ~ (Str("^") provided printDebug)
+          if (bounds.isTypeAlias) toTextCaret(bounds.lo)
           else if (ctx.settings.YshowVarBounds.value) "(" ~ toText(tp.origin) ~ "?" ~ toText(bounds) ~ ")"
           else toText(tp.origin)
         }

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -31,7 +31,7 @@ abstract class Printer {
    *  ### `atPrec` vs `changePrec`
    *
    *  This is to be used when changing precedence inside some sort of parentheses:
-   *  for instance, to print T[A]` use
+   *  for instance, to print `T[A]` use
    *  `toText(T) ~ '[' ~ atPrec(GlobalPrec) { toText(A) } ~ ']'`.
    *
    *  If the presence of the parentheses depends on precedence, inserting them manually is most certainly a bug.
@@ -60,8 +60,7 @@ abstract class Printer {
    *  A op B op' C parses as (A op B) op' C if op and op' are left-associative, and as
    *  A op (B op' C) if they're right-associative, so we need respectively
    *  ```scala
-   *  val isType = ??? // is this a term or type operator?
-   *  val prec = parsing.precedence(op, isType)
+   *  val prec = parsing.precedence(op)
    *  // either:
    *  changePrec(prec) { toText(a) ~ op ~ atPrec(prec + 1) { toText(b) } } // for left-associative op and op'
    *  // or:

--- a/tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.check
+++ b/tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.check
@@ -9,7 +9,7 @@
 -- [E170] Type Error: tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.scala:16:61 ----------------------------
 16 |  val c = js.constructorTag[NativeJSClass with NativeJSTrait] // error
    |                                                             ^
-   |                                                             (NativeJSClass & NativeJSTrait) is not a class type
+   |                                                             NativeJSClass & NativeJSTrait is not a class type
 -- [E170] Type Error: tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.scala:17:59 ----------------------------
 17 |  val d = js.constructorTag[NativeJSClass { def bar: Int }] // error
    |                                                           ^
@@ -25,7 +25,7 @@
 -- [E170] Type Error: tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.scala:22:49 ----------------------------
 22 |  val g = js.constructorTag[JSClass with JSTrait] // error
    |                                                 ^
-   |                                                 (JSClass & JSTrait) is not a class type
+   |                                                 JSClass & JSTrait is not a class type
 -- [E170] Type Error: tests/neg-scalajs/jsconstructortag-error-in-prepjsinterop.scala:23:53 ----------------------------
 23 |  val h = js.constructorTag[JSClass { def bar: Int }] // error
    |                                                     ^

--- a/tests/pos/i15813.scala
+++ b/tests/pos/i15813.scala
@@ -1,0 +1,3 @@
+class Box[T]
+def dep1[T1 <: Singleton, T2 <: T1](t1: T1)(t2: T2): Box[T1] = ???
+val d1 = dep1(1)(2)


### PR DESCRIPTION
Also, fix printing TypeVars when not using -Yprint-debug so that it
doesn't add redudant and misleading parentheses, which can lead to the
perception that a tuple was inferred.
