### PR TITLE
Use `baseVersion` for reference documentation

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1498,7 +1498,7 @@ object Build {
             .add(OutputDir("scaladoc/output/reference"))
             .add(SiteRoot(s"${temp.getAbsolutePath}/docs"))
             .add(ProjectName("Scala 3 Reference"))
-            .add(ProjectVersion("3.2.0")) // TODO: Change that later to the current version tag. (This must happen on first forward this branch to stable release tag)
+            .add(ProjectVersion(baseVersion))
             .remove[VersionsDictionaryUrl]
             .add(SourceLinks(List(
               s"${temp.getAbsolutePath}=github://lampepfl/dotty/language-reference-stable"


### PR DESCRIPTION
Now when we are syncing `language-reference-stable` with the release branches after each patch release, it is safe to use the `baseVersion` as a version for the documentation. It wasn't the case earlier because we assumed a slightly more complicated model for publishing the reference documentation.

Note to self:
This should be ported to both `main` and `release-3.2.2`. The former will be tried automatically, but will probably fail due to conflicts.

see: #15598