### PR TITLE
Refactor `Tree` parameterization

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable
 
 import scala.annotation.tailrec
 
-trait TreeInfo[T >: Untyped <: Type] { self: Trees.Instance[T] =>
+trait TreeInfo[T <: Untyped] { self: Trees.Instance[T] =>
 
   // Note: the <: Type constraint looks necessary (and is needed to make the file compile in dotc).
   // But Scalac accepts the program happily without it. Need to find out why.

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -15,11 +15,12 @@ import config.Printers.overload
 import annotation.internal.sharable
 import annotation.unchecked.uncheckedVariance
 import annotation.constructorOnly
+import compiletime.uninitialized
 import Decorators._
 
 object Trees {
 
-  type Untyped = Nothing
+  type Untyped = Type | Null
 
   /** The total number of created tree nodes, maintained if Stats.enabled */
   @sharable var ntrees: Int = 0
@@ -45,36 +46,34 @@ object Trees {
    *   - Type checking an untyped tree should remove all embedded `TypedSplice`
    *     nodes.
    */
-  abstract class Tree[-T >: Untyped](implicit @constructorOnly src: SourceFile)
+  abstract class Tree[+T <: Untyped](implicit @constructorOnly src: SourceFile)
   extends Positioned, SrcPos, Product, Attachment.Container, printing.Showable {
 
     if (Stats.enabled) ntrees += 1
 
     /** The type  constructor at the root of the tree */
-    type ThisTree[T >: Untyped] <: Tree[T]
+    type ThisTree[T <: Untyped] <: Tree[T]
 
-    protected var myTpe: T @uncheckedVariance = _
+    protected var myTpe: T @uncheckedVariance = uninitialized
 
     /** Destructively set the type of the tree. This should be called only when it is known that
      *  it is safe under sharing to do so. One use-case is in the withType method below
      *  which implements copy-on-write. Another use-case is in method interpolateAndAdapt in Typer,
      *  where we overwrite with a simplified version of the type itself.
      */
-    private[dotc] def overwriteType(tpe: T): Unit =
+    private[dotc] def overwriteType(tpe: T @uncheckedVariance): Unit =
       myTpe = tpe
 
     /** The type of the tree. In case of an untyped tree,
      *   an UnAssignedTypeException is thrown. (Overridden by empty trees)
      */
-    final def tpe: T @uncheckedVariance = {
-      if (myTpe == null)
-        throw UnAssignedTypeException(this)
-      myTpe
-    }
+    final def tpe: T =
+      if myTpe == null then throw UnAssignedTypeException(this)
+      myTpe.uncheckedNN
 
     /** Copy `tpe` attribute from tree `from` into this tree, independently
      *  whether it is null or not.
-    final def copyAttr[U >: Untyped](from: Tree[U]): ThisTree[T] = {
+    final def copyAttr[U <: Untyped](from: Tree[U]): ThisTree[T] = {
       val t1 = this.withSpan(from.span)
       val t2 =
         if (from.myTpe != null) t1.withType(from.myTpe.asInstanceOf[Type])
@@ -131,10 +130,9 @@ object Trees {
      */
     final def hasType: Boolean = myTpe != null
 
-    final def typeOpt: Type = myTpe match {
+    final def typeOpt: Type = myTpe match
       case tp: Type => tp
-      case _ => NoType
-    }
+      case null => NoType
 
     /** The denotation referred to by this tree.
      *  Defined for `DenotingTree`s and `ProxyTree`s, NoDenotation for other
@@ -166,7 +164,7 @@ object Trees {
     def toList: List[Tree[T]] = this :: Nil
 
     /** if this tree is the empty tree, the alternative, else this tree */
-    inline def orElse[U >: Untyped <: T](inline that: Tree[U]): Tree[U] =
+    inline def orElse[U >: T <: Untyped](inline that: Tree[U]): Tree[U] =
       if (this eq genericEmptyTree) that else this
 
     /** The number of nodes in this tree */
@@ -217,42 +215,42 @@ object Trees {
     override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
   }
 
-  class UnAssignedTypeException[T >: Untyped](tree: Tree[T]) extends RuntimeException {
+  class UnAssignedTypeException[T <: Untyped](tree: Tree[T]) extends RuntimeException {
     override def getMessage: String = s"type of $tree is not assigned"
   }
 
-  type LazyTree[-T >: Untyped] = Tree[T] | Lazy[Tree[T]]
-  type LazyTreeList[-T >: Untyped] = List[Tree[T]] | Lazy[List[Tree[T]]]
+  type LazyTree[+T <: Untyped] = Tree[T] | Lazy[Tree[T]]
+  type LazyTreeList[+T <: Untyped] = List[Tree[T]] | Lazy[List[Tree[T]]]
 
   // ------ Categories of trees -----------------------------------
 
   /** Instances of this class are trees for which isType is definitely true.
    *  Note that some trees have isType = true without being TypTrees (e.g. Ident, Annotated)
    */
-  trait TypTree[-T >: Untyped] extends Tree[T] {
-    type ThisTree[-T >: Untyped] <: TypTree[T]
+  trait TypTree[+T <: Untyped] extends Tree[T] {
+    type ThisTree[+T <: Untyped] <: TypTree[T]
     override def isType: Boolean = true
   }
 
   /** Instances of this class are trees for which isTerm is definitely true.
    *  Note that some trees have isTerm = true without being TermTrees (e.g. Ident, Annotated)
    */
-  trait TermTree[-T >: Untyped] extends Tree[T] {
-    type ThisTree[-T >: Untyped] <: TermTree[T]
+  trait TermTree[+T <: Untyped] extends Tree[T] {
+    type ThisTree[+T <: Untyped] <: TermTree[T]
     override def isTerm: Boolean = true
   }
 
   /** Instances of this class are trees which are not terms but are legal
    *  parts of patterns.
    */
-  trait PatternTree[-T >: Untyped] extends Tree[T] {
-    type ThisTree[-T >: Untyped] <: PatternTree[T]
+  trait PatternTree[+T <: Untyped] extends Tree[T] {
+    type ThisTree[+T <: Untyped] <: PatternTree[T]
     override def isPattern: Boolean = true
   }
 
   /** Tree's denotation can be derived from its type */
-  abstract class DenotingTree[-T >: Untyped](implicit @constructorOnly src: SourceFile) extends Tree[T] {
-    type ThisTree[-T >: Untyped] <: DenotingTree[T]
+  abstract class DenotingTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends Tree[T] {
+    type ThisTree[+T <: Untyped] <: DenotingTree[T]
     override def denot(using Context): Denotation = typeOpt.stripped match
       case tpe: NamedType => tpe.denot
       case tpe: ThisType => tpe.cls.denot
@@ -262,8 +260,8 @@ object Trees {
   /** Tree's denot/isType/isTerm properties come from a subtree
    *  identified by `forwardTo`.
    */
-  abstract class ProxyTree[-T >: Untyped](implicit @constructorOnly src: SourceFile)  extends Tree[T] {
-    type ThisTree[-T >: Untyped] <: ProxyTree[T]
+  abstract class ProxyTree[+T <: Untyped](implicit @constructorOnly src: SourceFile)  extends Tree[T] {
+    type ThisTree[+T <: Untyped] <: ProxyTree[T]
     def forwardTo: Tree[T]
     override def denot(using Context): Denotation = forwardTo.denot
     override def isTerm: Boolean = forwardTo.isTerm
@@ -271,24 +269,24 @@ object Trees {
   }
 
   /** Tree has a name */
-  abstract class NameTree[-T >: Untyped](implicit @constructorOnly src: SourceFile) extends DenotingTree[T] {
-    type ThisTree[-T >: Untyped] <: NameTree[T]
+  abstract class NameTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends DenotingTree[T] {
+    type ThisTree[+T <: Untyped] <: NameTree[T]
     def name: Name
   }
 
   /** Tree refers by name to a denotation */
-  abstract class RefTree[-T >: Untyped](implicit @constructorOnly src: SourceFile) extends NameTree[T] {
-    type ThisTree[-T >: Untyped] <: RefTree[T]
+  abstract class RefTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends NameTree[T] {
+    type ThisTree[+T <: Untyped] <: RefTree[T]
     def qualifier: Tree[T]
     override def isType: Boolean = name.isTypeName
     override def isTerm: Boolean = name.isTermName
   }
 
   /** Tree defines a new symbol */
-  trait DefTree[-T >: Untyped] extends DenotingTree[T] {
-    type ThisTree[-T >: Untyped] <: DefTree[T]
+  trait DefTree[+T <: Untyped] extends DenotingTree[T] {
+    type ThisTree[+T <: Untyped] <: DefTree[T]
 
-    private var myMods: untpd.Modifiers | Null = _
+    private var myMods: untpd.Modifiers | Null = uninitialized
 
     private[dotc] def rawMods: untpd.Modifiers =
       if (myMods == null) untpd.EmptyModifiers else myMods.uncheckedNN
@@ -313,7 +311,7 @@ object Trees {
 
   extension (mdef: untpd.DefTree) def mods: untpd.Modifiers = mdef.rawMods
 
-  sealed trait WithEndMarker[-T >: Untyped]:
+  sealed trait WithEndMarker[+T <: Untyped]:
     self: PackageDef[T] | NamedDefTree[T] =>
 
     import WithEndMarker.*
@@ -356,9 +354,9 @@ object Trees {
 
   end WithEndMarker
 
-  abstract class NamedDefTree[-T >: Untyped](implicit @constructorOnly src: SourceFile)
+  abstract class NamedDefTree[+T <: Untyped](implicit @constructorOnly src: SourceFile)
   extends NameTree[T] with DefTree[T] with WithEndMarker[T] {
-    type ThisTree[-T >: Untyped] <: NamedDefTree[T]
+    type ThisTree[+T <: Untyped] <: NamedDefTree[T]
 
     protected def srcName(using Context): Name =
       if name == nme.CONSTRUCTOR then nme.this_
@@ -395,8 +393,8 @@ object Trees {
    *  The envelope of a MemberDef contains the whole definition and has its point
    *  on the opening keyword (or the next token after that if keyword is missing).
    */
-  abstract class MemberDef[-T >: Untyped](implicit @constructorOnly src: SourceFile) extends NamedDefTree[T] {
-    type ThisTree[-T >: Untyped] <: MemberDef[T]
+  abstract class MemberDef[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends NamedDefTree[T] {
+    type ThisTree[+T <: Untyped] <: MemberDef[T]
 
     def rawComment: Option[Comment] = getAttachment(DocComment)
 
@@ -409,40 +407,40 @@ object Trees {
   }
 
   /** A ValDef or DefDef tree */
-  abstract class ValOrDefDef[-T >: Untyped](implicit @constructorOnly src: SourceFile) extends MemberDef[T] with WithLazyField[Tree[T]] {
-    type ThisTree[-T >: Untyped] <: ValOrDefDef[T]
+  abstract class ValOrDefDef[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends MemberDef[T] with WithLazyField[Tree[T]] {
+    type ThisTree[+T <: Untyped] <: ValOrDefDef[T]
     def name: TermName
     def tpt: Tree[T]
     def unforcedRhs: LazyTree[T] = unforced
     def rhs(using Context): Tree[T] = forceIfLazy
   }
 
-  trait ValOrTypeDef[-T >: Untyped] extends MemberDef[T]:
-    type ThisTree[-T >: Untyped] <: ValOrTypeDef[T]
+  trait ValOrTypeDef[+T <: Untyped] extends MemberDef[T]:
+    type ThisTree[+T <: Untyped] <: ValOrTypeDef[T]
 
-  type ParamClause[T >: Untyped] = List[ValDef[T]] | List[TypeDef[T]]
+  type ParamClause[T <: Untyped] = List[ValDef[T]] | List[TypeDef[T]]
 
   // ----------- Tree case classes ------------------------------------
 
   /** name */
-  case class Ident[-T >: Untyped] private[ast] (name: Name)(implicit @constructorOnly src: SourceFile)
+  case class Ident[+T <: Untyped] private[ast] (name: Name)(implicit @constructorOnly src: SourceFile)
     extends RefTree[T] {
-    type ThisTree[-T >: Untyped] = Ident[T]
+    type ThisTree[+T <: Untyped] = Ident[T]
     def qualifier: Tree[T] = genericEmptyTree
 
     def isBackquoted: Boolean = hasAttachment(Backquoted)
   }
 
-  class SearchFailureIdent[-T >: Untyped] private[ast] (name: Name, expl: => String)(implicit @constructorOnly src: SourceFile)
+  class SearchFailureIdent[+T <: Untyped] private[ast] (name: Name, expl: => String)(implicit @constructorOnly src: SourceFile)
     extends Ident[T](name) {
     def explanation = expl
     override def toString: String = s"SearchFailureIdent($explanation)"
   }
 
   /** qualifier.name, or qualifier#name, if qualifier is a type */
-  case class Select[-T >: Untyped] private[ast] (qualifier: Tree[T], name: Name)(implicit @constructorOnly src: SourceFile)
+  case class Select[+T <: Untyped] private[ast] (qualifier: Tree[T], name: Name)(implicit @constructorOnly src: SourceFile)
     extends RefTree[T] {
-    type ThisTree[-T >: Untyped] = Select[T]
+    type ThisTree[+T <: Untyped] = Select[T]
 
     override def denot(using Context): Denotation = typeOpt match
       case ConstantType(_) if ConstFold.foldedUnops.contains(name) =>
@@ -464,15 +462,15 @@ object Trees {
       else span
   }
 
-  class SelectWithSig[-T >: Untyped] private[ast] (qualifier: Tree[T], name: Name, val sig: Signature)(implicit @constructorOnly src: SourceFile)
+  class SelectWithSig[+T <: Untyped] private[ast] (qualifier: Tree[T], name: Name, val sig: Signature)(implicit @constructorOnly src: SourceFile)
     extends Select[T](qualifier, name) {
     override def toString: String = s"SelectWithSig($qualifier, $name, $sig)"
   }
 
   /** qual.this */
-  case class This[-T >: Untyped] private[ast] (qual: untpd.Ident)(implicit @constructorOnly src: SourceFile)
+  case class This[+T <: Untyped] private[ast] (qual: untpd.Ident)(implicit @constructorOnly src: SourceFile)
     extends DenotingTree[T] with TermTree[T] {
-    type ThisTree[-T >: Untyped] = This[T]
+    type ThisTree[+T <: Untyped] = This[T]
     // Denotation of a This tree is always the underlying class; needs correction for modules.
     override def denot(using Context): Denotation =
       typeOpt match {
@@ -484,21 +482,21 @@ object Trees {
   }
 
   /** C.super[mix], where qual = C.this */
-  case class Super[-T >: Untyped] private[ast] (qual: Tree[T], mix: untpd.Ident)(implicit @constructorOnly src: SourceFile)
+  case class Super[+T <: Untyped] private[ast] (qual: Tree[T], mix: untpd.Ident)(implicit @constructorOnly src: SourceFile)
     extends ProxyTree[T] with TermTree[T] {
-    type ThisTree[-T >: Untyped] = Super[T]
+    type ThisTree[+T <: Untyped] = Super[T]
     def forwardTo: Tree[T] = qual
   }
 
-  abstract class GenericApply[-T >: Untyped](implicit @constructorOnly src: SourceFile) extends ProxyTree[T] with TermTree[T] {
-    type ThisTree[-T >: Untyped] <: GenericApply[T]
+  abstract class GenericApply[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends ProxyTree[T] with TermTree[T] {
+    type ThisTree[+T <: Untyped] <: GenericApply[T]
     val fun: Tree[T]
     val args: List[Tree[T]]
     def forwardTo: Tree[T] = fun
   }
 
   object GenericApply:
-    def unapply[T >: Untyped](tree: Tree[T]): Option[(Tree[T], List[Tree[T]])] = tree match
+    def unapply[T <: Untyped](tree: Tree[T]): Option[(Tree[T], List[Tree[T]])] = tree match
       case tree: GenericApply[T] => Some((tree.fun, tree.args))
       case _ => None
 
@@ -509,9 +507,9 @@ object Trees {
     case InfixTuple   // r f (x1, ..., xN) where N != 1;  needs to be treated specially for an error message in typedApply
 
   /** fun(args) */
-  case class Apply[-T >: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class Apply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends GenericApply[T] {
-    type ThisTree[-T >: Untyped] = Apply[T]
+    type ThisTree[+T <: Untyped] = Apply[T]
 
     def setApplyKind(kind: ApplyKind) =
       putAttachment(untpd.KindOfApply, kind)
@@ -525,57 +523,57 @@ object Trees {
   }
 
   /** fun[args] */
-  case class TypeApply[-T >: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class TypeApply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends GenericApply[T] {
-    type ThisTree[-T >: Untyped] = TypeApply[T]
+    type ThisTree[+T <: Untyped] = TypeApply[T]
   }
 
   /** const */
-  case class Literal[-T >: Untyped] private[ast] (const: Constant)(implicit @constructorOnly src: SourceFile)
+  case class Literal[+T <: Untyped] private[ast] (const: Constant)(implicit @constructorOnly src: SourceFile)
     extends Tree[T] with TermTree[T] {
-    type ThisTree[-T >: Untyped] = Literal[T]
+    type ThisTree[+T <: Untyped] = Literal[T]
   }
 
   /** new tpt, but no constructor call */
-  case class New[-T >: Untyped] private[ast] (tpt: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class New[+T <: Untyped] private[ast] (tpt: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] with TermTree[T] {
-    type ThisTree[-T >: Untyped] = New[T]
+    type ThisTree[+T <: Untyped] = New[T]
   }
 
   /** expr : tpt */
-  case class Typed[-T >: Untyped] private[ast] (expr: Tree[T], tpt: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Typed[+T <: Untyped] private[ast] (expr: Tree[T], tpt: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends ProxyTree[T] with TermTree[T] {
-    type ThisTree[-T >: Untyped] = Typed[T]
+    type ThisTree[+T <: Untyped] = Typed[T]
     def forwardTo: Tree[T] = expr
   }
 
   /** name = arg, in a parameter list */
-  case class NamedArg[-T >: Untyped] private[ast] (name: Name, arg: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class NamedArg[+T <: Untyped] private[ast] (name: Name, arg: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] {
-    type ThisTree[-T >: Untyped] = NamedArg[T]
+    type ThisTree[+T <: Untyped] = NamedArg[T]
   }
 
   /** name = arg, outside a parameter list */
-  case class Assign[-T >: Untyped] private[ast] (lhs: Tree[T], rhs: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Assign[+T <: Untyped] private[ast] (lhs: Tree[T], rhs: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TermTree[T] {
-    type ThisTree[-T >: Untyped] = Assign[T]
+    type ThisTree[+T <: Untyped] = Assign[T]
   }
 
   /** { stats; expr } */
-  case class Block[-T >: Untyped] private[ast] (stats: List[Tree[T]], expr: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Block[+T <: Untyped] private[ast] (stats: List[Tree[T]], expr: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] {
-    type ThisTree[-T >: Untyped] = Block[T]
+    type ThisTree[+T <: Untyped] = Block[T]
     override def isType: Boolean = expr.isType
     override def isTerm: Boolean = !isType // this will classify empty trees as terms, which is necessary
   }
 
   /** if cond then thenp else elsep */
-  case class If[-T >: Untyped] private[ast] (cond: Tree[T], thenp: Tree[T], elsep: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class If[+T <: Untyped] private[ast] (cond: Tree[T], thenp: Tree[T], elsep: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TermTree[T] {
-    type ThisTree[-T >: Untyped] = If[T]
+    type ThisTree[+T <: Untyped] = If[T]
     def isInline = false
   }
-  class InlineIf[-T >: Untyped] private[ast] (cond: Tree[T], thenp: Tree[T], elsep: Tree[T])(implicit @constructorOnly src: SourceFile)
+  class InlineIf[+T <: Untyped] private[ast] (cond: Tree[T], thenp: Tree[T], elsep: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends If(cond, thenp, elsep) {
     override def isInline = true
     override def toString = s"InlineIf($cond, $thenp, $elsep)"
@@ -590,33 +588,33 @@ object Trees {
    *                of the closure is a function type, otherwise it is the type
    *                given in `tpt`, which must be a SAM type.
    */
-  case class Closure[-T >: Untyped] private[ast] (env: List[Tree[T]], meth: Tree[T], tpt: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Closure[+T <: Untyped] private[ast] (env: List[Tree[T]], meth: Tree[T], tpt: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TermTree[T] {
-    type ThisTree[-T >: Untyped] = Closure[T]
+    type ThisTree[+T <: Untyped] = Closure[T]
   }
 
   /** selector match { cases } */
-  case class Match[-T >: Untyped] private[ast] (selector: Tree[T], cases: List[CaseDef[T]])(implicit @constructorOnly src: SourceFile)
+  case class Match[+T <: Untyped] private[ast] (selector: Tree[T], cases: List[CaseDef[T]])(implicit @constructorOnly src: SourceFile)
     extends TermTree[T] {
-    type ThisTree[-T >: Untyped] = Match[T]
+    type ThisTree[+T <: Untyped] = Match[T]
     def isInline = false
   }
-  class InlineMatch[-T >: Untyped] private[ast] (selector: Tree[T], cases: List[CaseDef[T]])(implicit @constructorOnly src: SourceFile)
+  class InlineMatch[+T <: Untyped] private[ast] (selector: Tree[T], cases: List[CaseDef[T]])(implicit @constructorOnly src: SourceFile)
     extends Match(selector, cases) {
     override def isInline = true
     override def toString = s"InlineMatch($selector, $cases)"
   }
 
   /** case pat if guard => body */
-  case class CaseDef[-T >: Untyped] private[ast] (pat: Tree[T], guard: Tree[T], body: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class CaseDef[+T <: Untyped] private[ast] (pat: Tree[T], guard: Tree[T], body: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] {
-    type ThisTree[-T >: Untyped] = CaseDef[T]
+    type ThisTree[+T <: Untyped] = CaseDef[T]
   }
 
   /** label[tpt]: { expr } */
-  case class Labeled[-T >: Untyped] private[ast] (bind: Bind[T], expr: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Labeled[+T <: Untyped] private[ast] (bind: Bind[T], expr: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends NameTree[T] {
-    type ThisTree[-T >: Untyped] = Labeled[T]
+    type ThisTree[+T <: Untyped] = Labeled[T]
     def name: Name = bind.name
   }
 
@@ -625,33 +623,33 @@ object Trees {
    *  After program transformations this is not necessarily the enclosing method, because
    *  closures can intervene.
    */
-  case class Return[-T >: Untyped] private[ast] (expr: Tree[T], from: Tree[T] = genericEmptyTree)(implicit @constructorOnly src: SourceFile)
+  case class Return[+T <: Untyped] private[ast] (expr: Tree[T], from: Tree[T] = genericEmptyTree)(implicit @constructorOnly src: SourceFile)
     extends TermTree[T] {
-    type ThisTree[-T >: Untyped] = Return[T]
+    type ThisTree[+T <: Untyped] = Return[T]
   }
 
   /** while (cond) { body } */
-  case class WhileDo[-T >: Untyped] private[ast] (cond: Tree[T], body: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class WhileDo[+T <: Untyped] private[ast] (cond: Tree[T], body: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TermTree[T] {
-    type ThisTree[-T >: Untyped] = WhileDo[T]
+    type ThisTree[+T <: Untyped] = WhileDo[T]
   }
 
   /** try block catch cases finally finalizer */
-  case class Try[-T >: Untyped] private[ast] (expr: Tree[T], cases: List[CaseDef[T]], finalizer: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Try[+T <: Untyped] private[ast] (expr: Tree[T], cases: List[CaseDef[T]], finalizer: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TermTree[T] {
-    type ThisTree[-T >: Untyped] = Try[T]
+    type ThisTree[+T <: Untyped] = Try[T]
   }
 
   /** Seq(elems)
    *  @param  tpt  The element type of the sequence.
    */
-  case class SeqLiteral[-T >: Untyped] private[ast] (elems: List[Tree[T]], elemtpt: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class SeqLiteral[+T <: Untyped] private[ast] (elems: List[Tree[T]], elemtpt: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] {
-    type ThisTree[-T >: Untyped] = SeqLiteral[T]
+    type ThisTree[+T <: Untyped] = SeqLiteral[T]
   }
 
   /** Array(elems) */
-  class JavaSeqLiteral[-T >: Untyped] private[ast] (elems: List[Tree[T]], elemtpt: Tree[T])(implicit @constructorOnly src: SourceFile)
+  class JavaSeqLiteral[+T <: Untyped] private[ast] (elems: List[Tree[T]], elemtpt: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends SeqLiteral(elems, elemtpt) {
     override def toString: String = s"JavaSeqLiteral($elems, $elemtpt)"
   }
@@ -672,17 +670,17 @@ object Trees {
    *  different context: `bindings` represent the arguments to the inlined
    *  call, whereas `expansion` represents the body of the inlined function.
    */
-  case class Inlined[-T >: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Inlined[+T <: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] {
-    type ThisTree[-T >: Untyped] = Inlined[T]
+    type ThisTree[+T <: Untyped] = Inlined[T]
     override def isTerm = expansion.isTerm
     override def isType = expansion.isType
   }
 
   /** A type tree that represents an existing or inferred type */
-  case class TypeTree[-T >: Untyped]()(implicit @constructorOnly src: SourceFile)
+  case class TypeTree[+T <: Untyped]()(implicit @constructorOnly src: SourceFile)
     extends DenotingTree[T] with TypTree[T] {
-    type ThisTree[-T >: Untyped] = TypeTree[T]
+    type ThisTree[+T <: Untyped] = TypeTree[T]
     override def isEmpty: Boolean = !hasType
     override def toString: String =
       s"TypeTree${if (hasType) s"[$typeOpt]" else ""}"
@@ -693,25 +691,25 @@ object Trees {
    *    - as a (result-)type of an inferred ValDef or DefDef.
    *  Every TypeVar is created as the type of one InferredTypeTree.
    */
-  class InferredTypeTree[-T >: Untyped](implicit @constructorOnly src: SourceFile) extends TypeTree[T]
+  class InferredTypeTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends TypeTree[T]
 
   /** ref.type */
-  case class SingletonTypeTree[-T >: Untyped] private[ast] (ref: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class SingletonTypeTree[+T <: Untyped] private[ast] (ref: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends DenotingTree[T] with TypTree[T] {
-    type ThisTree[-T >: Untyped] = SingletonTypeTree[T]
+    type ThisTree[+T <: Untyped] = SingletonTypeTree[T]
   }
 
   /** tpt { refinements } */
-  case class RefinedTypeTree[-T >: Untyped] private[ast] (tpt: Tree[T], refinements: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class RefinedTypeTree[+T <: Untyped] private[ast] (tpt: Tree[T], refinements: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends ProxyTree[T] with TypTree[T] {
-    type ThisTree[-T >: Untyped] = RefinedTypeTree[T]
+    type ThisTree[+T <: Untyped] = RefinedTypeTree[T]
     def forwardTo: Tree[T] = tpt
   }
 
   /** tpt[args] */
-  case class AppliedTypeTree[-T >: Untyped] private[ast] (tpt: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class AppliedTypeTree[+T <: Untyped] private[ast] (tpt: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends ProxyTree[T] with TypTree[T] {
-    type ThisTree[-T >: Untyped] = AppliedTypeTree[T]
+    type ThisTree[+T <: Untyped] = AppliedTypeTree[T]
     def forwardTo: Tree[T] = tpt
   }
 
@@ -738,40 +736,40 @@ object Trees {
    *  source code written by the user with the trees used by the compiler (for
    *  example, to make "find all references" work in the IDE).
    */
-  case class LambdaTypeTree[-T >: Untyped] private[ast] (tparams: List[TypeDef[T]], body: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class LambdaTypeTree[+T <: Untyped] private[ast] (tparams: List[TypeDef[T]], body: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TypTree[T] {
-    type ThisTree[-T >: Untyped] = LambdaTypeTree[T]
+    type ThisTree[+T <: Untyped] = LambdaTypeTree[T]
   }
 
-  case class TermLambdaTypeTree[-T >: Untyped] private[ast] (params: List[ValDef[T]], body: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class TermLambdaTypeTree[+T <: Untyped] private[ast] (params: List[ValDef[T]], body: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TypTree[T] {
-    type ThisTree[-T >: Untyped] = TermLambdaTypeTree[T]
+    type ThisTree[+T <: Untyped] = TermLambdaTypeTree[T]
   }
 
   /** [bound] selector match { cases } */
-  case class MatchTypeTree[-T >: Untyped] private[ast] (bound: Tree[T], selector: Tree[T], cases: List[CaseDef[T]])(implicit @constructorOnly src: SourceFile)
+  case class MatchTypeTree[+T <: Untyped] private[ast] (bound: Tree[T], selector: Tree[T], cases: List[CaseDef[T]])(implicit @constructorOnly src: SourceFile)
     extends TypTree[T] {
-    type ThisTree[-T >: Untyped] = MatchTypeTree[T]
+    type ThisTree[+T <: Untyped] = MatchTypeTree[T]
   }
 
   /** => T */
-  case class ByNameTypeTree[-T >: Untyped] private[ast] (result: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class ByNameTypeTree[+T <: Untyped] private[ast] (result: Tree[T])(implicit @constructorOnly src: SourceFile)
   extends TypTree[T] {
-    type ThisTree[-T >: Untyped] = ByNameTypeTree[T]
+    type ThisTree[+T <: Untyped] = ByNameTypeTree[T]
   }
 
   /** >: lo <: hi
    *  >: lo <: hi = alias  for RHS of bounded opaque type
    */
-  case class TypeBoundsTree[-T >: Untyped] private[ast] (lo: Tree[T], hi: Tree[T], alias: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class TypeBoundsTree[+T <: Untyped] private[ast] (lo: Tree[T], hi: Tree[T], alias: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends TypTree[T] {
-    type ThisTree[-T >: Untyped] = TypeBoundsTree[T]
+    type ThisTree[+T <: Untyped] = TypeBoundsTree[T]
   }
 
   /** name @ body */
-  case class Bind[-T >: Untyped] private[ast] (name: Name, body: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Bind[+T <: Untyped] private[ast] (name: Name, body: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends NamedDefTree[T] with PatternTree[T] {
-    type ThisTree[-T >: Untyped] = Bind[T]
+    type ThisTree[+T <: Untyped] = Bind[T]
     override def isType: Boolean = name.isTypeName
     override def isTerm: Boolean = name.isTermName
 
@@ -780,9 +778,9 @@ object Trees {
   }
 
   /** tree_1 | ... | tree_n */
-  case class Alternative[-T >: Untyped] private[ast] (trees: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class Alternative[+T <: Untyped] private[ast] (trees: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends PatternTree[T] {
-    type ThisTree[-T >: Untyped] = Alternative[T]
+    type ThisTree[+T <: Untyped] = Alternative[T]
   }
 
   /** The typed translation of `extractor(patterns)` in a pattern. The translation has the following
@@ -799,26 +797,26 @@ object Trees {
    *    val result = fun(sel)(implicits)
    *    if (result.isDefined) "match patterns against result"
    */
-  case class UnApply[-T >: Untyped] private[ast] (fun: Tree[T], implicits: List[Tree[T]], patterns: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class UnApply[+T <: Untyped] private[ast] (fun: Tree[T], implicits: List[Tree[T]], patterns: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends ProxyTree[T] with PatternTree[T] {
-    type ThisTree[-T >: Untyped] = UnApply[T]
+    type ThisTree[+T <: Untyped] = UnApply[T]
     def forwardTo = fun
   }
 
   /** mods val name: tpt = rhs */
-  case class ValDef[-T >: Untyped] private[ast] (name: TermName, tpt: Tree[T], private var preRhs: LazyTree[T @uncheckedVariance])(implicit @constructorOnly src: SourceFile)
+  case class ValDef[+T <: Untyped] private[ast] (name: TermName, tpt: Tree[T], private var preRhs: LazyTree[T @uncheckedVariance])(implicit @constructorOnly src: SourceFile)
     extends ValOrDefDef[T], ValOrTypeDef[T] {
-    type ThisTree[-T >: Untyped] = ValDef[T]
+    type ThisTree[+T <: Untyped] = ValDef[T]
     assert(isEmpty || (tpt ne genericEmptyTree))
     def unforced: LazyTree[T] = preRhs
     protected def force(x: Tree[T @uncheckedVariance]): Unit = preRhs = x
   }
 
   /** mods def name[tparams](vparams_1)...(vparams_n): tpt = rhs */
-  case class DefDef[-T >: Untyped] private[ast] (name: TermName,
+  case class DefDef[+T <: Untyped] private[ast] (name: TermName,
       paramss: List[ParamClause[T]], tpt: Tree[T], private var preRhs: LazyTree[T @uncheckedVariance])(implicit @constructorOnly src: SourceFile)
     extends ValOrDefDef[T] {
-    type ThisTree[-T >: Untyped] = DefDef[T]
+    type ThisTree[+T <: Untyped] = DefDef[T]
     assert(tpt ne genericEmptyTree)
     def unforced: LazyTree[T] = preRhs
     protected def force(x: Tree[T @uncheckedVariance]): Unit = preRhs = x
@@ -842,9 +840,9 @@ object Trees {
    *  mods type name >: lo <: hi,          if rhs = TypeBoundsTree(lo, hi)      or
    *  mods type name >: lo <: hi = rhs     if rhs = TypeBoundsTree(lo, hi, alias) and opaque in mods
    */
-  case class TypeDef[-T >: Untyped] private[ast] (name: TypeName, rhs: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class TypeDef[+T <: Untyped] private[ast] (name: TypeName, rhs: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends MemberDef[T], ValOrTypeDef[T] {
-    type ThisTree[-T >: Untyped] = TypeDef[T]
+    type ThisTree[+T <: Untyped] = TypeDef[T]
 
     /** Is this a definition of a class? */
     def isClassDef: Boolean = rhs.isInstanceOf[Template[?]]
@@ -857,9 +855,9 @@ object Trees {
    *                            if this is of class untpd.DerivingTemplate.
    *                            Typed templates only have parents.
    */
-  case class Template[-T >: Untyped] private[ast] (constr: DefDef[T], parentsOrDerived: List[Tree[T]], self: ValDef[T], private var preBody: LazyTreeList[T @uncheckedVariance])(implicit @constructorOnly src: SourceFile)
+  case class Template[+T <: Untyped] private[ast] (constr: DefDef[T], parentsOrDerived: List[Tree[T]], self: ValDef[T], private var preBody: LazyTreeList[T @uncheckedVariance])(implicit @constructorOnly src: SourceFile)
     extends DefTree[T] with WithLazyField[List[Tree[T]]] {
-    type ThisTree[-T >: Untyped] = Template[T]
+    type ThisTree[+T <: Untyped] = Template[T]
     def unforcedBody: LazyTreeList[T] = unforced
     def unforced: LazyTreeList[T] = preBody
     protected def force(x: List[Tree[T @uncheckedVariance]]): Unit = preBody = x
@@ -870,9 +868,9 @@ object Trees {
   }
 
 
-  abstract class ImportOrExport[-T >: Untyped](implicit @constructorOnly src: SourceFile)
+  abstract class ImportOrExport[+T <: Untyped](implicit @constructorOnly src: SourceFile)
     extends DenotingTree[T] {
-    type ThisTree[-T >: Untyped] <: ImportOrExport[T]
+    type ThisTree[+T <: Untyped] <: ImportOrExport[T]
     val expr: Tree[T]
     val selectors: List[untpd.ImportSelector]
   }
@@ -881,36 +879,36 @@ object Trees {
    *  where a selector is either an untyped `Ident`, `name` or
    *  an untyped thicket consisting of `name` and `rename`.
    */
-  case class Import[-T >: Untyped] private[ast] (expr: Tree[T], selectors: List[untpd.ImportSelector])(implicit @constructorOnly src: SourceFile)
+  case class Import[+T <: Untyped] private[ast] (expr: Tree[T], selectors: List[untpd.ImportSelector])(implicit @constructorOnly src: SourceFile)
     extends ImportOrExport[T] {
-    type ThisTree[-T >: Untyped] = Import[T]
+    type ThisTree[+T <: Untyped] = Import[T]
   }
 
   /** export expr.selectors
    *  where a selector is either an untyped `Ident`, `name` or
    *  an untyped thicket consisting of `name` and `rename`.
    */
-  case class Export[-T >: Untyped] private[ast] (expr: Tree[T], selectors: List[untpd.ImportSelector])(implicit @constructorOnly src: SourceFile)
+  case class Export[+T <: Untyped] private[ast] (expr: Tree[T], selectors: List[untpd.ImportSelector])(implicit @constructorOnly src: SourceFile)
     extends ImportOrExport[T] {
-      type ThisTree[-T >: Untyped] = Export[T]
+      type ThisTree[+T <: Untyped] = Export[T]
   }
 
   /** package pid { stats } */
-  case class PackageDef[-T >: Untyped] private[ast] (pid: RefTree[T], stats: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class PackageDef[+T <: Untyped] private[ast] (pid: RefTree[T], stats: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends ProxyTree[T] with WithEndMarker[T] {
-    type ThisTree[-T >: Untyped] = PackageDef[T]
+    type ThisTree[+T <: Untyped] = PackageDef[T]
     def forwardTo: RefTree[T] = pid
     protected def srcName(using Context): Name = pid.name
   }
 
   /** arg @annot */
-  case class Annotated[-T >: Untyped] private[ast] (arg: Tree[T], annot: Tree[T])(implicit @constructorOnly src: SourceFile)
+  case class Annotated[+T <: Untyped] private[ast] (arg: Tree[T], annot: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends ProxyTree[T] {
-    type ThisTree[-T >: Untyped] = Annotated[T]
+    type ThisTree[+T <: Untyped] = Annotated[T]
     def forwardTo: Tree[T] = arg
   }
 
-  trait WithoutTypeOrPos[-T >: Untyped] extends Tree[T] {
+  trait WithoutTypeOrPos[+T <: Untyped] extends Tree[T] {
     override def withTypeUnchecked(tpe: Type): ThisTree[Type] = this.asInstanceOf[ThisTree[Type]]
     override def span: Span = NoSpan
     override def span_=(span: Span): Unit = {}
@@ -921,10 +919,10 @@ object Trees {
    *  The contained trees will be integrated when transformed with
    *  a `transform(List[Tree])` call.
    */
-  case class Thicket[-T >: Untyped](trees: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class Thicket[+T <: Untyped](trees: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] with WithoutTypeOrPos[T] {
     myTpe = NoType.asInstanceOf[T]
-    type ThisTree[-T >: Untyped] = Thicket[T]
+    type ThisTree[+T <: Untyped] = Thicket[T]
 
     def mapElems(op: Tree[T] => Tree[T] @uncheckedVariance): Thicket[T] = {
       val newTrees = trees.mapConserve(op)
@@ -950,12 +948,12 @@ object Trees {
       mapElems(_.withSpan(span)).asInstanceOf[this.type]
   }
 
-  class EmptyTree[T >: Untyped] extends Thicket(Nil)(NoSource) {
+  class EmptyTree[T <: Untyped] extends Thicket(Nil)(NoSource) {
     // assert(uniqueId != 1492)
     override def withSpan(span: Span) = throw AssertionError("Cannot change span of EmptyTree")
   }
 
-  class EmptyValDef[T >: Untyped] extends ValDef[T](
+  class EmptyValDef[T <: Untyped] extends ValDef[T](
     nme.WILDCARD, genericEmptyTree[T], genericEmptyTree[T])(NoSource) with WithoutTypeOrPos[T] {
     myTpe = NoType.asInstanceOf[T]
     setMods(untpd.Modifiers(PrivateLocal))
@@ -966,8 +964,8 @@ object Trees {
   @sharable val theEmptyTree = new EmptyTree[Type]()
   @sharable val theEmptyValDef = new EmptyValDef[Type]()
 
-  def genericEmptyValDef[T >: Untyped]: ValDef[T]       = theEmptyValDef.asInstanceOf[ValDef[T]]
-  def genericEmptyTree[T >: Untyped]: Thicket[T]        = theEmptyTree.asInstanceOf[Thicket[T]]
+  def genericEmptyValDef[T <: Untyped]: ValDef[T]       = theEmptyValDef.asInstanceOf[ValDef[T]]
+  def genericEmptyTree[T <: Untyped]: Thicket[T]        = theEmptyTree.asInstanceOf[Thicket[T]]
 
   /** Tree that replaces a level 1 splices in pickled (level 0) quotes.
    *  It is only used when picking quotes (will never be in a TASTy file).
@@ -978,13 +976,13 @@ object Trees {
    *  @param content Lambda that computes the content of the hole. This tree is empty when in a quote pickle.
    *  @param tpt Type of the hole
    */
-  case class Hole[-T >: Untyped](isTermHole: Boolean, idx: Int, args: List[Tree[T]], content: Tree[T], tpt: Tree[T])(implicit @constructorOnly src: SourceFile) extends Tree[T] {
-    type ThisTree[-T >: Untyped] <: Hole[T]
+  case class Hole[+T <: Untyped](isTermHole: Boolean, idx: Int, args: List[Tree[T]], content: Tree[T], tpt: Tree[T])(implicit @constructorOnly src: SourceFile) extends Tree[T] {
+    type ThisTree[+T <: Untyped] <: Hole[T]
     override def isTerm: Boolean = isTermHole
     override def isType: Boolean = !isTermHole
   }
 
-  def flatten[T >: Untyped](trees: List[Tree[T]]): List[Tree[T]] = {
+  def flatten[T <: Untyped](trees: List[Tree[T]]): List[Tree[T]] = {
     def recur(buf: ListBuffer[Tree[T]] | Null, remaining: List[Tree[T]]): ListBuffer[Tree[T]] | Null =
       remaining match {
         case Thicket(elems) :: remaining1 =>
@@ -1037,7 +1035,7 @@ object Trees {
 
   // ----- Generic Tree Instances, inherited from `tpt` and `untpd`.
 
-  abstract class Instance[T >: Untyped <: Type] { inst =>
+  abstract class Instance[T <: Untyped] { inst =>
 
     type Tree = Trees.Tree[T]
     type TypTree = Trees.TypTree[T]
@@ -1372,7 +1370,7 @@ object Trees {
      *  innermost enclosing call for which the inlined version is currently
      *  processed.
      */
-    protected def inlineContext(call: Tree)(using Context): Context = ctx
+    protected def inlineContext(call: tpd.Tree)(using Context): Context = ctx
 
     /** The context to use when mapping or accumulating over a tree */
     def localCtx(tree: Tree)(using Context): Context

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -42,7 +42,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   /** mods object name impl */
   case class ModuleDef(name: TermName, impl: Template)(implicit @constructorOnly src: SourceFile)
     extends MemberDef {
-    type ThisTree[-T >: Untyped] <: Trees.NameTree[T] with Trees.MemberDef[T] with ModuleDef
+    type ThisTree[+T <: Untyped] <: Trees.NameTree[T] with Trees.MemberDef[T] with ModuleDef
     def withName(name: Name)(using Context): ModuleDef = cpy.ModuleDef(this)(name.toTermName, impl)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -156,9 +156,9 @@ object Contexts {
     final def owner: Symbol = _owner
 
     /** The current tree */
-    private var _tree: Tree[? >: Untyped]= _
-    protected def tree_=(tree: Tree[? >: Untyped]): Unit = _tree = tree
-    final def tree: Tree[? >: Untyped] = _tree
+    private var _tree: Tree[? <: Untyped]= _
+    protected def tree_=(tree: Tree[? <: Untyped]): Unit = _tree = tree
+    final def tree: Tree[? <: Untyped] = _tree
 
     /** The current scope */
     private var _scope: Scope = _
@@ -469,7 +469,7 @@ object Contexts {
     }
 
     /** The context of expression `expr` seen as a member of a statement sequence */
-    def exprContext(stat: Tree[? >: Untyped], exprOwner: Symbol): Context =
+    def exprContext(stat: Tree[? <: Untyped], exprOwner: Symbol): Context =
       if (exprOwner == this.owner) this
       else if (untpd.isSuperConstrCall(stat) && this.owner.isClass) superCallContext
       else fresh.setOwner(exprOwner)
@@ -592,7 +592,7 @@ object Contexts {
       assert(owner != NoSymbol)
       this.owner = owner
       this
-    def setTree(tree: Tree[? >: Untyped]): this.type =
+    def setTree(tree: Tree[? <: Untyped]): this.type =
       util.Stats.record("Context.setTree")
       this.tree = tree
       this

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -745,16 +745,6 @@ object Types {
           // which means that we always defensively copy the type in the future. This second
           // measure is necessary because findMember calls might be cached, so do not
           // necessarily appear in nested order.
-          // Without the defensive copy, Typer.scala fails to compile at the line
-          //
-          //      untpd.rename(lhsCore, setterName).withType(setterType), WildcardType)
-          //
-          // because the subtype check
-          //
-          //      ThisTree[Untyped]#ThisTree[Typed] <: Tree[Typed]
-          //
-          // fails (in fact it thinks the underlying type of the LHS is `Tree[Untyped]`.)
-          //
           // Without the `openedTwice` trick, Typer.scala fails to Ycheck
           // at phase resolveSuper.
           val rt =

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -607,7 +607,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   def toText(sc: Scope): Text =
     ("Scope{" ~ dclsText(sc.toList) ~ "}").close
 
-  def toText[T >: Untyped](tree: Tree[T]): Text = {
+  def toText[T <: Untyped](tree: Tree[T]): Text = {
     def toTextElem(elem: Any): Text = elem match {
       case elem: Showable => elem.toText(this)
       case elem: List[?] => "List(" ~ Text(elem map toTextElem, ",") ~ ")"

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -149,7 +149,7 @@ abstract class Printer {
   def toText(sc: Scope): Text
 
   /** Textual representation of tree */
-  def toText[T >: Untyped](tree: Tree[T]): Text
+  def toText[T <: Untyped](tree: Tree[T]): Text
 
   /** Textual representation of source position */
   def toText(pos: SourcePosition): Text

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -614,7 +614,7 @@ object Erasure {
      *  are handled separately by [[typedDefDef]], [[typedValDef]] and [[typedTyped]].
      */
     override def typedTypeTree(tree: untpd.TypeTree, pt: Type)(using Context): TypeTree =
-      checkNotErasedClass(tree.withType(erasure(tree.tpe)))
+      checkNotErasedClass(tree.withType(erasure(tree.typeOpt)))
 
     /** This override is only needed to semi-erase type ascriptions */
     override def typedTyped(tree: untpd.Typed, pt: Type)(using Context): Tree =

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -65,7 +65,7 @@ class InterceptedMethods extends MiniPhase {
   override def transformApply(tree: Apply)(using Context): Tree = {
     lazy val qual = tree.fun match {
       case Select(qual, _) => qual
-      case ident @ Ident(_) =>
+      case ident: Ident =>
         ident.tpe match {
           case TermRef(prefix: TermRef, _) =>
             tpd.ref(prefix)

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -376,7 +376,7 @@ class TreeChecker extends Phase with SymTransformer {
 
     override def typedIdent(tree: untpd.Ident, pt: Type)(using Context): Tree = {
       assert(tree.isTerm || !ctx.isAfterTyper, tree.show + " at " + ctx.phase)
-      assert(tree.isType || ctx.mode.is(Mode.Pattern) && untpd.isWildcardArg(tree) || !needsSelect(tree.tpe), i"bad type ${tree.tpe} for $tree # ${tree.uniqueId}")
+      assert(tree.isType || ctx.mode.is(Mode.Pattern) && untpd.isWildcardArg(tree) || !needsSelect(tree.typeOpt), i"bad type ${tree.tpe} for $tree # ${tree.uniqueId}")
       assertDefined(tree)
 
       checkNotRepeated(super.typedIdent(tree, pt))

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -6,7 +6,6 @@ import core._
 import ast.{Trees, tpd, untpd, desugar}
 import util.Stats.record
 import util.{SrcPos, NoSourcePosition}
-import Trees.Untyped
 import Contexts._
 import Flags._
 import Symbols._
@@ -491,7 +490,7 @@ trait Applications extends Compatibility {
       i"${err.refStr(methRef)}$infoStr"
 
     /** Re-order arguments to correctly align named arguments */
-    def reorder[T >: Untyped](args: List[Trees.Tree[T]]): List[Trees.Tree[T]] = {
+    def reorder[T <: Untyped](args: List[Trees.Tree[T]]): List[Trees.Tree[T]] = {
 
       /** @param pnames    The list of parameter names that are missing arguments
        *  @param args      The list of arguments that are not yet passed, or that are waiting to be dropped
@@ -754,7 +753,7 @@ trait Applications extends Compatibility {
   /** Subclass of Application for type checking an Apply node, where
    *  types of arguments are either known or unknown.
    */
-  abstract class TypedApply[T >: Untyped](
+  abstract class TypedApply[T <: Untyped](
     app: untpd.Apply, fun: Tree, methRef: TermRef, args: List[Trees.Tree[T]], resultType: Type,
     override val applyKind: ApplyKind)(using Context)
   extends Application(methRef, fun.tpe, args, resultType) {

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -71,7 +71,7 @@ class ReTyper(nestingLevel: Int = 0) extends Typer(nestingLevel) with ReChecking
     promote(tree)
 
   override def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(using Context): TypTree =
-    promote(TypeTree(tree.tpe).withSpan(tree.span))
+    promote(TypeTree(tree.typeOpt).withSpan(tree.span))
 
   override def typedExport(exp: untpd.Export)(using Context): Export =
     promote(exp)
@@ -87,8 +87,8 @@ class ReTyper(nestingLevel: Int = 0) extends Typer(nestingLevel) with ReChecking
       // retract PatternOrTypeBits like in typedExpr
       withoutMode(Mode.PatternOrTypeBits)(typedUnadapted(tree.fun, AnyFunctionProto))
     val implicits1 = tree.implicits.map(typedExpr(_))
-    val patterns1 = tree.patterns.mapconserve(pat => typed(pat, pat.tpe))
-    untpd.cpy.UnApply(tree)(fun1, implicits1, patterns1).withType(tree.tpe)
+    val patterns1 = tree.patterns.mapconserve(pat => typed(pat, pat.typeOpt))
+    untpd.cpy.UnApply(tree)(fun1, implicits1, patterns1).withType(tree.typeOpt)
   }
 
   override def typedUnApply(tree: untpd.Apply, selType: Type)(using Context): Tree =


### PR DESCRIPTION
Refactor `Tree` parameterization to make use of -Yexplicit-nulls.

We now have:

```scala
   type Untyped = Type | Null
   abstract class Tree[+T <: Untyped]
   object untpd:
     type Tree = Tree[Untyped]
   object tpe:
     type Tree = Tree[Type]
```

Fixes #16298 