### PR TITLE
backport to stable reference docs quicklinks changes

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1901,12 +1901,12 @@ object ScaladocConfigs {
       Groups(true),
       QuickLinks(
         List(
-          "Download::https://www.scala-lang.org/download/",
-          "Documentation::https://docs.scala-lang.org/",
-          "Libraries::https://index.scala-lang.org",
-          "Contribute::https://www.scala-lang.org/contribute/",
+          "Learn::https://docs.scala-lang.org/",
+          "Install::https://www.scala-lang.org/download/",
+          "Playground::https://scastie.scala-lang.org",
+          "Find\u00A0A\u00A0Library::https://index.scala-lang.org",
+          "Community::https://www.scala-lang.org/community/",
           "Blog::https://www.scala-lang.org/blog/",
-          "Community::https://www.scala-lang.org/community/"
         )
       )
     )

--- a/project/scripts/cmdScaladocTests
+++ b/project/scripts/cmdScaladocTests
@@ -40,6 +40,6 @@ dist/target/pack/bin/scaladoc \
   -project-footer "Copyright (c) 2002-2022, LAMP/EPFL" \
   -default-template static-site-main \
   -author -groups -revision main -project-version "${DOTTY_BOOTSTRAPPED_VERSION}" \
-  "-quick-links:Download::https://www.scala-lang.org/download/,Documentation::https://docs.scala-lang.org/,Libraries::https://index.scala-lang.org,Contribute::https://www.scala-lang.org/contribute/,Blog::https://www.scala-lang.org/blog/,Community::https://www.scala-lang.org/community/" \
+  "-quick-links:Learn::https://docs.scala-lang.org/,Install::https://www.scala-lang.org/download/,Playground::https://scastie.scala-lang.org,Find A Library::https://index.scala-lang.org,Community::https://www.scala-lang.org/community/,Blog::https://www.scala-lang.org/blog/" \
   out/bootstrap/scaladoc-testcases/scala-"${DOTTY_NONBOOTSTRAPPED_VERSION}"/classes > "$tmp" 2>&1 || echo "generated testcases project with scripts"
 diff -rq "$OUT1" "scaladoc/output/testcases"


### PR DESCRIPTION
fix the quick links in the top nav bar

after:
<img width="1240" alt="Screenshot 2022-11-08 at 16 55 23" src="https://user-images.githubusercontent.com/13436592/200613015-5e1fb513-2da9-4ad6-8eb9-56306cf47803.png">