### PR TITLE
Avoid interpolating to `Nothing` in a special case

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -641,9 +641,9 @@ trait Inferencing { this: Typer =>
                   def hasLowerBound =
                     (constraint.nonParamBounds(tparam).lo ne tparam.underlying.bounds.lo)
                     || constraint.lower(tparam).nonEmpty
-                  def avoidNothing =
+                  def isSelectionPrefix =
                     (tp eq tvar) && pt.isInstanceOf[SelectionProto]
-                  if v.intValue != 1 || hasLowerBound || !avoidNothing then
+                  if v.intValue != 1 || hasLowerBound || !isSelectionPrefix then
                     // Don't interpolate to lower if there is no lower bound other than
                     // the declared one, the current type is exactly `tvar`, and the expression is
                     // followed by a selection. In this case we should wait so that we can

--- a/tests/pos/i16323.scala
+++ b/tests/pos/i16323.scala
@@ -1,0 +1,7 @@
+class Foo {
+  def member: String = this.toString
+}
+def method[T](c: T => Boolean): T = ???
+val y: Foo => Boolean = _ => true
+val x : String = "5"
+val _ = method(y).member // error


### PR DESCRIPTION
If we have an selection `e.m` where e's type is a type variable T that does not have a lower bound in the current constraint, avoid interpolating `T` to Nothing. Doing this would make the section ill-typed. Not interpolating `T` leaves the possibility open to instantiate it to its upper bound later in couldInstantiateTypeVar.

Fixes #16323