### PR TITLE
Remove contents of inline methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -113,12 +113,10 @@ class PickleQuotes extends MacroTransform {
             case _ =>
               val (contents, tptWithHoles) = makeHoles(tpt)
               PickleQuotes(quotes, tptWithHoles, contents, tpt.tpe, true)
-        case tree: DefDef if tree.symbol.is(Macro) =>
+        case tree: DefDef if tree.symbol.is(Macro) || tree.symbol.isInlineMethod =>
           // Shrink size of the tree. The methods have already been inlined.
           // TODO move to FirstTransform to trigger even without quotes
           cpy.DefDef(tree)(rhs = defaultValue(tree.rhs.tpe))
-        case _: DefDef if tree.symbol.isInlineMethod =>
-          tree
         case _ =>
           super.transform(tree)
   }

--- a/tests/pos-macros/i15985.scala
+++ b/tests/pos-macros/i15985.scala
@@ -1,0 +1,28 @@
+package anorm.macros
+sealed trait Row
+sealed trait SqlResult[A]
+
+import scala.quoted.{ Expr, Quotes, Type }
+
+private[anorm] object RowParserImpl {
+  def apply[A](using q:Quotes)(using a: Type[A]): Expr[Row => SqlResult[A]] = {
+    import q.reflect.*
+
+    inline def f1: Expr[SqlResult[A]] =
+      Match(???, ???).asExprOf[SqlResult[A]] // (using Type.of[anorm.macros.SqlResult[A]] })
+
+    inline def f2: Expr[SqlResult[A]] =
+      Match(???, ???).asExprOf[SqlResult[A]](using Type.of[SqlResult[A]])
+      // In Staging phase it becomes
+      //  ..asExprOf[..](using Type.of[{ @SplicedType type a$_$3 = a.Underlying; anorm.macros.SqlResult[a$_$3] }])
+
+    inline def f3(using Type[SqlResult[A]]): Expr[SqlResult[A]] =
+      Match(???, ???).asExprOf[SqlResult[A]]
+
+    f1
+    f2
+    f3
+
+    ???
+  }
+}


### PR DESCRIPTION
Remove contents of inline methods when pickling quotes in case these contain quoted expressions or types. Some artifacts of staging (such as type blocks) are not handled by the transformation phases that follow.

Fixes #15985