### PR TITLE
Only allow transparent inline summoning [experiment]

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -447,6 +447,7 @@ object Inlines:
                 case _ =>
                   evidence
             }
+          if ctx.isAfterTyper then report.error("Can not perform summonInline implicit search in non-transparent inline")
           return searchImplicit(callTypeArgs.head)
         }
       end if

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -983,8 +983,9 @@ trait Applications extends Compatibility {
           }
           typedDynamicApply(tree, isInsertedApply, pt)
         case _ =>
-          if (originalProto.isDropped) fun1
-          else if (fun1.symbol == defn.Compiletime_summonFrom)
+          if originalProto.isDropped then fun1
+          else if fun1.symbol == defn.Compiletime_summonFrom then
+            if ctx.isAfterTyper then report.error("Can not perform summonFrom implicit search in non-transparent inline")
             // Special handling of `summonFrom { ... }`.
             // We currently cannot use a macro for that since unlike other inline methods
             // summonFrom needs to expand lazily. For instance, in

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2395,6 +2395,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object Implicits extends ImplicitsModule:
       def search(tpe: TypeRepr): ImplicitSearchResult =
+        if ctx.isAfterTyper then report.error("Can not perform implicit search in non-transparent macro")
         ctx.typer.inferImplicitArg(tpe, Position.ofMacroExpansion.span)
     end Implicits
 

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -167,7 +167,7 @@ transparent inline def summonInline[T]: T =
  *  @tparam T the tuple containing the types of the values to be summoned
  *  @return the given values typed as elements of the tuple
  */
-inline def summonAll[T <: Tuple]: T =
+transparent inline def summonAll[T <: Tuple]: T =
   val res =
     inline erasedValue[T] match
       case _: EmptyTuple => EmptyTuple

--- a/tests/neg-macros/delegate-match-1/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-1/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted.*
 
 
-inline def f: Any = ${ fImpl }
+transparent inline def f: Any = ${ fImpl } : Any
 
 private def fImpl(using Quotes): Expr[Unit] = {
   import quotes.reflect.*

--- a/tests/neg-macros/delegate-match-2/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-2/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted.*
 
 
-inline def f: Any = ${ fImpl }
+transparent inline def f: Any = ${ fImpl } : Any
 
 private def fImpl (using Quotes) : Expr[Unit] = {
   import quotes.reflect.*

--- a/tests/neg-macros/delegate-match-3/Macro_1.scala
+++ b/tests/neg-macros/delegate-match-3/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted.*
 
 
-inline def f: Any = ${ fImpl }
+transparent inline def f: Any = ${ fImpl } : Any
 
 private def fImpl(using Quotes) : Expr[Unit] = {
   import quotes.reflect.*

--- a/tests/neg-macros/i10709/Macro_1.scala
+++ b/tests/neg-macros/i10709/Macro_1.scala
@@ -2,7 +2,7 @@ import scala.quoted.*
 import scala.compiletime.summonInline
 
 object Invalid {
-  inline def apply[A, B]: Any = ${ invalidImpl[A, B] }
+  transparent inline def apply[A, B]: Any = ${ invalidImpl[A, B] }: Any
 
   def invalidImpl[A, B](using qctx: Quotes, tpeA: Type[A], tpeB: Type[B]): Expr[Any] = {
     '{summonInline[B <:< A]}

--- a/tests/neg-macros/i13406/Test_2.scala
+++ b/tests/neg-macros/i13406/Test_2.scala
@@ -1,7 +1,7 @@
 // Test_2.scala
 trait Bar
 
-inline given derivedReducible(using scala.deriving.Mirror.SumOf[Qux[_]]): Bar =
+transparent inline given derivedReducible(using scala.deriving.Mirror.SumOf[Qux[_]]): Bar =
   scala.compiletime.summonInline[Bar]
   ???
 

--- a/tests/neg/i13044.scala
+++ b/tests/neg/i13044.scala
@@ -11,7 +11,7 @@ object Schema extends SchemaDerivation {
 }
 
 trait SchemaDerivation {
-  inline def recurse[A <: Tuple]: List[Schema[Any]] =
+  transparent inline def recurse[A <: Tuple]: List[Schema[Any]] =
     inline erasedValue[A] match {
       case _: (t *: ts) =>
         val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
@@ -19,7 +19,7 @@ trait SchemaDerivation {
       case _: EmptyTuple => Nil
     }
 
-  inline def derived[A]: Schema[A] =
+  transparent inline def derived[A]: Schema[A] =
     inline summonInline[Mirror.Of[A]] match {
       case m: Mirror.SumOf[A] =>
         lazy val subTypes = recurse[m.MirroredElemTypes]
@@ -34,7 +34,7 @@ trait SchemaDerivation {
         }
     }
 
-  inline given gen[A]: Schema[A] = derived
+  transparent inline given gen[A]: Schema[A] = derived
 }
 
 case class H(i: Int)

--- a/tests/neg/i13991.scala
+++ b/tests/neg/i13991.scala
@@ -4,8 +4,8 @@ trait Foo[X]:
 def foo =
   first[String] // error // before line 10 to test alignment of the error message `|`
 
-inline def second[A]: Int =
+transparent inline def second[A]: Int =
   compiletime.summonInline[Foo[A]].foo
 
-inline def first[A]: Int =
+transparent inline def first[A]: Int =
   second[A] + 42 // after line 10 to test alignment of the error message `|`

--- a/tests/pos-custom-args/i13044.scala
+++ b/tests/pos-custom-args/i13044.scala
@@ -11,7 +11,7 @@ object Schema extends SchemaDerivation {
 }
 
 trait SchemaDerivation {
-  inline def recurse[A <: Tuple]: List[Schema[Any]] =
+  transparent inline def recurse[A <: Tuple]: List[Schema[Any]] =
     inline erasedValue[A] match {
       case _: (t *: ts) =>
         val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
@@ -19,7 +19,7 @@ trait SchemaDerivation {
       case _: EmptyTuple => Nil
     }
 
-  inline def derived[A]: Schema[A] =
+  transparent inline def derived[A]: Schema[A] =
     inline summonInline[Mirror.Of[A]] match {
       case m: Mirror.SumOf[A] =>
         lazy val subTypes = recurse[m.MirroredElemTypes]
@@ -34,7 +34,7 @@ trait SchemaDerivation {
         }
     }
 
-  inline given gen[A]: Schema[A] = derived
+  transparent inline given gen[A]: Schema[A] = derived
 }
 
 case class H(i: Int)

--- a/tests/pos-macros/InlinedTypeOf.scala
+++ b/tests/pos-macros/InlinedTypeOf.scala
@@ -4,7 +4,7 @@ class Sm[T](t: T)
 
 object Foo {
 
-  inline def foo[T] = { compiletime.summonInline[Type[T]]; ??? }
+  transparent inline def foo[T] = { compiletime.summonInline[Type[T]]; ??? }
 
   def toexpr[T: Type](using Quotes) = foo[Sm[T]]
 

--- a/tests/pos-macros/i11479/Macro_1.scala
+++ b/tests/pos-macros/i11479/Macro_1.scala
@@ -1,9 +1,9 @@
 trait Foo
 given Foo: Foo()
-inline def summonFoo(): Foo = scala.compiletime.summonInline[Foo]
+transparent inline def summonFoo(): Foo = scala.compiletime.summonInline[Foo] : Foo
 
 package p:
   trait Bar
   given Bar: Bar()
-  inline def summonBar(): Bar = scala.compiletime.summonInline[Bar]
+  transparent inline def summonBar(): Bar = scala.compiletime.summonInline[Bar] : Bar
 

--- a/tests/pos-macros/i11628/macros.scala
+++ b/tests/pos-macros/i11628/macros.scala
@@ -21,4 +21,4 @@ def summonConversionImpl(using qctx: Quotes): Expr[Any] = {
   }
 }
 
-inline def summonConversion() = ${summonConversionImpl}
+transparent inline def summonConversion(): Any = ${summonConversionImpl} : Any

--- a/tests/pos-macros/i12510/Macro_1.scala
+++ b/tests/pos-macros/i12510/Macro_1.scala
@@ -1,8 +1,8 @@
 object M {
   import scala.quoted.*
 
-  inline def valueOfUnit: ValueOf[Unit] =
-    ${ _valueOfUnit }
+  transparent inline def valueOfUnit: ValueOf[Unit] =
+    ${ _valueOfUnit }: ValueOf[Unit]
 
   def _valueOfUnit(using Quotes): Expr[ValueOf[Unit]] = {
     import quotes.reflect.*

--- a/tests/pos-macros/i14185/Macro_1.scala
+++ b/tests/pos-macros/i14185/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted.*
 
 object Test {
-  inline def foo[A, M[_]]: Unit = ${ fooImpl[A, M] }
+  transparent inline def foo[A, M[_]]: Unit = ${ fooImpl[A, M] } : Unit
 
   private def fooImpl[A, M[_]](
       using

--- a/tests/pos-macros/i9296/Macros_1.scala
+++ b/tests/pos-macros/i9296/Macros_1.scala
@@ -5,8 +5,8 @@ import scala.concurrent.*
 
 object M {
 
-  inline def resolveInMacros[F[_],T](f: Future[T]):Conversion[Future[T],F[T]] =
-     ${ resolveInMacrosImpl[F,T]('f) }
+  transparent inline def resolveInMacros[F[_],T](f: Future[T]):Conversion[Future[T],F[T]] =
+     ${ resolveInMacrosImpl[F,T]('f) } : Conversion[Future[T],F[T]]
 
   def resolveInMacrosImpl[F[_]:Type,T:Type](f:Expr[Future[T]])(using qctx:Quotes):Expr[
                                                       Conversion[Future[T],F[T]]]={

--- a/tests/pos-special/fatal-warnings/not-looping-implicit.scala
+++ b/tests/pos-special/fatal-warnings/not-looping-implicit.scala
@@ -9,7 +9,7 @@ object Schema {
   implicit def mapSchema[A, B](implicit evA: Schema[A], evB: Schema[B]): Schema[Map[A, B]] =
     new Schema[Map[A, B]] {}
 
-  inline def recurse[Label, A <: Tuple](index: Int = 0): List[(String, Schema[Any], Int)] =
+  transparent inline def recurse[Label, A <: Tuple](index: Int = 0): List[(String, Schema[Any], Int)] =
     inline erasedValue[(Label, A)] match {
       case (_: (name *: names), _: (t *: ts)) =>
         val label       = constValue[name].toString
@@ -18,7 +18,7 @@ object Schema {
       case (_: EmptyTuple, _)                 => Nil
     }
 
-  inline def derived[A]: Schema[A] =
+  transparent inline def derived[A]: Schema[A] =
     inline summonInline[Mirror.Of[A]] match {
       case m: Mirror.SumOf[A]     =>
         lazy val members     = recurse[m.MirroredElemLabels, m.MirroredElemTypes]()
@@ -28,7 +28,7 @@ object Schema {
         new Schema[A] {}
     }
 
-  inline given gen[A]: Schema[A] = derived[A]
+  transparent inline given gen[A]: Schema[A] = derived[A]
 }
 
 sealed trait InputValue

--- a/tests/pos-special/typeclass-scaling.scala
+++ b/tests/pos-special/typeclass-scaling.scala
@@ -218,9 +218,9 @@ object typeclasses {
     import compiletime.*
     import scala.deriving.*
 
-    inline def tryEql[TT](x: TT, y: TT): Boolean = summonInline[Eq[TT]].eql(x, y)
+    transparent inline def tryEql[TT](x: TT, y: TT): Boolean = summonInline[Eq[TT]].eql(x, y)
 
-    inline def eqlElems[Elems <: Tuple](n: Int)(x: Product, y: Product): Boolean =
+    transparent inline def eqlElems[Elems <: Tuple](n: Int)(x: Product, y: Product): Boolean =
       inline erasedValue[Elems] match {
         case _: (elem *: elems1) =>
           tryEql[elem](x.productElement(n).asInstanceOf[elem], y.productElement(n).asInstanceOf[elem]) &&
@@ -229,7 +229,7 @@ object typeclasses {
           true
       }
 
-    inline def eqlCases[Alts](n: Int)(x: Any, y: Any, ord: Int): Boolean =
+    transparent inline def eqlCases[Alts](n: Int)(x: Any, y: Any, ord: Int): Boolean =
       inline erasedValue[Alts] match {
         case _: (alt *: alts1) =>
           if (ord == n)
@@ -242,7 +242,7 @@ object typeclasses {
           false
       }
 
-    inline def derived[T](implicit ev: Mirror.Of[T]): Eq[T] = new Eq[T] {
+    transparent inline def derived[T](implicit ev: Mirror.Of[T]): Eq[T] = new Eq[T] {
       def eql(x: T, y: T): Boolean =
         inline ev match {
           case m: Mirror.SumOf[T] =>
@@ -271,9 +271,9 @@ object typeclasses {
 
     def nextInt(buf: mutable.ListBuffer[Int]): Int = try buf.head finally buf.trimStart(1)
 
-    inline def tryPickle[T](buf: mutable.ListBuffer[Int], x: T): Unit = summonInline[Pickler[T]].pickle(buf, x)
+    transparent inline def tryPickle[T](buf: mutable.ListBuffer[Int], x: T): Unit = summonInline[Pickler[T]].pickle(buf, x)
 
-    inline def pickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], x: Product): Unit =
+    transparent inline def pickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], x: Product): Unit =
       inline erasedValue[Elems] match {
         case _: (elem *: elems1) =>
           tryPickle[elem](buf, x.productElement(n).asInstanceOf[elem])
@@ -281,7 +281,7 @@ object typeclasses {
         case _: EmptyTuple =>
       }
 
-    inline def pickleCases[Alts <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], x: Any, ord: Int): Unit =
+    transparent inline def pickleCases[Alts <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], x: Any, ord: Int): Unit =
       inline erasedValue[Alts] match {
         case _: (alt *: alts1) =>
           if (ord == n)
@@ -292,9 +292,9 @@ object typeclasses {
         case _: EmptyTuple =>
       }
 
-    inline def tryUnpickle[T](buf: mutable.ListBuffer[Int]): T = summonInline[Pickler[T]].unpickle(buf)
+    transparent inline def tryUnpickle[T](buf: mutable.ListBuffer[Int]): T = summonInline[Pickler[T]].unpickle(buf)
 
-    inline def unpickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], elems: Array[Any]): Unit =
+    transparent inline def unpickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], elems: Array[Any]): Unit =
       inline erasedValue[Elems] match {
         case _: (elem *: elems1) =>
           elems(n) = tryUnpickle[elem](buf)
@@ -302,7 +302,7 @@ object typeclasses {
         case _: EmptyTuple =>
       }
 
-    inline def unpickleCase[T, Elems <: Tuple](buf: mutable.ListBuffer[Int], m: Mirror.ProductOf[T]): T = {
+    transparent inline def unpickleCase[T, Elems <: Tuple](buf: mutable.ListBuffer[Int], m: Mirror.ProductOf[T]): T = {
       inline val size = constValue[Tuple.Size[Elems]]
       inline if (size == 0)
         m.fromProduct(EmptyTuple)
@@ -317,7 +317,7 @@ object typeclasses {
       }
     }
 
-    inline def unpickleCases[T, Alts <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], ord: Int): T =
+    transparent inline def unpickleCases[T, Alts <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], ord: Int): T =
       inline erasedValue[Alts] match {
         case _: (alt *: alts1) =>
           if (ord == n)
@@ -330,7 +330,7 @@ object typeclasses {
           throw new IndexOutOfBoundsException(s"unexpected ordinal number: $ord")
       }
 
-    inline def derived[T](implicit ev: Mirror.Of[T]): Pickler[T] = new {
+    transparent inline def derived[T](implicit ev: Mirror.Of[T]): Pickler[T] = new {
       def pickle(buf: mutable.ListBuffer[Int], x: T): Unit =
         inline ev match {
           case m: Mirror.SumOf[T] =>

--- a/tests/pos/i11174minimisation.scala
+++ b/tests/pos/i11174minimisation.scala
@@ -4,7 +4,7 @@ import scala.deriving.Mirror
 trait EnumerateNames[T]
 
 object EnumerateNames {
-  inline def derived[T]: EnumerateNames[T] =
+  transparent inline def derived[T]: EnumerateNames[T] =
     summonFrom {
       case ev: Mirror.Of[T] =>
         inline ev match

--- a/tests/pos/i11538b.scala
+++ b/tests/pos/i11538b.scala
@@ -4,6 +4,6 @@ package a:
 
 import a.{Foo, given}
 object test:
-  inline def summonInlineFoo = scala.compiletime.summonInline[Foo]
+  transparent inline def summonInlineFoo = scala.compiletime.summonInline[Foo]
   val summoned = summon[Foo]
   val summonedInline = summonInlineFoo

--- a/tests/pos/i11557.scala
+++ b/tests/pos/i11557.scala
@@ -8,5 +8,5 @@ def doEncoding(ctx: MyContext): Unit =
   summon[MyEncoder]
   summonInlineMyEncoder()
 
-inline def summonInlineMyEncoder(): Unit =
+transparent inline def summonInlineMyEncoder(): Unit =
   compiletime.summonInline[MyEncoder]

--- a/tests/pos/i12379a.scala
+++ b/tests/pos/i12379a.scala
@@ -1,4 +1,4 @@
-inline def convFail[Of, From](inline from : From) : Unit =
+transparent inline def convFail[Of, From](inline from : From) : Unit =
   val c = compiletime.summonInline[Conversion[from.type, Of]]
 
 inline def convOK[Of, From](inline from : From)(using c : Conversion[from.type, Of]) : Unit = {}

--- a/tests/pos/i12379b.scala
+++ b/tests/pos/i12379b.scala
@@ -1,4 +1,4 @@
-inline def convFail[Of, From](inline from : From) : Unit =
+transparent inline def convFail[Of, From](inline from : From) : Unit =
   val c = compiletime.summonInline[Conversion[From, Of]]
 
 inline def convOK[Of, From](inline from : From)(using c : Conversion[From, Of]) : Unit = {}

--- a/tests/pos/i12997.scala
+++ b/tests/pos/i12997.scala
@@ -7,7 +7,7 @@ val a = {
 }
 
 // doesn't
-inline def summonInt = {
+transparent inline def summonInt = {
     given Int = 0
     summonInline[Int]
 }

--- a/tests/pos/i13460.scala
+++ b/tests/pos/i13460.scala
@@ -16,18 +16,18 @@ object MyTypeClass {
   given IntTypeClass: MyTypeClass[Int] with
     def makeString(a: Int): String = a.toString
 
-  inline given derived[A](using m: Mirror.Of[A]): MyTypeClass[A] =
+  transparent inline given derived[A](using m: Mirror.Of[A]): MyTypeClass[A] =
     inline m match
       case p: Mirror.ProductOf[A] => productConverter(p)
 
 
-  private inline def summonElementTypeClasses[A](m: Mirror.Of[A]): IArray[Object] =
+  private transparent inline def summonElementTypeClasses[A](m: Mirror.Of[A]): IArray[Object] =
     // this doesn't work
     summonAll[Tuple.Map[m.MirroredElemTypes, [A] =>> Lazy[MyTypeClass[A]]]].toIArray
     // but this does
     // summonAll[Tuple.Map[Tuple.Map[m.MirroredElemTypes, MyTypeClass], Lazy]].toIArray
 
-  private inline def productConverter[A](m: Mirror.ProductOf[A]): MyTypeClass[A] = {
+  private transparent inline def productConverter[A](m: Mirror.ProductOf[A]): MyTypeClass[A] = {
     val elementTypeClasses = summonElementTypeClasses(m)
     new MyTypeClass[A] {
       def makeString(a: A): String = {

--- a/tests/run-custom-args/fatal-warnings/i11050.scala
+++ b/tests/run-custom-args/fatal-warnings/i11050.scala
@@ -109,7 +109,7 @@ object Show:
   given Show[Char]   with { def show(x: Char)   = s"'$x'"   }
   given Show[String] with { def show(x: String) = s"$"$x$"" }
 
-  inline def show[T](x: T): String = summonInline[Show[T]].show(x)
+  transparent inline def show[T](x: T): String = summonInline[Show[T]].show(x)
 
   transparent inline def derived[T](implicit ev: Mirror.Of[T]): Show[T] = new {
     def show(x: T): String = inline ev match {

--- a/tests/run-custom-args/typeclass-derivation1.scala
+++ b/tests/run-custom-args/typeclass-derivation1.scala
@@ -38,9 +38,9 @@ object Deriving {
   }
 
   object Eq {
-    inline def tryEq[T](x: T, y: T) = summonInline[Eq[T]].equals(x, y)
+    transparent inline def tryEq[T](x: T, y: T) = summonInline[Eq[T]].equals(x, y)
 
-    inline def deriveForSum[Alts <: Tuple](x: Any, y: Any): Boolean = inline erasedValue[Alts] match {
+    transparent inline def deriveForSum[Alts <: Tuple](x: Any, y: Any): Boolean = inline erasedValue[Alts] match {
       case _: (alt *: alts1) =>
         x match {
           case x: `alt` =>
@@ -54,7 +54,7 @@ object Deriving {
         false
     }
 
-    inline def deriveForProduct[Elems <: Tuple](xs: Elems, ys: Elems): Boolean = inline erasedValue[Elems] match {
+    transparent inline def deriveForProduct[Elems <: Tuple](xs: Elems, ys: Elems): Boolean = inline erasedValue[Elems] match {
       case _: (elem *: elems1) =>
         val xs1 = xs.asInstanceOf[elem *: elems1]
         val ys1 = ys.asInstanceOf[elem *: elems1]
@@ -64,11 +64,11 @@ object Deriving {
         true
     }
 
-    inline def derivedForSum[T, Alts <: Tuple](implicit ev: HasSumShape[T, Alts]): Eq[T] = new {
+    transparent inline def derivedForSum[T, Alts <: Tuple](implicit ev: HasSumShape[T, Alts]): Eq[T] = new {
       def equals(x: T, y: T): Boolean = deriveForSum[Alts](x, y)
     }
 
-    inline def derivedForProduct[T, Elems <: Tuple](implicit ev: HasProductShape[T, Elems]): Eq[T] = new {
+    transparent inline def derivedForProduct[T, Elems <: Tuple](implicit ev: HasProductShape[T, Elems]): Eq[T] = new {
       def equals(x: T, y: T): Boolean = deriveForProduct[Elems](ev.toProduct(x), ev.toProduct(y))
     }
 

--- a/tests/run-macros/i11161/Macro_1.scala
+++ b/tests/run-macros/i11161/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted._
 import scala.reflect.ClassTag
 
-inline def showType[T]: String = ${ showTypeImpl[T] }
+transparent inline def showType[T]: String = ${ showTypeImpl[T] } : String
 
 private def showTypeImpl[T: Type](using Quotes): Expr[String] =
   Expr.summon[ClassTag[T]] match

--- a/tests/run-macros/i7987/Macros_1.scala
+++ b/tests/run-macros/i7987/Macros_1.scala
@@ -3,7 +3,7 @@ import scala.deriving.*
 
 
 object Macros {
-  inline def m(): String = ${ macroImpl() }
+  transparent inline def m(): String = ${ macroImpl() } : String
 
   def macroImpl[T]()(using Quotes): Expr[String] = {
     Expr.summon[Mirror.Of[Some[Int]]] match

--- a/tests/run-macros/i8007/Macro_1.scala
+++ b/tests/run-macros/i8007/Macro_1.scala
@@ -13,8 +13,8 @@ object Macro1 {
   // Demonstrates the use of quoted pattern matching
   // over a refined type extracting the tuple type
   // for e.g., MirroredElemLabels
-  inline def test1[T](value: =>T): List[String] =
-    ${ test1Impl('value) }
+  transparent inline def test1[T](value: =>T): List[String] =
+    ${ test1Impl('value) }: List[String]
 
   def test1Impl[T: Type](value: Expr[T])(using Quotes): Expr[List[String]] = {
     import quotes.reflect.*

--- a/tests/run-macros/i8007/Macro_2.scala
+++ b/tests/run-macros/i8007/Macro_2.scala
@@ -40,7 +40,7 @@ object Macro2 {
     }
   }
 
-  inline def test2[T](value: =>T): Unit = ${ test2Impl('value) }
+  transparent inline def test2[T](value: =>T): Unit = ${ test2Impl('value) }: Unit
 
   def test2Impl[T: Type](value: Expr[T])(using Quotes): Expr[Unit] = {
     import quotes.reflect.*

--- a/tests/run-macros/i8007/Macro_3.scala
+++ b/tests/run-macros/i8007/Macro_3.scala
@@ -73,7 +73,7 @@ object Eq {
 }
 
 object Macro3 {
-  extension [T](inline x: T) inline def === (inline y: T)(using eq: Eq[T]): Boolean = eq.eqv(x, y)
+  extension [T](inline x: T) transparent inline def === (inline y: T)(using eq: Eq[T]): Boolean = eq.eqv(x, y)
 
-  implicit inline def eqGen[T]: Eq[T] = ${ Eq.derived[T] }
+  transparent implicit inline def eqGen[T]: Eq[T] = ${ Eq.derived[T] }
 }

--- a/tests/run-macros/quote-implicitMatch/Macro_1.scala
+++ b/tests/run-macros/quote-implicitMatch/Macro_1.scala
@@ -3,9 +3,9 @@ import collection.immutable.HashSet
 import scala.quoted.*
 
 
-inline def f1[T]() = ${ f1Impl[T] }
+transparent inline def f1[T](): Set[T] = ${ f1Impl[T] } : Set[T]
 
-def f1Impl[T: Type](using Quotes) = {
+def f1Impl[T: Type](using Quotes): Expr[Set[T]] = {
   Expr.summon[Ordering[T]] match {
     case Some(ord) => '{ new TreeSet[T]()($ord) }
     case _ => '{ new HashSet[T] }
@@ -15,9 +15,9 @@ def f1Impl[T: Type](using Quotes) = {
 class A
 class B
 
-inline def g = ${ gImpl }
+transparent inline def g = ${ gImpl } : Unit
 
-def gImpl(using Quotes) = {
+def gImpl(using Quotes): Expr[Unit] = {
   if (Expr.summon[A].isDefined) '{ println("A") }
   else if (Expr.summon[B].isDefined) '{ println("B") }
   else throw new MatchError("")

--- a/tests/run-macros/quoted-ToExpr-derivation-macro/Derivation_1.scala
+++ b/tests/run-macros/quoted-ToExpr-derivation-macro/Derivation_1.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 
 object ToExprMaker {
 
-  inline given derived[T](using inline m: Mirror.Of[T]): ToExpr[T] = ${ derivedExpr('m) }
+  transparent inline given derived[T](using inline m: Mirror.Of[T]): ToExpr[T] = ${ derivedExpr('m) } : ToExpr[T]
 
   private def derivedExpr[T](mirrorExpr: Expr[Mirror.Of[T]])(using Quotes, Type[T]): Expr[ToExpr[T]] = {
     val tpe = summonExprOrError[Type[T]]

--- a/tests/run-macros/quoted-ToExpr-derivation-macro/LibA_2.scala
+++ b/tests/run-macros/quoted-ToExpr-derivation-macro/LibA_2.scala
@@ -8,20 +8,20 @@ object LibA {
 
   sealed trait Opt[+T]
   object Opt:
-    inline given [T]: ToExpr[Opt[T]] = ToExprMaker.derived
+    transparent inline given [T]: ToExpr[Opt[T]] = ToExprMaker.derived
 
   case class Sm[T](t: T) extends Opt[T]
   object Sm:
-    inline given [T]: ToExpr[Sm[T]] = ToExprMaker.derived
+    transparent inline given [T]: ToExpr[Sm[T]] = ToExprMaker.derived
 
   case object Nn extends Opt[Nothing]:
-    inline given ToExpr[Nn.type] = ToExprMaker.derived
+    transparent inline given ToExpr[Nn.type] = ToExprMaker.derived
 
   import Opt.*
 
-  inline def optTwo = ${optTwoExpr}
-  inline def smTwo = ${smTwoExpr}
-  inline def none = ${noneExpr}
+  transparent inline def optTwo = ${optTwoExpr}
+  transparent inline def smTwo = ${smTwoExpr}
+  transparent inline def none = ${noneExpr}
 
   private def optTwoExpr(using Quotes): Expr[Opt[Int]] =
     summon[ToExpr[Opt[Int]]].apply(Sm(2))

--- a/tests/run-macros/quoted-ToExpr-derivation-macro/LibB_2.scala
+++ b/tests/run-macros/quoted-ToExpr-derivation-macro/LibB_2.scala
@@ -19,9 +19,9 @@ object LibB {
 
   import Opt.*
 
-  inline def optTwo = ${optTwoExpr}
-  inline def smTwo = ${smTwoExpr}
-  inline def none = ${noneExpr}
+  transparent inline def optTwo = ${optTwoExpr}
+  transparent inline def smTwo = ${smTwoExpr}
+  transparent inline def none = ${noneExpr}
 
   private def optTwoExpr(using Quotes): Expr[Opt[Int]] =
     summon[ToExpr[Opt[Int]]].apply(Sm(2))

--- a/tests/run-macros/quoted-ToExpr-derivation-macro/LibC_2.scala
+++ b/tests/run-macros/quoted-ToExpr-derivation-macro/LibC_2.scala
@@ -16,9 +16,9 @@ object LibC {
 
   import Opt.*
 
-  inline def optTwo = ${optTwoExpr}
-  inline def smTwo = ${smTwoExpr}
-  inline def none = ${noneExpr}
+  transparent inline def optTwo = ${optTwoExpr}
+  transparent inline def smTwo = ${smTwoExpr}
+  transparent inline def none = ${noneExpr}
 
   private def optTwoExpr(using Quotes): Expr[Opt[Int]] =
     summon[ToExpr[Opt[Int]]].apply(Sm(2))

--- a/tests/run-macros/quoted-liftable-derivation-macro-2/Derivation_1.scala
+++ b/tests/run-macros/quoted-liftable-derivation-macro-2/Derivation_1.scala
@@ -9,7 +9,7 @@ object Lft {
   given Lft[Int] with
     def toExpr(x: Int)(using Quotes) = Expr(x)
 
-  inline given derived[T](using inline m: Mirror.Of[T]): Lft[T] = ${ derivedExpr('m) }
+  transparent inline given derived[T](using inline m: Mirror.Of[T]): Lft[T] = ${ derivedExpr('m) } : Lft[T]
 
   private def derivedExpr[T](mirrorExpr: Expr[Mirror.Of[T]])(using Quotes, Type[T]): Expr[Lft[T]] = {
     val tpe = summonExprOrError[Type[T]]

--- a/tests/run-macros/quoted-liftable-derivation-macro-2/Lib_2.scala
+++ b/tests/run-macros/quoted-liftable-derivation-macro-2/Lib_2.scala
@@ -1,23 +1,23 @@
 
 sealed trait Opt[+T]
 object Opt:
-  inline given [T]: Lft[Opt[T]] = Lft.derived
+  transparent inline given [T]: Lft[Opt[T]] = Lft.derived
 
 case class Sm[T](t: T) extends Opt[T]
 object Sm:
-  inline given [T]: Lft[Sm[T]] = Lft.derived
+  transparent inline given [T]: Lft[Sm[T]] = Lft.derived
 
 case object Nn extends Opt[Nothing]:
-  inline given Lft[Nn.type] = Lft.derived
+  transparent inline given Lft[Nn.type] = Lft.derived
 
 object Lib {
 
   import scala.quoted._
   import Opt.*
 
-  inline def optTwo = ${optTwoExpr}
-  inline def smTwo = ${smTwoExpr}
-  inline def none = ${noneExpr}
+  transparent inline def optTwo = ${optTwoExpr}
+  transparent inline def smTwo = ${smTwoExpr}
+  transparent inline def none = ${noneExpr}
 
   private def optTwoExpr(using Quotes): Expr[Opt[Int]] =
     summon[Lft[Opt[Int]]].toExpr(Sm(2))

--- a/tests/run-macros/quoted-liftable-derivation-macro/Derivation_1.scala
+++ b/tests/run-macros/quoted-liftable-derivation-macro/Derivation_1.scala
@@ -9,7 +9,7 @@ object Lft {
   given Lft[Int] with
     def toExpr(x: Int)(using Type[Int], Quotes) = Expr(x)
 
-  inline given derived[T](using inline m: Mirror.Of[T]): Lft[T] = ${ derivedExpr('m) }
+  transparent inline given derived[T](using inline m: Mirror.Of[T]): Lft[T] = ${ derivedExpr('m) }: Lft[T]
 
   private def derivedExpr[T](mirrorExpr: Expr[Mirror.Of[T]])(using qctx: Quotes, tpe: Type[T]): Expr[Lft[T]] = {
     mirrorExpr match {

--- a/tests/run-macros/quoted-liftable-derivation-macro/Lib_2.scala
+++ b/tests/run-macros/quoted-liftable-derivation-macro/Lib_2.scala
@@ -8,9 +8,9 @@ object Lib {
   import scala.quoted._
   import Opt.*
 
-  inline def optTwo = ${optTwoExpr}
-  inline def smTwo = ${smTwoExpr}
-  inline def none = ${noneExpr}
+  transparent inline def optTwo = ${optTwoExpr}
+  transparent inline def smTwo = ${smTwoExpr}
+  transparent inline def none = ${noneExpr}
 
   private def optTwoExpr(using Quotes): Expr[Opt[Int]] =
     summon[Lft[Opt[Int]]].toExpr(Sm(2))

--- a/tests/run-macros/string-context-implicits/Macro_1.scala
+++ b/tests/run-macros/string-context-implicits/Macro_1.scala
@@ -1,7 +1,7 @@
 import scala.quoted.*
 
 
-extension (sc: StringContext) inline def showMe(inline args: Any*): String = ${ showMeExpr('sc, 'args) }
+extension (sc: StringContext) transparent inline def showMe(inline args: Any*): String = ${ showMeExpr('sc, 'args) } : String
 
 private def showMeExpr(sc: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes): Expr[String] =
   import quotes.reflect.report

--- a/tests/run/i11542.scala
+++ b/tests/run/i11542.scala
@@ -4,7 +4,7 @@ object demo {
 
   given Reader[Int]()
 
-  inline def summonReader[T <: Tuple]: List[Reader[_]] = inline compiletime.erasedValue[T] match {
+  transparent inline def summonReader[T <: Tuple]: List[Reader[_]] = inline compiletime.erasedValue[T] match {
     case _: EmptyTuple => Nil
     case _: (t *: ts) => compiletime.summonInline[Reader[t]] :: summonReader[ts]
   }
@@ -14,7 +14,7 @@ object demo {
     childReaders: List[Reader[_]]
   ) extends Reader[A]
 
-  inline given rdr[A <: Tuple](using m: deriving.Mirror.ProductOf[A]): Reader[A] = {
+  transparent inline given rdr[A <: Tuple](using m: deriving.Mirror.ProductOf[A]): Reader[A] = {
     new CombinedReader(m, summonReader[m.MirroredElemTypes])
   }
 

--- a/tests/run/i11542a.scala
+++ b/tests/run/i11542a.scala
@@ -2,5 +2,5 @@ type Foo = Tuple2[Int, Int]
 // case class Foo(x: Int, y: Int) // works
 class Reader(m: deriving.Mirror.ProductOf[Foo])
 given reader1(using m: deriving.Mirror.ProductOf[Foo]): Reader = new Reader(m)
-inline def summonReader(): Reader = compiletime.summonInline[Reader]
+transparent inline def summonReader(): Reader = compiletime.summonInline[Reader]
 @main def Test() = summonReader()

--- a/tests/run/i11563.scala
+++ b/tests/run/i11563.scala
@@ -7,17 +7,17 @@ trait Printer[T]:
 given Printer[String] with
   def format: String = "String"
 
-inline given[T](using mirror: Mirror.ProductOf[T]): Printer[T] = Printer.derived[T]
+transparent inline given[T](using mirror: Mirror.ProductOf[T]): Printer[T] = Printer.derived[T]
 
 object Printer:
   inline def apply[T](using printer: Printer[T]): Printer[T] = printer
 
-  inline def derived[T](using mirror: Mirror.ProductOf[T]): Printer[T] =
+  transparent inline def derived[T](using mirror: Mirror.ProductOf[T]): Printer[T] =
     val params = summonPrinters[mirror.MirroredElemTypes]
     new Printer[T] :
       def format: String = params.map(p => p.format).mkString(",")
 
-inline def summonPrinters[Types <: Tuple]: Seq[Printer[?]] = inline erasedValue[Types] match
+transparent inline def summonPrinters[Types <: Tuple]: Seq[Printer[?]] = inline erasedValue[Types] match
   case _: EmptyTuple => Seq.empty
   case _: (v *: vs) => summonInline[Printer[v]] +: summonPrinters[vs]
 

--- a/tests/run/i11961.scala
+++ b/tests/run/i11961.scala
@@ -28,14 +28,14 @@ object Printable:
          def print: Unit =
             elems.foreach(_.print)
 
-   inline given derived[T](using m: Mirror.Of[T]): Printable[T] =
+   transparent inline given derived[T](using m: Mirror.Of[T]): Printable[T] =
       val elemInstances = summonAllPrintable[m.MirroredElemTypes]
       inline m match
          case p: Mirror.ProductOf[T] => printProduct(p, elemInstances)
 
 end Printable
 
-inline def summonAllPrintable[T <: Tuple]: List[Printable[_]] =
+transparent inline def summonAllPrintable[T <: Tuple]: List[Printable[_]] =
    inline erasedValue[T] match
       case _: EmptyTuple => Nil
       case _: (t *: ts) => summonInline[Printable[t]] :: summonAllPrintable[ts]

--- a/tests/run/i12328.scala
+++ b/tests/run/i12328.scala
@@ -4,13 +4,13 @@ import scala.compiletime._
 trait Schema[T]
 
 object Schema {
-  inline def recurse[A <: Tuple]: List[Schema[Any]] =
+  transparent inline def recurse[A <: Tuple]: List[Schema[Any]] =
     inline erasedValue[A] match {
       case _: (t *: ts) => summonInline[Schema[t]].asInstanceOf[Schema[Any]] :: recurse[ts]
       case EmptyTuple   => Nil
     }
 
-  inline def derived[T]: Schema[T] =
+  transparent inline def derived[T]: Schema[T] =
     inline summonInline[Mirror.Of[T]] match {
       case m: Mirror.SumOf[T] =>
         val subTypes = recurse[m.MirroredElemTypes]
@@ -20,7 +20,7 @@ object Schema {
         new Schema[T] { }
   }
 
-  inline given gen[T]: Schema[T] = derived
+  transparent inline given gen[T]: Schema[T] = derived
 }
 
 @main def Test: Unit = {

--- a/tests/run/i13146.scala
+++ b/tests/run/i13146.scala
@@ -1,7 +1,7 @@
 import scala.deriving.*
 import scala.compiletime.{erasedValue, summonInline}
 
-inline def summonAll[T <: Tuple]: List[Eq[_]] =
+transparent inline def summonAll[T <: Tuple]: List[Eq[_]] =
   inline erasedValue[T] match
     case _: EmptyTuple => Nil
     case _: (t *: ts) => summonInline[Eq[t]] :: summonAll[ts]
@@ -31,7 +31,7 @@ object Eq:
           case ((x, y), elem) => check(elem)(x, y)
         }
 
-  inline given derived[T](using m: Mirror.Of[T]): Eq[T] =
+  transparent inline given derived[T](using m: Mirror.Of[T]): Eq[T] =
     lazy val elemInstances = summonAll[m.MirroredElemTypes]
     inline m match
       case s: Mirror.SumOf[T]     => eqSum(s, elemInstances)

--- a/tests/run/i13146a.scala
+++ b/tests/run/i13146a.scala
@@ -3,7 +3,7 @@ import scala.compiletime.{erasedValue, summonInline}
 
 // File that breaks the infinite loop caused by implicit search in i13146.scala
 
-inline def summonAll[P, T <: Tuple]: List[Eq[_]] =
+transparent inline def summonAll[P, T <: Tuple]: List[Eq[_]] =
   inline erasedValue[T] match
     case _: EmptyTuple => Nil
     case _: (t *: ts) => loopBreaker[P, t] :: summonAll[P, ts]
@@ -12,7 +12,7 @@ inline def summonAll[P, T <: Tuple]: List[Eq[_]] =
  *  @note aparently it needs to be defined separately from `summonAll` to avoid an infinite loop
  *  in inlining.
  */
-inline def loopBreaker[P, T]: Eq[T] = compiletime.summonFrom {
+transparent inline def loopBreaker[P, T]: Eq[T] = compiletime.summonFrom {
   case infiniteRecursion: (T =:= P) => compiletime.error("cannot derive Eq, it will cause an infinite loop")
   case recursiveEvidence: (T <:< P) =>
     // summonInline will work because to get here `P` must also have a Mirror instance
@@ -47,7 +47,7 @@ object Eq:
           case ((x, y), elem) => check(elem)(x, y)
         }
 
-  inline given derived[T](using m: Mirror.Of[T]): Eq[T] =
+  transparent inline given derived[T](using m: Mirror.Of[T]): Eq[T] =
     lazy val elemInstances = summonAll[T, m.MirroredElemTypes]
     inline m match
       case s: Mirror.SumOf[T]     => eqSum(s, elemInstances)

--- a/tests/run/i9011.scala
+++ b/tests/run/i9011.scala
@@ -14,7 +14,7 @@ object Eq {
     def eqv(x: Int, y: Int) = x == y
   }
 
-  inline def summonAll[T <: Tuple]: List[Eq[_]] = inline erasedValue[T] match {
+  transparent inline def summonAll[T <: Tuple]: List[Eq[_]] = inline erasedValue[T] match {
     case _: EmptyTuple => Nil
     case _: (t *: ts) => summonInline[Eq[t]] :: summonAll[ts]
   }
@@ -40,7 +40,7 @@ object Eq {
         }
     }
 
-  inline given derived[T](using m: Mirror.Of[T]): Eq[T] = {
+  transparent inline given derived[T](using m: Mirror.Of[T]): Eq[T] = {
     val elemInstances = summonAll[m.MirroredElemTypes]
     inline m match {
       case s: Mirror.SumOf[T]     => eqSum(s, elemInstances)

--- a/tests/run/i9473.scala
+++ b/tests/run/i9473.scala
@@ -1,7 +1,7 @@
 import scala.deriving.*
 import scala.compiletime.{erasedValue, summonInline}
 
-inline def summonAll[T <: Tuple]: List[Eq[_]] = inline erasedValue[T] match {
+transparent inline def summonAll[T <: Tuple]: List[Eq[_]] = inline erasedValue[T] match {
   case _: EmptyTuple => Nil
   case _: (t *: ts) => summonInline[Eq[t]] :: summonAll[ts]
 }
@@ -36,7 +36,7 @@ object Eq {
         }
     }
 
-  inline given derived[T](using m: Mirror.Of[T]): Eq[T] = {
+  transparent inline given derived[T](using m: Mirror.Of[T]): Eq[T] = {
     lazy val elemInstances = summonAll[m.MirroredElemTypes]
     inline m match {
       case s: Mirror.SumOf[T]     => eqSum(s, elemInstances)

--- a/tests/run/typeclass-derivation-doc-example.scala
+++ b/tests/run/typeclass-derivation-doc-example.scala
@@ -1,7 +1,7 @@
 import scala.deriving.*
 import scala.compiletime.{erasedValue, summonInline}
 
-inline def summonAll[T <: Tuple]: List[Eq[_]] = inline erasedValue[T] match {
+transparent inline def summonAll[T <: Tuple]: List[Eq[_]] = inline erasedValue[T] match {
   case _: EmptyTuple => Nil
   case _: (t *: ts) => summonInline[Eq[t]] :: summonAll[ts]
 }
@@ -36,7 +36,7 @@ object Eq {
         }
     }
 
-  inline given derived[T](using m: Mirror.Of[T]): Eq[T] = {
+  transparent inline given derived[T](using m: Mirror.Of[T]): Eq[T] = {
     val elemInstances = summonAll[m.MirroredElemTypes]
     inline m match {
       case s: Mirror.SumOf[T]     => eqSum(s, elemInstances)

--- a/tests/run/typeclass-derivation2a.scala
+++ b/tests/run/typeclass-derivation2a.scala
@@ -222,9 +222,9 @@ object Eq {
   import scala.compiletime.{erasedValue, summonInline}
   import TypeLevel.*
 
-  inline def tryEql[T](x: T, y: T) = summonInline[Eq[T]].eql(x, y)
+  transparent inline def tryEql[T](x: T, y: T) = summonInline[Eq[T]].eql(x, y)
 
-  inline def eqlElems[Elems <: Tuple](xm: Mirror, ym: Mirror, n: Int): Boolean =
+  transparent inline def eqlElems[Elems <: Tuple](xm: Mirror, ym: Mirror, n: Int): Boolean =
     inline erasedValue[Elems] match {
       case _: (elem *: elems1) =>
         tryEql[elem](xm(n).asInstanceOf, ym(n).asInstanceOf) &&
@@ -233,7 +233,7 @@ object Eq {
         true
     }
 
-  inline def eqlCases[Alts <: Tuple](xm: Mirror, ym: Mirror, n: Int): Boolean =
+  transparent inline def eqlCases[Alts <: Tuple](xm: Mirror, ym: Mirror, n: Int): Boolean =
     inline erasedValue[Alts] match {
       case _: (Shape.Case[alt, elems] *: alts1) =>
         if (xm.ordinal == n) eqlElems[elems](xm, ym, 0)
@@ -242,7 +242,7 @@ object Eq {
         false
     }
 
-  inline def derived[T, S <: Shape](implicit ev: Generic[T]): Eq[T] = new {
+  transparent inline def derived[T, S <: Shape](implicit ev: Generic[T]): Eq[T] = new {
     def eql(x: T, y: T): Boolean = {
       val xm = ev.reflect(x)
       val ym = ev.reflect(y)
@@ -273,9 +273,9 @@ object Pickler {
 
   def nextInt(buf: mutable.ListBuffer[Int]): Int = try buf.head finally buf.trimStart(1)
 
-  inline def tryPickle[T](buf: mutable.ListBuffer[Int], x: T): Unit = summonInline[Pickler[T]].pickle(buf, x)
+  transparent inline def tryPickle[T](buf: mutable.ListBuffer[Int], x: T): Unit = summonInline[Pickler[T]].pickle(buf, x)
 
-  inline def pickleElems[Elems <: Tuple](buf: mutable.ListBuffer[Int], elems: Mirror, n: Int): Unit =
+  transparent inline def pickleElems[Elems <: Tuple](buf: mutable.ListBuffer[Int], elems: Mirror, n: Int): Unit =
     inline erasedValue[Elems] match {
       case _: (elem *: elems1) =>
         tryPickle[elem](buf, elems(n).asInstanceOf[elem])
@@ -283,7 +283,7 @@ object Pickler {
       case _: EmptyTuple =>
     }
 
-  inline def pickleCases[Alts <: Tuple](buf: mutable.ListBuffer[Int], xm: Mirror, n: Int): Unit =
+  transparent inline def pickleCases[Alts <: Tuple](buf: mutable.ListBuffer[Int], xm: Mirror, n: Int): Unit =
     inline erasedValue[Alts] match {
       case _: (Shape.Case[alt, elems] *: alts1) =>
         if (xm.ordinal == n) pickleElems[elems](buf, xm, 0)
@@ -291,9 +291,9 @@ object Pickler {
       case _: EmptyTuple =>
     }
 
-  inline def tryUnpickle[T](buf: mutable.ListBuffer[Int]): T = summonInline[Pickler[T]].unpickle(buf)
+  transparent inline def tryUnpickle[T](buf: mutable.ListBuffer[Int]): T = summonInline[Pickler[T]].unpickle(buf)
 
-  inline def unpickleElems[Elems <: Tuple](buf: mutable.ListBuffer[Int], elems: Array[AnyRef], n: Int): Unit =
+  transparent inline def unpickleElems[Elems <: Tuple](buf: mutable.ListBuffer[Int], elems: Array[AnyRef], n: Int): Unit =
     inline erasedValue[Elems] match {
       case _: (elem *: elems1) =>
         elems(n) = tryUnpickle[elem](buf).asInstanceOf[AnyRef]
@@ -301,7 +301,7 @@ object Pickler {
       case _: EmptyTuple =>
     }
 
-  inline def unpickleCase[T, Elems <: Tuple](gen: Generic[T], buf: mutable.ListBuffer[Int], ordinal: Int): T = {
+  transparent inline def unpickleCase[T, Elems <: Tuple](gen: Generic[T], buf: mutable.ListBuffer[Int], ordinal: Int): T = {
     inline val size = constValue[Tuple.Size[Elems]]
     inline if (size == 0)
       gen.reify(gen.common.mirror(ordinal))
@@ -312,7 +312,7 @@ object Pickler {
     }
   }
 
-  inline def unpickleCases[T, Alts <: Tuple](r: Generic[T], buf: mutable.ListBuffer[Int], ordinal: Int, n: Int): T =
+  transparent inline def unpickleCases[T, Alts <: Tuple](r: Generic[T], buf: mutable.ListBuffer[Int], ordinal: Int, n: Int): T =
     inline erasedValue[Alts] match {
       case _: (Shape.Case[_, elems] *: alts1) =>
         if (n == ordinal) unpickleCase[T, elems](r, buf, ordinal)
@@ -321,7 +321,7 @@ object Pickler {
         throw new IndexOutOfBoundsException(s"unexpected ordinal number: $ordinal")
     }
 
-  inline def derived[T, S <: Shape](implicit ev: Generic[T]): Pickler[T] = new {
+  transparent inline def derived[T, S <: Shape](implicit ev: Generic[T]): Pickler[T] = new {
     def pickle(buf: mutable.ListBuffer[Int], x: T): Unit = {
       val xm = ev.reflect(x)
       inline erasedValue[ev.Shape] match {
@@ -354,9 +354,9 @@ object Show {
   import scala.compiletime.{erasedValue, summonInline}
   import TypeLevel.*
 
-  inline def tryShow[T](x: T): String = summonInline[Show[T]].show(x)
+  transparent inline def tryShow[T](x: T): String = summonInline[Show[T]].show(x)
 
-  inline def showElems[Elems <: Tuple](elems: Mirror, n: Int): List[String] =
+  transparent inline def showElems[Elems <: Tuple](elems: Mirror, n: Int): List[String] =
     inline erasedValue[Elems] match {
       case _: (elem *: elems1) =>
         val formal = elems.elementLabel(n)
@@ -366,7 +366,7 @@ object Show {
         Nil
     }
 
-  inline def showCases[Alts <: Tuple](xm: Mirror, n: Int): String =
+  transparent inline def showCases[Alts <: Tuple](xm: Mirror, n: Int): String =
     inline erasedValue[Alts] match {
       case _: (Shape.Case[alt, elems] *: alts1) =>
         if (xm.ordinal == n) showElems[elems](xm, 0).mkString(", ")
@@ -375,7 +375,7 @@ object Show {
         throw new MatchError(xm)
     }
 
-  inline def derived[T, S <: Shape](implicit ev: Generic[T]): Show[T] = new {
+  transparent inline def derived[T, S <: Shape](implicit ev: Generic[T]): Show[T] = new {
     def show(x: T): String = {
       val xm = ev.reflect(x)
       val args = inline erasedValue[ev.Shape] match {

--- a/tests/run/typeclass-derivation2b.scala
+++ b/tests/run/typeclass-derivation2b.scala
@@ -26,7 +26,7 @@ object TypeLevel {
 
   abstract class GenericSum[S] extends Generic[S] {
     def ordinal(x: S): Int
-    inline def alternative(inline n: Int): GenericProduct[_ <: S]
+    transparent inline def alternative(inline n: Int): GenericProduct[_ <: S]
   }
 
   abstract class GenericProduct[P] extends Generic[P] {
@@ -94,9 +94,9 @@ object Eq {
   import scala.compiletime.{erasedValue, summonInline}
   import TypeLevel.*
 
-  inline def tryEql[T](x: T, y: T) = summonInline[Eq[T]].eql(x, y)
+  transparent inline def tryEql[T](x: T, y: T) = summonInline[Eq[T]].eql(x, y)
 
-  inline def eqlElems[Elems <: Tuple](x: Product, y: Product, n: Int): Boolean =
+  transparent inline def eqlElems[Elems <: Tuple](x: Product, y: Product, n: Int): Boolean =
     inline erasedValue[Elems] match {
       case _: (elem *: elems1) =>
         tryEql[elem](
@@ -107,7 +107,7 @@ object Eq {
         true
     }
 
-  inline def eqlCases[T, Alts <: Tuple](x: T, y: T, genSum: GenericSum[T], ord: Int, inline n: Int): Boolean =
+  transparent inline def eqlCases[T, Alts <: Tuple](x: T, y: T, genSum: GenericSum[T], ord: Int, inline n: Int): Boolean =
     inline erasedValue[Alts] match {
       case _: (alt *: alts1) =>
         if (ord == n)
@@ -123,7 +123,7 @@ object Eq {
         false
     }
 
-  inline def derived[T](implicit ev: Generic[T]): Eq[T] = new Eq[T] {
+  transparent inline def derived[T](implicit ev: Generic[T]): Eq[T] = new Eq[T] {
     def eql(x: T, y: T): Boolean = {
       inline ev match {
         case evv: GenericSum[T] =>

--- a/tests/run/typeclass-derivation3.scala
+++ b/tests/run/typeclass-derivation3.scala
@@ -35,11 +35,11 @@ object typeclasses {
     import compiletime.*
     import scala.deriving.*
 
-    inline def tryEql[TT](x: TT, y: TT): Boolean = summonFrom {
+    transparent inline def tryEql[TT](x: TT, y: TT): Boolean = summonFrom {
       case eq: Eq[TT] => eq.eql(x, y)
     }
 
-    inline def eqlElems[Elems <: Tuple](n: Int)(x: Product, y: Product): Boolean =
+    transparent inline def eqlElems[Elems <: Tuple](n: Int)(x: Product, y: Product): Boolean =
       inline erasedValue[Elems] match {
         case _: (elem *: elems1) =>
           tryEql[elem](x.productElement(n).asInstanceOf[elem], y.productElement(n).asInstanceOf[elem]) &&
@@ -90,11 +90,11 @@ object typeclasses {
 
     def nextInt(buf: mutable.ListBuffer[Int]): Int = try buf.head finally buf.trimStart(1)
 
-    inline def tryPickle[T](buf: mutable.ListBuffer[Int], x: T): Unit = summonFrom {
+    transparent inline def tryPickle[T](buf: mutable.ListBuffer[Int], x: T): Unit = summonFrom {
       case pkl: Pickler[T] => pkl.pickle(buf, x)
     }
 
-    inline def pickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], x: Product): Unit =
+    transparent inline def pickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], x: Product): Unit =
       inline erasedValue[Elems] match {
         case _: (elem *: elems1) =>
           tryPickle[elem](buf, x.productElement(n).asInstanceOf[elem])
@@ -113,11 +113,11 @@ object typeclasses {
         case _: EmptyTuple =>
       }
 
-    inline def tryUnpickle[T](buf: mutable.ListBuffer[Int]): T = summonFrom {
+    transparent inline def tryUnpickle[T](buf: mutable.ListBuffer[Int]): T = summonFrom {
       case pkl: Pickler[T] => pkl.unpickle(buf)
     }
 
-    inline def unpickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], elems: Array[Any]): Unit =
+    transparent inline def unpickleElems[Elems <: Tuple](n: Int)(buf: mutable.ListBuffer[Int], elems: Array[Any]): Unit =
       inline erasedValue[Elems] match {
         case _: (elem *: elems1) =>
           elems(n) = tryUnpickle[elem](buf)
@@ -188,9 +188,9 @@ object typeclasses {
     import compiletime.*
     import deriving.*
 
-    inline def tryShow[T](x: T): String = summonInline[Show[T]].show(x)
+    transparent inline def tryShow[T](x: T): String = summonInline[Show[T]].show(x)
 
-    inline def showElems[Elems <: Tuple, Labels <: Tuple](n: Int)(x: Product): List[String] =
+    transparent inline def showElems[Elems <: Tuple, Labels <: Tuple](n: Int)(x: Product): List[String] =
       inline erasedValue[Elems] match {
         case _: (elem *: elems1) =>
           inline erasedValue[Labels] match {


### PR DESCRIPTION
What would need to change:
* `scala.compiletime.summonAll` should be transparent
* Uses of `summonFrom`, `summonInline`, `summonAll`, `Expr.summon` and `reflect.Implict.search` should be in transparent inline methods. Any inline method that calls one of those transitively should be transparent.
* Runtime staging summoning would not be allowed
* ...

Other uses of inlining after typer:
* Summoning `Type[T]` in `Staging` phase