### PR TITLE
Handle binding of beta reduced inlined lambdas 

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -743,8 +743,6 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
         Some(meth)
       case Block(Nil, expr) =>
         unapply(expr)
-      case Inlined(_, bindings, expr) if bindings.forall(isPureBinding) =>
-        unapply(expr)
       case _ =>
         None
     }

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -600,10 +600,12 @@ class InlineBytecodeTests extends DottyBytecodeTest {
       val instructions = instructionsFromMethod(fun)
       val expected = // TODO room for constant folding
         List(
-          Op(ICONST_1),
-          VarOp(ISTORE, 1),
           Op(ICONST_2),
-          VarOp(ILOAD, 1),
+          VarOp(ISTORE, 1),
+          Op(ICONST_1),
+          VarOp(ISTORE, 2),
+          Op(ICONST_2),
+          VarOp(ILOAD, 2),
           Op(IADD),
           Op(ICONST_3),
           Op(IADD),

--- a/tests/pos/i16374a.scala
+++ b/tests/pos/i16374a.scala
@@ -1,0 +1,7 @@
+def method(using String): String = ???
+
+inline def inlineMethod(inline op: String => Unit)(using String): Unit =
+  println(op(method))
+
+def test(using String) =
+  inlineMethod(c => print(c))

--- a/tests/pos/i16374b.scala
+++ b/tests/pos/i16374b.scala
@@ -1,0 +1,9 @@
+def method(using String): String = ???
+
+inline def identity[T](inline x: T): T = x
+
+inline def inlineMethod(inline op: String => Unit)(using String): Unit =
+  println(identity(op)(method))
+
+def test(using String) =
+  inlineMethod(c => print(c))

--- a/tests/pos/i16374c.scala
+++ b/tests/pos/i16374c.scala
@@ -1,0 +1,7 @@
+def method(using String): String = ???
+
+inline def inlineMethod(inline op: String => Unit)(using String): Unit =
+  println({ val a: Int = 1; op }.apply(method))
+
+def test(using String) =
+  inlineMethod(c => print(c))

--- a/tests/pos/i16374d.scala
+++ b/tests/pos/i16374d.scala
@@ -1,0 +1,4 @@
+inline def inline1(inline f: Int => Int): Int => Int = i => f(1)
+inline def inline2(inline f: Int => Int): Int = f(2) + 3
+def test: Int = inline2(inline1(2.+))
+


### PR DESCRIPTION
Handle all inline beta-reduction in the InlineReducer. All these
applications will contain `Inlined` nodes that need to be handled
without changing the nestedness of expressions in inlining scopes.

Fixes https://github.com/lampepfl/dotty/issues/16374