### PR TITLE
Avoid stackoverflow in ExplicitOuter

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -176,8 +176,9 @@ object ExplicitOuter {
           if prefix == NoPrefix then outerCls.typeRef.appliedTo(outerCls.typeParams.map(_ => TypeBounds.empty))
           else prefix.widen)
     val info = if (flags.is(Method)) ExprType(target) else target
+    val currentNestingLevel = ctx.nestingLevel
     atPhaseNoEarlier(explicitOuterPhase.next) { // outer accessors are entered at explicitOuter + 1, should not be defined before.
-      newSymbol(owner, name, SyntheticArtifact | flags, info, coord = cls.coord)
+      newSymbol(owner, name, SyntheticArtifact | flags, info, coord = cls.coord, nestingLevel = currentNestingLevel)
     }
   }
 

--- a/tests/neg/i16343.scala
+++ b/tests/neg/i16343.scala
@@ -1,0 +1,2 @@
+class Issue16343:
+  class MyWorker extends javax.swing.SwingWorker[Unit, Unit] // error


### PR DESCRIPTION
When transforming a class at ExplicitOuter we create outer accessors for it. The newSymbol call to do this takes place at phase ExplicitOuter + 1, but its arguments need to be evaluated at phase ExplicitOuter. This was not true for the nestingLevel argument, which demanded the denotation of the class at phase ExplicitOuter + 1, thus leading to the SO.

Interestingly, the same path is not taken if the class has all abstract members defined or is declared abstract. It's only in the error case that I could reproduce the SO.

Fixes #16343 