### PR TITLE
REPL: Fix crash when printing instances of value classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -505,6 +505,30 @@ object SymDenotations {
     /** `fullName` where `.' is the separator character */
     def fullName(using Context): Name = fullNameSeparated(QualifiedName)
 
+    /** The fully qualified name on the JVM of the class corresponding to this symbol. */
+    def binaryClassName(using Context): String =
+      val builder = new StringBuilder
+      val pkg = enclosingPackageClass
+      if !pkg.isEffectiveRoot then
+        builder.append(pkg.fullName.mangledString)
+        builder.append(".")
+      val flatName = this.flatName
+      // Some companion objects are fake (that is, they're a compiler fiction
+      // that doesn't correspond to a class that exists at runtime), this
+      // can happen in two cases:
+      // - If a Java class has static members.
+      // - If we create constructor proxies for a class (see NamerOps#addConstructorProxies).
+      //
+      // In both cases it's may be vital that we don't return the object name.
+      // For instance, sending it to zinc: when sbt is restarted, zinc will inspect the binary
+      // dependencies to see if they're still on the classpath, if it
+      // doesn't find them it will invalidate whatever referenced them, so
+      // any reference to a fake companion will lead to extra recompilations.
+      // Instead, use the class name since it's guaranteed to exist at runtime.
+      val clsFlatName = if isOneOf(JavaDefined | ConstructorProxy) then flatName.stripModuleClassSuffix else flatName
+      builder.append(clsFlatName.mangledString)
+      builder.toString
+
     private var myTargetName: Name | Null = null
 
     private def computeTargetName(targetNameAnnot: Option[Annotation])(using Context): Name =

--- a/compiler/src/dotty/tools/dotc/quoted/Interpreter.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/Interpreter.scala
@@ -200,12 +200,7 @@ abstract class Interpreter(pos: SrcPos, classLoader: ClassLoader)(using Context)
     }
     else {
       // nested object in an object
-      val className = {
-        val pack = sym.topLevelClass.owner
-        if (pack == defn.RootPackage || pack == defn.EmptyPackageClass) sym.flatName.toString
-        else pack.showFullName + "." + sym.flatName
-      }
-      val clazz = loadClass(className)
+      val clazz = loadClass(sym.binaryClassName)
       clazz.getConstructor().newInstance().asInstanceOf[Object]
     }
 

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -143,34 +143,7 @@ class ExtractDependencies extends Phase {
       def allowLocal = dep.context == DependencyByInheritance || dep.context == LocalDependencyByInheritance
       if (depFile.extension == "class") {
         // Dependency is external -- source is undefined
-
-        // The fully qualified name on the JVM of the class corresponding to `dep.to`
-        val binaryClassName = {
-          val builder = new StringBuilder
-          val pkg = dep.to.enclosingPackageClass
-          if (!pkg.isEffectiveRoot) {
-            builder.append(pkg.fullName.mangledString)
-            builder.append(".")
-          }
-          val flatName = dep.to.flatName
-          // Some companion objects are fake (that is, they're a compiler fiction
-          // that doesn't correspond to a class that exists at runtime), this
-          // can happen in two cases:
-          // - If a Java class has static members.
-          // - If we create constructor proxies for a class (see NamerOps#addConstructorProxies).
-          //
-          // In both cases it's vital that we don't send the object name to
-          // zinc: when sbt is restarted, zinc will inspect the binary
-          // dependencies to see if they're still on the classpath, if it
-          // doesn't find them it will invalidate whatever referenced them, so
-          // any reference to a fake companion will lead to extra recompilations.
-          // Instead, use the class name since it's guaranteed to exist at runtime.
-          val clsFlatName = if (dep.to.isOneOf(JavaDefined | ConstructorProxy)) flatName.stripModuleClassSuffix else flatName
-          builder.append(clsFlatName.mangledString)
-          builder.toString
-        }
-
-        processExternalDependency(depFile, binaryClassName)
+        processExternalDependency(depFile, dep.to.binaryClassName)
       } else if (allowLocal || depFile.file != sourceFile) {
         // We cannot ignore dependencies coming from the same source file because
         // the dependency info needs to propagate. See source-dependencies/trait-trait-211.

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -165,11 +165,14 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       Nil
     try load()
     catch
-      case e: ExceptionInInitializerError => List(renderError(e.getCause, sym.denot))
+      case e: ExceptionInInitializerError => List(renderError(e, sym.denot))
       case NonFatal(e) => List(renderError(e, sym.denot))
 
   /** Render the stack trace of the underlying exception. */
-  def renderError(cause: Throwable, d: Denotation)(using Context): Diagnostic =
+  def renderError(thr: Throwable, d: Denotation)(using Context): Diagnostic =
+    val cause = thr.getCause match
+      case e: ExceptionInInitializerError => e.getCause
+      case e => e
     // detect
     //at repl$.rs$line$2$.<clinit>(rs$line$2:1)
     //at repl$.rs$line$2.res1(rs$line$2)

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -130,14 +130,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
    */
   private def rewrapValueClass(sym: Symbol, value: Object)(using Context): Option[Object] =
     if ValueClasses.isDerivedValueClass(sym) then
-      val pkg = sym.enclosingPackageClass
-      val pkgName = if pkg.isEmptyPackage then "" else s"${pkg.fullName.mangledString}."
-      val clsFlatName = if sym.isOneOf(JavaDefined | ConstructorProxy) then
-        // See ExtractDependencies.recordDependency
-        sym.flatName.stripModuleClassSuffix
-      else sym.flatName
-      val valueClassName = pkgName + clsFlatName.mangledString
-      val valueClass = Class.forName(valueClassName, true, classLoader())
+      val valueClass = Class.forName(sym.binaryClassName, true, classLoader())
       valueClass.getConstructors.headOption.map(_.newInstance(value))
     else
       Some(value)

--- a/compiler/test-resources/repl/i15493
+++ b/compiler/test-resources/repl/i15493
@@ -142,3 +142,8 @@ val res33: Outer.Foo = Outer$Foo@17
 scala> res33.toString
 val res34: String = Outer$Foo@17
 
+scala> Vector.unapplySeq(Vector(2))
+val res35: scala.collection.SeqFactory.UnapplySeqWrapper[Int] = scala.collection.SeqFactory$UnapplySeqWrapper@df507bfd
+
+scala> new scala.concurrent.duration.DurationInt(5)
+val res36: scala.concurrent.duration.package.DurationInt = scala.concurrent.duration.package$DurationInt@5


### PR DESCRIPTION
By fixing `Rendering`'s `rewrapValueClass` to use the fully qualified class name

Sequel to #15545

Fixes #16322
Fixes #16387
