### PR TITLE
Remove unnecessary `println` from macro tests

### DIFF
--- a/tests/pos-macros/i8858/Macro_1.scala
+++ b/tests/pos-macros/i8858/Macro_1.scala
@@ -5,5 +5,5 @@ def mcrImpl(expr: Expr[Any])(using Quotes): Expr[Any] =
   import quotes.reflect._
   expr.asTerm match
     case Inlined(_, _, id1) =>
-      println(id1.tpe.widen.show)
+      id1.tpe.widen.show
   '{()}

--- a/tests/pos-macros/i9684/Macro_1.scala
+++ b/tests/pos-macros/i9684/Macro_1.scala
@@ -9,7 +9,6 @@ object X {
   def printTypeImpl[A:Type](x:Expr[A])(using Quotes): Expr[String] = {
     import quotes.reflect._
     val value: String = x.asTerm.tpe.show
-    println(value)
     Expr( value )
   }
 


### PR DESCRIPTION
These leak into the output of `testCompilation`.