### PR TITLE
Skip ambiguous reference error when symbols are aliases

### DIFF
--- a/tests/pos/t11921.scala
+++ b/tests/pos/t11921.scala
@@ -1,0 +1,16 @@
+object t1:
+  class C
+  class A:
+    val c: B.c.type = B.c
+  object B:
+    val c = new C
+    val a = new A:
+      def m = c    // not ambiguous, `this.c` and `B.c` are compatible paths
+
+object t2:
+  class C[T]:
+    type TT = T
+  object O:
+    type TT = String
+    class D extends C[TT]:
+      def n(x: TT) = x  // `TT` is not ambiguous, `this.TT` and `O.TT` are aliases


### PR DESCRIPTION
Follow-up for https://github.com/lampepfl/dotty/pull/8622, which introduced a new lookup ambiguity if a name is inherited from a parent and also found in an outer scope.

The error is avoided if the two symbols are aliases.