### PR TITLE
Prune CI unnecessary doc stack traces

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
@@ -228,6 +228,6 @@ case class TastyParser(
     try Traverser.traverseTree(root)(Symbol.spliceOwner)
     catch case e: Throwable =>
       println(s"Problem parsing ${root.pos}, documentation may not be generated.")
-      e.printStackTrace()
+      // e.printStackTrace()
 
     docs.result()


### PR DESCRIPTION
The scaladoc TastyParser fails when generating documentation for some files. Every time an error happens, the stack is unnecessarily printed. These stack makes updating the community build harder and the stack traces shadow the real errors.

<details>
<summary>Example</summary>

```
Problem parsing core/shared/src/main/scala/scodec/bits/BitVector.scala:[1576..1591..79383], documentation may not be generated.
java.lang.NumberFormatException: For input string: "
 1"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:569)
	at java.lang.Integer.parseInt(Integer.java:615)
	at scala.collection.StringOps$.toInt$extension(StringOps.scala:908)
	at dotty.tools.scaladoc.tasty.comments.Preparser$.$anonfun$7(Preparser.scala:176)
	at scala.collection.immutable.RedBlackTree$.transform(RedBlackTree.scala:968)
	at scala.collection.immutable.RedBlackTree$.transform(RedBlackTree.scala:967)
	at scala.collection.immutable.TreeMap.transform(TreeMap.scala:265)
	at scala.collection.immutable.TreeMap.transform(TreeMap.scala:73)
	at dotty.tools.scaladoc.tasty.comments.Preparser$.go$1(Preparser.scala:176)
	at dotty.tools.scaladoc.tasty.comments.Preparser$.preparse(Preparser.scala:186)
	at dotty.tools.scaladoc.tasty.ScaladocSupport$.parseCommentString(ScalaDocSupport.scala:15)
	at dotty.tools.scaladoc.tasty.ScaladocSupport$.parseComment(ScalaDocSupport.scala:60)
	at dotty.tools.scaladoc.tasty.BasicSupport.documentation(BasicSupport.scala:40)
	at dotty.tools.scaladoc.tasty.BasicSupport.documentation$(BasicSupport.scala:11)
	at dotty.tools.scaladoc.tasty.TastyParser.documentation(TastyParser.scala:169)
	at dotty.tools.scaladoc.tasty.ClassLikeSupport.mkMember(ClassLikeSupport.scala:492)
	at dotty.tools.scaladoc.tasty.ClassLikeSupport.mkMember$(ClassLikeSupport.scala:15)
	at dotty.tools.scaladoc.tasty.TastyParser.mkMember(TastyParser.scala:169)
	at dotty.tools.scaladoc.tasty.ClassLikeSupport.mkClass(ClassLikeSupport.scala:112)
	at dotty.tools.scaladoc.tasty.ClassLikeSupport.mkClass$(ClassLikeSupport.scala:15)
	at dotty.tools.scaladoc.tasty.TastyParser.mkClass(TastyParser.scala:169)
	at dotty.tools.scaladoc.tasty.ClassLikeSupport.parseClasslike(ClassLikeSupport.scala:298)
	at dotty.tools.scaladoc.tasty.ClassLikeSupport.parseClasslike$(ClassLikeSupport.scala:15)
	at dotty.tools.scaladoc.tasty.TastyParser.parseClasslike(TastyParser.scala:169)
	at dotty.tools.scaladoc.tasty.TastyParser$Traverser$2$.traverseTree(TastyParser.scala:223)
	at scala.quoted.Quotes$reflectModule$TreeTraverser.foldTree(Quotes.scala:4669)
	at scala.quoted.Quotes$reflectModule$TreeTraverser.foldTree$(Quotes.scala:4665)
	at dotty.tools.scaladoc.tasty.TastyParser$Traverser$2$.foldTree(TastyParser.scala:211)
	at dotty.tools.scaladoc.tasty.TastyParser$Traverser$2$.foldTree(TastyParser.scala:211)
	at scala.quoted.Quotes$reflectModule$TreeAccumulator.foldTrees$$anonfun$1(Quotes.scala:4557)
	at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
	at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
	at scala.collection.immutable.List.foldLeft(List.scala:79)
	at scala.quoted.Quotes$reflectModule$TreeAccumulator.foldTrees(Quotes.scala:4557)
	at scala.quoted.Quotes$reflectModule$TreeAccumulator.foldTrees$(Quotes.scala:4552)
	at dotty.tools.scaladoc.tasty.TastyParser$Traverser$2$.foldTrees(TastyParser.scala:211)
	at scala.quoted.Quotes$reflectModule$TreeAccumulator.foldOverTree(Quotes.scala:4620)
	at sbt.internal.inc.AnalyzingCompiler.doc(AnalyzingCompiler.scala:175)
	at sbt.internal.inc.AnalyzingCompiler.doc(AnalyzingCompiler.scala:133)
	at sbt.Doc$.$anonfun$scaladoc$1(Doc.scala:52)
	at sbt.Doc$.$anonfun$scaladoc$1$adapted(Doc.scala:40)
	at sbt.RawCompileLike$.$anonfun$prepare$1(RawCompileLike.scala:79)
	at sbt.RawCompileLike$.$anonfun$prepare$1$adapted(RawCompileLike.scala:72)
	at sbt.RawCompileLike$.$anonfun$cached$4(RawCompileLike.scala:63)
	at sbt.RawCompileLike$.$anonfun$cached$4$adapted(RawCompileLike.scala:61)
	at sbt.util.Tracked$.$anonfun$inputChangedW$1(Tracked.scala:219)
	at sbt.RawCompileLike$.$anonfun$cached$1(RawCompileLike.scala:68)
	at sbt.RawCompileLike$.$anonfun$cached$1$adapted(RawCompileLike.scala:52)
	at sbt.Defaults$.$anonfun$docTaskSettings$4(Defaults.scala:2157)
	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
	at sbt.Execute.work(Execute.scala:291)
	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
[success] Total time: 15 s, completed Nov 29, 2022 1:56:43 PM
```
</details>