### PR TITLE
Fix #16438: Supply dummy args for erroneous parent call in init check

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -855,7 +855,7 @@ object Semantic:
       // init "fake" param fields for parameters of primary and secondary constructors
       def addParamsAsFields(args: List[Value], ref: Ref, ctorDef: DefDef) =
         val params = ctorDef.termParamss.flatten.map(_.symbol)
-        assert(args.size == params.size, "arguments = " + args.size + ", params = " + params.size + ", ctro = " + ctor.show)
+        assert(args.size == params.size, "arguments = " + args.size + ", params = " + params.size + ", ctor = " + ctor.show)
         for (param, value) <- params.zip(args) do
           ref.updateField(param, value)
           printer.println(param.show + " initialized with " + value)

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -855,7 +855,7 @@ object Semantic:
       // init "fake" param fields for parameters of primary and secondary constructors
       def addParamsAsFields(args: List[Value], ref: Ref, ctorDef: DefDef) =
         val params = ctorDef.termParamss.flatten.map(_.symbol)
-        assert(args.size == params.size, "arguments = " + args.size + ", params = " + params.size)
+        assert(args.size == params.size, "arguments = " + args.size + ", params = " + params.size + ", ctro = " + ctor.show)
         for (param, value) <- params.zip(args) do
           ref.updateField(param, value)
           printer.println(param.show + " initialized with " + value)
@@ -1663,12 +1663,13 @@ object Semantic:
           // term arguments to B. That can only be done in a concrete class.
           val tref = typeRefOf(klass.typeRef.baseType(mixin).typeConstructor)
           val ctor = tref.classSymbol.primaryConstructor
-          if ctor.exists && ctor.paramSymss.isEmpty then
+          if ctor.exists then
             // The parameter check of traits comes late in the mixin phase.
-            // To avoid crash we ignore the initialization check for erroneous
-            // parent call code. See tests/neg/i16438.scala.
+            // To avoid crash we supply hot values for erroneous parent calls.
+            // See tests/neg/i16438.scala.
+            val args: List[ArgInfo] = ctor.info.paramInfoss.flatten.map(_ => ArgInfo(Hot, Trace.empty))
             extendTrace(superParent) {
-              superCall(tref, ctor, args = Nil, tasks)
+              superCall(tref, ctor, args, tasks)
             }
       }
 

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -1663,9 +1663,13 @@ object Semantic:
           // term arguments to B. That can only be done in a concrete class.
           val tref = typeRefOf(klass.typeRef.baseType(mixin).typeConstructor)
           val ctor = tref.classSymbol.primaryConstructor
-          if ctor.exists then extendTrace(superParent) {
-            superCall(tref, ctor, Nil, tasks)
-          }
+          if ctor.exists && ctor.paramSymss.isEmpty then
+            // The parameter check of traits comes late in the mixin phase.
+            // To avoid crash we ignore the initialization check for erroneous
+            // parent call code. See tests/neg/i16438.scala.
+            extendTrace(superParent) {
+              superCall(tref, ctor, args = Nil, tasks)
+            }
       }
 
       // initialize super classes after outers are set

--- a/tests/neg/i16438.scala
+++ b/tests/neg/i16438.scala
@@ -1,0 +1,4 @@
+// scalac: -Ysafe-init
+trait ATrait(val string: String, val int: Int)
+trait AnotherTrait( override val string: String, override val int: Int) extends ATrait
+case class ACaseClass(override val string: String) extends AnotherTrait(string, 3) // error


### PR DESCRIPTION
Fix #16438: Supply dummy args for erroneous parent call in init check