### PR TITLE
Typo in opaques-details.md

### DIFF
--- a/docs/_docs/reference/other-new-features/opaques-details.md
+++ b/docs/_docs/reference/other-new-features/opaques-details.md
@@ -40,7 +40,7 @@ object o:
 
 In this case we have inside the object (also for non-opaque types) that `o.T` is equal to
 `T` or its expanded form `o.this.T`. Equality is understood here as mutual subtyping, i.e.
-`o.T <: o.this.T` and `o.this.T <: T`. Furthermore, we have by the rules of opaque type aliases
+`o.T <: o.this.T` and `o.this.T <: o.T`. Furthermore, we have by the rules of opaque type aliases
 that `o.this.T` equals `R`. The two equalities compose. That is, inside `o`, it is
 also known that `o.T` is equal to `R`. This means the following code type-checks:
 


### PR DESCRIPTION
Looks like a typo. If not, then some clarification would be helpful to understand the semantics.