### PR TITLE
Require indent after colon at EOL

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1340,11 +1340,16 @@ object Parsers {
       // note: next is defined here because current == NEWLINE
       if (in.token == NEWLINE && p(in.next.token)) newLineOpt()
 
-    def colonAtEOLOpt(): Unit = {
+    def acceptIndent() =
+      if in.token != INDENT then
+        syntaxErrorOrIncomplete(em"indented definitions expected, ${in} found")
+
+    def colonAtEOLOpt(): Unit =
       possibleColonOffset = in.lastOffset
       in.observeColonEOL(inTemplate = false)
-      if in.token == COLONeol then in.nextToken()
-    }
+      if in.token == COLONeol then
+        in.nextToken()
+        acceptIndent()
 
     def argumentStart(): Unit =
       colonAtEOLOpt()
@@ -1364,8 +1369,7 @@ object Parsers {
         if in.lookahead.token == END then in.token = NEWLINE
         else
           in.nextToken()
-          if in.token != INDENT && in.token != LBRACE then
-            syntaxErrorOrIncomplete(em"indented definitions expected, ${in} found")
+          if in.token != LBRACE then acceptIndent()
       else
         newLineOptWhenFollowedBy(LBRACE)
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -944,7 +944,7 @@ object Parsers {
         lookahead.isArrow
         && {
           lookahead.nextToken()
-          lookahead.token == INDENT
+          lookahead.token == INDENT || lookahead.token == EOF
         }
       lookahead.nextToken()
       if lookahead.isIdent || lookahead.token == USCORE then

--- a/tests/neg/i16452.check
+++ b/tests/neg/i16452.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i16452.scala:2:8 -----------------------------------------------------------------------------------
+2 |// error
+  |        ^
+  |        indented definitions expected, eof found

--- a/tests/neg/i16452.scala
+++ b/tests/neg/i16452.scala
@@ -1,0 +1,2 @@
+val x = Seq(1, 2, 3).map:
+// error


### PR DESCRIPTION
Require indented definitions after a `:` at the end of a line where an argument is expected.

Fixes #16452