### PR TITLE
Only include accessible base classes in orDominator

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -209,7 +209,7 @@ object TypeOps:
 
   /** Approximate union type by intersection of its dominators.
    *  That is, replace a union type Tn | ... | Tn
-   *  by the smallest intersection type of base-class instances of T1,...,Tn.
+   *  by the smallest intersection type of accessible base-class instances of T1,...,Tn.
    *  Example: Given
    *
    *      trait C[+T]
@@ -370,8 +370,14 @@ object TypeOps:
         }
       }
 
+      def isAccessible(cls: ClassSymbol) =
+        if cls.isOneOf(AccessFlags) || cls.privateWithin.exists then
+          cls.isAccessibleFrom(tp.baseType(cls).normalizedPrefix)
+        else true
+
       // Step 3: Intersect base classes of both sides
-      val commonBaseClasses = orBaseClasses(tp)
+      val commonBaseClasses = orBaseClasses(tp).filterConserve(isAccessible)
+
       val doms = dominators(commonBaseClasses, Nil)
       def baseTp(cls: ClassSymbol): Type =
         tp.baseType(cls).mapReduceOr(identity)(mergeRefinedOrApplied)

--- a/tests/pos/i16474.scala
+++ b/tests/pos/i16474.scala
@@ -1,0 +1,13 @@
+object o:
+
+  private[o] trait A
+  trait B
+  class C extends A, B
+  class D extends A, B
+
+def test =
+  def f[T](x: T): T => T = identity
+  val g = f(if ??? then o.C() else o.D())
+  g(new o.B{})
+
+

--- a/tests/run/i16474/BaseProvider.java
+++ b/tests/run/i16474/BaseProvider.java
@@ -1,0 +1,6 @@
+// BaseProvider.java
+package repro.impl;
+
+import repro.*;
+abstract class BaseProvider{}
+

--- a/tests/run/i16474/Case1.java
+++ b/tests/run/i16474/Case1.java
@@ -1,0 +1,9 @@
+// Case1.java
+package repro;
+
+import repro.impl.*;
+
+public class Case1 extends Case1Provider implements Encrypter {
+  public Case1(){}
+}
+

--- a/tests/run/i16474/Case1Provider.java
+++ b/tests/run/i16474/Case1Provider.java
@@ -1,0 +1,5 @@
+// Case1Provider.java
+package repro.impl;
+
+public abstract class Case1Provider extends BaseProvider {}
+

--- a/tests/run/i16474/Case2.java
+++ b/tests/run/i16474/Case2.java
@@ -1,0 +1,8 @@
+// Case2.java
+package repro;
+
+import repro.impl.*;
+
+public class Case2 extends Case2Provider implements Encrypter {
+  public Case2(){}
+}

--- a/tests/run/i16474/Case2Provider.java
+++ b/tests/run/i16474/Case2Provider.java
@@ -1,0 +1,5 @@
+// Case2Provider.java
+package repro.impl;
+
+public abstract class Case2Provider extends BaseProvider {}
+

--- a/tests/run/i16474/Encrypter.java
+++ b/tests/run/i16474/Encrypter.java
@@ -1,0 +1,4 @@
+// Encrypter.java
+package repro;
+public interface Encrypter{}
+

--- a/tests/run/i16474/test.scala
+++ b/tests/run/i16474/test.scala
@@ -1,0 +1,14 @@
+// test.scala
+import repro.*
+import scala.util.Try
+
+def get(arg: Any): Try[Encrypter] = Try {
+  val x: Any = 1
+  arg match
+    case 1 => new Case1()
+    case 2 => new Case2()
+    case _ => throw new RuntimeException(s"Unsupported got $arg")
+}
+
+@main def Test =
+    val result = get(null)

--- a/tests/run/i16474/test.scala
+++ b/tests/run/i16474/test.scala
@@ -1,3 +1,4 @@
+// scalajs: --skip
 // test.scala
 import repro.*
 import scala.util.Try


### PR DESCRIPTION
By joining union types we could previously uncover inaccessible base classes that could lead to access errors at runtime. We now filter out such classes when computing the orDominator.

Fixes #16474