### PR TITLE
Take @targetName into account when resolving extension methods

### DIFF
--- a/tests/neg/i16464.scala
+++ b/tests/neg/i16464.scala
@@ -1,0 +1,6 @@
+
+implicit final class SomeOps(e: Int) extends AnyVal:
+  def -(other: Seq[Int]) = List(1)
+  def -(other: Seq[Long]) = List(2) // error: double definition
+
+def main(): Unit = 1 - Seq.empty[Int]

--- a/tests/pos/i16464.scala
+++ b/tests/pos/i16464.scala
@@ -1,0 +1,26 @@
+import scala.annotation.targetName
+
+object test1:
+  implicit final class SomeOps(e: Int) extends AnyVal:
+    @targetName("a")
+    def -(other: Seq[Int]) = List(1)
+    @targetName("b")
+    def -(other: Seq[Long]) = List(2)
+
+  def main(): Unit = 1 - Seq.empty[Int]
+
+object test2:
+  implicit final class SomeOps(e: Int) extends AnyVal:
+    @targetName("a")
+    def -(other: Seq[Int]) = List(1)
+    def -(other: Seq[Long]) = List(2)
+
+  def main(): Unit = 1 - Seq.empty[Int]
+
+object test3:
+  implicit final class SomeOps(e: Int) extends AnyVal:
+    def -(other: Seq[Int]) = List(1)
+    @targetName("b")
+    def -(other: Seq[Long]) = List(2)
+
+  def main(): Unit = 1 - Seq.empty[Int]

--- a/tests/run/i16464.scala
+++ b/tests/run/i16464.scala
@@ -1,0 +1,10 @@
+import scala.annotation.targetName
+
+implicit final class SomeOps(e: Int) extends AnyVal:
+  @targetName("a")
+  def -(other: Seq[Int]) = List(1)
+  @targetName("b")
+  def -(other: Seq[Long]) = List(2)
+
+@main
+def Test(): Unit = 1 - Seq.empty[Int]


### PR DESCRIPTION
Take @targetName into account when resolving extension methods of value classes

Before target name we only matched on signatures. This was OK, since multiple extension methods of the same class must be different, otherwise we will get a "have the same erasure" error later at erasurePhase. But with @targetName that's now a legal situation that needs to be resolved correctly. We do this by propagating the target name to the extension method and verifying that the target names of the original and extension methods match.

Fixes #16464