### PR TITLE
Don't rely on isProvisional to determine whether atoms computed

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3441,19 +3441,20 @@ object Types {
       val tp2w = tp2.widenSingletons
       if ((tp1 eq tp1w) && (tp2 eq tp2w)) this else TypeComparer.lub(tp1w, tp2w, isSoft = isSoft)
 
-    private def ensureAtomsComputed()(using Context): Unit =
+    private def ensureAtomsComputed()(using Context): Boolean =
       if atomsRunId != ctx.runId && !isProvisional then
         myAtoms = computeAtoms()
         myWidened = computeWidenSingletons()
         atomsRunId = ctx.runId
+        true
+      else
+        false
 
     override def atoms(using Context): Atoms =
-      ensureAtomsComputed()
-      if isProvisional then computeAtoms() else myAtoms
+      if ensureAtomsComputed() then myAtoms else computeAtoms()
 
     override def widenSingletons(using Context): Type =
-      ensureAtomsComputed()
-      if isProvisional then computeWidenSingletons() else myWidened
+      if ensureAtomsComputed() then myWidened else computeWidenSingletons()
 
     def derivedOrType(tp1: Type, tp2: Type, soft: Boolean = isSoft)(using Context): Type =
       if ((tp1 eq this.tp1) && (tp2 eq this.tp2) && soft == isSoft) this

--- a/tests/pos/i16486/defs_1.scala
+++ b/tests/pos/i16486/defs_1.scala
@@ -1,0 +1,17 @@
+// defs_1.scala
+import java.time.*
+
+type Temporal =
+  java.sql.Date |
+  LocalDateTime | LocalDate | LocalTime |
+  Instant
+
+given Conversion[String | Temporal, JsValue] =  ???
+
+sealed trait JsValue
+case class JsObject(value: Map[String, JsValue])
+
+object Json{
+  def obj(fields: Tuple2[String,  JsValue | Option[JsValue]]* ): JsObject = ???
+}
+

--- a/tests/pos/i16486/usage_2.scala
+++ b/tests/pos/i16486/usage_2.scala
@@ -1,0 +1,4 @@
+// usage_2.scala
+class Bug {
+  def searchJson = Json.obj("foo" -> "bar")
+}


### PR DESCRIPTION
isProvisional can flip at unpredictable points, so we cannot rely on it to be stable between the call to `ensureAtomsComputed` and after it.

Fixes #16486