### PR TITLE
Don't search implicit arguments in singleton type prefix

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -295,6 +295,8 @@ object ProtoTypes {
    */
   @sharable object AnySelectionProto extends SelectionProto(nme.WILDCARD, WildcardType, NoViewsAllowed, true)
 
+  @sharable object SingletonTypeProto extends SelectionProto(nme.WILDCARD, WildcardType, NoViewsAllowed, true)
+
   /** A prototype for selections in pattern constructors */
   class UnapplySelectionProto(name: Name) extends SelectionProto(name, WildcardType, NoViewsAllowed, true)
 

--- a/tests/pos/i16488.scala
+++ b/tests/pos/i16488.scala
@@ -1,0 +1,4 @@
+trait Ctx
+val f: Ctx ?=> Int = ???
+type Tpe = f.type
+


### PR DESCRIPTION
In a singleton type `f.type`, if `f` is a context function value, don't complete with implicit arguments.

Fixes #16488