### PR TITLE
Disallow inline given aliases with functions as RHS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -187,6 +187,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case MissingArgumentID // errorNumer 171
   case MissingImplicitArgumentID // errorNumber 172
   case CannotBeAccessedID // errorNumber 173
+  case InlineGivenCannotBeFunctionID // errorNumber 174
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2769,4 +2769,23 @@ extends ReferenceMsg(CannotBeAccessedID):
     i"$whatCanNot be accessed as a member of $pre$where.$whyNot"
   def explain(using Context) = ""
 
+class InlineGivenCannotBeFunction()(using Context)
+extends SyntaxMsg(InlineGivenCannotBeFunctionID):
+  def msg(using Context) =
+    i"""inline given alias cannot have a function value as right-hand side.
+       |Either drop `inline` or rewrite the given with an explicit `apply` method."""
+  def explain(using Context) =
+    i"""A function value on the right-hand side of an inline given alias would expand to
+       |an anonymous class. Each application of the inline given would then create a
+       |fresh copy of that class, which can increase code size in surprising ways.
+       |For that reason, functions are disallowed as right hand sides of inline given aliases.
+       |You should either drop `inline` or rewrite to an explicit `apply` method. E.g.
+       |
+       |    inline given Conversion[A, B] = x => x.toB // error
+       |
+       |should be re-formulated as
+       |
+       |    inline given Conversion[A, B] with
+       |      def apply(x: A) = x.toB
+     """
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2374,6 +2374,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if sym.isInlineMethod then
       if StagingContext.level > 0 then
         report.error("inline def cannot be within quotes", sym.sourcePos)
+      if sym.is(Given) && ddef.rhs.isInstanceOf[untpd.Function] then
+        report.error(InlineGivenCannotBeFunction(), ddef.rhs.srcPos)
       val rhsToInline = PrepareInlineable.wrapRHS(ddef, tpt1, rhs1)
       PrepareInlineable.registerInlineInfo(sym, rhsToInline)
 

--- a/tests/neg-macros/i11483/Macro_1.scala
+++ b/tests/neg-macros/i11483/Macro_1.scala
@@ -17,8 +17,8 @@ trait CpsMonad[F[_]]:
 @compileTimeOnly("await should be inside async block")
 def await[F[_],T](f:F[T])(using am:CpsMonad[F]):T = ???
 
-inline given conversion[F[_],T](using CpsMonad[F]): Conversion[F[T],T] =
-           x => await(x)
+inline given conversion[F[_],T](using CpsMonad[F]): Conversion[F[T],T] with
+  inline def apply(x: F[T]) = await(x)
 
 
 object X {

--- a/tests/neg/inline-givens.scala
+++ b/tests/neg/inline-givens.scala
@@ -1,0 +1,9 @@
+
+class Item(x: String)
+
+inline given a: Conversion[String, Item] =
+  Item(_)  // error
+
+inline given b: Conversion[String, Item] with
+  def apply(x: String) = Item(x)
+

--- a/tests/pos/i13900.scala
+++ b/tests/pos/i13900.scala
@@ -3,8 +3,8 @@ import scala.annotation.targetName
 opaque type Inlined[T] = T
 object Inlined:
   extension [T](inlined: Inlined[T]) def value: T = inlined
-  inline given fromValue[T <: Singleton]: Conversion[T, Inlined[T]] =
-    value => value
+  inline given fromValue[T <: Singleton]: Conversion[T, Inlined[T]] with
+    def apply(value: T) = value
   @targetName("fromValueWide")
   given fromValue[Wide]: Conversion[Wide, Inlined[Wide]] = value => value
 

--- a/tests/pos/i8276.scala
+++ b/tests/pos/i8276.scala
@@ -1,6 +1,7 @@
 object NOTHING
 
-inline given [A]: Conversion[NOTHING.type, Option[A]] = _ => None
+inline given [A]: Conversion[NOTHING.type, Option[A]] with
+  def apply(x: NOTHING.type) = None
 
 def apply[A](p: Vector[A], o: Option[A] = NOTHING): Unit = ???
 


### PR DESCRIPTION
```scala
    inline given a: Conversion[String, Item] = Item(_)  // error
```
will now produce this error:
```
5 |  inline given a: Conversion[String, Item] = Item(_)  // error
  |                                             ^^^^^^^
  |inline given alias cannot have a function value as right-hand side.
  |Either drop `inline` or rewrite the given with an explicit `apply` method.
  |-----------------------------------------------------------------------------
  | Explanation (enabled by `-explain`)
  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  | A function value on the right-hand side of an inline given alias would expand to
  | an anonymous class. Each application of the inline given would then create a
  | fresh copy of that class, which can increase code size in surprising ways.
  | For that reason, functions are disallowed as right hand sides of inline given aliases.
  | You should either drop `inline` or rewrite to an explicit `apply` method. E.g.
  |
  |     inline given Conversion[A, B] = x => x.toB // error
  |
  | should be re-formulated as
  |
  |     inline given Conversion[A, B] with
  |       def apply(x: A) = x.toB
  |
```
Fixes #16497
Alternative to #16499 