### PR TITLE
Trial balloon: Make default getters final

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -313,7 +313,7 @@ object desugar {
             rhs = vparam.rhs
           )
           .withMods(Modifiers(
-            meth.mods.flags & (AccessFlags | Synthetic) | (vparam.mods.flags & Inline),
+            meth.mods.flags & (AccessFlags | Synthetic) | (vparam.mods.flags & Inline) | Final,
             meth.mods.privateWithin))
         val rest = defaultGetters(vparams :: paramss1, n + 1)
         if vparam.rhs.isEmpty then rest else defaultGetter :: rest

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -757,13 +757,13 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       }
     }
 
-    override def If(tree: If)(cond: Tree = tree.cond, thenp: Tree = tree.thenp, elsep: Tree = tree.elsep)(using Context): If =
+    override def If(tree: If)(cond: Tree, thenp: Tree, elsep: Tree)(using Context): If =
       If(tree: Tree)(cond, thenp, elsep)
-    override def Closure(tree: Closure)(env: List[Tree] = tree.env, meth: Tree = tree.meth, tpt: Tree = tree.tpt)(using Context): Closure =
+    override def Closure(tree: Closure)(env: List[Tree], meth: Tree, tpt: Tree)(using Context): Closure =
       Closure(tree: Tree)(env, meth, tpt)
-    override def CaseDef(tree: CaseDef)(pat: Tree = tree.pat, guard: Tree = tree.guard, body: Tree = tree.body)(using Context): CaseDef =
+    override def CaseDef(tree: CaseDef)(pat: Tree, guard: Tree, body: Tree)(using Context): CaseDef =
       CaseDef(tree: Tree)(pat, guard, body)
-    override def Try(tree: Try)(expr: Tree = tree.expr, cases: List[CaseDef] = tree.cases, finalizer: Tree = tree.finalizer)(using Context): Try =
+    override def Try(tree: Try)(expr: Tree, cases: List[CaseDef], finalizer: Tree)(using Context): Try =
       Try(tree: Tree)(expr, cases, finalizer)
   }
 
@@ -790,7 +790,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     override def Closure(tree: Tree)(env: List[Tree], meth: Tree, tpt: Tree)(using Context): Closure =
             ta.assignType(untpdCpy.Closure(tree)(env, meth, tpt), meth, tpt)
 
-    override def Closure(tree: Closure)(env: List[Tree] = tree.env, meth: Tree = tree.meth, tpt: Tree = tree.tpt)(using Context): Closure =
+    override def Closure(tree: Closure)(env: List[Tree], meth: Tree, tpt: Tree)(using Context): Closure =
       Closure(tree: Tree)(env, meth, tpt)
   }
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -559,7 +559,7 @@ class CheckCaptures extends Recheck, SymTransformer:
      *  Otherwise, if the result type is boxed, simulate an unboxing by
      *  adding all references in the boxed capture set to the current environment.
      */
-    override def recheck(tree: Tree, pt: Type = WildcardType)(using Context): Type =
+    override def recheck(tree: Tree, pt: Type)(using Context): Type =
       if tree.isTerm && pt.isBoxedCapturing then
         val saved = curEnv
 

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -28,7 +28,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   protected def emptyFiles: Array[AbstractFile] = Array.empty
   protected def getSubDir(packageDirName: String): Option[AbstractFile] =
     Option(lookupPath(dir)(packageDirName.split(java.io.File.separator).toIndexedSeq, directory = true))
-  protected def listChildren(dir: AbstractFile, filter: Option[AbstractFile => Boolean] = None): Array[F] = filter match {
+  protected def listChildren(dir: AbstractFile, filter: Option[AbstractFile => Boolean]): Array[F] = filter match {
     case Some(f) => dir.iterator.filter(f).toArray
     case _ => dir.toArray
   }

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -321,7 +321,7 @@ class TreeChecker extends Phase with SymTransformer {
             assert(false, s"The type of a non-Super tree must not be a SuperType, but $tree has type $tp")
           case _ =>
 
-    override def typed(tree: untpd.Tree, pt: Type = WildcardType)(using Context): Tree = {
+    override def typed(tree: untpd.Tree, pt: Type)(using Context): Tree = {
       val tpdTree = super.typed(tree, pt)
       Typer.assertPositioned(tree)
       checkSuper(tpdTree)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1539,7 +1539,7 @@ trait NoChecking extends ReChecking {
   override def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean)(using Context): Type = tp
   override def checkImplicitConversionDefOK(sym: Symbol)(using Context): Unit = ()
   override def checkImplicitConversionUseOK(tree: Tree, expected: Type)(using Context): Unit = ()
-  override def checkFeasibleParent(tp: Type, pos: SrcPos, where: => String = "")(using Context): Type = tp
+  override def checkFeasibleParent(tp: Type, pos: SrcPos, where: => String)(using Context): Type = tp
   override def checkAnnotArgs(tree: Tree)(using Context): tree.type = tree
   override def checkNoTargetNameConflict(stats: List[Tree])(using Context): Unit = ()
   override def checkParentCall(call: Tree, caller: ClassSymbol)(using Context): Unit = ()

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2730,7 +2730,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def NoneModule: Symbol = dotc.core.Symbols.defn.NoneModule
       def SomeModule: Symbol = dotc.core.Symbols.defn.SomeClass.companionModule
       def ProductClass: Symbol = dotc.core.Symbols.defn.ProductClass
-      def FunctionClass(arity: Int, isImplicit: Boolean = false, isErased: Boolean = false): Symbol =
+      def FunctionClass(arity: Int, isImplicit: Boolean, isErased: Boolean): Symbol =
         dotc.core.Symbols.defn.FunctionSymbol(arity, isImplicit, isErased)
       def TupleClass(arity: Int): Symbol =
         dotc.core.Symbols.defn.TupleType(arity).nn.classSymbol.asClass

--- a/tests/pos/default-getter-variance.scala
+++ b/tests/pos/default-getter-variance.scala
@@ -14,7 +14,7 @@ class Bar1[+A] extends Foo[A] {
 }
 
 class Bar2[+A] extends Foo[A] {
-  override def count(f: A => Boolean = _ => true): Unit = {}
+  override def count(f: A => Boolean): Unit = {}
   // ... including overrides which also override the default getter:
   override def count2(f: A => Boolean): Unit = {}
   override def count2(): Unit = count(_ => true)

--- a/tests/pos/main-method-scheme-class-based.scala
+++ b/tests/pos/main-method-scheme-class-based.scala
@@ -81,7 +81,7 @@ class main extends MainAnnotation:
         case Some(t) => () => t
         case None => error(s"invalid argument for $argName: $arg")
 
-    def argGetter[T](argName: String, p: ArgumentParser[T], defaultValue: Option[T] = None): () => T =
+    def argGetter[T](argName: String, p: ArgumentParser[T], defaultValue: Option[T]): () => T =
       argInfos += ((argName, if defaultValue.isDefined then "?" else ""))
       val idx = args.indexOf(s"--$argName")
       val argOpt = if idx >= 0 then argAt(idx + 1) else nextPositionalArg()

--- a/tests/run/decorators/main.scala
+++ b/tests/run/decorators/main.scala
@@ -51,7 +51,7 @@ class main extends EntryPoint.Annotation:
           case Some(t) => () => t
           case None => error(s"invalid argument for $argName: $arg")
 
-      def nextArgGetter[T](argName: String, p: ArgumentParser[T], defaultValue: Option[T] = None): () => T =
+      def nextArgGetter[T](argName: String, p: ArgumentParser[T], defaultValue: Option[T]): () => T =
         argInfos += ((argName, if defaultValue.isDefined then "?" else ""))
         val idx = args.indexOf(s"--$argName")
         val argOpt = if idx >= 0 then argAt(idx + 1) else nextPositionalArg()


### PR DESCRIPTION
I want to see what the fallout is when we make default getters final, which is necessary if we want to make them inlineable.

So far I have seen ~20 occurrences in the compiler codebase itself and a handful more in the tests where an overriding function has exactly the same default argument as the overridden function, so the repeated default argument was redundant.

I have seen no occurrences in this codebase where the overriding function had a meaningful different default argument, except for tests that were specifically designed to test that feature.