### PR TITLE
Fix regression in cyclic constraint handling

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -693,7 +693,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
       def replaceParamIn(other: TypeParamRef) =
         val oldEntry = current.entry(other)
         val newEntry = oldEntry.substParam(param, replacement) match
-          case tp: TypeBounds => validBoundsFor(other, tp)
+          case tp: TypeBounds => current.validBoundsFor(other, tp)
           case tp => tp
         current = boundsLens.update(this, current, other, newEntry)
         var oldDepEntry = oldEntry


### PR DESCRIPTION
This regressed in 50eb0e979407cf2348d82eb34d6fe8a168ba5171 when `current.ensureNonCyclic` was incorrectly replaced by `validBoundsFor` which operates on `this`, not `current`.

This isn't the first time we make this error (cf
a8641c5cbe6ad22707ea52c639ee894cfa09db57), maybe we should refactor OrderingConstraint so that operations on `current` are done in the companion object where `this` isn't accessible.

Fixes #16471. Note that the test case from this issue couldn't be added because it fails `-Ycheck:typer`, but this was also the case before the regression. This is now tracked by #16524.