### PR TITLE
trait-parameters.md: delete invalid code from example

### DIFF
--- a/docs/_docs/reference/other-new-features/trait-parameters.md
+++ b/docs/_docs/reference/other-new-features/trait-parameters.md
@@ -79,7 +79,7 @@ The definition of `F` in the last line is implicitly expanded to
 class F(using iname: ImpliedName) extends
   Object,
   ImpliedGreeting(using iname),
-  ImpliedFormalGreeting(using iname)
+  ImpliedFormalGreeting
 ```
 Note the inserted reference to the super trait `ImpliedGreeting`, which was not mentioned explicitly.
 


### PR DESCRIPTION
This code doesn't compile and produces error:
```scala
class F(using iname: ImpliedName) extends
  Object,
  ImpliedGreeting(using iname),
  ImpliedFormalGreeting(using iname)
```

>[error] 15 |  ImpliedFormalGreeting(using iname)
>[error]    |  ^^^^^^^^^^^^^^^^^^^^^
>[error]    |constructor ImpliedFormalGreeting in trait ImpliedFormalGreeting does not take more parameters
>[error]    |----------------------------------------------------------------------------
>[error]    | Explanation (enabled by `-explain`)
>[error]    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
>[error]    | You have specified more parameter lists than defined in the method definition(s).


This will compile:
```scala
class F(using iname: ImpliedName) extends
  Object,
  ImpliedGreeting(using iname),
  ImpliedFormalGreeting
```

I understand, that maybe this is kinda pseudo-code.
>The definition of `F` in the last line is implicitly expanded to

But if it's stated that the original code will be "expanded" it sounds as if it we could do it ourselves manually and that would be effectively the same code. An alternative to deleting `(using iname)` could be commenting it out `//(using iname)`.