### PR TITLE
Bump Inkuire version to v1.0.0-M7

### DIFF
--- a/project/DocumentationWebsite.scala
+++ b/project/DocumentationWebsite.scala
@@ -42,7 +42,7 @@ object DocumentationWebsite {
     import _root_.scala.concurrent._
     import _root_.scala.concurrent.duration.Duration
     import ExecutionContext.Implicits.global
-    val inkuireVersion = "1.0.0-M3"
+    val inkuireVersion = "v1.0.0-M7"
     val inkuireLink = s"https://github.com/VirtusLab/Inkuire/releases/download/$inkuireVersion/inkuire.js"
     val inkuireDestinationFile = baseDest / "dotty_res" / "scripts" / "inkuire.js"
     sbt.IO.touch(inkuireDestinationFile)


### PR DESCRIPTION
The main improvement this version introduced was to add a fallback for 'orphan types' i.e. types we do not provide definitions for, but use in our signatures