### PR TITLE
Correctly unpickle Scala 2 private case classes in traits

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -67,11 +67,11 @@ object NamerOps:
       completer.withSourceModule(findModuleBuddy(name.sourceModuleName, scope))
 
   /** Find moduleClass/sourceModule in effective scope */
-  def findModuleBuddy(name: Name, scope: Scope)(using Context) = {
-    val it = scope.lookupAll(name).filter(_.is(Module))
-    if (it.hasNext) it.next()
+  def findModuleBuddy(name: Name, scope: Scope, alternate: Name = EmptyTermName)(using Context): Symbol =
+    var it = scope.lookupAll(name).filter(_.is(Module))
+    if !alternate.isEmpty then it ++= scope.lookupAll(alternate).filter(_.is(Module))
+    if it.hasNext then it.next()
     else NoSymbol.assertingErrorsReported(em"no companion $name in $scope")
-  }
 
   /** If a class has one of these flags, it does not get a constructor companion */
   private val NoConstructorProxyNeededFlags = Abstract | Trait | Case | Synthetic | Module | Invisible

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -89,7 +89,11 @@ object Scala2Unpickler {
         val sourceModule = denot.sourceModule.orElse {
           // For non-toplevel modules, `sourceModule` won't be set when completing
           // the module class, we need to go find it ourselves.
-          NamerOps.findModuleBuddy(cls.name.sourceModuleName, denot.owner.info.decls)
+          val modName = cls.name.sourceModuleName
+          val alternate =
+            if cls.privateWithin.exists && cls.owner.is(Trait) then modName.expandedName(cls.owner)
+            else EmptyTermName
+          NamerOps.findModuleBuddy(modName, denot.owner.info.decls, alternate)
         }
         denot.owner.thisType.select(sourceModule)
       else selfInfo

--- a/tests/pos/i16443/Test_2.scala
+++ b/tests/pos/i16443/Test_2.scala
@@ -1,0 +1,2 @@
+@main def Test =
+  println(NoTypeHints)

--- a/tests/pos/i16443/TypeHints_1.scala
+++ b/tests/pos/i16443/TypeHints_1.scala
@@ -1,0 +1,15 @@
+// This should be run with Scala 2.13
+trait TypeHints {
+  val hints: List[Class[_]]
+  def components: List[TypeHints] = List(this)
+
+  def + (hints: TypeHints): TypeHints = CompositeTypeHints(components ::: hints.components)
+
+  private case class CompositeTypeHints(override val components: List[TypeHints]) extends TypeHints {
+    override val hints: List[Class[_]] = components.flatMap(_.hints)
+  }
+}
+
+case object NoTypeHints extends TypeHints {
+  override val hints = Nil
+}


### PR DESCRIPTION
Fixes #16443

I don't know how to make a test that reproduces the exact problem. In the test of this commit `TypeHints_1.scala` should be compiled with Scala 2.13, but I am not sure how to implement that.