### PR TITLE
Freeze constraints in a condition check of maximiseType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -881,10 +881,6 @@ object TypeOps:
     }
 
     def instantiate(): Type = {
-      // if there's a change in variance in type parameters (between subtype tp1 and supertype tp2)
-      // then we don't want to maximise the type variables in the wrong direction.
-      // For instance 15967, A[-Z] and B[Y] extends A[Y], we don't want to maximise Y to Any
-      maximizeType(protoTp1.baseType(tp2.classSymbol), NoSpan)
       maximizeType(protoTp1, NoSpan)
       wildApprox(protoTp1)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -417,7 +417,7 @@ object Inferencing {
         if safeToInstantiate then tvar.instantiate(fromBelow = v == -1)
         else {
           val bounds = TypeComparer.fullBounds(tvar.origin)
-          if bounds.hi <:< bounds.lo || bounds.hi.classSymbol.is(Final) then
+          if (bounds.hi frozen_<:< bounds.lo) || bounds.hi.classSymbol.is(Final) then
             tvar.instantiate(fromBelow = false)
           else {
             // We do not add the created symbols to GADT constraint immediately, since they may have inter-dependencies.

--- a/tests/pos/i16339.scala
+++ b/tests/pos/i16339.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror
+sealed trait Get[X, +X2 <: X]
+case class Bar[Y, Y2 <: Y](value: Y2) extends Get[Y, Y2]
+
+class Test:
+  def t1[Z, Z2 <: Z](get: Get[Z, Z2]) = get match
+    case Bar(_) =>


### PR DESCRIPTION
Not doing so, in a context where GADT inferrence is enabled, such as in
TypeOps.refineUsingParent, leads to false inferrences.

Doing so, and removing the previous fix for #15967, fixes the regression
in #16339, and keeps #15967 as well as #16123 (which is somewhat
related) fixed.
