### PR TITLE
Enable returning classes from MacroAnnotations (part 3) 

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -65,7 +65,7 @@ class Inlining extends MacroTransform with IdentityDenotTransformer {
   private class InliningTreeMap extends TreeMapWithImplicits {
 
     /** List of top level classes added by macro annotation in a package object.
-     *  These are added the PackageDef that owns this particular package object.
+     *  These are added to the PackageDef that owns this particular package object.
      */
     private val topClasses = new collection.mutable.ListBuffer[Tree]
 

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -16,8 +16,7 @@ import dotty.tools.dotc.core.DenotTransformers.IdentityDenotTransformer
 
 
 /** Inlines all calls to inline methods that are not in an inline method or a quote */
-class Inlining extends MacroTransform with IdentityDenotTransformer {
-  thisPhase =>
+class Inlining extends MacroTransform {
 
   import tpd._
 
@@ -79,7 +78,7 @@ class Inlining extends MacroTransform with IdentityDenotTransformer {
             && StagingContext.level == 0
             && MacroAnnotations.hasMacroAnnotation(tree.symbol)
           then
-            val trees = new MacroAnnotations(thisPhase).expandAnnotations(tree)
+            val trees = (new MacroAnnotations).expandAnnotations(tree)
             val trees1 = trees.map(super.transform)
 
             // Find classes added to the top level from a package object

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -103,8 +103,7 @@ class Inlining extends MacroTransform with IdentityDenotTransformer {
         case _: PackageDef =>
           super.transform(tree) match
             case tree1: PackageDef if !topClasses.isEmpty =>
-              topClasses ++= tree1.stats
-              val newStats = topClasses.result()
+              val newStats = tree1.stats ::: topClasses.result()
               topClasses.clear()
               cpy.PackageDef(tree1)(tree1.pid, newStats)
             case tree1 => tree1

--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -119,13 +119,11 @@ class MacroAnnotations(thisPhase: DenotTransformer):
     annotInstance.transform(using quotes)(tree.asInstanceOf[quotes.reflect.Definition])
 
   /** Check that this tree can be added by the macro annotation and enter it if needed */
-  private def checkAndEnter(newTree: Tree, annotated: Symbol, annot: Annotation)(using Context) =
+  private def checkAndEnter(newTree: DefTree, annotated: Symbol, annot: Annotation)(using Context) =
     val sym = newTree.symbol
-    if sym.isClass then
-      report.error(i"macro annotation returning a `class` is not yet supported. $annot tried to add $sym", annot.tree)
-    else if sym.isType then
+    if sym.isType && !sym.isClass then
       report.error(i"macro annotation cannot return a `type`. $annot tried to add $sym", annot.tree)
-    else if sym.owner != annotated.owner then
+    else if sym.owner != annotated.owner && !(annotated.owner.isPackageObject && (sym.isClass || sym.is(Module)) && sym.owner == annotated.owner.owner) then
       report.error(i"macro annotation $annot added $sym with an inconsistent owner. Expected it to be owned by ${annotated.owner} but was owned by ${sym.owner}.", annot.tree)
     else if annotated.isClass && annotated.owner.is(Package) /*&& !sym.isClass*/ then
       report.error(i"macro annotation can not add top-level ${sym.showKind}. $annot tried to add $sym.", annot.tree)

--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -127,7 +127,7 @@ class MacroAnnotations(thisPhase: DenotTransformer):
       report.error(i"macro annotation $annot added $sym with an inconsistent owner. Expected it to be owned by ${annotated.owner} but was owned by ${sym.owner}.", annot.tree)
     else if annotated.isClass && annotated.owner.is(Package) /*&& !sym.isClass*/ then
       report.error(i"macro annotation can not add top-level ${sym.showKind}. $annot tried to add $sym.", annot.tree)
-    else
+    else if !sym.is(Module) then // To avoid entering it twice
       sym.enteredAfter(thisPhase)
 
 object MacroAnnotations:

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2484,12 +2484,12 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
       def newModule(owner: Symbol, name: String, modFlags: Flags, clsFlags: Flags, parents: List[TypeRepr], decls: Symbol => List[Symbol], privateWithin: Symbol): Symbol =
         assert(parents.nonEmpty && !parents.head.typeSymbol.is(dotc.core.Flags.Trait), "First parent must be a class")
-        val mod = dotc.core.Symbols.newCompleteModuleSymbol(
+        val mod = dotc.core.Symbols.newNormalizedModuleSymbol(
           owner,
           name.toTermName,
           modFlags | dotc.core.Flags.ModuleValCreationFlags,
           clsFlags | dotc.core.Flags.ModuleClassCreationFlags,
-          parents.asInstanceOf, // FIXME
+          parents,
           dotc.core.Scopes.newScope,
           privateWithin)
         val cls = mod.moduleClass.asClass

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2487,8 +2487,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         val mod = dotc.core.Symbols.newCompleteModuleSymbol(
           owner,
           name.toTermName,
-          modFlags | Flags.Final | Flags.Lazy | Flags.Module,
-          clsFlags | Flags.Final | Flags.Module,
+          modFlags | dotc.core.Flags.ModuleValCreationFlags,
+          clsFlags | dotc.core.Flags.ModuleClassCreationFlags,
           parents.asInstanceOf, // FIXME
           dotc.core.Scopes.newScope,
           privateWithin)

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -8,15 +8,16 @@ import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.untpd
 import dotty.tools.dotc.core.Annotations
 import dotty.tools.dotc.core.Contexts._
-import dotty.tools.dotc.core.Types
+import dotty.tools.dotc.core.Decorators._
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.NameKinds
+import dotty.tools.dotc.core.NameOps._
 import dotty.tools.dotc.core.StdNames._
-import dotty.tools.dotc.quoted.reflect._
-import dotty.tools.dotc.core.Decorators._
+import dotty.tools.dotc.core.Types
 import dotty.tools.dotc.NoCompilationUnit
-
-import dotty.tools.dotc.quoted.{MacroExpansion, PickledQuotes}
+import dotty.tools.dotc.quoted.MacroExpansion
+import dotty.tools.dotc.quoted.PickledQuotes
+import dotty.tools.dotc.quoted.reflect._
 
 import scala.quoted.runtime.{QuoteUnpickler, QuoteMatching}
 import scala.quoted.runtime.impl.printers._
@@ -2480,6 +2481,21 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         cls.enter(dotc.core.Symbols.newConstructor(cls, dotc.core.Flags.Synthetic, Nil, Nil))
         for sym <- decls(cls) do cls.enter(sym)
         cls
+
+      def newModule(owner: Symbol, name: String, modFlags: Flags, clsFlags: Flags, parents: List[TypeRepr], decls: Symbol => List[Symbol], privateWithin: Symbol): Symbol =
+        assert(parents.nonEmpty && !parents.head.typeSymbol.is(dotc.core.Flags.Trait), "First parent must be a class")
+        val mod = dotc.core.Symbols.newCompleteModuleSymbol(
+          owner,
+          name.toTermName,
+          modFlags | Flags.Final | Flags.Lazy | Flags.Module,
+          clsFlags | Flags.Final | Flags.Module,
+          parents.asInstanceOf, // FIXME
+          dotc.core.Scopes.newScope,
+          privateWithin)
+        val cls = mod.moduleClass.asClass
+        cls.enter(dotc.core.Symbols.newConstructor(cls, dotc.core.Flags.Synthetic, Nil, Nil))
+        for sym <- decls(cls) do cls.enter(sym)
+        mod
 
       def newMethod(owner: Symbol, name: String, tpe: TypeRepr): Symbol =
         newMethod(owner, name, tpe, Flags.EmptyFlags, noSymbol)

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -243,6 +243,14 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def unapply(cdef: ClassDef): (String, DefDef, List[Tree /* Term | TypeTree */], Option[ValDef], List[Statement]) =
         val rhs = cdef.rhs.asInstanceOf[tpd.Template]
         (cdef.name.toString, cdef.constructor, cdef.parents, cdef.self, rhs.body)
+
+      def module(module: Symbol, parents: List[Tree /* Term | TypeTree */], body: List[Statement]): (ValDef, ClassDef) = {
+        val cls = module.moduleClass
+        val clsDef = ClassDef(cls, parents, body)
+        val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
+        val modVal = ValDef(module, Some(newCls))
+        (modVal, clsDef)
+      }
     end ClassDef
 
     given ClassDefMethods: ClassDefMethods with

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -473,7 +473,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def unapply(cdef: ClassDef): (String, DefDef, List[Tree /* Term | TypeTree */], Option[ValDef], List[Statement])
 
 
-      /** Create the ValDef and ClassDef of a module.
+      /** Create the ValDef and ClassDef of a module (equivalent to an `object` declaration in source code).
        *
        *  Equivalent to
        *  ```
@@ -484,7 +484,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *    List(modValDef, modClassDef)
        *  ```
        *
-       *  @param module the module symbol (of the module lazy val)
+       *  @param module the module symbol (created using `Symbol.newModule`)
        *  @param parents parents of the module class
        *  @param body body of the module class
        *  @return The module lazy val definition and module class definition.
@@ -3713,7 +3713,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *
        *  This symbol starts without an accompanying definition.
        *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
-       *  this symbol to the ClassDef and ValDef constructor.
+       *  this symbol to `ClassDef.module`.
        *
        *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
        *        direct or indirect children of the reflection context's owner.

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3638,6 +3638,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
        *        direct or indirect children of the reflection context's owner.
        */
+      // TODO: add flags and privateWithin
       @experimental def newClass(parent: Symbol, name: String, parents: List[TypeRepr], decls: Symbol => List[Symbol], selfType: Option[TypeRepr]): Symbol
 
       /** Generates a new method symbol with the given parent, name and type.
@@ -4217,7 +4218,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     //   FLAGS   //
     ///////////////
 
-    /** FlagSet of a Symbol */
+    /** Flags of a Symbol */
     type Flags
 
     /** Module object of `type Flags`  */

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3666,7 +3666,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       @experimental def newClass(parent: Symbol, name: String, parents: List[TypeRepr], decls: Symbol => List[Symbol], selfType: Option[TypeRepr]): Symbol
 
       /** Generates a new module symbol with an associated module class symbol,
-       *  This returns the module symbol. The module class can be accessed calling `moduleClass` on this symbol.
+       *  this is equivalent to an `object` declaration in source code.
+       *  This method returns the module symbol. The module class can be accessed calling `moduleClass` on this symbol.
        *
        *  Example usage:
        *  ```scala

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3641,7 +3641,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       // TODO: add flags and privateWithin
       @experimental def newClass(parent: Symbol, name: String, parents: List[TypeRepr], decls: Symbol => List[Symbol], selfType: Option[TypeRepr]): Symbol
 
-      /** Generates a new module symbol with an associated module class symbol.
+      /** Generates a new module symbol with an associated module class symbol,
        *  This returns the module symbol. The module class can be accessed calling `moduleClass` on this symbol.
        *
        *  Example usage:
@@ -3684,10 +3684,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *
        *  @param parent The owner of the class
        *  @param name The name of the class
-       *  @param modFlags extra flags to with which the module symbol should be constructed
-       *  @param clsFlags extra flags to with which the module class symbol should be constructed
+       *  @param modFlags extra flags with which the module symbol should be constructed
+       *  @param clsFlags extra flags with which the module class symbol should be constructed
        *  @param parents The parent classes of the class. The first parent must not be a trait.
-       *  @param decls The member declarations of the module provided the symbol of this class
+       *  @param decls A function that takes the symbol of the module class as input and return the symbols of its declared members
        *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
        *
        *  This symbol starts without an accompanying definition.

--- a/tests/neg-macros/annot-mod-top-method-add-top-method/Macro_1.scala
+++ b/tests/neg-macros/annot-mod-top-method-add-top-method/Macro_1.scala
@@ -1,0 +1,13 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted._
+import scala.collection.mutable
+
+@experimental
+// Assumes annotation is on top level def or val
+class addTopLevelMethodOutsidePackageObject extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+    import quotes.reflect._
+    val methType = MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Int])
+    val methSym = Symbol.newMethod(Symbol.spliceOwner.owner, Symbol.freshName("toLevelMethod"), methType, Flags.EmptyFlags, Symbol.noSymbol)
+    val methDef = ValDef(methSym, Some(Literal(IntConstant(1))))
+    List(methDef, tree)

--- a/tests/neg-macros/annot-mod-top-method-add-top-method/Test_2.scala
+++ b/tests/neg-macros/annot-mod-top-method-add-top-method/Test_2.scala
@@ -1,0 +1,5 @@
+@addTopLevelMethodOutsidePackageObject // error
+def foo = 1
+
+@addTopLevelMethodOutsidePackageObject // error
+val bar = 1

--- a/tests/neg-macros/annot-mod-top-method-add-top-val/Macro_1.scala
+++ b/tests/neg-macros/annot-mod-top-method-add-top-val/Macro_1.scala
@@ -1,0 +1,12 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted._
+import scala.collection.mutable
+
+@experimental
+// Assumes annotation is on top level def or val
+class addTopLevelValOutsidePackageObject extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+    import quotes.reflect._
+    val valSym = Symbol.newVal(Symbol.spliceOwner.owner, Symbol.freshName("toLevelVal"), TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+    val valDef = ValDef(valSym, Some(Literal(IntConstant(1))))
+    List(valDef, tree)

--- a/tests/neg-macros/annot-mod-top-method-add-top-val/Test_2.scala
+++ b/tests/neg-macros/annot-mod-top-method-add-top-val/Test_2.scala
@@ -1,0 +1,5 @@
+@addTopLevelValOutsidePackageObject // error
+def foo = 1
+
+@addTopLevelValOutsidePackageObject // error
+val bar = 1

--- a/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -73,6 +73,7 @@ val experimentalDefinitionInLibrary = Set(
   // Need newClass variant that can add constructor parameters.
   // Need experimental annotation macros to check that design works.
   "scala.quoted.Quotes.reflectModule.ClassDefModule.apply",
+  "scala.quoted.Quotes.reflectModule.ClassDefModule.module",
   "scala.quoted.Quotes.reflectModule.SymbolModule.newClass",
   "scala.quoted.Quotes.reflectModule.SymbolModule.newModule",
   "scala.quoted.Quotes.reflectModule.SymbolModule.freshName",

--- a/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -74,6 +74,7 @@ val experimentalDefinitionInLibrary = Set(
   // Need experimental annotation macros to check that design works.
   "scala.quoted.Quotes.reflectModule.ClassDefModule.apply",
   "scala.quoted.Quotes.reflectModule.SymbolModule.newClass",
+  "scala.quoted.Quotes.reflectModule.SymbolModule.newModule",
   "scala.quoted.Quotes.reflectModule.SymbolModule.freshName",
   "scala.quoted.Quotes.reflectModule.SymbolMethods.info",
 

--- a/tests/run-macros/annot-add-global-class.check
+++ b/tests/run-macros/annot-add-global-class.check
@@ -1,4 +1,12 @@
-macro generated main
-executed in: Bar$macro$1
-macro generated main
-executed in: Bar$macro$2
+macro generated class
+executed in: Bar$macro$5
+macro generated class
+executed in: Bar$macro$6
+macro generated class
+executed in: a.Bar$macro$3
+macro generated class
+executed in: a.b.Bar$macro$1
+macro generated class
+executed in: a.Bar$macro$4
+macro generated class
+executed in: a.c.Bar$macro$2

--- a/tests/run-macros/annot-add-global-class.check
+++ b/tests/run-macros/annot-add-global-class.check
@@ -1,0 +1,4 @@
+macro generated main
+executed in: Bar$macro$1
+macro generated main
+executed in: Bar$macro$2

--- a/tests/run-macros/annot-add-global-class/Macro_1.scala
+++ b/tests/run-macros/annot-add-global-class/Macro_1.scala
@@ -1,3 +1,5 @@
+package mymacro
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-add-global-class/Macro_1.scala
+++ b/tests/run-macros/annot-add-global-class/Macro_1.scala
@@ -1,0 +1,28 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted._
+import scala.collection.mutable
+
+@experimental
+class addClass extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+    import quotes.reflect._
+    tree match
+      case DefDef(name, List(TermParamClause(Nil)), tpt, Some(rhs)) =>
+        val parents = List(TypeTree.of[Object])
+        def decls(cls: Symbol): List[Symbol] =
+          List(Symbol.newMethod(cls, "run", MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]), Flags.EmptyFlags, Symbol.noSymbol))
+
+        val newClassName = Symbol.freshName("Bar")
+        val cls = Symbol.newClass(Symbol.spliceOwner.owner, newClassName, parents = parents.map(_.tpe), decls, selfType = None)
+        val runSym = cls.declaredMethod("run").head
+
+        val runDef = DefDef(runSym, _ => Some(rhs))
+        val clsDef = ClassDef(cls, parents, body = List(runDef))
+
+        val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
+
+        val newDef = DefDef.copy(tree)(name, List(TermParamClause(Nil)), tpt, Some(Apply(Select(newCls, runSym), Nil)))
+        List(clsDef, newDef)
+      case _ =>
+        report.error("Annotation only supports `def` with one argument")
+        List(tree)

--- a/tests/run-macros/annot-add-global-class/Test_2.scala
+++ b/tests/run-macros/annot-add-global-class/Test_2.scala
@@ -1,5 +1,7 @@
+import mymacro.addClass
+
 @addClass def foo(): Unit =
-  println("macro generated main")
+  println("macro generated class")
   println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
 //> class Baz$macro$1 extends Object {
 //>   def run() =
@@ -10,16 +12,39 @@
 //>   new Baz$macro$1.run
 
 @addClass def bar(): Unit =
-  println("macro generated main")
+  println("macro generated class")
   println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
 //> class Baz$macro$2 extends Object {
 //>   def run() =
 //>     println("macro generated main")
 //>     println("executed in: " + getClass.getName)
 //> }
-//> def foo(): Unit =
+//> def bar(): Unit =
 //>   new Baz$macro$2.run
+
+package a:
+  @addClass def foo(): Unit =
+    println("macro generated class")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+
+  package b:
+    @addClass def foo(): Unit =
+      println("macro generated class")
+      println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+
+  @addClass def bar(): Unit =
+    println("macro generated class")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+
+  package c:
+    @addClass def foo(): Unit =
+      println("macro generated class")
+      println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
 
 @main def Test(): Unit =
   foo()
   bar()
+  a.foo()
+  a.b.foo()
+  a.bar()
+  a.c.foo()

--- a/tests/run-macros/annot-add-global-class/Test_2.scala
+++ b/tests/run-macros/annot-add-global-class/Test_2.scala
@@ -1,0 +1,25 @@
+@addClass def foo(): Unit =
+  println("macro generated main")
+  println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+//> class Baz$macro$1 extends Object {
+//>   def run() =
+//>     println("macro generated main")
+//>     println("executed in: " + getClass.getName)
+//> }
+//> def foo(): Unit =
+//>   new Baz$macro$1.run
+
+@addClass def bar(): Unit =
+  println("macro generated main")
+  println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+//> class Baz$macro$2 extends Object {
+//>   def run() =
+//>     println("macro generated main")
+//>     println("executed in: " + getClass.getName)
+//> }
+//> def foo(): Unit =
+//>   new Baz$macro$2.run
+
+@main def Test(): Unit =
+  foo()
+  bar()

--- a/tests/run-macros/annot-add-global-object.check
+++ b/tests/run-macros/annot-add-global-object.check
@@ -1,0 +1,4 @@
+macro generated main
+executed in: Test_2$package$Bar$macro$1$
+macro generated main
+executed in: Test_2$package$Bar$macro$2$

--- a/tests/run-macros/annot-add-global-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-global-object/Macro_1.scala
@@ -12,7 +12,7 @@ class addClass extends MacroAnnotation:
         def decls(cls: Symbol): List[Symbol] =
           List(Symbol.newMethod(cls, "run", MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]), Flags.EmptyFlags, Symbol.noSymbol))
 
-        val mod = Symbol.newModule(Symbol.spliceOwner, "Baz", Flags.EmptyFlags, Flags.EmptyFlags, parents.map(_.tpe), decls, Symbol.noSymbol)
+        val mod = Symbol.newModule(Symbol.spliceOwner, Symbol.freshName("Bar"), Flags.EmptyFlags, Flags.EmptyFlags, parents.map(_.tpe), decls, Symbol.noSymbol)
         val cls = mod.moduleClass
 
         val runSym = cls.declaredMethod("run").head

--- a/tests/run-macros/annot-add-global-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-global-object/Macro_1.scala
@@ -19,13 +19,10 @@ class addClass extends MacroAnnotation:
 
         val runDef = DefDef(runSym, _ => Some(rhs))
 
-        val clsDef = ClassDef(cls, parents, body = List(runDef))
-
-        val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
-        val modVal = ValDef(mod, Some(newCls))
+        val modDef = ClassDef.module(mod, parents, body = List(runDef))
 
         val newDef = DefDef.copy(tree)(name, List(TermParamClause(Nil)), tpt, Some(Apply(Select(Ref(mod), runSym), Nil)))
-        List(modVal, clsDef, newDef)
+        modDef.toList ::: newDef :: Nil
       case _ =>
         report.error("Annotation only supports `def` with one argument")
         List(tree)

--- a/tests/run-macros/annot-add-global-object/Test_2.scala
+++ b/tests/run-macros/annot-add-global-object/Test_2.scala
@@ -1,0 +1,28 @@
+@addClass def foo(): Unit =
+  println("macro generated main")
+  println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+//> object Baz$macro$1 {
+//>   def run() =
+//>     println("macro generated main")
+//>     println("executed in: " + getClass.getName)
+//> }
+//> def foo(): Unit =
+//>   Baz$macro$1.run
+
+@addClass def bar(): Unit =
+  println("macro generated main")
+  println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+//> object Baz$macro$2 {
+//>   def run() =
+//>     println("macro generated main")
+//>     println("executed in: " + getClass.getName)
+//> }
+//> def foo(): Unit =
+//>   Baz$macro$2.run
+
+object Bar:
+  def run() = ()
+
+@main def Test(): Unit =
+  foo()
+  bar()

--- a/tests/run-macros/annot-add-local-class.check
+++ b/tests/run-macros/annot-add-local-class.check
@@ -1,0 +1,4 @@
+macro generated main
+executed in: Test_2$package$Baz$1
+macro generated main
+executed in: Test_2$package$Baz$2

--- a/tests/run-macros/annot-add-local-class/Macro_1.scala
+++ b/tests/run-macros/annot-add-local-class/Macro_1.scala
@@ -1,0 +1,27 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted._
+import scala.collection.mutable
+
+@experimental
+class addClass extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+    import quotes.reflect._
+    tree match
+      case DefDef(name, List(TermParamClause(Nil)), tpt, Some(rhs)) =>
+        val parents = List(TypeTree.of[Object])
+        def decls(cls: Symbol): List[Symbol] =
+          List(Symbol.newMethod(cls, "run", MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]), Flags.EmptyFlags, Symbol.noSymbol))
+
+        val cls = Symbol.newClass(Symbol.spliceOwner, "Baz", parents = parents.map(_.tpe), decls, selfType = None)
+        val runSym = cls.declaredMethod("run").head
+
+        val runDef = DefDef(runSym, _ => Some(rhs))
+        val clsDef = ClassDef(cls, parents, body = List(runDef))
+
+        val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
+
+        val newDef = DefDef.copy(tree)(name, List(TermParamClause(Nil)), tpt, Some(Apply(Select(newCls, runSym), Nil)))
+        List(clsDef, newDef)
+      case _ =>
+        report.error("Annotation only supports `def` with one argument")
+        List(tree)

--- a/tests/run-macros/annot-add-local-class/Test_2.scala
+++ b/tests/run-macros/annot-add-local-class/Test_2.scala
@@ -1,0 +1,25 @@
+@main def Test(): Unit =
+  @addClass def foo(): Unit =
+    println("macro generated main")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+  //> class Baz extends Object {
+  //>   def run() =
+  //>     println("macro generated main")
+  //>     println("executed in: " + getClass.getName)
+  //> }
+  //> def foo(): Unit =
+  //>   new Baz().run
+
+  @addClass def bar(): Unit =
+    println("macro generated main")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+  //> class Baz extends Object {
+  //>   def run() =
+  //>     println("macro generated main")
+  //>     println("executed in: " + getClass.getName)
+  //> }
+  //> def Baz(): Unit =
+  //>   new Baz().run
+
+  foo()
+  bar()

--- a/tests/run-macros/annot-add-local-object.check
+++ b/tests/run-macros/annot-add-local-object.check
@@ -1,0 +1,4 @@
+macro generated main
+executed in: Test_2$package$Baz$2
+macro generated main
+executed in: Test_2$package$Baz$4

--- a/tests/run-macros/annot-add-local-object.check
+++ b/tests/run-macros/annot-add-local-object.check
@@ -1,4 +1,4 @@
 macro generated main
-executed in: Test_2$package$Baz$2
+executed in: Test_2$package$Baz$2$
 macro generated main
-executed in: Test_2$package$Baz$4
+executed in: Test_2$package$Baz$4$

--- a/tests/run-macros/annot-add-local-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-local-object/Macro_1.scala
@@ -19,10 +19,7 @@ class addClass extends MacroAnnotation:
 
         val runDef = DefDef(runSym, _ => Some(rhs))
 
-        val clsDef = ClassDef(cls, parents, body = List(runDef))
-
-        val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
-        val modVal = ValDef(mod, Some(newCls))
+        val (modVal, clsDef) = ClassDef.module(mod, parents, body = List(runDef))
 
         val newDef = DefDef.copy(tree)(name, List(TermParamClause(Nil)), tpt, Some(Apply(Select(Ref(mod), runSym), Nil)))
         List(modVal, clsDef, newDef)

--- a/tests/run-macros/annot-add-local-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-local-object/Macro_1.scala
@@ -1,0 +1,32 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted._
+import scala.collection.mutable
+
+@experimental
+class addClass extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+    import quotes.reflect._
+    tree match
+      case DefDef(name, List(TermParamClause(Nil)), tpt, Some(rhs)) =>
+        val parents = List(TypeTree.of[Object])
+        def decls(cls: Symbol): List[Symbol] =
+          List(Symbol.newMethod(cls, "run", MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]), Flags.Static, Symbol.noSymbol))
+
+        // FIXME: missing flags: Final | Module
+        // FIXME: how to set the self type?
+        val cls = Symbol.newClass(Symbol.spliceOwner, "Baz", parents = parents.map(_.tpe), decls, selfType = None)
+        val mod = Symbol.newVal(Symbol.spliceOwner, "Baz", cls.typeRef, Flags.Module | Flags.Lazy | Flags.Final, Symbol.noSymbol)
+        val runSym = cls.declaredMethod("run").head
+
+        val runDef = DefDef(runSym, _ => Some(rhs))
+
+        val clsDef = ClassDef(cls, parents, body = List(runDef))
+
+        val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
+        val modVal = ValDef(mod, Some(newCls))
+
+        val newDef = DefDef.copy(tree)(name, List(TermParamClause(Nil)), tpt, Some(Apply(Select(Ref(mod), runSym), Nil)))
+        List(modVal, clsDef, newDef)
+      case _ =>
+        report.error("Annotation only supports `def` with one argument")
+        List(tree)

--- a/tests/run-macros/annot-add-local-object/Test_2.scala
+++ b/tests/run-macros/annot-add-local-object/Test_2.scala
@@ -1,0 +1,25 @@
+@main def Test(): Unit =
+  @addClass def foo(): Unit =
+    println("macro generated main")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+  //> object Baz {
+  //>   def run() =
+  //>     println("macro generated main")
+  //>     println("executed in: " + getClass.getName)
+  //> }
+  //> def foo(): Unit =
+  //>   Baz.run
+
+  @addClass def bar(): Unit =
+    println("macro generated main")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+  //> object Baz {
+  //>   def run() =
+  //>     println("macro generated main")
+  //>     println("executed in: " + getClass.getName)
+  //> }
+  //> def Baz(): Unit =
+  //>   Baz.run
+
+  foo()
+  bar()

--- a/tests/run-macros/annot-add-nested-class.check
+++ b/tests/run-macros/annot-add-nested-class.check
@@ -1,0 +1,4 @@
+macro generated main
+executed in: Foo$Bar$macro$1
+macro generated main
+executed in: Foo$Bar$macro$2

--- a/tests/run-macros/annot-add-nested-class/Macro_1.scala
+++ b/tests/run-macros/annot-add-nested-class/Macro_1.scala
@@ -1,0 +1,28 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted._
+import scala.collection.mutable
+
+@experimental
+class addClass extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+    import quotes.reflect._
+    tree match
+      case DefDef(name, List(TermParamClause(Nil)), tpt, Some(rhs)) =>
+        val parents = List(TypeTree.of[Object])
+        def decls(cls: Symbol): List[Symbol] =
+          List(Symbol.newMethod(cls, "run", MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]), Flags.EmptyFlags, Symbol.noSymbol))
+
+        val newClassName = Symbol.freshName("Bar")
+        val cls = Symbol.newClass(Symbol.spliceOwner, newClassName, parents = parents.map(_.tpe), decls, selfType = None)
+        val runSym = cls.declaredMethod("run").head
+
+        val runDef = DefDef(runSym, _ => Some(rhs))
+        val clsDef = ClassDef(cls, parents, body = List(runDef))
+
+        val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
+
+        val newDef = DefDef.copy(tree)(name, List(TermParamClause(Nil)), tpt, Some(Apply(Select(newCls, runSym), Nil)))
+        List(clsDef, newDef)
+      case _ =>
+        report.error("Annotation only supports `def` with one argument")
+        List(tree)

--- a/tests/run-macros/annot-add-nested-class/Test_2.scala
+++ b/tests/run-macros/annot-add-nested-class/Test_2.scala
@@ -1,0 +1,26 @@
+class Foo():
+  @addClass def foo(): Unit =
+    println("macro generated main")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+  //> class Baz$macro$1 extends Object {
+  //>   def run() =
+  //>     println("macro generated main")
+  //>     println("executed in: " + getClass.getName)
+  //> }
+  //> def foo(): Unit =
+  //>   new Baz$macro$1.run
+
+  @addClass def bar(): Unit =
+    println("macro generated main")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+  //> class Baz$macro$2 extends Object {
+  //>   def run() =
+  //>     println("macro generated main")
+  //>     println("executed in: " + getClass.getName)
+  //> }
+  //> def foo(): Unit =
+  //>   new Baz$macro$2.run
+
+@main def Test(): Unit =
+  new Foo().foo()
+  new Foo().bar()

--- a/tests/run-macros/annot-add-nested-object.check
+++ b/tests/run-macros/annot-add-nested-object.check
@@ -1,0 +1,4 @@
+macro generated main
+executed in: Foo$Bar$macro$1$
+macro generated main
+executed in: Foo$Bar$macro$2$

--- a/tests/run-macros/annot-add-nested-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-nested-object/Macro_1.scala
@@ -12,7 +12,7 @@ class addClass extends MacroAnnotation:
         def decls(cls: Symbol): List[Symbol] =
           List(Symbol.newMethod(cls, "run", MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]), Flags.EmptyFlags, Symbol.noSymbol))
 
-        val mod = Symbol.newModule(Symbol.spliceOwner, "Baz", Flags.EmptyFlags, Flags.EmptyFlags, parents.map(_.tpe), decls, Symbol.noSymbol)
+        val mod = Symbol.newModule(Symbol.spliceOwner, Symbol.freshName("Bar"), Flags.EmptyFlags, Flags.EmptyFlags, parents.map(_.tpe), decls, Symbol.noSymbol)
         val cls = mod.moduleClass
 
         val runSym = cls.declaredMethod("run").head

--- a/tests/run-macros/annot-add-nested-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-nested-object/Macro_1.scala
@@ -19,10 +19,7 @@ class addClass extends MacroAnnotation:
 
         val runDef = DefDef(runSym, _ => Some(rhs))
 
-        val clsDef = ClassDef(cls, parents, body = List(runDef))
-
-        val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
-        val modVal = ValDef(mod, Some(newCls))
+        val (modVal, clsDef) = ClassDef.module(mod, parents, body = List(runDef))
 
         val newDef = DefDef.copy(tree)(name, List(TermParamClause(Nil)), tpt, Some(Apply(Select(Ref(mod), runSym), Nil)))
         List(modVal, clsDef, newDef)

--- a/tests/run-macros/annot-add-nested-object/Test_2.scala
+++ b/tests/run-macros/annot-add-nested-object/Test_2.scala
@@ -1,0 +1,26 @@
+class Foo():
+  @addClass def foo(): Unit =
+    println("macro generated main")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+  //> object Baz$macro$1 {
+  //>   def run() =
+  //>     println("macro generated main")
+  //>     println("executed in: " + getClass.getName)
+  //> }
+  //> def foo(): Unit =
+  //>   Baz$macro$1.run
+
+  @addClass def bar(): Unit =
+    println("macro generated main")
+    println("executed in: " + (new Throwable().getStackTrace().head.getClassName))
+  //> object Baz$macro$2 {
+  //>   def run() =
+  //>     println("macro generated main")
+  //>     println("executed in: " + getClass.getName)
+  //> }
+  //> def foo(): Unit =
+  //>   Baz$macro$2.run
+
+@main def Test(): Unit =
+  new Foo().foo()
+  new Foo().bar()

--- a/tests/run-macros/annot-macro-main.check
+++ b/tests/run-macros/annot-macro-main.check
@@ -1,0 +1,1 @@
+macro generated main

--- a/tests/run-macros/annot-macro-main/Macro_1.scala
+++ b/tests/run-macros/annot-macro-main/Macro_1.scala
@@ -1,0 +1,24 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted._
+import scala.collection.mutable
+
+@experimental
+class mainMacro extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+    import quotes.reflect._
+    tree match
+      case DefDef(name, List(TermParamClause(Nil)), _, _) =>
+        val parents = List(TypeTree.of[Object])
+        def decls(cls: Symbol): List[Symbol] =
+          List(Symbol.newMethod(cls, "main", MethodType(List("args"))(_ => List(TypeRepr.of[Array[String]]), _ => TypeRepr.of[Unit]), Flags.Static, Symbol.noSymbol))
+
+        val cls = Symbol.newClass(Symbol.spliceOwner.owner, name, parents = parents.map(_.tpe), decls, selfType = None)
+        val mainSym = cls.declaredMethod("main").head
+
+        val mainDef = DefDef(mainSym, _ => Some(Apply(Ref(tree.symbol), Nil)))
+        val clsDef = ClassDef(cls, parents, body = List(mainDef))
+
+        List(clsDef, tree)
+      case _ =>
+        report.error("Annotation only supports `def` without arguments")
+        List(tree)

--- a/tests/run-macros/annot-macro-main/Test_2.scala
+++ b/tests/run-macros/annot-macro-main/Test_2.scala
@@ -1,0 +1,1 @@
+@mainMacro def Test(): Unit = println("macro generated main")


### PR DESCRIPTION
Enable the addition of classes from a `MacroAnnotation`:
 * Can add new `class`/`object` definitions next to the annotated definition

Special cases:
 * An annotated top-level `def`, `val`, `var`, `lazy val` can return a `class`/`object`
   definition that is owned by the package or package object.

Related PRs:
 * Follows https://github.com/lampepfl/dotty/pull/16454