### PR TITLE
Fix dependent function setup for capture checking

### DIFF
--- a/tests/neg-custom-args/captures/i15925.scala
+++ b/tests/neg-custom-args/captures/i15925.scala
@@ -1,0 +1,13 @@
+import language.experimental.captureChecking
+
+class Unit
+object unit extends Unit
+
+type Foo[X] = [T] -> (op: X => T) -> T
+type Lazy[X] = Unit => X
+
+def force[X](fx: Foo[Lazy[X]]): X =
+  fx[X](f => f(unit))  // error
+
+def force2[X](fx: Foo[Unit => X]): X =
+  fx[X](f => f(unit))  // error


### PR DESCRIPTION
Fixes #15925.

This issue is caused by a bug in `mapInferred` during CC `Setup`. In this function we convert all top-level non-dependent functions to its dependent counterpart. However, it does not correctly handle the case when the type is an alias to function types. The problematic case in the pattern matching:
```scala
case tp @ AppliedType(tycon, args) =>
  val tycon1 = this(tycon)
  if defn.isNonRefinedFunction(tp) then
    // Convert toplevel generic function types to dependent functions
    val args0 = args.init
    var res0 = args.last
    val args1 = mapNested(args0)
    val res1 = this(res0)
    // ... do the conversion
```
It retrieves the argument and the result type of the function directly from the applied type arguments. This works for function classes. However, if the type here is a type alias to the function, e.g. `type Lazy[X] = Unit => X`, it is still recognized as a function (since `defn.isNonRefinedFunction` does dealiasing) but it is incorrect to get the argument and result type of the function from the type parameter list here (which is just `X :: Nil`).

To fix this, we will dealias the type and recurse when it is an alias to the function type.