### PR TITLE
Experiment: Track contexts and use an arena for their allocations

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -150,7 +150,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class CapturingTypeTree(refs: List[Tree], parent: Tree)(implicit @constructorOnly src: SourceFile) extends TypTree
 
   /** Short-lived usage in typer, does not need copy/transform/fold infrastructure */
-  case class DependentTypeTree(tp: List[Symbol] => Type)(implicit @constructorOnly src: SourceFile) extends Tree
+  case class DependentTypeTree(tp: List[Symbol] => Context ?=> Type)(implicit @constructorOnly src: SourceFile) extends Tree
 
   @sharable object EmptyTypeIdent extends Ident(tpnme.EMPTY)(NoSource) with WithoutTypeOrPos[Untyped] {
     override def isEmpty: Boolean = true

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -175,7 +175,7 @@ sealed abstract class CaptureSet extends Showable:
       case Nil =>
         addDependent(that)
     recur(elems.toList)
-      .showing(i"subcaptures $this <:< $that = ${result.show}", capt)
+      .showing(i"subcaptures $this <:< $that = $result", capt)
 
   /** Two capture sets are considered =:= equal if they mutually subcapture each other
    *  in a frozen state.

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -738,20 +738,21 @@ class CheckCaptures extends Recheck, SymTransformer:
        *  the innermost capturing type. The outer capture annotations can be
        *  reconstructed with the returned function.
        */
-      def destructCapturingType(tp: Type, reconstruct: Type => Type = x => x): ((Type, CaptureSet, Boolean), Type => Type) =
+      def destructCapturingType(tp: Type, reconstruct: Type => Context ?=> Type = (x: Type) => x)
+          : (Type, CaptureSet, Boolean, Type => Context ?=> Type) =
         tp.dealias match
           case tp @ CapturingType(parent, cs) =>
             if parent.dealias.isCapturingType then
               destructCapturingType(parent, res => reconstruct(tp.derivedCapturingType(res, cs)))
             else
-              ((parent, cs, tp.isBoxed), reconstruct)
+              (parent, cs, tp.isBoxed, reconstruct)
           case actual =>
-            ((actual, CaptureSet(), false), reconstruct)
+            (actual, CaptureSet(), false, reconstruct)
 
       def adapt(actual: Type, expected: Type, covariant: Boolean): Type = trace(adaptInfo(actual, expected, covariant), recheckr, show = true) {
         if expected.isInstanceOf[WildcardType] then actual
         else
-          val ((parent, cs, actualIsBoxed), recon) = destructCapturingType(actual)
+          val (parent, cs, actualIsBoxed, recon: (Type => Context ?=> Type)) = destructCapturingType(actual)
 
           val needsAdaptation = actualIsBoxed != expected.isBoxedCapturing
           val insertBox = needsAdaptation && covariant != actualIsBoxed

--- a/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
+++ b/compiler/src/dotty/tools/dotc/core/CheckRealizable.scala
@@ -15,7 +15,7 @@ object CheckRealizable {
   sealed abstract class Realizability(val msg: String) {
     def andAlso(other: => Realizability): Realizability =
       if (this == Realizable) other else this
-    def mapError(f: Realizability => Realizability): Realizability =
+    def mapError(f: Realizability => Context ?=> Realizability)(using Context): Realizability =
       if (this == Realizable) this else f(this)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -484,7 +484,7 @@ trait ConstraintHandling {
    */
   private def fixLevels(tp: Type, fromBelow: Boolean, maxLevel: Int, param: TypeParamRef)(using Context) =
 
-    def needsFix(tp: NamedType) =
+    def needsFix(tp: NamedType)(using Context) =
       (tp.prefix eq NoPrefix) && tp.symbol.nestingLevel > maxLevel
 
     /** An accumulator that determines whether levels need to be fixed

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -103,6 +103,8 @@ object Contexts {
   inline def withoutMode[T](mode: Mode)(inline op: Context ?=> T)(using ctx: Context): T =
     inMode(ctx.mode &~ mode)(op)
 
+  type Context = ContextCls
+
   /** A context is passed basically everywhere in dotc.
    *  This is convenient but carries the risk of captured contexts in
    *  objects that turn into space leaks. To combat this risk, here are some
@@ -122,7 +124,7 @@ object Contexts {
    *      of all class fields of type context; allow them only in whitelisted
    *      classes (which should be short-lived).
    */
-  abstract class Context(val base: ContextBase) { thiscontext =>
+  abstract class ContextCls(val base: ContextBase) { thiscontext =>
 
     protected given Context = this
 
@@ -516,7 +518,7 @@ object Contexts {
   /** A fresh context allows selective modification
    *  of its attributes using the with... methods.
    */
-  class FreshContext(base: ContextBase) extends Context(base) {
+  class FreshContext(base: ContextBase) extends ContextCls(base) {
 
     private var _outer: Context = uninitialized
     def outer: Context = _outer

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -79,12 +79,12 @@ object SymbolLoaders {
       // require yjp.jar at runtime. See SI-2089.
       if (ctx.settings.YtermConflict.value == "package" || ctx.mode.is(Mode.Interactive)) {
         report.warning(
-          s"Resolving package/object name conflict in favor of package ${preExisting.fullName}. The object will be inaccessible.")
+          em"Resolving package/object name conflict in favor of package ${preExisting.fullName}. The object will be inaccessible.")
         owner.asClass.delete(preExisting)
       }
       else if (ctx.settings.YtermConflict.value == "object") {
         report.warning(
-          s"Resolving package/object name conflict in favor of object ${preExisting.fullName}.  The package will be inaccessible.")
+          em"Resolving package/object name conflict in favor of object ${preExisting.fullName}.  The package will be inaccessible.")
         return NoSymbol
       }
       else
@@ -133,7 +133,7 @@ object SymbolLoaders {
         def checkPathMatches(path: List[TermName], what: String, tree: NameTree): Boolean = {
           val ok = filePath == path
           if (!ok)
-            report.warning(i"""$what ${tree.name} is in the wrong directory.
+            report.warning(em"""$what ${tree.name} is in the wrong directory.
                            |It was declared to be in package ${path.reverse.mkString(".")}
                            |But it is found in directory     ${filePath.reverse.mkString(File.separator.nn)}""",
               tree.srcPos.focus)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2403,8 +2403,9 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         NoType
     }
 
-  private def andTypeGen(tp1: Type, tp2: Type, op: (Type, Type) => Type,
-      original: (Type, Type) => Type = _ & _, isErased: Boolean = ctx.erasedTypes): Type = trace(s"andTypeGen(${tp1.show}, ${tp2.show})", subtyping, show = true) {
+  private def andTypeGen(tp1: Type, tp2: Type,
+      op: (Type, Type) => Context ?=> Type,
+      original: (Type, Type) => Context ?=> Type = _ & _, isErased: Boolean = ctx.erasedTypes): Type = trace(s"andTypeGen(${tp1.show}, ${tp2.show})", subtyping, show = true) {
     val t1 = distributeAnd(tp1, tp2)
     if (t1.exists) t1
     else {
@@ -2465,7 +2466,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    *    [X1, ..., Xn] -> op(tp1[X1, ..., Xn], tp2[X1, ..., Xn])
    */
   def liftIfHK(tp1: Type, tp2: Type,
-      op: (Type, Type) => Type, original: (Type, Type) => Type, combineVariance: (Variance, Variance) => Variance) = {
+      op: (Type, Type) => Context ?=> Type, original: (Type, Type) => Context ?=> Type, combineVariance: (Variance, Variance) => Context ?=> Variance) = {
     val tparams1 = tp1.typeParams
     val tparams2 = tp2.typeParams
     def applied(tp: Type) = tp.appliedTo(tp.typeParams.map(_.paramInfoAsSeenFrom(tp)))
@@ -2980,8 +2981,8 @@ object TypeComparer {
     comparing(_.provablyDisjoint(tp1, tp2))
 
   def liftIfHK(tp1: Type, tp2: Type,
-      op: (Type, Type) => Type, original: (Type, Type) => Type,
-      combineVariance: (Variance, Variance) => Variance)(using Context): Type =
+      op: (Type, Type) => Context ?=> Type, original: (Type, Type) => Context ?=> Type,
+      combineVariance: (Variance, Variance) => Context ?=> Variance)(using Context): Type =
     comparing(_.liftIfHK(tp1, tp2, op, original, combineVariance))
 
   def constValue(tp: Type)(using Context): Option[Constant] =

--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -102,7 +102,7 @@ object handleRecursive:
     while e != null && !e.isInstanceOf[StackOverflowError] do e = e.getCause
     e
 
-  def apply(op: String, details: => String, exc: Throwable, weight: Int = 1)(using Context): Nothing =
+  def apply(op: String, details: Context ?=> String, exc: Throwable, weight: Int = 1)(using Context): Nothing =
     if ctx.settings.YnoDecodeStacktraces.value then
       throw exc
     else exc match

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -532,7 +532,7 @@ object TypeOps:
    *  does not update `ctx.nestingLevel` when entering a block so I'm leaving
    *  this as Future Work™.
    */
-  def avoid(tp: Type, symsToAvoid: => List[Symbol])(using Context): Type = {
+  def avoid(tp: Type, symsToAvoid: Context ?=> List[Symbol])(using Context): Type = {
     val widenMap = new AvoidMap {
       @threadUnsafe lazy val forbidden = symsToAvoid.toSet
       def toAvoid(tp: NamedType) =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -30,7 +30,7 @@ import Hashable._
 import Uniques._
 import collection.mutable
 import config.Config
-import annotation.{tailrec, constructorOnly}
+import annotation.{tailrec, constructorOnly, threadUnsafe}
 import scala.util.hashing.{ MurmurHash3 => hashing }
 import config.Printers.{core, typr, matchTypes}
 import reporting.{trace, Message}
@@ -40,7 +40,6 @@ import cc.{CapturingType, CaptureSet, derivedCapturingType, isBoxedCapturing, Ev
 import CaptureSet.{CompareResult, IdempotentCaptRefMap, IdentityCaptRefMap}
 
 import scala.annotation.internal.sharable
-import scala.annotation.threadUnsafe
 
 import dotty.tools.dotc.transform.SymUtils._
 
@@ -3160,7 +3159,7 @@ object Types {
    *
    *  Where `RecThis(...)` points back to the enclosing `RecType`.
    */
-  class RecType(parentExp: RecType => Type) extends RefinedOrRecType with BindingType {
+  class RecType(@constructorOnly parentExp: RecType => Type) extends RefinedOrRecType with BindingType {
 
     // See discussion in findMember#goRec why these vars are needed
     private[Types] var opened: Boolean = false
@@ -3885,8 +3884,8 @@ object Types {
   }
 
   abstract case class MethodType(paramNames: List[TermName])(
-      paramInfosExp: MethodType => List[Type],
-      resultTypeExp: MethodType => Type)
+      @constructorOnly paramInfosExp: MethodType => List[Type],
+      @constructorOnly resultTypeExp: MethodType => Type)
     extends MethodOrPoly with TermLambda with NarrowCached { thisMethodType =>
 
     type This = MethodType
@@ -3912,7 +3911,10 @@ object Types {
     protected def prefixString: String = companion.prefixString
   }
 
-  final class CachedMethodType(paramNames: List[TermName])(paramInfosExp: MethodType => List[Type], resultTypeExp: MethodType => Type, val companion: MethodTypeCompanion)
+  final class CachedMethodType(paramNames: List[TermName])(
+      @constructorOnly paramInfosExp: MethodType => List[Type],
+      @constructorOnly resultTypeExp: MethodType => Type,
+      val companion: MethodTypeCompanion)
     extends MethodType(paramNames)(paramInfosExp, resultTypeExp)
 
   abstract class LambdaTypeCompanion[N <: Name, PInfo <: Type, LT <: LambdaType] {
@@ -4081,7 +4083,8 @@ object Types {
    *  Variances are stored in the `typeParams` list of the lambda.
    */
   class HKTypeLambda(val paramNames: List[TypeName], @constructorOnly variances: List[Variance])(
-      paramInfosExp: HKTypeLambda => List[TypeBounds], resultTypeExp: HKTypeLambda => Type)
+      @constructorOnly paramInfosExp: HKTypeLambda => List[TypeBounds],
+      @constructorOnly resultTypeExp: HKTypeLambda => Type)
   extends HKLambda with TypeLambda {
     type This = HKTypeLambda
     def companion: HKTypeLambda.type = HKTypeLambda
@@ -4149,7 +4152,8 @@ object Types {
    *  except it applies to terms and parameters do not have variances.
    */
   class PolyType(val paramNames: List[TypeName])(
-      paramInfosExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => Type)
+      @constructorOnly paramInfosExp: PolyType => List[TypeBounds],
+      @constructorOnly resultTypeExp: PolyType => Type)
   extends MethodOrPoly with TypeLambda {
 
     type This = PolyType
@@ -5569,7 +5573,7 @@ object Types {
       case result: CaptureRef if result.canBeTracked => result
   end BiTypeMap
 
-  abstract class TypeMap(implicit protected var mapCtx: Context)
+  abstract class TypeMap(using protected val mapCtx: Context)
   extends VariantTraversal with (Type => Type) { thisMap =>
 
     def apply(tp: Type): Type
@@ -5702,16 +5706,16 @@ object Types {
           derivedSuperType(tp, this(thistp), this(supertp))
 
         case tp: LazyRef =>
+          val mapCtx1 = mapCtx.asInstanceOf[FreshContext]
           LazyRef { refCtx =>
-            given Context = refCtx
-            val ref1 = tp.ref
-            if refCtx.runId == mapCtx.runId then this(ref1)
+            val ref1 = tp.ref(using refCtx)
+            if refCtx.runId == mapCtx1.runId then this(ref1)
             else // splice in new run into map context
-              val saved = mapCtx
-              mapCtx = mapCtx.fresh
-                .setPeriod(Period(refCtx.runId, mapCtx.phaseId))
-                .setRun(refCtx.run)
-              try this(ref1) finally mapCtx = saved
+              val savedPeriod = mapCtx1.period
+              val savedRun = mapCtx1.run
+              mapCtx1.setPeriod(Period(refCtx.runId, mapCtx1.phaseId)).setRun(refCtx.run)
+              try this(ref1)
+              finally mapCtx1.setPeriod(savedPeriod).setRun(savedRun)
           }
 
         case tp: ClassInfo =>
@@ -5778,7 +5782,7 @@ object Types {
     }
   }
 
-  @sharable object IdentityTypeMap extends TypeMap()(NoContext) {
+  @sharable object IdentityTypeMap extends TypeMap(using NoContext) {
     def apply(tp: Type): Type = tp
   }
 

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -168,7 +168,7 @@ object Scanners {
         errorButContinue(em"trailing separator is not allowed", offset + litBuf.length - 1)
   }
 
-  class Scanner(source: SourceFile, override val startFrom: Offset = 0, profile: Profile = NoProfile, allowIndent: Boolean = true)(using Context) extends ScannerCommon(source) {
+  class Scanner(source: SourceFile, override val startFrom: Offset = 0, profile: Profile = NoProfile, allowIndent: Boolean = true)(using ictx: Context) extends ScannerCommon(source) {
     val keepComments = !ctx.settings.YdropComments.value
 
     /** A switch whether operators at the start of lines can be infix operators */
@@ -201,7 +201,7 @@ object Scanners {
         error(em"illegal combination of -rewrite targets: ${enabled(0).name} and ${enabled(1).name}")
     }
 
-    private var myLanguageImportContext: Context = ctx
+    private var myLanguageImportContext: Context = ictx
     def languageImportContext = myLanguageImportContext
     final def languageImportContext_=(c: Context) = myLanguageImportContext = c
 

--- a/compiler/src/dotty/tools/dotc/printing/Highlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Highlighting.scala
@@ -7,7 +7,7 @@ import core.Contexts._
 
 object Highlighting {
 
-  abstract class Highlight(private val highlight: String) {
+  sealed abstract class Highlight(private val highlight: String) {
     def text: String
 
     def show(using Context): String = if ctx.useColors then highlight + text + Console.RESET else text

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -103,18 +103,18 @@ object report:
     if (ctx.settings.Ylog.value.containsPhase(ctx.phase))
       echo(s"[log ${ctx.phase}] $msg", pos)
 
-  def debuglog(msg: => String)(using Context): Unit =
+  def debuglog(msg: Context ?=> String)(using Context): Unit =
     if (ctx.debug) log(msg)
 
-  def informTime(msg: => String, start: Long)(using Context): Unit = {
+  def informTime(msg: Context ?=> String, start: Long)(using Context): Unit = {
     def elapsed = s" in ${currentTimeMillis - start}ms"
     informProgress(msg + elapsed)
   }
 
-  def informProgress(msg: => String)(using Context): Unit =
+  def informProgress(msg: Context ?=> String)(using Context): Unit =
     inform("[" + msg + "]")
 
-  def logWith[T](msg: => String)(value: T)(using Context): T = {
+  def logWith[T](msg: Context ?=> String)(value: T)(using Context): T = {
     log(msg + " " + value)
     value
   }

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -51,7 +51,7 @@ object Message:
    */
   private class Seen(disambiguate: Boolean):
 
-    val seen = new collection.mutable.HashMap[SeenKey, List[Recorded]]:
+    private val seen = new collection.mutable.HashMap[SeenKey, List[Recorded]]:
       override def default(key: SeenKey) = Nil
 
     var nonSensical = false

--- a/compiler/src/dotty/tools/dotc/reporting/WConf.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/WConf.scala
@@ -10,6 +10,7 @@ import dotty.tools.dotc.util.SourcePosition
 import java.util.regex.PatternSyntaxException
 import scala.annotation.internal.sharable
 import scala.util.matching.Regex
+import core.Decorators.em
 
 enum MessageFilter:
   def matches(message: Diagnostic): Boolean = this match
@@ -100,7 +101,7 @@ object WConf:
               |Note: for multiple filters, use `-Wconf:filter1:action1,filter2:action2`
               |      or alternatively          `-Wconf:filter1:action1 -Wconf:filter2:action2`""".stripMargin
           else ""
-        report.warning(s"Failed to parse `-Wconf` configuration: ${ctx.settings.Wconf.value.mkString(",")}\n${msgs.mkString("\n")}$multiHelp"))
+        report.warning(em"Failed to parse `-Wconf` configuration: ${ctx.settings.Wconf.value.mkString(",")}\n${msgs.mkString("\n")}$multiHelp"))
     cached._2
 
   def fromSettings(settings: List[String]): Either[List[String], WConf] =

--- a/compiler/src/dotty/tools/dotc/reporting/trace.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/trace.scala
@@ -90,8 +90,10 @@ trait TraceSyntax:
       val leading = s"==> $q?"
       val trailing = (res: T) => s"<== $q = ${showOp(res)}"
       var finalized = false
-      var logctx = ctx
-      while logctx.reporter.isInstanceOf[StoreReporter] do logctx = logctx.outer
+      def skipStoreReporter(c: Context): Context = c.reporter match
+        case _: StoreReporter => skipStoreReporter(c.outer)
+        case _ => c
+      val logctx = skipStoreReporter(ctx)
       def margin = ctx.base.indentTab * ctx.base.indent
       def doLog(s: String) = if isForced then println(s) else report.log(s)(using logctx)
       def finalize(msg: String) =

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -162,7 +162,7 @@ object ExtractDependencies {
     sym.fullName.stripModuleClassSuffix.toString
 
   /** Report an internal error in incremental compilation. */
-  def internalError(msg: => String, pos: SrcPos = NoSourcePosition)(using Context): Unit =
+  def internalError(msg: Context ?=> String, pos: SrcPos = NoSourcePosition)(using Context): Unit =
     report.error(em"Internal error in the incremental compiler while compiling ${ctx.compilationUnit.source}: $msg", pos)
 }
 
@@ -434,7 +434,7 @@ private class ExtractDependenciesCollector extends tpd.TreeTraverser { thisTreeT
     // Avoid cycles by remembering both the types (testcase:
     // tests/run/enum-values.scala) and the symbols of named types (testcase:
     // tests/pos-java-interop/i13575) we've seen before.
-    val seen = new mutable.HashSet[Symbol | Type]
+    private val seen = new mutable.HashSet[Symbol | Type]
     def traverse(tp: Type): Unit = if (!seen.contains(tp)) {
       seen += tp
       tp match {

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -9,6 +9,7 @@ import core.Annotations.Annotation
 import core.Flags
 import core.Names.Name
 import core.StdNames.tpnme
+import core.Decorators.em
 import scala.util.chaining.scalaUtilChainingOps
 
 import collection.mutable
@@ -59,7 +60,7 @@ class TypeOps:
 
   private def warn(msg: String)(using ctx: Context): Unit =
     report.warning(
-      s"Internal error in extracting SemanticDB while compiling ${ctx.compilationUnit.source}: ${msg}"
+      em"Internal error in extracting SemanticDB while compiling ${ctx.compilationUnit.source}: ${msg}"
     )
 
   private def registerFakeSymbol(sym: FakeSymbol)(using Context, SemanticSymbolBuilder): Unit =

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -262,7 +262,7 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
           if hasAnnotation then "@varargs"
           else if isBridge then "overriding a java varargs method"
           else "@varargs (on overridden method)"
-        report.error(s"$src produces a forwarder method that conflicts with ${conflict.showDcl}", original.srcPos)
+        report.error(em"$src produces a forwarder method that conflicts with ${conflict.showDcl}", original.srcPos)
       case Nil =>
         forwarder.enteredAfter(thisPhase)
   end addVarArgsForwarder

--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -197,7 +197,7 @@ trait FullParameterization {
        *  because it is kept by the `cpy` operation of the tree transformer.
        *  It needs to be rewritten to the common result type of `imeth` and `xmeth`.
        */
-      def rewireType(tpe: Type) = tpe match {
+      def rewireType(tpe: Type)(using Context) = tpe match {
         case tpe: TermRef if rewiredTarget(tpe.symbol, derived).exists => tpe.widen
         case _ => tpe
       }

--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -42,7 +42,7 @@ object HoistSuperArgs {
  *  as method parameters. The definition is installed in the scope enclosing the class,
  *  or, if that is a package, it is made a static method of the class itself.
  */
-class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase =>
+class HoistSuperArgs extends MiniPhase, IdentityDenotTransformer { thisPhase =>
   import ast.tpd._
 
   override def phaseName: String = HoistSuperArgs.name
@@ -122,7 +122,7 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
         case _                    => false
 
       /** Only rewire types that are owned by the current Hoister and is an param or accessor */
-      def needsRewire(tp: Type) = tp match {
+      def needsRewire(tp: Type)(using Context) = tp match {
         case ntp: NamedType =>
           val owner = ntp.symbol.maybeOwner
           (owner == cls || owner == constr) && ntp.symbol.isParamOrAccessor

--- a/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PCPCheckAndHeal.scala
@@ -246,9 +246,11 @@ class PCPCheckAndHeal(@constructorOnly ictx: Context) extends TreeMapWithStages(
         checkStable(tp, pos, "type witness")
         getQuoteTypeTags.getTagRef(tp)
       case _: SearchFailureType =>
+        val tpStr = tp.show
+        val reqTypeStr = reqType.show
         report.error(
           ctx.typer.missingArgMsg(tag, reqType, "")
-            .prepend(i"Reference to $tp within quotes requires a given $reqType in scope.\n")
+            .prepend(s"Reference to $tpStr within quotes requires a given $reqTypeStr in scope.\n")
             .append("\n"),
             pos)
         tp

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -101,7 +101,7 @@ class Pickler extends Phase {
           pickled
         }(using ExecutionContext.global)
       }
-      def force(): Array[Byte] =
+      def force()(using Context): Array[Byte] =
         val result = Await.result(pickledF, Duration.Inf)
         positionWarnings.foreach(report.warning(_))
         result

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -35,7 +35,8 @@ class Staging extends MacroTransform {
       // Recheck that PCP holds but do not heal any inconsistent types as they should already have been heald
       tree match {
         case PackageDef(pid, _) if tree.symbol.owner == defn.RootClass =>
-          val checker = new PCPCheckAndHeal(freshStagingContext) {
+          val stagingCtx = freshStagingContext
+          val checker = new PCPCheckAndHeal(stagingCtx) {
             override protected def tryHeal(sym: Symbol, tp: TypeRef, pos: SrcPos)(using Context): TypeRef = {
               def symStr =
                 if (sym.is(ModuleClass)) sym.sourceModule.show

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -169,7 +169,7 @@ class TreeChecker extends Phase with SymTransformer {
             everDefinedSyms.get(sym) match {
               case Some(t)  =>
                 if (t ne tree)
-                  report.warning(i"symbol ${sym.fullName} is defined at least twice in different parts of AST")
+                  report.warning(em"symbol ${sym.fullName} is defined at least twice in different parts of AST")
               // should become an error
               case None =>
                 everDefinedSyms(sym) = tree
@@ -179,7 +179,7 @@ class TreeChecker extends Phase with SymTransformer {
             if (ctx.settings.YcheckMods.value)
               tree match {
                 case t: untpd.MemberDef =>
-                  if (t.name ne sym.name) report.warning(s"symbol ${sym.fullName} name doesn't correspond to AST: ${t}")
+                  if (t.name ne sym.name) report.warning(em"symbol ${sym.fullName} name doesn't correspond to AST: ${t}")
                 // todo: compare trees inside annotations
                 case _ =>
               }
@@ -628,7 +628,7 @@ class TreeChecker extends Phase with SymTransformer {
       tree1
     }
 
-    override def ensureNoLocalRefs(tree: Tree, pt: Type, localSyms: => List[Symbol])(using Context): Tree =
+    override def ensureNoLocalRefs(tree: Tree, pt: Type, localSyms: Context ?=> List[Symbol])(using Context): Tree =
       tree
 
     override def adapt(tree: Tree, pt: Type, locked: TypeVars)(using Context): Tree = {

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -195,12 +195,13 @@ object TypeTestsCasts {
           def testCls = effectiveClass(testType.widen)
           def unboxedTestCls = effectiveClass(unboxedTestType.widen)
 
-          def unreachable(why: => String)(using Context): Boolean = {
-            if (flagUnrelated)
-              if (inMatch) report.error(em"this case is unreachable since $why", expr.srcPos)
-              else report.warning(em"this will always yield false since $why", expr.srcPos)
+          def unreachable(why: Message)(using Context): Boolean =
+            if flagUnrelated then
+              if inMatch then
+                report.error(why.prepend("this case is unreachable since "), expr.srcPos)
+              else
+                report.warning(why.prepend("this will always yield false since "), expr.srcPos)
             false
-          }
 
           /** Are `foundCls` and `testCls` classes that allow checks
            *  whether a test would be always false?
@@ -230,9 +231,9 @@ object TypeTestsCasts {
                   && !unboxedTestCls.derivesFrom(foundCls)
                   && (testCls.is(Final) || !testCls.is(Trait) && !foundCls.is(Trait))
                 if (foundCls.is(Final))
-                  unreachable(i"$exprType is not a subclass of $testCls")
+                  unreachable(em"$exprType is not a subclass of $testCls")
                 else if (unrelated)
-                  unreachable(i"$exprType and $testCls are unrelated")
+                  unreachable(em"$exprType and $testCls are unrelated")
                 else true
               }
               else true

--- a/compiler/src/dotty/tools/dotc/transform/init/Errors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Errors.scala
@@ -29,7 +29,7 @@ object Errors:
       buildStacktrace(trace, preamble)
 
     def issue(using Context): Unit =
-      report.warning(show, this.pos)
+      report.warning(em"$show", this.pos)
   end Error
 
   def buildStacktrace(trace: Seq[Tree], preamble: String)(using Context): String = if trace.isEmpty then "" else preamble + {

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1260,7 +1260,7 @@ trait Applications extends Compatibility {
     if !ctx.mode.is(Mode.InTypeTest) then
       checkMatchable(selType, tree.srcPos, pattern = true)
 
-    def notAnExtractor(tree: Tree): Tree =
+    def notAnExtractor(tree: Tree)(using Context): Tree =
       // prefer inner errors
       // e.g. report not found ident instead of not an extractor in tests/neg/i2950.scala
       if (!tree.tpe.isError && tree.tpe.isErroneous) tree

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -364,7 +364,7 @@ object Checking {
           && !sym.getAnnotation(defn.TargetNameAnnot).isDefined
           && !sym.is(Synthetic) =>
           report.warning(
-            i"$sym has an operator name; it should come with an @targetName annotation", sym.srcPos)
+            em"$sym has an operator name; it should come with an @targetName annotation", sym.srcPos)
         case _ =>
 
   /** Check that `info` of symbol `sym` is not cyclic.
@@ -395,7 +395,7 @@ object Checking {
   def checkRefinementNonCyclic(refinement: Tree, refineCls: ClassSymbol, seen: mutable.Set[Symbol])
     (using Context): Unit = {
     def flag(what: String, tree: Tree) =
-      report.warning(i"$what reference in refinement is deprecated", tree.srcPos)
+      report.warning(em"$what reference in refinement is deprecated", tree.srcPos)
     def forwardRef(tree: Tree) = flag("forward", tree)
     def selfRef(tree: Tree) = flag("self", tree)
     val checkTree = new TreeAccumulator[Unit] {
@@ -731,10 +731,10 @@ object Checking {
       (p1, p2) <- sym.paramSymss.flatten.lazyZip(sym2.paramSymss.flatten)
       if p1.is(Inline) != p2.is(Inline)
     do
-      report.error(
-          if p2.is(Inline) then "Cannot override inline parameter with a non-inline parameter"
-          else "Cannot override non-inline parameter with an inline parameter",
-          p1.srcPos)
+      if p2.is(Inline) then
+        report.error("Cannot override inline parameter with a non-inline parameter", p1.srcPos)
+      else
+        report.error("Cannot override non-inline parameter with an inline parameter", p1.srcPos)
 
   def checkValue(tree: Tree)(using Context): Unit =
     val sym = tree.tpe.termSymbol
@@ -1048,7 +1048,7 @@ trait Checking {
    *  are feasible, i.e. that their lower bound conforms to their upper bound. If a type
    *  argument is infeasible, issue and error and continue with upper bound.
    */
-  def checkFeasibleParent(tp: Type, pos: SrcPos, where: => String = "")(using Context): Type = {
+  def checkFeasibleParent(tp: Type, pos: SrcPos, where: Context ?=> String = "")(using Context): Type = {
     def checkGoodBounds(tp: Type) = tp match {
       case tp @ TypeBounds(lo, hi) if !(lo <:< hi) =>
         report.error(em"no type exists between low bound $lo and high bound $hi$where", pos)
@@ -1539,7 +1539,7 @@ trait NoChecking extends ReChecking {
   override def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean)(using Context): Type = tp
   override def checkImplicitConversionDefOK(sym: Symbol)(using Context): Unit = ()
   override def checkImplicitConversionUseOK(tree: Tree, expected: Type)(using Context): Unit = ()
-  override def checkFeasibleParent(tp: Type, pos: SrcPos, where: => String = "")(using Context): Type = tp
+  override def checkFeasibleParent(tp: Type, pos: SrcPos, where: Context ?=> String = "")(using Context): Type = tp
   override def checkAnnotArgs(tree: Tree)(using Context): tree.type = tree
   override def checkNoTargetNameConflict(stats: List[Tree])(using Context): Unit = ()
   override def checkParentCall(call: Tree, caller: ClassSymbol)(using Context): Unit = ()

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -266,7 +266,7 @@ object ErrorReporting {
       ownerSym.typeRef.nonClassTypeMembers.map(_.symbol)
     }.toList
 
-  def dependentMsg =
+  def dependentMsg: Message =
     """Term-dependent types are experimental,
       |they must be enabled with a `experimental.dependent` language import or setting""".stripMargin.toMessage
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -270,7 +270,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                   return pre.select(name, denot)
           case _ =>
             if imp.importSym.isCompleting then
-              report.warning(i"cyclic ${imp.importSym}, ignored", pos)
+              report.warning(em"cyclic ${imp.importSym}, ignored", pos)
         NoType
 
       /** The type representing a named import with enclosing name when imported
@@ -1113,7 +1113,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
    *  expected type of a block is the anonymous class defined inside it. In that
    *  case there's technically a leak which is not removed by the ascription.
    */
-  protected def ensureNoLocalRefs(tree: Tree, pt: Type, localSyms: => List[Symbol])(using Context): Tree = {
+  protected def ensureNoLocalRefs(tree: Tree, pt: Type, localSyms: Context ?=> List[Symbol])(using Context): Tree = {
     def ascribeType(tree: Tree, pt: Type): Tree = tree match {
       case block @ Block(stats, expr) if !expr.isInstanceOf[Closure] =>
         val expr1 = ascribeType(expr, pt)
@@ -2413,7 +2413,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if sym.is(Method) && sym.owner.denot.isRefinementClass then
       for annot <- sym.paramSymss.flatten.filter(_.isTerm).flatMap(_.getAnnotation(defn.ImplicitNotFoundAnnot)) do
         report.warning(
-          i"The annotation ${defn.ImplicitNotFoundAnnot} is not allowed on parameters of methods defined inside a refinement and it will have no effect",
+          em"The annotation ${defn.ImplicitNotFoundAnnot} is not allowed on parameters of methods defined inside a refinement and it will have no effect",
           annot.tree.sourcePos
         )
 
@@ -3773,7 +3773,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           tree.symbol.is(Module) &&
           tree.symbol.companionClass.is(Case) &&
           !tree.tpe.baseClasses.exists(defn.isFunctionClass) && {
-            report.warning("The method `apply` is inserted. The auto insertion will be deprecated, please write `" + tree.show + ".apply` explicitly.", tree.sourcePos)
+            report.warning(em"The method `apply` is inserted. The auto insertion will be deprecated, please write `$tree.apply` explicitly.", tree.sourcePos)
             true
           }
 
@@ -4227,7 +4227,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
   /** Types the body Scala 2 macro declaration `def f = macro <body>` */
   protected def typedScala2MacroBody(call: untpd.Tree)(using Context): Tree =
     // TODO check that call is to a method with valid signature
-    def typedPrefix(tree: untpd.RefTree)(splice: Context ?=> Tree => Tree)(using Context): Tree = {
+    def typedPrefix(tree: untpd.RefTree)(splice: Tree => Context ?=> Tree)(using Context): Tree = {
       tryAlternatively {
         splice(typedExpr(tree, defn.AnyType))
       } {

--- a/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
+++ b/compiler/src/dotty/tools/dotc/typer/VarianceChecker.scala
@@ -179,7 +179,7 @@ class VarianceChecker(using Context) {
     }
 
     override def traverse(tree: Tree)(using Context) = {
-      def sym = tree.symbol
+      val sym = tree.symbol
       // No variance check for private/protected[this] methods/values.
       def skip = !sym.exists
         || sym.name.is(InlineAccessorName) // TODO: should we exclude all synthetic members?
@@ -187,7 +187,7 @@ class VarianceChecker(using Context) {
         || sym.is(TypeParam) && sym.owner.isClass // already taken care of in primary constructor of class
       try tree match {
         case defn: MemberDef if skip =>
-          report.debuglog(s"Skipping variance check of ${sym.showDcl}")
+          report.debuglog(i"Skipping variance check of ${sym.showDcl}")
         case tree: TypeDef =>
           checkVariance(sym, tree.srcPos)
           tree.rhs match {

--- a/compiler/test/dotty/tools/ContextEscapeDetection.java
+++ b/compiler/test/dotty/tools/ContextEscapeDetection.java
@@ -9,24 +9,24 @@ import java.util.List;
 
 public abstract class ContextEscapeDetection {
     public static class TestContext{
-        public TestContext(WeakReference<Contexts.Context> context, String testName) {
+        public TestContext(WeakReference<Contexts.ContextCls> context, String testName) {
             this.context = context;
             this.testName = testName;
         }
 
-        public final WeakReference<Contexts.Context> context;
+        public final WeakReference<Contexts.ContextCls> context;
         public final String testName;
 
     }
     public static final List<TestContext> contexts = new LinkedList<TestContext>();
 
-    public abstract Contexts.Context getCtx();
+    public abstract Contexts.ContextCls getCtx();
 
     public abstract void clearCtx();
 
     @Before
     public synchronized void stealContext() {
-        contexts.add(new TestContext(new WeakReference<Contexts.Context>(this.getCtx()), this.getClass().getName()));
+        contexts.add(new TestContext(new WeakReference<Contexts.ContextCls>(this.getCtx()), this.getClass().getName()));
     }
 
     @After

--- a/sbt-bridge/src/dotty/tools/xsbt/CompilerBridgeDriver.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/CompilerBridgeDriver.java
@@ -55,12 +55,12 @@ public class CompilerBridgeDriver extends Driver {
     try {
       log.debug(this::infoOnCachedCompiler);
 
-      Contexts.Context initialCtx = initCtx()
+      Contexts.ContextCls initialCtx = initCtx()
         .fresh()
         .setReporter(reporter)
         .setSbtCallback(callback);
 
-      Contexts.Context context = setup(args, initialCtx).map(t -> t._2).getOrElse(() -> initialCtx);
+      Contexts.ContextCls context = setup(args, initialCtx).map(t -> t._2).getOrElse(() -> initialCtx);
 
       if (ScalacCommand.isHelpFlag(context.settings(), context.settingsState())) {
         throw new InterfaceCompileFailed(args, new Problem[0], StopInfoError);
@@ -91,7 +91,7 @@ public class CompilerBridgeDriver extends Driver {
           callback.problem(problem.category(), problem.position(), problem.message(), problem.severity(),
             true);
         }
-      } else {  
+      } else {
         delegate.printSummary();
       }
 

--- a/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
@@ -6,7 +6,7 @@ package dotty.tools.xsbt;
 import scala.Tuple2;
 import scala.collection.mutable.HashMap;
 
-import dotty.tools.dotc.core.Contexts.Context;
+import dotty.tools.dotc.core.Contexts.ContextCls;
 import dotty.tools.dotc.reporting.AbstractReporter;
 import dotty.tools.dotc.reporting.Diagnostic;
 import dotty.tools.dotc.reporting.Message;
@@ -28,11 +28,11 @@ final public class DelegatingReporter extends AbstractReporter {
   }
 
   @Override
-  public void printSummary(Context ctx) {
+  public void printSummary(ContextCls ctx) {
     delegate.printSummary();
   }
 
-  public void doReport(Diagnostic dia, Context ctx) {
+  public void doReport(Diagnostic dia, ContextCls ctx) {
     Severity severity = severityOf(dia.level());
     Position position = positionOf(dia.pos().nonInlined());
 

--- a/sbt-bridge/src/xsbt/CachedCompilerImpl.java
+++ b/sbt-bridge/src/xsbt/CachedCompilerImpl.java
@@ -8,7 +8,7 @@ import xsbti.compile.*;
 
 import java.io.File;
 
-import dotty.tools.dotc.core.Contexts.Context;
+import dotty.tools.dotc.core.Contexts.ContextCls;
 import dotty.tools.dotc.core.Contexts.ContextBase;
 import dotty.tools.dotc.Main;
 import dotty.tools.xsbt.InterfaceCompileFailed;
@@ -60,7 +60,7 @@ public class CachedCompilerImpl implements CachedCompiler {
       return msg;
     });
 
-    Context ctx = new ContextBase().initialCtx().fresh()
+    ContextCls ctx = new ContextBase().initialCtx().fresh()
       .setSbtCallback(callback)
       .setReporter(new DelegatingReporter(delegate));
 

--- a/sbt-bridge/src/xsbt/ConsoleInterface.java
+++ b/sbt-bridge/src/xsbt/ConsoleInterface.java
@@ -9,7 +9,6 @@ import scala.Some;
 
 import xsbti.Logger;
 
-import dotty.tools.dotc.core.Contexts.Context;
 import dotty.tools.repl.ReplDriver;
 import dotty.tools.repl.State;
 

--- a/sbt-bridge/src/xsbt/DottydocRunner.java
+++ b/sbt-bridge/src/xsbt/DottydocRunner.java
@@ -14,7 +14,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.ArrayList;
 
-import dotty.tools.dotc.core.Contexts.Context;
+import dotty.tools.dotc.core.Contexts.ContextCls;
 import dotty.tools.dotc.core.Contexts.ContextBase;
 import dotty.tools.dotc.reporting.Reporter;
 import dotty.tools.xsbt.InterfaceCompileFailed;
@@ -52,12 +52,12 @@ public class DottydocRunner {
     }
     args = retained.toArray(new String[retained.size()]);
 
-    Context ctx = new ContextBase().initialCtx().fresh()
+    ContextCls ctx = new ContextBase().initialCtx().fresh()
       .setReporter(new DelegatingReporter(delegate));
 
     try {
       Class<?> dottydocMainClass = Class.forName("dotty.tools.dottydoc.Main");
-      Method processMethod = dottydocMainClass.getMethod("process", args.getClass(), Context.class); // args.getClass() is String[]
+      Method processMethod = dottydocMainClass.getMethod("process", args.getClass(), ContextCls.class); // args.getClass() is String[]
       Reporter reporter = (Reporter) processMethod.invoke(null, args, ctx);
       if (reporter.hasErrors())
         throw new InterfaceCompileFailed(args, new xsbti.Problem[0], "DottyDoc Compilation Failed");

--- a/tests/pos-with-compiler-cc/dotc/Run.scala
+++ b/tests/pos-with-compiler-cc/dotc/Run.scala
@@ -350,6 +350,10 @@ class Run(comp: Compiler, @constructorOnly ictx0: Context) extends ImplicitRunIn
   /** Print summary of warnings and errors encountered */
   def printSummary(): Unit = {
     printMaxConstraint()
+    if true || ctx.settings.YdetailedStats.value then
+      println(s"""total contexts   : $totalContexts
+                 |scoped contexts  : $totalScoped
+                 |detached contexts: $totalDetached""".stripMargin)
     val r = runContext.reporter
     if !r.errorsReported then
       profile.printSummary()

--- a/tests/pos-with-compiler-cc/dotc/Run.scala
+++ b/tests/pos-with-compiler-cc/dotc/Run.scala
@@ -351,10 +351,11 @@ class Run(comp: Compiler, @constructorOnly ictx0: Context) extends ImplicitRunIn
   def printSummary(): Unit = {
     printMaxConstraint()
     if true || ctx.settings.YdetailedStats.value then
-      println(s"""total contexts   : $totalContexts
-                 |scoped contexts  : $totalScoped
-                 |detached contexts: $totalDetached
-                 |of which in scope: $totalScopedDetached""".stripMargin)
+      println(s"""total contexts   : ${runContext.base.totalContexts}
+                 |scoped contexts  : ${runContext.base.totalScoped}
+                 |detached contexts: ${runContext.base.totalDetached}
+                 |of which in scope: ${runContext.base.totalScopedDetached}
+                 |typer states     : ${TyperState.nextId}""".stripMargin)
     val r = runContext.reporter
     if !r.errorsReported then
       profile.printSummary()

--- a/tests/pos-with-compiler-cc/dotc/Run.scala
+++ b/tests/pos-with-compiler-cc/dotc/Run.scala
@@ -353,7 +353,8 @@ class Run(comp: Compiler, @constructorOnly ictx0: Context) extends ImplicitRunIn
     if true || ctx.settings.YdetailedStats.value then
       println(s"""total contexts   : $totalContexts
                  |scoped contexts  : $totalScoped
-                 |detached contexts: $totalDetached""".stripMargin)
+                 |detached contexts: $totalDetached
+                 |of which in scope: $totalScopedDetached""".stripMargin)
     val r = runContext.reporter
     if !r.errorsReported then
       profile.printSummary()

--- a/tests/pos-with-compiler-cc/dotc/ast/TreeTypeMap.scala
+++ b/tests/pos-with-compiler-cc/dotc/ast/TreeTypeMap.scala
@@ -99,8 +99,9 @@ class TreeTypeMap(
           constr = tmap.transformSub(constr),
           parents = parents.mapconserve(transform),
           self = tmap.transformSub(self),
-          body = impl.body mapconserve
-            (tmap.transform(_)(using ctx.withOwner(mapOwner(impl.symbol.owner))))
+          body = impl.body.mapconserve: stat =>
+            withOwner(mapOwner(impl.symbol.owner)):
+              tmap.transform(stat)
         ).withType(tmap.mapType(impl.tpe))
     case tree1 =>
       tree1.withType(mapType(tree1.tpe)) match {

--- a/tests/pos-with-compiler-cc/dotc/ast/untpd.scala
+++ b/tests/pos-with-compiler-cc/dotc/ast/untpd.scala
@@ -555,7 +555,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
 // --------- Copier/Transformer/Accumulator classes for untyped trees -----
 
-  def localCtx(tree: Tree)(using Context): Context = ctx
+  protected def localCtxAttached(tree: Tree)(using ctx: Context): Context = ctx
 
   override val cpy: UntypedTreeCopier = UntypedTreeCopier()
 

--- a/tests/pos-with-compiler-cc/dotc/cc/Synthetics.scala
+++ b/tests/pos-with-compiler-cc/dotc/cc/Synthetics.scala
@@ -62,7 +62,7 @@ object Synthetics:
    */
   private def addCaptureDeps(info: Type)(using Context): Type = info match
     case info: MethodType =>
-      val trackedParams = info.paramRefs.filter(atPhase(checkCapturesPhase)(_.isTracked))
+      val trackedParams = atPhase(checkCapturesPhase)(info.paramRefs.filter(_.isTracked))
       def augmentResult(tp: Type): Type = tp match
         case tp: MethodOrPoly =>
           tp.derivedLambdaType(resType = augmentResult(tp.resType))

--- a/tests/pos-with-compiler-cc/dotc/config/PathResolver.scala
+++ b/tests/pos-with-compiler-cc/dotc/config/PathResolver.scala
@@ -131,7 +131,7 @@ object PathResolver {
 
   def fromPathString(path: String)(using Context): ClassPath = {
     val settings = ctx.settings.classpath.update(path)
-    inContext(ctx.fresh.setSettings(settings)) {
+    inMappedContext(_.nextFresh.setSettings(settings)) {
       new PathResolver().result
     }
   }
@@ -149,7 +149,7 @@ object PathResolver {
       val ArgsSummary(sstate, rest, errors, warnings) =
         ctx.settings.processArguments(args.toList, true, ctx.settingsState)
       errors.foreach(println)
-      val pr = inContext(ctx.fresh.setSettings(sstate)) {
+      val pr = inMappedContext(_.nextFresh.setSettings(sstate)) {
         new PathResolver()
       }
       println(" COMMAND: 'scala %s'".format(args.mkString(" ")))

--- a/tests/pos-with-compiler-cc/dotc/core/ContextOps.scala
+++ b/tests/pos-with-compiler-cc/dotc/core/ContextOps.scala
@@ -84,10 +84,8 @@ object ContextOps:
     *  Owner might not exist (can happen for self valdefs), in which case
     *  no owner is set in result context
     */
-    def localContext(tree: untpd.Tree, owner: Symbol): FreshContext = inContext(ctx) {
-      val freshCtx = ctx.fresh.setTree(tree)
-      if owner.exists then freshCtx.setOwner(owner) else freshCtx
-    }
+    def localContext(tree: untpd.Tree, owner: Symbol, newScope: Boolean = false): DetachedContext =
+      inLocalContext(tree, owner, newScope)(c ?=> c.detach)(using ctx)
 
     /** Context where `sym` is defined, assuming we are in a nested context. */
     def defContext(sym: Symbol): Context = inContext(ctx) {

--- a/tests/pos-with-compiler-cc/dotc/core/Contexts.scala
+++ b/tests/pos-with-compiler-cc/dotc/core/Contexts.scala
@@ -65,6 +65,9 @@ object Contexts {
 
   @sharable private var ctxStack: List[ContextCls] = Nil
   @sharable private var level: Int = 0
+  @sharable var totalContexts: Int = 0
+  @sharable var totalScoped: Int = 0
+  @sharable var totalDetached: Int = 0
 
   def popTo(savedLevel: Int): Unit =
     if savedLevel != level then
@@ -475,6 +478,7 @@ object Contexts {
       val c = fresh
       ctxStack = c :: ctxStack
       level += 1
+      totalScoped += 1
       c
 
     /** A fresh clone of this context embedded in the specified `outer` context. */
@@ -540,6 +544,7 @@ object Contexts {
     inline def apply(c: ContextCls): DetachedContext =
       var cc = c
       while cc != null && cc.status != Status_detached do
+        totalDetached += 1
         cc.status = Status_detached
         cc = cc.outer
       c
@@ -563,6 +568,8 @@ object Contexts {
    *  of its attributes using the with... methods.
    */
   class FreshContext(base: ContextBase) extends ContextCls(base) { thiscontext =>
+
+    totalContexts += 1
 
     def checkValid() =
       assert(status != Status_invalid, this)

--- a/tests/pos-with-compiler-cc/dotc/core/MatchTypeTrace.scala
+++ b/tests/pos-with-compiler-cc/dotc/core/MatchTypeTrace.scala
@@ -28,7 +28,7 @@ object MatchTypeTrace:
    */
   def record(op: Context ?=> Any)(using Context): String =
     val trace = new MatchTrace
-    inContext(ctx.fresh.setProperty(MatchTrace, trace)) {
+    inMappedContext(_.nextFresh.setProperty(MatchTrace, trace)) {
       op
       if trace.entries.isEmpty then ""
       else

--- a/tests/pos-with-compiler-cc/dotc/core/TypeOps.scala
+++ b/tests/pos-with-compiler-cc/dotc/core/TypeOps.scala
@@ -748,9 +748,8 @@ object TypeOps:
 
     val childTp = if (child.isTerm) child.termRef else child.typeRef
 
-    inContext(ctx.fresh.setExploreTyperState().setFreshGADTBounds.addMode(Mode.GadtConstraintInference)) {
+    inMappedContext(_.nextFresh.setExploreTyperState().setFreshGADTBounds.addMode(Mode.GadtConstraintInference)):
       instantiateToSubType(childTp, parent).dealias
-    }
   }
 
   /** Instantiate type `tp1` to be a subtype of `tp2`

--- a/tests/pos-with-compiler-cc/dotc/core/TyperState.scala
+++ b/tests/pos-with-compiler-cc/dotc/core/TyperState.scala
@@ -16,7 +16,7 @@ import Decorators._
 import scala.annotation.internal.sharable
 
 object TyperState {
-  @sharable private var nextId: Int = 0
+  @sharable var nextId: Int = 0
   def initialState() =
     TyperState()
       .init(null, OrderingConstraint.empty)

--- a/tests/pos-with-compiler-cc/dotc/inlines/Inliner.scala
+++ b/tests/pos-with-compiler-cc/dotc/inlines/Inliner.scala
@@ -831,7 +831,8 @@ class Inliner(val call: tpd.Tree)(using DetachedContext):
       val tree1 =
         if tree.isInline then
           // TODO this might not be useful if we do not support #11291
-          val sel1 = typedExpr(tree.selector)(using ctx.addMode(Mode.ForceInline))
+          val sel1 = withMode(Mode.ForceInline):
+              typedExpr(tree.selector)
           untpd.cpy.Match(tree)(sel1, tree.cases)
         else tree
       super.typedMatch(tree1, pt)

--- a/tests/pos-with-compiler-cc/dotc/interactive/Completion.scala
+++ b/tests/pos-with-compiler-cc/dotc/interactive/Completion.scala
@@ -376,7 +376,7 @@ object Completion {
       if qual.tpe.isExactlyNothing || qual.tpe.isNullType then
         Map.empty
       else
-        implicitConversionTargets(qual)(using ctx.fresh.setExploreTyperState())
+        withExploreTyperState(implicitConversionTargets(qual))
           .flatMap(accessibleMembers)
           .toSeq
           .groupByName

--- a/tests/pos-with-compiler-cc/dotc/interactive/Interactive.scala
+++ b/tests/pos-with-compiler-cc/dotc/interactive/Interactive.scala
@@ -270,7 +270,7 @@ object Interactive {
     case Nil =>
       ctx.detach
     case first :: _ if first eq stat =>
-      ctx.exprContext(stat, exprOwner).detach
+      ctx.exprContext(stat, exprOwner)
     case (imp: Import) :: rest =>
       contextOfStat(rest, stat, exprOwner, ctx.importContext(imp, inContext(ctx){imp.symbol}))
     case _ :: rest =>
@@ -289,14 +289,14 @@ object Interactive {
           else contextOfStat(stats, nested, pkg.symbol.moduleClass, outer.packageContext(tree, tree.symbol))
         case tree: DefDef =>
           assert(tree.symbol.exists)
-          val localCtx = outer.localContext(tree, tree.symbol).setNewScope.detach
+          val localCtx = outer.localContext(tree, tree.symbol, newScope = true)
           for params <- tree.paramss; param <- params do localCtx.enter(param.symbol)
             // Note: this overapproximates visibility a bit, since value parameters are only visible
             // in subsequent parameter sections
           localCtx
         case tree: MemberDef =>
           if (tree.symbol.exists)
-            outer.localContext(tree, tree.symbol).detach
+            outer.localContext(tree, tree.symbol)
           else
             outer
         case tree @ Block(stats, expr) =>

--- a/tests/pos-with-compiler-cc/dotc/transform/AccessProxies.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/AccessProxies.scala
@@ -48,11 +48,11 @@ abstract class AccessProxies {
           if (accessor.name.isSetterName &&
               forwardedArgss.nonEmpty && forwardedArgss.head.nonEmpty) // defensive conditions
             accessRef.becomes(forwardedArgss.head.head)
-          else
+          else withOwner(accessor):
             accessRef
               .appliedToTypeTrees(forwardedTpts)
               .appliedToArgss(forwardedArgss)
-              .etaExpandCFT(using ctx.withOwner(accessor))
+              .etaExpandCFT
         rhs.withSpan(accessed.span)
       })
 

--- a/tests/pos-with-compiler-cc/dotc/transform/Bridges.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/Bridges.scala
@@ -144,7 +144,8 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
                     .select(nme.primitive.arrayApply)
                     .appliedTo(Literal(Constant(n))))
               case refs1 => refs1
-            expand(args ::: expandedRefs, resType, n - 1)(using ctx.withOwner(anonFun))
+            withOwner(anonFun):
+              expand(args ::: expandedRefs, resType, n - 1)
 
           val unadapted = Closure(anonFun, lambdaBody)
           cpy.Block(unadapted)(unadapted.stats,
@@ -153,7 +154,8 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
 
       val otherCount = contextResultCount(other)
       val start = contextFunctionResultTypeAfter(member, otherCount)(using preErasureCtx)
-      expand(args, start, memberCount - otherCount)(using ctx.withOwner(bridge))
+      withOwner(bridge):
+        expand(args, start, memberCount - otherCount)
     end etaExpand
 
     def bridgeRhs(argss: List[List[Tree]]) =

--- a/tests/pos-with-compiler-cc/dotc/transform/CookComments.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/CookComments.scala
@@ -14,15 +14,14 @@ class CookComments extends MegaPhase.MiniPhase {
   override def transformTypeDef(tree: tpd.TypeDef)(using Context): tpd.Tree = {
     if (ctx.settings.YcookComments.value && tree.isClassDef) {
       val cls = tree.symbol
-      val cookingCtx = ctx.localContext(tree, cls).setNewScope
       val template = tree.rhs.asInstanceOf[tpd.Template]
       val owner = template.self.symbol.orElse(cls)
 
-      template.body.foreach { stat =>
-        Docstrings.cookComment(stat.symbol, owner)(using cookingCtx)
-      }
+      inLocalContext(tree, cls, newScope = true):
+        template.body.foreach: stat =>
+          Docstrings.cookComment(stat.symbol, owner)
 
-      Docstrings.cookComment(cls, cls)(using cookingCtx)
+        Docstrings.cookComment(cls, cls)
     }
 
     tree

--- a/tests/pos-with-compiler-cc/dotc/transform/InstrumentCoverage.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/InstrumentCoverage.scala
@@ -200,7 +200,7 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
         InstrumentedParts.singleExprTree(coverageCall, transformed)
 
     override def transform(tree: Tree)(using Context): Tree =
-      inContext(transformCtx(tree)) { // necessary to position inlined code properly
+      inTransformCtx(tree) { // necessary to position inlined code properly
         tree match
           // simple cases
           case tree: (Import | Export | Literal | This | Super | New) => tree

--- a/tests/pos-with-compiler-cc/dotc/transform/MegaPhase.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/MegaPhase.scala
@@ -215,7 +215,7 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
 
     inline def inLocalContext[T](inline op: Context ?=> T)(using Context): T =
       val sym = tree.symbol
-      runWithOwner(if (sym.is(PackageVal)) sym.moduleClass else sym)(op)
+      withOwner(if (sym.is(PackageVal)) sym.moduleClass else sym)(op)
 
     def transformNamed(tree: Tree, start: Int, outerCtx: Context): Tree = tree match {
       case tree: Ident =>

--- a/tests/pos-with-compiler-cc/dotc/transform/Memoize.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/Memoize.scala
@@ -181,7 +181,8 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
           val rhsClass = tree.tpt.tpe.widenDealias.classSymbol
           val getterRhs =
             if isErasableBottomField(field, rhsClass) then erasedBottomTree(rhsClass)
-            else transformFollowingDeep(ref(field))(using ctx.withOwner(sym))
+            else withOwner(sym):
+              transformFollowingDeep(ref(field))
           val getterDef = cpy.DefDef(tree)(rhs = getterRhs)
           addAnnotations(fieldDef.denot)
           removeUnwantedAnnotations(sym, defn.GetterMetaAnnot)
@@ -209,7 +210,10 @@ class Memoize extends MiniPhase with IdentityDenotTransformer { thisPhase =>
             if isErasableBottomField(field, tree.termParamss.head.head.tpt.tpe.classSymbol)
             then Literal(Constant(()))
             else Assign(ref(field), adaptToField(field, ref(tree.termParamss.head.head.symbol)))
-          val setterDef = cpy.DefDef(tree)(rhs = transformFollowingDeep(initializer)(using ctx.withOwner(sym)))
+          val setterDef = cpy.DefDef(tree)(
+              rhs = withOwner(sym):
+                transformFollowingDeep(initializer)
+            )
           removeUnwantedAnnotations(sym, defn.SetterMetaAnnot)
           setterDef
       else

--- a/tests/pos-with-compiler-cc/dotc/transform/Recheck.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/Recheck.scala
@@ -409,11 +409,10 @@ abstract class Recheck extends Phase, SymTransformer:
       stats.foreach(recheck(_))
 
     def recheckDef(tree: ValOrDefDef, sym: Symbol)(using Context): Unit =
-      inContext(ctx.localContext(tree, sym)) {
+      inLocalContext(tree, sym):
         tree match
           case tree: ValDef => recheckValDef(tree, sym)
           case tree: DefDef => recheckDefDef(tree, sym)
-      }
 
     /** Recheck tree without adapting it, returning its new type.
      *  @param tree        the original tree
@@ -439,9 +438,11 @@ abstract class Recheck extends Phase, SymTransformer:
             // TODO: Should we allow for completers as for ValDefs or DefDefs?
             tree.rhs match
               case impl: Template =>
-                recheckClassDef(tree, impl, sym.asClass)(using ctx.localContext(tree, sym))
+                inLocalContext(tree, sym):
+                  recheckClassDef(tree, impl, sym.asClass)
               case _ =>
-                recheckTypeDef(tree, sym)(using ctx.localContext(tree, sym))
+                inLocalContext(tree, sym):
+                  recheckTypeDef(tree, sym)
           case tree: Labeled => recheckLabeled(tree, pt)
 
       def recheckUnnamed(tree: Tree, pt: Type): Type = tree match

--- a/tests/pos-with-compiler-cc/dotc/transform/patmat/Space.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/patmat/Space.scala
@@ -759,7 +759,8 @@ class SpaceEngine(using Context) extends SpaceLogic {
       constrs.forall { case (tp1, tp2) => typeParamMap(tp1) <:< typeParamMap(tp2) }
     }
 
-    checkConstraint(genConstraint(sp))(using ctx.fresh.setNewTyperState())
+    withExploreTyperState:
+      checkConstraint(genConstraint(sp))
   }
 
   def show(ss: Seq[Space]): String = ss.map(show).mkString(", ")

--- a/tests/pos-with-compiler-cc/dotc/typer/Deriving.scala
+++ b/tests/pos-with-compiler-cc/dotc/typer/Deriving.scala
@@ -296,7 +296,7 @@ trait Deriving {
           else errorTree(rhs, em"$resultType cannot be derived since ${resultType.typeSymbol} has no companion object")
       end typeclassInstance
 
-      def syntheticDef(sym: Symbol): Tree = inContext(ctx.fresh.setOwner(sym).setNewScope) {
+      def syntheticDef(sym: Symbol): Tree = inMappedContext(_.nextFresh.setOwner(sym).setNewScope) {
         if sym.is(Method) then tpd.DefDef(sym.asTerm, typeclassInstance(sym))
         else tpd.ValDef(sym.asTerm, typeclassInstance(sym)(Nil))
       }

--- a/tests/pos-with-compiler-cc/dotc/typer/EtaExpansion.scala
+++ b/tests/pos-with-compiler-cc/dotc/typer/EtaExpansion.scala
@@ -191,7 +191,9 @@ object LiftCoverage extends LiftImpure {
 
   def liftForCoverage(defs: mutable.ListBuffer[tpd.Tree], tree: tpd.Apply)(using Context) = {
     val liftedFun = liftApp(defs, tree.fun)
-    val liftedArgs = liftArgs(defs, tree.fun.tpe, tree.args)(using liftingArgsContext)
+    val liftedArgs =
+      inMappedContext(_.nextFresh.setProperty(LiftingArgs, true)):
+        liftArgs(defs, tree.fun.tpe, tree.args)
     tpd.cpy.Apply(tree)(liftedFun, liftedArgs)
   }
 }

--- a/tests/pos-with-compiler-cc/dotc/typer/Implicits.scala
+++ b/tests/pos-with-compiler-cc/dotc/typer/Implicits.scala
@@ -86,7 +86,7 @@ object Implicits:
    */
   abstract class ImplicitRefs(initctx: DetachedContext) extends caps.Pure {
     val irefCtx: DetachedContext =
-      if (initctx eq NoContext) initctx else initctx.retractMode(Mode.ImplicitsEnabled).detach
+      if initctx.isNoContext then initctx else initctx.retractMode(Mode.ImplicitsEnabled).detach
     protected given Context = irefCtx
 
     /** The nesting level of this context. Non-zero only in ContextialImplicits */

--- a/tests/pos-with-compiler-cc/dotc/typer/ImportSuggestions.scala
+++ b/tests/pos-with-compiler-cc/dotc/typer/ImportSuggestions.scala
@@ -323,7 +323,7 @@ trait ImportSuggestions:
     if ctx.phase == Phases.checkCapturesPhase then
       return "" // it's too late then to look for implicits
     val (fullMatches, headMatches) =
-      importSuggestions(pt)(using ctx.fresh.setExploreTyperState())
+      withExploreTyperState(importSuggestions(pt))
     implicits.println(i"suggestions for $pt in ${ctx.owner} = ($fullMatches%, %, $headMatches%, %)")
     val (suggestedRefs, help) =
       if fullMatches.nonEmpty then (fullMatches, "fix")

--- a/tests/pos-with-compiler-cc/dotc/typer/Inferencing.scala
+++ b/tests/pos-with-compiler-cc/dotc/typer/Inferencing.scala
@@ -27,9 +27,10 @@ object Inferencing {
    *  Variables that are successfully minimized do not count as uninstantiated.
    */
   def isFullyDefined(tp: Type, force: ForceDegree.Value)(using Context): Boolean = {
-    val nestedCtx = ctx.fresh.setNewTyperState()
-    val result = new IsFullyDefinedAccumulator(force)(using nestedCtx).process(tp)
-    if (result) nestedCtx.typerState.commit()
+    val nestedTS = ctx.typerState.fresh(committable = true)
+    val result = withTyperState(nestedTS):
+      new IsFullyDefinedAccumulator(force).process(tp)
+    if result then nestedTS.commit()
     result
   }
 

--- a/tests/pos-with-compiler-cc/dotc/typer/Typer.scala
+++ b/tests/pos-with-compiler-cc/dotc/typer/Typer.scala
@@ -2659,6 +2659,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         errorTree(exp, em"exports are only allowed from objects and classes, they can not belong to local blocks")
 
   def typedPackageDef(tree: untpd.PackageDef)(using Context): Tree =
+    //Test to check that runtime capture validation flags escaping contexts
+    //val escape = withMode(Mode.InPackageClauseName)(c ?=> c.asInstanceOf[Object])
+    //val out = escape.asInstanceOf[DetachedContext].outer
     val pid1 = withMode(Mode.InPackageClauseName)(typedExpr(tree.pid, AnySelectionProto))
     val pkg = pid1.symbol
     pid1 match


### PR DESCRIPTION
This is an experiment to use capture checking for contexts in the compiler so that contexts can be allocated and re-used safely from arena. 

