### PR TITLE
Performance optimization: only compute stack traces when needed

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -16,6 +16,7 @@ import core.Decorators._
 import config.{SourceVersion, Feature}
 import StdNames.nme
 import scala.annotation.internal.sharable
+import scala.util.control.NoStackTrace
 import transform.MacroAnnotations
 
 class CompilationUnit protected (val source: SourceFile) {
@@ -105,7 +106,7 @@ class CompilationUnit protected (val source: SourceFile) {
 
 object CompilationUnit {
 
-  class SuspendException extends Exception
+  class SuspendException extends Exception with NoStackTrace
 
   /** Make a compilation unit for top class `clsd` with the contents of the `unpickled` tree */
   def apply(clsd: ClassDenotation, unpickled: Tree, forceTrees: Boolean)(using Context): CompilationUnit =


### PR DESCRIPTION
I noticed that `Throwable#fillInStackTrace` (which is called from the constructor of Throwable) showed up while profiling the compiler. This is because several data structures we use (`Diagnostic` and `TypeError`) extend `Exception`. Since the stack trace is only used for debugging in some rare cases and is expensive to compute, it's worth avoiding it whenever possible. This can be done either by passing `false` to the `writableStackTrace` constructor parameter, by overriding `Throwable#fillInStackTrace` or by extending `scala.util.control.NoStackTrace`.

I ended up not touching `Diagnostic` in this PR because it will be changed in #16566 to not extend `Exception`.