### PR TITLE
Beta-reduce directly applied PolymorphicFunction

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -165,12 +165,13 @@ class InlineReducer(inliner: Inliner)(using Context):
     */
   def betaReduce(tree: Tree)(using Context): Tree = tree match {
     case Apply(Select(cl, nme.apply), args) if defn.isFunctionType(cl.tpe) =>
-      val bindingsBuf = new mutable.ListBuffer[ValDef]
+      val bindingsBuf = new mutable.ListBuffer[DefTree]
       def recur(cl: Tree): Option[Tree] = cl match
         case Block((ddef : DefDef) :: Nil, closure: Closure) if ddef.symbol == closure.meth.symbol =>
           ddef.tpe.widen match
             case mt: MethodType if ddef.paramss.head.length == args.length =>
-              Some(BetaReduce.reduceApplication(ddef, args, bindingsBuf))
+              // TODO beta reduce PolyType
+              Some(BetaReduce.reduceApplication(ddef, List(args), bindingsBuf))
             case _ => None
         case Block(stats, expr) if stats.forall(isPureBinding) =>
           recur(expr).map(cpy.Block(cl)(stats, _))

--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -12,8 +12,6 @@ import NameKinds.{InlineAccessorName, InlineBinderName, InlineScrutineeName}
 import config.Printers.inlining
 import util.SimpleIdentityMap
 
-import dotty.tools.dotc.transform.BetaReduce
-
 import collection.mutable
 
 /** A utility class offering methods for rewriting inlined code */
@@ -148,45 +146,6 @@ class InlineReducer(inliner: Inliner)(using Context):
         binding
     }
     binding1.withSpan(call.span)
-  }
-
-  /** Rewrite an application
-    *
-    *    ((x1, ..., xn) => b)(e1, ..., en)
-    *
-    *  to
-    *
-    *    val/def x1 = e1; ...; val/def xn = en; b
-    *
-    *  where `def` is used for call-by-name parameters. However, we shortcut any NoPrefix
-    *  refs among the ei's directly without creating an intermediate binding.
-    *
-    *  This variant of beta-reduction preserves the integrity of `Inlined` tree nodes.
-    */
-  def betaReduce(tree: Tree)(using Context): Tree = tree match {
-    case Apply(Select(cl, nme.apply), args) if defn.isFunctionType(cl.tpe) =>
-      val bindingsBuf = new mutable.ListBuffer[DefTree]
-      def recur(cl: Tree): Option[Tree] = cl match
-        case Block((ddef : DefDef) :: Nil, closure: Closure) if ddef.symbol == closure.meth.symbol =>
-          ddef.tpe.widen match
-            case mt: MethodType if ddef.paramss.head.length == args.length =>
-              // TODO beta reduce PolyType
-              Some(BetaReduce.reduceApplication(ddef, List(args), bindingsBuf))
-            case _ => None
-        case Block(stats, expr) if stats.forall(isPureBinding) =>
-          recur(expr).map(cpy.Block(cl)(stats, _))
-        case Inlined(call, bindings, expr) if bindings.forall(isPureBinding) =>
-          recur(expr).map(cpy.Inlined(cl)(call, bindings, _))
-        case Typed(expr, tpt) =>
-          recur(expr)
-        case _ => None
-      recur(cl) match
-        case Some(reduced) =>
-          seq(bindingsBuf.result(), reduced).withSpan(tree.span)
-        case None =>
-          tree
-    case _ =>
-      tree
   }
 
   /** The result type of reducing a match. It consists optionally of a list of bindings

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -21,6 +21,7 @@ import collection.mutable
 import reporting.trace
 import util.Spans.Span
 import dotty.tools.dotc.transform.Splicer
+import dotty.tools.dotc.transform.BetaReduce
 import quoted.QuoteUtils
 import scala.annotation.constructorOnly
 
@@ -811,7 +812,7 @@ class Inliner(val call: tpd.Tree)(using Context):
           case Quoted(Spliced(inner)) => inner
           case _ => tree
       val locked = ctx.typerState.ownedVars
-      val res = cancelQuotes(constToLiteral(betaReduce(super.typedApply(tree, pt)))) match {
+      val res = cancelQuotes(constToLiteral(BetaReduce(super.typedApply(tree, pt)))) match {
         case res: Apply if res.symbol == defn.QuotedRuntime_exprSplice
                         && StagingContext.level == 0
                         && !hasInliningErrors =>
@@ -824,7 +825,7 @@ class Inliner(val call: tpd.Tree)(using Context):
 
     override def typedTypeApply(tree: untpd.TypeApply, pt: Type)(using Context): Tree =
       val locked = ctx.typerState.ownedVars
-      val tree1 = inlineIfNeeded(constToLiteral(betaReduce(super.typedTypeApply(tree, pt))), pt, locked)
+      val tree1 = inlineIfNeeded(constToLiteral(BetaReduce(super.typedTypeApply(tree, pt))), pt, locked)
       if tree1.symbol.isQuote then
         ctx.compilationUnit.needsStaging = true
       tree1
@@ -1005,7 +1006,7 @@ class Inliner(val call: tpd.Tree)(using Context):
             super.transform(t1)
           case t: Apply =>
             val t1 = super.transform(t)
-            if (t1 `eq` t) t else reducer.betaReduce(t1)
+            if (t1 `eq` t) t else BetaReduce(t1)
           case Block(Nil, expr) =>
             super.transform(expr)
           case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -86,6 +86,8 @@ object BetaReduce:
         recur(expr, argss).map(cpy.Inlined(fn)(call, bindings, _))
       case Typed(expr, tpt) =>
         recur(expr, argss)
+      case TypeApply(Select(expr, nme.asInstanceOfPM), List(tpt)) =>
+        recur(expr, argss)
       case _ => None
     tree match
       case Apply(Select(fn, nme.apply), args) if defn.isFunctionType(fn.tpe) =>

--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -13,13 +13,14 @@ import scala.collection.mutable.ListBuffer
 
 /** Rewrite an application
  *
- *    (((x1, ..., xn) => b): T)(y1, ..., yn)
+ *    (([X1, ..., Xm] => (x1, ..., xn) => b): T)[T1, ..., Tm](y1, ..., yn)
  *
  *  where
  *
  *    - all yi are pure references without a prefix
  *    - the closure can also be contextual or erased, but cannot be a SAM type
- *    _ the type ascription ...: T is optional
+ *    - the type parameters Xi and type arguments Ti are optional
+ *    - the type ascription ...: T is optional
  *
  *  to
  *

--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -111,22 +111,11 @@ object BetaReduce:
       case _ =>
         tree
 
-  /** Beta-reduces a call to `ddef` with arguments `args` */
-  def apply(ddef: DefDef, argss: List[List[Tree]])(using Context) =
-    val bindings = new ListBuffer[DefTree]()
-    val expansion1 = reduceApplication(ddef, argss, bindings)
-    val bindings1 = bindings.result()
-    seq(bindings1, expansion1)
-
   /** Beta-reduces a call to `ddef` with arguments `args` and registers new bindings */
   def reduceApplication(ddef: DefDef, argss: List[List[Tree]], bindings: ListBuffer[DefTree])(using Context): Tree =
-    assert(argss.size == 1 || argss.size == 2)
-    val targs = if argss.size == 2 then argss.head else Nil
-    val args = argss.last
+    val (targs, args) = argss.flatten.partition(_.isType)
     val tparams = ddef.leadingTypeParams
     val vparams = ddef.termParamss.flatten
-    assert(targs.hasSameLengthAs(tparams))
-    assert(args.hasSameLengthAs(vparams))
 
     val targSyms =
       for (targ, tparam) <- targs.zip(tparams) yield

--- a/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
@@ -51,11 +51,12 @@ class InlinePatterns extends MiniPhase:
         case Apply(App(fn, argss), args) => (fn, argss :+ args)
         case _ => (app, Nil)
 
+  // TODO merge with BetaReduce.scala
   private def betaReduce(tree: Apply, fn: Tree, name: Name, args: List[Tree])(using Context): Tree =
     fn match
       case Block(TypeDef(_, template: Template) :: Nil, Apply(Select(New(_),_), Nil)) if template.constr.rhs.isEmpty =>
         template.body match
-          case List(ddef @ DefDef(`name`, _, _, _)) => BetaReduce(ddef, args)
+          case List(ddef @ DefDef(`name`, _, _, _)) => BetaReduce(ddef, List(args))
           case _ => tree
       case _ => tree
 

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -322,7 +322,10 @@ object PickleQuotes {
                   }
                   val Block(List(ddef: DefDef), _) = splice: @unchecked
                   // TODO: beta reduce inner closure? Or wait until BetaReduce phase?
-                  BetaReduce(ddef, List(spliceArgs)).select(nme.apply).appliedTo(args(2).asInstance(quotesType))
+                  BetaReduce(
+                    splice
+                      .select(nme.apply).appliedToArgs(spliceArgs))
+                      .select(nme.apply).appliedTo(args(2).asInstance(quotesType))
                 }
                 CaseDef(Literal(Constant(idx)), EmptyTree, rhs)
               }

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -322,7 +322,7 @@ object PickleQuotes {
                   }
                   val Block(List(ddef: DefDef), _) = splice: @unchecked
                   // TODO: beta reduce inner closure? Or wait until BetaReduce phase?
-                  BetaReduce(ddef, spliceArgs).select(nme.apply).appliedTo(args(2).asInstance(quotesType))
+                  BetaReduce(ddef, List(spliceArgs)).select(nme.apply).appliedTo(args(2).asInstance(quotesType))
                 }
                 CaseDef(Literal(Constant(idx)), EmptyTree, rhs)
               }

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -362,8 +362,9 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     object Term extends TermModule:
       def betaReduce(tree: Term): Option[Term] =
         tree match
+          // TODO support TypeApply. Would fix #15968.
           case app @ tpd.Apply(tpd.Select(fn, nme.apply), args) if dotc.core.Symbols.defn.isFunctionType(fn.tpe) =>
-            val app1 = dotc.transform.BetaReduce(app, fn, args)
+            val app1 = dotc.transform.BetaReduce(app, fn, List(args))
             if app1 eq app then None
             else Some(app1.withSpan(tree.span))
           case tpd.Block(Nil, expr) =>

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -362,20 +362,15 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     object Term extends TermModule:
       def betaReduce(tree: Term): Option[Term] =
         tree match
-          case app @ tpd.Apply(tpd.Select(fn, nme.apply), args) if dotc.core.Symbols.defn.isFunctionType(fn.tpe) =>
-            val app1 = dotc.transform.BetaReduce(app, fn, List(args))
-            if app1 eq app then None
-            else Some(app1.withSpan(tree.span))
-          case app @ tpd.Apply(tpd.TypeApply(tpd.Select(fn, nme.apply), targs), args) if fn.tpe.typeSymbol eq dotc.core.Symbols.defn.PolyFunctionClass =>
-            val app1 = dotc.transform.BetaReduce(app, fn, List(targs, app.args))
-            if app1 eq app then None
-            else Some(app1.withSpan(tree.span))
           case tpd.Block(Nil, expr) =>
             for e <- betaReduce(expr) yield tpd.cpy.Block(tree)(Nil, e)
           case tpd.Inlined(_, Nil, expr) =>
             betaReduce(expr)
           case _ =>
-            None
+            val tree1 = dotc.transform.BetaReduce(tree)
+            if tree1 eq tree then None
+            else Some(tree1.withSpan(tree.span))
+
     end Term
 
     given TermMethods: TermMethods with

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -608,6 +608,37 @@ class InlineBytecodeTests extends DottyBytecodeTest {
     }
   }
 
+  @Test def beta_reduce_function_of_opaque_types = {
+    val source = """object foo:
+                   |  opaque type T = Int
+                   |  inline def apply(inline op: T => T): T = op(2)
+                   |
+                   |class Test:
+                   | def test = foo { n => n }
+                 """.stripMargin
+
+    checkBCode(source) { dir =>
+      val clsIn      = dir.lookupName("Test.class", directory = false).input
+      val clsNode    = loadClassNode(clsIn)
+
+      val fun = getMethod(clsNode, "test")
+      val instructions = instructionsFromMethod(fun)
+      val expected =
+        List(
+          Field(GETSTATIC, "foo$", "MODULE$", "Lfoo$;"),
+          VarOp(ASTORE, 1),
+          VarOp(ALOAD, 1),
+          VarOp(ASTORE, 2),
+          Op(ICONST_2),
+          Op(IRETURN),
+        )
+
+      assert(instructions == expected,
+        "`i was not properly beta-reduced in `test`\n" + diffInstructions(instructions, expected))
+
+    }
+  }
+
   @Test def i9456 = {
     val source = """class Foo {
                    |  def test: Int = inline2(inline1(2.+))

--- a/tests/run-macros/i15968.check
+++ b/tests/run-macros/i15968.check
@@ -1,0 +1,5 @@
+{
+  type Z = java.lang.String
+  "foo".toString()
+}
+"foo".toString()

--- a/tests/run-macros/i15968/Macro_1.scala
+++ b/tests/run-macros/i15968/Macro_1.scala
@@ -1,0 +1,15 @@
+import scala.quoted.*
+
+inline def macroPolyFun[A](inline arg: A, inline f: [Z] => Z => String): String =
+  ${ macroPolyFunImpl[A]('arg, 'f) }
+
+private def macroPolyFunImpl[A: Type](arg: Expr[A], f: Expr[[Z] => Z => String])(using Quotes): Expr[String] =
+  Expr(Expr.betaReduce('{ $f($arg) }).show)
+
+
+inline def macroFun[A](inline arg: A, inline f: A => String): String =
+  ${ macroFunImpl[A]('arg, 'f) }
+
+private def macroFunImpl[A: Type](arg: Expr[A], f: Expr[A => String])(using Quotes): Expr[String] =
+  Expr(Expr.betaReduce('{ $f($arg) }).show)
+

--- a/tests/run-macros/i15968/Test_2.scala
+++ b/tests/run-macros/i15968/Test_2.scala
@@ -1,0 +1,3 @@
+@main def Test: Unit =
+  println(macroPolyFun("foo", [Z] => (arg: Z) => arg.toString))
+  println(macroFun("foo", arg => arg.toString))

--- a/tests/run-macros/inline-beta-reduce-polyfunction.check
+++ b/tests/run-macros/inline-beta-reduce-polyfunction.check
@@ -1,0 +1,7 @@
+{
+  type X = Int
+  {
+    println(1)
+    1
+  }
+}

--- a/tests/run-macros/inline-beta-reduce-polyfunction.scala
+++ b/tests/run-macros/inline-beta-reduce-polyfunction.scala
@@ -1,0 +1,5 @@
+transparent inline def foo(inline f: [X] => X => X): Int = f[Int](1)
+
+@main def Test: Unit =
+  val code = compiletime.codeOf(foo([X] => (x: X) => { println(x); x }))
+  println(code)


### PR DESCRIPTION
Beta-reduce directly applied PolymorphicFunction such as

```scala
([Z] => (arg: Z) => { def a: Z = arg; a }).apply[Int](2)
```
into
```scala
type Z = Int
val arg = 2
def a: Z = arg
a
```

Apply this beta reduction in the `BetaReduce` phase and `Expr.betaReduce`. Also, refactor the beta-reduce logic to avoid code duplication.

Fixes #15968