### PR TITLE
Safer Exceptions for Scala 3

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1765,6 +1765,11 @@ object desugar {
     }
 
     val desugared = tree match {
+      case ThrowsReturn(exceptions, rteTpe) =>
+        val r = exceptions.reduce((left, right) => InfixOp(left, Ident(nme.OR.toTypeName), right))
+        val args = AppliedTypeTree(Ident(defn.CanThrowClass.name), r)
+        Printers.saferExceptions.println(i"$args")
+        FunctionWithMods(args :: Nil, rteTpe, Modifiers(Flags.Given))
       case PolyFunction(targs, body) =>
         makePolyFunction(targs, body, pt) orElse tree
       case SymbolLit(str) =>

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1766,7 +1766,7 @@ object desugar {
 
     val desugared = tree match {
       case ThrowsReturn(exceptions, rteTpe) =>
-        val r = exceptions.reduce((left, right) => InfixOp(left, Ident(nme.OR.toTypeName), right))
+        val r = exceptions.reduce((left, right) => InfixOp(left, Ident(tpnme.OR), right))
         val args = AppliedTypeTree(Ident(defn.CanThrowClass.name), r)
         Printers.saferExceptions.println(i"$args")
         FunctionWithMods(args :: Nil, rteTpe, Modifiers(Flags.Given))

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1321,13 +1321,11 @@ object desugar {
   }
 
   /** Translate throws type `A throws E1 | ... | En` to
-   *  $throws[... $throws[A, E1] ... , En].
+   *  $throws[A, E1| ... | En].
    */
   def throws(tpt: Tree, op: Ident, excepts: Tree)(using Context): AppliedTypeTree = excepts match
     case Parens(excepts1) =>
       throws(tpt, op, excepts1)
-    case InfixOp(l, bar @ Ident(tpnme.raw.BAR), r) =>
-      throws(throws(tpt, op, l), bar, r)
     case e =>
       AppliedTypeTree(
         TypeTree(defn.throwsAlias.typeRef).withSpan(op.span), tpt :: excepts :: Nil)

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1768,8 +1768,9 @@ object desugar {
       case ThrowsReturn(exceptions, rteTpe) =>
         val r = exceptions.reduce((left, right) => InfixOp(left, Ident(tpnme.OR), right))
         val args = AppliedTypeTree(Ident(defn.CanThrowClass.name), r)
-        Printers.saferExceptions.println(i"$args")
-        FunctionWithMods(args :: Nil, rteTpe, Modifiers(Flags.Given))
+        val fn = FunctionWithMods(args :: Nil, rteTpe, Modifiers(Flags.Given))
+        Printers.saferExceptions.println(i"throws clased desugared to $fn")
+        fn
       case PolyFunction(targs, body) =>
         makePolyFunction(targs, body, pt) orElse tree
       case SymbolLit(str) =>

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -2,21 +2,34 @@ package dotty.tools
 package dotc
 package ast
 
-import core._
-import Types._, Names._, NameOps._, Flags._, util.Spans._, Contexts._, Constants._
-import typer.{ ConstFold, ProtoTypes }
-import SymDenotations._, Symbols._, Denotations._, StdNames._, Comments._
+import core.*
+import Types.*
+import Names.*
+import NameOps.*
+import Flags.*
+import util.Spans.*
+import Contexts.*
+import Constants.*
+import typer.{ConstFold, ProtoTypes}
+import SymDenotations.*
+import Symbols.*
+import Denotations.*
+import StdNames.*
+import Comments.*
+
 import collection.mutable.ListBuffer
 import printing.Printer
 import printing.Texts.Text
-import util.{Stats, Attachment, Property, SourceFile, NoSource, SrcPos, SourcePosition}
+import util.{Attachment, NoSource, Property, SourceFile, SourcePosition, SrcPos, Stats}
 import config.Config
 import config.Printers.overload
+
 import annotation.internal.sharable
 import annotation.unchecked.uncheckedVariance
 import annotation.constructorOnly
 import compiletime.uninitialized
-import Decorators._
+import Decorators.*
+import dotty.tools.dotc.ast.untpd.Tree
 
 object Trees {
 
@@ -692,6 +705,8 @@ object Trees {
    *  Every TypeVar is created as the type of one InferredTypeTree.
    */
   class InferredTypeTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends TypeTree[T]
+
+  class ThrowsReturn[+T <: Untyped](val rteTpe : Tree[T], val except : List[Any])(implicit @constructorOnly src: SourceFile) extends TypeTree[T]
 
   /** ref.type */
   case class SingletonTypeTree[+T <: Untyped] private[ast] (ref: Tree[T])(implicit @constructorOnly src: SourceFile)

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -69,6 +69,14 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class InterpolatedString(id: TermName, segments: List[Tree])(implicit @constructorOnly src: SourceFile)
     extends TermTree
 
+  /**
+   * A Sugar type wrapping the return type and the exceptions that might be thrown by a function
+   * @param exceptions - Exceptions that might be thrown
+   * @param rteTpe - Return type of the function
+   * @param src - source file of this tree
+   */
+  case class ThrowsReturn(exceptions: List[Tree], rteTpe: Tree)(implicit @constructorOnly src: SourceFile) extends Tree
+
   /** A function type or closure */
   case class Function(args: List[Tree], body: Tree)(implicit @constructorOnly src: SourceFile) extends Tree {
     override def isTerm: Boolean = body.isTerm
@@ -787,6 +795,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         this(x, expr)
       case CapturingTypeTree(refs, parent) =>
         this(this(x, refs), parent)
+      case ThrowsReturn(exceptions, rteTpe) =>
+        x
       case _ =>
         super.foldMoreCases(x, tree)
     }

--- a/compiler/src/dotty/tools/dotc/config/Printers.scala
+++ b/compiler/src/dotty/tools/dotc/config/Printers.scala
@@ -49,4 +49,5 @@ object Printers {
   val typr = noPrinter
   val unapp = noPrinter
   val variances = noPrinter
+  val saferExceptions = new Printer
 }

--- a/compiler/src/dotty/tools/dotc/config/Printers.scala
+++ b/compiler/src/dotty/tools/dotc/config/Printers.scala
@@ -49,5 +49,5 @@ object Printers {
   val typr = noPrinter
   val unapp = noPrinter
   val variances = noPrinter
-  val saferExceptions = new Printer
+  val saferExceptions = noPrinter
 }

--- a/compiler/src/dotty/tools/dotc/config/Printers.scala
+++ b/compiler/src/dotty/tools/dotc/config/Printers.scala
@@ -49,5 +49,5 @@ object Printers {
   val typr = noPrinter
   val unapp = noPrinter
   val variances = noPrinter
-  val saferExceptions = noPrinter
+  val saferExceptions = new Printer
 }

--- a/compiler/src/dotty/tools/dotc/core/JavaExceptionsInterop.scala
+++ b/compiler/src/dotty/tools/dotc/core/JavaExceptionsInterop.scala
@@ -1,0 +1,92 @@
+package dotty.tools.dotc.core
+
+import Contexts.*
+import Types.*
+import Symbols.*
+import Flags.JavaDefined
+import Names.*
+import dotty.tools.dotc.config.Feature
+import dotty.tools.dotc.config.Printers.saferExceptions
+import Decorators.i
+import dotty.tools.dotc.ast.Trees.ValOrDefDef
+
+/*
+TODO : Functionnality purposes
+  1 - Fetch from the java source (.java or .class) a list of all the thrown exceptions
+  2 - Create an disjonction type between all of them (use OrType to do that)
+  3 - Fix the TermName of the synthetic using clause generated in JavaExceptionsInterop::curryCanThrow
+
+TODO : Debuging purposes
+  1 - Add a new Printer to print information on "safer exceptions"
+  2 - Use the reporter to report warnings or error that may happen in this step
+*/
+
+object JavaExceptionsInterop :
+
+  /**
+   * Return the ClassSymbol that corresponds to
+   *   'scala.CanThrow' class
+   * @return
+   */
+  private inline def canThrowType(using Context) = defn.CanThrowClass
+
+  /**
+   * Checks if the "safer exceptions" feature is enables in a file
+   * To enable "safer exceptions", use this import :
+   *   'import scala.language.experimental.saferExceptions'
+   * @return (Boolean) - true is the feature is enabled. False otherwise
+   */
+  def isEnabled(using Context) = Feature.enabled(Feature.saferExceptions)
+
+  /**
+   *
+   *
+   * @param sym
+   * @param tp
+   * @return
+   */
+  def canThrowMember(sym: Symbol, tp: Type, exceptions : List[Type])(using Context) : Type =
+    //assert(sym.is(JavaDefined), "can only decorate java defined methods")
+    assert(isEnabled, "saferExceptions is disabled")
+    assert(exceptions.nonEmpty, "Cannot append empty exceptions")
+    saferExceptions.println(i"Synthesizing '$canThrowType' clause for symbol $sym of type: $tp")
+    println(i"Exceptions to add to the symbol are $exceptions")
+    println(tp)
+    tp match
+      case mtd@MethodType(terms) =>
+        val synthTp = curryCanThrow(mtd, terms, exceptions)
+        saferExceptions.println(i"Compiler synthesized type '$synthTp' for symbol $sym")
+        synthTp
+      case _ =>
+        tp
+
+
+  /**
+   * Add a curried parameters of type CanThrow[Excpetion] to the end of the parameter list
+   * @rtnType should be any other type
+   * */
+  def curryCanThrow(mtd : MethodType, param : List[TermName], exceptions : List[Type])(using Context) : Type =
+    mtd.resType match
+      case a@MethodType(terms) =>
+        CachedMethodType(terms)(_ => mtd.paramInfos, _ => curryCanThrow(a, terms, exceptions), mtd.companion)
+      case t =>
+        CachedMethodType(param)(_ => mtd.paramInfos, _ => canThrowMethodType(t, exceptions), mtd.companion)
+
+  def canThrowMethodType(resType : Type, exceptions : List[Type])(using Context) =
+    // First join all the expections with a disjonction
+    val reduced_exceptions = exceptions.reduce(OrType(_, _, true)) // TODO : Not sure what true does, to check...
+    saferExceptions.println(i"Joining all the Exception types into one disjonction type '$reduced_exceptions'")
+
+    // Apply the disjonction to the CanThrow type parameter
+    saferExceptions.println(i"Applying the exceptions '$reduced_exceptions' to the polymorphic type '$canThrowType'")
+    val genericType = canThrowType.typeRef.applyIfParameterized(reduced_exceptions :: Nil)
+    saferExceptions.println(i"Type of the synthetic '$canThrowType' clause is '$genericType'")
+
+    // Build the MethodTypeCompanion
+    val isErased = canThrowType is Flags.Erased
+    val companion = MethodType.companion(isContextual = true, isErased = isErased)
+
+    // TODO : Maybe use MethodType::fromSymbols instead of creating it from scratch ?
+    val syntheticClause = CachedMethodType(companion.syntheticParamNames(1))(_ => genericType :: Nil, _ => resType, companion)
+    saferExceptions.println(i"The synthetic clause is '$syntheticClause'")
+    syntheticClause

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3489,6 +3489,17 @@ object Types {
     /** Like `make`, but also supports higher-kinded types as argument */
     def makeHk(tp1: Type, tp2: Type)(using Context): Type =
       TypeComparer.liftIfHK(tp1, tp2, OrType(_, _, soft = true), makeHk, _ & _)
+
+    /**
+     * Recursively split an OrType
+     * @param tp
+     * @return
+     */
+    def split(tp: Type): List[Type] =
+      tp match
+        case OrType(lhs, rhs) => split(lhs) ::: split(rhs)
+        case _ => tp :: Nil
+    
   }
 
   /** An extractor object to pattern match against a nullable union.

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -21,6 +21,9 @@ import reporting._
 import dotty.tools.dotc.util.SourceFile
 import util.Spans._
 import scala.collection.mutable.ListBuffer
+import scala.runtime.stdLibPatches.language.experimental.saferExceptions
+import dotty.tools.dotc.printing.Printer
+import dotty.tools.dotc.config.Printers.saferExceptions as sfp
 
 object JavaParsers {
 
@@ -543,11 +546,12 @@ object JavaParsers {
       }
     }
 
-    def optThrows(): Unit =
+    def optThrows(): List[Tree] =
       if (in.token == THROWS) {
         in.nextToken()
         repsep(() => typ(), COMMA)
       }
+      Nil
 
     def methodBody(): Tree = atSpan(in.offset) {
       skipAhead()
@@ -576,11 +580,16 @@ object JavaParsers {
       if (in.token == LPAREN && rtptName != nme.EMPTY && !inInterface) {
         // constructor declaration
         val vparams = formalParams()
-        optThrows()
+        val exceptions = optThrows()
+        val throwsAnnotation =
+          for exc <- exceptions yield
+            val annot = genThrowsAnnotation(exc)
+            sfp.println(i"[JavaParsers] Parser will add ($annot) annotation in ${nme.CONSTRUCTOR}")
+            annot
         List {
           atSpan(start) {
             DefDef(nme.CONSTRUCTOR, joinParams(tparams, List(vparams)),
-                   TypeTree(), methodBody()).withMods(mods)
+                   TypeTree(), methodBody()).withMods(mods.withAnnotations(throwsAnnotation))
           }
         }
       }
@@ -593,7 +602,14 @@ object JavaParsers {
           // method declaration
           val vparams = formalParams()
           if (!isVoid) rtpt = optArrayBrackets(rtpt)
-          optThrows()
+          val exceptions = optThrows()
+          mods1 = mods1.withAnnotations{
+            for exc <- exceptions yield
+              val annot = genThrowsAnnotation(exc)
+              sfp.println(i"[JavaParsers] Parser will add ($annot) annotation in $name")
+              annot
+          }
+
           val bodyOk = !inInterface || mods.isOneOf(Flags.DefaultMethod | Flags.JavaStatic | Flags.Private)
           val body =
             if (bodyOk && in.token == LBRACE)
@@ -629,6 +645,9 @@ object JavaParsers {
         }
       }
     }
+
+    def genThrowsAnnotation(tpe: Tree) : Tree =
+      Apply(Select(New(Ident(tpnme.throws)), nme.CONSTRUCTOR), tpe :: Nil)
 
     /** Parse a sequence of field declarations, separated by commas.
       *  This one is tricky because a comma might also appear in an

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3599,7 +3599,7 @@ object Parsers {
         if(isIdent(nme.throws))
           in.nextToken()
           val except = commaSeparated(() => toplevelTyp())
-          Printers.saferExceptions.println(i"exceptions thrown are : $except")
+          Printers.saferExceptions.println(i"Parser will add a throws clause for the given exceptions : $except")
           except
         else
           Nil

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3595,13 +3595,20 @@ object Parsers {
      * @return A List of all the exceptions allowed to be thrown
      */
     def throwsClauseOpt : List[Tree] =
-      if in.featureEnabled(Feature.saferExceptions) then
-        if(isIdent(nme.throws))
-          in.nextToken()
-          val except = commaSeparated(() => toplevelTyp())
-          Printers.saferExceptions.println(i"Parser will add a throws clause for the given exceptions : $except")
+      val startOffset = in.offset
+      if (isIdent(nme.throws))
+        in.nextToken()
+        val except = commaSeparated(() => toplevelTyp())
+        Printers.saferExceptions.println(i"Parser will add a throws clause for the given exceptions : $except")
+        if in.featureEnabled(Feature.saferExceptions) then
           except
         else
+          report.error(
+            em"""
+                |This syntax is part of the 'safer exceptions' project. To enable it, please add
+                |the following import :
+                |   import scala.language.experimental.saferExceptions
+                |""".stripMargin, source.atSpan(Span(startOffset, in.offset)))
           Nil
       else
         Nil

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3576,13 +3576,24 @@ object Parsers {
             if (!isExprIntro) syntaxError(MissingReturnType(), in.lastOffset)
             accept(EQUALS)
             expr()
-
-        val ddef = DefDef(name, joinParams(tparams, vparamss), tpt, rhs)
+        val tpe =
+          if exceptions.nonEmpty then
+            ThrowsReturn(exceptions, tpt)
+          else
+            tpt
+        val ddef = DefDef(name, joinParams(tparams, vparamss), tpe, rhs)
         if (isBackquoted(ident)) ddef.pushAttachment(Backquoted, ())
         finalizeDef(ddef, mods1, start)
       }
     }
 
+    /**
+     * Parse a 'throws' declaration.
+     * If the saferException feature is disabled, this function
+     * will return Nil.
+     * ThrowsClause := (throws toplevelTyp (, toplevelTyp)*)?
+     * @return A List of all the exceptions allowed to be thrown
+     */
     def throwsClauseOpt : List[Tree] =
       if in.featureEnabled(Feature.saferExceptions) then
         if(isIdent(nme.throws))

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -948,7 +948,7 @@ trait Applications extends Compatibility {
         val capabities = for e <- exceptions yield checkCanThrow(e, tree.span)
         if exceptions.nonEmpty then
           report.warning(
-            i""" A function was called (${sym.name}) in a context where safer exceptions is enabled.
+            em""" A function was called (${sym.name}) in a context where safer exceptions is enabled.
                 | This function throws an exception.
                 | ${exceptions zip capabities}
                 |""".stripMargin, tree.srcPos)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -919,11 +919,6 @@ trait Applications extends Compatibility {
    */
   def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree = {
 
-    def splitOr(tpe: Type): List[Type] =
-      tpe match
-        case OrType(lhs, rhs) => splitOr(lhs) ::: splitOr(rhs)
-        case _ => tpe :: Nil
-
     def realApply(using Context): Tree = {
       val resultProto = tree.fun match
         case Select(New(tpt), _) if pt.isInstanceOf[ValueType] =>
@@ -944,7 +939,7 @@ trait Applications extends Compatibility {
         val sym: Symbol = fun1.symbol
         val annot = sym.annotations
         val throwsAnnot = annot.filter(ThrownException.unapply(_).isDefined)
-        val exceptions = throwsAnnot.map(ThrownException.unapply(_).get).flatMap(splitOr)
+        val exceptions = throwsAnnot.map(ThrownException.unapply(_).get).flatMap(OrType.split)
         saferExceptions.println(i"symbol $sym throws $exceptions")
         val capabities = for e <- exceptions yield checkCanThrow(e, tree.span)
         saferExceptions.println(i"fetch capabilities $capabities to satisfy conditions of $sym")

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -941,6 +941,7 @@ trait Applications extends Compatibility {
         val throwsAnnot = annot.filter(ThrownException.unapply(_).isDefined)
         val exceptions = throwsAnnot.map(ThrownException.unapply(_).get).flatMap(OrType.split)
         saferExceptions.println(i"symbol $sym throws $exceptions")
+        // TODO HR : Still need to add those capabilities in the capture set
         val capabities = for e <- exceptions yield checkCanThrow(e, tree.span)
         saferExceptions.println(i"fetch capabilities $capabities to satisfy conditions of $sym")
         if exceptions.nonEmpty then

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -945,7 +945,9 @@ trait Applications extends Compatibility {
         val annot = sym.annotations
         val throwsAnnot = annot.filter(ThrownException.unapply(_).isDefined)
         val exceptions = throwsAnnot.map(ThrownException.unapply(_).get).flatMap(splitOr)
+        saferExceptions.println(i"symbol $sym throws $exceptions")
         val capabities = for e <- exceptions yield checkCanThrow(e, tree.span)
+        saferExceptions.println(i"fetch capabilities $capabities to satisfy conditions of $sym")
         if exceptions.nonEmpty then
           report.warning(
             em""" A function was called (${sym.name}) in a context where safer exceptions is enabled.

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -2,46 +2,45 @@ package dotty.tools
 package dotc
 package typer
 
-import core._
-import ast._
-import Contexts._
-import Types._
-import Flags._
-import Names._
-import StdNames._
-import Symbols._
-import Trees._
-import ProtoTypes._
-import Scopes._
-import CheckRealizable._
+import core.*
+import ast.*
+import Contexts.*
+import Types.*
+import Flags.*
+import Names.*
+import StdNames.*
+import Symbols.*
+import Trees.*
+import ProtoTypes.*
+import Scopes.*
+import CheckRealizable.*
 import ErrorReporting.errorTree
 import util.Spans.Span
 import Phases.refchecksPhase
 import Constants.Constant
-
 import util.SrcPos
 import util.Spans.Span
 import rewrites.Rewrites.patch
 import inlines.Inlines
-import transform.SymUtils._
-import transform.ValueClasses._
-import Decorators._
+import transform.SymUtils.*
+import transform.ValueClasses.*
+import Decorators.*
 import ErrorReporting.{err, errorType}
-import config.Printers.{typr, patmatch}
+import config.Printers.{patmatch, saferExceptions, typr}
 import NameKinds.DefaultGetterName
-import NameOps._
+import NameOps.*
 import SymDenotations.{NoCompleter, NoDenotation}
 import Applications.unapplyArgs
 import Inferencing.isFullyDefined
 import transform.patmat.SpaceEngine.isIrrefutable
 import config.Feature
 import config.Feature.sourceVersion
-import config.SourceVersion._
+import config.SourceVersion.*
 import printing.Formatting.hlAsKeyword
 import transform.TypeUtils.*
 
 import collection.mutable
-import reporting._
+import reporting.*
 
 object Checking {
   import tpd._
@@ -1462,6 +1461,7 @@ trait Checking {
    */
   def checkCanThrow(tp: Type, span: Span)(using Context): Tree =
     if Feature.enabled(Feature.saferExceptions) && tp.isCheckedException then
+      saferExceptions.println(i"checking if CanThrow is in scope for type $tp")
       ctx.typer.implicitArgTree(defn.CanThrowClass.typeRef.appliedTo(tp), span)
     else
       EmptyTree

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1277,7 +1277,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if (ctx.mode is Mode.Type) typedFunctionType(tree, pt)
     else typedFunctionValue(tree, pt)
 
-  // TODO HR : Change this function to infer the return type before desugaring a throws clause
   def typedFunctionType(tree: untpd.Function, pt: Type)(using Context): Tree = {
     val untpd.Function(args, body) = tree
     var funFlags = tree match {
@@ -1343,7 +1342,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     }
   }
 
-  // TODO HR : Change this function to infer the return type before desugaring a throws clause
   def typedFunctionValue(tree: untpd.Function, pt: Type)(using Context): Tree = {
     val untpd.Function(params: List[untpd.ValDef] @unchecked, _) = tree: @unchecked
 
@@ -1859,7 +1857,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       val capabilityProof = caughtExceptions.reduce(OrType(_, _, true))
       untpd.Block(makeCanThrow(capabilityProof), expr)
 
-  // TODO HR : Change this to infer all the CanThrow capabilities instead of the desugar
   def typedTry(tree: untpd.Try, pt: Type)(using Context): Try = {
     val expr2 :: cases2x = harmonic(harmonize, pt) {
       val cases1 = typedCases(tree.cases, EmptyTree, defn.ThrowableType, pt.dropIfProto)
@@ -1871,7 +1868,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     assignType(cpy.Try(tree)(expr2, cases2, finalizer1), expr2, cases2)
   }
 
-    // TODO HR : Change this to infer all the CanThrow capabilities instead of the desugar
   def typedTry(tree: untpd.ParsedTry, pt: Type)(using Context): Try =
     val cases: List[untpd.CaseDef] = tree.handler match
       case Match(EmptyTree, cases) => cases
@@ -1881,7 +1877,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         desugar.makeTryCase(handler1) :: Nil
     typedTry(untpd.Try(tree.expr, cases, tree.finalizer).withSpan(tree.span), pt)
 
-  // TODO HR : Maybe change it if we want to infer the throws annotation
   def typedThrow(tree: untpd.Throw)(using Context): Tree =
     val expr1 = typed(tree.expr, defn.ThrowableType)
     val cap = checkCanThrow(expr1.tpe.widen, tree.span)
@@ -1987,7 +1982,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     assignType(cpy.RefinedTypeTree(tree)(tpt1, refinements1), tpt1, refinements1, refineCls)
   }
 
-    // TODO HR : Remove anything related to the infix type $throws
   def typedAppliedTypeTree(tree: untpd.AppliedTypeTree)(using Context): Tree = {
     tree.args match
       case arg :: _ if arg.isTerm =>
@@ -2312,8 +2306,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     vdef1.setDefTree
   }
 
-  // TODO HR : Should we modifiy this function,
-  // TODO HR : Yes, if we want to infer the throws clauses too
   def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(using Context): Tree = {
     if (!sym.info.exists) { // it's a discarded synthetic case class method, drop it
       assert(sym.is(Synthetic) && desugar.isRetractableCaseClassMethodName(sym.name))

--- a/library/src/scala/CanThrow.scala
+++ b/library/src/scala/CanThrow.scala
@@ -2,12 +2,13 @@ package scala
 import language.experimental.erasedDefinitions
 import annotation.{implicitNotFound, experimental, capability}
 
-/** A capability class that allows to throw exception `E`. When used with the
+/**
+ * A capability class that allows to throw exception `E`. When used with the
  *  experimental.saferExceptions feature, a `throw Ex()` expression will require
  *  a given of class `CanThrow[Ex]` to be available.
  */
 @experimental @capability
-@implicitNotFound("The capability to throw exception ${E} is missing.\nThe capability can be provided by one of the following:\n - Adding a using clause `(using CanThrow[${E}])` to the definition of the enclosing method\n - Adding `throws ${E}` clause after the result type of the enclosing method\n - Wrapping this piece of code with a `try` block that catches ${E}")
+@implicitNotFound("The capability to throw exception of type ${E} is missing.\nThe capability can be provided by one of the following:\n - Adding `throws ${E}` clause after the parameter list of the enclosing method\n - Adding `throws ${E}` clause after the result type of the enclosing method\n - Wrapping this piece of code with a `try` block that catches ${E}")
 erased class CanThrow[-E <: Exception]
 
 @experimental

--- a/library/src/scala/CanThrow.scala
+++ b/library/src/scala/CanThrow.scala
@@ -11,6 +11,11 @@ import annotation.{implicitNotFound, experimental, capability}
 erased class CanThrow[-E <: Exception]
 
 @experimental
+object CanThrow:
+  def apply[A <: Exception, B <: Exception](ct1: CanThrow[A], ct2: CanThrow[B]): CanThrow[A | B] =
+    compiletime.erasedValue
+
+@experimental
 object unsafeExceptions:
   given canThrowAny: CanThrow[Exception] = compiletime.erasedValue
 

--- a/tests/safer-exceptions/neg/t01.scala
+++ b/tests/safer-exceptions/neg/t01.scala
@@ -1,0 +1,5 @@
+import java.io.IOException
+
+class GenericExc[T] extends Exception
+
+def test throws IOException, GenericExc[Int] : Unit = ()

--- a/tests/safer-exceptions/neg/t01.scala
+++ b/tests/safer-exceptions/neg/t01.scala
@@ -1,5 +1,9 @@
 import java.io.IOException
 
-class GenericExc[T] extends Exception
-
 def test throws IOException, GenericExc[Int] : Unit = ()
+/*
+-- [E040] Syntax Error: tests\safer-exceptions\neg\t01.scala:5:9 ---------------
+  5 |def test throws IOException, GenericExc[Int] : Unit = ()
+  |         ^^^^^^
+  |         '=' expected, but identifier found
+*/

--- a/tests/safer-exceptions/pos/JavaTestFile.java
+++ b/tests/safer-exceptions/pos/JavaTestFile.java
@@ -1,9 +1,10 @@
 package test.saferExceptions.pos;
+import scala.language.experimental.captureChecking;
 
 import java.io.IOException;
 
 public class JavaTestFile {
 
-    public static void test() throws IOException {}
+    public static void javatest() throws IOException {}
 
 }

--- a/tests/safer-exceptions/pos/JavaTestFile.java
+++ b/tests/safer-exceptions/pos/JavaTestFile.java
@@ -1,0 +1,9 @@
+package test.saferExceptions.pos;
+
+import java.io.IOException;
+
+public class JavaTestFile {
+
+    public static void test() throws IOException {}
+
+}

--- a/tests/safer-exceptions/pos/t01.scala
+++ b/tests/safer-exceptions/pos/t01.scala
@@ -1,6 +1,20 @@
-import language.experimental.saferExceptions
+package test.saferExceptions.pos
+
+import language.experimental.{saferExceptions}
 import java.io.IOException
+import java.io.FileNotFoundException
 
 class GenericExc[T] extends Exception
 
-def test throws IOException, GenericExc[Int] : Unit = ()
+def test throws IOException, FileNotFoundException :Unit = throw new IOException("")
+
+// Main method cannot have implicit parameters nor return typpe
+// Why ? and how can we avoid this ?
+//@main def a(args : Array[String]) throws IOException : Unit =
+//  test
+
+trait AFoo :
+  def foo(x : Int) throws Exception : Int
+
+class Foo extends AFoo :
+  def foo(x : Int) throws IOException, FileNotFoundException : Int = x

--- a/tests/safer-exceptions/pos/t01.scala
+++ b/tests/safer-exceptions/pos/t01.scala
@@ -1,12 +1,21 @@
 package test.saferExceptions.pos
 
-import language.experimental.{saferExceptions}
+import language.experimental.saferExceptions
 import java.io.IOException
+import java.io.FileInputStream
 import java.io.FileNotFoundException
 
-class GenericExc[T] extends Exception
+class ScalaException extends Exception
 
-def test throws IOException, FileNotFoundException :Unit = throw new IOException("")
+def test() throws ScalaException :Unit = throw new ScalaException
+/*
+-- Warning: tests\safer-exceptions\pos\t01.scala:8:29 --------------------------
+8 |class ScalaException extends Exception
+  |                             ^^^^^^^^^
+  | A Java function was called (<init>) in a context where safer exceptions is enabled.
+  | This function might throw an exception.
+  | Handling of Java method is yet to be implemented.
+*/
 
 // Main method cannot have implicit parameters nor return typpe
 // Why ? and how can we avoid this ?

--- a/tests/safer-exceptions/pos/t01.scala
+++ b/tests/safer-exceptions/pos/t01.scala
@@ -1,0 +1,6 @@
+import language.experimental.saferExceptions
+import java.io.IOException
+
+class GenericExc[T] extends Exception
+
+def test throws IOException, GenericExc[Int] : Unit = ()

--- a/tests/safer-exceptions/pos/t01.scala
+++ b/tests/safer-exceptions/pos/t01.scala
@@ -7,7 +7,10 @@ import java.io.FileNotFoundException
 
 class ScalaException extends Exception
 
+@throws[IOException | ScalaException]
 def test() throws ScalaException :Unit = throw new ScalaException
+
+def tt throws ScalaException, IOException: Unit = test()
 /*
 -- Warning: tests\safer-exceptions\pos\t01.scala:8:29 --------------------------
 8 |class ScalaException extends Exception
@@ -23,7 +26,7 @@ def test() throws ScalaException :Unit = throw new ScalaException
 //  test
 
 trait AFoo :
-  def foo(x : Int) throws Exception : Int
+  def foo(x : Int) throws Exception : Unit = tt
 
 class Foo extends AFoo :
-  def foo(x : Int) throws IOException, FileNotFoundException : Int = x
+  override def foo(x : Int) throws Exception : Unit = ???

--- a/tests/safer-exceptions/pos/t02.scala
+++ b/tests/safer-exceptions/pos/t02.scala
@@ -1,9 +1,16 @@
 package test.saferExceptions.pos
 
 import language.experimental.saferExceptions
+import language.experimental.captureChecking
 import test.saferExceptions.pos.JavaTestFile
 
-def checkJavaFunction : Unit = JavaTestFile.test()
+given a :CanThrow[Exception] = compiletime.erasedValue
+//given b :CanThrow[Exception] = compiletime.erasedValue
+
+@throws[Exception]
+def checkJavaFunction() throws Exception: Unit =
+  //given c :CanThrow[Exception] = compiletime.erasedValue
+  JavaTestFile.javatest()
 /*
 -- Warning: tests\safer-exceptions\pos\t02.scala:6:48 --------------------------
 6 |def checkJavaFunction : Unit = JavaTestFile.test()
@@ -13,3 +20,6 @@ def checkJavaFunction : Unit = JavaTestFile.test()
   | Handling of Java method is yet to be implemented.
 
 */
+
+def aa throws Exception: Unit =
+  checkJavaFunction()

--- a/tests/safer-exceptions/pos/t02.scala
+++ b/tests/safer-exceptions/pos/t02.scala
@@ -1,0 +1,15 @@
+package test.saferExceptions.pos
+
+import language.experimental.saferExceptions
+import test.saferExceptions.pos.JavaTestFile
+
+def checkJavaFunction : Unit = JavaTestFile.test()
+/*
+-- Warning: tests\safer-exceptions\pos\t02.scala:6:48 --------------------------
+6 |def checkJavaFunction : Unit = JavaTestFile.test()
+  |                               ^^^^^^^^^^^^^^^^^^^
+  | A Java function was called (test) in a context where safer exceptions is enabled.
+  | This function might throw an exception.
+  | Handling of Java method is yet to be implemented.
+
+*/

--- a/tests/safer-exceptions/pos/t03.scala
+++ b/tests/safer-exceptions/pos/t03.scala
@@ -1,13 +1,16 @@
 import language.experimental.saferExceptions
-import java.io.*
 
-def multipleErrors() throws IOException, SecurityException : Int = ???
+class A extends Exception
+class B extends Exception
+class C extends Exception
+def multipleErrors() throws A, B, C : Int = ???
 
-@main def main : Int =
+def main : Int =
   try
     try
       multipleErrors()
     catch
-      case _: IOException => ???
+      case _: A => ???
   catch
-    case _: SecurityException => ???
+    case _: B => ???
+    case _: C => ???

--- a/tests/safer-exceptions/pos/t03.scala
+++ b/tests/safer-exceptions/pos/t03.scala
@@ -1,0 +1,13 @@
+import language.experimental.saferExceptions
+import java.io.*
+
+def multipleErrors() throws IOException, SecurityException : Int = ???
+
+@main def main : Int =
+  try
+    try
+      multipleErrors()
+    catch
+      case _: IOException => ???
+  catch
+    case _: SecurityException => ???

--- a/tests/safer-exceptions/t04.scala
+++ b/tests/safer-exceptions/t04.scala
@@ -1,10 +1,10 @@
-import scala.language.experimental.saferExceptions
+//import scala.language.experimental.saferExceptions
 
-@throws[Exception]
-def test : Int = ???
+//@throws[Exception]
+def test throws Exception : Int = ???
 
 def main : Int =
-  //try
-  test
-  //catch
-  //  case _: Exception => ???
+  try
+    test
+  catch
+    case _: Exception => ???

--- a/tests/safer-exceptions/t04.scala
+++ b/tests/safer-exceptions/t04.scala
@@ -1,0 +1,10 @@
+import scala.language.experimental.saferExceptions
+
+@throws[Exception]
+def test : Int = ???
+
+def main : Int =
+  //try
+  test
+  //catch
+  //  case _: Exception => ???


### PR DESCRIPTION
This PR improve the implementation of _safer exceptions_ as introduced in Scala 3.1 (see PR #11721 by @odersky).

The suggested implementation completes the _safer exceptions_ project by adding missing checks. The following changes have been added:

- [X] Changes to the syntax to allow throws clauses in function definition. When enabling the _safer exceptions_ feature, the following function definition is allowed : `def foo throws Exception = ???`
- [X] Fix overriding problems when functions throws exceptions
- [X] Drop _contextual parameter lists_ to bring a [`CanThrow`](https://docs.scala-lang.org/scala3/reference/experimental/canthrow.html) capabilities into a certain scope
- [X] Favor _contextual functions_ and [_union types_](https://docs.scala-lang.org/scala3/reference/new-types/union-types.html) when desugaring throws clauses
- [X] Change the semantics of _implicit search_ of `CanThrow` capabilities
- [ ] Add to the bytecode the exceptions a function might throw
- [X] Require a `CanThrow` capability for all function annotated with the [`@throws`](https://scala-lang.org/api/3.1.0/scala/throws.html) annotation
- [ ] Add override checks for methods with `@throws` annotations
- [ ] Implement special handling for `CanThrow` capabilities for [main-methods](https://docs.scala-lang.org/scala3/reference/changed-features/main-functions.html)
- [X] Change the semantics of the [`$throws`](https://scala-lang.org/api/3.1.0/scala/runtime.html#$throws-0) infix type to reflect the changes
- [ ] Add "ghost" capabilities to the corresponding capture set

- Syntax changes - `throws` clauses : When enabled, the following code is accepted 
```scala
import scala.language.experimental.saferExceptions

class A extends Exception
class B extends Exception

// New syntax to declare checked exceptions
def foo throws A, B = ???

// Declare checked exceptions using $throws infix type
def foo : Unit throws A | B = ???

// Desugared representation of both syntaxes
def foo : CanThrow[A | B] ?=> Unit = ???
```

- `@throws` annotation : The following function declarations are equivalent
```scala
@throws[Exception]
def foo : Unit = ???

def foo throws Exception : Unit = ???
```

Please note that this PR is part of my semester project in @lampepfl. The project was done under the supervison of @abgruszecki and @odersky.