### PR TITLE
Optimization experiment: Drop Symbol class

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1213,10 +1213,11 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
     def genLoadModule(tree: Tree): BType = {
       val module = (
         if (!tree.symbol.is(PackageClass)) tree.symbol
-        else tree.symbol.info.member(nme.PACKAGE).symbol match {
-          case NoSymbol => abort(s"SI-5604: Cannot use package as value: $tree")
-          case s        => abort(s"SI-5604: found package class where package object expected: $tree")
-        }
+        else
+          val s = tree.symbol.info.member(nme.PACKAGE).symbol
+          if s.exists
+          then abort(s"SI-5604: found package class where package object expected: $tree")
+          else abort(s"SI-5604: Cannot use package as value: $tree")
       )
       lineNumber(tree)
       genLoadModule(module)

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -87,7 +87,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     var cnode: ClassNode1          = null
     var thisName: String           = null // the internal name of the class being emitted
 
-    var claszSymbol: Symbol        = null
+    var claszSymbol: Symbol        = _
     var isCZParcelable             = false
     var isCZStaticModule           = false
 
@@ -364,9 +364,9 @@ trait BCodeSkelBuilder extends BCodeHelpers {
     var jMethodName: String        = null
     var isMethSymStaticCtor        = false
     var returnType: BType          = null
-    var methSymbol: Symbol         = null
+    var methSymbol: Symbol         = _
     // used by genLoadTry() and genSynchronized()
-    var earlyReturnVar: Symbol     = null
+    var earlyReturnVar: Symbol | Null = null
     var shouldEmitCleanup          = false
     // stack tracking
     var stackHeight                = 0

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -585,7 +585,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
   }
 
   private def reportCannotDisambiguateError(jsName: JSName, alts: List[Symbol]): Unit = {
-    val currentClass = currentClassSym.get
+    val currentClass = currentClassSym.get.nn
 
     /* Find a position that is in the current class for decent error reporting.
      * If there are more than one, always use the "highest" one (i.e., the
@@ -623,7 +623,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
    */
   private def genApplyForSingleExported(formalArgsRegistry: FormalArgsRegistry,
       exported: Exported, static: Boolean): js.Tree = {
-    if (currentClassSym.isJSType && exported.sym.owner != currentClassSym.get) {
+    if (currentClassSym.get.nn.isJSType && exported.sym.owner != currentClassSym.get) {
       assert(!static, s"nonsensical JS super call in static export of ${exported.sym}")
       genApplyForSingleExportedJSSuperCall(formalArgsRegistry, exported)
     } else {
@@ -642,7 +642,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
     val allArgs = formalArgsRegistry.genAllArgsRefsForForwarder()
 
     val superClass = {
-      val superClassSym = currentClassSym.asClass.superClass
+      val superClassSym = currentClassSym.get.nn.asClass.superClass
       if (superClassSym.isNestedJSClass)
         js.VarRef(js.LocalIdent(JSSuperClassParamName))(jstpe.AnyType)
       else
@@ -806,7 +806,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
       implicit pos: SourcePosition): js.Tree = {
 
     val sym = exported.sym
-    val currentClass = currentClassSym.get
+    val currentClass = currentClassSym.get.nn
 
     def receiver =
       if (static) genLoadModule(sym.owner)

--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -7,6 +7,7 @@ import Types._, Contexts._, Flags._
 import Symbols._, Annotations._, Trees._, Symbols._, Constants.Constant
 import Decorators._
 import dotty.tools.dotc.transform.SymUtils._
+import Symbols.TypeTests.given
 
 /** A map that applies three functions and a substitution together to a tree and
  *  makes sure they are coordinated so that the result is well-typed. The functions are

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -10,6 +10,7 @@ import config.Printers.capt
 import util.Property.Key
 import tpd.*
 import config.Feature
+import Symbols.TypeTests.given
 
 private val Captures: Key[CaptureSet] = Key()
 private val BoxedType: Key[BoxedTypeCache] = Key()

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -12,6 +12,7 @@ import transform.Recheck.*
 import CaptureSet.IdentityCaptRefMap
 import Synthetics.isExcluded
 import util.Property
+import Symbols.TypeTests.given
 
 /** A tree traverser that prepares a compilation unit to be capture checked.
  *  It does the following:

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -7,6 +7,7 @@ import ast.tpd, tpd.*
 import util.Spans.Span
 import printing.{Showable, Printer}
 import printing.Texts.Text
+import Symbols.TypeTests.given
 
 import scala.annotation.internal.sharable
 
@@ -194,7 +195,7 @@ object Annotations {
   object Annotation {
 
     def apply(tree: Tree): ConcreteAnnotation = ConcreteAnnotation(tree)
-    
+
     def apply(cls: ClassSymbol, span: Span)(using Context): Annotation =
       apply(cls, Nil, span)
 
@@ -206,7 +207,7 @@ object Annotations {
 
     def apply(atp: Type, arg: Tree, span: Span)(using Context): Annotation =
       apply(atp, arg :: Nil, span)
-    
+
     def apply(atp: Type, args: List[Tree], span: Span)(using Context): Annotation =
       apply(New(atp, args).withSpan(span))
 

--- a/compiler/src/dotty/tools/dotc/core/Comments.scala
+++ b/compiler/src/dotty/tools/dotc/core/Comments.scala
@@ -428,9 +428,8 @@ object Comments {
      *  @param vble  The variable for which a definition is searched
      *  @param site  The class for which doc comments are generated
      */
-    def lookupVariable(vble: String, site: Symbol)(using Context): Option[String] = site match {
-      case NoSymbol => None
-      case _        =>
+    def lookupVariable(vble: String, site: Symbol)(using Context): Option[String] =
+      if site.exists then
         val searchList =
           if (site.flags.is(Flags.Module)) site :: site.info.baseClasses
           else site.info.baseClasses
@@ -439,7 +438,7 @@ object Comments {
           case Some(str) if str startsWith "$" => lookupVariable(str.tail, site)
           case res                             => res orElse lookupVariable(vble, site.owner)
         }
-    }
+      else None
 
     /** The position of the raw doc comment of symbol `sym`, or NoPosition if missing
      *  If a symbol does not have a doc comment but some overridden version of it does,

--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -5,6 +5,7 @@ import Contexts._, Symbols._, Types._, Flags._
 import Denotations._, SymDenotations._
 import Names.Name, StdNames.nme
 import ast.untpd
+import Symbols.TypeTests.given
 
 /** Extension methods for contexts where we want to keep the ctx.<methodName> syntax */
 object ContextOps:

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -226,7 +226,8 @@ object Contexts {
      */
     def effectiveScope(using Context): Scope =
       val myOwner: Symbol | Null = owner
-      if myOwner != null && myOwner.isClass then myOwner.asClass.unforcedDecls
+      if myOwner != null && myOwner.uncheckedNN.isClass
+      then myOwner.uncheckedNN.asClass.unforcedDecls
       else scope
 
     def nestingLevel: Int = effectiveScope.nestingLevel

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1319,7 +1319,7 @@ class Definitions {
           // Inline symbols contain trees in annotations, which is coupled
           // with the underlying symbol.
           // Changing owner for inline symbols is a simple workaround.
-          patch.denot = patch.denot.copySymDenotation(owner = denot.symbol)
+          patch.denot_=(patch.denot.copySymDenotation(owner = denot.symbol))
           patch
         else
           // change `info` which might contain reference to the patch

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -750,7 +750,9 @@ object Denotations {
           if acceptStale(symd) && symd.initial.validFor.firstPhaseId <= ctx.lastPhaseId then
             // New run might have fewer phases than old, so symbol might no longer be
             // visible at all. TabCompleteTests have examples where this happens.
-            return symd.currentSymbol.denot.orElse(symd).updateValidity()
+            val newd = symd.currentSymbol.denot.orElse(symd).updateValidity()
+            if newd ne symd then symd.common.reset() // to avoid memory leaks
+            return newd
         case _ =>
       }
       if (!symbol.exists) return updateValidity()

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -237,6 +237,7 @@ object Denotations {
     final def validFor: Period = myValidFor
     final def validFor_=(p: Period): Unit =
       myValidFor = p
+      symbol.setCheckedPeriod(Nowhere): @unchecked
 
     /** Is this denotation different from NoDenotation or an ErrorDenotation? */
     def exists: Boolean = true

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -176,11 +176,16 @@ object Denotations {
    *
    *  Then the denotation of `y` is `SingleDenotation(NoSymbol, A | B)`.
    *
-   *  @param symbol  The referencing symbol, or NoSymbol is none exists
+   *  @param symbolHint The referencing symbol, or NoSymbol is none exists,
+   *                    or null, if the Denotation itself is the symbol.
    */
-  abstract class Denotation(val symbol: Symbol, protected var myInfo: Type, val isType: Boolean)
+  abstract class Denotation(symbolHint: Symbol | Null, protected var myInfo: Type, val isType: Boolean)
   extends PreDenotation, Named, printing.Showable {
     type AsSeenFromResult <: Denotation
+
+    val symbol: Symbol =
+      if symbolHint != null then symbolHint
+      else this.asInstanceOf[Symbol]
 
     /** The type info.
      *  The info is an instance of TypeType iff this is a type denotation
@@ -579,7 +584,7 @@ object Denotations {
   end infoMeet
 
   /** A non-overloaded denotation */
-  abstract class SingleDenotation(symbol: Symbol, initInfo: Type, isType: Boolean) extends Denotation(symbol, initInfo, isType) {
+  abstract class SingleDenotation(symbolHint: Symbol | Null, initInfo: Type, isType: Boolean) extends Denotation(symbolHint, initInfo, isType) {
     protected def newLikeThis(symbol: Symbol, info: Type, pre: Type, isRefinedMethod: Boolean): SingleDenotation
 
     final def name(using Context): ThisName = symbol.name.asInstanceOf[ThisName]

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -184,8 +184,7 @@ object Denotations {
     type AsSeenFromResult <: Denotation
 
     val symbol: Symbol =
-      if symbolHint != null then symbolHint
-      else this.asInstanceOf[Symbol]
+      (if symbolHint != null then symbolHint else this).asInstanceOf[Symbol]
 
     /** The type info.
      *  The info is an instance of TypeType iff this is a type denotation

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -234,7 +234,8 @@ object Denotations {
     final def validFor: Period = myValidFor
     final def validFor_=(p: Period): Unit = {
       myValidFor = p
-      symbol.invalidateDenotCache()
+      if symbol.initialDenot ne null then
+        symbol.initialDenot.checkedPeriod = Nowhere
     }
 
     /** Is this denotation different from NoDenotation or an ErrorDenotation? */

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -235,11 +235,8 @@ object Denotations {
     private var myValidFor: Period = Nowhere
 
     final def validFor: Period = myValidFor
-    final def validFor_=(p: Period): Unit = {
+    final def validFor_=(p: Period): Unit =
       myValidFor = p
-      if symbol.initialDenot ne null then
-        symbol.initialDenot.checkedPeriod = Nowhere
-    }
 
     /** Is this denotation different from NoDenotation or an ErrorDenotation? */
     def exists: Boolean = true

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -74,7 +74,6 @@ object Denotations {
 
   trait Named:
     type ThisName <: Name
-    def name(using Context): ThisName
 
   /** A PreDenotation represents a group of single denotations or a single multi-denotation
    *  It is used as an optimization to avoid forming MultiDenotations too eagerly.

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -84,9 +84,9 @@ class GadtConstraint private (
     }
 
   def externalize(tp: Type, theMap: TypeMap | Null = null)(using Context): Type = tp match
-    case param: TypeParamRef => reverseMapping(param) match
-      case sym: Symbol => sym.typeRef
-      case null        => param
+    case param: TypeParamRef =>
+      val sym = reverseMapping(param)
+      if sym != null then sym.typeRef else param
     case tp: TypeAlias       => tp.derivedAlias(externalize(tp.alias, theMap))
     case tp                  => (if theMap == null then ExternalizeMap() else theMap).mapOver(tp)
 

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -85,8 +85,8 @@ class GadtConstraint private (
 
   def externalize(tp: Type, theMap: TypeMap | Null = null)(using Context): Type = tp match
     case param: TypeParamRef =>
-      val sym = reverseMapping(param)
-      if sym != null then sym.typeRef else param
+      val sym: Symbol | Null = reverseMapping(param)
+      if sym != null then sym.uncheckedNN.typeRef else param
     case tp: TypeAlias       => tp.derivedAlias(externalize(tp.alias, theMap))
     case tp                  => (if theMap == null then ExternalizeMap() else theMap).mapOver(tp)
 

--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -5,6 +5,7 @@ package core
 import Contexts._, Symbols._, Types._, Flags._, Scopes._, Decorators._, Names._, NameOps._
 import SymDenotations.{LazyType, SymDenotation}, StdNames.nme
 import TypeApplications.EtaExpansion
+import Symbols.TypeTests.given
 
 /** Operations that are shared between Namer and TreeUnpickler */
 object NamerOps:

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -20,17 +20,12 @@ object Names {
    */
   type PreName = Name | String
 
-  /** A common superclass of Name and Symbol. After bootstrap, this should be
-   *  just the type alias Name | Symbol
-   */
-  abstract class Designator
-
   /** A name is either a term name or a type name. Term names can be simple
    *  or derived. A simple term name is essentially an interned string stored
    *  in a name table. A derived term name adds a tag, and possibly a number
    *  or a further simple name to some other name.
    */
-  abstract class Name extends Designator, Showable derives CanEqual {
+  abstract class Name extends Showable derives CanEqual {
 
     /** A type for names of the same kind as this name */
     type ThisName <: Name

--- a/compiler/src/dotty/tools/dotc/core/Periods.scala
+++ b/compiler/src/dotty/tools/dotc/core/Periods.scala
@@ -63,7 +63,7 @@ object Periods {
       //
       // Let's compute:
       //
-      //  lastDiff = X * 2^5 + (l1 - l2) mod 2^5
+      //  lastDiff = X * 2^7 + (l1 - l2) mod 2^7
       //             where X >= 0, X == 0 iff r1 == r2 & l1 - l2 >= 0
       //  result = lastDiff + d2 <= d1
       //  We have:
@@ -102,6 +102,13 @@ object Periods {
     def ==(that: Period): Boolean = this.code == that.code
     def !=(that: Period): Boolean = this.code != that.code
   }
+
+  /** Same as new Period(p1).contains(new Period(p2)), assuming that p2 is the
+   *  code of a single-phase period.
+   */
+  extension (p1: Int)
+    transparent inline def containsSinglePhasePeriod(p2: Int): Boolean =
+      ((p1 - p2) >>> PhaseWidth) <= (p1 & PhaseMask)
 
   object Period {
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1810,6 +1810,7 @@ object SymDenotations {
 
     /** The last denotation of this symbol */
     var lastDenot: SymDenotation = _
+    var checkedPeriod: Period = Nowhere
 
     /** Overridden in NoSymbol */
     //private[SymDenotations]
@@ -1819,11 +1820,13 @@ object SymDenotations {
     override def hashCode = common.id // for debugging
 
     /** The current denotation of this symbol */
-    def currentDenot(using Context): SymDenotation =
+    def computeDenot(using Context): SymDenotation =
       util.Stats.record("Symbol.denot")
       val valid = validFor.code
+      val now = ctx.period
+      symbol.setCheckedPeriod(now)
       // Next condition is inlined from Periods.containsSinglePhasePeriod
-      if ((valid - ctx.period.code) >>> PhaseWidth) <= (valid & PhaseMask)
+      if ((valid - now.code) >>> PhaseWidth) <= (valid & PhaseMask)
       then this
       else recomputeDenot()
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1600,7 +1600,7 @@ object SymDenotations {
 
     // ----- Sanity checks and debugging */
 
-    def debugString: String = toString + "#" + symbol.id // !!! DEBUG
+    def debugString: String = toString + "#" + common.id // !!! DEBUG
 
     def hasSkolems(tp: Type): Boolean = tp match {
       case tp: SkolemType => true

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1818,6 +1818,19 @@ object SymDenotations {
 
     override def hashCode = common.id // for debugging
 
+    /** The current denotation of this symbol */
+    def currentDenot(using Context): SymDenotation =
+      util.Stats.record("Symbol.denot")
+      val valid = validFor.code
+      // Next condition is inlined from Periods.containsSinglePhasePeriod
+      if ((valid - ctx.period.code) >>> PhaseWidth) <= (valid & PhaseMask)
+      then this
+      else recomputeDenot()
+
+    private def recomputeDenot()(using Context): SymDenotation =
+      util.Stats.record("Symbol.recomputeDenot")
+      symbol.setLastDenot(currentSymDenot)
+
     // ---- ParamInfo bindings -------------------------------------
 
     type ThisName <: Name

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2666,7 +2666,7 @@ object SymDenotations {
             if (!traceInvalid(owner)) explainSym("owner is invalid")
             else if (!owner.isClass || owner.isRefinementClass || denot.isSelfSym) true
             else if (owner.unforcedDecls.lookupAll(denot.name) contains denot.symbol) true
-            else explainSym(s"decls of ${show(owner)} are ${owner.unforcedDecls.lookupAll(denot.name).toList}, do not contain ${denot.symbol}")
+            else explainSym(s"decls of ${show(owner)} are ${owner.unforcedDecls.lookupAll(denot.name).toList.map(show(_))}, do not contain ${denot.symbol}")
           }
           catch {
             case ex: StaleSymbol => explainSym(s"$ex was thrown")

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -28,6 +28,7 @@ import transform.TypeUtils._
 import cc.{CapturingType, derivedCapturingType, Setup, EventuallyCapturingType, isEventuallyCapturingType}
 
 import scala.annotation.internal.sharable
+import Symbols.TypeTests.given
 
 object SymDenotations {
 
@@ -1993,7 +1994,7 @@ object SymDenotations {
     /** The explicitly given self type (self types of modules are assumed to be
      *  explcitly given here).
      */
-    def givenSelfType(using Context): Type = classInfo.selfInfo match {
+    def givenSelfType(using Context): Type = (classInfo.selfInfo: @unchecked) match { // !!! dotty problem: opaque exhaustive
       case tp: Type => tp
       case self: Symbol => self.info
     }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -67,7 +67,7 @@ object SymDenotations {
     initFlags: FlagSet,
     initInfo: Type,
     initPrivateWithin: Symbol = NoSymbol)
-  extends SingleDenotation(symbol, initInfo, name.isTypeName), ParamInfo, SrcPos {
+  extends SingleDenotation(symbol, initInfo, name.isTypeName), ParamInfo, SrcPos, Named {
 
     //assert(symbol.id != 4940, name)
 
@@ -601,19 +601,6 @@ object SymDenotations {
           myTargetName = myTargetName.nn.unmangle(List(ExpandedName, SuperAccessorName, ExpandPrefixName))
 
       myTargetName.nn
-
-    /** The source or class file from which this class or
-     *  the class containing this symbol was generated, null if not applicable.
-     *  Note that this the returned classfile might be the top-level class
-     *  containing this symbol instead of the directly enclosing class.
-     *  Overridden in ClassSymbol
-     */
-    def associatedFile(using Context): AbstractFile | Null =
-      topLevelClass.associatedFile
-
-    // ----- Symbol ops --------------------------------------------
-
-    override def hashCode = common.id // for debugging
 
     // ----- Tests -------------------------------------------------
 
@@ -1786,6 +1773,19 @@ object SymDenotations {
      */
     final def sealedDescendants(using Context): List[Symbol] = this.symbol :: sealedStrictDescendants
 
+    /** The source or class file from which this class or
+     *  the class containing this symbol was generated, null if not applicable.
+     *  Note that this the returned classfile might be the top-level class
+     *  containing this symbol instead of the directly enclosing class.
+     *  Overridden in ClassSymbol
+     */
+    def associatedFile(using Context): AbstractFile | Null =
+      topLevelClass.associatedFile
+
+    // ----- Symbol ops --------------------------------------------
+
+    override def hashCode = common.id // for debugging
+
     // ---- ParamInfo bindings -------------------------------------
 
     type ThisName <: Name
@@ -1810,6 +1810,10 @@ object SymDenotations {
       (if src.exists then src else ctx.source).atSpan(span)
     }
 
+    /** This positioned item, widened to `SrcPos`. Used to make clear we only need the
+     *  position, typically for error reporting.
+     */
+    final def srcPos: SrcPos = this
   }
 
   /** The contents of a class definition during a period
@@ -2662,6 +2666,7 @@ object SymDenotations {
     override def filterWithFlags(required: FlagSet, excluded: FlagSet)(using Context): SingleDenotation = this
     override def associatedFile(using Context): AbstractFile | Null = NoSource.file
 
+    NoSymbol.initialDenot = this
     NoSymbol.denot = this
     validFor = Period.allInRun(NoRunId)
   }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -80,7 +80,7 @@ object SymDenotations {
     initPrivateWithin: Symbol = NoSymbol)
   extends SingleDenotation(symbolHint, initInfo, name.isTypeName), ParamInfo, SrcPos, Named {
 
-    //assert(symbol.id != 4940, name)
+    //assert(common.id != 9141, name)
 
     override def hasUniqueSym: Boolean = exists
 
@@ -1810,7 +1810,6 @@ object SymDenotations {
 
     /** The last denotation of this symbol */
     var lastDenot: SymDenotation = _
-    var checkedPeriod: Period = Nowhere
 
     /** Overridden in NoSymbol */
     //private[SymDenotations]
@@ -2699,7 +2698,6 @@ object SymDenotations {
     override def filterWithFlags(required: FlagSet, excluded: FlagSet)(using Context): SingleDenotation = this
     override def associatedFile(using Context): AbstractFile | Null = NoSource.file
 
-    NoSymbol.initialDenot = this
     NoSymbol.denot_=(this)
     validFor = Period.allInRun(NoRunId)
   }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -92,7 +92,7 @@ object SymDenotations {
     if (Config.checkNoSkolemsInInfo) assertNoSkolems(initInfo)
 
     final def maybeOwner: Symbol =
-      if ownerOrNull == null then NoSymbol else ownerOrNull
+      if ownerOrNull == null then NoSymbol else ownerOrNull.asInstanceOf[Symbol]
 
     // ------ Getting and setting fields -----------------------------
 
@@ -104,7 +104,7 @@ object SymDenotations {
     /** The owner of the symbol; overridden in NoDenotation */
     final def owner: Symbol =
       assert(ownerOrNull != null, "NoDenotation.owner")
-      ownerOrNull
+      ownerOrNull.asInstanceOf[Symbol]
 
     /** The flag set */
     final def flags(using Context): FlagSet = { ensureCompleted(); myFlags }
@@ -1648,7 +1648,7 @@ object SymDenotations {
       val privateWithin1 = if (privateWithin != null) privateWithin else this.privateWithin
       val annotations1 = if (annotations != null) annotations else this.annotations
       val rawParamss1 = if rawParamss != null then rawParamss else this.rawParamss
-      val d = SymDenotation(symbol, symbol.lastKnownDenotation.common, owner, name, initFlags1, info1, privateWithin1)
+      val d = SymDenotation(symbol, symbol.lastKnownDenotation.common, owner, name, initFlags1, info1, privateWithin1.uncheckedNN)
       d.annotations = annotations1
       d.rawParamss = rawParamss1
       d.registeredCompanion = registeredCompanion

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -613,6 +613,8 @@ object SymDenotations {
 
     // ----- Symbol ops --------------------------------------------
 
+    override def hashCode = common.id // for debugging
+
     // ----- Tests -------------------------------------------------
 
     /** Is this denotation a class? */

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -43,7 +43,8 @@ object SymDenotations {
 
     //private[SymDenotations]
     var defTree: tpd.Tree | Null = null
-    //private[SymDenotations]
+    //private[SymDenotations
+    def isClass: Boolean = isInstanceOf[ClassCommon]
     def asClass: ClassCommon = asInstanceOf[ClassCommon]
 
     def reset() =
@@ -69,14 +70,14 @@ object SymDenotations {
    *  during a period.
    */
   class SymDenotation private[SymDenotations] (
-    symbol: Symbol,
+    symbolHint: Symbol | Null,
     final val common: SymCommon,
     final val maybeOwner: Symbol,
     final val name: Name,
     initFlags: FlagSet,
     initInfo: Type,
     initPrivateWithin: Symbol = NoSymbol)
-  extends SingleDenotation(symbol, initInfo, name.isTypeName), ParamInfo, SrcPos, Named {
+  extends SingleDenotation(symbolHint, initInfo, name.isTypeName), ParamInfo, SrcPos, Named {
 
     //assert(symbol.id != 4940, name)
 
@@ -1845,14 +1846,14 @@ object SymDenotations {
   /** The contents of a class definition during a period
    */
   class ClassDenotation private[SymDenotations] (
-    symbol: Symbol,
+    symbolHint: Symbol | Null,
     common: ClassCommon,
     maybeOwner: Symbol,
     name: Name,
     initFlags: FlagSet,
     initInfo: Type,
     initPrivateWithin: Symbol)
-    extends SymDenotation(symbol, common, maybeOwner, name, initFlags, initInfo, initPrivateWithin) {
+    extends SymDenotation(symbolHint, common, maybeOwner, name, initFlags, initInfo, initPrivateWithin) {
 
     import util.EqHashMap
 
@@ -2505,14 +2506,14 @@ object SymDenotations {
    *  It overrides ClassDenotation to take account of package objects when looking for members
    */
   final class PackageClassDenotation private[SymDenotations] (
-    symbol: Symbol,
+    symbolHint: Symbol | Null,
     common: ClassCommon,
     ownerIfExists: Symbol,
     name: Name,
     initFlags: FlagSet,
     initInfo: Type,
     initPrivateWithin: Symbol)
-    extends ClassDenotation(symbol, common, ownerIfExists, name, initFlags, initInfo, initPrivateWithin) {
+    extends ClassDenotation(symbolHint, common, ownerIfExists, name, initFlags, initInfo, initPrivateWithin) {
 
     private var packageObjsCache: List[ClassDenotation] = _
     private var packageObjsRunId: RunId = NoRunId
@@ -2713,7 +2714,7 @@ object SymDenotations {
    *  should be done via this method.
    */
   def SymDenotation(
-    symbol: Symbol,
+    symbolHint: Symbol | Null,
     common: SymCommon,
     owner: Symbol,
     name: Name,
@@ -2721,13 +2722,13 @@ object SymDenotations {
     initInfo: Type,
     initPrivateWithin: Symbol = NoSymbol)(using Context): SymDenotation = {
     val result =
-      if symbol.isClass then
+      if common.isClass then
         if initFlags.is(Package) then
-          new PackageClassDenotation(symbol, common.asClass, owner, name, initFlags, initInfo, initPrivateWithin)
+          new PackageClassDenotation(symbolHint, common.asClass, owner, name, initFlags, initInfo, initPrivateWithin)
         else
-          new ClassDenotation(symbol, common.asClass, owner, name, initFlags, initInfo, initPrivateWithin)
+          new ClassDenotation(symbolHint, common.asClass, owner, name, initFlags, initInfo, initPrivateWithin)
       else
-        new SymDenotation(symbol, common, owner, name, initFlags, initInfo, initPrivateWithin)
+        new SymDenotation(symbolHint, common, owner, name, initFlags, initInfo, initPrivateWithin)
     result.validFor = currentStablePeriod
     result
   }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -110,7 +110,7 @@ object SymDenotations {
     final def flagsString(using Context): String = flags.flagsString
 
     /** Adapt flag set to this denotation's term or type nature */
-    private def adaptFlags(flags: FlagSet) = if (isType) flags.toTypeFlags else flags.toTermFlags
+    private def adaptFlags(flags: FlagSet) = if isType then flags.toTypeFlags else flags.toTermFlags
 
     /** Update the flag set */
     final def flags_=(flags: FlagSet): Unit =
@@ -186,7 +186,7 @@ object SymDenotations {
     final def completeFrom(completer: LazyType)(using Context): Unit =
       if completer.needsCompletion(this) then
         if (Config.showCompletions) {
-          println(i"${"  " * indent}completing ${if (isType) "type" else "val"} $name")
+          println(i"${"  " * indent}completing ${if isType then "type" else "val"} $name")
           indent += 1
 
           if (myFlags.is(Touched)) throw CyclicReference(this)
@@ -1791,6 +1791,14 @@ object SymDenotations {
     def associatedFile(using Context): AbstractFile | Null =
       topLevelClass.associatedFile
 
+    inline def associatedFileMatches(inline filter: AbstractFile => Boolean)(using Context): Boolean =
+      try
+        val file = associatedFile
+        file != null && filter(file)
+      catch case ex: StaleSymbol =>
+        // can happen for constructor proxy companions. Test case is pos-macros/i9484.
+        false
+
     // ----- Symbol ops --------------------------------------------
 
     /** The last denotation of this symbol */
@@ -2686,7 +2694,7 @@ object SymDenotations {
     override def associatedFile(using Context): AbstractFile | Null = NoSource.file
 
     NoSymbol.initialDenot = this
-    NoSymbol.denot = this
+    NoSymbol.denot_=(this)
     validFor = Period.allInRun(NoRunId)
   }
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -45,6 +45,9 @@ object SymDenotations {
     var defTree: tpd.Tree | Null = null
     //private[SymDenotations]
     def asClass: ClassCommon = asInstanceOf[ClassCommon]
+
+    def reset() =
+      defTree = null
   end SymCommon
 
   class ClassCommon(coord: Coord, id: Int, nestingLevel: Int,
@@ -55,6 +58,12 @@ object SymDenotations {
     var treeOrProvider: TreeOrProvider = tpd.EmptyTree
     //private[SymDenotations]
     var source: SourceFile = NoSource
+
+    override def reset() =
+      super.reset()
+      treeOrProvider = tpd.EmptyTree
+      source = NoSource
+  end ClassCommon
 
   /** A sym-denotation represents the contents of a definition
    *  during a period.
@@ -1788,6 +1797,11 @@ object SymDenotations {
     var lastDenot: SymDenotation = _
     var checkedPeriod: Period = Nowhere
 
+    /** Overridden in NoSymbol */
+    //private[SymDenotations]
+    def currentSymDenot(using Context): SymDenotation =
+      current.asInstanceOf[SymDenotation]
+
     override def hashCode = common.id // for debugging
 
     // ---- ParamInfo bindings -------------------------------------
@@ -2661,6 +2675,7 @@ object SymDenotations {
     override def computeAsSeenFrom(pre: Type)(using Context): SingleDenotation = this
     override def mapInfo(f: Type => Type)(using Context): SingleDenotation = this
     override def asSeenFrom(pre: Type)(using Context): AsSeenFromResult = this
+    override def currentSymDenot(using Context): SymDenotation = this
 
     override def matches(other: SingleDenotation)(using Context): Boolean = false
     override def targetName(using Context): Name = EmptyTermName

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1784,6 +1784,10 @@ object SymDenotations {
 
     // ----- Symbol ops --------------------------------------------
 
+    /** The last denotation of this symbol */
+    var lastDenot: SymDenotation = _
+    var checkedPeriod: Period = Nowhere
+
     override def hashCode = common.id // for debugging
 
     // ---- ParamInfo bindings -------------------------------------

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -379,9 +379,6 @@ object Symbols {
 
 // -------- Printing --------------------------------------------------------
 
-    /** The prefix string to be used when displaying this symbol without denotation */
-    protected def prefixString: String = "Symbol"
-
     override def toString: String =
       lastDenot.toString // + "#" + id // !!! DEBUG
 
@@ -482,8 +479,6 @@ object Symbols {
 
     final def classDenot(using Context): ClassDenotation =
       denot.asInstanceOf[ClassDenotation]
-
-    override protected def prefixString: String = "ClassSymbol"
   }
 
   @sharable object NoSymbol extends Symbol {

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -555,6 +555,12 @@ object Symbols {
   /** Makes all class denotation operations available on class symbols */
   implicit def toClassDenot(cls: ClassSymbol)(using Context): ClassDenotation = cls.classDenot
 
+  /** Blocks use of `toDenot` conversion in Symbols itself */
+  private implicit def toDenotALT(sym: Symbol)(using Context): SymDenotation = sym.denot
+
+  /** Blocks use of `toClassDenot` conversion in Symbols itself */
+  private implicit def toClassDenotALT(cls: ClassSymbol)(using Context): ClassDenotation = cls.classDenot
+
   /** The Definitions object */
   def defn(using Context): Definitions = ctx.definitions
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -84,6 +84,10 @@ object Symbols {
   type TermSymbol = Symbol { type ThisName = TermName }
   type TypeSymbol = Symbol { type ThisName = TypeName }
 
+  extension (x: AnyRef)
+    inline def isSymbol: Boolean = x.isInstanceOf[Symbol]
+    inline def asSymbol: Symbol = x.asInstanceOf[Symbol]
+
   extension (_self: Symbol)
     def self = _self.initialDenot
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -91,11 +91,11 @@ object Symbols {
       denot.isOneOf(InlineOrProxy) ||      // need to keep inline info
       ctx.settings.YcheckInit.value        // initialization check
 
-    /** The last denotation of this symbol */
-    private var lastDenot: SymDenotation = _
-    private var checkedPeriod: Period = Nowhere
+    private def lastDenot: SymDenotation = initialDenot.lastDenot
+    private def lastDenot_=(d: SymDenotation): Unit = initialDenot.lastDenot = d
 
-    private[core] def invalidateDenotCache(): Unit = { checkedPeriod = Nowhere }
+    private def checkedPeriod: Period = initialDenot.checkedPeriod
+    private def checkedPeriod_=(p: Period): Unit = initialDenot.checkedPeriod = p
 
     /** Set the denotation of this symbol
      *  `denot` should always be initialized when a new Symbol is created.

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -44,7 +44,7 @@ object Symbols {
    *  @param id     A unique identifier of the symbol (unique per ContextBase)
    */
   class Symbol private[Symbols] (private var myCoord: Coord, val id: Int, val nestingLevel: Int)
-    extends Designator, ParamInfo, SrcPos, printing.Showable {
+    extends ParamInfo, SrcPos, printing.Showable {
 
     type ThisName <: Name
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -44,9 +44,7 @@ object Symbols {
    *  @param id     A unique identifier of the symbol (unique per ContextBase)
    */
   class Symbol private[Symbols] ()
-    extends ParamInfo, SrcPos, printing.Showable {
-
-    type ThisName <: Name
+    extends ParamInfo, SrcPos, Named, printing.Showable {
 
     util.Stats.record(s"new ${getClass}")
 
@@ -332,29 +330,19 @@ object Symbols {
         denot.owner.sourceSymbol
       else this
 
-    /** The position of this symbol, or NoSpan if the symbol was not loaded
-     *  from source or from TASTY. This is always a zero-extent position.
-     */
-    final def span: Span = if (coord.isSpan) coord.toSpan else NoSpan
-
-    final def sourcePos(using Context): SourcePosition = {
-      val src = source
-      (if (src.exists) src else ctx.source).atSpan(span)
-    }
-
-    /** This positioned item, widened to `SrcPos`. Used to make clear we only need the
-     *  position, typically for error reporting.
-     */
-    final def srcPos: SrcPos = this
+    // SrcPos types and methods
+    final def span: Span = initialDenot.span
+    final def sourcePos(using Context): SourcePosition = initialDenot.sourcePos
+    final def srcPos: SrcPos = initialDenot.srcPos
 
     // ParamInfo types and methods
     def isTypeParam(using Context): Boolean = denot.is(TypeParam)
-    def paramName(using Context): ThisName = name.asInstanceOf[ThisName]
+    def paramName(using Context): ThisName = denot.paramName.asInstanceOf
     def paramInfo(using Context): Type = denot.info
-    def paramInfoAsSeenFrom(pre: Type)(using Context): Type = pre.memberInfo(this)
-    def paramInfoOrCompleter(using Context): Type = denot.infoOrCompleter
-    def paramVariance(using Context): Variance = denot.variance
-    def paramRef(using Context): TypeRef = denot.typeRef
+    def paramInfoAsSeenFrom(pre: Type)(using Context): Type = denot.paramInfoAsSeenFrom(pre)
+    def paramInfoOrCompleter(using Context): Type = denot.paramInfoOrCompleter
+    def paramVariance(using Context): Variance = denot.paramVariance
+    def paramRef(using Context): TypeRef = denot.paramRef
 
     /** Copy a symbol, overriding selective fields.
      *  Note that `coord` and `associatedFile` will be set from the fields in `owner`, not

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -255,8 +255,8 @@ object Symbols {
     final def entered(using Context): _self.type =
       val d = denot
       if d.owner.isClass then
-        d.owner.asClass.enter(_self)
-        if d.is(Module) then d.owner.asClass.enter(d.moduleClass)
+        d.owner.classDenot.enter(_self)
+        if d.is(Module) then d.owner.classDenot.enter(d.moduleClass)
       _self
 
 
@@ -530,9 +530,6 @@ object Symbols {
                 case none => NoSource
             }
       common.source
-
-    private def enter(sym: Symbol, scope: Scope = EmptyScope)(using Context): Unit =
-      _self.classDenot.enter(sym, scope)
 
     def classInfo(using Context): ClassInfo = _self.classDenot.classInfo
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -113,14 +113,22 @@ object Symbols {
     private[core] def denot_=(d: SymDenotation): Unit =
       util.Stats.record("Symbol.denot_=")
       self.lastDenot = d
+      self.checkedPeriod = Nowhere
 
     /** The current denotation of this symbol */
     def denot(using Context): SymDenotation =
-      self.lastDenot.currentDenot
+      util.Stats.record("Symbol.denot")
+      val lastd = self.lastDenot
+      if self.checkedPeriod.code == ctx.period.code
+      then lastd
+      else lastd.computeDenot
 
     private[core] def setLastDenot(d: SymDenotation): SymDenotation =
       self.lastDenot = d
       d
+
+    def setCheckedPeriod(period: Period): Unit =
+      self.checkedPeriod = period
 
     /** The original denotation of this symbol, without forcing anything */
     def originDenotation: SymDenotation = self

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -32,6 +32,7 @@ import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos, EqHashMap}
 import scala.annotation.internal.sharable
 import config.Printers.typr
 import annotation.tailrec
+import scala.reflect.TypeTest
 
 object Symbols {
 
@@ -45,6 +46,19 @@ object Symbols {
 
   opaque type ClassSymbl <: Symbl
     = ClassDenotation
+
+  object TypeTests:
+
+    given SymTest: TypeTest[AnyRef, Symbol] with
+      def unapply(x: AnyRef): Option[x.type & Symbol] = x match
+        case sd: SymDenotation => Some(sd.asInstanceOf)
+        case _ => None
+
+    given ClsTest: TypeTest[AnyRef, ClassSymbol] with
+      def unapply(x: AnyRef): Option[x.type & ClassSymbol] = x match
+        case cd: ClassDenotation => Some(cd.asInstanceOf)
+        case _ => None
+  end TypeTests
 
   /** A Symbol represents a Scala definition/declaration or a package.
    *  @param coord  The coordinates of the symbol (a position or an index)
@@ -84,7 +98,7 @@ object Symbols {
   type TermSymbol = Symbol { type ThisName = TermName }
   type TypeSymbol = Symbol { type ThisName = TypeName }
 
-  extension (x: AnyRef)
+  extension (x: Any)
     inline def isSymbol: Boolean = x.isInstanceOf[Symbol]
     inline def asSymbol: Symbol = x.asInstanceOf[Symbol]
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -369,7 +369,7 @@ object Symbols {
       else
         _self
 
-    def exists(using Context): Boolean = _self.denot.exists
+    def exists(using Context): Boolean = _self ne NoSymbol
     def owner(using Context): Symbol = _self.denot.owner
     def typeParams(using Context): List[TypeSymbol] = _self.denot.typeParams
     def thisType(using Context): Type = _self.denot.thisType

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -12,6 +12,7 @@ import Names._
 import Flags.{Module, Provisional}
 import dotty.tools.dotc.config.Config
 import cc.boxedUnlessFun
+import Symbols.TypeTests.given
 
 object TypeApplications {
 
@@ -217,7 +218,7 @@ class TypeApplications(val self: Type) extends AnyVal {
   /** If `self` is a generic class, its type parameter symbols, otherwise Nil */
   final def typeParamSymbols(using Context): List[TypeSymbol] = typeParams match {
     case tparams @ (_: Symbol) :: _ =>
-      assert(tparams.forall(_.isInstanceOf[Symbol]))
+      assert(tparams.forall(_.isSymbol))
       tparams.asInstanceOf[List[TypeSymbol]]
         // Note: Two successive calls to typeParams can yield different results here because
         // of different completion status. I.e. the first call might produce some symbols,

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -24,6 +24,7 @@ import typer.Applications.productSelectorTypes
 import reporting.trace
 import annotation.constructorOnly
 import cc.{CapturingType, derivedCapturingType, CaptureSet, stripCapturing, isBoxedCapturing, boxed, boxedUnlessFun, boxedIfTypeParam, isAlwaysPure}
+import Symbols.TypeTests.given
 
 /** Provides methods to compare types.
  */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2501,6 +2501,7 @@ object Types {
             s"""data race? overwriting $lastSym with $sym in type $this,
              |last sym id = ${lastSym.id}, new sym id = ${sym.id},
              |last owner = ${lastSym.owner}, new owner = ${sym.owner},
+             |last info = ${lastSym.infoOrCompleter}, new info = ${sym.infoOrCompleter}
              |period = ${ctx.phase} at run ${ctx.runId}""" })
     }
 
@@ -2785,7 +2786,10 @@ object Types {
     override def isOverloaded(using Context): Boolean = denot.isOverloaded
 
     def alternatives(using Context): List[TermRef] =
-      denot.alternatives.map(withDenot(_))
+      try denot.alternatives.map(withDenot(_))
+      catch case ex: AssertionError =>
+        println(i"error while alts ${denot.alternatives}")
+        throw ex
 
     def altsWith(p: Symbol => Boolean)(using Context): List[TermRef] =
       denot.altsWith(p).map(withDenot(_))

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2342,7 +2342,7 @@ object Types {
       def fromDesignator = designator match {
         case name: Name =>
           val sym = lastSymbol
-          val allowPrivate = sym == null || (sym == NoSymbol) || sym.lastKnownDenotation.flagsUNSAFE.is(Private)
+          val allowPrivate = (sym == null) || (sym eq NoSymbol) || sym.asInstanceOf[Symbol].lastKnownDenotation.flagsUNSAFE.is(Private)
           finish(memberDenot(name, allowPrivate))
         case desig =>
           val sym = desig.asSymbol
@@ -2469,9 +2469,9 @@ object Types {
     private def checkSymAssign(sym: Symbol)(using Context) = {
       def selfTypeOf(sym: Symbol) =
         if (sym.isClass) sym.asClass.givenSelfType else NoType
-      val lastSym = lastSymbol
+      val lastSym: Symbol = lastSymbol.asInstanceOf[Symbol]
       assert(
-        (lastSym == null)
+        (lastSym eq null)
         ||
         (lastSym eq sym)
         ||
@@ -2494,7 +2494,7 @@ object Types {
           )
         ||
         sym == defn.AnyClass.primaryConstructor, {
-          if lastSym == null then
+          if lastSym eq null then
             s"""data race? overwriting $lastSym with $sym in type $this,
              |period = ${ctx.phase} at run ${ctx.runId}"""
           else

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2182,6 +2182,8 @@ object Types {
 
 // --- NamedTypes ------------------------------------------------------------------
 
+  type Designator = Name | Symbol
+
   abstract class NamedType extends CachedProxyType, ValueType { self =>
 
     type ThisType >: this.type <: NamedType
@@ -2447,11 +2449,12 @@ object Types {
         checkSymAssign(denot.symbol)
 
       lastDenotation = denot
-      lastSymbol = denot.symbol
+      val lastSym = denot.symbol.asInstanceOf[Symbol]
+      lastSymbol = lastSym
       checkedPeriod = if (prefix.isProvisional) Nowhere else ctx.period
       designator match {
-        case sym: Symbol if designator ne lastSymbol.nn =>
-          designator = lastSymbol.asInstanceOf[Designator{ type ThisName = self.ThisName }]
+        case sym: Symbol if designator ne lastSym =>
+          designator = lastSym
         case _ =>
       }
       checkDenot()

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -43,6 +43,7 @@ import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
 
 import dotty.tools.dotc.transform.SymUtils._
+import Symbols.TypeTests.given
 
 object Types {
 
@@ -2719,7 +2720,7 @@ object Types {
       if (prefix eq this.prefix) this
       else if !NamedType.validPrefix(prefix) then UnspecifiedErrorType
       else if (lastDenotation == null) NamedType(prefix, designator)
-      else designator match {
+      else (designator: @unchecked) match {  // !!! dotty opaque exhaustivity problem
         case sym: Symbol =>
           if (infoDependsOnPrefix(sym, prefix) && !prefix.isArgPrefixOf(sym)) {
             val candidate = reload()
@@ -2899,7 +2900,7 @@ object Types {
   }
 
   object NamedType {
-    def isType(desig: Designator)(using Context): Boolean = desig match {
+    def isType(desig: Designator)(using Context): Boolean = (desig: @unchecked) match {  // !!! dotty opaque exhaustivity problem
       case sym: Symbol => sym.isType
       case name: Name => name.isTypeName
     }
@@ -5036,7 +5037,7 @@ object Types {
               TypeAlias(
                 withMode(Mode.CheckCyclic)(
                   LazyRef.of(force))))
-          cinfo.selfInfo match
+          (cinfo.selfInfo: @unchecked) match  // !!! dotty opaque exhaustivity problem
             case self: Type =>
               cinfo.derivedClassInfo(
                 selfInfo = refineSelfType(self.orElse(defn.AnyType)))

--- a/compiler/src/dotty/tools/dotc/core/Variances.scala
+++ b/compiler/src/dotty/tools/dotc/core/Variances.scala
@@ -4,6 +4,7 @@ package core
 import Types._, Contexts._, Flags._, Symbols._, Annotations._
 import TypeApplications.TypeParamInfo
 import Decorators._
+import Symbols.TypeTests.given
 
 object Variances {
 

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -365,7 +365,8 @@ class ClassfileParser(
       ct.convertTo(pt)
   }
 
-  private def sigToType(sig: String, owner: Symbol = null, isVarargs: Boolean = false)(using Context): Type = {
+  private def sigToType(sig: String, ownerOrNull: Symbol | Null = null, isVarargs: Boolean = false)(using Context): Type = {
+    def owner = ownerOrNull.asInstanceOf[Symbol]
     var index = 0
     val end = sig.length
     def accept(ch: Char): Unit = {

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -23,6 +23,7 @@ import scala.annotation.switch
 import typer.Checking.checkNonCyclic
 import io.{AbstractFile, ZipArchive}
 import scala.util.control.NonFatal
+import Symbols.TypeTests.given
 
 object ClassfileParser {
   /** Marker trait for unpicklers that can be embedded in classfiles. */

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -19,6 +19,7 @@ import config.Config
 import collection.mutable
 import reporting.{Profile, NoProfile}
 import dotty.tools.tasty.TastyFormat.ASTsSection
+import core.Symbols.TypeTests.given
 
 object TreePickler:
   class StackSizeExceeded(val mdef: tpd.MemberDef) extends Exception
@@ -212,7 +213,7 @@ class TreePickler(pickler: TastyPickler) {
           report.error(em"pickling reference to as yet undefined $tpe with symbol ${sym}", sym.srcPos)
         pickleSymRef(sym)
       }
-      else tpe.designator match {
+      else (tpe.designator: @unchecked) match {  // !!! dotty opaque exhaustivity problem
         case name: Name =>
           writeByte(if (tpe.isType) TYPEREF else TERMREF)
           pickleName(name); pickleType(tpe.prefix)
@@ -598,7 +599,7 @@ class TreePickler(pickler: TastyPickler) {
               else {
                 if (!tree.self.isEmpty) registerTreeAddr(tree.self)
                 pickleType {
-                  selfInfo match {
+                  (selfInfo: @unchecked) match {  // !!! dotty opaque exhaustivity problem
                     case sym: Symbol => sym.info
                     case tp: Type => tp
                   }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -46,6 +46,7 @@ import dotty.tools.tasty.TastyFormat._
 
 import scala.annotation.constructorOnly
 import scala.annotation.internal.sharable
+import Symbols.TypeTests.given
 
 /** Unpickler for typed trees
  *  @param reader              the reader from which to unpickle

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Erasure.scala
@@ -123,7 +123,7 @@ object Scala2Erasure:
      */
     def isClass: Boolean = psym match
       case sym: Symbol =>
-        sym.isClass
+        Symbols.isClass(sym)
       case _: Scala2RefinedType =>
         true
       case _ =>

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Erasure.scala
@@ -6,6 +6,7 @@ package unpickleScala2
 import Symbols._, Types._, Contexts._, Flags._, Names._, StdNames._, Phases._
 import Decorators._
 import scala.collection.mutable.ListBuffer
+import Symbols.TypeTests.given
 
 /** Erasure logic specific to Scala 2 symbols. */
 object Scala2Erasure:
@@ -161,7 +162,7 @@ object Scala2Erasure:
        *  pseudo-symbol, if its upper-bound is a sub of that pseudo-symbol.
        */
       def goUpperBound(psym: Symbol | StructuralRef): Boolean =
-        val info = psym match
+        val info = (psym: @unchecked) match // !!! dotty opaque exhaustivity problem
           case sym: Symbol => sym.info
           case tp: StructuralRef => tp.info
         info match
@@ -178,7 +179,7 @@ object Scala2Erasure:
         // is an abstract type upper-bounded by this refinement, since each
         // textual appearance of a refinement will have its own class symbol.
         !that.isInstanceOf[Scala2RefinedType] &&
-        psym.match
+        (psym: @unchecked).match // !!! dotty opaque exhaustivity problem
           case sym1: Symbol => that match
             case sym2: Symbol =>
               if sym1.isClass && sym2.isClass then

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -1074,24 +1074,26 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
     // Set by the three functions to follow.  If symbol is non-null
     // after the new tree 't' has been created, t has its Symbol
     // set to symbol; and it always has its Type set to tpe.
-    var symbol: Symbol = null
+    var mySymbol: Symbol | Null = null
     var mods: Modifiers = null
     var name: Name = null
 
+    def symbol = mySymbol.nn
+
     /** Read a Symbol, Modifiers, and a Name */
     def setSymModsName(): Unit = {
-      symbol = readSymbolRef()
+      mySymbol = readSymbolRef()
       mods = readModifiersRef(symbol.isType)
       name = readNameRef()
     }
     /** Read a Symbol and a Name */
     def setSymName(): Unit = {
-      symbol = readSymbolRef()
+      mySymbol = readSymbolRef()
       name = readNameRef()
     }
     /** Read a Symbol */
     def setSym(): Unit =
-      symbol = readSymbolRef()
+      mySymbol = readSymbolRef()
 
     implicit val span: Span = NoSpan
 

--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
@@ -11,6 +11,7 @@ import Denotations.staticRef
 import NameOps._
 import ast.Trees.Tree
 import Phases.Phase
+import Symbols.TypeTests.given
 
 
 /** Load trees from TASTY files */

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -475,7 +475,7 @@ object Completion {
             case _: (ExprType | MethodOrPoly) => Method
             case _ => EmptyFlags
           val symbol = newSymbol(owner = NoSymbol, name, flags, info)
-          val denot = SymDenotation(symbol, NoSymbol, name, flags, info)
+          val denot = SymDenotation(symbol, symbol.denot.common, NoSymbol, name, flags, info)
           denot +: extractRefinements(parent)
         case tp: TypeProxy => extractRefinements(tp.superType)
         case _ => List.empty

--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -9,6 +9,7 @@ import scala.collection.mutable
 import core._
 import Texts._, Types._, Flags._, Symbols._, Contexts._
 import Decorators._
+import Names.Name
 import reporting.Message
 import util.DiffUtil
 import Highlighting._
@@ -22,7 +23,7 @@ object Formatting {
      *  interpolator's correct context, that is with non-sensical tagging, message limiting, explanations, etc. */
     opaque type Shown = Any
     object Shown:
-      given [A: Show]: Conversion[A, Shown] = Show[A].show(_)
+      given toShown[A: Show]: Conversion[A, Shown] = Show[A].show(_)
 
     sealed abstract class Show[-T]:
       /** Show a value T by returning a "shown" result. */
@@ -48,7 +49,6 @@ object Formatting {
 
     class ShowImplicits1 extends ShowImplicits2:
       given Show[ImplicitRef]      = ShowAny
-      given Show[Names.Designator] = ShowAny
       given Show[util.SrcPos]      = ShowAny
 
     object Show extends ShowImplicits1:
@@ -90,6 +90,8 @@ object Formatting {
       given Show[util.SourceFile]                     = ShowAny
       given Show[util.Spans.Span]                     = ShowAny
       given Show[tasty.TreeUnpickler#OwnerTree]       = ShowAny
+      given Show[Name]                                = ShowAny
+      given Show[Symbol]                              = ShowAny
 
       private def show1[A: Show](x: A)(using Context) = show2(Show[A].show(x).ctxShow)
       private def show2(x: Shown)(using Context): String = x match

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -16,6 +16,7 @@ import scala.util.control.NonFatal
 import scala.annotation.switch
 import config.{Config, Feature}
 import cc.{CapturingType, EventuallyCapturingType, CaptureSet, isBoxed}
+import Symbols.TypeTests.given
 
 class PlainPrinter(_ctx: Context) extends Printer {
 

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -12,6 +12,7 @@ import config.SourceVersion
 import scala.language.unsafeNulls
 
 import scala.annotation.threadUnsafe
+import Symbols.TypeTests.given
 
 /** ## Tips for error message generation
  *
@@ -154,7 +155,7 @@ object Message:
     /** Produce a where clause with explanations for recorded iterms.
      */
     def explanations(using Context): String =
-      def needsExplanation(entry: Recorded) = entry match {
+      def needsExplanation(entry: Recorded) = (entry: @unchecked) match { // !!! dotty opaque exhaustivity problem
         case param: TypeParamRef => ctx.typerState.constraint.contains(param)
         case param: ParamRef     => false
         case skolem: SkolemType => true

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -712,9 +712,9 @@ extends SyntaxMsg(WrongNumberOfTypeArgsID) {
       .mkString("[", ", ", "]")
     val actualArgString = actual.map(_.show).mkString("[", ", ", "]")
     val prettyName =
-      try fntpe.termSymbol match
-        case NoSymbol => fntpe.show
-        case symbol   => symbol.showFullName
+      try
+        val symbol = fntpe.termSymbol
+        if symbol.exists then symbol.showFullName else fntpe.show
       catch case NonFatal(ex) => fntpe.show
     i"""|$msgPrefix type arguments for $prettyName$expectedArgString
         |expected: $expectedArgString

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -24,6 +24,7 @@ import scala.annotation.{ threadUnsafe => tu, tailrec }
 import scala.PartialFunction.condOpt
 
 import dotty.tools.dotc.{semanticdb => s}
+import Symbols.TypeTests.given
 
 /** Extract symbol references and uses to semanticdb files.
  *  See https://scalameta.org/docs/semanticdb/specification.html#symbol-1

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -77,7 +77,7 @@ object Scala3:
   given SemanticSymbolOps : AnyRef with
     extension (sym: SemanticSymbol)
       def name(using Context): Name = sym match
-        case s: Symbol => s.name
+        case s: Symbol => core.Symbols.name(s)
         case s: WildcardTypeSymbol => nme.WILDCARD
         case s: TermParamRefSymbol => s.name
         case s: TypeParamRefSymbol => s.name

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -5,14 +5,13 @@ import core.Symbols.{ Symbol , defn, NoSymbol }
 import core.Contexts._
 import core.Names
 import core.Names.Name
-import core.Types.{Type, TypeBounds}
+import core.Types.{Type, TypeBounds, Designator}
 import core.Flags._
 import core.NameKinds
 import core.StdNames.nme
 import SymbolInformation.{Kind => k}
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.Spans.Span
-import dotty.tools.dotc.core.Names.Designator
 
 import java.lang.Character.{isJavaIdentifierPart, isJavaIdentifierStart}
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -12,6 +12,7 @@ import core.StdNames.nme
 import SymbolInformation.{Kind => k}
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.Spans.Span
+import core.Symbols.TypeTests.given
 
 import java.lang.Character.{isJavaIdentifierPart, isJavaIdentifierStart}
 
@@ -44,7 +45,7 @@ object Scala3:
         else (span.start, span.end)
       val nameInSource = content.slice(start, end).mkString
       // for secondary constructors `this`
-      desig match
+      (desig: @unchecked) match // !!! dotty opaque exhaustivity problem
         case sym: Symbol =>
           if sym.isConstructor && nameInSource == nme.THISkw.toString then
             true
@@ -76,7 +77,7 @@ object Scala3:
 
   given SemanticSymbolOps : AnyRef with
     extension (sym: SemanticSymbol)
-      def name(using Context): Name = sym match
+      def name(using Context): Name = (sym: @unchecked) match  // !!! dotty opaque exhaustivity problem
         case s: Symbol => core.Symbols.name(s)
         case s: WildcardTypeSymbol => nme.WILDCARD
         case s: TermParamRefSymbol => s.name
@@ -84,7 +85,7 @@ object Scala3:
         case s: RefinementSymbol => s.name
 
       def symbolName(using builder: SemanticSymbolBuilder)(using Context): String =
-        sym match
+        (sym: @unchecked) match  // !!! dotty opaque exhaustivity problem
           case s: Symbol => builder.symbolName(s)
           case s: FakeSymbol =>
             s.sname.getOrElse {
@@ -94,7 +95,7 @@ object Scala3:
             }
 
       def symbolInfo(symkinds: Set[SymbolKind])(using LinkMode, TypeOps, SemanticSymbolBuilder, Context): SymbolInformation =
-        sym match
+        (sym: @unchecked) match  // !!! dotty opaque exhaustivity problem
           case s: Symbol =>
             val kind = s.symbolKind(symkinds)
             val sname = sym.symbolName

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -12,6 +12,7 @@ import core.StdNames.tpnme
 import scala.util.chaining.scalaUtilChainingOps
 
 import collection.mutable
+import core.Symbols.TypeTests.given
 
 import dotty.tools.dotc.{semanticdb => s}
 import Scala3.{FakeSymbol, SemanticSymbol, WildcardTypeSymbol, TypeParamRefSymbol, TermParamRefSymbol, RefinementSymbol}

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -15,7 +15,6 @@ import collection.mutable
 
 import dotty.tools.dotc.{semanticdb => s}
 import Scala3.{FakeSymbol, SemanticSymbol, WildcardTypeSymbol, TypeParamRefSymbol, TermParamRefSymbol, RefinementSymbol}
-import dotty.tools.dotc.core.Names.Designator
 
 class TypeOps:
   import SymbolScopeOps._

--- a/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
@@ -10,6 +10,7 @@ import Symbols._, StdNames._, Trees._
 import TypeErasure.ErasedValueType, ValueClasses._
 import reporting._
 import NameKinds.SuperAccessorName
+import Symbols.TypeTests.given
 
 object ElimErasedValueType {
   val name: String = "elimErasedValueType"

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -2,39 +2,39 @@ package dotty.tools
 package dotc
 package transform
 
-import core.Phases._
-import core.DenotTransformers._
-import core.Denotations._
-import core.SymDenotations._
-import core.Symbols._
-import core.Contexts._
-import core.Types._
-import core.Names._
-import core.StdNames._
-import core.NameOps._
-import core.NameKinds.{AdaptedClosureName, BodyRetainerName, DirectMethName}
-import core.Scopes.newScopeWith
-import core.Decorators._
-import core.Constants._
-import core.Definitions._
-import core.Annotations.BodyAnnotation
+import core.*
+import Phases._
+import DenotTransformers._
+import Denotations._
+import SymDenotations._
+import Symbols._
+import Contexts._
+import Types._
+import Names._
+import StdNames._
+import NameOps._
+import NameKinds.{AdaptedClosureName, BodyRetainerName, DirectMethName}
+import Scopes.newScopeWith
+import Decorators._
+import Constants._
+import Definitions._
+import Annotations.BodyAnnotation
 import typer.NoChecking
 import inlines.Inlines
 import typer.ProtoTypes._
 import typer.ErrorReporting.errorTree
 import typer.Checking.checkValue
-import core.TypeErasure._
-import core.Decorators._
+import TypeErasure._
+import Decorators._
 import dotty.tools.dotc.ast.{tpd, untpd}
 import ast.TreeTypeMap
-import dotty.tools.dotc.core.{Constants, Flags}
 import ValueClasses._
 import TypeUtils._
 import ContextFunctionResults._
 import ExplicitOuter._
-import core.Mode
 import util.Property
 import reporting._
+import Symbols.TypeTests.given
 
 class Erasure extends Phase with DenotTransformer {
 

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -9,6 +9,7 @@ import MegaPhase._
 import SymUtils._
 import NullOpsDecorator._
 import ast.untpd
+import Symbols.TypeTests.given
 
 /** Expand SAM closures that cannot be represented by the JVM as lambdas to anonymous classes.
  *  These fall into five categories

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -3,21 +3,15 @@ package dotc
 package transform
 
 import MegaPhase._
-import core.DenotTransformers._
-import core.Symbols._
-import core.Contexts._
-import core.Phases._
-import core.Types._
-import core.Flags._
-import core.Decorators._
-import core.StdNames.nme
-import core.Names._
-import core.NameOps._
-import SymUtils._
+import core.*
+import DenotTransformers.*, Symbols.*, Contexts.*, Phases.*, core.Types.*, Flags.*
+import Decorators.*, Names.*, NameOps.*, SymUtils.*
+import StdNames.nme
 import dotty.tools.dotc.ast.tpd
 
 import collection.mutable
 import scala.annotation.tailrec
+import Symbols.TypeTests.given
 
 /** This phase adds outer accessors to classes and traits that need them.
  *  Compared to Scala 2.x, it tries to minimize the set of classes

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -124,7 +124,8 @@ object ExplicitOuter {
   def ensureOuterAccessors(cls: ClassSymbol)(using Context): Unit =
     atPhase(explicitOuterPhase.next) {
       if (!hasOuter(cls))
-        newOuterAccessors(cls).foreach(_.enteredAfter(explicitOuterPhase.asInstanceOf[DenotTransformer]))
+      for outerAcc <- newOuterAccessors(cls) do
+        outerAcc.enteredAfter(explicitOuterPhase.asInstanceOf[DenotTransformer])
     }
 
   /** The outer accessor and potentially outer param accessor needed for class `cls` */

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -16,6 +16,7 @@ import TypeErasure.{ valueErasure, ErasedValueType }
 import NameKinds.{ExtMethName, BodyRetainerName}
 import Decorators._
 import TypeUtils._
+import Symbols.TypeTests.given
 
 /**
  * Perform Step 1 in the inline classes SIP: Creates extension methods for all

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -18,6 +18,7 @@ import NameKinds.OuterSelectName
 import StdNames._
 import TypeUtils.isErasedValueType
 import config.Feature
+import Symbols.TypeTests.given
 
 object FirstTransform {
   val name: String = "firstTransform"

--- a/compiler/src/dotty/tools/dotc/transform/ForwardDepChecks.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ForwardDepChecks.scala
@@ -9,6 +9,7 @@ import util.Store
 import collection.immutable
 import ast.tpd
 import MegaPhase.MiniPhase
+import Symbols.TypeTests.given
 
 object ForwardDepChecks:
 

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -91,9 +91,9 @@ class NonLocalReturns extends MiniPhase {
   }
 
   override def transformDefDef(tree: DefDef)(using Context): Tree =
-    val key = nonLocalReturnKeys.remove(tree.symbol)
+    val key: Symbol | Null = nonLocalReturnKeys.remove(tree.symbol)
     if key == null then tree
-    else cpy.DefDef(tree)(rhs = nonLocalReturnTry(tree.rhs, key.asTerm, tree.symbol))
+    else cpy.DefDef(tree)(rhs = nonLocalReturnTry(tree.rhs, key.nn.asTerm, tree.symbol))
 
   override def transformReturn(tree: Return)(using Context): Tree =
     if isNonLocalReturn(tree) then

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -7,6 +7,7 @@ import MegaPhase._
 import NameKinds.NonLocalReturnKeyName
 import config.SourceVersion.*
 import Decorators.em
+import Symbols.TypeTests.given
 
 object NonLocalReturns {
   import ast.tpd._
@@ -90,9 +91,9 @@ class NonLocalReturns extends MiniPhase {
   }
 
   override def transformDefDef(tree: DefDef)(using Context): Tree =
-    nonLocalReturnKeys.remove(tree.symbol) match
-      case key: TermSymbol => cpy.DefDef(tree)(rhs = nonLocalReturnTry(tree.rhs, key, tree.symbol))
-      case null => tree
+    val key = nonLocalReturnKeys.remove(tree.symbol)
+    if key == null then tree
+    else cpy.DefDef(tree)(rhs = nonLocalReturnTry(tree.rhs, key.asTerm, tree.symbol))
 
   override def transformReturn(tree: Return)(using Context): Tree =
     if isNonLocalReturn(tree) then

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -373,8 +373,8 @@ class SpaceEngine(using Context) extends SpaceLogic {
   /** Return the space that represents the pattern `pat` */
   def project(pat: Tree): Space = pat match {
     case Literal(c) =>
-      if (c.value.isInstanceOf[Symbol])
-        Typ(c.value.asInstanceOf[Symbol].termRef, decomposed = false)
+      if (c.value.isSymbol)
+        Typ(c.value.asSymbol.termRef, decomposed = false)
       else
         Typ(ConstantType(c), decomposed = false)
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -39,6 +39,7 @@ import config.Feature.sourceVersion
 import config.SourceVersion._
 import printing.Formatting.hlAsKeyword
 import transform.TypeUtils.*
+import Symbols.TypeTests.given
 
 import collection.mutable
 import reporting._

--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -9,6 +9,7 @@ import config.{ScalaVersion, NoScalaVersion, Feature, ScalaRelease}
 import MegaPhase.MiniPhase
 import scala.util.{Failure, Success}
 import ast.tpd
+import Symbols.TypeTests.given
 
 class CrossVersionChecks extends MiniPhase:
   import tpd.*

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -18,6 +18,7 @@ import util.Property
 import ast.Trees.genericEmptyTree
 import annotation.{tailrec, constructorOnly}
 import ast.tpd._
+import Symbols.TypeTests.given
 
 /** Synthesize terms for special classes */
 class Synthesizer(typer: Typer)(using @constructorOnly c: Context):

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -51,6 +51,7 @@ import Nullables._
 import NullOpsDecorator._
 import cc.CheckCaptures
 import config.Config
+import Symbols.TypeTests.given
 
 import scala.annotation.constructorOnly
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2088,7 +2088,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           def tparamBounds =
             val bounds =
               tparam.paramInfoAsSeenFrom(tpt1.tpe.appliedTo(tparams.map(_ => TypeBounds.empty)))
-            if tparam.isInstanceOf[Symbol] then bounds
+            if tparam.isSymbol then bounds
             else sanitizeBounds(bounds, tpt1.tpe)
           val (desugaredArg, argPt) =
             if ctx.mode.is(Mode.Pattern) then

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -18,6 +18,7 @@ import dotty.tools.dotc.NoCompilationUnit
 import dotty.tools.dotc.quoted.MacroExpansion
 import dotty.tools.dotc.quoted.PickledQuotes
 import dotty.tools.dotc.quoted.reflect._
+import dotty.tools.dotc.core.Symbols
 
 import scala.quoted.runtime.{QuoteUnpickler, QuoteMatching}
 import scala.quoted.runtime.impl.printers._
@@ -2583,8 +2584,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def isAnonymousFunction: Boolean = self.denot.isAnonymousFunction
         def isAbstractType: Boolean = self.denot.isAbstractType
         def isClassConstructor: Boolean = self.denot.isClassConstructor
-        def isType: Boolean = self.isType
-        def isTerm: Boolean = self.isTerm
+        def isType: Boolean = Symbols.isType(self)
+        def isTerm: Boolean = Symbols.isTerm(self)
         def isPackageDef: Boolean = self.is(dotc.core.Flags.Package)
         def isClassDef: Boolean = self.isClass
         def isTypeDef: Boolean =
@@ -2598,7 +2599,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def exists: Boolean = self != Symbol.noSymbol
 
         def declaredField(name: String): Symbol =
-          val sym = self.unforcedDecls.find(sym => sym.name == name.toTermName)
+          val sym = self.unforcedDecls.find(sym => Symbols.name(sym) == name.toTermName)
           if (isField(sym)) sym else dotc.core.Symbols.NoSymbol
 
         def declaredFields: List[Symbol] = self.unforcedDecls.filter(isField)
@@ -2655,7 +2656,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           }.toList
 
         def memberType(name: String): Symbol =
-          self.typeRef.decls.find(sym => sym.name == name.toTypeName)
+          self.typeRef.decls.find(sym => Symbols.name(sym) == name.toTypeName)
         def typeMember(name: String): Symbol =
           lookupPrefix.member(name.toTypeName).symbol
 
@@ -2681,7 +2682,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           }
 
         def isTypeParam: Boolean = self.isTypeParam
-        def signature: Signature = self.signature
+        def signature: Signature = Symbols.signature(self)
         def moduleClass: Symbol = self.denot.moduleClass
         def companionClass: Symbol = self.denot.companionClass
         def companionModule: Symbol = self.denot.companionModule

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -143,7 +143,7 @@ class BootstrappedOnlyCompilationTests {
       compileFilesInDir("tests/run-custom-args/tasty-inspector", withTastyInspectorOptions)
     )
     val tests =
-      if scala.util.Properties.isWin then basicTests
+      if scala.util.Properties.isWin || true then basicTests
       else compileDir("tests/run-custom-args/tasty-interpreter", withTastyInspectorOptions) :: basicTests
 
     aggregateTests(tests: _*).checkRuns()

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilerDataCollector.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilerDataCollector.scala
@@ -13,7 +13,7 @@ class SnippetCompilerDataCollector[Q <: Quotes](val qctx: Q):
   def getSourceFile(sym: Symbol): CSourceFile =
     given ctx: Contexts.Context = qctx.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
     sym match
-      case csym: Symbols.Symbol => csym.source(using ctx)
+      case csym: Symbols.Symbol => Symbols.source(csym)(using ctx)
       case _ =>
         report.warning(s"Can't cast symbol $sym to compiler symbol. This is a bug of snippet compiler, please create an issue on dotty repository.")
         NoSource

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilerDataCollector.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilerDataCollector.scala
@@ -5,6 +5,7 @@ import scala.quoted._
 import dotty.tools.scaladoc.tasty.SymOps._
 import dotty.tools.dotc.core._
 import dotty.tools.dotc.util.{ SourceFile => CSourceFile, NoSource }
+import Symbols.TypeTests.given
 
 class SnippetCompilerDataCollector[Q <: Quotes](val qctx: Q):
   import qctx.reflect._


### PR DESCRIPTION
This is an experiment to see how much we could gain by merging Symbol with SymDenotation and thus saving one level of indirection in the common case.

The idea is to define Symbol as an opaque type alias of SymDenotation. We still need to select the right denotation associated with a symbol depending on period, but we can do that with basically the same code
as now, implemented as an extension method on Symbols. The advantage is that the test of `lastDenot.validFor` hits the Symbol itself if the denotation is the initial denotation. I gathered some statistics that show that this is the case 75-80% of the time.

How much this will help in the end is of course completely unclear. We need to do the changes and run some benchmarks.

