### PR TITLE
Delay opaque alias checking until PostTyper

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -433,6 +433,13 @@ class PostTyper extends MacroTransform with IdentityDenotTransformer { thisPhase
         case SingletonTypeTree(ref) =>
           Checking.checkRealizable(ref.tpe, ref.srcPos)
           super.transform(tree)
+        case tree: TypeBoundsTree =>
+          val TypeBoundsTree(lo, hi, alias) = tree
+          if !alias.isEmpty then
+            val bounds = TypeBounds(lo.tpe, hi.tpe)
+            if !bounds.contains(alias.tpe) then
+              report.error(em"type ${alias.tpe} outside bounds $bounds", tree.srcPos)
+          super.transform(tree)
         case tree: TypeTree =>
           tree.withType(
             tree.tpe match {

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2164,10 +2164,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     val alias1 = typed(alias)
     val lo2 = if (lo1.isEmpty) typed(untpd.TypeTree(defn.NothingType)) else lo1
     val hi2 = if (hi1.isEmpty) typed(untpd.TypeTree(defn.AnyType)) else hi1
-    if !alias1.isEmpty then
-      val bounds = TypeBounds(lo2.tpe, hi2.tpe)
-      if !bounds.contains(alias1.tpe) then
-        report.error(em"type ${alias1.tpe} outside bounds $bounds", tree.srcPos)
     assignType(cpy.TypeBoundsTree(tree)(lo2, hi2, alias1), lo2, hi2, alias1)
 
   def typedBind(tree: untpd.Bind, pt: Type)(using Context): Tree = {

--- a/tests/neg/i8337.scala
+++ b/tests/neg/i8337.scala
@@ -1,6 +1,6 @@
 trait Foo[F <: Foo[F]]
 class Bar extends Foo[Bar]
 
-object Q {    // error: recursion limit exceeded
-  opaque type X <: Foo[X] = Bar // error: out of bounds // error
+object Q {    // error: cyclic reference
+  opaque type X <: Foo[X] = Bar // error: cyclic reference
 }

--- a/tests/neg/opaque-bounds-1.scala
+++ b/tests/neg/opaque-bounds-1.scala
@@ -1,0 +1,13 @@
+abstract class Test {
+  opaque type FlagSet = Int
+
+  opaque type Flag <: FlagSet = String  // error: type String outside bounds  <: Test.this.FlagSet
+
+  object Flag {
+    def make(s: String): Flag = s
+  }
+
+  val f: Flag = Flag.make("hello")
+  val g: FlagSet = f
+
+}

--- a/tests/neg/opaque-bounds.scala
+++ b/tests/neg/opaque-bounds.scala
@@ -2,7 +2,7 @@ class Test { // error: class Test cannot be instantiated
 
   opaque type FlagSet = Int
 
-  opaque type Flag <: FlagSet = String  // error: type String outside bounds  <: Test.this.FlagSet
+  opaque type Flag <: FlagSet = String
 
   object Flag {
     def make(s: String): Flag = s

--- a/tests/pos/recursive-opaques.scala
+++ b/tests/pos/recursive-opaques.scala
@@ -1,0 +1,12 @@
+object Syms:
+  import SymDs.*
+  opaque type Symbol <: AnyRef
+    = SymDenotation
+  opaque type ClassSymbol <: Symbol
+    = ClassDenotation
+
+object SymDs:
+  import Syms.*
+  class SymDenotation(sym: Symbol)
+  class ClassDenotation(sym: Symbol) extends SymDenotation(sym)
+


### PR DESCRIPTION
When we have a TypeBounds tree that also has an alias, we checked that the alias is within bounds at Typer. This could provoke a CyclicReference when processing opaque type aliases where the type has a bound and also the alias refers back to the type. We avoid the problem by performing the check at PostTyper, analogous to other bounds checks.

Fixes #16642