### PR TITLE
Dealias in ConstantValue, for inline if cond

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -1079,7 +1079,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
         case Inlined(_, Nil, expr) => unapply(expr)
         case Block(Nil, expr) => unapply(expr)
         case _ =>
-          tree.tpe.widenTermRefExpr.normalized match
+          tree.tpe.widenTermRefExpr.dealias.normalized match
             case ConstantType(Constant(x)) => Some(x)
             case _ => None
   }

--- a/tests/pos/i16641.scala
+++ b/tests/pos/i16641.scala
@@ -1,0 +1,25 @@
+trait Logger {
+  inline def debug: debug = valueOf[debug]
+  final type debug = false
+
+  // fails
+  inline final def log(inline s: String): Unit =
+    inline if (debug) println(s)
+}
+
+trait BaseLogger extends Logger {
+  // fails
+  def bar() = log("case1")
+}
+
+object Logger {
+  inline def log(s: String): Unit =
+    inline if (valueOf[Logger#debug]) println(s)
+}
+
+class Test:
+  def fails(x: BaseLogger) =
+    x.log("case2")
+
+  def works =
+    Logger.log("case3")


### PR DESCRIPTION
With the change in AvoidMap's derivedSelect, making it widen less
aggressively, now inlining can return a constant value typed with an
alias to a constant type, e.g. `false: BaseLogger_this.False`.
Similarly to inline val, we can dealias these.

Fixes #16641.