### PR TITLE
Fix -Wunused:import registering constructor ("<init>") instead of its owner (also fix false positive for enum)

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -27,6 +27,7 @@ import dotty.tools.dotc.core.Definitions
 import dotty.tools.dotc.core.Types.ConstantType
 import dotty.tools.dotc.core.NameKinds.WildcardParamName
 import dotty.tools.dotc.core.Types.TermRef
+import dotty.tools.dotc.core.Types.NameFilter
 
 
 
@@ -326,9 +327,10 @@ object CheckUnused:
      */
     def registerUsed(sym: Symbol, name: Option[Name])(using Context): Unit =
       if !isConstructorOfSynth(sym) && !doNotRegister(sym) then
-        usedInScope.top += ((sym, sym.isAccessibleAsIdent, name))
         if sym.isConstructor && sym.exists then
           registerUsed(sym.owner, None) // constructor are "implicitly" imported with the class
+        else
+          usedInScope.top += ((sym, sym.isAccessibleAsIdent, name))
 
     /** Register a symbol that should be ignored */
     def addIgnoredUsage(sym: Symbol)(using Context): Unit =

--- a/tests/neg-custom-args/fatal-warnings/i15503a.scala
+++ b/tests/neg-custom-args/fatal-warnings/i15503a.scala
@@ -251,3 +251,8 @@ package foo.testing.imports.precedence:
   import scala.collection.immutable.{BitSet => _, _} // error
   import scala.collection.immutable.BitSet // OK
   def t = BitSet.empty
+
+package foo.test.enums:
+  enum A: // OK
+    case B extends A // OK
+    case C extends A // OK

--- a/tests/neg-custom-args/fatal-warnings/i15503i.scala
+++ b/tests/neg-custom-args/fatal-warnings/i15503i.scala
@@ -65,3 +65,12 @@ package foo.test.scala.annotation:
     @unused private def c = 3 // OK
 
     def other = b
+
+package foo.test.companionprivate:
+  class A:
+    import A.b // OK
+    def a = b // OK
+
+  object A:
+    private def b = c // OK
+    def c = List(1,2,3) // OK


### PR DESCRIPTION
This solves the issue #16650.

The issue is that `member(sym.name)` failed to resolve when a type contains multiple identical name. Here the `dotty.tools.dotc.util` package contains multiple "<init>" (constructor), so `member` fail to resolve the name

The solution is to register the owner of the contructor instead of the constructor itself.

:warning: I couldn't create a test where this appends, I tested it by `publishLocal` and testing the code in a different project with this code from #16650 (also didn't check on the metals build):
```scala
//> using lib "org.scala-lang::scala3-compiler:3.3.0-RC1-bin-20230109-f56089b-NIGHTLY"
//> using scala "3.3.0-RC1-bin-20230109-f56089b-NIGHTLY"
//> using option "-Wunused:all"

import dotty.tools.dotc.util.LinearSet

@main
def run = 
  val a = 123
  println("Hello!")
```
```bash
sbt> run
[info] compiling 1 Scala source to .../target/scala-3.3.0-RC1-bin-SNAPSHOT/classes ...
[warn] -- Warning: ..../src/main/scala/Main.scala:5:29 
[warn] 5 |import dotty.tools.dotc.util.LinearSet
[warn]   |                             ^^^^^^^^^
[warn]   |                             unused import
[warn] -- Warning:.../src/main/scala/Main.scala:10:6 
[warn] 10 |  val a = 123
[warn]    |      ^
[warn]    |      unused local definition
[warn] two warnings found
[info] running run 
Hello!
```
### EDIT
Also add a related fix for import generated by enum (false positive)