### PR TITLE
Use `Object.toString` for `quoted.{Expr, Type}`

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/ExprImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/ExprImpl.scala
@@ -20,6 +20,4 @@ final class ExprImpl(val tree: tpd.Tree, val scope: Scope) extends Expr[Any] {
   }
 
   override def hashCode(): Int = tree.hashCode()
-
-  override def toString: String = "'{ ... }"
 }

--- a/compiler/src/scala/quoted/runtime/impl/TypeImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/TypeImpl.scala
@@ -14,6 +14,4 @@ final class TypeImpl(val typeTree: tpd.Tree, val scope: Scope) extends Type[?] {
   }
 
   override def hashCode(): Int = typeTree.hashCode()
-
-  override def toString: String = "Type.of[...]"
 }


### PR DESCRIPTION
Alternative to #16556.

The default to string implementation gives more information on the expression or type than `'{...}` or `Type.of[..]`. With this string representation, we will know the class and instance hash.