### PR TITLE
Don't treat package object's <init> methods as package members

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2515,9 +2515,12 @@ object SymDenotations {
             multi.filterWithPredicate(_.symbol.associatedFile == chosen)
       end dropStale
 
-      if symbol eq defn.ScalaPackageClass then
+      if name == nme.CONSTRUCTOR then
+        NoDenotation // packages don't have constructors, even if package objects do.
+      else if symbol eq defn.ScalaPackageClass then
+        // revert order: search package first, then nested package objects
         val denots = super.computeMembersNamed(name)
-        if denots.exists || name == nme.CONSTRUCTOR then denots
+        if denots.exists then denots
         else recur(packageObjs, NoDenotation)
       else recur(packageObjs, NoDenotation)
     end computeMembersNamed


### PR DESCRIPTION
Extends [`b848c57` (#7862)](https://github.com/lampepfl/dotty/pull/7862/commits/b848c57dbde3d754f04261276993a432b3909476) to all packages.

Previously when asking for `dotty.tools.dotc.util.<init>` we'd get a TypeError because both
`LinearMap$package`'s and `LinearSet$package`'s constructors have the same modification time (in the jar).
