### PR TITLE
Fix #16675 : `-Wunused` false positive on case class generated method, due to flags used to distinguish case accessors.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -367,7 +367,7 @@ object CheckUnused:
             explicitParamInScope += memDef
         else if currScopeType.top == ScopeType.Local then
           localDefInScope += memDef
-        else if currScopeType.top == ScopeType.Template && memDef.symbol.is(Private, butNot = SelfName) then
+        else if memDef.shouldReportPrivateDef then
           privateDefInScope += memDef
 
     /** Register pattern variable */
@@ -589,9 +589,12 @@ object CheckUnused:
 
       private def isValidParam(using Context): Boolean =
         val sym = memDef.symbol
-        (sym.is(Param) || sym.isAllOf(PrivateParamAccessor)) &&
+        (sym.is(Param) || sym.isAllOf(PrivateParamAccessor | Local, butNot = CaseAccessor)) &&
         !isSyntheticMainParam(sym)  &&
         !sym.shouldNotReportParamOwner
+
+      private def shouldReportPrivateDef(using Context): Boolean = 
+        currScopeType.top == ScopeType.Template && !memDef.symbol.isConstructor && memDef.symbol.is(Private, butNot = SelfName | Synthetic | CaseAccessor)
 
     extension (imp: tpd.Import)
       /** Enum generate an import for its cases (but outside them), which should be ignored */

--- a/tests/neg-custom-args/fatal-warnings/i15503c.scala
+++ b/tests/neg-custom-args/fatal-warnings/i15503c.scala
@@ -18,3 +18,10 @@ class A:
     val x = 1 // OK
     def y = 2 // OK
     def z = g // OK
+
+package foo.test.contructors:
+  case class A private (x:Int) // OK
+  class B private (val x: Int) // OK
+  class C private (private val x: Int) // error
+  class D private (private val x: Int): // OK
+    def y = x

--- a/tests/neg-custom-args/fatal-warnings/i15503i.scala
+++ b/tests/neg-custom-args/fatal-warnings/i15503i.scala
@@ -74,3 +74,50 @@ package foo.test.companionprivate:
   object A:
     private def b = c // OK
     def c = List(1,2,3) // OK
+
+package foo.test.possibleclasses:
+  case class AllCaseClass(
+    k: Int, // OK
+    private val y: Int // OK /* Kept as it can be taken from pattern */
+  )(
+    s: Int, // error /* But not these */
+    val t: Int, // OK
+    private val z: Int // error
+  )       
+
+  case class AllCaseUsed(
+    k: Int, // OK
+    private val y: Int // OK
+  )(
+    s: Int, // OK
+    val t: Int, // OK
+    private val z: Int // OK
+  ) {
+    def a = k + y + s + t + z
+  }
+
+  class AllClass(
+    k: Int, // error
+    private val y: Int // error
+  )(
+    s: Int, // error
+    val t: Int, // OK
+    private val z: Int // error
+  )      
+
+  class AllUsed(
+    k: Int, // OK
+    private val y: Int // OK
+  )(
+    s: Int, // OK
+    val t: Int, // OK
+    private val z: Int // OK
+  ) {
+    def a = k + y + s + t + z
+  } 
+
+package foo.test.from.i16675:
+  case class PositiveNumber private (i: Int) // OK
+  object PositiveNumber:
+    def make(i: Int): Option[PositiveNumber] = //OK 
+      Option.when(i >= 0)(PositiveNumber(i)) // OK


### PR DESCRIPTION
@szymon-rd  This fixes #16675. This add more flags checks on symbol to distinguish generated method and various accessors generated by case classes

### DONE
- Fix flag confusion between (case)accessor and (potentially) generated method in classes
- Update test suits