### PR TITLE
Fix #16680 by registering `Ident` not containing a symbol

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -81,7 +81,12 @@ class CheckUnused extends MiniPhase:
     ctx
 
   override def prepareForIdent(tree: tpd.Ident)(using Context): Context =
-    _key.unusedDataApply(_.registerUsed(tree.symbol, Some(tree.name)))
+    if tree.symbol.exists then 
+      _key.unusedDataApply(_.registerUsed(tree.symbol, Some(tree.name)))
+    else if tree.hasType then
+      _key.unusedDataApply(_.registerUsed(tree.tpe.classSymbol, Some(tree.name)))
+    else
+      ctx
 
   override def prepareForSelect(tree: tpd.Select)(using Context): Context =
     _key.unusedDataApply(_.registerUsed(tree.symbol, Some(tree.name)))

--- a/tests/neg-custom-args/fatal-warnings/i15503a.scala
+++ b/tests/neg-custom-args/fatal-warnings/i15503a.scala
@@ -256,3 +256,13 @@ package foo.test.enums:
   enum A: // OK
     case B extends A // OK
     case C extends A // OK
+
+package foo.test.typeapply.hklamdba.i16680:
+  package foo:
+    trait IO[A]
+
+  package bar:
+    import foo.IO // OK
+
+    def f[F[_]]: String = "hello"
+    def go = f[IO]


### PR DESCRIPTION
- Register their type instead
- Fix #16680
- Update test suit
@szymon-rd 