### PR TITLE
Fix atoms computation of OrType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3441,20 +3441,19 @@ object Types {
       val tp2w = tp2.widenSingletons
       if ((tp1 eq tp1w) && (tp2 eq tp2w)) this else TypeComparer.lub(tp1w, tp2w, isSoft = isSoft)
 
-    private def ensureAtomsComputed()(using Context): Boolean =
-      if atomsRunId != ctx.runId && !isProvisional then
+    private def ensureAtomsComputed()(using Context): Unit =
+      if atomsRunId != ctx.runId then
         myAtoms = computeAtoms()
         myWidened = computeWidenSingletons()
-        atomsRunId = ctx.runId
-        true
-      else
-        false
+        if !isProvisional then atomsRunId = ctx.runId
 
     override def atoms(using Context): Atoms =
-      if ensureAtomsComputed() then myAtoms else computeAtoms()
+      ensureAtomsComputed()
+      myAtoms
 
     override def widenSingletons(using Context): Type =
-      if ensureAtomsComputed() then myWidened else computeWidenSingletons()
+      ensureAtomsComputed()
+      myWidened
 
     def derivedOrType(tp1: Type, tp2: Type, soft: Boolean = isSoft)(using Context): Type =
       if ((tp1 eq this.tp1) && (tp2 eq this.tp2) && soft == isSoft) this


### PR DESCRIPTION
Previously, pos/i7034.scala took more than a minute to compile on my M1 MacBook Pro. Now it takes 5 seconds. The file consists of an IArray with over 4000 string literal elements. The previous caching logic was faulty, which means there was a lot of repeated computation of large immutable sets.