### PR TITLE
Fix check whether classtag can be generated for match types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -520,8 +520,9 @@ object TypeErasure {
         case _: ClassInfo => true
         case _ => false
       }
-    case tp: TypeParamRef => false
-    case tp: TypeBounds => false
+    case _: TypeParamRef => false
+    case _: TypeBounds => false
+    case _: MatchType => false
     case tp: TypeProxy => hasStableErasure(tp.translucentSuperType)
     case tp: AndType => hasStableErasure(tp.tp1) && hasStableErasure(tp.tp2)
     case tp: OrType  => hasStableErasure(tp.tp1) && hasStableErasure(tp.tp2)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1071,7 +1071,7 @@ object Types {
      *  @param relaxedCheck   if true type `Null` becomes a subtype of non-primitive value types in TypeComparer.
      *  @param matchLoosely   if true the types `=> T` and `()T` are seen as overriding each other.
      *  @param checkClassInfo if true we check that ClassInfos are within bounds of abstract types
-     * 
+     *
      *  @param isSubType      a function used for checking subtype relationships.
      */
     final def overrides(that: Type, relaxedCheck: Boolean, matchLoosely: => Boolean, checkClassInfo: Boolean = true,

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -52,14 +52,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
             if defn.SpecialClassTagClasses.contains(sym) then
               classTagModul.select(sym.name.toTermName).withSpan(span)
             else
-              def clsOfType(tp: Type): Type = tp.dealias.underlyingMatchType match
-                case matchTp: MatchType =>
-                  matchTp.alternatives.map(clsOfType) match
-                    case ct1 :: cts if cts.forall(ct1 == _) => ct1
-                    case _ => NoType
-                case _ =>
-                  escapeJavaArray(erasure(tp))
-              val ctype = clsOfType(tp)
+              val ctype = escapeJavaArray(erasure(tp))
               if ctype.exists then
                 classTagModul.select(nme.apply)
                   .appliedToType(tp)

--- a/tests/neg/i15618.check
+++ b/tests/neg/i15618.check
@@ -16,3 +16,9 @@
    |
    |                                                case Float32 => Float
    |                                                case Int32 => Int
+-- [E172] Type Error: tests/neg/i15618.scala:21:33 ---------------------------------------------------------------------
+21 |  def toArray: Array[T] = Array() // error
+   |                                 ^
+   |                                 No ClassTag available for T
+   |
+   |                                 where:    T is a type in class Tensor2 with bounds <: Int | Float

--- a/tests/neg/i15618.scala
+++ b/tests/neg/i15618.scala
@@ -16,8 +16,16 @@ class Tensor[T <: DType](dtype: T):
   def toSeq: Seq[ScalaType[T]] = Seq()
   def toArray: Array[ScalaType[T]] = Array() // error
 
+class Tensor2[T <: Int | Float](dtype: T):
+  def toSeq: Seq[T] = Seq()
+  def toArray: Array[T] = Array() // error
+
 @main
 def Test =
   val t = Tensor(Float32) // Tensor[Float32]
   println(t.toSeq.headOption) // works, Seq[Float]
   println(t.toArray.headOption) // ClassCastException
+
+  val t2 = Tensor2(0.0f) // Tensor2[Float]
+  println(t.toSeq.headOption)
+  println(t.toArray.headOption)

--- a/tests/pos/i16706.scala
+++ b/tests/pos/i16706.scala
@@ -1,0 +1,17 @@
+import scala.deriving.Mirror
+import scala.reflect.ClassTag
+
+type TupleUnionLub[T <: Tuple, Lub, Acc <: Lub] <: Lub = T match {
+  case (h & Lub) *: t => TupleUnionLub[t, Lub, Acc | h]
+  case EmptyTuple     => Acc
+}
+
+transparent inline given derived[A](
+    using m: Mirror.SumOf[A],
+    idClassTag: ClassTag[TupleUnionLub[m.MirroredElemTypes, A, Nothing]]
+): Unit = ()
+
+sealed trait Foo
+case class FooA(a: Int) extends Foo
+
+val instance = derived[Foo] // error

--- a/tests/pos/i16707.scala
+++ b/tests/pos/i16707.scala
@@ -1,0 +1,11 @@
+import scala.deriving.Mirror
+import scala.reflect.ClassTag
+
+transparent inline given derived[A](
+      using m: Mirror.ProductOf[A],
+      idClassTag: ClassTag[Tuple.Union[m.MirroredElemTypes]]
+  ): Unit = ???
+
+case class Foo(a: Int)
+
+val instance = derived[Foo] // error


### PR DESCRIPTION
The previous check, meant to address #15618, tested whether all alternatives of a match type had the same classtag and only then permitted a classtag for the match type. This was the wrong test. It did not work for recursive match types, because it could lead to stack overflow for them. And it did not take into account that match types could be reduced.

A better test is to simply declare that match types themselves don't have a stable erasure, just like TypeBounds don't have a stable erasure. If we find an applied type with a match type as definition, we proceed to its translucent supertype, which will try a match type reduction. If that succeeds we produce the classtag of the redux. If not, we end up with an unreduced matchtype and refuse to generate a classtag for it.

Fixes #16706
Fixes #16707