### PR TITLE
Add `capability` modifier for capability classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -199,6 +199,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
     case class Erased()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Erased)
 
+    case class Capability()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Capability)
+
     case class Final()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Final)
 
     case class Sealed()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Sealed)

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -377,6 +377,9 @@ object Flags {
   /** Symbol cannot be found as a member during typer */
   val (Invisible @ _, _, _) = newFlags(45, "<invisible>")
 
+  /** Labeled with `capability` modifier (capability class)  */
+  val (Capability @ _, _, _) = newFlags(46, "capability")
+
   // ------------ Flags following this one are not pickled ----------------------------------
 
   /** Symbol is not a member of its owner */
@@ -449,7 +452,7 @@ object Flags {
     commonFlags(Private, Protected, Final, Case, Implicit, Given, Override, JavaStatic, Transparent, Erased)
 
   val TypeSourceModifierFlags: FlagSet =
-    CommonSourceModifierFlags.toTypeFlags | Abstract | Sealed | Opaque | Open
+    CommonSourceModifierFlags.toTypeFlags | Abstract | Sealed | Opaque | Open | Capability
 
   val TermSourceModifierFlags: FlagSet =
     CommonSourceModifierFlags.toTermFlags | Inline | AbsOverride | Lazy

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -377,6 +377,7 @@ object NameKinds {
   val DirectMethName: SuffixNameKind = new SuffixNameKind(DIRECT, "$direct")
   val AdaptedClosureName: SuffixNameKind = new SuffixNameKind(ADAPTEDCLOSURE, "$adapted") { override def definesNewName = true }
   val SyntheticSetterName: SuffixNameKind = new SuffixNameKind(SETTER, "_$eq")
+  val CapabilityBaseClassName: SuffixNameKind = new SuffixNameKind(CAPBASECLASS, "_$base")
 
   /** A name together with a signature. Used in Tasty trees. */
   object SignedName extends NameKind(SIGNED) {

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -462,6 +462,7 @@ object StdNames {
     val equalsNumObject : N     = "equalsNumObject"
     val equals_ : N             = "equals"
     val erased: N               = "erased"
+    val capability: N           = "capability"
     val error: N                = "error"
     val eval: N                 = "eval"
     val eqlAny: N               = "eqlAny"

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -190,6 +190,7 @@ object Parsers {
     def isPureArrow(name: Name): Boolean = isIdent(name) && Feature.pureFunsEnabled
     def isPureArrow: Boolean = isPureArrow(nme.PUREARROW) || isPureArrow(nme.PURECTXARROW)
     def isErased = isIdent(nme.erased) && in.erasedEnabled
+    def isCapability = isIdent(nme.capability) && Feature.ccEnabled
     def isSimpleLiteral =
       simpleLiteralTokens.contains(in.token)
       || isIdent(nme.raw.MINUS) && numericLitTokens.contains(in.lookahead.token)
@@ -2959,6 +2960,7 @@ object Parsers {
       case IDENTIFIER =>
         name match {
           case nme.erased if in.erasedEnabled => Mod.Erased()
+          case nme.capability if Feature.ccEnabled => Mod.Capability()
           case nme.inline => Mod.Inline()
           case nme.opaque => Mod.Opaque()
           case nme.open => Mod.Open()

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -1172,7 +1172,7 @@ object Scanners {
 
     def isSoftModifier: Boolean =
       token == IDENTIFIER
-      && (softModifierNames.contains(name) || name == nme.erased && erasedEnabled)
+      && (softModifierNames.contains(name) || (name == nme.erased && erasedEnabled) || (name == nme.capability && Feature.ccEnabled))
 
     def isSoftModifierInModifierPosition: Boolean =
       isSoftModifier && inModifierPosition()

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -377,6 +377,8 @@ object TastyFormat {
     final val DEFAULTGETTER = 11     // The name `<meth-name>$default$<param-num>`
                                      // of a default getter that returns a default argument.
 
+    final val CAPBASECLASS = 19      // The name of the base class for the capability `<name>_$base`
+
     final val SUPERACCESSOR = 20     // The name of a super accessor `super$name` created by SuperAccesors.
 
     final val INLINEACCESSOR = 21    // The name of an inline accessor `inline$name`
@@ -414,6 +416,7 @@ object TastyFormat {
       case INLINEACCESSOR => "INLINEACCESSOR"
       case BODYRETAINER => "BODYRETAINER"
       case OBJECTCLASS => "OBJECTCLASS"
+      case CAPBASECLASS => "CAPBASECLASS"
       case SIGNED => "SIGNED"
       case TARGETSIGNED => "TARGETSIGNED"
       case id => s"NotANameTag($id)"


### PR DESCRIPTION
This is a proof-of-concept PR for adding a modifier for capability classes, so that we can write:
```scala
erased capability class CanIO
```
which will be desugared into:
```scala
erased class CanIO_$base
type CanIO = {*} CanIO_$base
```

This is meant to be a replacement for `@capability` annotation, and should fix #16725.

This PR:
- add the modifier `capability`
- add desugaring logic

