### PR TITLE
Hint about forbidden combination of implicit values and conversions

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2748,7 +2748,7 @@ class MissingImplicitArgument(
           i"\n- ${imp.symbol.showDcl}${convs.map(c => "\n    - " + c.symbol.showDcl).mkString}"
         def noChainConversionsNote(ignoredConversions: Iterable[(TermRef, Iterable[TermRef])]): Option[String] = {
           val convsFormatted = ignoredConversions.map{ (imp, convs) =>
-            i"\n- ${imp.symbol.showDcl}${convs.map(c => "\n    - " + c.symbol.showDcl).mkString}"
+            s"\n- ${imp.symbol.showDcl}${convs.map(c => "\n    - " + c.symbol.showDcl).mkString}"
           }.mkString
           Option.when(ignoredConversions.nonEmpty)(
               i"\n\nNote: implicit conversions are not automatically applied to arguments of using clauses. " +

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2745,10 +2745,10 @@ class MissingImplicitArgument(
         def hiddenImplicitNote(s: SearchSuccess) =
           i"\n\nNote: ${s.ref.symbol.showLocated} was not considered because it was not imported with `import given`."
         def noChainConversionsNote(ignoredConversions: Iterable[TermRef]): Option[String] =
-          Option.when(s.nonEmpty)(
-              i"\n\nNote: Chaining implicit conversions are not allowed in Scala. " +
-              i"The following conversions are in scope:${s.map(g => s"\n  - ${g.symbol.showDcl}").mkString}" +
-              i"\nIf there is an implicit `Conversion[A, ${pt.show}]` and an implicit `A` in scope, you can explicitly pass the argument, e.g. `(using summon[A])`"
+          Option.when(ignoredConversions.nonEmpty)(
+              i"\n\nNote: implicit conversions are not automatically applied to implicit arguments. " +
+              i"You will have to pass the argument explicitly.\n" +
+              i"The following conversions in scope result in ${pt.show}: ${ignoredConversions.map(g => s"\n  - ${g.symbol.showDcl}").mkString}"
           )
         super.msgPostscript
         ++ ignoredInstanceNormalImport.map(hiddenImplicitNote)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2746,7 +2746,7 @@ class MissingImplicitArgument(
           i"\n\nNote: ${s.ref.symbol.showLocated} was not considered because it was not imported with `import given`."
         def noChainConversionsNote(ignoredConversions: Iterable[TermRef]): Option[String] =
           Option.when(ignoredConversions.nonEmpty)(
-              i"\n\nNote: implicit conversions are not automatically applied to implicit arguments. " +
+              i"\n\nNote: implicit conversions are not automatically applied to arguments of using clauses. " +
               i"You will have to pass the argument explicitly.\n" +
               i"The following conversions in scope result in ${pt.show}: ${ignoredConversions.map(g => s"\n  - ${g.symbol.showDcl}").mkString}"
           )

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2555,7 +2555,7 @@ class MissingImplicitArgument(
     where: String,
     paramSymWithMethodCallTree: Option[(Symbol, tpd.Tree)] = None,
     ignoredInstanceNormalImport: => Option[SearchSuccess],
-    ignoredConversions: => Set[SearchSuccess]
+    ignoredConversions: => Iterable[TermRef]
   )(using Context) extends TypeMsg(MissingImplicitArgumentID), ShowMatchTrace(pt):
 
   arg.tpe match
@@ -2744,9 +2744,9 @@ class MissingImplicitArgument(
         // show all available additional info
         def hiddenImplicitNote(s: SearchSuccess) =
           i"\n\nNote: ${s.ref.symbol.showLocated} was not considered because it was not imported with `import given`."
-        def noChainConversionsNote(s: Set[SearchSuccess]): Option[String] =
-          Option.when(s.isEmpty)(
-              i"\n\nNote: Chaining implicit conversions is no longer allowed in Scala. The following conversions were ignored: ${s.map(_.ref.symbol.showLocated).mkString("\n")}"
+        def noChainConversionsNote(s: Iterable[TermRef]): Option[String] =
+          Option.when(s.nonEmpty)(
+              i"\n\nNote: Chaining implicit conversions is no longer allowed in Scala. The following conversions were ignored:${s.map(g => "\n  - " + g.symbol.showLocated).mkString}"
           )
         super.msgPostscript
         ++ ignoredInstanceNormalImport.map(hiddenImplicitNote)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2746,7 +2746,9 @@ class MissingImplicitArgument(
           i"\n\nNote: ${s.ref.symbol.showLocated} was not considered because it was not imported with `import given`."
         def noChainConversionsNote(s: Iterable[TermRef]): Option[String] =
           Option.when(s.nonEmpty)(
-              i"\n\nNote: Chaining implicit conversions is no longer allowed in Scala. The following conversions were ignored:${s.map(g => "\n  - " + g.symbol.showLocated).mkString}"
+              i"\n\nNote: Chaining implicit conversions is no longer allowed in Scala. " +
+              i"The following conversions were ignored:${s.map(g => s"\n  - ${g.symbol.showDcl}").mkString}" +
+              i"\nIf there is an implicit `Conversion[A, ${pt.show}]` and an implicit `A` in scope, you need to explicitly pass the argument, e.g. `(using summon[A])`"
           )
         super.msgPostscript
         ++ ignoredInstanceNormalImport.map(hiddenImplicitNote)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2744,7 +2744,7 @@ class MissingImplicitArgument(
         // show all available additional info
         def hiddenImplicitNote(s: SearchSuccess) =
           i"\n\nNote: ${s.ref.symbol.showLocated} was not considered because it was not imported with `import given`."
-        def noChainConversionsNote(s: Iterable[TermRef]): Option[String] =
+        def noChainConversionsNote(ignoredConversions: Iterable[TermRef]): Option[String] =
           Option.when(s.nonEmpty)(
               i"\n\nNote: Chaining implicit conversions are not allowed in Scala. " +
               i"The following conversions are in scope:${s.map(g => s"\n  - ${g.symbol.showDcl}").mkString}" +

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2746,9 +2746,9 @@ class MissingImplicitArgument(
           i"\n\nNote: ${s.ref.symbol.showLocated} was not considered because it was not imported with `import given`."
         def noChainConversionsNote(s: Iterable[TermRef]): Option[String] =
           Option.when(s.nonEmpty)(
-              i"\n\nNote: Chaining implicit conversions is no longer allowed in Scala. " +
-              i"The following conversions were ignored:${s.map(g => s"\n  - ${g.symbol.showDcl}").mkString}" +
-              i"\nIf there is an implicit `Conversion[A, ${pt.show}]` and an implicit `A` in scope, you need to explicitly pass the argument, e.g. `(using summon[A])`"
+              i"\n\nNote: Chaining implicit conversions are not allowed in Scala. " +
+              i"The following conversions are in scope:${s.map(g => s"\n  - ${g.symbol.showDcl}").mkString}" +
+              i"\nIf there is an implicit `Conversion[A, ${pt.show}]` and an implicit `A` in scope, you can explicitly pass the argument, e.g. `(using summon[A])`"
           )
         super.msgPostscript
         ++ ignoredInstanceNormalImport.map(hiddenImplicitNote)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2555,7 +2555,7 @@ class MissingImplicitArgument(
     where: String,
     paramSymWithMethodCallTree: Option[(Symbol, tpd.Tree)] = None,
     ignoredInstanceNormalImport: => Option[SearchSuccess],
-    ignoredConversions: => Iterable[(TermRef, Iterable[TermRef])]
+    ignoredConvertibleImplicits: => Iterable[TermRef]
   )(using Context) extends TypeMsg(MissingImplicitArgumentID), ShowMatchTrace(pt):
 
   arg.tpe match
@@ -2746,19 +2746,16 @@ class MissingImplicitArgument(
           i"\n\nNote: ${s.ref.symbol.showLocated} was not considered because it was not imported with `import given`."
         def showImplicitAndConversions(imp: TermRef, convs: Iterable[TermRef]) =
           i"\n- ${imp.symbol.showDcl}${convs.map(c => "\n    - " + c.symbol.showDcl).mkString}"
-        def noChainConversionsNote(ignoredConversions: Iterable[(TermRef, Iterable[TermRef])]): Option[String] = {
-          val convsFormatted = ignoredConversions.map{ (imp, convs) =>
-            s"\n- ${imp.symbol.showDcl}${convs.map(c => "\n    - " + c.symbol.showDcl).mkString}"
-          }.mkString
-          Option.when(ignoredConversions.nonEmpty)(
-              i"\n\nNote: implicit conversions are not automatically applied to arguments of using clauses. " +
-              i"You will have to pass the argument explicitly.\n" +
-              i"The following conversions in scope result in ${pt.show}: $convsFormatted"
+        def noChainConversionsNote(ignoredConvertibleImplicits: Iterable[TermRef]): Option[String] =
+          Option.when(ignoredConvertibleImplicits.nonEmpty)(
+            i"\n\nNote: implicit conversions are not automatically applied to arguments of using clauses. " +
+            i"You will have to pass the argument explicitly.\n" +
+            i"The following implicits in scope can be converted to ${pt.show}:" +
+            ignoredConvertibleImplicits.map { imp => s"\n- ${imp.symbol.showDcl}"}.mkString
           )
-        }
         super.msgPostscript
         ++ ignoredInstanceNormalImport.map(hiddenImplicitNote)
-            .orElse(noChainConversionsNote(ignoredConversions))
+            .orElse(noChainConversionsNote(ignoredConvertibleImplicits))
             .getOrElse(ctx.typer.importSuggestionAddendum(pt))
 
   def explain(using Context) = ""

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2750,7 +2750,7 @@ class MissingImplicitArgument(
           Option.when(ignoredConvertibleImplicits.nonEmpty)(
             i"\n\nNote: implicit conversions are not automatically applied to arguments of using clauses. " +
             i"You will have to pass the argument explicitly.\n" +
-            i"The following implicits in scope can be converted to ${pt.show}:" +
+            i"The following implicits in scope can be implicitly converted to ${pt.show}:" +
             ignoredConvertibleImplicits.map { imp => s"\n- ${imp.symbol.showDcl}"}.mkString
           )
         super.msgPostscript

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -962,9 +962,7 @@ trait Implicits:
             .map(_.underlyingRef)
             .distinctBy(_.denot)
             .filter { imp =>
-              !isImplicitDefConversion(imp.underlying)
-                && imp.symbol != defn.Predef_conforms
-                && canBeConverted(imp, fail.expectedType)
+              !isImplicitDefConversion(imp.underlying) && canBeConverted(imp, fail.expectedType)
             }
         else
           Nil

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -926,9 +926,10 @@ trait Implicits:
     def ignoredConversions = arg.tpe match
       case fail: SearchFailureType =>
         if (fail.expectedType eq pt) || isFullyDefined(fail.expectedType, ForceDegree.none) then
-          ImplicitSearch(fail.expectedType, dummyTreeOfType(WildcardType), arg.span).allImplicits
+          ctx.implicits.eligible(ViewProto(WildcardType, wildApprox(fail.expectedType)))
+            .collect { case c if c.isConversion => c.ref }
         else
-          Set.empty
+          Nil
 
     MissingImplicitArgument(arg, pt, where, paramSymWithMethodCallTree, ignoredInstanceNormalImport, ignoredConversions)
   }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -935,8 +935,17 @@ trait Implicits:
           allImplicits(ctx.implicits).map { imp =>
             // todo imp.underlyingRef.underlying does not work for implicit functions or givens
             // with type or implicit parameters
-            val convs = ctx.implicits.eligible(ViewProto(imp.underlyingRef.underlying, wildApprox(fail.expectedType)))
-            (imp.underlyingRef, convs.map(_.ref))
+            val impRef = imp.underlyingRef
+            val impResultType = wildApprox(impRef.underlying.finalResultType)
+            val convs = ctx.implicits.eligible(ViewProto(impResultType, fail.expectedType))
+              .filter { conv =>
+                if !conv.isConversion then false
+                else
+                  // Actually feed the summoned implicit into the Conversion to
+                  // check if it works
+                  true
+              }
+            (impRef, convs.map(_.ref))
           }.filter(_._2.nonEmpty)
         else
           Nil

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -962,7 +962,9 @@ trait Implicits:
             .map(_.underlyingRef)
             .distinctBy(_.denot)
             .filter { imp =>
-              !isImplicitDefConversion(imp.underlying) && canBeConverted(imp, fail.expectedType)
+              !isImplicitDefConversion(imp.underlying)
+                && imp.symbol != defn.Predef_conforms
+                && canBeConverted(imp, fail.expectedType)
             }
         else
           Nil

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -923,7 +923,14 @@ trait Implicits:
           // example where searching for a nested type causes an infinite loop.
           None
 
-    MissingImplicitArgument(arg, pt, where, paramSymWithMethodCallTree, ignoredInstanceNormalImport)
+    def ignoredConversions = arg.tpe match
+      case fail: SearchFailureType =>
+        if (fail.expectedType eq pt) || isFullyDefined(fail.expectedType, ForceDegree.none) then
+          ImplicitSearch(fail.expectedType, dummyTreeOfType(WildcardType), arg.span).allImplicits
+        else
+          Set.empty
+
+    MissingImplicitArgument(arg, pt, where, paramSymWithMethodCallTree, ignoredInstanceNormalImport, ignoredConversions)
   }
 
   /** A string indicating the formal parameter corresponding to a  missing argument */

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -188,6 +188,7 @@ class CompilationTests {
       compileFile("tests/neg-custom-args/i13026.scala", defaultOptions.and("-print-lines")),
       compileFile("tests/neg-custom-args/i13838.scala", defaultOptions.and("-Ximplicit-search-limit", "1000")),
       compileFile("tests/neg-custom-args/jdk-9-app.scala", defaultOptions.and("-release:8")),
+      compileFile("tests/neg/i16453.scala", defaultOptions),
     ).checkExpectedErrors()
   }
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -188,7 +188,6 @@ class CompilationTests {
       compileFile("tests/neg-custom-args/i13026.scala", defaultOptions.and("-print-lines")),
       compileFile("tests/neg-custom-args/i13838.scala", defaultOptions.and("-Ximplicit-search-limit", "1000")),
       compileFile("tests/neg-custom-args/jdk-9-app.scala", defaultOptions.and("-release:8")),
-      compileFile("tests/neg/i16453.scala", defaultOptions),
     ).checkExpectedErrors()
   }
 

--- a/tests/neg/i16453.check
+++ b/tests/neg/i16453.check
@@ -3,7 +3,7 @@
    |                     ^
    |No given instance of type Option[Int] was found for parameter x of method summon in object Predef
    |
-   |Note: implicit conversions are not automatically applied to implicit arguments. You will have to pass the argument explicitly.
+   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
    |The following conversions in scope result in Option[Int]: 
    |  - final given def given_Conversion_T_Option[T]: Conversion[T, Option[T]]
    |  - implicit def toOption[T](t: T): Option[T]
@@ -12,7 +12,7 @@
    |                         ^
    |No given instance of type Option[Int] was found for parameter e of method implicitly in object Predef
    |
-   |Note: implicit conversions are not automatically applied to implicit arguments. You will have to pass the argument explicitly.
+   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
    |The following conversions in scope result in Option[Int]: 
    |  - final given def given_Conversion_T_Option[T]: Conversion[T, Option[T]]
    |  - implicit def toOption[T](t: T): Option[T]

--- a/tests/neg/i16453.check
+++ b/tests/neg/i16453.check
@@ -1,7 +1,8 @@
 -- [E172] Type Error: tests/neg/i16453.scala:10:43 ---------------------------------------------------------------------
 10 |  val fails = summon[String => Option[Int]] // error
    |                                           ^
-   |     No given instance of type String => Option[Int] was found for parameter x of method summon in object Predef
+   |No given instance of type String => Option[Int] was found for parameter x of method summon in object Predef
    |
-   |     Note: Chaining implicit conversions is no longer allowed in Scala. The following conversions were ignored:
-   |       - given instance given_Conversion_Function_Function
+   |Note: Chaining implicit conversions is no longer allowed in Scala. The following conversions were ignored:
+   |  - final given def given_Conversion_Function_Function[T]: Conversion[String => T, String => Option[T]]
+   |If there is an implicit `Conversion[A, String => Option[Int]]` and an implicit `A` in scope, you need to explicitly pass the argument, e.g. `(using summon[A])`

--- a/tests/neg/i16453.check
+++ b/tests/neg/i16453.check
@@ -3,16 +3,16 @@
    |                     ^
    |No given instance of type Option[Int] was found for parameter x of method summon in object Predef
    |
-   |Note: Chaining implicit conversions are not allowed in Scala. The following conversions are in scope:
+   |Note: implicit conversions are not automatically applied to implicit arguments. You will have to pass the argument explicitly.
+   |The following conversions in scope result in Option[Int]: 
    |  - final given def given_Conversion_T_Option[T]: Conversion[T, Option[T]]
    |  - implicit def toOption[T](t: T): Option[T]
-   |If there is an implicit `Conversion[A, Option[Int]]` and an implicit `A` in scope, you can explicitly pass the argument, e.g. `(using summon[A])`
 -- [E172] Type Error: tests/neg/i16453.scala:15:25 ---------------------------------------------------------------------
 15 |  implicitly[Option[Int]] // error
    |                         ^
    |No given instance of type Option[Int] was found for parameter e of method implicitly in object Predef
    |
-   |Note: Chaining implicit conversions are not allowed in Scala. The following conversions are in scope:
+   |Note: implicit conversions are not automatically applied to implicit arguments. You will have to pass the argument explicitly.
+   |The following conversions in scope result in Option[Int]: 
    |  - final given def given_Conversion_T_Option[T]: Conversion[T, Option[T]]
    |  - implicit def toOption[T](t: T): Option[T]
-   |If there is an implicit `Conversion[A, Option[Int]]` and an implicit `A` in scope, you can explicitly pass the argument, e.g. `(using summon[A])`

--- a/tests/neg/i16453.check
+++ b/tests/neg/i16453.check
@@ -1,12 +1,45 @@
--- [E172] Type Error: tests/neg/i16453.scala:19:21 ---------------------------------------------------------------------
-19 |  summon[Option[Int]] // error
+-- [E172] Type Error: tests/neg/i16453.scala:21:19 ---------------------------------------------------------------------
+21 |  summon[List[Int]] // error
+   |                   ^
+   |                 No given instance of type List[Int] was found for parameter x of method summon in object Predef
+-- [E172] Type Error: tests/neg/i16453.scala:23:21 ---------------------------------------------------------------------
+23 |  summon[Option[Int]] // error
    |                     ^
    |No given instance of type Option[Int] was found for parameter x of method summon in object Predef
    |
    |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
-   |The following conversions in scope can be converted to Option[Int]:
-   |- given bar: Int
--- [E172] Type Error: tests/neg/i16453.scala:20:25 ---------------------------------------------------------------------
-20 |  implicitly[Option[Int]] // error
+   |The following implicits in scope can be implicitly converted to Option[Int]:
+   |- final lazy given val baz3: Char
+   |- final lazy given val bar3: Int
+-- [E172] Type Error: tests/neg/i16453.scala:24:26 ---------------------------------------------------------------------
+24 |  implicitly[Option[Char]] // error
+   |                          ^
+   |No given instance of type Option[Char] was found for parameter e of method implicitly in object Predef
+   |
+   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
+   |The following implicits in scope can be implicitly converted to Option[Char]:
+   |- final lazy given val baz3: Char
+-- [E172] Type Error: tests/neg/i16453.scala:25:20 ---------------------------------------------------------------------
+25 |  implicitly[String] // error
+   |                    ^
+   |No given instance of type String was found for parameter e of method implicitly in object Predef
+   |
+   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
+   |The following implicits in scope can be implicitly converted to String:
+   |- final lazy given val baz3: Char
+-- [E172] Type Error: tests/neg/i16453.scala:35:16 ---------------------------------------------------------------------
+35 |  summon[String] // error
+   |                ^
+   |No given instance of type String was found for parameter x of method summon in object Predef
+   |
+   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
+   |The following implicits in scope can be implicitly converted to String:
+   |- implicit val baz2: Char
+-- [E172] Type Error: tests/neg/i16453.scala:36:25 ---------------------------------------------------------------------
+36 |  implicitly[Option[Int]] // error
    |                         ^
-   |           No given instance of type Option[Int] was found for parameter e of method implicitly in object Predef
+   |No given instance of type Option[Int] was found for parameter e of method implicitly in object Predef
+   |
+   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
+   |The following implicits in scope can be implicitly converted to Option[Int]:
+   |- implicit val bar2: Int

--- a/tests/neg/i16453.check
+++ b/tests/neg/i16453.check
@@ -1,18 +1,12 @@
--- [E172] Type Error: tests/neg/i16453.scala:14:21 ---------------------------------------------------------------------
-14 |  summon[Option[Int]] // error
+-- [E172] Type Error: tests/neg/i16453.scala:19:21 ---------------------------------------------------------------------
+19 |  summon[Option[Int]] // error
    |                     ^
    |No given instance of type Option[Int] was found for parameter x of method summon in object Predef
    |
    |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
-   |The following conversions in scope result in Option[Int]: 
-   |  - final given def given_Conversion_T_Option[T]: Conversion[T, Option[T]]
-   |  - implicit def toOption[T](t: T): Option[T]
--- [E172] Type Error: tests/neg/i16453.scala:15:25 ---------------------------------------------------------------------
-15 |  implicitly[Option[Int]] // error
+   |The following conversions in scope can be converted to Option[Int]:
+   |- given bar: Int
+-- [E172] Type Error: tests/neg/i16453.scala:20:25 ---------------------------------------------------------------------
+20 |  implicitly[Option[Int]] // error
    |                         ^
-   |No given instance of type Option[Int] was found for parameter e of method implicitly in object Predef
-   |
-   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
-   |The following conversions in scope result in Option[Int]: 
-   |  - final given def given_Conversion_T_Option[T]: Conversion[T, Option[T]]
-   |  - implicit def toOption[T](t: T): Option[T]
+   |           No given instance of type Option[Int] was found for parameter e of method implicitly in object Predef

--- a/tests/neg/i16453.check
+++ b/tests/neg/i16453.check
@@ -1,0 +1,7 @@
+-- [E172] Type Error: tests/neg/i16453.scala:10:43 ---------------------------------------------------------------------
+10 |  val fails = summon[String => Option[Int]] // error
+   |                                           ^
+   |     No given instance of type String => Option[Int] was found for parameter x of method summon in object Predef
+   |
+   |     Note: Chaining implicit conversions is no longer allowed in Scala. The following conversions were ignored:
+   |       - given instance given_Conversion_Function_Function

--- a/tests/neg/i16453.check
+++ b/tests/neg/i16453.check
@@ -1,8 +1,18 @@
--- [E172] Type Error: tests/neg/i16453.scala:10:43 ---------------------------------------------------------------------
-10 |  val fails = summon[String => Option[Int]] // error
-   |                                           ^
-   |No given instance of type String => Option[Int] was found for parameter x of method summon in object Predef
+-- [E172] Type Error: tests/neg/i16453.scala:14:21 ---------------------------------------------------------------------
+14 |  summon[Option[Int]] // error
+   |                     ^
+   |No given instance of type Option[Int] was found for parameter x of method summon in object Predef
    |
-   |Note: Chaining implicit conversions is no longer allowed in Scala. The following conversions were ignored:
-   |  - final given def given_Conversion_Function_Function[T]: Conversion[String => T, String => Option[T]]
-   |If there is an implicit `Conversion[A, String => Option[Int]]` and an implicit `A` in scope, you need to explicitly pass the argument, e.g. `(using summon[A])`
+   |Note: Chaining implicit conversions are not allowed in Scala. The following conversions are in scope:
+   |  - final given def given_Conversion_T_Option[T]: Conversion[T, Option[T]]
+   |  - implicit def toOption[T](t: T): Option[T]
+   |If there is an implicit `Conversion[A, Option[Int]]` and an implicit `A` in scope, you can explicitly pass the argument, e.g. `(using summon[A])`
+-- [E172] Type Error: tests/neg/i16453.scala:15:25 ---------------------------------------------------------------------
+15 |  implicitly[Option[Int]] // error
+   |                         ^
+   |No given instance of type Option[Int] was found for parameter e of method implicitly in object Predef
+   |
+   |Note: Chaining implicit conversions are not allowed in Scala. The following conversions are in scope:
+   |  - final given def given_Conversion_T_Option[T]: Conversion[T, Option[T]]
+   |  - implicit def toOption[T](t: T): Option[T]
+   |If there is an implicit `Conversion[A, Option[Int]]` and an implicit `A` in scope, you can explicitly pass the argument, e.g. `(using summon[A])`

--- a/tests/neg/i16453.scala
+++ b/tests/neg/i16453.scala
@@ -1,11 +1,16 @@
 import scala.language.implicitConversions
 
-given [T]: Conversion[String => T, String => Option[T]] = ???
+// Scala 3 style conversion
+given [T]: Conversion[T, Option[T]] = ???
+// Scala 2 style conversion
+implicit def toOption[T](t: T): Option[T] = Option(t)
+
 // This one is irrelevant, shouldn't be included in error message
-given irrelevant[T]: Conversion[String => T, String => Byte] = ???
+given irrelevant: Conversion[Int, Option[Long]] = ???
 
 def test() = {
-  given foo: (String => Int) = _ => 42
+  given foo: Int = 0
 
-  val fails = summon[String => Option[Int]] // error
+  summon[Option[Int]] // error
+  implicitly[Option[Int]] // error
 }

--- a/tests/neg/i16453.scala
+++ b/tests/neg/i16453.scala
@@ -3,7 +3,7 @@ import scala.language.implicitConversions
 trait Foo { type T }
 
 // Scala 3 style conversion
-// given [T]: Conversion[T, Option[T]] = ???
+given [T]: Conversion[T, Option[T]] = ???
 given [F <: Foo](using f: F): Conversion[f.T, Option[f.T]] = ???
 // Scala 2 style conversion
 implicit def toOption[T](t: T): Option[T] = Option(t)

--- a/tests/neg/i16453.scala
+++ b/tests/neg/i16453.scala
@@ -2,20 +2,36 @@ import scala.language.implicitConversions
 
 trait Foo { type T }
 
-// Scala 3 style conversion
-given [T]: Conversion[T, Option[T]] = ???
-given [F <: Foo](using f: F): Conversion[f.T, Option[f.T]] = ???
-// Scala 2 style conversion
-implicit def toOption[T](t: T): Option[T] = Option(t)
-
 // This one is irrelevant, shouldn't be included in error message
-given irrelevant: Conversion[Int, Option[Long]] = ???
+given irrelevant: Long = ???
 
-def test() = {
+/** Use Scala 3 givens/conversions */
+def testScala3() = {
+  given c1[T]: Conversion[T, Option[T]] = ???
+  given c2[F <: Foo](using f: F): Conversion[f.T, Option[f.T]] = ???
+  given Conversion[Char, String] = ???
+  given Conversion[Char, Option[Int]] = ???
+
   given foo: Foo with
     type T = Int
-  given bar: Int = 0
+  given bar3: Int = 0
+  given baz3: Char = 'a'
+
+  // This should get the usual error
+  summon[List[Int]] // error
 
   summon[Option[Int]] // error
+  implicitly[Option[Char]] // error
+  implicitly[String] // error
+}
+
+/** Use Scala 2 implicits */
+def testScala2() = {
+  implicit def toOpt[T](t: T): Option[T] = ???
+  implicit def char2Str(c: Char): String = ???
+  implicit val bar2: Int = 1
+  implicit val baz2: Char = 'b'
+
+  summon[String] // error
   implicitly[Option[Int]] // error
 }

--- a/tests/neg/i16453.scala
+++ b/tests/neg/i16453.scala
@@ -1,0 +1,11 @@
+import scala.language.implicitConversions
+
+given [T]: Conversion[String => T, String => Option[T]] = ???
+// This one is irrelevant, shouldn't be included in error message
+given irrelevant[T]: Conversion[String => T, String => Byte] = ???
+
+def test() = {
+  given foo: (String => Int) = _ => 42
+
+  val fails = summon[String => Option[Int]] // error
+}

--- a/tests/neg/i16453.scala
+++ b/tests/neg/i16453.scala
@@ -1,7 +1,10 @@
 import scala.language.implicitConversions
 
+trait Foo { type T }
+
 // Scala 3 style conversion
-given [T]: Conversion[T, Option[T]] = ???
+// given [T]: Conversion[T, Option[T]] = ???
+given [F <: Foo](using f: F): Conversion[f.T, Option[f.T]] = ???
 // Scala 2 style conversion
 implicit def toOption[T](t: T): Option[T] = Option(t)
 
@@ -9,7 +12,9 @@ implicit def toOption[T](t: T): Option[T] = Option(t)
 given irrelevant: Conversion[Int, Option[Long]] = ???
 
 def test() = {
-  given foo: Int = 0
+  given foo: Foo with
+    type T = Int
+  given bar: Int = 0
 
   summon[Option[Int]] // error
   implicitly[Option[Int]] // error


### PR DESCRIPTION
For fixing #16453.

When an implicit argument of some type `T` is missing, this looks for all `Conversion`s in scope resulting in type `T` and includes a note that you can't combine implicit values and conversions. However, if it does find a `Conversion[A, T]`, it doesn't check if there's actually an implicit `A` in scope. The desired example message in the original issue did also find an implicit value to give as input to the `Conversion`, but I figured that's extra work for the compiler to do and might not be desired.

Also, the error message doesn't show the actual source of the found conversions, it's showing generated mangled names. I'll have to fix that.

It's my first time making a change to the dotc code, so please tell me if I've done something wrong.