### PR TITLE
Improve `New`/`Select` -Ycheck message

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -141,7 +141,7 @@ class TreeChecker extends Phase with SymTransformer {
       override def apply(parent: Tree, tree: Tree)(using Context): Tree = {
         tree match {
           case tree: New if !parent.isInstanceOf[tpd.Select] =>
-            assert(assertion = false, i"`New` node must be wrapped in a `Select`:\n  parent = ${parent.show}\n  child = ${tree.show}")
+            assert(assertion = false, i"`New` node must be wrapped in a `Select` of the constructor:\n  parent = ${parent.show}\n  child = ${tree.show}")
           case _: Annotated =>
             // Don't check inside annotations, since they're allowed to contain
             // somewhat invalid trees.


### PR DESCRIPTION
We mention that the constructor must be selected. This should be all the information needed in case someone writes a buggy macro that does not include the `Select` around the `New`.

Closed #16357