### PR TITLE
Prepare bodies of inline forwarders eagerly

### DIFF
--- a/tests/pos-macros/i14131.scala
+++ b/tests/pos-macros/i14131.scala
@@ -1,0 +1,11 @@
+class Dog:
+  inline given bark(using msg: String = "Woof!"): String = s"bark: $msg"
+
+class Wolf:
+  private val dog: Dog = Dog()
+  export dog.given
+
+def test =
+  val w = Wolf()
+  import w.given
+  summon[String]

--- a/tests/pos/i16469.scala
+++ b/tests/pos/i16469.scala
@@ -1,0 +1,15 @@
+class Context {
+  def normalMethod(): String = "normal"
+  inline def inlineMethod(): String = "inline"
+}
+
+class Script(ctx: Context) {
+  export ctx.*
+  normalMethod()
+  inlineMethod()
+}
+
+class MyScript(context: Context) extends Script(context) {
+  normalMethod()
+  inlineMethod()
+}


### PR DESCRIPTION
* Fix context owner of `PrepareInlineable.registerInlineInfo`. It should have as owner the inline method (`forwarder` in this case).
* Eagerly compute the inlinable RHS. Because we create the forwarder already typed, we do not evaluate/force in typer the `LazyBodyAnnotation` which is what triggers the computation of the inline accessors. This happened in posttyper which was too late. There might be a cleaner solution to this problem, maybe forcing the annotation explicitly.

Fixes #14131
Fixes #16469