### PR TITLE
Fix Scaladoc crash when extending non-Scala-3 classes (short-term fix for 3.3.x)

### DIFF
--- a/scaladoc-testcases/src/tests/nonScala3Parent.scala
+++ b/scaladoc-testcases/src/tests/nonScala3Parent.scala
@@ -1,0 +1,13 @@
+package tests
+package nonScala3Parent
+
+import javax.swing.JPanel
+import javax.swing.JFrame
+
+// https://github.com/lampepfl/dotty/issues/15927
+
+trait Foo1 extends Numeric[Any]
+trait Foo2 extends JPanel
+trait Foo3 extends JFrame
+trait Foo4 extends Ordering[Any]
+trait Foo5 extends Enumeration

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -266,7 +266,8 @@ trait ClassLikeSupport:
     def getParentsAsTreeSymbolTuples: List[(Tree, Symbol)] =
       if noPosClassDefs.contains(c.symbol) then Nil
       else for
-        parentTree <- c.parents if parentTree.pos.start != parentTree.pos.end // We assume here that order is correct
+        // TODO: add exists function to position methods in Quotes and replace the condition here for checking the JPath
+        parentTree <- c.parents if parentTree.pos.sourceFile.getJPath.isDefined && parentTree.pos.start != parentTree.pos.end // We assume here that order is correct
         parentSymbol = parentTree match
           case t: TypeTree => t.tpe.typeSymbol
           case tree if tree.symbol.isClassConstructor => tree.symbol.owner

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -106,3 +106,5 @@ class ImplicitMembers extends SignatureTest(
   Seq("def"),
   filterFunc = _.toString.endsWith("OuterClass$ImplicitMemberTarget.html")
 )
+
+class NonScala3Parent extends SignatureTest("nonScala3Parent", SignatureTest.all)


### PR DESCRIPTION
Added jpath check to `ClassLikeSupport` getParentsAsTreeSymbolTuples — check for whether the non-scala3 parent exists before checking the start and end of the span to confirm whether the span exists in getParentsAsTreeSymbolTuples.

Fixes #15927