### PR TITLE
Fix Scaladoc crash when extending non-Scala-3 classes (long-term fix for 3.4.0)

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2850,6 +2850,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     given PositionMethods: PositionMethods with
       extension (self: Position)
+        def exists: Boolean = self.exists
         def start: Int = self.start
         def end: Int = self.end
         def sourceFile: SourceFile = self.source

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -4499,6 +4499,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Position` */
     trait PositionMethods {
       extension (self: Position)
+        /** Whether we have Span information at all */
+        def exists: Boolean
 
         /** The start offset in the source file */
         def start: Int

--- a/scaladoc-testcases/src/tests/nonScala3Parent.scala
+++ b/scaladoc-testcases/src/tests/nonScala3Parent.scala
@@ -1,0 +1,13 @@
+package tests
+package nonScala3Parent
+
+import javax.swing.JPanel
+import javax.swing.JFrame
+
+// https://github.com/lampepfl/dotty/issues/15927
+
+trait Foo1 extends Numeric[Any]
+trait Foo2 extends JPanel
+trait Foo3 extends JFrame
+trait Foo4 extends Ordering[Any]
+trait Foo5 extends Enumeration

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -266,7 +266,7 @@ trait ClassLikeSupport:
     def getParentsAsTreeSymbolTuples: List[(Tree, Symbol)] =
       if noPosClassDefs.contains(c.symbol) then Nil
       else for
-        parentTree <- c.parents if parentTree.pos.start != parentTree.pos.end // We assume here that order is correct
+        parentTree <- c.parents if parentTree.pos.exists && parentTree.pos.start != parentTree.pos.end // We assume here that order is correct
         parentSymbol = parentTree match
           case t: TypeTree => t.tpe.typeSymbol
           case tree if tree.symbol.isClassConstructor => tree.symbol.owner

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -106,3 +106,5 @@ class ImplicitMembers extends SignatureTest(
   Seq("def"),
   filterFunc = _.toString.endsWith("OuterClass$ImplicitMemberTarget.html")
 )
+
+class NonScala3Parent extends SignatureTest("nonScala3Parent", SignatureTest.all)


### PR DESCRIPTION
Extend the PositionMethods with an exists method, since the other methods are not safe to call on non-existing Spans.

Not eligible for backport to 3.3 because of API addition. See #16759 for a workaround that uses the current API.

Fixes #15927