### PR TITLE
Add default scaladoc settings to scaladoc artifact publishing

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -843,6 +843,7 @@ object Build {
       "-sourcepath", (Compile / sourceDirectories).value.map(_.getAbsolutePath).distinct.mkString(File.pathSeparator),
       "-Yexplicit-nulls",
     ),
+    (Compile / doc / scalacOptions) ++= ScaladocConfigs.DefaultGenerationSettings.value.settings
   )
 
   lazy val `scala3-library` = project.in(file("library")).asDottyLibrary(NonBootstrapped)
@@ -1892,8 +1893,7 @@ object ScaladocConfigs {
     )
   }
 
-  lazy val DefaultGenerationConfig = Def.task {
-    def distLocation = (dist / pack).value
+  lazy val DefaultGenerationSettings = Def.task {
     def projectVersion = version.value
     def socialLinks = SocialLinks(List(
       "github::https://github.com/lampepfl/dotty",
@@ -1932,6 +1932,11 @@ object ScaladocConfigs {
         )
       )
     )
+  }
+
+  lazy val DefaultGenerationConfig = Def.task {
+    def distLocation = (dist / pack).value
+    DefaultGenerationSettings.value
   }
 
   lazy val Scaladoc = Def.task {

--- a/project/ScaladocGeneration.scala
+++ b/project/ScaladocGeneration.scala
@@ -141,6 +141,7 @@ object ScaladocGeneration {
     def remove[T <: Arg[_]: ClassTag]: GenerationConfig
     def withTargets(targets: Seq[String]): GenerationConfig
     def serialize: String
+    def settings: Seq[String]
   }
 
   object GenerationConfig {
@@ -172,6 +173,9 @@ object ScaladocGeneration {
         .map(_.serialize)
          ++ targets
       ).mkString(" ")
+
+      override def settings: Seq[String] =
+        args.map(_.serialize) ++ targets
 
       private def argsWithout[T <: Arg[_]](
         implicit tag: ClassTag[T]


### PR DESCRIPTION
Add default scaladoc settings to the artifact publishing config, so that the published scaladoc jars for the scala3-library will be more consistent with the hosted scaladoc. This also enables publishing InkuireDb for the scala3-library.