### PR TITLE
Small correction in documentation

### DIFF
--- a/docs/_docs/reference/changed-features/interpolation-escapes.md
+++ b/docs/_docs/reference/changed-features/interpolation-escapes.md
@@ -4,7 +4,7 @@ title: "Escapes in interpolations"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/changed-features/interpolation-escapes.html
 ---
 
-In Scala 2 there is no straightforward way to represent a single quote character `"` in a single quoted interpolation. A `\` character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether the `"` character should be escaped or used as a terminator.
+In Scala 2 there is no straightforward way to represent a double-quote character `"` in a quoted interpolation(except in triple-quote interpolation). A `\` character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether the `"` character should be escaped or used as a terminator.
 
 In Scala 3, we can use the `$` meta character of interpolations to escape a `"` character. Example:
 

--- a/docs/_docs/reference/changed-features/interpolation-escapes.md
+++ b/docs/_docs/reference/changed-features/interpolation-escapes.md
@@ -4,7 +4,7 @@ title: "Escapes in interpolations"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/changed-features/interpolation-escapes.html
 ---
 
-In Scala 2 there is no straightforward way to represent a double-quote character `"` in a quoted interpolation(except in triple-quote interpolation). A `\` character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether the `"` character should be escaped or used as a terminator.
+In Scala 2 there is no straightforward way to represent a double-quote character `"` in a quoted interpolation (except in triple-quote interpolation). A `\` character can't be used for that because interpolators themselves decide how to handle escaping, so the parser doesn't know whether the `"` character should be escaped or used as a terminator.
 
 In Scala 3, we can use the `$` meta character of interpolations to escape a `"` character. Example:
 


### PR DESCRIPTION
I believe that the current doc is confusing a bit. Readers might get confused with the usage `single quote` in the doc with the `'` symbol.  I also added an additional message to avoid confusion between that and the triple quote interpolation.