### PR TITLE
Attach explanation message to diagnostic message

### DIFF
--- a/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
@@ -39,13 +39,16 @@ final public class DelegatingReporter extends AbstractReporter {
     StringBuilder rendered = new StringBuilder();
     rendered.append(messageAndPos(dia, ctx));
     Message message = dia.msg();
+    StringBuilder messageBuilder = new StringBuilder();
+    messageBuilder.append(message.message());
     String diagnosticCode = String.valueOf(message.errorId().errorNumber());
     boolean shouldExplain = Diagnostic.shouldExplain(dia, ctx);
     if (shouldExplain && !message.explanation().isEmpty()) {
       rendered.append(explanation(message, ctx));
+      messageBuilder.append(System.lineSeparator()).append(explanation(message, ctx));
     }
 
-    delegate.log(new Problem(position, message.message(), severity, rendered.toString(), diagnosticCode));
+    delegate.log(new Problem(position, messageBuilder.toString(), severity, rendered.toString(), diagnosticCode));
   }
 
   private static Severity severityOf(int level) {


### PR DESCRIPTION
When the `-explain` flag was turned on, an explanation message wasn't displayed in the Metals and Scala CLI. This was because both of these tools only print the message from the [Problem.message](https://github.com/lampepfl/dotty/blob/c0a7d128671d063a2b566abdaa08fe7fa83c2d06/sbt-bridge/src/dotty/tools/xsbt/Problem.java#L17) field.

To resolve this issue, I attached the explanation content to the `Problem.message` field, which will now be displayed in the Metals and Scala CLI.

This PR addresses a [issue](https://github.com/VirtusLab/scala-cli/issues/1285) from `scala-cli`.

