### PR TITLE
Disable `ExtractSemanticDB` phase when writing to output directory defined as JAR.

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -24,6 +24,7 @@ import scala.annotation.{ threadUnsafe => tu, tailrec }
 import scala.PartialFunction.condOpt
 
 import dotty.tools.dotc.{semanticdb => s}
+import dotty.tools.io.{AbstractFile, JarArchive}
 
 /** Extract symbol references and uses to semanticdb files.
  *  See https://scalameta.org/docs/semanticdb/specification.html#symbol-1
@@ -38,7 +39,9 @@ class ExtractSemanticDB extends Phase:
   override val description: String = ExtractSemanticDB.description
 
   override def isRunnable(using Context) =
-    super.isRunnable && ctx.settings.Xsemanticdb.value
+    import ExtractSemanticDB.{semanticdbTarget, outputDirectory}
+    def writesToOutputJar = semanticdbTarget.isEmpty && outputDirectory.isInstanceOf[JarArchive]
+    super.isRunnable && ctx.settings.Xsemanticdb.value && !writesToOutputJar
 
   // Check not needed since it does not transform trees
   override def isCheckable: Boolean = false
@@ -475,6 +478,13 @@ object ExtractSemanticDB:
   val name: String = "extractSemanticDB"
   val description: String = "extract info into .semanticdb files"
 
+  private def semanticdbTarget(using Context): Option[Path] =
+    Option(ctx.settings.semanticdbTarget.value)
+      .filterNot(_.isEmpty)
+      .map(Paths.get(_))
+
+  private def outputDirectory(using Context): AbstractFile = ctx.settings.outputDir.value
+
   def write(
     source: SourceFile,
     occurrences: List[SymbolOccurrence],
@@ -482,14 +492,8 @@ object ExtractSemanticDB:
     synthetics: List[Synthetic],
   )(using Context): Unit =
     def absolutePath(path: Path): Path = path.toAbsolutePath.normalize
-    val semanticdbTarget =
-      val semanticdbTargetSetting = ctx.settings.semanticdbTarget.value
-      absolutePath(
-        if semanticdbTargetSetting.isEmpty then ctx.settings.outputDir.value.jpath
-        else Paths.get(semanticdbTargetSetting)
-      )
     val relPath = SourceFile.relativePath(source, ctx.settings.sourceroot.value)
-    val outpath = semanticdbTarget
+    val outpath = absolutePath(semanticdbTarget.getOrElse(outputDirectory.jpath))
       .resolve("META-INF")
       .resolve("semanticdb")
       .resolve(relPath)


### PR DESCRIPTION
Change extracted from https://github.com/lampepfl/dotty/pull/15322 where the issue was discovered

Writing to outputDirectory when it is a JAR can lead to producing malformed file, it is using FileOutputStream which works somehow correct, but if we would open the same JAR again in later phase (eg. genBCode) header of the file would be malformed: the result file grows in size respectively to provided input, but we can read only files written by SemanticDB phase.