### PR TITLE
Fix static lazy field holder for GraalVM

### DIFF
--- a/bench-micro/src/main/scala/dotty/tools/benchmarks/lazyvals/InitializedAccessInt.scala
+++ b/bench-micro/src/main/scala/dotty/tools/benchmarks/lazyvals/InitializedAccessInt.scala
@@ -1,0 +1,30 @@
+package dotty.tools.benchmarks.lazyvals
+
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+import LazyVals.LazyIntHolder
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class InitializedAccessInt {
+
+  var holder: LazyIntHolder = _
+
+  @Setup
+  def prepare: Unit = {
+    holder = new LazyIntHolder
+    holder.value
+  }
+
+  @Benchmark
+  def measureInitialized(bh: Blackhole) = {
+    bh.consume(holder)
+    bh.consume(holder.value)
+  }
+}

--- a/bench-micro/src/main/scala/dotty/tools/benchmarks/lazyvals/InitializedObject.scala
+++ b/bench-micro/src/main/scala/dotty/tools/benchmarks/lazyvals/InitializedObject.scala
@@ -1,0 +1,22 @@
+package dotty.tools.benchmarks.lazyvals
+
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+import LazyVals.ObjectHolder
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class InitializedObject {
+
+  @Benchmark
+  def measureInitialized(bh: Blackhole) = {
+    bh.consume(ObjectHolder)
+    bh.consume(ObjectHolder.value)
+  }
+}

--- a/bench-micro/src/main/scala/dotty/tools/benchmarks/lazyvals/LazyVals.scala
+++ b/bench-micro/src/main/scala/dotty/tools/benchmarks/lazyvals/LazyVals.scala
@@ -50,4 +50,22 @@ object LazyVals {
             }
         }
     }
+
+    class LazyIntHolder {
+        lazy val value: Int = {
+            (System.nanoTime() % 1000).toInt
+        }
+    }
+
+    object ObjectHolder {
+        lazy val value: String = {
+            System.nanoTime() % 5 match {
+                case 0 => "abc"
+                case 1 => "def"
+                case 2 => "ghi"
+                case 3 => "jkl"
+                case 4 => "mno"
+            }
+        }
+    }
 }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -151,7 +151,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
 
         // !!! Part of this logic is duplicated in JSCodeGen.genCompilationUnit
         claszSymbol.info.decls.foreach { f =>
-          if f.isField && !f.name.is(LazyBitMapName) then
+          if f.isField && !f.name.is(LazyBitMapName) && !f.name.is(LazyLocalName) then
             f.setFlag(JavaStatic)
         }
 

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -22,7 +22,7 @@ import dotty.tools.dotc.report
 import tpd._
 
 import StdNames.nme
-import NameKinds.LazyBitMapName
+import NameKinds.{LazyBitMapName, LazyLocalName}
 import Names.Name
 
 class DottyBackendInterface(val outputDirectory: AbstractFile, val superCallsMap: ReadOnlyMap[Symbol, Set[ClassSymbol]])(using val ctx: Context) {
@@ -129,10 +129,11 @@ object DottyBackendInterface {
        *        the new lazy val encoding: https://github.com/lampepfl/dotty/issues/7140
        */
       def isStaticModuleField(using Context): Boolean =
-        sym.owner.isStaticModuleClass && sym.isField && !sym.name.is(LazyBitMapName)
+        sym.owner.isStaticModuleClass && sym.isField && !sym.name.is(LazyBitMapName) && !sym.name.is(LazyLocalName)
 
       def isStaticMember(using Context): Boolean = (sym ne NoSymbol) &&
-        (sym.is(JavaStatic) || sym.isScalaStatic || sym.isStaticModuleField)
+          (sym.is(JavaStatic) || sym.isScalaStatic || sym.isStaticModuleField)
+
         // guard against no sumbol cause this code is executed to select which call type(static\dynamic) to use to call array.clone
 
       /**

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -674,7 +674,6 @@ object LazyVals {
       val cas: TermName                    = N.cas.toTermName
       val getOffset: TermName              = N.getOffset.toTermName
       val getOffsetStatic: TermName        = "getOffsetStatic".toTermName
-      val getStaticFieldOffset: TermName   = "getStaticFieldOffset".toTermName
       val getDeclaredField: TermName       = "getDeclaredField".toTermName
     }
     val flag: TermName        = "flag".toTermName

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -467,7 +467,6 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
     containerSymbol.addAnnotation(Annotation(defn.VolatileAnnot, containerSymbol.span)) // private @volatile var _x: AnyRef
     containerSymbol.addAnnotations(x.symbol.annotations) // pass annotations from original definition
     containerSymbol.removeAnnotation(defn.ScalaStaticAnnot)
-    containerSymbol.resetFlag(JavaStatic)
     val getOffset =
         Select(ref(defn.LazyValsModule), lazyNme.RLazyVals.getOffsetStatic)
     val containerTree = ValDef(containerSymbol, nullLiteral)

--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -142,14 +142,6 @@ object LazyVals {
     r
   }
 
-  def getStaticFieldOffset(field: java.lang.reflect.Field): Long = {
-    @nowarn
-    val r = unsafe.staticFieldOffset(field)
-    if (debug)
-      println(s"getStaticFieldOffset(${field.getDeclaringClass}, ${field.getName}) = $r")
-    r
-  }
-
   def getOffsetStatic(field: java.lang.reflect.Field) =
     @nowarn
     val r = unsafe.objectFieldOffset(field)

--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -142,6 +142,14 @@ object LazyVals {
     r
   }
 
+  def getStaticFieldOffset(field: java.lang.reflect.Field): Long = {
+    @nowarn
+    val r = unsafe.staticFieldOffset(field)
+    if (debug)
+      println(s"getStaticFieldOffset(${field.getDeclaringClass}, ${field.getName}) = $r")
+    r
+  }
+
   def getOffsetStatic(field: java.lang.reflect.Field) =
     @nowarn
     val r = unsafe.objectFieldOffset(field)

--- a/tests/printing/transformed/lazy-vals-new.check
+++ b/tests/printing/transformed/lazy-vals-new.check
@@ -10,19 +10,19 @@ package <empty> {
     @static private def <clinit>(): Unit =
       {
         A.OFFSET$_m_0 =
-          scala.runtime.LazyVals.getStaticFieldOffset(
+          scala.runtime.LazyVals.getOffsetStatic(
             classOf[Object {...}].getDeclaredField("x$lzy1"))
         ()
       }
     @static @static val OFFSET$_m_0: Long =
-      scala.runtime.LazyVals.getStaticFieldOffset(
+      scala.runtime.LazyVals.getOffsetStatic(
         classOf[Object {...}].getDeclaredField("x$lzy1"))
     private def writeReplace(): Object =
       new scala.runtime.ModuleSerializationProxy(classOf[A])
-    @volatile private lazy <static> var x$lzy1: Object = null
+    @volatile private lazy var x$lzy1: Object = null
     lazy def x(): Int =
       {
-        val result: Object = A#x$lzy1
+        val result: Object = A.x$lzy1
         if result.isInstanceOf[Int] then scala.Int.unbox(result) else
           if result.eq(scala.runtime.LazyVals.NullValue) then
             scala.Int.unbox(null) else scala.Int.unbox(A.x$lzyINIT1())
@@ -30,10 +30,10 @@ package <empty> {
     private def x$lzyINIT1(): Object =
       while <empty> do
         {
-          val current: Object = A#x$lzy1
+          val current: Object = A.x$lzy1
           if current.eq(null) then
             if
-              scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0, null,
+              scala.runtime.LazyVals.objCAS(this, A.OFFSET$_m_0, null,
                 scala.runtime.LazyVals.Evaluating)
              then
               {
@@ -49,15 +49,15 @@ package <empty> {
                   }
                  finally
                   if
-                    scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0,
+                    scala.runtime.LazyVals.objCAS(this, A.OFFSET$_m_0,
                       scala.runtime.LazyVals.Evaluating, result).unary_!()
                    then
                     {
                       val lock: scala.runtime.LazyVals.LazyVals$Waiting =
-                        A#x$lzy1.asInstanceOf[
+                        A.x$lzy1.asInstanceOf[
                           scala.runtime.LazyVals.LazyVals$Waiting]
-                      scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0,
-                        lock, result)
+                      scala.runtime.LazyVals.objCAS(this, A.OFFSET$_m_0, lock,
+                        result)
                       lock.countDown()
                     }
                    else ()
@@ -71,8 +71,8 @@ package <empty> {
              then
               if current.eq(scala.runtime.LazyVals.Evaluating) then
                 {
-                  scala.runtime.LazyVals.objCAS(classOf[A], A.OFFSET$_m_0,
-                    current, new scala.runtime.LazyVals.LazyVals$Waiting())
+                  scala.runtime.LazyVals.objCAS(this, A.OFFSET$_m_0, current,
+                    new scala.runtime.LazyVals.LazyVals$Waiting())
                   ()
                 }
                else


### PR DESCRIPTION
The new lazy vals implementation was not working in graalvm's native image. The generated holder for the lazy value was static post-compilation. It caused the generated code to perform CAS operate on bad addresses and throw Bus Error.
Issue on oracle/graalvm: https://github.com/oracle/graal/issues/5863
This PR removes the static modifier from the lazy val holder and makes it accessible via `MODULE$` instead. It fixes the CAS on GraalVM and does not have a performance impact, at least judging by the benchmark I've added to this PR.