### PR TITLE
Fix #12621: Scala.js: Better error message for JS trait ctor param.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
@@ -888,6 +888,9 @@ class PrepJSInterop extends MacroTransform with IdentityDenotTransformer { thisP
             report.error("A non-native JS trait cannot contain private members", tree)
           } else if (sym.is(Lazy)) {
             report.error("A non-native JS trait cannot contain lazy vals", tree)
+          } else if (sym.is(ParamAccessor)) {
+            // #12621
+            report.error("A non-native JS trait cannot have constructor parameters", tree)
           } else if (!sym.is(Deferred)) {
             /* Tell the back-end not to emit this thing. In fact, this only
              * matters for mixed-in members created from this member.

--- a/tests/neg-scalajs/js-trait-ctor-param.check
+++ b/tests/neg-scalajs/js-trait-ctor-param.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg-scalajs/js-trait-ctor-param.scala:9:34 -------------------------------------------------------------
+9 |trait NonNativeBagHolderTrait(val bag: Bag) extends js.Any // error
+  |                              ^^^^^^^^^^^^
+  |                              A non-native JS trait cannot have constructor parameters

--- a/tests/neg-scalajs/js-trait-ctor-param.scala
+++ b/tests/neg-scalajs/js-trait-ctor-param.scala
@@ -1,0 +1,9 @@
+import scala.scalajs.js
+import scala.scalajs.js.annotation.*
+
+@js.native
+trait Bag extends js.Any {
+  val str: String
+}
+
+trait NonNativeBagHolderTrait(val bag: Bag) extends js.Any // error


### PR DESCRIPTION
JS traits cannot have constructor params any more than they can have concrete term members. This improves the error message in that case.