### PR TITLE
improvement: Small fixes to allow using Metals with scaladoc with sbt

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -360,6 +360,7 @@ object Build {
 
   // Settings used when compiling dotty with a non-bootstrapped dotty
   lazy val commonBootstrappedSettings = commonDottySettings ++ NoBloopExport.settings ++ Seq(
+    // To enable support of scaladoc and language-server projects you need to change this to true and use sbt as your build server
     bspEnabled := false,
     (Compile / unmanagedSourceDirectories) += baseDirectory.value / "src-bootstrapped",
 
@@ -1130,6 +1131,7 @@ object Build {
     enablePlugins(DottyJSPlugin).
     dependsOn(`scala3-library-bootstrappedJS`).
     settings(
+      bspEnabled := false,
       scalacOptions --= Seq("-Xfatal-warnings", "-deprecation"),
 
       // Required to run Scala.js tests.

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,7 +1,4 @@
 // Used by VersionUtil to get gitHash and commitDate
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "4.11.0.201803080745-r"
 
-
-Compile / unmanagedSourceDirectories +=
-  baseDirectory.value / "../language-server/src/dotty/tools/languageserver/config"
 libraryDependencies += Dependencies.`jackson-databind`


### PR DESCRIPTION
This would require just setting `bspEnabled := true`, but not for sjsJUnitTests which seem to cause inifinite loop of compilations.

I also need to work a bit on Bloop to also make it work.

This still needs https://github.com/scalameta/metals/pull/4938