### PR TITLE
Patmat: Use less type variables in prefix inference

### DIFF
--- a/tests/patmat/i12408.check
+++ b/tests/patmat/i12408.check
@@ -1,2 +1,2 @@
-13: Pattern Match Exhaustivity: X[<?>] & (X.this : X[T]).A(_), X[<?>] & (X.this : X[T]).C(_)
+13: Pattern Match Exhaustivity: A(_), C(_)
 21: Pattern Match

--- a/tests/pos/i16785.scala
+++ b/tests/pos/i16785.scala
@@ -1,0 +1,11 @@
+class VarImpl[Lbl, A]
+
+class Outer[|*|[_, _], Lbl1]:
+  type Var[A1] = VarImpl[Lbl1, A1]
+
+  sealed trait Foo[G]
+  case class Bar[T, U]()
+    extends Foo[Var[T] |*| Var[U]]
+
+  def go[X](scr: Foo[Var[X]]): Unit = scr match // was: compile hang
+    case Bar() => ()


### PR DESCRIPTION
In code like:

    class Outer:
      sealed trait Foo
      case class Bar() extends Foo

      def mat(foo: Foo) = foo match
        case Bar() =>

When in the course of decomposing the scrutinee's type, which is
`Outer.this.Foo`, we're trying to instantiate subclass `Outer.this.Bar`,
the `Outer.this` is fixed - it needn't be inferred, via type variables
and type bounds.  Cutting down on type variables, particularly when GADT
symbols are also present, can really speed up the operation, including
making code that used to hang forever compile speedily.

Fixes #16785
