### PR TITLE
Remove experimental from Mirror#fromProductTyped

### DIFF
--- a/library/src/scala/deriving/Mirror.scala
+++ b/library/src/scala/deriving/Mirror.scala
@@ -52,7 +52,6 @@ object Mirror {
 
   extension [T](p: ProductOf[T])
     /** Create a new instance of type `T` with elements taken from product `a`. */
-    @annotation.experimental
     def fromProductTyped[A <: scala.Product, Elems <: p.MirroredElemTypes](a: A)(using m: ProductOf[A] { type MirroredElemTypes = Elems }): T =
       p.fromProduct(a)
 

--- a/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-custom-args/tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -58,10 +58,6 @@ val experimentalDefinitionInLibrary = Set(
   //// New feature: into
   "scala.annotation.allowConversions",
 
-  //// New APIs: Mirror
-  // Can be stabilized in 3.3.0 or later.
-  "scala.deriving.Mirror$.fromProductTyped", // This API is a bit convoluted. We may need some more feedback before we can stabilize it.
-
   //// New feature: Macro annotations
   "scala.annotation.MacroAnnotation",
 


### PR DESCRIPTION
This was first released in 3.1.3 so it seems like it could have `@experimental` removed. Feel free to close if there's some other process that determines when to remove experimental status for an API addition like this.