### PR TITLE
fix: ensure syntax blocks for ebnf are marked as such

### DIFF
--- a/docs/_docs/reference/changed-features/imports.md
+++ b/docs/_docs/reference/changed-features/imports.md
@@ -46,7 +46,7 @@ are offered under settings `-source 3.1-migration -rewrite`.
 
 ## Syntax
 
-```
+```ebnf
 Import            ::=  ‘import’ ImportExpr {‘,’ ImportExpr}
 ImportExpr        ::= SimpleRef {‘.’ id} ‘.’ ImportSpec
                     | SimpleRef `as` id

--- a/docs/_docs/reference/changed-features/match-syntax.md
+++ b/docs/_docs/reference/changed-features/match-syntax.md
@@ -47,7 +47,7 @@ The syntactical precedence of match expressions has been changed.
 
 The new syntax of match expressions is as follows.
 
-```
+```ebnf
 InfixExpr    ::=  ...
                |  InfixExpr MatchClause
 SimpleExpr   ::=  ...

--- a/docs/_docs/reference/changed-features/pattern-bindings.md
+++ b/docs/_docs/reference/changed-features/pattern-bindings.md
@@ -50,7 +50,7 @@ for case (x, y) <- elems yield (y, x)  // returns List((2, 1), (4, 3))
 ## Syntax Changes
 
 Generators in for expressions may be prefixed with `case`.
-```
+```ebnf
 Generator      ::=  [‘case’] Pattern1 ‘<-’ Expr
 ```
 

--- a/docs/_docs/reference/changed-features/structural-types-spec.md
+++ b/docs/_docs/reference/changed-features/structural-types-spec.md
@@ -6,7 +6,7 @@ nightlyOf: https://docs.scala-lang.org/scala3/reference/changed-features/structu
 
 ## Syntax
 
-```
+```ebnf
 SimpleType    ::= ... | Refinement
 Refinement    ::= ‘{’ RefineStatSeq ‘}’
 RefineStatSeq ::=  RefineStat {semi RefineStat}

--- a/docs/_docs/reference/changed-features/vararg-splices.md
+++ b/docs/_docs/reference/changed-features/vararg-splices.md
@@ -24,7 +24,7 @@ The old syntax for splice arguments will be phased out.
 
 ## Syntax
 
-```
+```ebnf
 ArgumentPatterns  ::=  ‘(’ [Patterns] ‘)’
                     |  ‘(’ [Patterns ‘,’] Pattern2 ‘*’ ‘)’
 

--- a/docs/_docs/reference/contextual/context-bounds.md
+++ b/docs/_docs/reference/contextual/context-bounds.md
@@ -47,7 +47,7 @@ done automatically under `-rewrite`.
 
 ## Syntax
 
-```
+```ebnf
 TypeParamBounds   ::=  [SubtypeBounds] {ContextBound}
 ContextBound      ::=  ‘:’ Type
 ```

--- a/docs/_docs/reference/contextual/context-functions-spec.md
+++ b/docs/_docs/reference/contextual/context-functions-spec.md
@@ -6,7 +6,7 @@ nightlyOf: https://docs.scala-lang.org/scala3/reference/contextual/context-funct
 
 ## Syntax
 
-```
+```ebnf
 Type              ::=  ...
                     |  FunArgTypes ‘?=>’ Type
 Expr              ::=  ...

--- a/docs/_docs/reference/contextual/derivation.md
+++ b/docs/_docs/reference/contextual/derivation.md
@@ -486,7 +486,7 @@ method please read more at [How to write a type class `derived` method using mac
 
 ## Syntax
 
-```
+```ebnf
 Template          ::=  InheritClauses [TemplateBody]
 EnumDef           ::=  id ClassConstr InheritClauses EnumBody
 InheritClauses    ::=  [‘extends’ ConstrApps] [‘derives’ QualId {‘,’ QualId}]

--- a/docs/_docs/reference/contextual/extension-methods.md
+++ b/docs/_docs/reference/contextual/extension-methods.md
@@ -285,7 +285,7 @@ def position(s: String)(ch: Char, n: Int): Int =
 Here are the syntax changes for extension methods and collective extensions relative
 to the [current syntax](../syntax.md).
 
-```
+```ebnf
 BlockStat         ::=  ... | Extension
 TemplateStat      ::=  ... | Extension
 TopStat           ::=  ... | Extension

--- a/docs/_docs/reference/contextual/given-imports.md
+++ b/docs/_docs/reference/contextual/given-imports.md
@@ -103,7 +103,7 @@ given instances once their user base has migrated.
 
 ## Syntax
 
-```
+```ebnf
 Import            ::=  ‘import’ ImportExpr {‘,’ ImportExpr}
 Export            ::=  ‘export’ ImportExpr {‘,’ ImportExpr}
 ImportExpr        ::=  SimpleRef {‘.’ id} ‘.’ ImportSpec

--- a/docs/_docs/reference/contextual/givens.md
+++ b/docs/_docs/reference/contextual/givens.md
@@ -10,7 +10,7 @@ that serve for synthesizing arguments to [context parameters](./using-clauses.md
 ```scala
 trait Ord[T]:
   def compare(x: T, y: T): Int
-  extension (x: T) 
+  extension (x: T)
     def < (y: T) = compare(x, y) < 0
     def > (y: T) = compare(x, y) > 0
 
@@ -174,7 +174,7 @@ is created for each reference.
 
 Here is the syntax for given instances:
 
-```
+```ebnf
 TmplDef             ::=  ...
                      |   ‘given’ GivenDef
 GivenDef            ::=  [GivenSig] StructuralInstance

--- a/docs/_docs/reference/contextual/using-clauses.md
+++ b/docs/_docs/reference/contextual/using-clauses.md
@@ -151,7 +151,7 @@ def summon[T](using x: T): x.type = x
 
 Here is the new syntax of parameters and arguments seen as a delta from the [standard context free syntax of Scala 3](../syntax.md). `using` is a soft keyword, recognized only at the start of a parameter or argument list. It can be used as a normal identifier everywhere else.
 
-```
+```ebnf
 ClsParamClause      ::=  ... | UsingClsParamClause
 DefParamClause      ::=  ... | UsingParamClause
 UsingClsParamClause ::=  ‘(’ ‘using’ (ClsParams | Types) ‘)’

--- a/docs/_docs/reference/enums/adts.md
+++ b/docs/_docs/reference/enums/adts.md
@@ -154,7 +154,7 @@ The changes are specified below as deltas with respect to the Scala syntax given
 
  1. Enum definitions are defined as follows:
 
-    ```
+    ```ebnf
     TmplDef   ::=  `enum' EnumDef
     EnumDef   ::=  id ClassConstr [`extends' [ConstrApps]] EnumBody
     EnumBody  ::=  [nl] ‘{’ [SelfType] EnumStat {semi EnumStat} ‘}’
@@ -164,7 +164,7 @@ The changes are specified below as deltas with respect to the Scala syntax given
 
  2. Cases of enums are defined as follows:
 
-    ```
+    ```ebnf
     EnumCase  ::=  `case' (id ClassConstr [`extends' ConstrApps]] | ids)
     ```
 

--- a/docs/_docs/reference/experimental/named-typeargs-spec.md
+++ b/docs/_docs/reference/experimental/named-typeargs-spec.md
@@ -10,7 +10,7 @@ In this section we give more details about the [named type arguments](named-type
 
 The addition to the grammar is:
 
-```
+```ebnf
 SimpleExpr1       ::=  ...
                     |  SimpleExpr (TypeArgs | NamedTypeArgs)
 NamedTypeArgs     ::=  ‘[’ NamedTypeArg {‘,’ NamedTypeArg} ‘]’
@@ -19,7 +19,7 @@ NamedTypeArg      ::=  id ‘=’ Type
 
 Note in particular that named arguments cannot be passed to type constructors:
 
-``` scala
+```scala
 class C[T]
 
 val x: C[T = Int] = // error

--- a/docs/_docs/reference/metaprogramming/macros-spec.md
+++ b/docs/_docs/reference/metaprogramming/macros-spec.md
@@ -57,7 +57,7 @@ extends simply-typed lambda calculus with quotes and splices.
 ### Syntax
 
 The syntax of terms, values, and types is given as follows:
-```
+```ebnf
 Terms         t  ::=  x                 variable
                       (x: T) => t       lambda
                       t t               application
@@ -77,7 +77,7 @@ Typing rules are formulated using a stack of environments
 `Es`. Individual environments `E` consist as usual of variable
 bindings `x: T`. Environments can be combined using the two
 combinators `'` and `$`.
-```
+```ebnf
 Environment   E  ::=  ()                empty
                       E, x: T
 
@@ -108,7 +108,7 @@ rule says that splice and quotes cancel each other out. The third rule
 is a context rule; it says that reduction is allowed in the hole `[ ]`
 position of an evaluation context.  Evaluation contexts `e` and
 splice evaluation context `e_s` are defined syntactically as follows:
-```
+```ebnf
 Eval context    e    ::=  [ ]  |  e t  |  v e  |  'e_s[${e}]
 Splice context  e_s  ::=  [ ]  |  (x: T) => e_s  |  e_s t  |  u e_s
 ```

--- a/docs/_docs/reference/metaprogramming/simple-smp.md
+++ b/docs/_docs/reference/metaprogramming/simple-smp.md
@@ -23,7 +23,7 @@ replace evaluation contexts with contextual typing rules. While this
 is more verbose, it makes it easier to set up the meta theory.
 
 ## Syntax
-```
+```ebnf
 Terms         t  ::=  x                 variable
                       (x: T) => t       lambda
                       t t               application

--- a/docs/_docs/reference/new-types/dependent-function-types-spec.md
+++ b/docs/_docs/reference/new-types/dependent-function-types-spec.md
@@ -8,7 +8,7 @@ Initial implementation in [PR #3464](https://github.com/lampepfl/dotty/pull/3464
 
 ## Syntax
 
-```
+```ebnf
 FunArgTypes       ::=  InfixType
                     |  ‘(’ [ FunArgType {',' FunArgType } ] ‘)’
                     |  ‘(’ TypedFunParam {',' TypedFunParam } ‘)’

--- a/docs/_docs/reference/new-types/intersection-types-spec.md
+++ b/docs/_docs/reference/new-types/intersection-types-spec.md
@@ -12,7 +12,7 @@ with the usual precedence and subject to usual resolving rules.
 Unless shadowed by another definition, it resolves to the type `scala.&`,
 which acts as a type alias to an internal representation of intersection types.
 
-```
+```ebnf
 Type              ::=  ...| InfixType
 InfixType         ::=  RefinedType {id [nl] RefinedType}
 ```

--- a/docs/_docs/reference/new-types/type-lambdas-spec.md
+++ b/docs/_docs/reference/new-types/type-lambdas-spec.md
@@ -6,7 +6,7 @@ nightlyOf: https://docs.scala-lang.org/scala3/reference/new-types/type-lambdas-s
 
 ## Syntax
 
-```
+```ebnf
 Type            ::=  ... |  TypeParamClause ‘=>>’ Type
 TypeParamClause ::=  ‘[’ TypeParam {‘,’ TypeParam} ‘]’
 TypeParam       ::=  {Annotation} (id [HkTypeParamClause] | ‘_’) TypeBounds

--- a/docs/_docs/reference/other-new-features/export.md
+++ b/docs/_docs/reference/other-new-features/export.md
@@ -176,7 +176,7 @@ extension (x: String)
 
 ## Syntax changes:
 
-```
+```ebnf
 TemplateStat      ::=  ...
                     |  Export
 TopStat           ::=  ...

--- a/docs/_docs/reference/other-new-features/indentation.md
+++ b/docs/_docs/reference/other-new-features/indentation.md
@@ -174,12 +174,12 @@ The syntax changes allowing this are as follows:
 
 Define for an arbitrary sequence of tokens or non-terminals `TS`:
 
-```
+```ebnf
 :<<< TS >>>   ::=   ‘{’ TS ‘}’
                 |   <colon> <indent" TS <outdent>
 ```
 Then the grammar changes as follows:
-```
+```ebnf
 TemplateBody      ::=  :<<< [SelfType] TemplateStat {semi TemplateStat} >>>
 EnumBody          ::=  :<<< [SelfType] EnumStat {semi EnumStat} >>>
 Refinement        ::=  :<<< [RefineDcl] {semi [RefineDcl]} >>>
@@ -229,7 +229,7 @@ xs.foldLeft(0): (x, y) =>
 
 The grammar changes for optional braces around arguments are as follows.
 
-```
+```ebnf
 SimpleExpr       ::=  ...
                    |  SimpleExpr ColonArgument
 InfixExpr        ::=  ...
@@ -430,7 +430,7 @@ If none of these criteria apply, it's often better to not use an end marker sinc
 
 ### Syntax
 
-```
+```ebnf
 EndMarker         ::=  ‘end’ EndMarkerTag    -- when followed by EOL
 EndMarkerTag      ::=  id | ‘if’ | ‘while’ | ‘for’ | ‘match’ | ‘try’
                     |  ‘new’ | ‘this’ | ‘given’ | ‘extension’ | ‘val’

--- a/docs/_docs/reference/other-new-features/opaques-details.md
+++ b/docs/_docs/reference/other-new-features/opaques-details.md
@@ -6,7 +6,7 @@ nightlyOf: https://docs.scala-lang.org/scala3/reference/other-new-features/opaqu
 
 ## Syntax
 
-```
+```ebnf
 Modifier          ::=  ...
                     |  ‘opaque’
 ```


### PR DESCRIPTION
I see that this was done in the past in
https://github.com/lampepfl/dotty/pull/14958/files, but then reverted in
https://github.com/lampepfl/dotty/pull/14958. Like many commits, there
really isn't an explanation of the revert, but from reading between the
lines I assume the `;` was the actual issue, not the syntax
highlighting. As it was pointed out, syntax.js doesn't actually support
`ebnf`. They do say they support `bnf`, but that didn't really work when I
was testing. Either way, this pr makes sure that we _do_ mark the
snippets as `ebnf`. The reason for this isn't necessarily so that we
_get_ syntax highlighting for these, but so that syntax.js doesn't infer
the wrong type of syntax and provide odd highlighting like we currently
have. This also helps to ensure screen readers know what type of
codeblock this is.

fixes #14697
