### PR TITLE
deps(scaladoc): update flexmark from 0.42.12 to 0.62.2

### DIFF
--- a/dist/bin/scaladoc
+++ b/dist/bin/scaladoc
@@ -61,15 +61,20 @@ classpathArgs () {
   CLASS_PATH+="$(find_lib "*tasty-core*")$PSEP"
   CLASS_PATH+="$(find_lib "*scala3-tasty-inspector*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-0*")$PSEP"
-  CLASS_PATH+="$(find_lib "*flexmark-html-parser*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-ext-anchorlink*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-ext-autolink*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-ext-emoji*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-ext-gfm-strikethrough*")$PSEP"
-  CLASS_PATH+="$(find_lib "*flexmark-ext-gfm-tables*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-ext-gfm-tasklist*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-ext-wikilink*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-ext-yaml-front-matter*")$PSEP"
+  CLASS_PATH+="$(find_lib "*flexmark-ext-tables*")$PSEP"
+  CLASS_PATH+="$(find_lib "*flexmark-ext-ins*")$PSEP"
+  CLASS_PATH+="$(find_lib "*flexmark-ext-superscript*")$PSEP"
+  CLASS_PATH+="$(find_lib "*flexmark-util-ast*")$PSEP"
+  CLASS_PATH+="$(find_lib "*flexmark-util-data*")$PSEP"
+  CLASS_PATH+="$(find_lib "*flexmark-util-dependency*")$PSEP"
+  CLASS_PATH+="$(find_lib "*flexmark-util-misc*")$PSEP"
   CLASS_PATH+="$(find_lib "*liqp*")$PSEP"
   CLASS_PATH+="$(find_lib "*jsoup*")$PSEP"
   CLASS_PATH+="$(find_lib "*jackson-dataformat-yaml*")$PSEP"
@@ -80,7 +85,6 @@ classpathArgs () {
   CLASS_PATH+="$(find_lib "*jline-reader*")$PSEP"
   CLASS_PATH+="$(find_lib "*jline-terminal-3*")$PSEP"
   CLASS_PATH+="$(find_lib "*jline-terminal-jna*")$PSEP"
-  CLASS_PATH+="$(find_lib "*flexmark-util*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-formatter*")$PSEP"
   CLASS_PATH+="$(find_lib "*autolink-0.6*")$PSEP"
   CLASS_PATH+="$(find_lib "*flexmark-jira-converter*")$PSEP"
@@ -93,9 +97,6 @@ classpathArgs () {
   CLASS_PATH+="$(find_lib "*protobuf-java*")$PSEP"
   CLASS_PATH+="$(find_lib "*util-interface*")$PSEP"
   CLASS_PATH+="$(find_lib "*jna-5*")$PSEP"
-  CLASS_PATH+="$(find_lib "*flexmark-ext-tables*")$PSEP"
-  CLASS_PATH+="$(find_lib "*flexmark-ext-ins*")$PSEP"
-  CLASS_PATH+="$(find_lib "*flexmark-ext-superscript*")$PSEP"
   CLASS_PATH+="$(find_lib "*antlr4-runtime*")$PSEP"
 
   jvm_cp_args="-classpath \"$CLASS_PATH\""
@@ -123,6 +124,10 @@ case "$1" in
 done
 
 classpathArgs
+
+echo "----------"
+echo $jvm_cp_args | grep tables
+echo "----------"
 
 eval "\"$JAVACMD\"" \
      ${JAVA_OPTS:-$default_java_opts} \

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1130,6 +1130,7 @@ object Build {
     enablePlugins(DottyJSPlugin).
     dependsOn(`scala3-library-bootstrappedJS`).
     settings(
+      bspEnabled := false,
       scalacOptions --= Seq("-Xfatal-warnings", "-deprecation"),
 
       // Required to run Scala.js tests.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,16 +10,15 @@ object Dependencies {
   val `jackson-dataformat-yaml` =
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
 
-  private val flexmarkVersion = "0.42.12"
+  private val flexmarkVersion = "0.64.0"
 
   val flexmarkDeps = Seq(
     "com.vladsch.flexmark" % "flexmark" % flexmarkVersion,
-    "com.vladsch.flexmark" % "flexmark-html-parser" % flexmarkVersion,
+    "com.vladsch.flexmark" % "flexmark-util-html" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-anchorlink" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-autolink" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-emoji" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-gfm-strikethrough" % flexmarkVersion,
-    "com.vladsch.flexmark" % "flexmark-ext-gfm-tables" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-gfm-tasklist" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-wikilink" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % flexmarkVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,10 +10,13 @@ object Dependencies {
   val `jackson-dataformat-yaml` =
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
 
-  private val flexmarkVersion = "0.64.0"
+  // Freeze on 0.62.x as 0.64.0 requires Java 11
+  private val flexmarkVersion = "0.62.2"
 
   val flexmarkDeps = Seq(
     "com.vladsch.flexmark" % "flexmark" % flexmarkVersion,
+    "com.vladsch.flexmark" % "flexmark-util-ast" % flexmarkVersion,
+    "com.vladsch.flexmark" % "flexmark-util-data" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-util-html" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-anchorlink" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-autolink" % flexmarkVersion,
@@ -21,6 +24,7 @@ object Dependencies {
     "com.vladsch.flexmark" % "flexmark-ext-gfm-strikethrough" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-gfm-tasklist" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-wikilink" % flexmarkVersion,
+    "com.vladsch.flexmark" % "flexmark-ext-tables" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % flexmarkVersion,
   )
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,7 +1,4 @@
 // Used by VersionUtil to get gitHash and commitDate
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "4.11.0.201803080745-r"
 
-
-Compile / unmanagedSourceDirectories +=
-  baseDirectory.value / "../language-server/src/dotty/tools/languageserver/config"
 libraryDependencies += Dependencies.`jackson-databind`

--- a/scaladoc/src/dotty/tools/scaladoc/DocContext.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/DocContext.scala
@@ -1,11 +1,9 @@
 package dotty.tools.scaladoc
 
 import java.io.File
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-import scala.jdk.CollectionConverters._
 import dotty.tools.scaladoc.site.StaticSiteContext
 import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.util.SourceFile
@@ -13,9 +11,6 @@ import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
-import scala.io.Codec
-import java.net.URL
-import scala.util.Try
 import scala.collection.mutable
 import dotty.tools.scaladoc.util.Check.checkJekyllIncompatPath
 

--- a/scaladoc/src/dotty/tools/scaladoc/Main.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/Main.scala
@@ -1,16 +1,6 @@
 package dotty.tools.scaladoc
 
-import java.util.ServiceLoader
-import java.io.File
-import java.util.jar._
-import scala.jdk.CollectionConverters._
-import collection.immutable.ArraySeq
-
-import java.nio.file.Files
-
-import dotty.tools.dotc.config.Settings._
-import dotty.tools.dotc.config.CommonScalaSettings
-import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.Contexts.ContextBase
 
 /** Main class for the doctool when used from cli. */
 class Main:

--- a/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
@@ -1,20 +1,15 @@
 package dotty.tools.scaladoc
 
-import java.util.ServiceLoader
 import java.io.File
 import java.io.FileWriter
-import java.util.jar._
-import scala.jdk.CollectionConverters._
-import collection.immutable.ArraySeq
+import java.nio.file.Paths
 
-import java.nio.file.{ Files, Paths }
+import collection.immutable.ArraySeq
 
 import dotty.tools.dotc.config.Settings._
 import dotty.tools.dotc.config.{ CommonScalaSettings, AllScalaSettings }
 import dotty.tools.dotc.reporting.Reporter
 import dotty.tools.dotc.core.Contexts._
-
-import dotty.tools.scaladoc.Inkuire
 import dotty.tools.scaladoc.Inkuire._
 
 object Scaladoc:

--- a/scaladoc/src/dotty/tools/scaladoc/ScaladocCommand.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ScaladocCommand.scala
@@ -1,20 +1,9 @@
 package dotty.tools.scaladoc
 
-import java.util.ServiceLoader
-import java.io.File
-import java.util.jar._
-import scala.jdk.CollectionConverters._
-import collection.immutable.ArraySeq
-
-import java.nio.file.Files
-
 import dotty.tools.dotc.config.Settings._
-import dotty.tools.dotc.config.CommonScalaSettings
-import dotty.tools.scaladoc.Scaladoc._
-import dotty.tools.dotc.config.Settings.Setting.value
 import dotty.tools.dotc.config.Properties._
 import dotty.tools.dotc.config.CliCommand
-import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.Contexts.Context
 
 object ScaladocCommand extends CliCommand:
   type ConcreteSettings = ScaladocSettings

--- a/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
@@ -1,20 +1,7 @@
 package dotty.tools.scaladoc
 
-import java.util.ServiceLoader
-import java.io.File
-import java.util.jar._
-import scala.jdk.CollectionConverters._
-import collection.immutable.ArraySeq
-
-import java.nio.file.Files
-
 import dotty.tools.dotc.config.Settings._
 import dotty.tools.dotc.config.AllScalaSettings
-import dotty.tools.scaladoc.Scaladoc._
-import dotty.tools.dotc.config.Settings.Setting.value
-import dotty.tools.dotc.config.Properties._
-import dotty.tools.dotc.config.CliCommand
-import dotty.tools.dotc.core.Contexts._
 
 class ScaladocSettings extends SettingGroup with AllScalaSettings:
   val unsupportedSettings = Seq(

--- a/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
@@ -1,9 +1,5 @@
 package dotty.tools.scaladoc
 
-import java.nio.file.Path
-import java.nio.file.Paths
-import dotty.tools.dotc.core.Contexts.Context
-
 enum SocialLinks(val url: String, val className: String):
   case Github(ghUrl: String) extends SocialLinks(ghUrl, "gh")
   case Twitter(tUrl: String) extends SocialLinks(tUrl, "twitter")

--- a/scaladoc/src/dotty/tools/scaladoc/SourceLinks.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/SourceLinks.scala
@@ -2,7 +2,6 @@ package dotty.tools.scaladoc
 
 import java.nio.file.Path
 import java.nio.file.Paths
-import dotty.tools.dotc.core.Contexts.Context
 import scala.util.matching.Regex
 
 def pathToString(p: Path) =

--- a/scaladoc/src/dotty/tools/scaladoc/compat.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/compat.scala
@@ -3,7 +3,6 @@ package dotty.tools.scaladoc
 import java.util.stream.Stream // comment out - wrong error!
 import java.util.stream.Collectors
 import java.util.Collections
-import java.nio.file.Path
 import com.vladsch.flexmark.util.ast.{Node => MdNode}
 import dotty.tools.scaladoc.tasty.comments.wiki.WikiDocElement
 import scala.jdk.CollectionConverters._

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -2,18 +2,9 @@ package dotty.tools.scaladoc
 package renderers
 
 import util.HTML._
-import scala.jdk.CollectionConverters._
-import java.net.URI
-import java.net.URL
 import dotty.tools.scaladoc.site._
-import scala.util.Try
 import org.jsoup.Jsoup
-import java.nio.file.Paths
-import java.nio.file.Path
 import java.nio.file.Files
-import java.nio.file.FileVisitOption
-import java.io.File
-import dotty.tools.scaladoc.staticFileSymbolUUID
 
 class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: DocContext)
   extends Renderer(rootPackage, members, extension = "html"):

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Locations.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Locations.scala
@@ -1,18 +1,10 @@
 package dotty.tools.scaladoc
 package renderers
 
-import util.HTML._
 import scala.jdk.CollectionConverters._
 import java.net.URI
-import java.net.URL
 import dotty.tools.scaladoc.site._
-import scala.util.Try
-import org.jsoup.Jsoup
 import java.nio.file.Paths
-import java.nio.file.Path
-import java.nio.file.Files
-import java.io.File
-import scala.util.matching._
 import dotty.tools.scaladoc.util.Escape._
 
 val UnresolvedLocationLink = "#"

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MarkdownRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MarkdownRenderer.scala
@@ -2,17 +2,6 @@ package dotty.tools.scaladoc
 package renderers
 
 import util.HTML._
-import scala.jdk.CollectionConverters._
-import java.net.URI
-import java.net.URL
-import dotty.tools.scaladoc.site._
-import scala.util.Try
-import org.jsoup.Jsoup
-import java.nio.file.Paths
-import java.nio.file.Path
-import java.nio.file.Files
-import java.nio.file.FileVisitOption
-import java.io.File
 
 class MarkdownRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: DocContext)
   extends Renderer(rootPackage, members, extension = "md"):

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
@@ -7,9 +7,6 @@ import util.HTML.{div, *}
 
 import scala.jdk.CollectionConverters.*
 import dotty.tools.scaladoc.translators.FilterAttributes
-import dotty.tools.scaladoc.tasty.comments.markdown.DocFlexmarkRenderer
-import com.vladsch.flexmark.util.ast.Node as MdNode
-import dotty.tools.scaladoc.tasty.comments.wiki.WikiDocElement
 import org.jsoup.Jsoup
 import translators.*
 

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Renderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Renderer.scala
@@ -2,18 +2,11 @@ package dotty.tools.scaladoc
 package renderers
 
 import util.HTML._
-import scala.jdk.CollectionConverters._
 import collection.mutable.ListBuffer
-import java.net.URI
-import java.net.URL
 import dotty.tools.scaladoc.site._
-import scala.util.Try
-import org.jsoup.Jsoup
 import java.nio.file.Paths
 import java.nio.file.Path
 import java.nio.file.Files
-import java.nio.file.FileVisitOption
-import java.io.File
 
 case class Page(link: Link, content: Member | ResolvedTemplate | String, children: Seq[Page], hidden: Boolean = false):
   def withNewChildren(newChildren: Seq[Page]) = copy(children = children ++ newChildren)

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -2,16 +2,10 @@ package dotty.tools.scaladoc
 package renderers
 
 import util.HTML._
-import scala.jdk.CollectionConverters._
-import java.net.URI
 import java.net.URL
-import dotty.tools.scaladoc.site._
-import scala.util.Try
-import org.jsoup.Jsoup
 import java.nio.file.Paths
 import java.nio.file.Path
 import java.nio.file.Files
-import java.io.File
 import dotty.tools.scaladoc.translators.FilterAttributes
 import util._
 import translators._
@@ -190,7 +184,6 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
 
     def docPartRenderPlain(d: DocPart): String =
       import dotty.tools.scaladoc.tasty.comments.wiki._
-      import com.vladsch.flexmark.util.ast.{Node => MdNode}
       def renderPlain(wd: WikiDocElement): String =
         wd match
           case Paragraph(text) => renderPlain(text)

--- a/scaladoc/src/dotty/tools/scaladoc/site/FlexmarkSectionWrapper.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/FlexmarkSectionWrapper.scala
@@ -4,7 +4,6 @@ package site
 import com.vladsch.flexmark.util.{ast => mdu, sequence}
 import com.vladsch.flexmark.{ast => mda}
 import com.vladsch.flexmark.formatter.Formatter
-import com.vladsch.flexmark.util.options.MutableDataSet
 import scala.jdk.CollectionConverters._
 
 import dotty.tools.scaladoc.tasty.comments.markdown.Section

--- a/scaladoc/src/dotty/tools/scaladoc/site/common.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/common.scala
@@ -12,12 +12,13 @@ import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension
 import com.vladsch.flexmark.ext.tables.TablesExtension
 import com.vladsch.flexmark.ext.yaml.front.matter.{AbstractYamlFrontMatterVisitor, YamlFrontMatterExtension}
 import com.vladsch.flexmark.parser.{Parser, ParserEmulationProfile}
-import com.vladsch.flexmark.util.options.{DataHolder, MutableDataSet}
 import com.vladsch.flexmark.ext.wikilink.WikiLinkExtension
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.html.HtmlRenderer
 
 import scala.jdk.CollectionConverters._
+import com.vladsch.flexmark.util.data.DataHolder
+import com.vladsch.flexmark.util.data.MutableDataSet
 
 val docsRootDRI: DRI = DRI(location = "_docs/index", symbolUUID = staticFileSymbolUUID)
 val apiPageDRI: DRI = DRI(location = "api/index")

--- a/scaladoc/src/dotty/tools/scaladoc/site/templates.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/templates.scala
@@ -11,7 +11,6 @@ import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension
 import com.vladsch.flexmark.ext.tables.TablesExtension
 import com.vladsch.flexmark.ext.yaml.front.matter.{AbstractYamlFrontMatterVisitor, YamlFrontMatterExtension}
 import com.vladsch.flexmark.parser.{Parser, ParserEmulationProfile}
-import com.vladsch.flexmark.util.options.{DataHolder, MutableDataSet}
 import com.vladsch.flexmark.html.HtmlRenderer
 import com.vladsch.flexmark.formatter.Formatter
 import liqp.Template

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
@@ -4,7 +4,6 @@ package snippets
 import com.vladsch.flexmark.util.{ast => mdu, sequence}
 import com.vladsch.flexmark.{ast => mda}
 import com.vladsch.flexmark.formatter.Formatter
-import com.vladsch.flexmark.util.options.MutableDataSet
 import scala.jdk.CollectionConverters._
 
 import dotty.tools.scaladoc.tasty.comments.markdown.ExtendedFencedCodeBlock

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
@@ -7,7 +7,6 @@ import scala.util.Try
 import com.vladsch.flexmark.util.{ast => mdu, sequence}
 import com.vladsch.flexmark.{ast => mda}
 import com.vladsch.flexmark.formatter.Formatter
-import com.vladsch.flexmark.util.options.MutableDataSet
 import com.vladsch.flexmark.util.sequence.BasedSequence
 
 import scala.quoted._

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MarkdownParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MarkdownParser.scala
@@ -9,7 +9,6 @@ import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.sequence.CharSubSequence
 import com.vladsch.flexmark.parser.ParserEmulationProfile
-import com.vladsch.flexmark.ext.gfm.tables.TablesExtension
 import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
 import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension
 import com.vladsch.flexmark.ext.emoji.EmojiExtension
@@ -17,10 +16,12 @@ import com.vladsch.flexmark.ext.autolink.AutolinkExtension
 import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension
 import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension
 import com.vladsch.flexmark.ext.wikilink.WikiLinkExtension
-import com.vladsch.flexmark.util.options.{ DataHolder, MutableDataSet }
-import com.vladsch.flexmark.util.builder.Extension
 
 import scala.jdk.CollectionConverters._
+import com.vladsch.flexmark.util.misc.Extension
+import com.vladsch.flexmark.ext.tables.TablesExtension
+import com.vladsch.flexmark.util.data.MutableDataSet
+import com.vladsch.flexmark.util.data.DataHolder
 
 object MarkdownParser {
 

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/DocFlexmarkExtension.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/DocFlexmarkExtension.scala
@@ -15,6 +15,9 @@ import com.vladsch.flexmark._
 
 import dotty.tools.scaladoc.snippets._
 import scala.jdk.CollectionConverters._
+import com.vladsch.flexmark.util.data.MutableDataHolder
+import com.vladsch.flexmark.util.data.DataHolder
+import com.vladsch.flexmark.html.renderer.NodeRenderingHandler.CustomNodeRenderer
 
 class DocLinkNode(
   val target: DocLink,
@@ -40,7 +43,7 @@ class DocFlexmarkParser(resolveLink: String => DocLink) extends Parser.ParserExt
   class Factory extends LinkRefProcessorFactory:
     override def getBracketNestingLevel(options: DataHolder) = 1
     override def getWantExclamationPrefix(options: DataHolder) = false
-    override def create(doc: Document): LinkRefProcessor =
+    override def apply(doc: Document): LinkRefProcessor =
       new WikiLinkLinkRefProcessor(doc):
         override def createNode(nodeChars: BasedSequence): Node =
           val chars = nodeChars.toString.substring(2, nodeChars.length - 2)
@@ -75,7 +78,7 @@ case class DocFlexmarkRenderer(renderLink: (DocLink, String) => String)
         )
 
     object Factory extends NodeRendererFactory:
-      override def create(options: DataHolder): NodeRenderer = Render
+      override def apply(options: DataHolder): NodeRenderer = Render
 
     def extend(htmlRendererBuilder: HtmlRenderer.Builder, tpe: String): Unit =
       htmlRendererBuilder.nodeRendererFactory(Factory)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SectionRenderingExtension.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SectionRenderingExtension.scala
@@ -3,17 +3,23 @@ package tasty.comments.markdown
 
 import com.vladsch.flexmark.html.*
 import com.vladsch.flexmark.html.renderer.*
+import com.vladsch.flexmark.html.renderer.NodeRenderingHandler.CustomNodeRenderer
 import com.vladsch.flexmark.parser.*
 import com.vladsch.flexmark.ext.wikilink.*
 import com.vladsch.flexmark.ext.wikilink.internal.WikiLinkLinkRefProcessor
 import com.vladsch.flexmark.util.ast.*
 import com.vladsch.flexmark.util.options.*
 import com.vladsch.flexmark.util.sequence.BasedSequence
-import com.vladsch.flexmark.util.html.{AttributeImpl, Attributes}
 import com.vladsch.flexmark.*
 import com.vladsch.flexmark.ast.FencedCodeBlock
 
 import scala.collection.mutable
+import com.vladsch.flexmark.util.data.MutableDataHolder
+import com.vladsch.flexmark.util.html.Attributes
+import com.vladsch.flexmark.util.html.AttributeImpl
+import com.vladsch.flexmark.util.data.DataHolder
+import com.vladsch.flexmark.util.html.Attribute
+import com.vladsch.flexmark.util.html.MutableAttributes
 
 
 object SectionRenderingExtension extends HtmlRenderer.HtmlRendererExtension:
@@ -30,18 +36,19 @@ object SectionRenderingExtension extends HtmlRenderer.HtmlRendererExtension:
       repeatedIds.update((c, header.getText), repeatedIds((c, header.getText)) + 1)
       val id = idGenerator.getId(header.getText.append(ifSuffixStr))
       val anchor = AnchorLink(s"#$id")
-      val attributes = Attributes()
       val headerClass: String = header.getLevel match
         case 1 => "h500"
         case 2 => "h500"
         case 3 => "h400"
         case 4 => "h300"
         case _ => "h50"
-      attributes.addValue(AttributeImpl.of("class", headerClass))
+      //val a: Attribute = AttributeImpl.of("class", headerClass)
+      val attributes = MutableAttributes()
+      attributes.addValue("class", headerClass)
       val embeddedAttributes = EmbeddedAttributeProvider.EmbeddedNodeAttributes(header, attributes)
       header.prependChild(embeddedAttributes)
       header.prependChild(anchor)
-      html.attr(AttributeImpl.of("id", id)).withAttr.tag("section", false, false, () => {
+      html.attr("id", id).withAttr.tag("section", false, false, () => {
         c.render(header)
         body.foreach(c.render)
       })
@@ -59,7 +66,8 @@ object SectionRenderingExtension extends HtmlRenderer.HtmlRendererExtension:
       )
 
   object Factory extends NodeRendererFactory:
-    override def create(options: DataHolder): NodeRenderer = Render
+    override def apply(options: DataHolder): NodeRenderer = Render
+
 
   def extend(htmlRendererBuilder: HtmlRenderer.Builder, tpe: String): Unit =
     htmlRendererBuilder.nodeRendererFactory(Factory)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SnippetRenderingExtension.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SnippetRenderingExtension.scala
@@ -13,6 +13,9 @@ import com.vladsch.flexmark.util.options._
 import com.vladsch.flexmark.util.sequence.BasedSequence
 import com.vladsch.flexmark._
 import com.vladsch.flexmark.ast.FencedCodeBlock
+import com.vladsch.flexmark.util.data.MutableDataHolder
+import com.vladsch.flexmark.html.renderer.NodeRenderingHandler.CustomNodeRenderer
+import com.vladsch.flexmark.util.data.DataHolder
 
 /**
  * SnippetRenderingExtension is responsible for running an analysis for scala codeblocks in the static documentation/scaladoc comments.
@@ -39,7 +42,7 @@ object SnippetRenderingExtension extends HtmlRenderer.HtmlRendererExtension:
       )
 
   object Factory extends NodeRendererFactory:
-    override def create(options: DataHolder): NodeRenderer = Render
+    override def apply(options: DataHolder): NodeRenderer = Render
 
   def extend(htmlRendererBuilder: HtmlRenderer.Builder, tpe: String): Unit =
     htmlRendererBuilder.nodeRendererFactory(Factory)

--- a/scaladoc/test/dotty/tools/scaladoc/site/TemplateFileTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/TemplateFileTests.scala
@@ -202,6 +202,7 @@ class TemplateFileTests:
         content -> "md"
       )
     )
+
   @Test
   def markdown(): Unit =
     testTemplate(
@@ -222,10 +223,10 @@ class TemplateFileTests:
       ext = "md"
     ) { t =>
       assertEquals(
-        """<section id="hello-there">
-        |<h1 class="h500"><a href="#hello-there" class="anchor"></a>Hello there!</h1>
+        """<section id="hello-there2">
+        |<h1 class="h500"><a href="#hello-there2" class="anchor"></a>Hello there2!</h1>
         |</section>""".stripMargin,
-      t.resolveInner(RenderingContext(Map("msg" -> "there"))).code.trim())
+      t.resolveInner(RenderingContext(Map("msg" -> "there2"))).code.trim())
     }
 
   @Test

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTest.scala
@@ -13,7 +13,6 @@ import dotty.tools.dotc.reporting.{ Diagnostic, StoreReporter }
 import com.vladsch.flexmark.util.{ast => mdu, sequence}
 import com.vladsch.flexmark.{ast => mda}
 import com.vladsch.flexmark.formatter.Formatter
-import com.vladsch.flexmark.util.options.MutableDataSet
 import scala.jdk.CollectionConverters._
 
 import dotty.tools.scaladoc.tasty.comments.markdown.ExtendedFencedCodeBlock


### PR DESCRIPTION
This pr updates the flexmark dependencies used in Scaladoc from 0.42.12, which is from 2019, up to the ~latest release of 0.64.0~ to 0.62.2. This is mainly done to tackle a bunch of CVEs that are attached to the old versions of
flexmark.

fixes #16223
