### PR TITLE
Print owner of bind symbol with -Yprint-debug-owners

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -571,7 +571,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         if (lo eq hi) && alias.isEmpty then optText(lo)(" = " ~ _)
         else optText(lo)(" >: " ~ _) ~ optText(hi)(" <: " ~ _) ~ optText(alias)(" = " ~ _)
       case bind @ Bind(name, body) =>
-        keywordText("given ").provided(tree.symbol.isOneOf(GivenOrImplicit) && !homogenizedView) ~ // Used for scala.quoted.Type in quote patterns (not pickled)
+        toTextOwner(bind) ~ keywordText("given ").provided(tree.symbol.isOneOf(GivenOrImplicit) && !homogenizedView) ~ // Used for scala.quoted.Type in quote patterns (not pickled)
         changePrec(InfixPrec) { nameIdText(bind) ~ " @ " ~ toText(body) }
       case Alternative(trees) =>
         changePrec(OrPrec) { toText(trees, " | ") }


### PR DESCRIPTION
Compiling with `-Yprint-debug-owners` now prints the owners of `Bind` trees.

#### Before 
```scala
class Foo() extends Object() {
  [owner = class Foo]def fooImpl: Int =
    1:Int match {
      case x @ y @ _:Int => 0
  }
}
```


#### After
```scala
class Foo() extends Object() {
  [owner = class Foo]def fooImpl: Int =
    1:Int match {
      case [owner = method fooImpl]x @ [owner = method fooImpl]y @ _:Int => 0
    }
}
```