### PR TITLE
Handle pickled forward references in pickled expressions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -74,6 +74,9 @@ class TreeUnpickler(reader: TastyReader,
    */
   private val typeAtAddr = new mutable.HashMap[Addr, Type]
 
+  /** If this is a pickled quote, the owner of the quote, otherwise NoSymbol. */
+  private var rootOwner: Symbol = NoSymbol
+
   /** The root symbol denotation which are defined by the Tasty file associated with this
    *  TreeUnpickler. Set by `enterTopLevel`.
    */
@@ -106,6 +109,7 @@ class TreeUnpickler(reader: TastyReader,
 
   /** The unpickled trees */
   def unpickle(mode: UnpickleMode)(using Context): List[Tree] = {
+    if mode != UnpickleMode.TopLevel then rootOwner = ctx.owner
     assert(roots != null, "unpickle without previous enterTopLevel")
     val rdr = new TreeReader(reader)
     mode match {
@@ -1635,7 +1639,7 @@ class TreeUnpickler(reader: TastyReader,
             pickling.println(i"no owner for $addr among $cs%, %")
             throw ex
         }
-      try search(children, NoSymbol)
+      try search(children, rootOwner)
       catch {
         case ex: TreeWithoutOwner =>
           pickling.println(s"ownerTree = $ownerTree")

--- a/tests/pos-macros/i16843a/Macro_1.scala
+++ b/tests/pos-macros/i16843a/Macro_1.scala
@@ -1,0 +1,13 @@
+import scala.quoted.*
+
+case class Foo(x: Int)
+
+inline def foo = ${ fooImpl }
+
+def fooImpl(using Quotes) =
+  val tmp = '{
+    1 match
+      case x @ (y: Int) => 0
+  }
+
+  '{}

--- a/tests/pos-macros/i16843a/Test_2.scala
+++ b/tests/pos-macros/i16843a/Test_2.scala
@@ -1,0 +1,1 @@
+val x = foo

--- a/tests/pos-macros/i16843b/Macro_1.scala
+++ b/tests/pos-macros/i16843b/Macro_1.scala
@@ -1,0 +1,18 @@
+import scala.quoted.*
+
+inline def foo: Int = ${ fooImpl }
+
+def fooImpl(using Quotes): Expr[Int] =
+  '{
+    val b = ${
+      val a = '{
+        (1: Int) match
+          case x @ (y: Int) => 0
+      }
+      a
+    }
+
+    (1: Int) match
+      case x @ (y: Int) => 0
+  }
+

--- a/tests/pos-macros/i16843b/Test_2.scala
+++ b/tests/pos-macros/i16843b/Test_2.scala
@@ -1,0 +1,1 @@
+def test = foo


### PR DESCRIPTION
To compute forward references it was assumed that the owner of that symbol can be found in the TASTy. This is not always the case with TASTy expressions of pickled quotes. The owner might be outside the quote, in this case the context already has the owner of the referenced symbol. These are local symbols defined at the top-level of the TASTy.

Fixes #16843