### PR TITLE
Always load REPL classes in macros including the output directory

### DIFF
--- a/compiler/test-resources/repl-macros/i15104a
+++ b/compiler/test-resources/repl-macros/i15104a
@@ -1,0 +1,7 @@
+scala> import scala.quoted._
+scala> object Foo { def macroImpl(using Quotes) = Expr(1) }
+// defined object Foo
+scala> inline def foo = ${ Foo.macroImpl }
+def foo: Int
+scala> foo
+val res0: Int = 1

--- a/compiler/test-resources/repl-macros/i15104b
+++ b/compiler/test-resources/repl-macros/i15104b
@@ -1,0 +1,5 @@
+scala> import scala.quoted._
+scala> object Foo { def macroImpl(using Quotes) = Expr(1); inline def foo = ${ Foo.macroImpl } }
+// defined object Foo
+scala> Foo.foo
+val res0: Int = 1

--- a/compiler/test-resources/repl-macros/i15104c
+++ b/compiler/test-resources/repl-macros/i15104c
@@ -1,0 +1,7 @@
+scala> import scala.quoted._
+scala> def macroImpl(using Quotes) = Expr(1)
+def macroImpl(using x$1: quoted.Quotes): quoted.Expr[Int]
+scala> inline def foo = ${ macroImpl }
+def foo: Int
+scala> foo
+val res0: Int = 1

--- a/compiler/test-resources/repl-macros/i5551
+++ b/compiler/test-resources/repl-macros/i5551
@@ -1,8 +1,7 @@
 scala> import scala.quoted._
 scala> def assertImpl(expr: Expr[Boolean])(using q: Quotes) = '{ if !($expr) then throw new AssertionError("failed assertion")}
 def assertImpl
-  (expr: quoted.Expr[Boolean])
-     (using q: quoted.Quotes): quoted.Expr[Unit]
+  (expr: quoted.Expr[Boolean])(using q: quoted.Quotes): quoted.Expr[Unit]
 scala>   inline def assert(expr: => Boolean): Unit =  ${ assertImpl('{expr}) }
 def assert(expr: => Boolean): Unit
 

--- a/compiler/test/dotty/tools/repl/ScriptedTests.scala
+++ b/compiler/test/dotty/tools/repl/ScriptedTests.scala
@@ -3,11 +3,15 @@ package tools
 package repl
 
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
 /** Runs all tests contained in `compiler/test-resources/repl/` */
 class ScriptedTests extends ReplTest {
 
   @Test def replTests = scripts("/repl").foreach(testFile)
+
+  @Category(Array(classOf[BootstrappedOnlyTests]))
+  @Test def replMacrosTests = scripts("/repl-macros").foreach(testFile)
 
   @Test def typePrinterTests = scripts("/type-printer").foreach(testFile)
 }


### PR DESCRIPTION
Fixes #15104

Also re-enable `compiler/test-resources/repl-macros` tests.