### PR TITLE
Reference syncing v3.0

### DIFF
--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -70,19 +70,45 @@ jobs:
   backport-to-main:
     name: Create pull request with backport to main
     permissions:
-      pull-requests: write  # for repo-sync/pull-request to create a PR
+      contents: write       # it pushes a new branch
+      pull-requests: write  # it creates a pr
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v3
-      - uses: repo-sync/pull-request@v2
         with:
-          destination_branch: main
-          pr_label: area:documentation
-          pr_title: Sync with the stable documentation branch
-          pr_body: |
-            This pull request is syncing the main with changes from language-reference-stable.
+          fetch-depth: 0
 
-            It was created automatically after ${{ github.event.head_commit.id }} by @${{ github.event.head_commit.author.username }}
-          pr_assignee: ${{ github.event.head_commit.author.username }}
+      - name: Sync files with main
+        run: |
+          Retained=`cat .github/workflows/reference-sync/paths.txt`
+          git restore --source=origin/main -- .
+          echo "$Retained" | xargs git restore --
 
+      - name: Commit
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "github-actions[bot]"
+          git add -A .
+          git commit -m "Sync the documentation branch"
+
+      - name: Push
+        run: |
+          BranchName=reference-merge-${{ github.event.head_commit.id }}
+          Url=${{ github.server_url }}
+          Server=${Url#*://}
+          Scheme=${Url%%://*}
+          Remote=${Scheme}://${{ github.token }}@${Server}/${{ github.repository }}
+          git push $Remote HEAD:refs/heads/$BranchName
+
+      - name: Format the message and create a pull request
+        run: |
+          <.github/workflows/reference-sync/pr-template.md sed -E "
+            s^<<commit-id>>^${{ github.event.head_commit.id }}^g;
+            s^<<author>>^${{ github.event.head_commit.author.username }}^g;
+            s^<<repo-url>>^${Url}/${{ github.repository }}^g;
+            s^<<branch-name>>^${BranchName}^g;
+          " \
+            | hub pull-request -f -b main -h ${BranchName} -a ${{ github.event.head_commit.author.username }} -l area:documentation -F -

--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -74,6 +74,7 @@ jobs:
       pull-requests: write  # it creates a pr
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      BRANCH_NAME: reference-merge-${{ github.event.head_commit.id }}
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
@@ -96,19 +97,18 @@ jobs:
 
       - name: Push
         run: |
-          BranchName=reference-merge-${{ github.event.head_commit.id }}
           Url=${{ github.server_url }}
           Server=${Url#*://}
           Scheme=${Url%%://*}
           Remote=${Scheme}://${{ github.token }}@${Server}/${{ github.repository }}
-          git push $Remote HEAD:refs/heads/$BranchName
+          git push $Remote HEAD:refs/heads/$BRANCH_NAME
 
-      - name: Format the message and create a pull request
+      - name: Prepare the message and create a pull request
         run: |
           <.github/workflows/reference-sync/pr-template.md sed -E "
             s^<<commit-id>>^${{ github.event.head_commit.id }}^g;
             s^<<author>>^${{ github.event.head_commit.author.username }}^g;
             s^<<repo-url>>^${Url}/${{ github.repository }}^g;
-            s^<<branch-name>>^${BranchName}^g;
+            s^<<branch-name>>^${BRANCH_NAME}^g;
           " \
-            | hub pull-request -f -b main -h ${BranchName} -a ${{ github.event.head_commit.author.username }} -l area:documentation -F -
+            | hub pull-request -f -b main -h ${BRANCH_NAME} -a ${{ github.event.head_commit.author.username }} -l area:documentation -F -

--- a/.github/workflows/reference-sync/paths.txt
+++ b/.github/workflows/reference-sync/paths.txt
@@ -1,0 +1,3 @@
+.github/workflows
+scaladoc
+docs

--- a/.github/workflows/reference-sync/paths.txt
+++ b/.github/workflows/reference-sync/paths.txt
@@ -1,3 +1,9 @@
 .github/workflows
-scaladoc
+changelogs
 docs
+scaladoc
+scaladoc-js
+scaladoc-testcases
+scaladoc
+CONTRIBUTING.md
+MAINTENANCE.md

--- a/.github/workflows/reference-sync/pr-template.md
+++ b/.github/workflows/reference-sync/pr-template.md
@@ -1,0 +1,5 @@
+Sync with the stable documentation branch
+
+This pull request is syncing the main with changes from language-reference-stable.
+
+It was created automatically after <<commit-id>> by @<<author>>. Due to how GitHub calculates the diff for PRs, the `Files changed` tab will contain incorrect information. The correct diff can be found [here](<<repo-url>>/compare/main..<<branch-name>>).


### PR DESCRIPTION
Yet another rework of our workflow for syncing the changes on `language-reference-stable` with `main`. 

#### How it works
Every time someone adds changes to the `language-reference-stable` branch, there is a job being run. That job restores all the files to the state that is on the current `main`, then restores selected paths (specified in `.github/workflows/reference-sync/paths.txt) to the state from `language-reference-stable`. Then we create a new commit. What is important is that the only parent of that commit is the current head of `language-reference-stable`. When we later push that commit to the new remote branch and make pr we will see all conflicts in a correct way. 

#### Benefits
- There is no chance for changing anything outside of selected paths, so no longer accidental tasty version downgrades
- Conflicts inside of documentation are calculated correctly
- The PR is done from the fresh branch, so it can be modified without risking changing something on stable documentation branch

#### Problems
- The branch is created in `lampepfl/dotty` repo and not in  `dotty-staging/dotty`. We could change that but it would require supplying additional github token. I don't see it as a big problem as this branch would be deleted right after the merge.
- The diff shown in the `Files changed` tab for sync PRs will be incorrect. This is because github is displaying the output of `git diff A...B` instead of `git diff A..B` what would be much more intuitive. In other words, github displays diff between the head of the PR and merge-base and not between the head and the base of the PR. That means that `Files changed` will contain some changes that are already applied to the main. To mitigate that the action is adding link to the "correct" diff in every sync PR.