### PR TITLE
ClassfileParser: Avoid cycle when accessing companion in inner class lookup

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -1086,10 +1086,10 @@ class ClassfileParser(
           if (sym == classRoot.symbol)
             staticScope.lookup(name)
           else {
-            var module = sym.companionModule
-            if (!module.exists && sym.isAbsent())
-              module = sym.scalacLinkedClass
-            module.info.member(name).symbol
+            var moduleClass = sym.registeredCompanion
+            if (!moduleClass.exists && sym.isAbsent())
+              moduleClass = sym.scalacLinkedClass
+            moduleClass.info.member(name).symbol
           }
         else if (sym == classRoot.symbol)
           instanceScope.lookup(name)

--- a/sbt-test/java-compat/i15288/QueryRequest.java
+++ b/sbt-test/java-compat/i15288/QueryRequest.java
@@ -1,0 +1,9 @@
+interface CopyableBuilder<B, T> {}
+interface ToCopyableBuilder<B, T> {}
+
+public class QueryRequest implements ToCopyableBuilder<QueryRequest.Builder, QueryRequest> {
+    public static Builder builder() { throw new UnsupportedOperationException(); }
+    public interface Builder extends CopyableBuilder<Builder, QueryRequest> {
+        void build();
+    }
+}

--- a/sbt-test/java-compat/i15288/Test.scala
+++ b/sbt-test/java-compat/i15288/Test.scala
@@ -1,0 +1,2 @@
+class Test:
+  def makeQuery = QueryRequest.builder().build()

--- a/sbt-test/java-compat/i15288/build.sbt
+++ b/sbt-test/java-compat/i15288/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := sys.props("plugin.scalaVersion")

--- a/sbt-test/java-compat/i15288/test
+++ b/sbt-test/java-compat/i15288/test
@@ -1,0 +1,5 @@
+## This could just be a pos test checked by FromTastyTests, but
+## ParallelTesting#compileTastyInDir does not support test with multiple files
+## currently.
+> compile
+> doc


### PR DESCRIPTION
Previously, the call to `info` on the module val could lead to a cycle since the module val might be in the process of being completed. This commit fixes this by only using the module class which is all we need to lookup members.

Fixes #15288.
Fixes #14059.

Co-Authored-By: Tom Grigg <tomegrigg@gmail.com>