### PR TITLE
Insert top level type variables before typing quote pattern

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1518,7 +1518,7 @@ object Trees {
         paramss.mapConserve(transformParams)
 
       protected def transformMoreCases(tree: Tree)(using Context): Tree = {
-        assert(ctx.reporter.errorsReported)
+        assert(ctx.reporter.errorsReported, tree)
         tree
       }
     }

--- a/tests/neg-macros/quotedPatterns-5.scala
+++ b/tests/neg-macros/quotedPatterns-5.scala
@@ -2,7 +2,7 @@ import scala.quoted.*
 object Test {
   def test(x: quoted.Expr[Int])(using Quotes): Unit = x match {
     case '{ type t; 4 } => Type.of[t]
-    case '{ type t; poly[t]($x); 4 } => // error: duplicate pattern variable: t
+    case '{ type t; poly[t]($x); 4 } =>
     case '{ type `t`; poly[`t`]($x); 4 } =>
       Type.of[t] // error
     case _ =>

--- a/tests/pos-macros/i14708.scala
+++ b/tests/pos-macros/i14708.scala
@@ -1,0 +1,18 @@
+import scala.quoted.*
+
+object Main {
+  def foo(a: Expr[Any])(using Quotes) = {
+    a match {
+      case '{ ($x: Set[t]).toSet } =>
+      case '{ ($x: Set[t]).toSet[t] } =>
+      case '{ val a = 1; a; ($x: Set[t]).toSet } =>
+      case '{ type u; ($x: Set[`u`]).toSet } =>
+      case '{ type t; ($x: Set[t]).toSet } =>
+      case '{ varargs(${_}*) } =>
+      case '{ type u; ($x: t, $y: t, $z: u) } =>
+      case _ =>
+    }
+  }
+}
+
+def varargs(x: Any*): Unit = ()

--- a/tests/pos-macros/i16265.scala
+++ b/tests/pos-macros/i16265.scala
@@ -4,6 +4,6 @@ class Foo(val value: Int)
 
 def foo(exprs: Expr[Any])(using Quotes): Any =
   exprs match
-    case '{ $tuple: (Foo *: tail) } =>
+    case '{ type tail <: Tuple; $tuple: (Foo *: tail) } => // FIXME infer bounds of tail
       val x = '{ ${tuple}.head.value }
       ???

--- a/tests/pos-macros/i7264b.scala
+++ b/tests/pos-macros/i7264b.scala
@@ -1,7 +1,7 @@
 import scala.quoted.*
 class Foo {
   def f[T2: Type](e: Expr[T2])(using Quotes) = e match {
-    case '{ $x: *:[Int, t] } =>
+    case '{ type t <: Tuple; $x: *:[Int, t] } => // FIXME infer bounds of tail
       Type.of[ *:[Int, t] ]
   }
 }


### PR DESCRIPTION
The following code
```scala
case '{ type u; ($x: t, $y: t, $z: u) }
```
is desugared to
```scala
case '{ type t; type u; ($x: `t`, $y: `t`, $z: `u`) }
```

Fixes #14708