### PR TITLE
Harden tpd.Apply/TypeApply in case of errors

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -47,11 +47,17 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       Apply(expr, args)
     case _: RefTree | _: GenericApply | _: Inlined | _: Hole =>
       ta.assignType(untpd.Apply(fn, args), fn, args)
+    case _ =>
+      assert(ctx.reporter.errorsReported)
+      ta.assignType(untpd.Apply(fn, args), fn, args)
 
   def TypeApply(fn: Tree, args: List[Tree])(using Context): TypeApply = fn match
     case Block(Nil, expr) =>
       TypeApply(expr, args)
     case _: RefTree | _: GenericApply =>
+      ta.assignType(untpd.TypeApply(fn, args), fn, args)
+    case _ =>
+      assert(ctx.reporter.errorsReported)
       ta.assignType(untpd.TypeApply(fn, args), fn, args)
 
   def Literal(const: Constant)(using Context): Literal =

--- a/tests/neg/i16861.scala
+++ b/tests/neg/i16861.scala
@@ -1,0 +1,2 @@
+given foo[T]: Any = summon[bar] // error
+def bar: Nothing = ???

--- a/tests/neg/i16861a.scala
+++ b/tests/neg/i16861a.scala
@@ -1,0 +1,4 @@
+import scala.quoted.*
+trait Foo
+object Foo:
+  inline given foo[T <: Foo]: T = summon[Type.of[T]] // error


### PR DESCRIPTION
Harden tpd.Apply/TypeApply in case of errors to accept non-sensical terms as functions.

Fixes #16861