### PR TITLE
Don't eta expand unary varargs methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3922,7 +3922,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               else defn.functionArity(ptNorm)
             else
               val nparams = wtp.paramInfos.length
-              if nparams > 0 || pt.eq(AnyFunctionProto) then nparams
+              if nparams > 1
+                  || nparams == 1 && !wtp.isVarArgsMethod
+                  || pt.eq(AnyFunctionProto)
+              then nparams
               else -1 // no eta expansion in this case
           adaptNoArgsUnappliedMethod(wtp, funExpected, arity)
         case _ =>

--- a/tests/neg/i16820.check
+++ b/tests/neg/i16820.check
@@ -1,0 +1,22 @@
+-- Error: tests/neg/i16820.scala:5:11 ----------------------------------------------------------------------------------
+5 |  val x1 = f  // error
+  |           ^
+  |           missing arguments for method f in object Test
+-- [E100] Syntax Error: tests/neg/i16820.scala:6:11 --------------------------------------------------------------------
+6 |  val x2 = g  // error
+  |           ^
+  |           method g in object Test must be called with () argument
+  |
+  | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/i16820.scala:8:14 ----------------------------------------------------------------------------------
+8 |  val x3 = "".formatted // error
+  |           ^^^^^^^^^^^^
+  |           missing arguments for method formatted in class String
+-- Error: tests/neg/i16820.scala:9:40 ----------------------------------------------------------------------------------
+9 |  val x4 = java.nio.file.Paths.get(".").toRealPath // error
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |           missing arguments for method toRealPath in trait Path
+-- Error: tests/neg/i16820.scala:13:14 ---------------------------------------------------------------------------------
+13 |def test = Foo(3)  // error
+   |           ^^^^^^
+   |           missing arguments for method apply in object Foo

--- a/tests/neg/i16820.scala
+++ b/tests/neg/i16820.scala
@@ -1,0 +1,13 @@
+object Test:
+  def f(xs: Int*) = xs.sum
+  def g() = 1
+
+  val x1 = f  // error
+  val x2 = g  // error
+
+  val x3 = "".formatted // error
+  val x4 = java.nio.file.Paths.get(".").toRealPath // error
+
+// #14567
+case class Foo(x: Int)(xs: String*)
+def test = Foo(3)  // error

--- a/tests/pos/i14367.scala
+++ b/tests/pos/i14367.scala
@@ -1,5 +1,5 @@
 def m(i: Int*) = i.sum
-val f1 = m
+val f1: Seq[Int] => Int = m
 val f2 = i => m(i*)
 
 def n(i: Seq[Int]) = i.sum

--- a/tests/pos/i14567.scala
+++ b/tests/pos/i14567.scala
@@ -1,2 +1,0 @@
-case class Foo(x: Int)(xs: String*)
-def test = Foo(3)


### PR DESCRIPTION
A unary varargs method sits between nullary methods that sometimes get a () argument inferred (i.e. for methods coming from Java) and other methods that can be eta expanded. The safest strategy for them is to do neither, and expect either an explicit expected function type, or an explicit argument. That's also what Scala 2 does.

Fixes #16820

Reclassifies #14567 to be a neg test (with the error message suggested in the original issue for #14567)