### PR TITLE
Always use adapted type in withDenotation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2503,17 +2503,17 @@ object Types {
      *  might depend on the given prefix.
      *  Note: If T is an abstract type in trait or class C, its info depends
      *  even on C.this if class C has a self type that refines the info of T.
-     *  Currently, "refines" means an actual refinement type that constrains the
-     *  name `T`. We should try to extend that also to other classes that introduce
-     *  a new bining for `T`. Furthermore, we should also treat term members
-     *  in this way.
+     *  We should also treat term members in this way.
      */
     private def infoDependsOnPrefix(symd: SymDenotation, prefix: Type)(using Context): Boolean =
 
       def refines(tp: Type, name: Name): Boolean = tp match
         case AndType(tp1, tp2) => refines(tp1, name) || refines(tp2, name)
         case RefinedType(parent, rname, _) => rname == name || refines(parent, name)
-        case tp: RecType => refines(tp.parent, name)
+        case tp: ClassInfo =>
+          val other = tp.cls.infoOrCompleter.nonPrivateMember(name)
+          other.exists && other.symbol != symd.symbol
+        case tp: TypeProxy => refines(tp.underlying, name)
         case _ => false
 
       def givenSelfTypeOrCompleter(cls: Symbol) = cls.infoOrCompleter match

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -245,7 +245,7 @@ extends NotFoundMsg(MissingIdentID) {
   }
 }
 
-class TypeMismatch(found: Type,  expected: Type, inTree: Option[untpd.Tree],  addenda: => String*)(using Context)
+class TypeMismatch(found: Type, expected: Type, inTree: Option[untpd.Tree], addenda: => String*)(using Context)
   extends TypeMismatchMsg(found, expected)(TypeMismatchID):
 
   def msg(using Context) =

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -19,6 +19,7 @@ i12299a.scala
 i13871.scala
 i15181.scala
 i15922.scala
+t5031_2.scala
 
 # Tree is huge and blows stack for printing Text
 i7034.scala


### PR DESCRIPTION
When creating a NamedType with a given overloaded denotation, make sure that the type has a Name as designator. This prevents accidentally overwriting a more precise symbolic TermRef that refers to one specific alternative of the denotation.

This might be enough to fix #16884.

EDIT: It wasn't enough but the second commit [46e82dd](https://github.com/lampepfl/dotty/pull/16901/commits/46e82dd4bb32faa65c5d85c1f10b91eaca9256eb) should fix it. The second commit never overwrites in `withDenot`. It can do that because we fix `infoDependsOnPrefix` to work correctly for abstract types that are refined in a self type. It turned out that previously we needed some TypeRefs to keep their Name designators because that way we would recompute their info with a `member` operation. If these TypeRefs had a symbol designator they would be recomputed wrongly by `symd.current` in `fromDesignator` because the preceding `infoDependsOnPrefix` test was faulty.

It would be great if we could maintain the general invariant that NamedTypes with overloaded denotations always have names as designators. But that looks very hard when we take into account that we need to update named types to new runs. A type might have a single denotation in one round and an overloaded one in the next.