### PR TITLE
Add tests for clause interleaving to safe initialization test suite.

### DIFF
--- a/tests/init/neg/interleaving-params.scala
+++ b/tests/init/neg/interleaving-params.scala
@@ -1,0 +1,9 @@
+import scala.language.experimental.clauseInterleaving
+
+class Params{
+    def bar[T](x: T)[T]: String = ??? // error
+    def zoo(x: Int)[T, U](x: U): T = ??? // error
+    def bbb[T <: U](x: U)[U]: U = ??? // error // error
+    def f0[T](implicit x: T)[U](y: U) = (x,y) // error
+    def f1[T](implicit x: T)[U] = (x,y) // error
+}

--- a/tests/init/pos/interleaving-overload.scala
+++ b/tests/init/pos/interleaving-overload.scala
@@ -1,0 +1,20 @@
+import scala.language.experimental.clauseInterleaving
+
+class A{
+
+    def f1[T](x: Any)[U] = ???
+    def f1[T](x: Int)[U] = ???
+
+    f1(1)
+    f1("hello")
+
+    case class B[U](x: Int)
+    def b[U](x: Int) = B[U](x)
+
+    def f2[T]: [U] => Int => B[U] = [U] => (x: Int) => b[U](x)
+
+    f2(1)
+    f2[Any](1)
+    f2[Any][Any](1)
+
+}

--- a/tests/init/pos/interleaving-overload.scala
+++ b/tests/init/pos/interleaving-overload.scala
@@ -7,6 +7,8 @@ class A{
 
     f1(1)
     f1("hello")
+    f1[Boolean]("a")[Int]
+    f1[Boolean](1)[Int]
 
     case class B[U](x: Int)
     def b[U](x: Int) = B[U](x)
@@ -16,5 +18,7 @@ class A{
     f2(1)
     f2[Any](1)
     f2[Any][Any](1)
+
+    b[Int](5)
 
 }

--- a/tests/init/pos/interleaving-params.scala
+++ b/tests/init/pos/interleaving-params.scala
@@ -1,0 +1,8 @@
+import scala.language.experimental.clauseInterleaving
+
+class Params{
+    type U
+    def foo[T](x: T)[U >: x.type <: T](using U)[L <: List[U]](l: L): L = ???
+    def aaa(x: U): U = ???
+    def bbb[T <: U](x: U)[U]: U = ???
+}

--- a/tests/init/pos/interleaving-params.scala
+++ b/tests/init/pos/interleaving-params.scala
@@ -1,3 +1,5 @@
+import scala.collection.mutable.AbstractSet
+import scala.collection.mutable.BitSet
 import scala.language.experimental.clauseInterleaving
 
 class Params{
@@ -5,4 +7,13 @@ class Params{
     def foo[T](x: T)[U >: x.type <: T](using U)[L <: List[U]](l: L): L = ???
     def aaa(x: U): U = ???
     def bbb[T <: U](x: U)[U]: U = ???
+
+    foo[AbstractSet[Int]](BitSet())[AbstractSet[Int]](using BitSet())[List[AbstractSet[Int]]](List[AbstractSet[Int]]())
+}
+
+class Param2 extends Params {
+    type U = AbstractSet[Int]
+
+    aaa(BitSet())
+    bbb[BitSet](BitSet())[AbstractSet[Int]]
 }


### PR DESCRIPTION
Copies the following tests to the safe initialization test suite to ensure the initialization checker can handle clause interleaving.
- tests/pos/interleaving-params.scala
- tests/pos/interleaving-overload.scala
- tests/neg/interleaving-params.scala