### PR TITLE
Support type variable with bounds in quoted pattern

### DIFF
--- a/docs/_docs/reference/metaprogramming/macros.md
+++ b/docs/_docs/reference/metaprogramming/macros.md
@@ -530,6 +530,7 @@ def empty[T: Type]: Expr[T] =
   Type.of[T] match
     case '[String] => '{ "" }
     case '[List[t]] => '{ List.empty[t] }
+    case '[type t <: Option[Int]; List[`t`]] => '{ List.empty[t] }
     ...
 ```
 

--- a/docs/_docs/reference/syntax.md
+++ b/docs/_docs/reference/syntax.md
@@ -277,7 +277,7 @@ ColonArgument     ::=  colon [LambdaStart]
 LambdaStart       ::=  FunParams (‘=>’ | ‘?=>’)
                     |  HkTypeParamClause ‘=>’
 Quoted            ::=  ‘'’ ‘{’ Block ‘}’
-                    |  ‘'’ ‘[’ Type ‘]’
+                    |  ‘'’ ‘[’ TypeBlock ‘]’
 ExprSplice        ::= spliceId                                                  -- if inside quoted block
                     |  ‘$’ ‘{’ Block ‘}’                                        -- unless inside quoted pattern
                     |  ‘$’ ‘{’ Pattern ‘}’                                      -- when inside quoted pattern
@@ -296,6 +296,8 @@ BlockStat         ::=  Import
                     |  Extension
                     |  Expr1
                     |  EndMarker
+TypeBlock         ::=  {TypeBlockStat semi} Type
+TypeBlockStat     ::=  ‘type’ {nl} TypeDcl
 
 ForExpr           ::=  ‘for’ ‘(’ Enumerators0 ‘)’ {nl} [‘do‘ | ‘yield’] Expr
                     |  ‘for’ ‘{’ Enumerators0 ‘}’ {nl} [‘do‘ | ‘yield’] Expr

--- a/tests/pos-macros/i10864/Macro_1.scala
+++ b/tests/pos-macros/i10864/Macro_1.scala
@@ -1,0 +1,15 @@
+import scala.quoted._
+
+case class T(t: Type[_])
+
+object T {
+  def impl[T <: AnyKind](using tt: Type[T])(using Quotes): Expr[Unit] = {
+    val t = T(tt)
+    t.t match
+      case '[type x <: AnyKind; `x`] => // ok
+      case _ => quotes.reflect.report.error("not ok :(")
+    '{}
+  }
+
+  inline def run[T <: AnyKind] = ${ impl[T] }
+}

--- a/tests/pos-macros/i10864/Test_2.scala
+++ b/tests/pos-macros/i10864/Test_2.scala
@@ -1,0 +1,4 @@
+def test =
+  T.run[List]
+  T.run[Map]
+  T.run[Tuple22]

--- a/tests/pos-macros/i10864a/Macro_1.scala
+++ b/tests/pos-macros/i10864a/Macro_1.scala
@@ -1,0 +1,19 @@
+import scala.quoted._
+
+case class T(t: Type[_])
+
+object T {
+  def impl[T <: AnyKind](using tt: Type[T])(using Quotes): Expr[Unit] = {
+    val t = T(tt)
+    t.t match
+      case '[type x; `x`] =>
+        assert(Type.show[x] == "scala.Int", Type.show[x])
+      case '[type f[X]; `f`] =>
+        assert(Type.show[f] == "[A >: scala.Nothing <: scala.Any] => scala.collection.immutable.List[A]", Type.show[f])
+      case '[type f <: AnyKind; `f`] =>
+        assert(Type.show[f] == "[K >: scala.Nothing <: scala.Any, V >: scala.Nothing <: scala.Any] => scala.collection.immutable.Map[K, V]", Type.show[f])
+    '{}
+  }
+
+  inline def run[T <: AnyKind] = ${ impl[T] }
+}

--- a/tests/pos-macros/i10864a/Test_2.scala
+++ b/tests/pos-macros/i10864a/Test_2.scala
@@ -1,0 +1,5 @@
+@main
+def run =
+  T.run[Int]
+  T.run[List]
+  T.run[Map]

--- a/tests/pos-macros/i11738.scala
+++ b/tests/pos-macros/i11738.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+def blah[A](using Quotes, Type[A]): Expr[Unit] =
+  Type.of[A] match
+    case '[h *: t] => println(s"h = ${Type.show[h]}, t = ${Type.show[t]}") // ok
+    case '[type f[X]; `f`[a]]   => println(s"f = ${Type.show[f]}, a = ${Type.show[a]}") // error
+    case _         =>
+  '{()}

--- a/tests/pos-macros/i7264.scala
+++ b/tests/pos-macros/i7264.scala
@@ -3,5 +3,6 @@ class Foo {
   def f[T2](t: Type[T2])(using Quotes) = t match {
     case '[ *:[Int, t2] ] =>
       Type.of[ *:[Int, t2] ]
+    case '[ type t <: Tuple; *:[`t`, `t`] ] =>
   }
 }


### PR DESCRIPTION
Support explicit type variable definition in quoted patterns. This allows users to set explicit bounds or use the binding twice.

```scala
case '[type x; `x`] =>
case '[type x; Map[`x`, `x`]] =>
case '[type x <: List[Any]; `x`] =>
case '[type f[X]; `f`] =>
case '[type f <: AnyKind; `f`] =>
```

Previously this was only possible on quoted expression patterns `case '{ ... }`. We also had no way to set bounds for type variables in quoted type patterns.


Fixes #10864
Fixes #11738

SIP: https://github.com/scala/improvement-proposals/pull/59