### PR TITLE
Forward port deprecation exclusion

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -69,8 +69,8 @@ class CrossVersionChecks extends MiniPhase:
 
     for annot <- sym.getAnnotation(defn.DeprecatedAnnot) do
       if !skipWarning then
-        val msg = annot.argumentConstant(0).map(": " + _.stringValue).getOrElse("")
-        val since = annot.argumentConstant(1).map(" since " + _.stringValue).getOrElse("")
+        val msg = annot.argumentConstantString(0).filter(!_.isEmpty).map(": " + _).getOrElse("")
+        val since = annot.argumentConstantString(1).filter(!_.isEmpty).map(" since " + _).getOrElse("")
         report.deprecationWarning(em"${sym.showLocated} is deprecated${since}${msg}", pos)
 
   private def checkExperimentalSignature(sym: Symbol, pos: SrcPos)(using Context): Unit =

--- a/tests/pos/i11022.scala
+++ b/tests/pos/i11022.scala
@@ -1,0 +1,12 @@
+
+// was pos/t2799.scala
+// scalac: -deprecation -Werror
+
+@deprecated("hi mom", "") case class Bob ()
+
+@deprecated("other mother", "")
+trait T
+
+object T extends T {
+  def t = Bob()
+}


### PR DESCRIPTION
Deprecation is suppressed if enclosing element is deprecated; the exclusion is extended to include "if companion of enclosing element is deprecated."

Fixes #11022 