### PR TITLE
Derivation documentation: use `inline def derived` so that `derives` is employed

### DIFF
--- a/docs/_docs/reference/contextual/derivation-macro.md
+++ b/docs/_docs/reference/contextual/derivation-macro.md
@@ -31,7 +31,7 @@ given derived[T: Type](using Quotes): Expr[Eq[T]]
 and for comparison reasons we give the same signature we had with `inline`:
 
 ```scala
-inline given derived[T](using Mirror.Of[T]): Eq[T] = ???
+inline def derived[T](using Mirror.Of[T]): Eq[T] = ???
 ```
 
 Note, that since a type is used in a subsequent stage it will need to be lifted

--- a/docs/_docs/reference/contextual/derivation.md
+++ b/docs/_docs/reference/contextual/derivation.md
@@ -419,7 +419,7 @@ object Eq:
           case ((x, y), elem) => check(elem)(x, y)
         }
 
-  inline given derived[T](using m: Mirror.Of[T]): Eq[T] =
+  inline def derived[T](using m: Mirror.Of[T]): Eq[T] =
     lazy val elemInstances = summonAll[m.MirroredElemTypes]
     inline m match
       case s: Mirror.SumOf[T]     => eqSum(s, elemInstances)


### PR DESCRIPTION
This PR complements the the issue

 * https://github.com/lampepfl/dotty/issues/16916
