### PR TITLE
Backport "Restrict captureWildcards to only be used if needed"

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4474,6 +4474,8 @@ object Types {
 
     def hasWildcardArg(using Context): Boolean = args.exists(isBounds)
 
+    def hasCaptureConversionArg(using Context): Boolean = args.exists(_.typeSymbol == defn.TypeBox_CAP)
+
     def derivedAppliedType(tycon: Type, args: List[Type])(using Context): Type =
       if ((tycon eq this.tycon) && (args eq this.args)) this
       else tycon.appliedTo(args)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4474,8 +4474,6 @@ object Types {
 
     def hasWildcardArg(using Context): Boolean = args.exists(isBounds)
 
-    def hasCaptureConversionArg(using Context): Boolean = args.exists(_.typeSymbol == defn.TypeBox_CAP)
-
     def derivedAppliedType(tycon: Type, args: List[Type])(using Context): Type =
       if ((tycon eq this.tycon) && (args eq this.args)) this
       else tycon.appliedTo(args)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -714,8 +714,8 @@ trait Applications extends Compatibility {
         || argMatch == ArgMatch.CompatibleCAP
             && {
               val argtpe1 = argtpe.widen
-              val captured = captureWildcards(argtpe1)
-              (captured ne argtpe1) && isCompatible(captured, formal.widenExpr)
+              val captured = captureWildcardsCompat(argtpe1, formal.widenExpr)
+              captured ne argtpe1
             }
 
     /** The type of the given argument */
@@ -2412,4 +2412,9 @@ trait Applications extends Compatibility {
   def isApplicableExtensionMethod(methodRef: TermRef, receiverType: Type)(using Context): Boolean =
     methodRef.symbol.is(ExtensionMethod) && !receiverType.isBottomType &&
       tryApplyingExtensionMethod(methodRef, nullLiteral.asInstance(receiverType)).nonEmpty
+
+  def captureWildcardsCompat(tp: Type, pt: Type)(using Context): Type =
+    val captured = captureWildcards(tp)
+    if (captured ne tp) && isCompatible(captured, pt) then captured
+    else tp
 }

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -542,6 +542,10 @@ object Inferencing {
     case tp: AnnotatedType => tp.derivedAnnotatedType(captureWildcards(tp.parent), tp.annot)
     case _ => tp
   }
+
+  def hasCaptureConversionArg(tp: Type)(using Context): Boolean = tp match
+    case tp: AppliedType => tp.args.exists(_.typeSymbol == defn.TypeBox_CAP)
+    case _ => false
 }
 
 trait Inferencing { this: Typer =>

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -497,9 +497,15 @@ object ProtoTypes {
       if wideFormal eq formal then targ1
       else targ1.tpe match
         case tp: AppliedType if tp.hasCaptureConversionArg =>
-          errorTree(targ1,
-            em"""argument for by-name parameter contains capture conversion skolem types:
-                |$tp""")
+          stripCast(targ1).tpe match
+            case tp: AppliedType if tp.hasWildcardArg =>
+              errorTree(targ1,
+                em"""argument for by-name parameter is not a value
+                    |and contains wildcard arguments: $tp
+                    |
+                    |Assign it to a val and pass that instead.
+                    |""")
+            case _ => targ1
         case _ => targ1
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -501,15 +501,13 @@ object ProtoTypes {
 
     def checkNoWildcardCaptureForCBN(targ1: Tree)(using Context): Tree = {
       if hasCaptureConversionArg(targ1.tpe) then
-        stripCast(targ1).tpe match
-          case tp: AppliedType if tp.hasWildcardArg =>
-            errorTree(targ1,
-              em"""argument for by-name parameter is not a value
-                  |and contains wildcard arguments: $tp
-                  |
-                  |Assign it to a val and pass that instead.
-                  |""")
-          case _ => targ1
+        val tp = stripCast(targ1).tpe
+        errorTree(targ1,
+          em"""argument for by-name parameter is not a value
+              |and contains wildcard arguments: $tp
+              |
+              |Assign it to a val and pass that instead.
+              |""")
       else targ1
     }
 

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -13,6 +13,7 @@ import Decorators._
 import Uniques._
 import inlines.Inlines
 import config.Printers.typr
+import Inferencing.*
 import ErrorReporting.*
 import util.SourceFile
 import TypeComparer.necessarySubType
@@ -495,18 +496,21 @@ object ProtoTypes {
         force = true)
       val targ1 = typer.adapt(targ, wideFormal, locked)
       if wideFormal eq formal then targ1
-      else targ1.tpe match
-        case tp: AppliedType if tp.hasCaptureConversionArg =>
-          stripCast(targ1).tpe match
-            case tp: AppliedType if tp.hasWildcardArg =>
-              errorTree(targ1,
-                em"""argument for by-name parameter is not a value
-                    |and contains wildcard arguments: $tp
-                    |
-                    |Assign it to a val and pass that instead.
-                    |""")
-            case _ => targ1
-        case _ => targ1
+      else checkNoWildcardCaptureForCBN(targ1)
+    }
+
+    def checkNoWildcardCaptureForCBN(targ1: Tree)(using Context): Tree = {
+      if hasCaptureConversionArg(targ1.tpe) then
+        stripCast(targ1).tpe match
+          case tp: AppliedType if tp.hasWildcardArg =>
+            errorTree(targ1,
+              em"""argument for by-name parameter is not a value
+                  |and contains wildcard arguments: $tp
+                  |
+                  |Assign it to a val and pass that instead.
+                  |""")
+          case _ => targ1
+      else targ1
     }
 
     /** The type of the argument `arg`, or `NoType` if `arg` has not been typed before

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1570,6 +1570,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 else if ((tree.tpt `eq` untpd.ContextualEmptyTree) && mt.paramNames.isEmpty)
                   // Note implicitness of function in target type since there are no method parameters that indicate it.
                   TypeTree(defn.FunctionOf(Nil, mt.resType, isContextual = true, isErased = false))
+                else if mt.resType.match { case tp: AppliedType => tp.hasCaptureConversionArg case _ => false } then
+                  errorTree(tree,
+                    em"""cannot turn method type $mt into closure
+                        |because it has capture conversion skolem types""")
                 else
                   EmptyTree
             }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3944,7 +3944,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             return adaptConstant(tree, ConstantType(converted))
         case _ =>
 
-      val captured = captureWildcards(wtp)
+      val captured = captureWildcardsCompat(wtp, pt)
       if (captured `ne` wtp)
         return readapt(tree.cast(captured))
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1570,7 +1570,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 else if ((tree.tpt `eq` untpd.ContextualEmptyTree) && mt.paramNames.isEmpty)
                   // Note implicitness of function in target type since there are no method parameters that indicate it.
                   TypeTree(defn.FunctionOf(Nil, mt.resType, isContextual = true, isErased = false))
-                else if mt.resType.match { case tp: AppliedType => tp.hasCaptureConversionArg case _ => false } then
+                else if hasCaptureConversionArg(mt.resType) then
                   errorTree(tree,
                     em"""cannot turn method type $mt into closure
                         |because it has capture conversion skolem types""")

--- a/tests/neg/t9419.scala
+++ b/tests/neg/t9419.scala
@@ -1,0 +1,22 @@
+trait Magic[S]:
+  def init: S
+  def step(s: S): String
+
+object IntMagic extends Magic[Int]:
+  def init = 0
+  def step(s: Int): String = (s - 1).toString
+
+object StrMagic extends Magic[String]:
+  def init = "hi"
+  def step(s: String): String = s.reverse
+
+object Main:
+  def onestep[T](m: () => Magic[T]): String = m().step(m().init)
+  def unostep[T](m:    => Magic[T]): String = m.step(m.init)
+
+  val iter: Iterator[Magic[?]] = Iterator(IntMagic, StrMagic)
+
+  // was: class java.lang.String cannot be cast to class java.lang.Integer
+  def main(args: Array[String]): Unit =
+    onestep(() => iter.next()) // error
+    unostep(iter.next())       // error

--- a/tests/neg/t9419.scala
+++ b/tests/neg/t9419.scala
@@ -14,9 +14,11 @@ object Main:
   def onestep[T](m: () => Magic[T]): String = m().step(m().init)
   def unostep[T](m:    => Magic[T]): String = m.step(m.init)
 
-  val iter: Iterator[Magic[?]] = Iterator(IntMagic, StrMagic)
+  val iter: Iterator[Magic[?]] = Iterator.tabulate(Int.MaxValue)(i => if i % 2 == 0 then IntMagic else StrMagic)
 
   // was: class java.lang.String cannot be cast to class java.lang.Integer
   def main(args: Array[String]): Unit =
     onestep(() => iter.next()) // error
     unostep(iter.next())       // error
+    val m = iter.next()
+    unostep(m)                 // ok, because m is a value

--- a/tests/neg/t9419.zio-http.scala
+++ b/tests/neg/t9419.zio-http.scala
@@ -1,0 +1,18 @@
+// Minimisation of how the fix for t9419 affected zio-http
+import java.util.concurrent.Future as JFuture
+
+trait Test:
+  def shutdownGracefully(): JFuture[_]
+
+  def executedWildcard(jFuture: => JFuture[_]): Unit
+  def executedGeneric[A](jFuture: => JFuture[A]): Unit
+  def executedWildGen[A](jFuture: => JFuture[? <: A]): Unit
+
+  // Even though JFuture is morally covariant, at least currently,
+  // there's no definition-side variance, so it's treated as invariant.
+  // So we have to be concerned that two different values of `JFuture[A]`
+  // with different types, blowing up together.  So error in `fails`.
+  def works = executedWildcard(shutdownGracefully())
+  def fails = executedGeneric(shutdownGracefully()) // error
+  def fixed = executedGeneric(shutdownGracefully().asInstanceOf[JFuture[Any]]) // fix
+  def best2 = executedWildGen(shutdownGracefully()) // even better, use use-site variance in the method

--- a/tests/pos/t9419.jackson.scala
+++ b/tests/pos/t9419.jackson.scala
@@ -1,0 +1,20 @@
+// from failure in the community project
+// jackson-module-scala
+// in ScalaAnnotationIntrospectorModule.scala:139:12
+
+import scala.language.implicitConversions
+
+trait EnrichedType[X]:
+  def value: X
+
+trait ClassW extends EnrichedType[Class[_]]:
+  def extendsScalaClass = false
+
+class Test:
+  implicit def mkClassW(c: => Class[_]): ClassW = new ClassW:
+    lazy val value = c
+
+  def test1(c1: Class[_]) = c1.extendsScalaClass           // ok: c1 is a value
+  def test2(c2: Class[_]) = mkClassW(c2).extendsScalaClass // ok: c2 is a value
+  // c1 in test1 goes throw adapting to find the extension method and gains the wildcard capture cast then
+  // c2 in test2 goes straight to typedArg, as it's already an arg, so it never gets wildcard captured

--- a/tests/pos/t9419.specs2.scala
+++ b/tests/pos/t9419.specs2.scala
@@ -1,0 +1,13 @@
+// Minimisation of how the fix for t9419 affected specs2
+class MustExpectable[T](tm: () => T):
+  def must_==(other: => Any) = tm() == other
+
+class Foo
+
+object Main:
+  implicit def theValue[T](t: => T): MustExpectable[T] = new MustExpectable(() => t)
+  def main(args: Array[String]): Unit =
+    val cls = classOf[Foo]
+    val instance = new Foo()
+    val works = cls must_== cls
+    val fails = instance.getClass must_== cls


### PR DESCRIPTION
Backports #16799 and #16732

The first PR was marked as needing backporting to 3.3.0 even though it fixed a regression that first appeared after branching off the release branch for 3.3.0. It relied on the changes from #16732, so I also cherry-picked them.

I don't remember exactly why we decided to backport those changes, so I'm leaving it to @dwijnand to decide. 