### PR TITLE
Warn on use of inferred quote type variable bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -160,6 +160,8 @@ trait QuotesAndSplices {
       case _ => TypeBounds.empty
     val typeSym = newSymbol(spliceOwner(ctx), name, EmptyFlags, typeSymInfo, NoSymbol, tree.span)
     typeSym.addAnnotation(Annotation(New(ref(defn.QuotedRuntimePatterns_patternTypeAnnot.typeRef)).withSpan(tree.span)))
+    if !(typeSymInfo =:= TypeBounds.empty) then
+      report.warning(em"Type variable `$tree` has partially inferred bounds$pt.\n\nConsider defining bounds explicitly `'{ $typeSym$pt; ... }`", tree.srcPos)
     val pat = typedPattern(expr, defn.QuotedTypeClass.typeRef.appliedTo(typeSym.typeRef))(
         using spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
     pat.select(tpnme.Underlying)

--- a/tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.check
+++ b/tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.check
@@ -1,0 +1,12 @@
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:9:18 -----------------------------------
+9 |    case '{ $x: C[t] } => // error
+  |                  ^
+  |                  Type variable `t` has partially inferred bounds <: Int.
+  |
+  |                  Consider defining bounds explicitly `'{ type t <: Int; ... }`
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:10:18 ----------------------------------
+10 |    case '{ $x: D[t] } => // error
+   |                  ^
+   |                  Type variable `t` has partially inferred bounds >: Null <: String.
+   |
+   |                  Consider defining bounds explicitly `'{ type t >: Null <: String; ... }`

--- a/tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala
+++ b/tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala
@@ -1,0 +1,11 @@
+import scala.quoted.*
+
+class C[T <: Int]
+class D[T >: Null <: String]
+
+def test(e: Expr[Any])(using Quotes) =
+  e match
+    case '{ $x: t } =>
+    case '{ $x: C[t] } => // error
+    case '{ $x: D[t] } => // error
+    case '{ type t <: Int; $x: C[`t`] } =>


### PR DESCRIPTION
This kind of inference is not reliable in general. We can only consider the bounds from type constructor where the type variable is defined but any other constraints are ignored. Therefore it is not possible to properly infer the type bounds of the type variable.

The solution is simple, write the bounds explicitly and just check that those bounds conform to the use site of the type variable.