### PR TITLE
Quoted pattern type variables without backticks

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -20,17 +20,18 @@ import dotty.tools.dotc.staging.StagingLevel.*
 import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.dotc.typer.Implicits._
 import dotty.tools.dotc.typer.Inferencing._
+import dotty.tools.dotc.util.Property
 import dotty.tools.dotc.util.Spans._
 import dotty.tools.dotc.util.Stats.record
 import dotty.tools.dotc.reporting.IllegalVariableInPatternAlternative
 import scala.collection.mutable
 
-
 /** Type quotes `'{ ... }` and splices `${ ... }` */
 trait QuotesAndSplices {
   self: Typer =>
 
-  import tpd._
+  import tpd.*
+  import QuotesAndSplices.*
 
   /** Translate `'{ e }` into `scala.quoted.Expr.apply(e)` and `'[T]` into `scala.quoted.Type.apply[T]`
    *  while tracking the quotation level in the context.
@@ -150,19 +151,26 @@ trait QuotesAndSplices {
    *  The resulting pattern is the split in `splitQuotePattern`.
    */
   def typedQuotedTypeVar(tree: untpd.Ident, pt: Type)(using Context): Tree =
-    def spliceOwner(ctx: Context): Symbol =
-      if (ctx.mode.is(Mode.QuotedPattern)) spliceOwner(ctx.outer) else ctx.owner
-    val name = tree.name.toTypeName
-    val nameOfSyntheticGiven = PatMatGivenVarName.fresh(tree.name.toTermName)
-    val expr = untpd.cpy.Ident(tree)(nameOfSyntheticGiven)
     val typeSymInfo = pt match
       case pt: TypeBounds => pt
       case _ => TypeBounds.empty
-    val typeSym = newSymbol(spliceOwner(ctx), name, EmptyFlags, typeSymInfo, NoSymbol, tree.span)
-    typeSym.addAnnotation(Annotation(New(ref(defn.QuotedRuntimePatterns_patternTypeAnnot.typeRef)).withSpan(tree.span)))
-    val pat = typedPattern(expr, defn.QuotedTypeClass.typeRef.appliedTo(typeSym.typeRef))(
-        using spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
-    pat.select(tpnme.Underlying)
+    getQuotedPatternTypeVariable(tree.name.asTypeName) match
+      case Some(typeSym) =>
+        if !(typeSymInfo =:= TypeBounds.empty) then
+          report.warning(em"Ignored bound$typeSymInfo\n\nConsider defining bounds explicitly `'{ $typeSym$typeSymInfo; ... }`", tree.srcPos)
+        ref(typeSym)
+      case None =>
+        def spliceOwner(ctx: Context): Symbol =
+          if (ctx.mode.is(Mode.QuotedPattern)) spliceOwner(ctx.outer) else ctx.owner
+        val name = tree.name.toTypeName
+        val nameOfSyntheticGiven = PatMatGivenVarName.fresh(tree.name.toTermName)
+        val expr = untpd.cpy.Ident(tree)(nameOfSyntheticGiven)
+        val typeSym = newSymbol(spliceOwner(ctx), name, EmptyFlags, typeSymInfo, NoSymbol, tree.span)
+        typeSym.addAnnotation(Annotation(New(ref(defn.QuotedRuntimePatterns_patternTypeAnnot.typeRef)).withSpan(tree.span)))
+        addQuotedPatternTypeVariable(typeSym)
+        val pat = typedPattern(expr, defn.QuotedTypeClass.typeRef.appliedTo(typeSym.typeRef))(
+            using spliceContext.retractMode(Mode.QuotedPattern).withOwner(spliceOwner(ctx)))
+        pat.select(tpnme.Underlying)
 
   def typedHole(tree: untpd.Hole, pt: Type)(using Context): Tree =
     val tpt = typedType(tree.tpt)
@@ -393,11 +401,24 @@ trait QuotesAndSplices {
       case Some(argPt: ValueType) => argPt // excludes TypeBounds
       case _ => defn.AnyType
     }
-    val quoted0 = desugar.quotedPattern(quoted, untpd.TypedSplice(TypeTree(quotedPt)))
-    val quoteCtx = quoteContext.addMode(Mode.QuotedPattern).retractMode(Mode.Pattern)
-    val quoted1 =
-      if quoted.isType then typedType(quoted0, WildcardType)(using quoteCtx)
-      else typedExpr(quoted0, WildcardType)(using quoteCtx)
+    val (untpdTypeVariables, quoted0) = desugar.quotedPatternTypeVariables(desugar.quotedPattern(quoted, untpd.TypedSplice(TypeTree(quotedPt))))
+
+    val (typeTypeVariables, patternCtx) =
+      val quoteCtx = quotePatternContext()
+      if untpdTypeVariables.isEmpty then (Nil, quoteCtx)
+      else typedBlockStats(untpdTypeVariables)(using quoteCtx)
+
+    val quoted1 = inContext(patternCtx) {
+      for typeVariable <- typeTypeVariables do
+        addQuotedPatternTypeVariable(typeVariable.symbol)
+
+      val pattern =
+        if quoted.isType then typedType(quoted0, WildcardType)
+        else typedExpr(quoted0, WildcardType)
+
+      if untpdTypeVariables.isEmpty then pattern
+      else tpd.Block(typeTypeVariables, pattern)
+    }
 
     val (typeBindings, shape, splices) = splitQuotePattern(quoted1)
 
@@ -453,4 +474,25 @@ trait QuotesAndSplices {
       patterns = splicePat :: Nil,
       proto = quoteClass.typeRef.appliedTo(replaceBindings(quoted1.tpe) & quotedPt))
   }
+}
+
+object QuotesAndSplices {
+  import tpd._
+
+  /** Key for mapping from quoted pattern type variable names into their symbol */
+  private val TypeVariableKey = new Property.Key[collection.mutable.Map[TypeName, Symbol]]
+
+  /** Get the symbol for the quoted pattern type variable if it exists */
+  def getQuotedPatternTypeVariable(name: TypeName)(using Context): Option[Symbol] =
+    ctx.property(TypeVariableKey).get.get(name)
+
+    /** Get the symbol for the quoted pattern type variable if it exists */
+  def addQuotedPatternTypeVariable(sym: Symbol)(using Context): Unit =
+    ctx.property(TypeVariableKey).get.update(sym.name.asTypeName, sym)
+
+  /** Context used to type the contents of a quoted */
+  def quotePatternContext()(using Context): Context =
+    quoteContext.fresh.setNewScope
+      .addMode(Mode.QuotedPattern).retractMode(Mode.Pattern)
+      .setProperty(TypeVariableKey, collection.mutable.Map.empty)
 }

--- a/docs/_docs/reference/metaprogramming/macros.md
+++ b/docs/_docs/reference/metaprogramming/macros.md
@@ -504,18 +504,22 @@ def let(x: Expr[Any])(using Quotes): Expr[Any] =
 let('{1}) // will return a `Expr[Any]` that contains an `Expr[Int]]`
 ```
 
-While we can define the type variable in the middle of the pattern, their normal form is to define them as a `type` with a lower case name at the start of the pattern.
-We use the Scala backquote `` `t` `` naming convention which interprets the string within the backquote as a literal name identifier.
-This is typically used when we have names that contain special characters that are not allowed for normal Scala identifiers.
-But we use it to explicitly state that this is a reference to that name and not the introduction of a new variable.
-```scala
-  case '{ type t; $x: `t` } =>
-```
-This is a bit more verbose but has some expressivity advantages such as allowing to define bounds on the variables and be able to refer to them several times in any scope of the pattern.
+It is also possible to refer to the same type variable multiple times in a pattern.
 
 ```scala
-  case '{ type t >: List[Int] <: Seq[Int]; $x: `t` } =>
-  case '{ type t; $x: (`t`, `t`) } =>
+  case '{ $x: (t, t) } =>
+```
+
+While we can define the type variable in the middle of the pattern, their normal form is to define them as a `type` with a lower case name at the start of the pattern.
+
+```scala
+  case '{ type t; $x: t } =>
+```
+
+This is a bit more verbose but has some expressivity advantages such as allowing to define bounds on the variables.
+
+```scala
+  case '{ type t >: List[Int] <: Seq[Int]; $x: t } =>
 ```
 
 

--- a/tests/neg-macros/quotedPatterns-5.scala
+++ b/tests/neg-macros/quotedPatterns-5.scala
@@ -2,7 +2,7 @@ import scala.quoted.*
 object Test {
   def test(x: quoted.Expr[Int])(using Quotes): Unit = x match {
     case '{ type t; 4 } => Type.of[t]
-    case '{ type t; poly[t]($x); 4 } => // error: duplicate pattern variable: t
+    case '{ type t; poly[t]($x); 4 } =>
     case '{ type `t`; poly[`t`]($x); 4 } =>
       Type.of[t] // error
     case _ =>

--- a/tests/pos-macros/quote-pattern-type-variable-no-escape.scala
+++ b/tests/pos-macros/quote-pattern-type-variable-no-escape.scala
@@ -1,0 +1,12 @@
+import scala.quoted.*
+
+def foo[T: Type](expr: Expr[Any])(using Quotes): Any =
+  expr match
+    case '{ $x: Map[t, t] } =>
+    case '{ type t; $x: Any } =>
+    case '{ type t; $x: Map[t, t] } =>
+    case '{ ($x: Set[t]).toSet[t] } =>
+
+  Type.of[T] match
+    case '[Map[t, t]] =>
+    case '[(t, t, t, t, t, t, t)] =>


### PR DESCRIPTION
With this change we can support references to quote pattern type variables without backticks.

#### Reduces overhead when using explicit type variable definition
```scala
case '{ type t; ... : F[t] }
```
SIP: https://github.com/scala/improvement-proposals/blob/main/content/quote-pattern-type-variable-syntax.md?plain=1#L66-L70

#### Enable the use of many type variable definitions without an explicit type variable definition
```scala
case '{ ... : F[t, t] }
```

SIP: https://github.com/scala/improvement-proposals/blob/main/content/quote-pattern-type-variable-syntax.md?plain=1#L72-L78