### PR TITLE
Space: Cache space decomposition & other refactoring

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -530,9 +530,12 @@ class Definitions {
   })
 
   @tu lazy val ListClass: Symbol       = requiredClass("scala.collection.immutable.List")
+  def ListType: TypeRef                = ListClass.typeRef
   @tu lazy val ListModule: Symbol      = requiredModule("scala.collection.immutable.List")
   @tu lazy val NilModule: Symbol       = requiredModule("scala.collection.immutable.Nil")
+  def NilType: TermRef                 = NilModule.termRef
   @tu lazy val ConsClass: Symbol       = requiredClass("scala.collection.immutable.::")
+  def ConsType: TypeRef                = ConsClass.typeRef
   @tu lazy val SeqFactoryClass: Symbol = requiredClass("scala.collection.SeqFactory")
 
   @tu lazy val SingletonClass: ClassSymbol =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2182,7 +2182,7 @@ object Types {
 
 // --- NamedTypes ------------------------------------------------------------------
 
-  abstract class NamedType extends CachedProxyType, ValueType { self =>
+  abstract class NamedType extends CachedProxyType, ValueType, Product { self =>
 
     type ThisType >: this.type <: NamedType
     type ThisName <: Name
@@ -2190,6 +2190,8 @@ object Types {
     val prefix: Type
     def designator: Designator
     protected def designator_=(d: Designator): Unit
+    def _1: Type
+    def _2: Designator
 
     assert(NamedType.validPrefix(prefix), s"invalid prefix $prefix")
 
@@ -2905,6 +2907,7 @@ object Types {
     def apply(prefix: Type, designator: Name, denot: Denotation)(using Context): NamedType =
       if (designator.isTermName) TermRef.apply(prefix, designator.asTermName, denot)
       else TypeRef.apply(prefix, designator.asTypeName, denot)
+    def unapply(tp: NamedType): NamedType = tp
 
     def validPrefix(prefix: Type): Boolean = prefix.isValueType || (prefix eq NoPrefix)
   }

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -2,11 +2,10 @@ package dotty.tools
 package dotc
 package transform
 
-import scala.annotation.tailrec
 import core._
 import MegaPhase._
-import collection.mutable
 import Symbols._, Contexts._, Types._, StdNames._, NameOps._
+import patmat.SpaceEngine
 import util.Spans._
 import typer.Applications.*
 import SymUtils._
@@ -16,8 +15,11 @@ import Decorators._
 import NameKinds.{PatMatStdBinderName, PatMatAltsName, PatMatResultName}
 import config.Printers.patmatch
 import reporting._
-import dotty.tools.dotc.ast._
+import ast._
 import util.Property._
+
+import scala.annotation.tailrec
+import scala.collection.mutable
 
 /** The pattern matching transform.
  *  After this phase, the only Match nodes remaining in the code are simple switches
@@ -45,9 +47,8 @@ class PatternMatcher extends MiniPhase {
       val translated = new Translator(matchType, this).translateMatch(tree)
 
       // check exhaustivity and unreachability
-      val engine = new patmat.SpaceEngine
-      engine.checkExhaustivity(tree)
-      engine.checkRedundancy(tree)
+      SpaceEngine.checkExhaustivity(tree)
+      SpaceEngine.checkRedundancy(tree)
 
       translated.ensureConforms(matchType)
     }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -67,11 +67,15 @@ sealed trait Space:
       isSubspaceCache.getOrElseUpdate(b, computeIsSubspace(this, b))
     }
 
-  private var mySimplified: Space = _
+  private var mySimplified: Space | Null = _
 
   def simplify(using Context): Space =
-    if mySimplified == null then mySimplified = SpaceEngine.computeSimplify(this)
-    mySimplified
+    val simplified = mySimplified
+    if simplified == null then
+      val simplified = SpaceEngine.computeSimplify(this)
+      mySimplified = simplified
+      simplified
+    else simplified
 end Space
 
 /** Empty space */
@@ -84,15 +88,19 @@ case object Empty extends Space
  *
  */
 case class Typ(tp: Type, decomposed: Boolean = true) extends Space:
-  private var myDecompose: List[Typ] = _
+  private var myDecompose: List[Typ] | Null = _
 
   def canDecompose(using Context): Boolean = decompose != SpaceEngine.ListOfTypNoType
 
   def decompose(using Context): List[Typ] =
-    if myDecompose == null then myDecompose = tp match
-      case SpaceEngine.Parts(parts) => parts.map(Typ(_, decomposed = true))
-      case _                        => SpaceEngine.ListOfTypNoType
-    myDecompose
+    val decompose = myDecompose
+    if decompose == null then
+      val decompose = tp match
+        case SpaceEngine.Parts(parts) => parts.map(Typ(_, decomposed = true))
+        case _                        => SpaceEngine.ListOfTypNoType
+      myDecompose = decompose
+      decompose
+    else decompose
 end Typ
 
 /** Space representing an extractor pattern */

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -72,7 +72,7 @@ sealed trait Space:
       isSubspaceCache.getOrElseUpdate(b, computeIsSubspace(a, b))
     }
 
-  @sharable private var mySimplified: Space | Null = _
+  @sharable private var mySimplified: Space | Null = null
 
   def simplify(using Context): Space =
     val simplified = mySimplified
@@ -93,7 +93,7 @@ case object Empty extends Space
  *
  */
 case class Typ(tp: Type, decomposed: Boolean = true) extends Space:
-  private var myDecompose: List[Typ] | Null = _
+  private var myDecompose: List[Typ] | Null = null
 
   def canDecompose(using Context): Boolean = decompose != SpaceEngine.ListOfTypNoType
 

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -23,6 +23,7 @@ import reporting._
 import config.Printers.{exhaustivity => debug}
 import util.{SrcPos, NoSourcePosition}
 
+import scala.annotation.internal.sharable
 import scala.collection.mutable
 
 /* Space logic for checking exhaustivity and unreachability of pattern matching
@@ -58,7 +59,7 @@ import scala.collection.mutable
 sealed trait Space:
   import SpaceEngine.*
 
-  private val isSubspaceCache = mutable.HashMap.empty[Space, Boolean]
+  @sharable private val isSubspaceCache = mutable.HashMap.empty[Space, Boolean]
 
   def isSubspace(b: Space)(using Context): Boolean =
     val a = this
@@ -71,7 +72,7 @@ sealed trait Space:
       isSubspaceCache.getOrElseUpdate(b, computeIsSubspace(a, b))
     }
 
-  private var mySimplified: Space | Null = _
+  @sharable private var mySimplified: Space | Null = _
 
   def simplify(using Context): Space =
     val simplified = mySimplified

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -61,10 +61,14 @@ sealed trait Space:
   private val isSubspaceCache = mutable.HashMap.empty[Space, Boolean]
 
   def isSubspace(b: Space)(using Context): Boolean =
-    if this == Empty then true
+    val a = this
+    val a2 = a.simplify
+    val b2 = b.simplify
+    if (a ne a2) || (b ne b2) then a2.isSubspace(b2)
+    else if a == Empty then true
     else if b == Empty then false
     else trace(s"isSubspace(${show(this)}, ${show(b)})", debug) {
-      isSubspaceCache.getOrElseUpdate(b, computeIsSubspace(this, b))
+      isSubspaceCache.getOrElseUpdate(b, computeIsSubspace(a, b))
     }
 
   private var mySimplified: Space | Null = _

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -611,11 +611,11 @@ object SpaceEngine {
           case tp if !TypeComparer.provablyDisjoint(tp, tpB) => AndType(tp, tpB)
 
       case OrType(tp1, tp2)                            => List(tp1, tp2)
-      case _: SingletonType                            => ListOfNoType
       case tp if tp.isRef(defn.BooleanClass)           => List(ConstantType(Constant(true)), ConstantType(Constant(false)))
       case tp if tp.isRef(defn.UnitClass)              => ConstantType(Constant(())) :: Nil
       case tp if tp.classSymbol.isAllOf(JavaEnumTrait) => tp.classSymbol.children.map(_.termRef)
-      case tp @ TypeRef(Parts(parts), _)               => parts.map(tp.derivedSelect)
+      case tp @ NamedType(Parts(parts), _)             => parts.map(tp.derivedSelect)
+      case _: SingletonType                            => ListOfNoType
 
       case tp @ AppliedType(Parts(parts), targs) if tp.classSymbol.children.isEmpty =>
         // It might not obvious that it's OK to apply the type arguments of a parent type to child types.

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -613,9 +613,10 @@ object SpaceEngine {
       case OrType(tp1, tp2)                            => List(tp1, tp2)
       case tp if tp.isRef(defn.BooleanClass)           => List(ConstantType(Constant(true)), ConstantType(Constant(false)))
       case tp if tp.isRef(defn.UnitClass)              => ConstantType(Constant(())) :: Nil
-      case tp if tp.classSymbol.isAllOf(JavaEnumTrait) => tp.classSymbol.children.map(_.termRef)
       case tp @ NamedType(Parts(parts), _)             => parts.map(tp.derivedSelect)
       case _: SingletonType                            => ListOfNoType
+      case tp if tp.classSymbol.isAllOf(JavaEnumTrait) => tp.classSymbol.children.map(_.termRef)
+        // the class of a java enum value is the enum class, so this must follow SingletonType to not loop infinitely
 
       case tp @ AppliedType(Parts(parts), targs) if tp.classSymbol.children.isEmpty =>
         // It might not obvious that it's OK to apply the type arguments of a parent type to child types.

--- a/compiler/test/dotty/tools/dotc/transform/patmat/SpaceEngineTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/patmat/SpaceEngineTest.scala
@@ -20,7 +20,7 @@ class SpaceEngineTest:
     val engine = patmat.SpaceEngine()
     import engine.*
 
-    val tp      = defn.ConsClass.typeRef.appliedTo(defn.AnyType)
+    val tp      = defn.ConsType.appliedTo(defn.AnyType)
     val unappTp = requiredMethod("scala.collection.immutable.::.unapply").termRef
     val params  = List(Empty, Typ(tp))
 

--- a/compiler/test/dotty/tools/dotc/transform/patmat/SpaceEngineTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/patmat/SpaceEngineTest.scala
@@ -11,14 +11,14 @@ import vulpix.TestConfiguration, TestConfiguration.basicClasspath
 import org.junit, junit.Test, junit.Assert.*
 
 class SpaceEngineTest:
+  import SpaceEngine.*
+
   @Test def isSubspaceTest1: Unit = inCompilerContext(basicClasspath) {
     // Testing the property of `isSubspace` that:
     // isSubspace(a, b)  <=>  simplify(simplify(a) - simplify(a)) == Empty
     // Previously there were no simplify calls,
     // and this is a counter-example,
     // for which you need either to simplify(b) or simplify the minus result.
-    val engine = patmat.SpaceEngine()
-    import engine.*
 
     val tp      = defn.ConsType.appliedTo(defn.AnyType)
     val unappTp = requiredMethod("scala.collection.immutable.::.unapply").termRef

--- a/tests/patmat/java-enum1/ParameterModifier.java
+++ b/tests/patmat/java-enum1/ParameterModifier.java
@@ -1,0 +1,8 @@
+public enum ParameterModifier {
+    Repeated,
+    Plain,
+    ByName;
+
+    private ParameterModifier() {
+    }
+}

--- a/tests/patmat/java-enum1/Test.scala
+++ b/tests/patmat/java-enum1/Test.scala
@@ -1,0 +1,6 @@
+class Test:
+  private def showParameterModifier(base: String, pm: ParameterModifier): String = pm match {
+    case ParameterModifier.Plain    => base
+    case ParameterModifier.Repeated => base + "*"
+    case ParameterModifier.ByName   => "=> " + base
+  }


### PR DESCRIPTION
Firstly, make SpaceEngine an object, in line with many other parts of the compiler, moving the cache it had for
isSubspace onto Space instances themselves, also like many other parts of the compiler.  This also just helps
code navigation - avoid navigating to the interface all the time...

Then add a cache for decompose, canDecompose and simplify, so the costly result isn't computed multiple times.
And finally, look to define canDecompose in terms of decompose, so the logic is shared.
