### PR TITLE
Fix beta-reduction with `Nothing` and `null` args

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -128,7 +128,10 @@ object BetaReduce:
             ref.symbol
           case _ =>
             val flags = Synthetic | (param.symbol.flags & Erased)
-            val tpe = if arg.tpe.dealias.isInstanceOf[ConstantType] then arg.tpe.dealias else arg.tpe.widen
+            val tpe =
+              if arg.tpe.isBottomType then param.tpe.widenTermRefExpr
+              else if arg.tpe.dealias.isInstanceOf[ConstantType] then arg.tpe.dealias
+              else arg.tpe.widen
             val binding = ValDef(newSymbol(ctx.owner, param.name, flags, tpe, coord = arg.span), arg).withSpan(arg.span)
             if !(tpe.isInstanceOf[ConstantType] && isPureExpr(arg)) then
               bindings += binding

--- a/tests/pos/i15165.scala
+++ b/tests/pos/i15165.scala
@@ -1,0 +1,6 @@
+def test1 = { (y: Int) => y + 1 }.apply(???)
+
+class C:
+  def x: Int = 8
+
+def test2 = { (c: C) => c.x }.apply(null)


### PR DESCRIPTION
Use parameter type as binding type when the argument is of type `Nothing` or `null`.

Fixes part of #15165