### PR TITLE
Support type variable definitions in quoted patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1111,6 +1111,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if ctx.mode.is(Mode.SafeNulls)
       && !exprCtx.mode.is(Mode.SafeNulls)
       && pt.isValueType
+      && !tree.isType
       && !inContext(exprCtx.addMode(Mode.SafeNulls))(expr1.tpe <:< pt) then
       expr1 = expr1.cast(pt)
 

--- a/docs/_docs/reference/syntax.md
+++ b/docs/_docs/reference/syntax.md
@@ -274,7 +274,7 @@ ColonArgument     ::=  colon [LambdaStart]
 LambdaStart       ::=  FunParams (‘=>’ | ‘?=>’)
                     |  HkTypeParamClause ‘=>’
 Quoted            ::=  ‘'’ ‘{’ Block ‘}’
-                    |  ‘'’ ‘[’ Type ‘]’
+                    |  ‘'’ ‘[’ TypeBlock ‘]’
 ExprSplice        ::= spliceId                                                  -- if inside quoted block
                     |  ‘$’ ‘{’ Block ‘}’                                        -- unless inside quoted pattern
                     |  ‘$’ ‘{’ Pattern ‘}’                                      -- when inside quoted pattern
@@ -293,6 +293,8 @@ BlockStat         ::=  Import
                     |  Extension
                     |  Expr1
                     |  EndMarker
+TypeBlock         ::=  {TypeBlockStat semi} Type
+TypeBlockStat     ::=  ‘type’ {nl} TypeDcl
 
 ForExpr           ::=  ‘for’ ‘(’ Enumerators0 ‘)’ {nl} [‘do‘ | ‘yield’] Expr
                     |  ‘for’ ‘{’ Enumerators0 ‘}’ {nl} [‘do‘ | ‘yield’] Expr

--- a/tests/pos-macros/i7264.scala
+++ b/tests/pos-macros/i7264.scala
@@ -3,5 +3,7 @@ class Foo {
   def f[T2](t: Type[T2])(using Quotes) = t match {
     case '[ *:[Int, t2] ] =>
       Type.of[ *:[Int, t2] ]
+    case '[ type t <: Tuple; *:[Int, `t`] ] =>
+    case '[ type t <: Tuple; *:[`t`, `t`] ] =>
   }
 }


### PR DESCRIPTION
Support explicit type variable definition in quoted patterns. This allows users to set explicit bounds or use the binding twice.

Previously this was only possible on quoted expression patterns case '{ ... }.

```scala
case '[type x; `x`] =>
case '[type x; Map[`x`, `x`]] =>
case '[type x <: List[Any]; `x`] =>
```

In combination with #16907 it would also allow
```scala
case '[type f[X]; `f`] =>
case '[type f <: AnyKind; `f`] =>
```
and therefore solve #10864 and #11738

This is part a part of #16910 that does not need a minor release.