### PR TITLE
Simplify `QuoteMatcher.&&&` using `optional`

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/optional.scala
+++ b/compiler/src/dotty/tools/dotc/util/optional.scala
@@ -1,0 +1,19 @@
+package dotty.tools.dotc.util
+
+import scala.util.boundary
+
+/** Return type that indicates that the method returns a T or aborts to the enclosing boundary with a `None` */
+type optional[T] = boundary.Label[None.type] ?=> T
+
+/** A prompt for `Option`, which establishes a boundary which `_.?` on `Option` can return */
+object optional:
+  inline def apply[T](inline body: optional[T]): Option[T] =
+    boundary(Some(body))
+
+  extension [T](r: Option[T])
+    inline def ? (using label: boundary.Label[None.type]): T = r match
+      case Some(x) => x
+      case None => boundary.break(None)
+
+  inline def break()(using label: boundary.Label[None.type]): Nothing =
+    boundary.break(None)


### PR DESCRIPTION
Use `optional` boundary abstraction in `QuoteMatcher`.  Specifically to reduce the syntactic and runtime overhead of `&&&`. For this we define `optional` in the compiler utils to make it available in the compiler.

Also, use `Seq` concatenation instead of `Tuple` concatenation to have the types of elements.