### PR TITLE
Traverse annotations instead of just registering, fixes #16877

### DIFF
--- a/tests/neg-custom-args/fatal-warnings/i15503i.scala
+++ b/tests/neg-custom-args/fatal-warnings/i15503i.scala
@@ -142,3 +142,12 @@ package foo.test.i16822:
     val x = ExampleEnum.List // OK
     println(x) // OK
   }
+
+package foo.test.i16877:
+  import scala.collection.immutable.HashMap // OK
+  import scala.annotation.StaticAnnotation // OK
+
+  class ExampleAnnotation(val a: Object) extends StaticAnnotation // OK
+
+  @ExampleAnnotation(new HashMap()) // OK
+  class Test //OK


### PR DESCRIPTION
@szymon-rd  Fixes #16877 
- Traverse the tree of annotations
- Update test suits

The issue is that the annotation was registered but not traversed.