### PR TITLE
Improve override detection in CheckUnused, fixes #16865

### DIFF
--- a/tests/neg-custom-args/fatal-warnings/i15503e.scala
+++ b/tests/neg-custom-args/fatal-warnings/i15503e.scala
@@ -55,3 +55,15 @@ package foo.test.trivial:
 
 package foo.test.i16955:
   class S(var r: String) // OK
+
+package foo.test.i16865:
+  trait Foo:
+    def fn(a: Int, b: Int): Int // OK
+  trait Bar extends Foo
+
+  object Ex extends Bar:
+    def fn(a: Int, b: Int): Int = b + 3 // OK
+
+  object Ex2 extends Bar:
+    override def fn(a: Int, b: Int): Int = b + 3 // OK
+


### PR DESCRIPTION
@szymon-rd, fixes #16865

- CheckUnused detects override from base type in addition of `override` flag
- Update test suit