### PR TITLE
Fix reflect `SuperType.supertpe` and printing super types and type lambdas

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1865,7 +1865,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     given SuperTypeMethods: SuperTypeMethods with
       extension (self: SuperType)
         def thistpe: TypeRepr = self.thistpe
-        def supertpe: TypeRepr = self.thistpe
+        def supertpe: TypeRepr = self.supertpe
       end extension
     end SuperTypeMethods
 

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1368,28 +1368,24 @@ object SourceCode {
 
     private def printProtectedOrPrivate(definition: Definition): Boolean = {
       var prefixWasPrinted = false
-      def printWithin(within: TypeRepr) = within match {
-        case TypeRef(_, name) => this += name
-        case _ => printFullClassName(within)
-      }
-      if (definition.symbol.flags.is(Flags.Protected)) {
+      def printWithin(within: Option[TypeRepr]) = within match
+        case _ if definition.symbol.flags.is(Flags.Local) => inSquare(this += "this")
+        case Some(TypeRef(_, name)) => inSquare(this += name)
+        case Some(within) => inSquare(printFullClassName(within))
+        case _ =>
+
+      if definition.symbol.flags.is(Flags.Protected) then
         this += highlightKeyword("protected")
-        definition.symbol.protectedWithin match {
-          case Some(within) =>
-            inSquare(printWithin(within))
-          case _ =>
-        }
+        printWithin(definition.symbol.protectedWithin)
         prefixWasPrinted = true
-      } else {
-        definition.symbol.privateWithin match {
-          case Some(within) =>
-            this += highlightKeyword("private")
-            inSquare(printWithin(within))
-            prefixWasPrinted = true
-          case _ =>
-        }
-      }
-      if (prefixWasPrinted)
+      else
+        val privateWithin = definition.symbol.privateWithin
+        if privateWithin.isDefined || definition.symbol.flags.is(Flags.Private) then
+          this += highlightKeyword("private")
+          printWithin(definition.symbol.privateWithin)
+          prefixWasPrinted = true
+
+      if prefixWasPrinted then
         this += " "
       prefixWasPrinted
     }

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1189,12 +1189,12 @@ object SourceCode {
         }
 
       case SuperType(thistpe, supertpe) =>
-        printType(supertpe)
+        printType(thistpe)
         this += highlightTypeDef(".super")
 
       case TypeLambda(paramNames, tparams, body) =>
         inSquare(printMethodicTypeParams(paramNames, tparams))
-        this += highlightTypeDef(" => ")
+        this += highlightTypeDef(" =>> ")
         printType(body)
 
       case ParamRef(lambda, idx) =>

--- a/tests/pos-macros/hk-quoted-type-patterns/Macro_1.scala
+++ b/tests/pos-macros/hk-quoted-type-patterns/Macro_1.scala
@@ -5,9 +5,9 @@ private def impl(x: Expr[Any])(using Quotes): Expr[Unit] = {
     case '{ foo[x] } =>
       assert(Type.show[x] == "scala.Int", Type.show[x])
     case '{ type f[X]; foo[`f`] } =>
-      assert(Type.show[f] == "[A >: scala.Nothing <: scala.Any] => scala.collection.immutable.List[A]", Type.show[f])
+      assert(Type.show[f] == "[A >: scala.Nothing <: scala.Any] =>> scala.collection.immutable.List[A]", Type.show[f])
     case '{ type f <: AnyKind; foo[`f`] } =>
-      assert(Type.show[f] == "[K >: scala.Nothing <: scala.Any, V >: scala.Nothing <: scala.Any] => scala.collection.immutable.Map[K, V]", Type.show[f])
+      assert(Type.show[f] == "[K >: scala.Nothing <: scala.Any, V >: scala.Nothing <: scala.Any] =>> scala.collection.immutable.Map[K, V]", Type.show[f])
     case x => throw MatchError(x.show)
   '{}
 }

--- a/tests/run-macros/i10863.check
+++ b/tests/run-macros/i10863.check
@@ -1,1 +1,1 @@
-[A >: scala.Nothing <: scala.Any] => scala.collection.immutable.List[A]
+[A >: scala.Nothing <: scala.Any] =>> scala.collection.immutable.List[A]

--- a/tests/run-macros/i8514b.check
+++ b/tests/run-macros/i8514b.check
@@ -1,5 +1,5 @@
 B
-A[[T >: scala.Nothing <: scala.Any] => P[T], scala.Predef.String]
+A[[T >: scala.Nothing <: scala.Any] =>> P[T], scala.Predef.String]
 java.lang.Object
 scala.Matchable
 scala.Any

--- a/tests/run-macros/tasty-simplified.check
+++ b/tests/run-macros/tasty-simplified.check
@@ -1,4 +1,4 @@
 Functor[scala.collection.immutable.List]
-Unapply[[F >: scala.Nothing <: [_$9 >: scala.Nothing <: scala.Any] => scala.Any] => Functor[F], Wrap[scala.Int]]
-Unapply[[F >: scala.Nothing <: [_$9 >: scala.Nothing <: scala.Any] => scala.Any] => Functor[F], Wrap[Dummy]]
+Unapply[[F >: scala.Nothing <: [_$9 >: scala.Nothing <: scala.Any] =>> scala.Any] =>> Functor[F], Wrap[scala.Int]]
+Unapply[[F >: scala.Nothing <: [_$9 >: scala.Nothing <: scala.Any] =>> scala.Any] =>> Functor[F], Wrap[Dummy]]
 Functor[scala.Option]

--- a/tests/run-macros/term-show/Macro_1.scala
+++ b/tests/run-macros/term-show/Macro_1.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+object TypeToolbox {
+  inline def show(inline v: Any): String = ${ showImpl('v) }
+  private def showImpl(using Quotes)(v: Expr[Any]): Expr[String] =
+    import quotes.reflect.*
+    Expr(v.show)
+}

--- a/tests/run-macros/term-show/Test_2.scala
+++ b/tests/run-macros/term-show/Test_2.scala
@@ -1,0 +1,29 @@
+object Test {
+  import TypeToolbox.*
+  def main(args: Array[String]): Unit = {
+   assert(show {
+      class C {
+        def a = 0
+        private def b = 0
+        private[this] def c = 0
+        private[C] def d = 0
+        protected def e = 0
+        protected[this] def f = 0
+        protected[C] def g = 0
+      }
+    }
+    ==
+    """{
+      |  class C() {
+      |    def a: scala.Int = 0
+      |    private[this] def b: scala.Int = 0
+      |    private[this] def c: scala.Int = 0
+      |    private[C] def d: scala.Int = 0
+      |    protected def e: scala.Int = 0
+      |    protected[this] def f: scala.Int = 0
+      |    protected[C] def g: scala.Int = 0
+      |  }
+      |  ()
+      |}""".stripMargin)
+  }
+}

--- a/tests/run-macros/type-show/Test_2.scala
+++ b/tests/run-macros/type-show/Test_2.scala
@@ -9,7 +9,7 @@ object Test {
     assert(show[Int => Int] == "scala.Function1[scala.Int, scala.Int]")
     assert(show[(Int, String)] == "scala.Tuple2[scala.Int, scala.Predef.String]")
     assert(show[[X] =>> X match { case Int => Int }] ==
-      """[X >: scala.Nothing <: scala.Any] => X match  {
+      """[X >: scala.Nothing <: scala.Any] =>> X match  {
         |  case scala.Int => scala.Int
         |}""".stripMargin)
     assert(showStructure[[X] =>> X match { case Int => Int }] == """TypeLambda(List(X), List(TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Nothing"), TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Any"))), MatchType(TypeRef(ThisType(TypeRef(NoPrefix(), "scala")), "Any"), ParamRef(binder, 0), List(MatchCase(TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int"), TypeRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "Int")))))""")

--- a/tests/run-staging/i5965.check
+++ b/tests/run-staging/i5965.check
@@ -11,7 +11,7 @@ List(1, 2, 3)
 }
 Some(4)
 {
-  val y: [V >: scala.Nothing <: scala.Any] => scala.collection.immutable.Map[scala.Int, V][scala.Int] = scala.Predef.Map.apply[scala.Int, scala.Int](scala.Predef.ArrowAssoc[scala.Int](4).->[scala.Int](1))
+  val y: [V >: scala.Nothing <: scala.Any] =>> scala.collection.immutable.Map[scala.Int, V][scala.Int] = scala.Predef.Map.apply[scala.Int, scala.Int](scala.Predef.ArrowAssoc[scala.Int](4).->[scala.Int](1))
 
   (y: scala.collection.immutable.Map[scala.Int, scala.Int])
 }


### PR DESCRIPTION
Fixes reflect `SuperType.supertpe` to return `supertpe` instead of `thistpe`.

Fixes the printer for supertypes. Maybe this could be improved as it currently ignores the `supertpe` field when printing. But it's aligned with [PlainPrinter](https://github.com/lampepfl/dotty/blob/3.3.0-RC3/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala#L358).

Fixes the printer to print type lambdas as `=>>` instead of `=>`.

Fixes printing private and protected modifiers (before, `private` was only printed when scoped to an enclosing type definition).