### PR TITLE
Fix race condition in new LazyVals

### DIFF
--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -45,6 +45,7 @@ object LazyVals {
 
   /* ------------- Start of public API ------------- */
 
+  // This trait extends Serializable to fix #16806 that caused a race condition
   sealed trait LazyValControlState extends Serializable
 
   /**

--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -45,7 +45,7 @@ object LazyVals {
 
   /* ------------- Start of public API ------------- */
 
-  sealed trait LazyValControlState
+  sealed trait LazyValControlState extends Serializable
 
   /**
    * Used to indicate the state of a lazy val that is being

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -26,6 +26,11 @@ object MiMaFilters {
     ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.into"),
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$into$"),
     // end of New experimental features in 3.3.X
+
+    // Added java.io.Serializable as LazyValControlState supertype
+    ProblemFilters.exclude[MissingTypesProblem]("scala.runtime.LazyVals$LazyValControlState"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.runtime.LazyVals$Waiting"),
+
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyBuffer.reset"),

--- a/tests/run/i16806.check
+++ b/tests/run/i16806.check
@@ -1,0 +1,2 @@
+Success
+Success

--- a/tests/run/i16806.scala
+++ b/tests/run/i16806.scala
@@ -1,0 +1,42 @@
+import java.util.concurrent.Semaphore
+import scala.runtime.LazyVals.Evaluating
+
+object Repro {
+
+  case object DFBit
+  final class DFError extends Exception("")
+  final class DFType[+T](val value: T | DFError) extends AnyVal
+
+  def asIR(dfType: DFType[DFBit.type]): DFBit.type = dfType.value match
+  case dfTypeIR: DFBit.type => dfTypeIR
+  case err: DFError         => throw new DFError
+
+  object Holder {
+    val s = new Semaphore(1, false)
+    final lazy val Bit = {
+      s.release()
+      new DFType[DFBit.type](DFBit)
+    }
+  }
+
+  @main
+  def Test =
+    val a = new Thread() {
+      override def run(): Unit =
+        Holder.s.acquire()
+        val x = Holder.Bit.value
+        assert(!x.isInstanceOf[Evaluating.type])
+        println("Success")
+    }
+    val b = new Thread() {
+      override def run(): Unit =
+        Holder.s.acquire()
+        val x = Holder.Bit.value
+        assert(!x.isInstanceOf[Evaluating.type])
+        println("Success")
+    }
+    a.start()
+    b.start()
+    a.join(300)
+    b.join(300)
+}

--- a/tests/run/i16806.scala
+++ b/tests/run/i16806.scala
@@ -1,5 +1,4 @@
 import java.util.concurrent.Semaphore
-import scala.runtime.LazyVals.Evaluating
 
 object Repro {
 
@@ -25,14 +24,14 @@ object Repro {
       override def run(): Unit =
         Holder.s.acquire()
         val x = Holder.Bit.value
-        assert(!x.isInstanceOf[Evaluating.type])
+        assert(x.isInstanceOf[DFBit.type])
         println("Success")
     }
     val b = new Thread() {
       override def run(): Unit =
         Holder.s.acquire()
         val x = Holder.Bit.value
-        assert(!x.isInstanceOf[Evaluating.type])
+        assert(x.isInstanceOf[DFBit.type])
         println("Success")
     }
     a.start()

--- a/tests/run/i16806.scala
+++ b/tests/run/i16806.scala
@@ -1,3 +1,4 @@
+//scalajs: --skip
 import java.util.concurrent.Semaphore
 
 object Repro {


### PR DESCRIPTION
Resolve #16806 

In the repro, `Evaluating` was generated as a subtype of `Serializable`, and the type of lazy value was erased to `Serializable` - these together broke the optimized condition checking if the value is initialized. For lazy val of type `A` we were checking if `LazyValControlState <: A`, and if that was not the case, we assumed it would be safe to just generate the condition `_value.isInstanceOf[A]`. If that condition was true in runtime, we assumed that the value was already calculated and returned it. If it was `Evaluating` and `A =:= Serializable`, then we assumed so falsely. The easiest fix is to just make the `LazyValControlState <: Serializable`, I will check if it doesn't affect performance. 