### PR TITLE
Fix failing neg/i16820 test on JDK < 15

### DIFF
--- a/tests/neg/i16820.check
+++ b/tests/neg/i16820.check
@@ -8,15 +8,11 @@
   |           method g in object Test must be called with () argument
   |
   | longer explanation available when compiling with `-explain`
--- Error: tests/neg/i16820.scala:8:14 ----------------------------------------------------------------------------------
-8 |  val x3 = "".formatted // error
-  |           ^^^^^^^^^^^^
-  |           missing arguments for method formatted in class String
--- Error: tests/neg/i16820.scala:9:40 ----------------------------------------------------------------------------------
-9 |  val x4 = java.nio.file.Paths.get(".").toRealPath // error
+-- Error: tests/neg/i16820.scala:7:40 ----------------------------------------------------------------------------------
+7 |  val x3 = java.nio.file.Paths.get(".").toRealPath // error
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |           missing arguments for method toRealPath in trait Path
--- Error: tests/neg/i16820.scala:13:14 ---------------------------------------------------------------------------------
-13 |def test = Foo(3)  // error
+-- Error: tests/neg/i16820.scala:11:14 ---------------------------------------------------------------------------------
+11 |def test = Foo(3)  // error
    |           ^^^^^^
    |           missing arguments for method apply in object Foo

--- a/tests/neg/i16820.scala
+++ b/tests/neg/i16820.scala
@@ -4,9 +4,7 @@ object Test:
 
   val x1 = f  // error
   val x2 = g  // error
-
-  val x3 = "".formatted // error
-  val x4 = java.nio.file.Paths.get(".").toRealPath // error
+  val x3 = java.nio.file.Paths.get(".").toRealPath // error
 
 // #14567
 case class Foo(x: Int)(xs: String*)


### PR DESCRIPTION
Fixes #16969 

`String.formatted` is a method added in JDK 15. In Scala, we also define the extension methods with the same name. Because of that the code in the snippet failed in unexpected manner.