### PR TITLE
Fix caching issue caused by incorrect isProvisional check

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -118,10 +118,9 @@ object Types {
         if t.mightBeProvisional then
           t.mightBeProvisional = t match
             case t: TypeRef =>
-              !t.currentSymbol.isStatic && {
+              t.currentSymbol.isProvisional || !t.currentSymbol.isStatic && {
                 (t: Type).mightBeProvisional = false // break cycles
-                t.symbol.isProvisional
-                || test(t.prefix, theAcc)
+                test(t.prefix, theAcc)
                 || t.denot.infoOrCompleter.match
                     case info: LazyType => true
                     case info: AliasingBounds => test(info.alias, theAcc)

--- a/tests/pos/i16950.scala
+++ b/tests/pos/i16950.scala
@@ -1,0 +1,11 @@
+object Foo:
+  def bar(x : Bar.YOf[Any]): Unit = ???
+
+trait K:
+  type CType <: Bar.YOf[Any]
+  def foo : K =
+    val x : CType = ???
+    x // was: error: Found: CType, Expected: K
+
+object Bar:
+  type YOf[T] = K { type M }


### PR DESCRIPTION
A static TypeRef can still be provisional if it's currently being completed (see the logic in `Namer#TypeDefCompleter#typeSig`).

Fixes #16950.