### PR TITLE
add regression test for pattern match on path-dependent type

### DIFF
--- a/tests/pos/t16827.scala
+++ b/tests/pos/t16827.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror
+
+trait Outer[F[_]]:
+  sealed trait Inner
+  trait Inner1 extends Inner
+  def foo(rv: Either[Inner, Int]) =
+    rv match
+      case Right(_) =>
+      case Left(_) =>


### PR DESCRIPTION
this was fixed recently (by @dwijnand in #16827), but the test case is simpler than the one in the PR and the problem manifested differently (as a reachability warning, whereas the original bug report was about very long compilation time)

minimized from user code on the Typelevel Discord

thanks @BalmungSan for the minimization help
