### PR TITLE
Fix: tap target of the menu in Mobile version

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/layout/header.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/header.css
@@ -89,6 +89,7 @@
   #mobile-menu-toggle {
     margin-left: calc(3 * var(--base-spacing));
     display: block;
+    padding: 16px;
   }
 
   .header-container-right .text-button {

--- a/scaladoc/resources/dotty_res/styles/theme/layout/mobileMenu.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/mobileMenu.css
@@ -154,6 +154,8 @@
 
 #mobile-menu-close {
   margin-left: auto;
+  width: 48px;
+  height: 48px;
 }
 
 #mobile-menu-close:disabled {


### PR DESCRIPTION
In this PR, I increase the size of the target taps of the opening and closing menu buttons in the mobile version.

- Open button
Before: 
<img width="88" alt="Screenshot 2023-02-27 at 15 35 37" src="https://user-images.githubusercontent.com/44496264/221592366-93d93b49-0bd4-4b51-aa8e-a33c8043a461.png">
After: 
<img width="148" alt="Screenshot 2023-02-27 at 15 30 21" src="https://user-images.githubusercontent.com/44496264/221592418-b32502ee-24b9-4725-84e4-0c57fef08541.png">

- Close button
Before:
<img width="158" alt="Screenshot 2023-02-27 at 15 36 06" src="https://user-images.githubusercontent.com/44496264/221592542-28b2c8fa-ad83-49eb-ac15-f3e908a14fff.png">
After:
<img width="141" alt="Screenshot 2023-02-27 at 15 31 03" src="https://user-images.githubusercontent.com/44496264/221592574-9db1143e-ff9a-4813-a18c-c899634cda6b.png">

Closes #16834