### PR TITLE
Fix: padding top in mobile version

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/layout/content.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/content.css
@@ -91,6 +91,7 @@
 @media (max-width: 768px) {
 
   #content {
+    padding-top: calc(5 * var(--base-spacing));
     padding-bottom: calc(6 * var(--base-spacing));
   }
 

--- a/scaladoc/resources/dotty_res/styles/theme/layout/content.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/content.css
@@ -91,7 +91,7 @@
 @media (max-width: 768px) {
 
   #content {
-    padding-top: calc(5 * var(--base-spacing));
+    padding-top: calc(10 * var(--base-spacing));
     padding-bottom: calc(6 * var(--base-spacing));
   }
 


### PR DESCRIPTION
In this PR, I reduce the size of the padding top in the mobile version
Before:
<img width="378" alt="Screenshot 2023-02-27 at 15 47 05" src="https://user-images.githubusercontent.com/44496264/221817542-41634639-269b-4fd2-a9f9-f04dcb7c3421.png">


After:
<img width="378" alt="Screenshot 2023-02-27 at 15 47 49" src="https://user-images.githubusercontent.com/44496264/221595384-0a8a7c3e-6f21-42bc-8506-96cffbe4aad6.png">

Closes #16833