### PR TITLE
scaladoc should pick up warning flags

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -49,7 +49,7 @@ object ScalaSettings:
     else defaultWidth
   }
 
-trait AllScalaSettings extends CommonScalaSettings, PluginSettings, VerboseSettings, WarningSettings, XSettings, YSettings:
+trait AllScalaSettings extends CommonScalaSettings, PluginSettings, VerboseSettings, XSettings, YSettings:
   self: SettingGroup =>
 
   /* Path related settings */
@@ -87,7 +87,7 @@ trait AllScalaSettings extends CommonScalaSettings, PluginSettings, VerboseSetti
 end AllScalaSettings
 
 /** Settings shared by compiler and scaladoc */
-trait CommonScalaSettings:
+trait CommonScalaSettings extends WarningSettings:
   self: SettingGroup =>
 
   /* Path related settings */


### PR DESCRIPTION
Is there a reason why the warning flags do not get used for Scaladoc?

```sbt
scalaVersion := "3.3.0-RC3"
Compile / scalacOptions := Seq("-Werror", "-Wconf:any:error")
```

```
> Compile / doc
...
[info] Skipping unused scalacOptions: -Werror, -Wconf
...
```

In Scala 2.13 these flags do get used when compiling scaladoc (At least `-Werror` does)

If you don't want to support all of the warning flags for scaladoc, would it be at least possible to support at least `-Werror`/`-Xfatal-warnings`? That would be easy too by just moving the `val XfatalWarnings...` from line 161 from the `WarningTrait` into the `CommonScalaSettings` trait.

This PR is somehow similar #13233 / #13061