### PR TITLE
Fix: Correct the nightly version cut off in scaladoc

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/layout/header.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/header.css
@@ -72,7 +72,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  width: calc(9 * var(--base-spacing));
+  width: auto;
 }
 
 .single {
@@ -102,6 +102,10 @@
 
   #search-toggle {
     display: none;
+  }
+
+  .projectVersion{
+    width: calc(9 * var(--base-spacing));
   }
 }
 

--- a/scaladoc/resources/dotty_res/styles/theme/layout/header.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/header.css
@@ -105,7 +105,7 @@
   }
 
   .projectVersion{
-    width: calc(9 * var(--base-spacing));
+    max-width: calc(12 * var(--base-spacing));
   }
 }
 


### PR DESCRIPTION
In this commit I corrected the cut off of the nightly version by changing : 
- The width in auto for desktop version
- The max-width in `calc(12 * var(--base-spacing));` for better responsiveness 

Desktop
Before:
<img width="994" alt="Screenshot 2023-03-01 at 11 04 44" src="https://user-images.githubusercontent.com/44496264/222109159-79249ec2-359c-4782-9dcc-88c75ca10454.png">

After:
<img width="1001" alt="Screenshot 2023-03-01 at 11 04 27" src="https://user-images.githubusercontent.com/44496264/222109141-630a85ef-d2c2-4312-b143-d54f97c2506e.png">

Mobile
Before:
<img width="409" alt="Screenshot 2023-03-01 at 11 13 07" src="https://user-images.githubusercontent.com/44496264/222109747-253c685e-44ea-4e5d-8330-f2576c729895.png">

After:
<img width="409" alt="Screenshot 2023-03-01 at 11 07 12" src="https://user-images.githubusercontent.com/44496264/222108968-ae3cc503-cca2-4a65-a76d-9d7e1006e131.png">

Fixes: #16588