### PR TITLE
Generate kind-correct wildcards when selecting from a wildcard

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -20,6 +20,7 @@ i13871.scala
 i15181.scala
 i15922.scala
 t5031_2.scala
+i16997.scala
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/tests/pos/i16997.min.scala
+++ b/tests/pos/i16997.min.scala
@@ -1,0 +1,12 @@
+class Fn:
+  class R[Y]
+
+case class Foo[F[_]](nest: Foo[F]):
+  case class Bar[G[_], R[_]](value: Foo[G])
+
+  def bar[G[_]](using fn: Fn): Bar[G, fn.R] = ???
+
+  def part[G[_]](using fn: Fn): Bar[G, fn.R] =
+    (bar[G], ()) match
+      case (Bar(value), ()) =>
+        Bar(Foo(value))

--- a/tests/pos/i16997.scala
+++ b/tests/pos/i16997.scala
@@ -1,0 +1,63 @@
+class Funs {
+  sealed trait ->[A, B]
+}
+
+/**
+ * Binary tree with leafs holding values of types `F[X]`, `F[Y]`, ...
+ * The complete structure of the tree is expressed by the type `A`, using the tags for branches and leafs.
+ *
+ * @tparam <*> tag for branches
+ * @tparam T tag for leafs.
+ * @tparam F value type of leafs. Each leaf holds a value of type `F[T]`, for some type `T`.
+ * @tparam A captures the complete structure of the tree
+ */
+enum Tree[<*>[_, _], T[_], F[_], A] {
+  case Branch[<*>[_, _], T[_], F[_], A, B](
+    l: Tree[<*>, T, F, A],
+    r: Tree[<*>, T, F, B],
+  ) extends Tree[<*>, T, F, A <*> B]
+
+  case Leaf[<*>[_, _], T[_], F[_], A](
+    value: F[A],
+  ) extends Tree[<*>, T, F, T[A]]
+
+  def <*>[B](that: Tree[<*>, T, F, B]): Tree[<*>, T, F, A <*> B] =
+    Branch(this, that)
+
+  def partition[G[_], H[_]](
+    f: [x] => F[x] => Either[G[x], H[x]],
+  )(using
+    funs: Funs,
+  ): Partitioned[G, H, funs.->] =
+    this match {
+      case Leaf(a) =>
+        f(a) match
+          case Left(a)  => Partitioned.Left(Leaf(a))
+          case Right(a) => Partitioned.Right(Leaf(a))
+      case Branch(l, r) =>
+        import Partitioned.{Both, Left, Right}
+        import l.Partitioned.{Both => LBoth, Left => LLeft, Right => LRight}
+        import r.Partitioned.{Both => RBoth, Left => RLeft, Right => RRight}
+
+        (l.partition(f), r.partition(f)) match
+          case (LLeft(lg),     RLeft(rg))     => Left(lg <*> rg)
+          case (LLeft(lg),     RRight(rh))    => Both(lg, rh)
+          case (LLeft(lg),     RBoth(rg, rh)) => Both(lg <*> rg, rh)
+          case (LRight(lh),    RLeft(rg))     => Both(rg, lh)
+          case (LRight(lh),    RRight(rh))    => Right(lh <*> rh)
+          case (LRight(lh),    RBoth(rg, rh)) => Both(rg, lh <*> rh)
+          case (LBoth(lg, lh), RLeft(rg))     => Both(lg <*> rg, lh)
+          case (LBoth(lg, lh), RRight(rh))    => Both(lg, lh <*> rh)
+          case (LBoth(lg, lh), RBoth(rg, rh)) => Both(lg <*> rg, lh <*> rh)
+    }
+
+  // note that `->` is never even used, to keep this reproduction case small
+  enum Partitioned[G[_], H[_], ->[_, _]] {
+    case Left(value: Tree[<*>, T, G, A])
+    case Right(value: Tree[<*>, T, H, A])
+    case Both[G[_], H[_], X, Y, ->[_, _]](
+      l: Tree[<*>, T, G, X],
+      r: Tree[<*>, T, H, Y],
+    ) extends Partitioned[G, H, ->]
+  }
+}


### PR DESCRIPTION
Previously, derivedSelect would incorrectly approximate `fn.R` by `? >: Nothing <: Any` in `i16997.min.scala`, which subsequently lead to a kind-incorrect type application `Any[Y]` that broke type inference. #16999 proposed to fix this by changing type inference, but it seems like we don't need to do that if we make sure our wildcards are always kind-correct.

Note that the wildcard logic in lookupRefined could be removed: it seems like it was supposed to be used by `reduceProjection` according to its documentation, but the constructor of `NamedType` disallows wildcards as prefixes so it didn't actually do anything there.

Co-Authored-By: Dale Wijnand <dale.wijnand@gmail.com>