### PR TITLE
Avoid creation of `@SplicedType` quote local refrences

### DIFF
--- a/tests/pos-macros/i17026.scala
+++ b/tests/pos-macros/i17026.scala
@@ -1,0 +1,3 @@
+import scala.quoted.*
+def macroImpl(using Quotes) =
+  '{ def weird[A: Type](using Quotes) = Type.of[A] }

--- a/tests/pos-macros/i17026b.scala
+++ b/tests/pos-macros/i17026b.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+def macroImpl(using Quotes) =
+  '{
+    def weird[A: ToExpr: Type](a: A)(using quotes: Quotes) =
+      '{ Some(${ Expr(a) }) }
+  }


### PR DESCRIPTION
The type declarations annotated with `@SplicedType` are only meant for types that come from outside the quote. If the reference to the `Type[T]` is to a definition within the quote (i.e. its level is grater than 0) we can use it directly. The `@SplicedType` for that type will be generated in a future compilation phase when the `Type[T]` definition reaches level 0.

Fixes #17026