### PR TITLE
Scaladoc: Fix expand icon not changing on anchor link

### DIFF
--- a/scaladoc/resources/dotty_res/scripts/ux.js
+++ b/scaladoc/resources/dotty_res/scripts/ux.js
@@ -309,6 +309,10 @@ document
       var selected = document.getElementById(location.hash.substring(1));
       if (selected) {
         selected.classList.toggle("expand");
+        selected.classList.toggle("expanded");
+        const btn = selected.querySelector(".icon-button");
+        btn.classList.toggle("expand");
+        btn.classList.toggle("expanded");
       }
     }
   }


### PR DESCRIPTION
i.e. this:
![Peek 2023-03-06 16-56](https://user-images.githubusercontent.com/39772805/223163382-e2bd9b6c-68de-49ba-8bb7-d14507a0a454.gif)
