### PR TITLE
Add optimization to reduce extra iterations of the safe init checker.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Cache.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Cache.scala
@@ -75,6 +75,8 @@ class Cache[Config, Res]:
    */
   protected var changed: Boolean = false
 
+  protected var cacheUsed: Boolean = false
+
   /** Used to avoid allocation, its state does not matter */
   protected given MutableTreeWrapper = new MutableTreeWrapper
 
@@ -99,7 +101,9 @@ class Cache[Config, Res]:
    */
   def cachedEval(config: Config, expr: Tree, cacheResult: Boolean, default: Res)(eval: Tree => Res): Res =
     this.get(config, expr) match
-    case Some(value) => value
+    case Some(value) =>
+      cacheUsed = true
+      value
     case None =>
       val assumeValue: Res =
         this.last.get(config, expr) match
@@ -124,6 +128,8 @@ class Cache[Config, Res]:
 
   def hasChanged = changed
 
+  def isUsed = cacheUsed
+
   /** Prepare cache for the next iteration
    *
    *  1. Reset changed flag.
@@ -132,6 +138,7 @@ class Cache[Config, Res]:
    */
   def prepareForNextIteration()(using Context) =
     this.changed = false
+    this.cacheUsed = false
     this.last = this.current
     this.current = Map.empty
 end Cache

--- a/compiler/src/dotty/tools/dotc/transform/init/Cache.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Cache.scala
@@ -85,7 +85,9 @@ class Cache[Config, Res]:
   protected given MutableTreeWrapper = new MutableTreeWrapper
 
   def get(config: Config, expr: Tree): Option[Res] =
-    current.get(config, expr)
+    val res = current.get(config, expr)
+    cacheUsed = cacheUsed || res.nonEmpty
+    res
 
   /** Evaluate an expression with cache
    *
@@ -105,9 +107,7 @@ class Cache[Config, Res]:
    */
   def cachedEval(config: Config, expr: Tree, cacheResult: Boolean, default: Res)(eval: Tree => Res): Res =
     this.get(config, expr) match
-    case Some(value) =>
-      cacheUsed = true
-      value
+    case Some(value) => value
     case None =>
       val assumeValue: Res =
         this.last.get(config, expr) match

--- a/compiler/src/dotty/tools/dotc/transform/init/Cache.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Cache.scala
@@ -75,6 +75,10 @@ class Cache[Config, Res]:
    */
   protected var changed: Boolean = false
 
+  /** Whether any value in the cache was accessed after being added.
+  *   If no cached values are used after they are added for the first time
+  *   then another iteration of analysis is not needed.
+  */
   protected var cacheUsed: Boolean = false
 
   /** Used to avoid allocation, its state does not matter */

--- a/compiler/src/dotty/tools/dotc/transform/init/Cache.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Cache.scala
@@ -75,10 +75,10 @@ class Cache[Config, Res]:
    */
   protected var changed: Boolean = false
 
-  /** Whether any value in the cache was accessed after being added.
-  *   If no cached values are used after they are added for the first time
-  *   then another iteration of analysis is not needed.
-  */
+  /** Whether any value in the output cache (this.current) was accessed
+   *  after being added. If no cached values are used after they are added
+   *  for the first time then another iteration of analysis is not needed.
+   */
   protected var cacheUsed: Boolean = false
 
   /** Used to avoid allocation, its state does not matter */

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -1101,15 +1101,12 @@ object Semantic:
    *
    *  The class to be checked must be an instantiable concrete class.
    */
-  private def checkClass(classSym: ClassSymbol)(using Cache.Data, Context): Int =
+  private def checkClass(classSym: ClassSymbol)(using Cache.Data, Context): Unit =
     val thisRef = ThisRef(classSym)
     val tpl = classSym.defTree.asInstanceOf[TypeDef].rhs.asInstanceOf[Template]
 
-    var accum = 0
-
     @tailrec
     def iterate(): Unit = {
-      accum += 1
       given Promoted = Promoted.empty(classSym)
       given Trace = Trace.empty.add(classSym.defTree)
       given reporter: Reporter.BufferedReporter = new Reporter.BufferedReporter
@@ -1132,19 +1129,15 @@ object Semantic:
     }
 
     iterate()
-
-    accum - 1
   end checkClass
 
   /**
    * Check the specified concrete classes
    */
   def checkClasses(classes: List[ClassSymbol])(using Context): Unit =
-    var total = 0
     given Cache.Data()
     for classSym <- classes if isConcreteClass(classSym) do
       total += checkClass(classSym)
-    System.err.nn.println(total)
 
 // ----- Semantic definition --------------------------------
   type ArgInfo = TraceValue[Value]

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -1137,7 +1137,7 @@ object Semantic:
   def checkClasses(classes: List[ClassSymbol])(using Context): Unit =
     given Cache.Data()
     for classSym <- classes if isConcreteClass(classSym) do
-      total += checkClass(classSym)
+      checkClass(classSym)
 
 // ----- Semantic definition --------------------------------
   type ArgInfo = TraceValue[Value]


### PR DESCRIPTION
If the cache is never accessed on a certain iteration of safe initializing checking for a class, then another iteration is not needed. Implementing this optimization and compiling Dotty, we observe the following improvements:
From 4158 total iterations to 4004.
From 460 extra iterations to 306.

Running the initialization tests in `tests/init` we have the following improvements:
From 790 total iterations to 708.
From 139 extra iterations to 57.