### PR TITLE
Properly encode splice hole using PolyFunction

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -48,7 +48,7 @@ class ExpandSAMs extends MiniPhase:
       tpt.tpe match {
         case NoType =>
           tree // it's a plain function
-        case tpe if defn.isContextFunctionType(tpe) =>
+        case tpe if defn.isFunctionOrPolyType(tpe) =>
           tree
         case tpe @ SAMType(_) if tpe.isRef(defn.PartialFunctionClass) =>
           val tpe1 = checkRefinements(tpe, fn)

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -331,16 +331,15 @@ object PickleQuotes {
                     args(1).select(nme.apply).appliedTo(Literal(Constant(i))).asInstance(argType)
                   }
                   val Block(List(ddef: DefDef), _) = splice: @unchecked
-
-                  val typeArgs = ddef.symbol.info match
-                    case pt: PolyType => pt.paramInfos
-                    case _ => Nil
-
-                  val sel1 = splice.changeOwner(ddef.symbol.owner, ctx.owner).select(nme.apply)
-                  val appTpe = if typeParamCount == 0 then sel1 else sel1.appliedToTypes(List.fill(typeParamCount)(defn.AnyType))
-                  val app1 = appTpe.appliedToArgs(spliceArgs)
-                  val sel2 = app1.select(nme.apply)
-                  sel2.appliedTo(args(2).asInstance(quotesType))
+                  val quotes = args(2).asInstance(quotesType)
+                  val dummyTargs = List.fill(typeParamCount)(defn.AnyType)
+                  // Generate: <splice>.apply[<dummyTargs>*](<spliceArgs>*).apply(<quotes>)
+                  splice.changeOwner(ddef.symbol.owner, ctx.owner)
+                    .select(nme.apply)
+                    .appliedToTypes(dummyTargs)
+                    .appliedToArgs(spliceArgs)
+                    .select(nme.apply)
+                    .appliedTo(quotes)
                 }
                 CaseDef(Literal(Constant(idx)), EmptyTree, rhs)
               }

--- a/compiler/src/dotty/tools/dotc/transform/Splicing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicing.scala
@@ -39,7 +39,7 @@ object Splicing:
  *
  *  After this phase we have the invariant where all splices have the following shape
  *  ```
- *  {{{ <holeIdx> | <holeType> | <captures>* | (<capturedTerms>*) => <spliceContent> }}}
+ *  {{{ <holeIdx> | <holeType> | <captures>* | [<capturedTypes>*] => (<capturedTerms>*) => <spliceContent> }}}
  *  ```
  *  where `<spliceContent>` does not contain any free references to quoted definitions and `<captures>*`
  *  contains the quotes with references to all cross-quote references. There are some special rules
@@ -186,7 +186,7 @@ class Splicing extends MacroTransform:
    *  ```
    *  is transformed into
    * ```scala
-   *  {{{ <holeIdx++> | T2 | x, X | (x$1: Expr[T1], X$1: Type[X]) => (using Quotes) ?=> {... ${x$1} ...  X$1.Underlying ...}  }}}
+   *  {{{ <holeIdx++> | T2 | x, X | [X$2] => (x$1: Expr[T1], X$1: Type[X$2]) => (using Quotes) ?=> {... ${x$1} ...  X$1.Underlying ...}  }}}
    *  ```
    */
   private class SpliceTransformer(spliceOwner: Symbol, isCaptured: Symbol => Boolean) extends Transformer:

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -670,6 +670,9 @@ object TreeChecker {
       else assert(tpt.typeOpt =:= pt)
 
       // Check that the types of the args conform to the types of the contents of the hole
+      val typeArgsTypes = args.collect { case arg if arg.isType =>
+        arg.typeOpt
+      }
       val argQuotedTypes = args.map { arg =>
         if arg.isTerm then
           val tpe = arg.typeOpt.widenTermRefExpr match
@@ -687,7 +690,29 @@ object TreeChecker {
       val contextualResult =
         defn.FunctionOf(List(defn.QuotesClass.typeRef), expectedResultType, isContextual = true)
       val expectedContentType =
-        defn.FunctionOf(argQuotedTypes, contextualResult)
+        if typeArgsTypes.isEmpty then defn.FunctionOf(argQuotedTypes, contextualResult)
+        else RefinedType(defn.PolyFunctionType, nme.apply, PolyType(typeArgsTypes.map(_ => TypeBounds.empty))(pt =>
+          val tpParamMap = new TypeMap {
+            private val mapping = typeArgsTypes.map(_.typeSymbol).zip(pt.paramRefs).toMap
+            def apply(tp: Type): Type = tp match
+              case tp: TypeRef => mapping.getOrElse(tp.typeSymbol, tp)
+              case tp => mapOver(tp)
+          }
+          MethodType(
+            args.zipWithIndex.map { case (arg, idx) =>
+              if arg.isTerm then
+                val tpe = arg.typeOpt.widenTermRefExpr match
+                  case _: MethodicType =>
+                    // Special erasure for captured function references
+                    // See `SpliceTransformer.transformCapturedApplication`
+                    defn.AnyType
+                  case tpe => tpe
+                defn.QuotedExprClass.typeRef.appliedTo(tpParamMap(tpe))
+              else defn.QuotedTypeClass.typeRef.appliedTo(tpParamMap(arg.typeOpt))
+            },
+            tpParamMap(contextualResult))
+          )
+        )
       assert(content.typeOpt =:= expectedContentType, i"unexpected content of hole\nexpected: ${expectedContentType}\nwas: ${content.typeOpt}")
 
       tree1

--- a/tests/pos-macros/captured-type.scala
+++ b/tests/pos-macros/captured-type.scala
@@ -1,0 +1,6 @@
+import scala.quoted.*
+
+object Foo:
+  def baz(using Quotes): Unit = '{
+    def f[T](x: T): T = ${ identity('{ x: T }) }
+  }


### PR DESCRIPTION
#### Background
The splicing phase replaces the spaces with holes that do not refer to any term of the surrounding quote. This is done using a lambda that receives the captured references as `Expr[...]` and splices them where they are used in the splice.

```scala
'{
  val x: Int = ...
  ${ ... '{ ... x ..} ... }: Long
}
```
becomes
```scala
'{
  val x: Int = ...
  {{{ 0 | Long | x | (x2: Expr[Int]) => { ... '{ ... $x2 ..} ... }  }}}
}
```
then the lambda is extracted from the quote in the `pickleQuotes` phase. This can be done safely because there are no more references to any local variables.


#### Limitation
If there is a type defined in the quote, we currently generate the equivalent `Type[..]`. We end up generating something like

```scala
'{
  type T
  ${ ... T ... '{ ... T ..} ... }: Long
}
```
becomes
```scala
'{
  type T
  {{{ 0 | Long | T | (t: Type[T]) => { ... T .. '{ ... t.Underlying..} ... }  }}}
}
```
This takes care correctly of the run-time aspect of the transformation. But when we extract the lambda from the quote we end up with references to `T` that are out of scope. This extrusion happens to work but is not ideal. Erasure removes those types making the tree well formed again.

#### The Solution
Use polymorphic function types to abstract the content of the hole fully.

```diff
'{
  type T
-  {{{ 0 | Long | T |         (t: Type[T])  => { ... T  .. '{ ... t.Underlying..} ... }  }}}
+  {{{ 0 | Long | T | [T2] => (t: Type[T2]) => { ... T2 .. '{ ... t.Underlying..} ... }  }}}
}
```
This PR implements this change.

#### Other

~Based on #17070, #17059, #17054~