### PR TITLE
Fix: Add Doctype to be in standard mode

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -41,13 +41,17 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
       case _ => Nil)
       :+ (Attr("data-pathToRoot") := pathToRoot(page.link.dri))
 
-    html(attrs: _*)(
+    val htmlTag = html(attrs: _*)(
       head((mkHead(page) :+ docHead):_*),
       body(
         if !page.hasFrame then docBody
         else mkFrame(page.link, parents, docBody, toc)
       )
     )
+
+    val doctypeTag = s"<!DOCTYPE html>"
+    val finalTag = raw(doctypeTag + htmlTag.toString)
+    finalTag
 
   override def render(): Unit =
     val renderedResources = renderResources()


### PR DESCRIPTION
In this PR, I added the `<!DOCTYPE html>` in the HtmlRenderer file. 
I combined in the def page content the tag html with all the content of the page (head, body,...) and the Doctype.

## Result :
<img width="400" alt="Screenshot 2023-03-13 at 16 03 43" src="https://user-images.githubusercontent.com/44496264/224742326-280b1f86-e578-4f25-8d13-9ca39f6c0aec.png">

(On chrome)
<img width="400" alt="Screenshot 2023-03-13 at 16 04 36" src="https://user-images.githubusercontent.com/44496264/224742405-c5dbc809-c085-4cde-aa4d-4faffc088682.png">

Fixes #16803