### PR TITLE
Include `P` in the implicit scope of `P.this.type`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -622,6 +622,8 @@ trait ImplicitRunInfo:
                 traverse(t.prefix)
             case t: ThisType if t.cls.is(Module) && t.cls.isStaticOwner =>
               traverse(t.cls.sourceModule.termRef)
+            case t: ThisType =>
+              traverse(t.tref)
             case t: ConstantType =>
               traverse(t.underlying)
             case t: TypeParamRef =>
@@ -743,6 +745,7 @@ trait ImplicitRunInfo:
    *   - If `T` is a singleton reference, the anchors of its underlying type, plus,
    *     if `T` is of the form `(P#x).type`, the anchors of `P`.
    *   - If `T` is the this-type of a static object, the anchors of a term reference to that object.
+   *   - If `T` is some other this-type `P.this.type`, the anchors of `P`.
    *   - If `T` is some other type, the union of the anchors of each constituent type of `T`.
    *
    *  The _implicit scope_ of a type `tp` is the smallest set S of term references (i.e. TermRefs)

--- a/docs/_docs/reference/changed-features/implicit-resolution.md
+++ b/docs/_docs/reference/changed-features/implicit-resolution.md
@@ -67,7 +67,8 @@ Opaque type aliases count as anchors only outside the scope where their alias is
   1. If _T_ is a reference to a type parameter, the union of the anchors of both of its bounds.
   1. If _T_ is a singleton reference, the anchors of its underlying type, plus,
     if _T_ is of the form _(P#x).type_, the anchors of _P_.
-  1. If _T_ is the this-type _o.this_ of a static object _o_, the anchors of a term reference _o.type_ to that object.
+  1. If _T_ is the this-type _o.this_ of a static object _o_, the anchors of a term reference _o.type_ to that object,
+  1. If _T_ is some other this-type _P.this.type_, the anchors of _P_.
   1. If _T_ is some other type, the union of the anchors of each constituent type of _T_.
 
  **Definition:** The _implicit scope_ of a type _T_ is the smallest set _S_ of term references such that

--- a/tests/pos/this-implicit-scope.scala
+++ b/tests/pos/this-implicit-scope.scala
@@ -1,0 +1,6 @@
+class Foo[+T]
+class Elem:
+  def one(a: Elem, x: Foo[a.type]): Int = x.ext
+  def two(x: Foo[Elem.this.type]): Int  = x.ext
+object Elem:
+  extension (x: Foo[Elem]) def ext: Int = 1


### PR DESCRIPTION
Before this commit, `one` compiled but `two` didn't in:
```scala
class Foo[+T]
class Elem:
  def one(a: Elem, x: Foo[a.type]): Int = x.ext
  def two(x: Foo[Elem.this.type]): Int  = x.ext
object Elem:
  extension (x: Foo[Elem]) def ext: Int = 1
```

This happened because the anchors of the singleton reference `a.type` includes its underlying type `Elem`, but `Elem.this.type` has no anchors at all. This commit changes the definition of anchors to rectify this, which also brings us closer to how Scala 2 behaves.