### PR TITLE
optimization: avoid NotGiven allocations

### DIFF
--- a/library/src/scala/util/NotGiven.scala
+++ b/library/src/scala/util/NotGiven.scala
@@ -31,11 +31,13 @@ trait LowPriorityNotGiven {
 }
 object NotGiven extends LowPriorityNotGiven {
 
+  private val cachedValue = new NotGiven[Nothing]()
+
   /** A value of type `NotGiven` to signal a successful search for `NotGiven[C]` (i.e. a failing
    *  search for `C`). A reference to this value will be explicitly constructed by Dotty's
    *  implicit search algorithm
    */
-  def value: NotGiven[Nothing] = new NotGiven[Nothing]()
+  def value: NotGiven[Nothing] = cachedValue
 
   /** One of two ambiguous methods used to emulate negation in Scala 2 */
   given amb1[T](using ev: T): NotGiven[T] = ???


### PR DESCRIPTION
## Problem

I've been working on a library that uses `NotGiven` in the hot path, which ends up producing an extra allocation on every use. I thought JIT compilation would be able to optimize it away but that isn't the case in some benchmarks. For example:

Benchmark: https://github.com/fwbrasil/kyo/blob/main/kyo-bench/src/main/scala/kyo/bench/NarrowBindMapBench.scala
Flamegraph: https://getkyo.io/dev/profile/4990c20/kyo.bench.NarrowBindMapBench.forkKyo-Throughput/flame-cpu-forward.html

## Solution

Make `NotGiven.value` a `val` instead of `def`.

## Notes

- I'm assuming the identity of a `NotGiven` object isn't relevant.
- Should I use an internal field and keep `NotGiven.value` as `def` to avoid binary compatibility issues?