### PR TITLE
Check trait constructor for accessibility even if not called at Typer

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2512,7 +2512,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             // allow missing type parameters if there are implicit arguments to pass
             // since we can infer type arguments from them
         val constr = psym.primaryConstructor
-        if constr.exists then
+        if psym.is(Trait) && constr.exists && !cls.isRefinementClass then
           ensureAccessible(constr.termRef, superAccess = true, tree.srcPos)
       else
         checkParentCall(result, cls)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2511,6 +2511,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           checkSimpleKinded(parent)
             // allow missing type parameters if there are implicit arguments to pass
             // since we can infer type arguments from them
+        val constr = psym.primaryConstructor
+        if constr.exists then
+          ensureAccessible(constr.termRef, superAccess = true, tree.srcPos)
       else
         checkParentCall(result, cls)
       if cls is Case then

--- a/tests/neg/i17089.scala
+++ b/tests/neg/i17089.scala
@@ -1,0 +1,4 @@
+object o:
+  trait T private[o]()
+
+def test = new o.T { } // error


### PR DESCRIPTION
This allows to restrict inheritance of traits even if the constructor is not called, or not called at Typer.

Fixes #17089