### PR TITLE
Fix: Remove the duplicate parameter when generating the scaladoc.

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
@@ -414,7 +414,7 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
           val argsSig = SignatureBuilder()
             .functionTermParameters(on.argsLists)
             .content
-          val sig = typeSig ++ Signature(Plain(s"(${on.name}: ")) ++ on.signature ++ Signature(Plain(")")) ++ argsSig
+          val sig = typeSig ++ argsSig
           MGroup(span(cls := "groupHeader")(sig.map(renderElement(_))), members.sortBy(_.name).toSeq, on.name) -> on.position
       }.toSeq.sortBy(_._2).map(_._1)
 


### PR DESCRIPTION
When generating Scaladoc, a duplicate of the parameter appears at the beginning of each signature.
The solution here was to remove this line, as the parameter is already present in the argsSig value.

Before :
<img width="300" alt="Screenshot 2023-03-13 at 15 25 43" src="https://user-images.githubusercontent.com/44496264/224735195-8ff3f79a-83d9-4fa0-a5af-99da5aa30b9c.png">

After :
<img width="300" alt="Screenshot 2023-03-13 at 15 24 05" src="https://user-images.githubusercontent.com/44496264/224735171-3eb67419-8b98-499e-a180-58202b54826b.png">

I didn't do a test because I don't think there is one (or I couldn't find it). But if needed, a next PR or a next commit to add them can be done.

Fixes: #16647 
