### PR TITLE
Fix: Validation for API link

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
@@ -30,9 +30,15 @@ trait SiteRenderer(using DocContext) extends Locations:
   def siteContent(pageDri: DRI, content: ResolvedTemplate): PageContent =
     import content.ctx
     def tryAsDri(str: String): Option[String] =
-      val (path, prefix) = str match
+      val newStr =
+        str.dropWhile(c => c == '.' || c == '/').replaceAll("/", ".") match
+          case str if str.endsWith("$.html") => str.stripSuffix("$.html")
+          case str if str.endsWith(".html") => str.stripSuffix(".html")
+          case _ => str
+
+      val (path, prefix) = newStr match
         case HashRegex(path, prefix) => (path, prefix)
-        case _ => (str, "")
+        case _ => (newStr, "")
 
       val res = ctx.driForLink(content.template.file, path).filter(driExists)
       res.headOption.map(pathToPage(pageDri, _) + prefix)
@@ -46,27 +52,16 @@ trait SiteRenderer(using DocContext) extends Locations:
         resolveLink(pageDri, str.stripPrefix("/"))
       )
       def asStaticSite: Option[String] = tryAsDri(str)
-      def asApiLink: Option[String] =
-        val strWithoutHtml = if str.endsWith("$.html") then
-          str.stripSuffix("$.html")
-          else
-            str.stripSuffix(".html")
-        val sourceDir = Paths.get("src", "main", "scala")
-        val scalaPath = sourceDir.resolve(s"$strWithoutHtml.scala")
-        val scalaDirPath = sourceDir.resolve(strWithoutHtml)
-        Option.when(Files.exists(scalaPath)|| Files.exists(scalaDirPath))(resolveLink(pageDri, str))
 
       /* Link resolving checks performs multiple strategies with following priority:
         1. We check if the link is a valid URL e.g. http://dotty.epfl.ch
-        2. We check if the link leads to other static site
+        2. We check if the link leads to other static site or API pages, example: [[exemple.scala.Foo]] || [Foo](../exemple/scala/Foo.html)
         3. We check if the link leads to existing asset e.g. images/logo.svg -> <static-site-root>/_assets/images/logo.svg
-        4. We check if the link leads to existing API page
       */
 
       asValidURL
         .orElse(asStaticSite)
         .orElse(asAsset)
-        .orElse(asApiLink)
         .getOrElse {
           report.warn(s"Unable to resolve link '$str'", content.template.templateFile.file)
           str

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
@@ -47,13 +47,14 @@ trait SiteRenderer(using DocContext) extends Locations:
       )
       def asStaticSite: Option[String] = tryAsDri(str)
       def asApiLink: Option[String] =
-        {
-        val strWithoutHtml = str.stripSuffix(".html").stripPrefix("/")
+        val strWithoutHtml = if str.endsWith("$.html") then
+          str.stripSuffix("$.html")
+          else
+            str.stripSuffix(".html")
         val sourceDir = Paths.get("src", "main", "scala")
         val scalaPath = sourceDir.resolve(s"$strWithoutHtml.scala")
         val scalaDirPath = sourceDir.resolve(strWithoutHtml)
         Option.when(Files.exists(scalaPath)|| Files.exists(scalaDirPath))(resolveLink(pageDri, str))
-      }
 
       /* Link resolving checks performs multiple strategies with following priority:
         1. We check if the link is a valid URL e.g. http://dotty.epfl.ch


### PR DESCRIPTION
In this PR: 
I change the regular path from `../exception/scala/Foo.html` to `exception.scala.Foo` to use the DRI resolver function.

## Context:

I have a Hello World project with a `Foo` class and a `Foo2` object within a package `exception.scala`
<img width="225" alt="Screenshot 2023-06-07 at 12 45 47" src="https://github.com/lampepfl/dotty/assets/44496264/1d155f81-5910-44b4-be0c-b495cd75e597">


### Example 1 (No warning):

<img width="500" alt="Screenshot 2023-06-07 at 15 38 07" src="https://github.com/lampepfl/dotty/assets/44496264/cf341967-8743-480a-9f35-7c27ed78a691">

### Result:

<img width="800" alt="Screenshot 2023-06-07 at 12 50 13" src="https://github.com/lampepfl/dotty/assets/44496264/ccea1646-3501-4ad2-b9d0-ee5d8bbac969">
As you can see, as expected there is no warning for these links.

### Example 2 (Warnings):

<img width="500" alt="Screenshot 2023-06-07 at 15 41 00" src="https://github.com/lampepfl/dotty/assets/44496264/9309a851-24d6-472e-839e-444c0dc58bb6">

### Result:

<img width="800" alt="Screenshot 2023-06-07 at 15 41 13" src="https://github.com/lampepfl/dotty/assets/44496264/1b8986f9-d06c-4eda-9599-e4f2cc0343f7">

Fixes: #16695