### PR TITLE
Strip `index.html` from external API url

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/ExternalDocLink.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ExternalDocLink.scala
@@ -25,10 +25,12 @@ object ExternalDocLink:
     case Failure(e) => fail(mapping, s"Unable to parse $descr. Exception $e occured")
   }
 
+  private def stripIndex(url: String): String = url.stripSuffix("index.html").stripSuffix("/") + "/"
+
   def parseLegacy(mapping: String): Either[String, ExternalDocLink] =
     mapping.split("#").toList match
       case path :: apiUrl :: Nil => for {
-        url <- tryParse(mapping, "url")(URL(apiUrl))
+        url <- tryParse(mapping, "url")(URL(stripIndex(apiUrl)))
       } yield ExternalDocLink(
         List(s"${Regex.quote(path)}.*".r),
         url,
@@ -55,7 +57,7 @@ object ExternalDocLink:
       case regexStr :: docToolStr :: urlStr :: rest =>
         for {
           regex <- tryParse(mapping, "regex")(regexStr.r)
-          url <- tryParse(mapping, "url")(URL(urlStr))
+          url <- tryParse(mapping, "url")(URL(stripIndex(urlStr)))
           doctool <- doctoolByName(docToolStr)
           packageList <- parsePackageList(rest)
         } yield ExternalDocLink(


### PR DESCRIPTION
Ports this fix from Scaladoc 2.

https://github.com/scala/scala/blob/15538c7365bbb03f37d06b59f050241683972c71/src/scaladoc/scala/tools/nsc/doc/Settings.scala#L281-L287

Without it, links to external docs are broken for several libraries.