### PR TITLE
Fix captured references to singleton types

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -162,6 +162,10 @@ class PickleQuotes extends MacroTransform {
               case info: ClassInfo => info.parents.reduce(_ & _)
               case info => info.hiBound
             apply(hiBound)
+          case tp @ TermRef(pre, _) if isLocalPath(pre) =>
+            apply(tp.widenTermRefExpr)
+          case ThisType(ref @ TypeRef(pre, _)) if isLocalPath(pre) =>
+            apply(ref)
           case tp =>
             mapOver(tp)
 

--- a/compiler/src/dotty/tools/dotc/transform/Splicing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicing.scala
@@ -231,7 +231,7 @@ class Splicing extends MacroTransform:
                 // Dealias references to captured types
                 TypeTree(tree.tpe.dealias)
             else super.transform(tree)
-        case tree: TypeTree =>
+        case _: TypeTree | _: SingletonTypeTree =>
           if containsCapturedType(tree.tpe) && level >= 1 then getTagRefFor(tree)
           else tree
         case tree @ Assign(lhs: RefTree, rhs) =>
@@ -360,9 +360,8 @@ class Splicing extends MacroTransform:
       )
 
     private def capturedType(tree: Tree)(using Context): Symbol =
-      val tpe = tree.tpe.widenTermRefExpr
       val bindingSym = refBindingMap
-        .getOrElseUpdate(tree.symbol, (TypeTree(tree.tpe), newQuotedTypeClassBinding(tpe)))._2
+        .getOrElseUpdate(tree.symbol, (TypeTree(tree.tpe), newQuotedTypeClassBinding(tree.tpe)))._2
       bindingSym
 
     private def capturedPartTypes(tpt: Tree)(using Context): Tree =

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -663,7 +663,7 @@ object TreeChecker {
       // Check that we only add the captured type `T` instead of a more complex type like `List[T]`.
       // If we have `F[T]` with captured `F` and `T`, we should list `F` and `T` separately in the args.
       for arg <- args do
-        assert(arg.isTerm || arg.tpe.isInstanceOf[TypeRef], "Expected TypeRef in Hole type args but got: " + arg.tpe)
+        assert(arg.isTerm || arg.tpe.isInstanceOf[TypeRef] || arg.tpe.isInstanceOf[TermRef] || arg.tpe.isInstanceOf[ThisType], "Expected TypeRef or TermRef in Hole type args but got: " + arg.tpe)
 
       // Check result type of the hole
       if isTermHole then assert(tpt.typeOpt <:< pt)

--- a/tests/pos-macros/this-type-capture/Macro_1.scala
+++ b/tests/pos-macros/this-type-capture/Macro_1.scala
@@ -1,0 +1,29 @@
+import scala.quoted.*
+
+object Macro:
+  inline def generateCode: Unit = ${ testThisPaths }
+
+  def testThisPaths(using Quotes): Expr[Unit] =
+    '{
+      trait E extends G:
+        type V
+        val f: F
+        ${
+          val expr = '{
+            // val _: Any = this // FIXME: this should work
+            // val _: Any = f // FIXME: this should work
+            val _: this.type = ???
+            val _: V = ???
+            val _: this.V = ???
+            val _: this.f.V = ???
+            val _: this.type = ???
+            val _: this.f.type = ???
+          }
+          expr
+        }
+      trait F:
+        type V
+    }
+
+trait G:
+  val f: Any

--- a/tests/pos-macros/this-type-capture/Test_2.scala
+++ b/tests/pos-macros/this-type-capture/Test_2.scala
@@ -1,0 +1,1 @@
+@main def test = Macro.generateCode


### PR DESCRIPTION
When we had a reference to a `x.type` we mistakenly captured `x` instead of `x.type`. This was caused because `SingletonTypeTree` was not handled in `Splicing`. Fixing this uncovered some inconsistencies with the types in the encoding of the hole captured types and contents. These have been fixed as well.

Needs fix for #17137