### PR TITLE
Add init test for cacheResult flag

### DIFF
--- a/tests/init/pos/recursive.scala
+++ b/tests/init/pos/recursive.scala
@@ -1,0 +1,9 @@
+class A {
+  def p(cb: Int => Int): Int = cb(0)
+
+  val q: List[Int] = {
+    def f(x: Int): Int => Int = y => p(f(y))
+    List(1, 2).map(f(3))
+  }
+  val n: Int = 4
+}


### PR DESCRIPTION
This test checks for the presence of the `cacheResult = true` flag on the call to cachedEval from [Semantic.scala:992](https://github.com/lampepfl/dotty/blob/e3aeed198717e6764f2a27b70a22a03b03a87a0b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala#L992). Without that flag, the compiler crashes on this test with `-Ysafe-init`.