### PR TITLE
Fix needsOuterIfReferenced

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -13,6 +13,7 @@ import core.Decorators._
 import core.StdNames.nme
 import core.Names._
 import core.NameOps._
+import core.NameKinds.SuperArgName
 import SymUtils._
 import dotty.tools.dotc.ast.tpd
 
@@ -197,10 +198,16 @@ object ExplicitOuter {
   private def outerAccName(cls: ClassSymbol)(using Context): TermName =
     nme.OUTER.expandedName(cls)
 
+  private def outerOwner(sym: Symbol)(using Context): Symbol =
+    val owner = sym.effectiveOwner
+    if owner.name.is(SuperArgName) || owner.isLocalDummy
+    then owner.enclosingClass
+    else owner
+
   /** Class needs an outer pointer, provided there is a reference to an outer this in it. */
   def needsOuterIfReferenced(cls: ClassSymbol)(using Context): Boolean =
     !(cls.isStatic
-      || cls.effectiveOwner.isStaticOwner
+      || outerOwner(cls).isStaticOwner
       || cls.is(PureInterface)
      )
 

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -199,9 +199,9 @@ object ExplicitOuter {
 
   /** Class needs an outer pointer, provided there is a reference to an outer this in it. */
   def needsOuterIfReferenced(cls: ClassSymbol)(using Context): Boolean =
-    !(cls.isStatic ||
-      cls.owner.enclosingClass.isStaticOwner ||
-      cls.is(PureInterface)
+    !(cls.isStatic
+      || cls.effectiveOwner.isStaticOwner
+      || cls.is(PureInterface)
      )
 
   /** Class unconditionally needs an outer pointer. This is the case if
@@ -226,7 +226,9 @@ object ExplicitOuter {
 
   /** The outer parameter accessor of cass `cls` */
   private def outerParamAccessor(cls: ClassSymbol)(using Context): TermSymbol =
-    cls.info.decl(nme.OUTER).symbol.asTerm
+    val outer = cls.info.decl(nme.OUTER).symbol
+    assert(outer.isTerm, i"missing outer accessor in $cls")
+    outer.asTerm
 
   /** The outer accessor of class `cls`. To find it is a bit tricky. The
    *  class might have been moved with new owners between ExplicitOuter and Erasure,

--- a/tests/pos/i17135.scala
+++ b/tests/pos/i17135.scala
@@ -1,0 +1,53 @@
+package doobie
+
+// original example
+def someFunction(param: Int): Int = {
+  sealed trait Foo {
+    def asString: String = this match {
+      case Foo.CaseC => "C"
+    }
+  }
+  object Foo {
+    // Having an object here crashes the compiler.
+    object CaseC extends Foo
+  }
+
+  ???
+}
+
+// minimization
+def foo =
+  class Bar {
+    // Having an object here crashes the compiler.
+    lazy val CaseC =
+      class Baz extends Foo
+      new Baz()
+  }
+  val Bar: Bar = new Bar()
+  trait Foo {
+    def asString = Bar.CaseC
+  }
+
+// variant: outer is lazy val
+lazy val lazyfoo =
+  class Bar {
+    // Having an object here crashes the compiler.
+    lazy val CaseC =
+      class Baz extends Foo
+      new Baz()
+  }
+  val Bar: Bar = new Bar()
+  trait Foo {
+    def asString = Bar.CaseC
+  }
+
+// other example
+def bar =
+  sealed trait GADT2[A] extends Product with Serializable
+
+  object GADT2 {
+    case class IsDir(path: String) extends GADT2[_root_.scala.Boolean]
+    case class Exists(path: String) extends GADT2[_root_.scala.Boolean]
+    case class ReadBytes(path: String) extends GADT2[_root_.scala.Array[_root_.scala.Byte]]
+    case class CopyOver(src: Seq[_root_.scala.Byte], path: String) extends GADT2[Int]
+  }

--- a/tests/pos/t0049.scala
+++ b/tests/pos/t0049.scala
@@ -1,3 +1,6 @@
 class C1(x: AnyRef) {};
 
 class C2 extends C1({ class A extends AnyRef {}; (new A) : AnyRef }) {};
+
+class Outer:
+  class C2 extends C1({ class A extends AnyRef {}; (new A) : AnyRef }) {};


### PR DESCRIPTION
#17135 shows that traits also need an outer accessor if they are in a toplevel method (or lazy val).

Fixes #17135