### PR TITLE
WIP: Verify links in docs

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
@@ -112,53 +112,18 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
   def validationLink(str: String): String =
     def asValidURL = Try(URL(str)).toOption.map(_ => str)
 
-    def asAsset =
-      Option.when(
-      Files.exists(Paths.get("src/main/ressources").resolve(str.stripPrefix("/")))
-    )(
-      s"src/main/ressources/$str"
-    )
-
-    def asStaticSite: Option[String] =
-      Option.when(
-      Files.exists(Paths.get("docs/_docs").resolve(str.stripPrefix("/")))
-    )(
-      s"docs/_docs/$str"
-    )
-
-    def asApiLink: Option[String] =
-      val strWithoutHtml = if str.endsWith("$.html") then
-        str.stripSuffix("$.html")
-        else
-          str.stripSuffix(".html")
-      val sourceDir = Paths.get("src", "main", "scala")
-      val scalaPath = sourceDir.resolve(s"$strWithoutHtml.scala")
-      val scalaDirPath = sourceDir.resolve(strWithoutHtml)
-      Option.when(
-        Files.exists(scalaPath) || Files.exists(scalaDirPath))
-        (
-          s"api/$strWithoutHtml.html"
-          )
-
+    def asAsset: Option[String] = Option.when(
+      Files.exists(Paths.get("docs/_assets").resolve(str))
+      )(
+        s"docs/_assets/$str"
+        )
 
     asValidURL
-      .orElse(asStaticSite)
       .orElse(asAsset)
-      .orElse(asApiLink)
       .getOrElse{
         report.warning(s"Unable to resolve link '$str'")
         str
       }
-
-    // println(asValidURL)
-
-    // println(Paths.get("src/main/ressources").resolve(str.stripPrefix("/")).toAbsolutePath)
-    // println(Files.exists(Paths.get("src/main/ressources").resolve(str.stripPrefix("/"))))
-    // def asAsset = Option.when(
-    //   Files.exists(Paths.get("docs/_assets").resolve(str.stripPrefix("/")))
-    // )(
-    //   s"docs/_assets/$str"
-    // )
 
   def memberInfo(m: Member, withBrief: Boolean = false, full: Boolean = false): Seq[AppliedTag] =
     val comment = m.docs
@@ -188,14 +153,6 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
     document.select("img").forEach(element =>
       element.attr("src", validationLink(element.attr("src")))
     )
-
-    document.select("a").forEach(element =>
-      element.attr("href", processLocalLinkWithGuard(element.attr("href")))
-    )
-
-    // document2.select("a").forEach(element =>
-    //   println("BONJOUR"+element.attr("href"))
-    // ) <--- Take some href that I don't want
 
     Seq(
       Option.when(withBrief && comment.flatMap(_.short).nonEmpty)(div(cls := "documentableBrief doc")(comment.flatMap(_.short).fold("")(renderDocPart))),

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
@@ -112,7 +112,7 @@ abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
               case None => sym.dri
             DocLink.ToDRI(dri, targetText)
           case None =>
-            val txt = s"No DRI found for query"
+            val txt = s"No DRI found for query, the link seems to be wrong or the file may not exist."
             val msg = s"$txt: $queryStr"
 
             if (!summon[DocContext].args.noLinkWarnings) then

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Preparser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Preparser.scala
@@ -4,9 +4,6 @@ package tasty.comments
 import scala.collection.mutable
 import scala.collection.immutable.SortedMap
 import scala.util.matching.Regex
-import java.net.URL
-import java.nio.file.{Paths, Files}
-import scala.util.Try
 
 object Preparser {
   import Regexes._
@@ -14,7 +11,7 @@ object Preparser {
   /** Parses a raw comment string into a `Comment` object. */
   def preparse(
     comment: List[String],
-  )(using DocContext): PreparsedComment = {
+  ): PreparsedComment = {
 
     /** Parses a comment (in the form of a list of lines) to a `Comment`
       * instance, recursively on lines. To do so, it splits the whole comment
@@ -132,32 +129,7 @@ object Preparser {
         val stripTags = List(inheritDiagramTag, contentDiagramTag, SimpleTagKey("template"), SimpleTagKey("documentable"))
         val tagsWithoutDiagram = tags.filterNot(pair => stripTags.contains(pair._1))
 
-        def processLink: Unit =
-          if (!summon[DocContext].args.noLinkWarnings) then tags.get(SimpleTagKey("see")).get.foreach(link => {
-            val newLink = link.replaceAll("\\[\\[|\\]\\]", "")
-            val newUrl = new URL(newLink)
-            if(Try(newUrl).isSuccess) {
-              if(newUrl.getPath.contains("/docs/")) {
-                if (newLink.contains("oracle") || newLink.contains("excludeValidation")) then None
-                else
-                  // We check if the internal link to the static documentation is valid
-                  val docPath = newUrl.getPath.substring(newUrl.getPath.indexOf("/docs/"))
-                  .replaceFirst("/docs/(docs/)?", "docs/_docs/")
-                  .replace(".html", ".md")
-                  println(docPath)
-                  val fileExists = Files.exists(Paths.get(docPath))
-                  if !fileExists then
-                    val newDocPath = docPath + ".md"
-                    if !Files.exists(Paths.get(newDocPath)) then report.warning(s"Link to $newLink will return a 404 not found")
-              }
-              else None
-            }
-            else None
-          })
-
         val bodyTags: mutable.Map[TagKey, List[String]] =
-          if tags.get(SimpleTagKey("see")).isDefined then
-            processLink
           mutable.Map((tagsWithoutDiagram).toSeq: _*)
 
         def allTags(key: SimpleTagKey): List[String] =


### PR DESCRIPTION
Here is my proposed PR to check that the links in the API comments (@see) are valid and point to valid static documentation.

## Validations:

- [x] The link is valid

- [x] Assets
Example: `![bar.png](/ressources/bar.png)`

- [ ] Static pages
Example: `[foo](./foo.md)`

- [x] API documentation
 Example: `[[com.example.Foo]]`
A validation is already done in [Comments.resolveLink](https://github.com/lampepfl/dotty/blob/main/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala). But there is an Issue https://github.com/lampepfl/dotty/issues/17550

## Def ProcessLink:
This function allows to check both that a string is a valid url with the Try, but also that this link leads to an existing static documentation.
When one of these two conditions is not met, a warning is sent when the documentation is generated.
### Result:
<img width="595" alt="Screenshot 2023-03-29 at 12 01 09" src="https://user-images.githubusercontent.com/44496264/228499561-a9ddf2f3-6416-45c8-bf57-a3f891a16c54.png">

## Disable Validation:

### First method

**A yaml in a folder, with each file and sub-folder having a warning validation disabled**.

- Take the path where a method is started
- Verify if a validation.yaml is present in the folder or the previous folder with a line like:
    - noValidation: true
- if yes, disable the warning.

### Second method

**A yaml with a folder list, all the files in each folder have warning validation disabled**

- Search for the generalValidation.yaml file in a specific folder (Like ressource)
- Take the name of each folder in this file
- During the validation @see, if the name of the folder of the file correspond to one of the name in the file, deactivate the warning


Fixes: #16229 