### PR TITLE
Do not issue deprecation warnings when declaring deprecated case classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -604,6 +604,7 @@ object Flags {
   val Scala2Trait: FlagSet                   = Scala2x | Trait
   val SyntheticArtifact: FlagSet             = Synthetic | Artifact
   val SyntheticCase: FlagSet                 = Synthetic | Case
+  val SyntheticMethod: FlagSet               = Synthetic | Method
   val SyntheticModule: FlagSet               = Synthetic | Module
   val SyntheticOpaque: FlagSet               = Synthetic | Opaque
   val SyntheticParam: FlagSet                = Synthetic | Param

--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -52,7 +52,8 @@ class CrossVersionChecks extends MiniPhase:
       owner.isDeprecated
       || isEnumOwner(owner)
 
-    /**Scan the chain of outer declaring scopes from the current context
+    /**Skip warnings for synthetic members of case classes during declaration and
+     * scan the chain of outer declaring scopes from the current context
      * a deprecation warning will be skipped if one the following holds
      * for a given declaring scope:
      * - the symbol associated with the scope is also deprecated.
@@ -60,10 +61,13 @@ class CrossVersionChecks extends MiniPhase:
      *   a module that declares `sym`, or the companion class of the
      *   module that declares `sym`.
      */
-    def skipWarning(using Context) =
-      ctx.owner.ownersIterator.exists(if sym.isEnumCase then isDeprecatedOrEnum else _.isDeprecated)
+    def skipWarning(using Context): Boolean =
+      (ctx.owner.is(Synthetic) && sym.is(CaseClass))
+        || ctx.owner.ownersIterator.exists(if sym.isEnumCase then isDeprecatedOrEnum else _.isDeprecated)
 
-    for annot <- sym.getAnnotation(defn.DeprecatedAnnot) do
+    // Also check for deprecation of the companion class for synthetic methods
+    val toCheck = sym :: (if sym.isAllOf(SyntheticMethod) then sym.owner.companionClass :: Nil else Nil)
+    for sym <- toCheck; annot <- sym.getAnnotation(defn.DeprecatedAnnot) do
       if !skipWarning then
         val msg = annot.argumentConstant(0).map(": " + _.stringValue).getOrElse("")
         val since = annot.argumentConstant(1).map(" since " + _.stringValue).getOrElse("")

--- a/tests/neg-custom-args/deprecation/i11022.check
+++ b/tests/neg-custom-args/deprecation/i11022.check
@@ -1,0 +1,20 @@
+-- Error: tests/neg-custom-args/deprecation/i11022.scala:8:7 -----------------------------------------------------------
+8 |val a: CaseClass = CaseClass(42)        // error: deprecated type // error: deprecated apply method
+  |       ^^^^^^^^^
+  |       class CaseClass is deprecated: no CaseClass
+-- Error: tests/neg-custom-args/deprecation/i11022.scala:8:19 ----------------------------------------------------------
+8 |val a: CaseClass = CaseClass(42)        // error: deprecated type // error: deprecated apply method
+  |                   ^^^^^^^^^
+  |                   class CaseClass is deprecated: no CaseClass
+-- Error: tests/neg-custom-args/deprecation/i11022.scala:9:7 -----------------------------------------------------------
+9 |val b: CaseClass = new CaseClass(42)    // error: deprecated type // error: deprecated class
+  |       ^^^^^^^^^
+  |       class CaseClass is deprecated: no CaseClass
+-- Error: tests/neg-custom-args/deprecation/i11022.scala:9:23 ----------------------------------------------------------
+9 |val b: CaseClass = new CaseClass(42)    // error: deprecated type // error: deprecated class
+  |                       ^^^^^^^^^
+  |                       class CaseClass is deprecated: no CaseClass
+-- Error: tests/neg-custom-args/deprecation/i11022.scala:10:14 ---------------------------------------------------------
+10 |val c: Unit = CaseClass(42).magic()     // error: deprecated apply method
+   |              ^^^^^^^^^
+   |              class CaseClass is deprecated: no CaseClass

--- a/tests/neg-custom-args/deprecation/i11022.scala
+++ b/tests/neg-custom-args/deprecation/i11022.scala
@@ -1,0 +1,11 @@
+@deprecated("no CaseClass")
+case class CaseClass(rgb: Int):
+  def magic(): Unit = ()
+
+object CaseClass:
+  def notDeprecated(): Unit = ()
+
+val a: CaseClass = CaseClass(42)        // error: deprecated type // error: deprecated apply method
+val b: CaseClass = new CaseClass(42)    // error: deprecated type // error: deprecated class
+val c: Unit = CaseClass(42).magic()     // error: deprecated apply method
+val d: Unit = CaseClass.notDeprecated() // compiles

--- a/tests/pos/i11022.scala
+++ b/tests/pos/i11022.scala
@@ -1,0 +1,3 @@
+// scalac: -Werror -deprecation
+@deprecated("no CaseClass")
+case class CaseClass(rgb: Int)


### PR DESCRIPTION
Do trigger a deprecation warning when calling synthetic members of the companion object of a deprecated case class.

Fixes #11022 