### PR TITLE
Detail UnapplyInvalidReturnType error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1962,7 +1962,11 @@ class UnapplyInvalidReturnType(unapplyResult: Type, unapplyName: Name)(using Con
         |To be used as an extractor, an unapply method has to return a type that either:
         | - has members ${Magenta("isEmpty: Boolean")} and ${Magenta("get: S")} (usually an ${Green("Option[S]")})
         | - is a ${Green("Boolean")}
-        | - is a ${Green("Product")} (like a ${Magenta("Tuple2[T1, T2]")})
+        | - is a ${Green("Product")} (like a ${Magenta("Tuple2[T1, T2]")}) of arity i with i >= 1, and has members _1 to _i
+        |
+        |See: https://docs.scala-lang.org/scala3/reference/changed-features/pattern-matching.html#fixed-arity-extractors
+        |
+        |Examples:
         |
         |class A(val i: Int)
         |

--- a/tests/neg/17077.scala
+++ b/tests/neg/17077.scala
@@ -1,0 +1,14 @@
+case class IsIntResult()
+
+object IsInt:
+    def unapply(x: Int): IsIntResult = IsIntResult()
+
+@main def test =
+  val v: String | Int = "Blop"
+  val res =
+    v match
+      case IsInt() => 43 // error: cannot use a product of arity zero as a return type for unapply
+                         // see UnapplyInvalidReturnType in messages.scala
+                         // and https://docs.scala-lang.org/scala3/reference/changed-features/pattern-matching.html#fixed-arity-extractors
+      case _ => 42
+  println(res)

--- a/tests/pos/17077.scala
+++ b/tests/pos/17077.scala
@@ -1,0 +1,20 @@
+class MyProduct extends Product:
+    def foo = ???
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any = 42
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[MyProduct]
+    def _1 = 42
+
+object MyProductUnapply:
+    def unapply(x: Int): MyProduct = MyProduct()
+
+@main def test =
+  val v: String | Int = "Blop"
+  val res =
+    v match
+      case MyProductUnapply(y) => y // works: a product of arity 1 is accepted as the return type of unapply
+                                    // see UnapplyInvalidReturnType in messages.scala
+                                    // and https://docs.scala-lang.org/scala3/reference/changed-features/pattern-matching.html#fixed-arity-extractors
+      case _ => 42
+  println(res)
+


### PR DESCRIPTION
Investigated during today's issue spree with @natsukagami and @TheElectronWill. Fixes #17077.

The [reference documentation on “Product Match”](https://docs.scala-lang.org/scala3/reference/changed-features/pattern-matching.html#product-match) states:

> - `U <: Product`
> - `N > 0` is the maximum number of consecutive (`val` or parameterless `def`) `_1: P1 ... _N: PN` members in `U`
> - Pattern-matching on exactly `N` patterns with types `P1, P2, ..., PN`

From the second item:
- empty products as return types for `unapply` are not accepted (`N > 0`)
- a `Product` return type must have `_1`..`_n` members

Therefore, it seems that the current behavior is correct.

Side note: `Product0` has been removed: https://github.com/lampepfl/dotty/pull/10398. 

This PR adds 2 tests that confirm the current behavior, and adds details in the error message.
