### PR TITLE
Fix: Remove the duplicate logo

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -207,11 +207,11 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
       }
 
     val darkProjectLogoElem =
-      darkProjectLogo.flatMap {
+      darkProjectLogo.orElse(projectLogo).flatMap {
         case Resource.File(path, _) =>
           Some(span(id := "dark-project-logo", cls := "project-logo")(img(src := resolveRoot(link.dri, path))))
         case _ => None
-      }.orElse(projectLogoElem)
+      }
 
     val parentsHtml =
       val innerTags = parents.flatMap[TagArg](b => Seq(


### PR DESCRIPTION
- I added an orElse to the snippet so that the dark logo works and there is no duplicate logo.
### Before
<img width="569" alt="Screenshot 2023-03-29 at 14 51 09" src="https://user-images.githubusercontent.com/44496264/228541357-77ca6c2a-4413-45fd-a283-40f304d88c4a.png">
### After 
<img width="569" alt="Screenshot 2023-03-29 at 14 48 22" src="https://user-images.githubusercontent.com/44496264/228541334-c9a3eccc-1d4a-475b-b03b-3698bde162fb.png">

Fixes: #16693 