### PR TITLE
Fix: Modify the CSS so that the logo of the generated documentation is adaptive

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/layout/header.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/header.css
@@ -63,6 +63,14 @@
   align-items: center;
 }
 
+.logo-container .project-logo {
+  max-width: 40px;
+}
+
+.logo-container .project-logo img {
+  max-width: 100%;
+}
+
 #mobile-menu-toggle {
   display: none;
 }


### PR DESCRIPTION
- Add a fixed width of the span
- Add a 100% for the img in the span
## Before:
<img width="506" alt="Screenshot 2023-03-29 at 15 18 30" src="https://user-images.githubusercontent.com/44496264/228550706-5174562f-b92e-4daf-b25a-a19af01494c2.png">

## After:
<img width="506" alt="Screenshot 2023-03-29 at 15 18 19" src="https://user-images.githubusercontent.com/44496264/228550784-42853609-c709-4aed-b100-a598c754a5e7.png">

Fixes: #17171