### PR TITLE
Allow Tuple.Head and Tuple.Tail to work with EmptyTuple

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -27,6 +27,8 @@ i9804.scala
 i13433.scala
 i16649-irrefutable.scala
 strict-pattern-bindings-3.0-migration.scala
+i17186b.scala
+i11982a.scala
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -96,7 +96,7 @@ object Tuple {
   }
 
   /** Type of the head of a tuple */
-  type Head[X <: NonEmptyTuple] = X match {
+  type Head[X <: Tuple] = X match {
     case x *: _ => x
   }
 
@@ -108,7 +108,7 @@ object Tuple {
   }
 
   /** Type of the tail of a tuple */
-  type Tail[X <: NonEmptyTuple] <: Tuple = X match {
+  type Tail[X <: Tuple] <: Tuple = X match {
     case _ *: xs => xs
   }
 

--- a/tests/pos/i11982a.scala
+++ b/tests/pos/i11982a.scala
@@ -6,9 +6,9 @@ object Unpair {
 
   def unpair[X <: Tuple2[?, ?]](
       using a: ValueOf[Tuple.Head[X]],
-            b: ValueOf[Tuple.Head[Tuple.Tail[X]]]  // error
-  ): Tuple2[Tuple.Head[X], Tuple.Head[Tuple.Tail[X]]] =  // error
+            b: ValueOf[Tuple.Head[Tuple.Tail[X]]]
+  ): Tuple2[Tuple.Head[X], Tuple.Head[Tuple.Tail[X]]] =
     type AA = Tuple.Head[X]
-    type BB = Tuple.Head[Tuple.Tail[X]]  // error
+    type BB = Tuple.Head[Tuple.Tail[X]]
     pair[AA, BB](using a, b)
 }

--- a/tests/pos/i17186a.scala
+++ b/tests/pos/i17186a.scala
@@ -1,0 +1,5 @@
+type second[X <: Tuple2[Any, Any]] = Tuple.Head[Tuple.Tail[X]]
+type middle[X <: Tuple3[Any, Any, Any]] = Tuple.Head[Tuple.Tail[X]]
+
+val a: Tuple.Head[Tuple.Tail[Tuple2[Int, String]]] = ???
+val b: Tuple.Head[Tuple.Tail[Tuple3[Int, String, Boolean]]] = ???

--- a/tests/pos/i17186b.scala
+++ b/tests/pos/i17186b.scala
@@ -1,0 +1,5 @@
+type SecondOfTwo[X <: Tuple2[Any, Any]] = Tuple.Head[Tuple.Tail[X]]
+val a = implicitly[SecondOfTwo[Tuple2[Int, String]] =:= String]
+
+type LastOfThree[X <: Tuple3[Any, Any, Any]] = Tuple.Tail[Tuple.Tail[X]]
+val b = implicitly[LastOfThree[Tuple3[Int, String, Boolean]] =:= Tuple1[Boolean]]


### PR DESCRIPTION
Fixes #17186. 

I think this is correct behaviour since we already allow things like

```Scala
val a = List(1).tail
val b = Tuple1(1).tail
```