### PR TITLE
Fix: Found the DRI query when method name ends with '!' or '$' 

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
@@ -236,12 +236,18 @@ object MemberLookup extends MemberLookup {
       // Scaladoc overloading support allows terminal * (and they're meaningless)
       val cleanStr = str.stripSuffix("*")
 
-      if cleanStr endsWith "$" then
+      cleanStr match {
+      case s"$name$$" if name.charAt(0).isUpper =>
         Selector(cleanStr.init, SelectorKind.ForceTerm)
-      else if cleanStr endsWith "!" then
-        Selector(cleanStr.init, SelectorKind.ForceType)
-      else
+      case s"$name$$" =>
         Selector(cleanStr, SelectorKind.NoForce)
+      case s"$name!" if name.charAt(0).isUpper =>
+        Selector(cleanStr.init, SelectorKind.ForceType)
+      case s"$name!" =>
+        Selector(cleanStr, SelectorKind.NoForce)
+      case _ =>
+        Selector(cleanStr, SelectorKind.NoForce)
+      }
     }
   }
 }


### PR DESCRIPTION
In this condition I check if the fist char of the link is Upper (So Class || Object) else I check it's a method. Otherwise It's a method. 
Thus there is no confusion between the link to the apply method of an object such as: MyList$ or a simple method named myList_$. This allows to find the right DRI for each.
- Line 241: Check for an Object
- Line 243: Check for a method ends with a `$`
- Line 245: Check for a Class
- Line 247: Check for a method ends with `!`
## Example: 
<img width="641" alt="Screenshot 2023-04-03 at 11 21 09" src="https://user-images.githubusercontent.com/44496264/229468421-a5ede027-7ebc-4c56-906c-00e84a864487.png">

### Before:
<img width="600" alt="Screenshot 2023-04-03 at 11 21 21" src="https://user-images.githubusercontent.com/44496264/229468662-051a5b55-5bb9-4271-b60e-88986ef8054f.png">

<img width="600" alt="Screenshot 2023-04-03 at 11 22 01" src="https://user-images.githubusercontent.com/44496264/229468637-327580f9-d35c-4313-8c71-3ece341508c8.png">

### After:
<img width="600" alt="Screenshot 2023-04-03 at 11 18 39" src="https://user-images.githubusercontent.com/44496264/229468705-a927d8c0-b339-4564-b3d2-c194044a77ea.png">

<img width="600" alt="Screenshot 2023-04-03 at 11 23 00" src="https://user-images.githubusercontent.com/44496264/229468717-21baa8f3-f230-493b-9cdb-1fdc57e98c3c.png">

I think new tests should be added.

Fixes: #16627 