### PR TITLE
documentation: fix tokens that can start indentation region

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -523,7 +523,8 @@ object Scanners {
      *
      *      The following tokens can start an indentation region:
      *
-     *         :  =  =>  <-  if  then  else  while  do  try  catch  finally  for  yield  match
+     *         :  =  =>  <-  if  then  else  while  do  try  catch  
+     *         finally  for  yield  match  throw  return  with
      *
      *      Inserting an INDENT starts a new indentation region with the indentation of the current
      *      token as indentation width.


### PR DESCRIPTION
## What:
The documentation currently states:
```
     *      The following tokens can start an indentation region:
     *
     *         :  =  =>  <-  if  then  else  while  do  try  catch  finally  for  yield  match
```

This is not actually true, however, if you look at the source of the predicate
which determines which tokens can start an indentation region: https://github.com/lampepfl/dotty/blob/865aa639c98e0a8771366b3ebc9580cc8b61bfeb/compiler/src/dotty/tools/dotc/parsing/Tokens.scala#L276

In particular, if I'm not mistaken, `return`, `throw`, and `with` are all also tokens which have this property.

This PR just amends the documentation to reflect that.