### PR TITLE
Add new HOLETYPES to TASTy format 

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -146,11 +146,12 @@ class TreeTypeMap(
           val bind1 = tmap.transformSub(bind)
           val expr1 = tmap.transform(expr)
           cpy.Labeled(labeled)(bind1, expr1)
-        case tree @ Hole(_, _, args, content, tpt) =>
+        case tree @ Hole(_, _, targs, args, content, tpt) =>
+          val targs1 = targs.mapConserve(transform)
           val args1 = args.mapConserve(transform)
           val content1 = transform(content)
           val tpt1 = transform(tpt)
-          cpy.Hole(tree)(args = args1, content = content1, tpt = tpt1)
+          cpy.Hole(tree)(targs = targs1, args = args1, content = content1, tpt = tpt1)
         case tree1 =>
           super.transform(tree1)
       }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -978,13 +978,20 @@ object Trees {
   /** Tree that replaces a level 1 splices in pickled (level 0) quotes.
    *  It is only used when picking quotes (will never be in a TASTy file).
    *
+   *  Hole created by this compile separate the targs from the args. Holes
+   *  generated with 3.0-3.3 contain all type args and targs in any order in
+   *  a single list. For backwards compatibility we read holes from tasty as
+   *  if they had no targs and have only args. Therefore the args may contain
+   *  type trees.
+   *
    *  @param isTermHole If this hole is a term, otherwise it is a type hole.
    *  @param idx The index of the hole in it's enclosing level 0 quote.
-   *  @param args The arguments of the splice to compute its content
-   *  @param content Lambda that computes the content of the hole. This tree is empty when in a quote pickle.
+   *  @param targs The type arguments of the splice to compute its content
+   *  @param args The term (or type) arguments of the splice to compute its content
    *  @param tpt Type of the hole
+   *  @param content Lambda that computes the content of the hole. This tree is empty when in a quote pickle.
    */
-  case class Hole[+T <: Untyped](isTermHole: Boolean, idx: Int, args: List[Tree[T]], content: Tree[T], tpt: Tree[T])(implicit @constructorOnly src: SourceFile) extends Tree[T] {
+  case class Hole[+T <: Untyped](isTermHole: Boolean, idx: Int, targs: List[Tree[T]], args: List[Tree[T]], content: Tree[T], tpt: Tree[T])(implicit @constructorOnly src: SourceFile) extends Tree[T] {
     type ThisTree[+T <: Untyped] <: Hole[T]
     override def isTerm: Boolean = isTermHole
     override def isType: Boolean = !isTermHole
@@ -1337,9 +1344,9 @@ object Trees {
         case tree: Thicket if (trees eq tree.trees) => tree
         case _ => finalize(tree, untpd.Thicket(trees)(sourceFile(tree)))
       }
-      def Hole(tree: Tree)(isTerm: Boolean, idx: Int, args: List[Tree], content: Tree, tpt: Tree)(using Context): Hole = tree match {
-        case tree: Hole if isTerm == tree.isTerm && idx == tree.idx && args.eq(tree.args) && content.eq(tree.content) && content.eq(tree.content) => tree
-        case _ => finalize(tree, untpd.Hole(isTerm, idx, args, content, tpt)(sourceFile(tree)))
+      def Hole(tree: Tree)(isTerm: Boolean, idx: Int, targs: List[Tree], args: List[Tree], content: Tree, tpt: Tree)(using Context): Hole = tree match {
+        case tree: Hole if isTerm == tree.isTerm && idx == tree.idx && targs.eq(tree.targs) && args.eq(tree.args) && content.eq(tree.content) && content.eq(tree.content) => tree
+        case _ => finalize(tree, untpd.Hole(isTerm, idx, targs, args, content, tpt)(sourceFile(tree)))
       }
 
       // Copier methods with default arguments; these demand that the original tree
@@ -1362,8 +1369,8 @@ object Trees {
         TypeDef(tree: Tree)(name, rhs)
       def Template(tree: Template)(using Context)(constr: DefDef = tree.constr, parents: List[Tree] = tree.parents, derived: List[untpd.Tree] = tree.derived, self: ValDef = tree.self, body: LazyTreeList = tree.unforcedBody): Template =
         Template(tree: Tree)(constr, parents, derived, self, body)
-      def Hole(tree: Hole)(isTerm: Boolean = tree.isTerm, idx: Int = tree.idx, args: List[Tree] = tree.args, content: Tree = tree.content, tpt: Tree = tree.tpt)(using Context): Hole =
-        Hole(tree: Tree)(isTerm, idx, args, content, tpt)
+      def Hole(tree: Hole)(isTerm: Boolean = tree.isTerm, idx: Int = tree.idx, targs: List[Tree] = tree.targs, args: List[Tree] = tree.args, content: Tree = tree.content, tpt: Tree = tree.tpt)(using Context): Hole =
+        Hole(tree: Tree)(isTerm, idx, targs, args, content, tpt)
 
     }
 
@@ -1494,8 +1501,8 @@ object Trees {
             case Thicket(trees) =>
               val trees1 = transform(trees)
               if (trees1 eq trees) tree else Thicket(trees1)
-            case tree @ Hole(_, _, args, content, tpt) =>
-              cpy.Hole(tree)(args = transform(args), content = transform(content), tpt = transform(tpt))
+            case tree @ Hole(_, _, targs, args, content, tpt) =>
+              cpy.Hole(tree)(targs = transform(targs), args = transform(args), content = transform(content), tpt = transform(tpt))
             case _ =>
               transformMoreCases(tree)
           }
@@ -1635,8 +1642,8 @@ object Trees {
               this(this(x, arg), annot)
             case Thicket(ts) =>
               this(x, ts)
-            case Hole(_, _, args, content, tpt) =>
-              this(this(this(x, args), content), tpt)
+            case Hole(_, _, targs, args, content, tpt) =>
+              this(this(this(this(x, targs), args), content), tpt)
             case _ =>
               foldMoreCases(x, tree)
           }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -976,8 +976,11 @@ object Trees {
   def genericEmptyTree[T <: Untyped]: Thicket[T]        = theEmptyTree.asInstanceOf[Thicket[T]]
 
   /** Tree that replaces a level 1 splices in pickled (level 0) quotes.
+   *
    *  It is only used when encoding pickled quotes. These will be encoded
-   *  as TastyQuoteHole when pickled.
+   *  as TastyQuoteHole when pickled. These holes will be inserted in the
+   *  Staging phase and pickled (without the content) as TASTy HOLE in the
+   *  PickleQuotes phase.
    *
    *  @param isTermHole If this hole is a term, otherwise it is a type hole.
    *  @param idx The index of the hole in it's enclosing level 0 quote.
@@ -993,7 +996,9 @@ object Trees {
   }
 
   /** Tree that replaces a level 1 splices in pickled (level 0) quotes.
-   *  It is only used when picking quotes (will never be in a TASTy file).
+   *  It is only used when unpicking quotes TASTy HOLE. These holes will
+   *  only be present in pickled quotes. These are unpickled and replaced
+   *  with other trees in PickledQuotes.
    *
    *  Hole created by this compiler separate the targs from the args. Holes
    *  generated with 3.0-3.3 contain all type args and targs in any order in

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -995,7 +995,7 @@ object Trees {
   /** Tree that replaces a level 1 splices in pickled (level 0) quotes.
    *  It is only used when picking quotes (will never be in a TASTy file).
    *
-   *  Hole created by this compile separate the targs from the args. Holes
+   *  Hole created by this compiler separate the targs from the args. Holes
    *  generated with 3.0-3.3 contain all type args and targs in any order in
    *  a single list. For backwards compatibility we read holes from tasty as
    *  if they had no targs and have only args. Therefore the args may contain

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -391,8 +391,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def Throw(expr: Tree)(using Context): Tree =
     ref(defn.throwMethod).appliedTo(expr)
 
-  def Hole(isTermHole: Boolean, idx: Int, args: List[Tree], content: Tree, tpt: Tree)(using Context): Hole =
-    ta.assignType(untpd.Hole(isTermHole, idx, args, content, tpt), tpt)
+  def Hole(isTermHole: Boolean, idx: Int, targs: List[Tree], args: List[Tree], content: Tree, tpt: Tree)(using Context): Hole =
+    ta.assignType(untpd.Hole(isTermHole, idx, targs, args, content, tpt), tpt)
 
   // ------ Making references ------------------------------------------------------
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -427,7 +427,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def PackageDef(pid: RefTree, stats: List[Tree])(implicit src: SourceFile): PackageDef = new PackageDef(pid, stats)
   def Annotated(arg: Tree, annot: Tree)(implicit src: SourceFile): Annotated = new Annotated(arg, annot)
   def Hole(isTermHole: Boolean, idx: Int, targs: List[Tree], args: List[Tree], content: Tree, tpt: Tree)(implicit src: SourceFile): Hole = new Hole(isTermHole, idx, targs, args, content, tpt)
-  def PickledHole(isTermHole: Boolean, idx: Int, args: List[Tree], tpt: Tree)(implicit src: SourceFile): PickledHole = new PickledHole(isTermHole, idx, args, tpt)
+  def TastyQuoteHole(isTermHole: Boolean, idx: Int, args: List[Tree], tpt: Tree)(implicit src: SourceFile): TastyQuoteHole = new TastyQuoteHole(isTermHole, idx, args, tpt)
 
   // ------ Additional creation methods for untyped only -----------------
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -427,6 +427,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def PackageDef(pid: RefTree, stats: List[Tree])(implicit src: SourceFile): PackageDef = new PackageDef(pid, stats)
   def Annotated(arg: Tree, annot: Tree)(implicit src: SourceFile): Annotated = new Annotated(arg, annot)
   def Hole(isTermHole: Boolean, idx: Int, targs: List[Tree], args: List[Tree], content: Tree, tpt: Tree)(implicit src: SourceFile): Hole = new Hole(isTermHole, idx, targs, args, content, tpt)
+  def PickledHole(isTermHole: Boolean, idx: Int, args: List[Tree], tpt: Tree)(implicit src: SourceFile): PickledHole = new PickledHole(isTermHole, idx, args, tpt)
 
   // ------ Additional creation methods for untyped only -----------------
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -426,7 +426,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def Export(expr: Tree, selectors: List[ImportSelector])(implicit src: SourceFile): Export = new Export(expr, selectors)
   def PackageDef(pid: RefTree, stats: List[Tree])(implicit src: SourceFile): PackageDef = new PackageDef(pid, stats)
   def Annotated(arg: Tree, annot: Tree)(implicit src: SourceFile): Annotated = new Annotated(arg, annot)
-  def Hole(isTermHole: Boolean, idx: Int, args: List[Tree], content: Tree, tpt: Tree)(implicit src: SourceFile): Hole = new Hole(isTermHole, idx, args, content, tpt)
+  def Hole(isTermHole: Boolean, idx: Int, targs: List[Tree], args: List[Tree], content: Tree, tpt: Tree)(implicit src: SourceFile): Hole = new Hole(isTermHole, idx, targs, args, content, tpt)
 
   // ------ Additional creation methods for untyped only -----------------
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -672,9 +672,7 @@ class TreePickler(pickler: TastyPickler) {
             pickleType(tpt.tpe, richTypes = true)
             if targs.nonEmpty then
               writeByte(HOLETYPES)
-              withLength {
-                targs.foreach(targ => pickleType(targ.tpe))
-              }
+              withLength { targs.foreach(pickleTree) }
             args.foreach(pickleTree)
           }
       }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -665,11 +665,12 @@ class TreePickler(pickler: TastyPickler) {
               pickleTree(hi)
               pickleTree(alias)
           }
-        case Hole(_, idx, args, _, tpt) =>
+        case Hole(_, idx, targs, args, _, tpt) =>
           writeByte(HOLE)
           withLength {
             writeNat(idx)
             pickleType(tpt.tpe, richTypes = true)
+            targs.foreach(pickleTree)
             args.foreach(pickleTree)
           }
       }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -670,7 +670,11 @@ class TreePickler(pickler: TastyPickler) {
           withLength {
             writeNat(idx)
             pickleType(tpt.tpe, richTypes = true)
-            targs.foreach(pickleTree)
+            if targs.nonEmpty then
+              writeByte(HOLETYPES)
+              withLength {
+                targs.foreach(targ => pickleType(targ.tpe))
+              }
             args.foreach(pickleTree)
           }
       }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1506,10 +1506,9 @@ class TreeUnpickler(reader: TastyReader,
       val targs =
         if nextByte == HOLETYPES then
           readByte()
-          val typesEnd = readEnd()
-          until(typesEnd)(readType()).map(TypeTree(_))
+          until(readEnd()) { readTpt() }
         else Nil
-      val args = until(end)(readTerm())
+      val args = until(end) { readTerm() }
       TastyQuoteHole(true, idx, targs ::: args, TypeTree(tpe)).withType(tpe)
 
     def readLater[T <: AnyRef](end: Addr, op: TreeReader => Context ?=> T)(using Context): Trees.Lazy[T] =

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1438,8 +1438,9 @@ class TreeUnpickler(reader: TastyReader,
             case HOLE =>
               val idx = readNat()
               val tpe = readType()
+              val targs = Nil // TODO read tags seprately from args
               val args = until(end)(readTerm())
-              Hole(true, idx, args, EmptyTree, TypeTree(tpe)).withType(tpe)
+              Hole(true, idx, targs, args, EmptyTree, TypeTree(tpe)).withType(tpe)
             case _ =>
               readPathTerm()
           }
@@ -1472,8 +1473,9 @@ class TreeUnpickler(reader: TastyReader,
           val end = readEnd()
           val idx = readNat()
           val tpe = readType()
+          val targs = Nil // TODO read tags seprately from args
           val args = until(end)(readTerm())
-          Hole(false, idx, args, EmptyTree, TypeTree(tpe)).withType(tpe)
+          Hole(false, idx, targs, args, EmptyTree, TypeTree(tpe)).withType(tpe)
         case _ =>
           if (isTypeTreeTag(nextByte)) readTerm()
           else {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1439,7 +1439,7 @@ class TreeUnpickler(reader: TastyReader,
               val idx = readNat()
               val tpe = readType()
               val args = until(end)(readTerm())
-              PickledHole(true, idx, args, TypeTree(tpe)).withType(tpe)
+              TastyQuoteHole(true, idx, args, TypeTree(tpe)).withType(tpe)
             case _ =>
               readPathTerm()
           }
@@ -1473,7 +1473,7 @@ class TreeUnpickler(reader: TastyReader,
           val idx = readNat()
           val tpe = readType()
           val args = until(end)(readTerm())
-          PickledHole(false, idx, args, TypeTree(tpe)).withType(tpe)
+          TastyQuoteHole(false, idx, args, TypeTree(tpe)).withType(tpe)
         case _ =>
           if (isTypeTreeTag(nextByte)) readTerm()
           else {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1438,9 +1438,8 @@ class TreeUnpickler(reader: TastyReader,
             case HOLE =>
               val idx = readNat()
               val tpe = readType()
-              val targs = Nil // TODO read tags seprately from args
               val args = until(end)(readTerm())
-              Hole(true, idx, targs, args, EmptyTree, TypeTree(tpe)).withType(tpe)
+              PickledHole(true, idx, args, TypeTree(tpe)).withType(tpe)
             case _ =>
               readPathTerm()
           }
@@ -1473,9 +1472,8 @@ class TreeUnpickler(reader: TastyReader,
           val end = readEnd()
           val idx = readNat()
           val tpe = readType()
-          val targs = Nil // TODO read tags seprately from args
           val args = until(end)(readTerm())
-          Hole(false, idx, targs, args, EmptyTree, TypeTree(tpe)).withType(tpe)
+          PickledHole(false, idx, args, TypeTree(tpe)).withType(tpe)
         case _ =>
           if (isTypeTreeTag(nextByte)) readTerm()
           else {

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -725,12 +725,12 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       case MacroTree(call) =>
         keywordStr("macro ") ~ toTextGlobal(call)
       case Hole(isTermHole, idx, targs, args, content, tpt) =>
-        val (prefix, postfix) = if isTermHole then ("{{{", "}}}") else ("[[[", "]]]")
+        val (prefix, postfix) = if isTermHole then ("${", "}") else ("$[", "]")
         val targsText = ("[" ~ toTextGlobal(targs, ", ") ~ "]").provided(targs.nonEmpty)
         val argsText =  ("(" ~ toTextGlobal(args, ", ") ~ ")").provided(args.nonEmpty)
         val tptText = toTextGlobal(tpt)
         val contentText = ("|" ~~ toTextGlobal(content)).provided(content ne EmptyTree)
-        prefix ~~ idx.toString ~ targsText ~ argsText ~ ":" ~~ tptText ~~ contentText ~~ postfix
+        prefix ~~ "`" ~ idx.toString ~ "`" ~ targsText ~ argsText ~ ":" ~~ tptText ~~ contentText ~~ postfix
       case CapturingTypeTree(refs, parent) =>
         parent match
           case ImpureByNameTypeTree(bntpt) =>

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -724,12 +724,13 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         "Thicket {" ~~ toTextGlobal(trees, "\n") ~~ "}"
       case MacroTree(call) =>
         keywordStr("macro ") ~ toTextGlobal(call)
-      case Hole(isTermHole, idx, args, content, tpt) =>
+      case Hole(isTermHole, idx, targs, args, content, tpt) =>
         val (prefix, postfix) = if isTermHole then ("{{{", "}}}") else ("[[[", "]]]")
-        val argsText = toTextGlobal(args, ", ")
-        val contentText = toTextGlobal(content)
+        val targsText = ("[" ~ toTextGlobal(targs, ", ") ~ "]").provided(targs.nonEmpty)
+        val argsText =  ("(" ~ toTextGlobal(args, ", ") ~ ")").provided(args.nonEmpty)
         val tptText = toTextGlobal(tpt)
-        prefix ~~ idx.toString ~~ "|" ~~ tptText ~~ "|" ~~ argsText ~~ "|" ~~ contentText ~~ postfix
+        val contentText = ("|" ~~ toTextGlobal(content)).provided(content ne EmptyTree)
+        prefix ~~ idx.toString ~ targsText ~ argsText ~ ":" ~~ tptText ~~ contentText ~~ postfix
       case CapturingTypeTree(refs, parent) =>
         parent match
           case ImpureByNameTypeTree(bntpt) =>

--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -100,14 +100,14 @@ object PickledQuotes {
   private def spliceTerms(tree: Tree, typeHole: TypeHole, termHole: ExprHole)(using Context): Tree = {
     def evaluateHoles = new TreeMap {
       override def transform(tree: tpd.Tree)(using Context): tpd.Tree = tree match {
-        case Hole(isTermHole, idx, targs, args, _, _) =>
+        case PickledHole(isTermHole, idx, args, _) =>
           inContext(SpliceScope.contextWithNewSpliceScope(tree.sourcePos)) {
             if isTermHole then
               val quotedExpr = termHole match
                 case ExprHole.V1(evalHole) =>
-                  evalHole.nn.apply(idx, reifyExprHoleV1Args(targs ::: args), QuotesImpl())
+                  evalHole.nn.apply(idx, reifyExprHoleV1Args(args), QuotesImpl())
                 case ExprHole.V2(evalHole) =>
-                  evalHole.nn.apply(idx, reifyExprHoleV2Args(targs ::: args), QuotesImpl())
+                  evalHole.nn.apply(idx, reifyExprHoleV2Args(args), QuotesImpl())
 
               val filled = PickledQuotes.quotedExprToTree(quotedExpr)
 
@@ -165,15 +165,15 @@ object PickledQuotes {
             val tree = typeHole match
               case TypeHole.V1(evalHole) =>
                 tdef.rhs match
-                  case TypeBoundsTree(_, Hole(_, idx, targs, args, _, _), _) =>
+                  case TypeBoundsTree(_, PickledHole(_, idx, args, _), _) =>
                     // To keep for backwards compatibility. In some older version holes where created in the bounds.
-                    val quotedType = evalHole.nn.apply(idx, reifyTypeHoleArgs(targs ::: args))
+                    val quotedType = evalHole.nn.apply(idx, reifyTypeHoleArgs(args))
                     PickledQuotes.quotedTypeToTree(quotedType)
                   case TypeBoundsTree(_, tpt, _) =>
                     // To keep for backwards compatibility. In some older version we missed the creation of some holes.
                     tpt
               case TypeHole.V2(types) =>
-                val Hole(_, idx, _, _, _, _) = tdef.rhs: @unchecked
+                val PickledHole(_, idx, _, _) = tdef.rhs: @unchecked
                 PickledQuotes.quotedTypeToTree(types.nn.apply(idx))
             (tdef.symbol, tree.tpe)
         }.toMap

--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -100,7 +100,7 @@ object PickledQuotes {
   private def spliceTerms(tree: Tree, typeHole: TypeHole, termHole: ExprHole)(using Context): Tree = {
     def evaluateHoles = new TreeMap {
       override def transform(tree: tpd.Tree)(using Context): tpd.Tree = tree match {
-        case PickledHole(isTermHole, idx, args, _) =>
+        case TastyQuoteHole(isTermHole, idx, args, _) =>
           inContext(SpliceScope.contextWithNewSpliceScope(tree.sourcePos)) {
             if isTermHole then
               val quotedExpr = termHole match
@@ -165,7 +165,7 @@ object PickledQuotes {
             val tree = typeHole match
               case TypeHole.V1(evalHole) =>
                 tdef.rhs match
-                  case TypeBoundsTree(_, PickledHole(_, idx, args, _), _) =>
+                  case TypeBoundsTree(_, TastyQuoteHole(_, idx, args, _), _) =>
                     // To keep for backwards compatibility. In some older version holes where created in the bounds.
                     val quotedType = evalHole.nn.apply(idx, reifyTypeHoleArgs(args))
                     PickledQuotes.quotedTypeToTree(quotedType)
@@ -173,7 +173,7 @@ object PickledQuotes {
                     // To keep for backwards compatibility. In some older version we missed the creation of some holes.
                     tpt
               case TypeHole.V2(types) =>
-                val PickledHole(_, idx, _, _) = tdef.rhs: @unchecked
+                val TastyQuoteHole(_, idx, _, _) = tdef.rhs: @unchecked
                 PickledQuotes.quotedTypeToTree(types.nn.apply(idx))
             (tdef.symbol, tree.tpe)
         }.toMap

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -126,7 +126,7 @@ class PickleQuotes extends MacroTransform {
       private val contents = List.newBuilder[Tree]
       override def transform(tree: tpd.Tree)(using Context): tpd.Tree =
         tree match
-          case tree @ Hole(isTerm, _, _, content, _) =>
+          case tree @ Hole(isTerm, _, _, _, content, _) =>
             if !content.isEmpty then
               contents += content
             val holeType =

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -28,43 +28,42 @@ import scala.annotation.constructorOnly
  *  Transforms top level quote
  *   ```
  *   '{ ...
- *      @TypeSplice type X0 = {{ 0 | .. | contentsTpe0 | .. }}
- *      @TypeSplice type X2 = {{ 1 | .. | contentsTpe1 | .. }}
+ *      @TypeSplice type X0 = $[ `0`: ... | contentsTpe0 ]
+ *      type X1
  *      val x1: U1 = ???
  *      val x2: U2 = ???
  *      ...
- *      {{{ 3 | x1 | contents0 | T0 }}} // hole
+ *      ${ `2`(x1): T0 | contents0 } // Hole
  *      ...
- *      {{{ 4 | x2 | contents1 | T1 }}} // hole
+ *      ${ `3`[X1](x2): T1 | contents1 } // Hole
  *      ...
- *      {{{ 5 | x1, x2 | contents2 | T2 }}} // hole
+ *      ${ `4`(x1, x2): T2 | contents2 } // Hole
  *      ...
  *    }
  *    ```
  *  to
  *    ```
  *     unpickleExprV2(
- *       pickled = [[ // PICKLED TASTY
- *       @TypeSplice type X0 // with bounds that do not contain captured types
- *       @TypeSplice type X1 // with bounds that do not contain captured types
+ *       pickled = tasty""" // PICKLED TASTY
+ *         @TypeSplice type X0 // with bounds that do not contain captured types
+ *         type X1
  *         val x1 = ???
  *         val x2 = ???
  *         ...
- *      {{{ 0 | x1 | | T0 }}} // hole
- *      ...
- *      {{{ 1 | x2 | | T1 }}} // hole
- *      ...
- *      {{{ 2 | x1, x2 | | T2 }}} // hole
+ *         ${ `0`(x1): T0 } // Hole
  *         ...
- *       ]],
+ *         ${ `1`[X1](x2): T1 } // Hole
+ *         ...
+ *         ${ `2`(x1, x2): T2 } // Hole
+ *         ...
+ *       """,
  *       typeHole = (idx: Int, args: List[Any]) => idx match {
  *         case 0 => contentsTpe0.apply(args(0).asInstanceOf[Type[?]]) // beta reduced
- *         case 1 => contentsTpe1.apply(args(0).asInstanceOf[Type[?]]) // beta reduced
  *       },
  *       termHole = (idx: Int, args: List[Any], quotes: Quotes) => idx match {
- *         case 3 => content0.apply(args(0).asInstanceOf[Expr[U1]]).apply(quotes) // beta reduced
- *         case 4 => content1.apply(args(0).asInstanceOf[Expr[U2]]).apply(quotes) // beta reduced
- *         case 5 => content2.apply(args(0).asInstanceOf[Expr[U1]], args(1).asInstanceOf[Expr[U2]]).apply(quotes) // beta reduced
+ *         case 0 => content0.apply(args(0).asInstanceOf[Expr[U1]]).apply(quotes) // beta reduced
+ *         case 1 => content1.apply(args(0).asInstanceOf[Expr[U2]]).apply(quotes) // beta reduced
+ *         case 2 => content2.apply(args(0).asInstanceOf[Expr[U1]], args(1).asInstanceOf[Expr[U2]]).apply(quotes) // beta reduced
  *       },
  *     )
  *    ```

--- a/compiler/src/dotty/tools/dotc/transform/Splicing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicing.scala
@@ -132,7 +132,7 @@ class Splicing extends MacroTransform:
             case None =>
               val holeIdx = numHoles
               numHoles += 1
-              val hole = tpd.Hole(false, holeIdx, Nil, ref(qual), TypeTree(tp))
+              val hole = tpd.Hole(false, holeIdx, Nil, Nil, ref(qual), TypeTree(tp))
               typeHoles.put(qual.symbol, hole)
               hole
           cpy.TypeDef(tree)(rhs = hole)
@@ -199,7 +199,6 @@ class Splicing extends MacroTransform:
       val newTree = transform(tree)
       val (typeRefs, typeBindings) = typeBindingMap.values.toList.unzip
       val (termRefs, termBindings) = termBindingMap.values.toList.unzip
-      val refs = typeRefs ::: termRefs
       val bindings = typeBindings ::: termBindings
       val bindingsTypes = bindings.map(_.termRef.widenTermRefExpr)
       val methType = MethodType(bindingsTypes, newTree.tpe)
@@ -207,7 +206,7 @@ class Splicing extends MacroTransform:
       val ddef = DefDef(meth, List(bindings), newTree.tpe, newTree.changeOwner(ctx.owner, meth))
       val fnType = defn.FunctionType(bindings.size, isContextual = false).appliedTo(bindingsTypes :+ newTree.tpe)
       val closure = Block(ddef :: Nil, Closure(Nil, ref(meth), TypeTree(fnType)))
-      tpd.Hole(true, holeIdx, refs, closure, TypeTree(tpe))
+      tpd.Hole(true, holeIdx, typeRefs, termRefs, closure, TypeTree(tpe))
 
     override def transform(tree: tpd.Tree)(using Context): tpd.Tree =
       tree match

--- a/compiler/src/dotty/tools/dotc/transform/Splicing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicing.scala
@@ -189,8 +189,8 @@ class Splicing extends MacroTransform:
    *  ```
    */
   private class SpliceTransformer(spliceOwner: Symbol, isCaptured: Symbol => Boolean) extends Transformer:
-    private val typeBindingMap = mutable.Map.empty[Symbol, (Tree, Symbol)]
-    private val termBindingMap = mutable.Map.empty[Symbol, (Tree, Symbol)]
+    private val typeBindingMap = mutable.LinkedHashMap.empty[Symbol, (Tree, Symbol)]
+    private val termBindingMap = mutable.LinkedHashMap.empty[Symbol, (Tree, Symbol)]
     /** Reference to the `Quotes` instance of the current level 1 splice */
     private var quotes: Tree | Null = null // TODO: add to the context
     private var healedTypes: QuoteTypeTags | Null = null // TODO: add to the context

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -168,7 +168,7 @@ trait QuotesAndSplices {
     val tpt = typedType(tree.tpt)
     assignType(tree, tpt)
 
-  def typedPickledHole(tree: untpd.PickledHole, pt: Type)(using Context): Tree =
+  def typedTastyQuoteHole(tree: untpd.TastyQuoteHole, pt: Type)(using Context): Tree =
     val tpt = typedType(tree.tpt)
     assignType(tree, tpt)
 

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -168,6 +168,10 @@ trait QuotesAndSplices {
     val tpt = typedType(tree.tpt)
     assignType(tree, tpt)
 
+  def typedPickledHole(tree: untpd.PickledHole, pt: Type)(using Context): Tree =
+    val tpt = typedType(tree.tpt)
+    assignType(tree, tpt)
+
   private def checkSpliceOutsideQuote(tree: untpd.Tree)(using Context): Unit =
     if (level == 0 && !ctx.owner.ownersIterator.exists(_.isInlineMethod))
       report.error("Splice ${...} outside quotes '{...} or inline method", tree.srcPos)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -536,7 +536,7 @@ trait TypeAssigner {
   def assignType(tree: untpd.Hole, tpt: Tree)(using Context): Hole =
     tree.withType(tpt.tpe)
 
-  def assignType(tree: untpd.PickledHole, tpt: Tree)(using Context): PickledHole =
+  def assignType(tree: untpd.TastyQuoteHole, tpt: Tree)(using Context): TastyQuoteHole =
     tree.withType(tpt.tpe)
 }
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -536,6 +536,8 @@ trait TypeAssigner {
   def assignType(tree: untpd.Hole, tpt: Tree)(using Context): Hole =
     tree.withType(tpt.tpe)
 
+  def assignType(tree: untpd.PickledHole, tpt: Tree)(using Context): PickledHole =
+    tree.withType(tpt.tpe)
 }
 
 object TypeAssigner extends TypeAssigner:

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3035,7 +3035,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           case tree: untpd.Splice => typedSplice(tree, pt)
           case tree: untpd.MacroTree => report.error("Unexpected macro", tree.srcPos); tpd.nullLiteral  // ill-formed code may reach here
           case tree: untpd.Hole => typedHole(tree, pt)
-          case tree: untpd.PickledHole => typedPickledHole(tree, pt)
+          case tree: untpd.TastyQuoteHole => typedTastyQuoteHole(tree, pt)
           case _ => typedUnadapted(desugar(tree, pt), pt, locked)
         }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3035,6 +3035,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           case tree: untpd.Splice => typedSplice(tree, pt)
           case tree: untpd.MacroTree => report.error("Unexpected macro", tree.srcPos); tpd.nullLiteral  // ill-formed code may reach here
           case tree: untpd.Hole => typedHole(tree, pt)
+          case tree: untpd.PickledHole => typedPickledHole(tree, pt)
           case _ => typedUnadapted(desugar(tree, pt), pt, locked)
         }
 

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -37,7 +37,8 @@ object MiMaFilters {
     ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyBuffer.reset"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyFormat.APPLYsigpoly"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyHash.pjwHash64"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.util.Util.dble")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.util.Util.dble"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyFormat.HOLETYPES"),
   )
   val Interfaces: Seq[ProblemFilter] = Seq(
     ProblemFilters.exclude[ReversedMissingMethodProblem]("dotty.tools.dotc.interfaces.Diagnostic.diagnosticRelatedInformation"),

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -122,7 +122,10 @@ Standard-Section: "ASTs" TopLevelStat*
                   MATCHtpt       Length bound_Term? sel_Term CaseDef*              -- sel match { CaseDef } where `bound` is optional upper bound of all rhs
                   BYNAMEtpt             underlying_Term                            -- => underlying
                   SHAREDterm            term_ASTRef                                -- Link to previously serialized term
-                  HOLE           Length idx_Nat tpe_Type arg_Tree*                 -- Splice hole with index `idx`, the type of the hole `tpe`, type and term arguments of the hole `arg`s
+                  HOLE           Length idx_Nat tpe_Type HoleTypes? arg_Tree*      -- Splice hole with index `idx`, the type of the hole `tpe`, type arguments of the hole `targ`s and term arguments of the hole `arg`s
+                                                                                      -- Note: From 3.0 to 3.3 `args` could contain type arguments as well. This is no longer the case.
+  HoleTypes     = HOLETYPES      Length targ_Type*
+
 
 
   CaseDef       = CASEDEF        Length pat_Term rhs_Tree guard_Tree?              -- case pat if guard => rhs
@@ -586,6 +589,7 @@ object TastyFormat {
   final val MATCHtpt = 191
   final val MATCHCASEtype = 192
 
+  final val HOLETYPES = 254
   final val HOLE = 255
 
   final val firstNatTreeTag = SHAREDterm
@@ -600,6 +604,7 @@ object TastyFormat {
     firstASTTreeTag <= tag && tag <= BOUNDED ||
     firstNatASTTreeTag <= tag && tag <= NAMEDARG ||
     firstLengthTreeTag <= tag && tag <= MATCHtpt ||
+    tag == HOLETYPES ||
     tag == HOLE
 
   def isParamTag(tag: Int): Boolean = tag == PARAM || tag == TYPEPARAM
@@ -804,6 +809,7 @@ object TastyFormat {
     case PRIVATEqualified => "PRIVATEqualified"
     case PROTECTEDqualified => "PROTECTEDqualified"
     case HOLE => "HOLE"
+    case HOLETYPES => "HOLETYPES"
   }
 
   /** @return If non-negative, the number of leading references (represented as nats) of a length/trees entry.

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -124,7 +124,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   SHAREDterm            term_ASTRef                                -- Link to previously serialized term
                   HOLE           Length idx_Nat tpe_Type HoleTypes? arg_Tree*      -- Splice hole with index `idx`, the type of the hole `tpe`, type arguments of the hole `targ`s and term arguments of the hole `arg`s
                                                                                       -- Note: From 3.0 to 3.3 `args` could contain type arguments as well. This is no longer the case.
-  HoleTypes     = HOLETYPES      Length targ_Type*
+  HoleTypes     = HOLETYPES      Length targ_Tree*
 
 
 

--- a/tests/pos-macros/captured-type/Macro_1.scala
+++ b/tests/pos-macros/captured-type/Macro_1.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+inline def foo[U](u: U): U = ${ fooImpl[U]('u) }
+
+def fooImpl[U: Type](u: Expr[U])(using Quotes): Expr[U] = '{
+  def f[T](x: T): T = ${ identity('{ x: T }) }
+  f[U]($u)
+}

--- a/tests/pos-macros/captured-type/Test_2.scala
+++ b/tests/pos-macros/captured-type/Test_2.scala
@@ -1,0 +1,3 @@
+def test =
+  foo(1)
+  foo("abc")


### PR DESCRIPTION
This is a new encoding of HOLE that differentiates between type and
term arguments of the hole.

```
Term      = ...
            HOLE Length idx_Nat tpe_Type HoleTypes? arg_Tree*
                -- Splice hole with index `idx`, the type of the hole `tpe`,
                   type arguments of the hole `targ`s and term arguments
                   of the hole `arg`s
HoleTypes = HOLETYPES Length targ_Type*
```

We will only have hole `targs` if there is a type defined in a quote and used in a nested quote. Most of the time we do not have those types and therefore no overhead in the encoding compared to before this change.

Based on #17144