### PR TITLE
Refactor: Improve error messaging in sidebar YAML parser

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
@@ -45,13 +45,13 @@ object Sidebar:
       Sidebar.Category(Option.when(title.nonEmpty)(title), Option.when(index.nonEmpty)(index), subsection.asScala.map(toSidebar(_, content)).toList, Option.when(dir.nonEmpty)(dir))
     case RawInput(title, page, index, subsection, dir, hidden) =>
       if title.isEmpty() then
-        val msg = "Error parsing YAML configuration file: Title is not provided."
+        val msg = s"Error parsing YAML configuration file: 'title' is not provided."
         report.error(s"$msg\n$schemaMessage")
       else if title.nonEmpty && (page.isEmpty() || index.isEmpty()) then
-        val msg = "Error parsing YAML configuration file: Index or page path to at least one page is missing."
+        val msg = s"Error parsing YAML configuration file: 'index' or 'page' path is missing for title '$title'."
         report.error(s"$msg\n$schemaMessage")
       else
-        val msg = "The parsing seems not to have been done correctly."
+        val msg = s"The parsing seems not to have been done correctly."
         report.warning(s"$msg\n$schemaMessage")
       Sidebar.Page(None, page, hidden)
 

--- a/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
@@ -55,7 +55,7 @@ object Sidebar:
         report.warning(s"$msg\n$schemaMessage")
       Sidebar.Page(None, page, hidden)
 
-  private def schemaMessage: String =
+  def schemaMessage: String =
     s"""Static site YAML configuration file should comply with the following description:
       |The root element of static site needs to be <subsection>
       |`title` and `directory` properties are ignored in root subsection.
@@ -73,8 +73,7 @@ object Sidebar:
       |  hidden: <boolean> # optional - Default value is false.
       |
       |For more information visit:
-      |https://docs.scala-lang.org/scala3/guides/scaladoc/static-site.html
-      |""".stripMargin
+      |https://docs.scala-lang.org/scala3/guides/scaladoc/static-site.html""".stripMargin
 
   def load(content: String | java.io.File)(using CompilerContext): Sidebar.Category =
     import scala.util.Try

--- a/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
@@ -44,13 +44,15 @@ object Sidebar:
     case RawInput(title, page, index, subsection, dir, hidden) if page.isEmpty && (!subsection.isEmpty() || !index.isEmpty()) =>
       Sidebar.Category(Option.when(title.nonEmpty)(title), Option.when(index.nonEmpty)(index), subsection.asScala.map(toSidebar(_, content)).toList, Option.when(dir.nonEmpty)(dir))
     case RawInput(title, page, index, subsection, dir, hidden) =>
-      val errors = (title.isEmpty(), page.isEmpty(), index.isEmpty(), subsection.isEmpty(), dir.isEmpty())
-      errors match
-        case (true, _, _, _, _) =>
-          report.error(s"Title is not provided.\n$schemaMessage")
-        case (false, true, true, _, _) =>
-          report.error(s"Index or page path to at least one page is missing.\n$schemaMessage")
-        case _ => report.error(s"Error parsing YAML configuration file.\n$schemaMessage")
+      if title.isEmpty() then
+        val msg = "Error parsing YAML configuration file: Title is not provided."
+        report.error(s"$msg\n$schemaMessage")
+      else if title.nonEmpty && (page.isEmpty() || index.isEmpty()) then
+        val msg = "Error parsing YAML configuration file: Index or page path to at least one page is missing."
+        report.error(s"$msg\n$schemaMessage")
+      else
+        val msg = "The parsing seems not to have been done correctly."
+        report.warning(s"$msg\n$schemaMessage")
       Sidebar.Page(None, page, hidden)
 
   private def schemaMessage: String =

--- a/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
@@ -32,17 +32,6 @@ object Sidebar:
 
   private object RawInputTypeRef extends TypeReference[RawInput]
 
-  private def pageWithNoTitle(content: String | java.io.File): String =
-    val fileContent = content match {
-    case file: java.io.File => Source.fromFile(file).getLines().mkString("\n")
-    case str: String => str
-    }
-    val lines = fileContent.split("\n")
-    lines.zipWithIndex
-    .find { case (line, i) => line.trim.startsWith("page:") && !lines(i - 1).contains("- title:") }
-    .map(_._1.trim.stripPrefix("page:"))
-    .getOrElse("")
-
   private def toSidebar(r: RawInput, content: String | java.io.File)(using CompilerContext): Sidebar = r match
     case RawInput(title, page, index, subsection, dir, hidden) if page.nonEmpty && index.isEmpty && subsection.isEmpty() =>
       val sidebarPath = content match
@@ -57,14 +46,13 @@ object Sidebar:
       Sidebar.Category(Option.when(title.nonEmpty)(title), Option.when(index.nonEmpty)(index), subsection.asScala.map(toSidebar(_, content)).toList, Option.when(dir.nonEmpty)(dir))
     case RawInput(title, page, index, subsection, dir, hidden) =>
       if title.isEmpty() && index.isEmpty() then
-        val page = pageWithNoTitle(content).trim()
-        val msg = s"Error parsing YAML configuration file: 'title' is not provided for page '$page'."
+        val msg = "`title` property is missing for some page."
         report.error(s"$msg\n$schemaMessage")
       else if title.nonEmpty && (page.isEmpty() || index.isEmpty()) then
         val msg = s"Error parsing YAML configuration file: 'index' or 'page' path is missing for title '$title'."
         report.error(s"$msg\n$schemaMessage")
       else
-        val msg = s"Error parsing YAML configuration file."
+        val msg = "Problem when parsing YAML configuration file."
         report.warning(s"$msg\n$schemaMessage")
       Sidebar.Page(None, page, hidden)
 

--- a/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
@@ -91,7 +91,7 @@ class SidebarParserTest:
       |          - page: my-page6/my-page6/my-page6.md
       """.stripMargin
 
-  private val msgNoTitle = "Error parsing YAML configuration file: 'title' is not provided for page 'my-page7/my-page7.md'."
+  private val msgNoTitle = "`title` property is missing for some page."
   private val msgNoPage = "Error parsing YAML configuration file: 'index' or 'page' path is missing for title 'My title'."
 
   private def schemaMessage: String = Sidebar.schemaMessage

--- a/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
@@ -34,6 +34,55 @@ class SidebarParserTest:
       |          - page: my-page6/my-page6/my-page6.md
       """.stripMargin
 
+  private val sidebarErrorNoTitle =
+      """index: index.md
+      |subsection:
+      |    page: my-page1.md
+      |  - page: my-page2.md
+      |  - page: my-page3/subsection
+      |  - title: Reference
+      |    subsection:
+      |      - page: my-page3.md
+      |        hidden: true
+      |  - index: my-page4/index.md
+      |    subsection:
+      |      - page: my-page4/my-page4.md
+      |  - title: My subsection
+      |    index: my-page5/index.md
+      |    subsection:
+      |      - page: my-page5/my-page5.md
+      |  - subsection:
+      |      - page: my-page7/my-page7.md
+      |  - index: my-page6/index.md
+      |    subsection:
+      |      - index: my-page6/my-page6/index.md
+      |        subsection:
+      |          - page: my-page6/my-page6/my-page6.md
+      """.stripMargin
+
+  private val msg = "Error parsing YAML configuration file: Title is not provided."
+
+  private def schemaMessage: String =
+    s"""Static site YAML configuration file should comply with the following description:
+      |The root element of static site needs to be <subsection>
+      |`title` and `directory` properties are ignored in root subsection.
+      |
+      |<subsection>:
+      |  title: <string> # optional - Default value is file name. Title can be also set using front-matter.
+      |  index: <string> # optional - If not provided, default empty index template is generated.
+      |  directory: <string> # optional - By default, directory name is title name in kebab case.
+      |  subsection: # optional - If not provided, pages are loaded from the index directory
+      |    - <subsection> | <page>
+      |  # either index or subsection needs to be present
+      |<page>:
+      |  title: <string> # optional - Default value is file name. Title can be also set using front-matter.
+      |  page: <string>
+      |  hidden: <boolean> # optional - Default value is false.
+      |
+      |For more information visit:
+      |https://docs.scala-lang.org/scala3/guides/scaladoc/static-site.html
+      |""".stripMargin
+
   @Test
   def loadSidebar(): Unit = assertEquals(
     Sidebar.Category(
@@ -53,3 +102,16 @@ class SidebarParserTest:
     ),
     Sidebar.load(sidebar)(using testContext)
   )
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def loadSidebarError(): Unit =
+    assertEquals(
+    Sidebar.Category(
+      None,
+      None,
+      List(),
+      None
+    ),
+    Sidebar.load(sidebarErrorNoTitle)(using testContext)
+    )
+    throw new IllegalArgumentException(s"$msg\n$schemaMessage")

--- a/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
@@ -3,6 +3,10 @@ package site
 
 import org.junit.Test
 import org.junit.Assert._
+import dotty.tools.scaladoc.site.Sidebar
+import dotty.tools.scaladoc.site.Sidebar.RawInput
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 
 // TODO add negaitve and more details tests
 class SidebarParserTest:
@@ -34,10 +38,10 @@ class SidebarParserTest:
       |          - page: my-page6/my-page6/my-page6.md
       """.stripMargin
 
-  private val sidebarErrorNoTitle =
-      """index: index.md
+  private val sidebarErrorNoPage =
+    """index: index.md
       |subsection:
-      |    page: my-page1.md
+      |  - title: My title
       |  - page: my-page2.md
       |  - page: my-page3/subsection
       |  - title: Reference
@@ -60,28 +64,12 @@ class SidebarParserTest:
       |          - page: my-page6/my-page6/my-page6.md
       """.stripMargin
 
-  private val msg = "Error parsing YAML configuration file: Title is not provided."
+  private val msgNoTitle = "Error parsing YAML configuration file: Title is not provided."
+  private val msgNoPage = "Error parsing YAML configuration file: Index or page path to at least one page is missing."
 
-  private def schemaMessage: String =
-    s"""Static site YAML configuration file should comply with the following description:
-      |The root element of static site needs to be <subsection>
-      |`title` and `directory` properties are ignored in root subsection.
-      |
-      |<subsection>:
-      |  title: <string> # optional - Default value is file name. Title can be also set using front-matter.
-      |  index: <string> # optional - If not provided, default empty index template is generated.
-      |  directory: <string> # optional - By default, directory name is title name in kebab case.
-      |  subsection: # optional - If not provided, pages are loaded from the index directory
-      |    - <subsection> | <page>
-      |  # either index or subsection needs to be present
-      |<page>:
-      |  title: <string> # optional - Default value is file name. Title can be also set using front-matter.
-      |  page: <string>
-      |  hidden: <boolean> # optional - Default value is false.
-      |
-      |For more information visit:
-      |https://docs.scala-lang.org/scala3/guides/scaladoc/static-site.html
-      |""".stripMargin
+  private def schemaMessage: String = Sidebar.schemaMessage
+
+  private val noPageExpectedError = s"$msgNoPage\n$schemaMessage\nPage my-page2.md does not exist.\nPage my-page3/subsection does not exist.\nPage my-page3.md does not exist.\nPage my-page4/my-page4.md does not exist.\nPage my-page5/my-page5.md does not exist.\nPage my-page7/my-page7.md does not exist.\nPage my-page6/my-page6/my-page6.md does not exist."
 
   @Test
   def loadSidebar(): Unit = assertEquals(
@@ -103,15 +91,11 @@ class SidebarParserTest:
     Sidebar.load(sidebar)(using testContext)
   )
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def loadSidebarError(): Unit =
-    assertEquals(
-    Sidebar.Category(
-      None,
-      None,
-      List(),
-      None
-    ),
-    Sidebar.load(sidebarErrorNoTitle)(using testContext)
-    )
-    throw new IllegalArgumentException(s"$msg\n$schemaMessage")
+    val out = new ByteArrayOutputStream()
+    Console.withErr(new PrintStream(out)) {
+      Sidebar.load(sidebarErrorNoPage)(using testContext)
+    }
+    val error = out.toString().trim()
+    assertEquals(noPageExpectedError, error)

--- a/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
@@ -38,6 +38,32 @@ class SidebarParserTest:
       |          - page: my-page6/my-page6/my-page6.md
       """.stripMargin
 
+  private val sidebarNoTitle =
+    """index: index.md
+      |subsection:
+      |    page: my-page1.md
+      |  - page: my-page2.md
+      |  - page: my-page3/subsection
+      |  - title: Reference
+      |    subsection:
+      |      - page: my-page3.md
+      |        hidden: true
+      |  - index: my-page4/index.md
+      |    subsection:
+      |      - page: my-page4/my-page4.md
+      |  - title: My subsection
+      |    index: my-page5/index.md
+      |    subsection:
+      |      - page: my-page5/my-page5.md
+      |  - subsection:
+      |      - page: my-page7/my-page7.md
+      |  - index: my-page6/index.md
+      |    subsection:
+      |      - index: my-page6/my-page6/index.md
+      |        subsection:
+      |          - page: my-page6/my-page6/my-page6.md
+      """.stripMargin
+
   private val sidebarErrorNoPage =
     """index: index.md
       |subsection:
@@ -64,12 +90,10 @@ class SidebarParserTest:
       |          - page: my-page6/my-page6/my-page6.md
       """.stripMargin
 
-  private val msgNoTitle = "Error parsing YAML configuration file: Title is not provided."
-  private val msgNoPage = "Error parsing YAML configuration file: Index or page path to at least one page is missing."
+  private val msgNoTitle = "Error parsing YAML configuration file: 'title' is not provided."
+  private val msgNoPage = "Error parsing YAML configuration file: 'index' or 'page' path is missing for title 'My title'."
 
   private def schemaMessage: String = Sidebar.schemaMessage
-
-  private val noPageExpectedError = s"$msgNoPage\n$schemaMessage\nPage my-page2.md does not exist.\nPage my-page3/subsection does not exist.\nPage my-page3.md does not exist.\nPage my-page4/my-page4.md does not exist.\nPage my-page5/my-page5.md does not exist.\nPage my-page7/my-page7.md does not exist.\nPage my-page6/my-page6/my-page6.md does not exist."
 
   @Test
   def loadSidebar(): Unit = assertEquals(
@@ -92,10 +116,23 @@ class SidebarParserTest:
   )
 
   @Test
-  def loadSidebarError(): Unit =
+  def loadSidebarNoPageError: Unit =
     val out = new ByteArrayOutputStream()
     Console.withErr(new PrintStream(out)) {
       Sidebar.load(sidebarErrorNoPage)(using testContext)
     }
+    println(out.toString())
     val error = out.toString().trim()
-    assertEquals(noPageExpectedError, error)
+
+    assert(error.contains(msgNoPage) && error.contains(schemaMessage))
+
+
+  @Test
+  def loadSidebarNoTitleError(): Unit =
+    val out = new ByteArrayOutputStream()
+    Console.withErr(new PrintStream(out)) {
+      Sidebar.load(sidebarNoTitle)(using testContext)
+    }
+    val error = out.toString().trim()
+
+    assert(error.contains(msgNoTitle) && error.contains(schemaMessage))

--- a/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
@@ -8,7 +8,7 @@ import dotty.tools.scaladoc.site.Sidebar.RawInput
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 
-// TODO add negaitve and more details tests
+// TODO add negative and more details tests
 class SidebarParserTest:
 
   private val sidebar =
@@ -41,6 +41,7 @@ class SidebarParserTest:
   private val sidebarNoTitle =
     """index: index.md
       |subsection:
+      |  - title: My title
       |    page: my-page1.md
       |  - page: my-page2.md
       |  - page: my-page3/subsection
@@ -56,7 +57,7 @@ class SidebarParserTest:
       |    subsection:
       |      - page: my-page5/my-page5.md
       |  - subsection:
-      |      - page: my-page7/my-page7.md
+      |        page: my-page7/my-page7.md
       |  - index: my-page6/index.md
       |    subsection:
       |      - index: my-page6/my-page6/index.md
@@ -90,7 +91,7 @@ class SidebarParserTest:
       |          - page: my-page6/my-page6/my-page6.md
       """.stripMargin
 
-  private val msgNoTitle = "Error parsing YAML configuration file: 'title' is not provided."
+  private val msgNoTitle = "Error parsing YAML configuration file: 'title' is not provided for page 'my-page7/my-page7.md'."
   private val msgNoPage = "Error parsing YAML configuration file: 'index' or 'page' path is missing for title 'My title'."
 
   private def schemaMessage: String = Sidebar.schemaMessage


### PR DESCRIPTION
### Validations
On this PR I added some errors for different conditions : 

- [x] Error when a path in page is wrong 
- [x] Error when an index or a page path for a title is missing 
(It is therefore activated with the `title.isEmpty` condition. So far I've only found that when a user forgets a title it gives r = RawInput(,,,[],,false) in the toSidebar function. Thus, title.isEmpty is necessarily empty. However, if another error produces an r = RawInput(,,[],,false). This condition and its error message will no longer make sense. I am therefore less sure about this condition.)
- [x] Error when a title for a page is missing

- [x]  Warning when something is wrong but it does not interfere with the generation.

### Tests
I added two functions in SidebarParserTest.
The purpose of these functions is to check if it contains the `schemaMessage` which is the general template sent in all error messages + the unique error message for each error.

### IE
I also noticed that @gringrape wanted to work on this issue, if a code has already been done on his side, I am quite open to resume the work started or to close my PR to leave his. I am also open to any suggestions for adding errors.

Fixes: #15326 