### PR TITLE
Correction from an absolute value to a relative value for wide screens.

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/layout/content.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/content.css
@@ -27,7 +27,7 @@
 
 #content > div:first-child {
   width: calc(100vw - 232px - 313px - 68px * 3);
-  max-width: 720px;
+  max-width: 70%;
 }
 
 


### PR DESCRIPTION
In this PR, I have the absolute value in relative value, which allows the content to better adapt to screen sizes.
I didn't think it was necessary to add a media query to change the absolute value only at a certain screen size but I can do it if needed.

## Before 
### 2000px width 
<img width="600" alt="Screenshot 2023-04-11 at 16 16 06" src="https://user-images.githubusercontent.com/44496264/231193700-8d5b926d-e54e-46e8-b7a5-23d565b1a36a.png">

### 3000px width
<img width="600" alt="Screenshot 2023-04-11 at 16 16 15" src="https://user-images.githubusercontent.com/44496264/231193755-cbafcba2-b38e-4fb1-964f-f3e26207bd5b.png">

## After
### 2000px width
<img width="600" alt="Screenshot 2023-04-11 at 16 17 53" src="https://user-images.githubusercontent.com/44496264/231193766-bd16bf53-0462-41e9-b799-83eff29b1c68.png">

### 3000px width
<img width="600" alt="Screenshot 2023-04-11 at 16 17 36" src="https://user-images.githubusercontent.com/44496264/231193797-edb1fd7d-65ba-4e86-a771-943dd9a9b485.png">

Fixes: #17217
