### PR TITLE
Feat: Add a custom icon

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/components/button/icon-button.css
+++ b/scaladoc/resources/dotty_res/styles/theme/components/button/icon-button.css
@@ -539,9 +539,15 @@
   display: none;
 }
 
-.icon-button.custom::after{
-  content: var(--bgimage);
-  max-width: fit-content;
+.icon-button.custom::after {
+  content: "";
+  background-image: var(--bgimage);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .theme-dark .icon-button.custom-dark{
@@ -549,8 +555,14 @@
 }
 
 .theme-dark .icon-button.custom-dark::after{
-  content: var(--bgimage-dark);
-  max-width: fit-content;
+  content: "";
+  background-image: var(--bgimage-dark);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .theme-dark .icon-button.custom{

--- a/scaladoc/resources/dotty_res/styles/theme/components/button/icon-button.css
+++ b/scaladoc/resources/dotty_res/styles/theme/components/button/icon-button.css
@@ -539,8 +539,18 @@
   display: none;
 }
 
+.icon-button.custom::after{
+  content: var(--bgimage);
+  max-width: fit-content;
+}
+
 .theme-dark .icon-button.custom-dark{
   display: unset;
+}
+
+.theme-dark .icon-button.custom-dark::after{
+  content: var(--bgimage-dark);
+  max-width: fit-content;
 }
 
 .theme-dark .icon-button.custom{

--- a/scaladoc/resources/dotty_res/styles/theme/components/button/icon-button.css
+++ b/scaladoc/resources/dotty_res/styles/theme/components/button/icon-button.css
@@ -533,6 +533,28 @@
   content: url("../../../../images/icon-buttons/gitter/dark/selected.svg");
 }
 
+/* custom button */
+
+.icon-button.custom-dark{
+  display: none;
+}
+
+.theme-dark .icon-button.custom-dark{
+  display: unset;
+}
+
+.theme-dark .icon-button.custom{
+  display: none;
+}
+
+.icon-button.custom:hover{
+  opacity: 0.8;
+}
+
+.icon-button.custom-dark:hover{
+  opacity: 0.8;
+}
+
 /* copy button */
 
 .icon-button.copy-button::after {

--- a/scaladoc/resources/dotty_res/styles/theme/layout/footer.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/footer.css
@@ -64,7 +64,7 @@
     display: none;
   }
 
-  #footer.mobile-footer  .text-mobile {
+  #footer.mobile-footer .text-mobile {
     display: flex;
     width: 100%;
     justify-content: center;
@@ -78,5 +78,5 @@
   #footer.mobile-footer > .text-mobile {
     display: flex;
   }
-  
+
 }

--- a/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
@@ -43,7 +43,8 @@ class ScaladocSettings extends SettingGroup with AllScalaSettings:
 
   val socialLinks: Setting[List[String]] =
     MultiStringSetting("-social-links", "social-links",
-      "Links to social sites. '[github|twitter|gitter|discord]::link' syntax is used.")
+      "Links to social sites. '[github|twitter|gitter|discord]::link' syntax is used." +
+        "'custom::link::white_icon_name::black_icon_name' is also allowed, in this case icons must be present in 'images/'' directory.")
 
   val deprecatedSkipPackages: Setting[List[String]] =
     MultiStringSetting("-skip-packages", "packages", "Deprecated, please use `-skip-by-id` or `-skip-by-regex`")

--- a/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
@@ -43,8 +43,7 @@ class ScaladocSettings extends SettingGroup with AllScalaSettings:
 
   val socialLinks: Setting[List[String]] =
     MultiStringSetting("-social-links", "social-links",
-      "Links to social sites. '[github|twitter|gitter|discord]::link' syntax is used." +
-        "'custom::link::white_icon_name::black_icon_name' is also allowed, in this case icons must be present in 'images/'' directory.")
+      "Links to social sites. '[github|twitter|gitter|discord]::link' or 'custom::link::light_icon_file_name[::dark_icon_file_name]' syntax is used. For custom links, the icons must be present in '_assets/images/'")
 
   val deprecatedSkipPackages: Setting[List[String]] =
     MultiStringSetting("-skip-packages", "packages", "Deprecated, please use `-skip-by-id` or `-skip-by-regex`")

--- a/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
@@ -1,10 +1,15 @@
 package dotty.tools.scaladoc
 
-enum SocialLinks(val url: String, val className: String):
-  case Github(ghUrl: String) extends SocialLinks(ghUrl, "gh")
-  case Twitter(tUrl: String) extends SocialLinks(tUrl, "twitter")
-  case Gitter(gUrl: String) extends SocialLinks(gUrl, "gitter")
-  case Discord(dUrl: String) extends SocialLinks(dUrl, "discord")
+import java.nio.file.Path
+import java.nio.file.Paths
+import dotty.tools.dotc.core.Contexts.Context
+
+enum SocialLinks(val url: String, val whiteIcon: String, val darkIcon: String, val className: String):
+  case Github(ghUrl: String) extends SocialLinks(ghUrl, "", "", "gh")
+  case Twitter(tUrl: String) extends SocialLinks(tUrl, "", "", "twitter")
+  case Gitter(gUrl: String) extends SocialLinks(gUrl, "", "", "gitter")
+  case Discord(dUrl: String) extends SocialLinks(dUrl, "", "", "discord")
+  case Custom(cUrl: String, firstIcon: String, secondIcon: String) extends SocialLinks(cUrl, firstIcon, secondIcon, "custom")
 
 object SocialLinks:
   def parse(s: String): Either[String, SocialLinks] =
@@ -19,5 +24,8 @@ object SocialLinks:
       case "gitter" => Left(errorPrefix + "For 'gitter' arg expected one argument: url")
       case "discord" if splitted.size == 2 => Right(Discord(splitted(1)))
       case "discord" => Left(errorPrefix + "For 'discord' arg expected one argument: url")
+      case "custom" if splitted.size == 4 => Right(Custom(splitted(1), splitted(2), splitted(3)))
+      case "custom" if splitted.size == 3 => Right(Custom(splitted(1), splitted(2), splitted(2)))
+      case "custom" => Left(errorPrefix + "For 'custom' arg expected three arguments: url, white icon name, black icon name")
       case _ => Left(errorPrefix)
     }

--- a/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
@@ -14,7 +14,7 @@ object SocialLinks:
     val errorPrefix = s"Social links arg $s is invalid: "
     val splitted = s.split("::")
 
-    splitted.head match {
+    splitted.head.toLowerCase match {
       case "github" if splitted.size == 2 => Right(Github(splitted(1)))
       case "github" => Left(errorPrefix + "For 'github' arg expected one argument: url")
       case "twitter" if splitted.size == 2 => Right(Twitter(splitted(1)))
@@ -25,6 +25,6 @@ object SocialLinks:
       case "discord" => Left(errorPrefix + "For 'discord' arg expected one argument: url")
       case LowercaseNamePattern() if splitted.size == 4 => Right(Custom(splitted(1), splitted(2), splitted(3)))
       case LowercaseNamePattern() if splitted.size == 3 => Right(Custom(splitted(1), splitted(2), splitted(2)))
-      case LowercaseNamePattern() => Left(errorPrefix + "For 'custom' two minimum arguments are expected: url, white icon name, [dark icon name]")
+      case LowercaseNamePattern() => Left(errorPrefix + "For the 'custom' link, a minimum of two arguments is expected: URL, light icon file name, [dark icon file name]")
       case _ => Left(errorPrefix)
     }

--- a/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
@@ -4,12 +4,12 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import dotty.tools.dotc.core.Contexts.Context
 
-enum SocialLinks(val url: String, val whiteIcon: String, val darkIcon: String, val className: String):
-  case Github(ghUrl: String) extends SocialLinks(ghUrl, "", "", "gh")
-  case Twitter(tUrl: String) extends SocialLinks(tUrl, "", "", "twitter")
-  case Gitter(gUrl: String) extends SocialLinks(gUrl, "", "", "gitter")
-  case Discord(dUrl: String) extends SocialLinks(dUrl, "", "", "discord")
-  case Custom(cUrl: String, firstIcon: String, secondIcon: String) extends SocialLinks(cUrl, firstIcon, secondIcon, "custom")
+enum SocialLinks(val url: String, val className: String):
+  case Github(ghUrl: String) extends SocialLinks(ghUrl, "gh")
+  case Twitter(tUrl: String) extends SocialLinks(tUrl, "twitter")
+  case Gitter(gUrl: String) extends SocialLinks(gUrl, "gitter")
+  case Discord(dUrl: String) extends SocialLinks(dUrl, "discord")
+  case Custom(cUrl: String, lightIcon: String, darkIcon: String) extends SocialLinks(cUrl, "custom")
 
 object SocialLinks:
   def parse(s: String): Either[String, SocialLinks] =

--- a/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
@@ -8,9 +8,12 @@ enum SocialLinks(val url: String, val className: String):
   case Custom(cUrl: String, lightIcon: String, darkIcon: String) extends SocialLinks(cUrl, "custom")
 
 object SocialLinks:
+  val LowercaseNamePattern = "^[a-z]+$".r
+
   def parse(s: String): Either[String, SocialLinks] =
     val errorPrefix = s"Social links arg $s is invalid: "
     val splitted = s.split("::")
+
     splitted.head match {
       case "github" if splitted.size == 2 => Right(Github(splitted(1)))
       case "github" => Left(errorPrefix + "For 'github' arg expected one argument: url")
@@ -20,8 +23,8 @@ object SocialLinks:
       case "gitter" => Left(errorPrefix + "For 'gitter' arg expected one argument: url")
       case "discord" if splitted.size == 2 => Right(Discord(splitted(1)))
       case "discord" => Left(errorPrefix + "For 'discord' arg expected one argument: url")
-      case "custom" if splitted.size == 4 => Right(Custom(splitted(1), splitted(2), splitted(3)))
-      case "custom" if splitted.size == 3 => Right(Custom(splitted(1), splitted(2), splitted(2)))
-      case "custom" => Left(errorPrefix + "For 'custom' arg expected three arguments: url, white icon name, black icon name")
+      case LowercaseNamePattern() if splitted.size == 4 => Right(Custom(splitted(1), splitted(2), splitted(3)))
+      case LowercaseNamePattern() if splitted.size == 3 => Right(Custom(splitted(1), splitted(2), splitted(2)))
+      case LowercaseNamePattern() => Left(errorPrefix + "For 'custom' two minimum arguments are expected: url, white icon name, [dark icon name]")
       case _ => Left(errorPrefix)
     }

--- a/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/SocialLinks.scala
@@ -1,9 +1,5 @@
 package dotty.tools.scaladoc
 
-import java.nio.file.Path
-import java.nio.file.Paths
-import dotty.tools.dotc.core.Contexts.Context
-
 enum SocialLinks(val url: String, val className: String):
   case Github(ghUrl: String) extends SocialLinks(ghUrl, "gh")
   case Twitter(tUrl: String) extends SocialLinks(tUrl, "twitter")

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -2,9 +2,18 @@ package dotty.tools.scaladoc
 package renderers
 
 import util.HTML._
+import scala.jdk.CollectionConverters._
+import java.net.URI
+import java.net.URL
 import dotty.tools.scaladoc.site._
+import scala.util.Try
 import org.jsoup.Jsoup
+import java.nio.file.Paths
+import java.nio.file.Path
 import java.nio.file.Files
+import java.nio.file.FileVisitOption
+import java.io.File
+import dotty.tools.scaladoc.staticFileSymbolUUID
 
 class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: DocContext)
   extends Renderer(rootPackage, members, extension = "html"):
@@ -167,10 +176,10 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
     args.socialLinks.map { link =>
       a(href := link.url) (
         link match
-          case SocialLinks.Custom(_, lightIcon, darkIcon) => 
+          case SocialLinks.Custom(_, lightIcon, darkIcon) =>
             Seq(
-              img(cls := s"icon-button ${icon(link)}", src := s"../../../../images/$lightIcon"),
-              img(cls := s"icon-button ${icon(link)}-dark", src := s"../../../images/$darkIcon")
+              button(cls := s"icon-button ${icon(link)}", style := s"--bgimage:url(../../../../images/$lightIcon)"),
+              button(cls := s"icon-button ${icon(link)}-dark", style := s"--bgimage-dark:url(../../../../images/$darkIcon)")
             )
           case _ =>
             button(cls := s"icon-button ${icon(link)}")

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -2,18 +2,9 @@ package dotty.tools.scaladoc
 package renderers
 
 import util.HTML._
-import scala.jdk.CollectionConverters._
-import java.net.URI
-import java.net.URL
 import dotty.tools.scaladoc.site._
-import scala.util.Try
 import org.jsoup.Jsoup
-import java.nio.file.Paths
-import java.nio.file.Path
 import java.nio.file.Files
-import java.nio.file.FileVisitOption
-import java.io.File
-import dotty.tools.scaladoc.staticFileSymbolUUID
 
 class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: DocContext)
   extends Renderer(rootPackage, members, extension = "html"):

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -166,13 +166,14 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
     def icon(link: SocialLinks) = link.className
     args.socialLinks.map { link =>
       a(href := link.url) (
-        if icon(link) == "custom" then
-          Seq(
-            img(cls := s"icon-button ${icon(link)}", src := s"../../../../images/${link.whiteIcon}"),
-            img(cls := s"icon-button ${icon(link)}-dark", src := s"../../../../images/${link.darkIcon}")
-          )
-        else
-          button(cls := s"icon-button ${icon(link)}")
+        link match
+          case SocialLinks.Custom(_, lightIcon, darkIcon) => 
+            Seq(
+              img(cls := s"icon-button ${icon(link)}", src := s"../../../../images/$lightIcon"),
+              img(cls := s"icon-button ${icon(link)}-dark", src := s"../../../images/$darkIcon")
+            )
+          case _ =>
+            button(cls := s"icon-button ${icon(link)}")
       )
     }
 

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -166,7 +166,13 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
     def icon(link: SocialLinks) = link.className
     args.socialLinks.map { link =>
       a(href := link.url) (
-        button(cls := s"icon-button ${icon(link)}")
+        if icon(link) == "custom" then
+          Seq(
+            img(cls := s"icon-button ${icon(link)}", src := s"../../../../images/${link.whiteIcon}"),
+            img(cls := s"icon-button ${icon(link)}-dark", src := s"../../../../images/${link.darkIcon}")
+          )
+        else
+          button(cls := s"icon-button ${icon(link)}")
       )
     }
 
@@ -308,18 +314,7 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
             "Generated with"
           ),
           div(cls := "right-container")(
-            a(href := "https://github.com/lampepfl/dotty") (
-              button(cls := "icon-button gh")
-            ),
-            a(href := "https://twitter.com/scala_lang") (
-              button(cls := "icon-button twitter")
-            ),
-            a(href := "https://discord.com/invite/scala") (
-              button(cls := "icon-button discord"),
-            ),
-            a(href := "https://gitter.im/scala/scala") (
-              button(cls := "icon-button gitter"),
-            ),
+            socialLinks,
             div(cls := "text")(textFooter)
           ),
           div(cls := "text-mobile")(textFooter)

--- a/scaladoc/test/dotty/tools/scaladoc/SocialLinksTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/SocialLinksTest.scala
@@ -36,12 +36,17 @@ class SocialLinksTest:
     val expected = SocialLinks.Custom("https://custom.com/test", "custom", "custom-dark")
     assertEquals(expected, SocialLinks.parse(customLink).getOrElse(null))
 
+  @Test def customLinkUpper(): Unit =
+    val customLink = "Namecustom::https://custom.com/test::custom"
+    val expected = SocialLinks.Custom("https://custom.com/test", "custom", "custom")
+    assertEquals(expected, SocialLinks.parse(customLink).getOrElse(null))
+
   @Test def parseRegexError(): Unit =
-    val regexErrorLink = "nameCustom::https://custom.com/test::custom::custom-dark::custom"
+    val regexErrorLink = "nameCustom3::https://custom.com/test::custom::custom-dark::custom"
     val expected = s"Social links arg $regexErrorLink is invalid: "
     assertEquals(expected, SocialLinks.parse(regexErrorLink).left.getOrElse(null))
 
   @Test def parseLinkWithError(): Unit =
     val errorLink = "namecustom::https://custom.com/test::custom::custom-dark::custom"
-    val expected = s"Social links arg $errorLink is invalid: For 'custom' two minimum arguments are expected: url, white icon name, [dark icon name]"
+    val expected = s"Social links arg $errorLink is invalid: For the 'custom' link, a minimum of two arguments is expected: URL, light icon file name, [dark icon file name]"
     assertEquals(expected, SocialLinks.parse(errorLink).left.getOrElse(null))

--- a/scaladoc/test/dotty/tools/scaladoc/SocialLinksTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/SocialLinksTest.scala
@@ -1,0 +1,47 @@
+package dotty.tools.scaladoc
+
+import org.junit.Test
+import org.junit.Assert._
+import dotty.tools.scaladoc.SocialLinks
+
+class SocialLinksTest:
+
+  @Test def githubLink(): Unit =
+    val githubLink = "github::https://github.com/test"
+    val expected = SocialLinks.Github("https://github.com/test")
+    assertEquals(expected, SocialLinks.parse(githubLink).getOrElse(null))
+
+  @Test def twitterLink(): Unit =
+    val twitterLink = "twitter::https://twitter.com/test"
+    val expected = SocialLinks.Twitter("https://twitter.com/test")
+    assertEquals(expected, SocialLinks.parse(twitterLink).getOrElse(null))
+
+  @Test def gitterLink(): Unit =
+    val gitterLink = "gitter::https://gitter.im/test"
+    val expected = SocialLinks.Gitter("https://gitter.im/test")
+    assertEquals(expected, SocialLinks.parse(gitterLink).getOrElse(null))
+
+  @Test def discordLink(): Unit =
+    val discordLink = "discord::https://discord.gg/test"
+    val expected = SocialLinks.Discord("https://discord.gg/test")
+    assertEquals(expected, SocialLinks.parse(discordLink).getOrElse(null))
+
+  @Test def customLinkLight(): Unit =
+    val customLink = "namecustom::https://custom.com/test::custom"
+    val expected = SocialLinks.Custom("https://custom.com/test", "custom", "custom")
+    assertEquals(expected, SocialLinks.parse(customLink).getOrElse(null))
+
+  @Test def customLinkLightAndDark(): Unit =
+    val customLink = "namecustom::https://custom.com/test::custom::custom-dark"
+    val expected = SocialLinks.Custom("https://custom.com/test", "custom", "custom-dark")
+    assertEquals(expected, SocialLinks.parse(customLink).getOrElse(null))
+
+  @Test def parseRegexError(): Unit =
+    val regexErrorLink = "nameCustom::https://custom.com/test::custom::custom-dark::custom"
+    val expected = s"Social links arg $regexErrorLink is invalid: "
+    assertEquals(expected, SocialLinks.parse(regexErrorLink).left.getOrElse(null))
+
+  @Test def parseLinkWithError(): Unit =
+    val errorLink = "namecustom::https://custom.com/test::custom::custom-dark::custom"
+    val expected = s"Social links arg $errorLink is invalid: For 'custom' two minimum arguments are expected: url, white icon name, [dark icon name]"
+    assertEquals(expected, SocialLinks.parse(errorLink).left.getOrElse(null))


### PR DESCRIPTION
In this PR, I'm adding the new custom icons feature. This allows users to add one or more custom icons (in png or svg format).

- [x] Add custom
- [x] Src from the CSS file
- [x] Fix size for png
- [x] Multiple custom icons
- [x] The user must use a name in lowercase for custom icon 
- [x] Add tests 

### Code:

![image](https://github.com/lampepfl/dotty/assets/44496264/81c3d901-7403-40c6-bb11-667e3b5bd3ef)

IE:
Dark icon is optional so you can just put:
```"-social-links:custom::https://joyofcoding.org/sponsoring.html::joycoding.png,custom::lucasleblanc.com::lucasLogo.svg,github::https://github.com/Dedelweiss"```

### Result:
<img width="1920" alt="Screenshot 2023-06-29 at 16 16 48" src="https://github.com/lampepfl/dotty/assets/44496264/4fd8bca0-bc36-4ed8-bedb-ec670d2095ec">


I think a next Issue/PR will be needed to improve the tap target of the footer's icons.

Fixes: #16856