### PR TITLE
Fix: Correction of the siteRoot path

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
@@ -207,7 +207,7 @@ object Scaladoc:
         classpath.get,
         bootclasspath.get,
         destFile,
-        siteRoot.nonDefault,
+        Option(siteRoot.withDefault(siteRoot.default)),
         projectVersion.nonDefault,
         projectLogo.nonDefault,
         projectFooter.nonDefault,


### PR DESCRIPTION
- For the first issue, when a user set ./docs to the default value of ScalaSettings, the code only took a value that was not the default `siteRoot.nonDefault`. To fix this, I put a getOrElse to try and get the default value.


- For the second problem, I noticed when I cloned the code that the user was calling layouts that did not exist. Be careful with this as it can indeed produce an error. Solving this problem was enough to remove the non-existent layout calls.

Fixes: #15306