### PR TITLE
Add new EXPLICITtpt to TASTy format

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -694,7 +694,10 @@ class TreePickler(pickler: TastyPickler) {
           withLength {
             writeNat(idx)
             pickleType(tree.tpe, richTypes = true)
-            args.foreach(pickleTree)
+            args.foreach { arg =>
+              if arg.isType then writeByte(EXPLICITtpt)
+              pickleTree(arg)
+            }
           }
       }
       catch {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -695,7 +695,9 @@ class TreePickler(pickler: TastyPickler) {
             writeNat(idx)
             pickleType(tree.tpe, richTypes = true)
             args.foreach { arg =>
-              if arg.isType then writeByte(EXPLICITtpt)
+              arg.tpe match
+                case _: TermRef if arg.isType => writeByte(EXPLICITtpt)
+                case _ =>
               pickleTree(arg)
             }
           }

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -5,6 +5,7 @@ object MiMaFilters {
   val Library: Seq[ProblemFilter] = Seq(
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
+    ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyFormat.EXPLICITtpt"),
   )
   val Interfaces: Seq[ProblemFilter] = Seq(
   )

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -122,6 +122,8 @@ Standard-Section: "ASTs" TopLevelStat*
                   MATCHtpt       Length bound_Term? sel_Term CaseDef*              -- sel match { CaseDef } where `bound` is optional upper bound of all rhs
                   BYNAMEtpt             underlying_Term                            -- => underlying
                   SHAREDterm            term_ASTRef                                -- Link to previously serialized term
+    -- pickled quote trees:                                                        -- These trees can only appear in pickled quotes. They will never be in a TASTy file.
+                  EXPLICITtpt           tpt_Term                                   -- Tag for a type tree that in a context where it is not explicitly known that this tree is a type.
                   HOLE           Length idx_Nat tpe_Type arg_Tree*                 -- Splice hole with index `idx`, the type of the hole `tpe`, type and term arguments of the hole `arg`s
 
 
@@ -511,6 +513,8 @@ object TastyFormat {
   final val RECtype = 100
   final val SINGLETONtpt = 101
   final val BOUNDED = 102
+  final val EXPLICITtpt = 103
+
 
   // Cat. 4:    tag Nat AST
 
@@ -659,6 +663,7 @@ object TastyFormat {
        | ANNOTATEDtpt
        | BYNAMEtpt
        | MATCHtpt
+       | EXPLICITtpt
        | BIND => true
     case _ => false
   }
@@ -803,6 +808,7 @@ object TastyFormat {
     case ANNOTATION => "ANNOTATION"
     case PRIVATEqualified => "PRIVATEqualified"
     case PROTECTEDqualified => "PROTECTEDqualified"
+    case EXPLICITtpt => "EXPLICITtpt"
     case HOLE => "HOLE"
   }
 

--- a/tests/pos-macros/captured-type/Macro_1.scala
+++ b/tests/pos-macros/captured-type/Macro_1.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+inline def foo[U](u: U): U = ${ fooImpl[U]('u) }
+
+def fooImpl[U: Type](u: Expr[U])(using Quotes): Expr[U] = '{
+  def f[T](x: T): T = ${ identity('{ x: T }) }
+  f[U]($u)
+}

--- a/tests/pos-macros/captured-type/Test_2.scala
+++ b/tests/pos-macros/captured-type/Test_2.scala
@@ -1,0 +1,3 @@
+def test =
+  foo(1)
+  foo("abc")


### PR DESCRIPTION
This is a new encoding of HOLE that differentiates between type and term arguments of the hole.

```
-- pickled quote trees: These trees can only appear in pickled quotes. They will never be in a TASTy file.
  EXPLICITtpt tpt_Term
    -- Tag for a type tree that in a context where it is not explicitly known that this tree is a type.
  HOLE Length idx_Nat tpe_Type arg_Tree*
    -- Splice hole with index `idx`, the type of the hole `tpe`, type and term arguments of the hole `arg`s
```

We will pickle type trees in `arg_Tree` using the `EXPLICITtpt` tag.

We will only have hole captured types if there is a type defined in a quote and used in a nested quote. Most of the time we do not have those types and therefore no overhead in the encoding compared to before this change.

Alternative to #17225
Fixes #17137