### PR TITLE
Don't render the "$" for module

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -525,7 +525,7 @@ trait ClassLikeSupport:
     experimental: Option[Annotation] = None
   ) = Member(
     name = symbol.normalizedName,
-    fullName = symbol.fullName,
+    fullName = symbol.normalizedFullName,
     dri = symbol.dri,
     kind = kind,
     visibility = symbol.getVisibility(),

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/NameNormalizer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/NameNormalizer.scala
@@ -17,6 +17,18 @@ object NameNormalizer {
       val escaped = escapedName(constructorNormalizedName)
       escaped
     }
+    
+    def ownerNameChain: List[String] = {
+      import reflect.*
+      if s.isNoSymbol then List.empty
+      else if s == defn.EmptyPackageClass then List.empty
+      else if s == defn.RootPackage then List.empty
+      else if s == defn.RootClass then List.empty
+      else s.owner.ownerNameChain :+ s.normalizedName
+    }  
+      
+    def normalizedFullName: String =
+      s.ownerNameChain.mkString(".")
 
   private val ignoredKeywords: Set[String] = Set("this")
 


### PR DESCRIPTION
In this PR:
- I deleted the $ in the file `NameNormalizer`
- 
The ownerNameChain extension method generates a list of normalized owner names for a symbol, starting with the immediate owner and ending with the top-level owner. 
The normalizedFullName extension method combines the results of ownerNameChain into a single string with "." separators.

### Before:
<img width="800" alt="Screenshot 2023-04-24 at 13 06 12" src="https://user-images.githubusercontent.com/44496264/233979570-da502b7a-58c0-4486-a4bc-91fd5ea94e5b.png">
<img width="800" alt="Screenshot 2023-04-24 at 13 06 21" src="https://user-images.githubusercontent.com/44496264/233979575-d7dbc0a9-db40-4e07-ad42-731ed17700e2.png">
### After:
<img width="800" alt="Screenshot 2023-04-24 at 13 07 35" src="https://user-images.githubusercontent.com/44496264/233979596-ad5f032d-92e5-4673-af5d-6b75a0649466.png">
<img width="800" alt="Screenshot 2023-04-24 at 13 07 42" src="https://user-images.githubusercontent.com/44496264/233979600-677d188d-6a9c-45c4-89ee-ea7b0b2bc010.png">

Fixes: #15880