### PR TITLE
Allow contextual functions with erased parameters to be integrated

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1509,7 +1509,6 @@ class Definitions {
 
   /** Is an context function class.
    *   - ContextFunctionN for N >= 0
-   *   - ErasedContextFunctionN for N > 0
    */
   def isContextFunctionClass(cls: Symbol): Boolean = scalaClassName(cls).isContextFunction
 

--- a/tests/pos-custom-args/erased/tailrec.scala
+++ b/tests/pos-custom-args/erased/tailrec.scala
@@ -1,0 +1,20 @@
+import scala.annotation.tailrec
+
+erased class Foo1
+class Foo2
+
+@tailrec
+final def test1(n: Int, acc: Int): (Foo1, Foo2) ?=> Int =
+  if n <= 0 then acc
+  else test1(n - 1, acc * n)
+
+@tailrec
+final def test2(n: Int, acc: Int): Foo1 ?=> Int =
+  if n <= 0 then acc
+  else test2(n - 1, acc * n)
+
+@main def Test() =
+  given Foo1 = Foo1()
+  given Foo2 = Foo2()
+  test1(10, 0)
+  test2(10, 0)


### PR DESCRIPTION


## Fix #17147

- Allow contextual functions with erased parameters to be integrated

<!-- TODO description of the change -->


<!-- Ideally should have a called "Fix #XYZ: A SHORT FIX DESCRIPTION" -->
