### PR TITLE
java.net.URL constructors are deprecated since Java 20

### DIFF
--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -6,7 +6,7 @@ package dotty.tools.dotc.classpath
 import scala.language.unsafeNulls
 
 import java.io.{File => JFile}
-import java.net.URL
+import java.net.{URI, URL}
 import java.nio.file.{FileSystems, Files}
 
 import dotty.tools.dotc.classpath.PackageNameUtils.{packageContains, separatePkgAndClassNames}
@@ -194,7 +194,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
     if (inPackage.isRoot) ClassPathEntries(packages(inPackage), Nil)
     else ClassPathEntries(packages(inPackage), classes(inPackage))
 
-  def asURLs: Seq[URL] = Seq(new URL("jrt:/"))
+  def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
   // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
   // java models them as entries in the new "module path", we'll probably need to follow this.
   def asClassPathStrings: Seq[String] = Nil

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -5,7 +5,7 @@ import scala.language.unsafeNulls
 import dotty.tools.io.ClassRepresentation
 import dotty.tools.io.{AbstractFile, VirtualDirectory}
 import FileUtils._
-import java.net.URL
+import java.net.{URI, URL}
 
 import dotty.tools.io.ClassPath
 
@@ -37,7 +37,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   def isPackage(f: AbstractFile): Boolean = f.isPackage
 
   // mimic the behavior of the old nsc.util.DirectoryClassPath
-  def asURLs: Seq[URL] = Seq(new URL(dir.name))
+  def asURLs: Seq[URL] = Seq(new URI(dir.name).toURL)
   def asClassPathStrings: Seq[String] = Seq(dir.path)
 
   override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl.apply

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -10,7 +10,7 @@ package io
 import scala.language.unsafeNulls
 
 import java.net.MalformedURLException
-import java.net.URL
+import java.net.{ URI, URL }
 import java.util.regex.PatternSyntaxException
 
 import File.pathSeparator
@@ -182,7 +182,7 @@ object ClassPath {
   }
 
   def specToURL(spec: String): Option[URL] =
-    try Some(new URL(spec))
+    try Some(new URI(spec).toURL)
     catch { case _: MalformedURLException => None }
 
   def manifests: List[java.net.URL] = {

--- a/compiler/src/dotty/tools/repl/AbstractFileClassLoader.scala
+++ b/compiler/src/dotty/tools/repl/AbstractFileClassLoader.scala
@@ -17,7 +17,7 @@ import scala.language.unsafeNulls
 
 import io.AbstractFile
 
-import java.net.{URL, URLConnection, URLStreamHandler}
+import java.net.{URI, URL, URLConnection, URLStreamHandler}
 import java.util.Collections
 
 class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader) extends ClassLoader(parent):
@@ -26,7 +26,7 @@ class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader) exten
   override protected def findResource(name: String) =
     findAbstractFile(name) match
       case null => null
-      case file => new URL(null, s"memory:${file.path}", new URLStreamHandler {
+      case file => URL.of(new URI(s"memory:${file.path}"), new URLStreamHandler {
         override def openConnection(url: URL): URLConnection = new URLConnection(url) {
           override def connect() = ()
           override def getInputStream = file.input

--- a/scaladoc/src/dotty/tools/scaladoc/ExternalDocLink.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ExternalDocLink.scala
@@ -1,8 +1,8 @@
 package dotty.tools.scaladoc
 
-import java.net.URL
-import scala.util.matching._
-import scala.util.{ Try, Success, Failure }
+import java.net.{URI, URL}
+import scala.util.matching.*
+import scala.util.{Failure, Success, Try}
 
 case class ExternalDocLink(
   originRegexes: List[Regex],
@@ -30,7 +30,7 @@ object ExternalDocLink:
   def parseLegacy(mapping: String): Either[String, ExternalDocLink] =
     mapping.split("#").toList match
       case path :: apiUrl :: Nil => for {
-        url <- tryParse(mapping, "url")(URL(stripIndex(apiUrl)))
+        url <- tryParse(mapping, "url")(URI(stripIndex(apiUrl)).toURL)
       } yield ExternalDocLink(
         List(s"${Regex.quote(path)}.*".r),
         url,
@@ -42,7 +42,7 @@ object ExternalDocLink:
   def parse(mapping: String): Either[String, ExternalDocLink] =
 
     def parsePackageList(elements: List[String]) = elements match
-     case List(urlStr) => tryParse(mapping, "packageList")(Some(URL(urlStr)))
+     case List(urlStr) => tryParse(mapping, "packageList")(Some(URI(urlStr).toURL))
      case Nil => Right(None)
      case other => fail(mapping, s"Provided multiple package lists: $other")
 
@@ -57,7 +57,7 @@ object ExternalDocLink:
       case regexStr :: docToolStr :: urlStr :: rest =>
         for {
           regex <- tryParse(mapping, "regex")(regexStr.r)
-          url <- tryParse(mapping, "url")(URL(stripIndex(urlStr)))
+          url <- tryParse(mapping, "url")(URI(stripIndex(urlStr)).toURL)
           doctool <- doctoolByName(docToolStr)
           packageList <- parsePackageList(rest)
         } yield ExternalDocLink(

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -572,4 +572,4 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
         case Resource.URL(url) =>
           Nil
         case Resource.URLToCopy(url, dest) =>
-          Seq(copy(new URL(url).openStream(), dest))
+          Seq(copy(new URI(url).toURL.openStream(), dest))

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
@@ -40,7 +40,7 @@ trait SiteRenderer(using DocContext) extends Locations:
 
     def processLocalLink(str: String): String =
       val staticSiteRootPath = content.ctx.root.toPath.toAbsolutePath
-      def asValidURL: Option[String] = Try(URL(str)).toOption.map(_ => str)
+      def asValidURL: Option[String] = Try(URI(str).toURL).toOption.map(_ => str)
       def asAsset: Option[String] = Option.when(
         Files.exists(staticSiteRootPath.resolve("_assets").resolve(str.stripPrefix("/")))
       )(

--- a/tests/pos-with-compiler-cc/dotc/classpath/DirectoryClassPath.scala
+++ b/tests/pos-with-compiler-cc/dotc/classpath/DirectoryClassPath.scala
@@ -195,7 +195,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
     if (inPackage.isRoot) ClassPathEntries(packages(inPackage), Nil)
     else ClassPathEntries(packages(inPackage), classes(inPackage))
 
-  def asURLs: Seq[URL] = Seq(new URL("jrt:/"))
+  def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
   // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
   // java models them as entries in the new "module path", we'll probably need to follow this.
   def asClassPathStrings: Seq[String] = Nil

--- a/tests/pos-with-compiler-cc/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/tests/pos-with-compiler-cc/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -38,7 +38,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   def isPackage(f: AbstractFile): Boolean = f.isPackage
 
   // mimic the behavior of the old nsc.util.DirectoryClassPath
-  def asURLs: Seq[URL] = Seq(new URL(dir.name))
+  def asURLs: Seq[URL] = Seq(new URI(dir.name).toURL)
   def asClassPathStrings: Seq[String] = Seq(dir.path)
 
   override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl.apply


### PR DESCRIPTION
With warnings treated as errors, compiler compilation using JDK 20 fails with errors like the following:

```
[error] -- Error: compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala:197:33 
[error] 197 |  def asURLs: Seq[URL] = Seq(new URL("jrt:/"))
[error]     |                                 ^^^
[error]     |constructor URL in class URL is deprecated since : see corresponding Javadoc for more information.
```

The deprecation notices suggest to use `URI#toURL()` to construct instances of URL.