### PR TITLE
Fix #17187: allow patches with same span

### DIFF
--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -23,10 +23,7 @@ object Rewrites {
     private[Rewrites] val pbuf = new mutable.ListBuffer[Patch]()
 
     def addPatch(span: Span, replacement: String): Unit =
-      pbuf.indexWhere(p => p.span.start == span.start && p.span.end == span.end) match {
-        case i if i >= 0 => pbuf.update(i, Patch(span, replacement))
-        case _           => pbuf += Patch(span, replacement)
-      }
+      pbuf += Patch(span, replacement)
 
     def apply(cs: Array[Char]): Array[Char] = {
       val delta = pbuf.map(_.delta).sum

--- a/compiler/src/dotty/tools/dotc/util/Spans.scala
+++ b/compiler/src/dotty/tools/dotc/util/Spans.scala
@@ -86,7 +86,6 @@ object Spans {
       || containsInner(this, that.end)
       || containsInner(that, this.start)
       || containsInner(that, this.end)
-      || this.start == that.start && this.end == that.end   // exact match in one point
       )
     }
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -81,6 +81,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i9632.scala", defaultOptions.and("-indent", "-rewrite")),
       compileFile("tests/rewrites/i11895.scala", defaultOptions.and("-indent", "-rewrite")),
       compileFile("tests/rewrites/i12340.scala", unindentOptions.and("-rewrite")),
+      compileFile("tests/rewrites/i17187.scala", unindentOptions.and("-rewrite")),
     ).checkRewrites()
   }
 

--- a/tests/rewrites/i12340.check
+++ b/tests/rewrites/i12340.check
@@ -3,6 +3,15 @@ class C {
   def f = 42
 } // end C
 
+class A {
+  class B {
+    class C {
+      def foo = 42
+    }
+
+  } // end B
+}
+
 def f(i: Int) = {
   if i < 42 then
     println(i)

--- a/tests/rewrites/i12340.scala
+++ b/tests/rewrites/i12340.scala
@@ -3,6 +3,13 @@ class C:
   def f = 42
 end C
 
+class A:
+  class B:
+    class C:
+      def foo = 42
+
+  end B
+
 def f(i: Int) =
   if i < 42 then
     println(i)

--- a/tests/rewrites/i17187.check
+++ b/tests/rewrites/i17187.check
@@ -1,0 +1,44 @@
+
+object A {
+  object B {
+    def a = 2
+  }
+}
+
+def m1 = {
+  def b = {
+    def c = 2
+  }
+}
+
+def m2 =
+  if true then {
+    val x = 3
+    if (false)
+      x
+    else {
+      val y = 4
+      y
+    }
+  }
+
+def m3 =
+  try {
+    val n2 = 21
+    val n1 = 4
+    n2 / n1
+  }
+  catch {
+    case _ => 4
+  }
+
+def m4 = {
+  val n2 = 21
+  try {
+    val n1 = 4
+    n2 / n1
+  }
+  catch {
+    case _ => 4
+  }
+}

--- a/tests/rewrites/i17187.scala
+++ b/tests/rewrites/i17187.scala
@@ -1,0 +1,33 @@
+
+object A:
+  object B:
+    def a = 2
+
+def m1 =
+  def b =
+    def c = 2
+
+def m2 =
+  if true then
+    val x = 3
+    if (false)
+      x
+    else
+      val y = 4
+      y
+
+def m3 =
+  try
+    val n2 = 21
+    val n1 = 4
+    n2 / n1
+  catch
+    case _ => 4
+
+def m4 =
+  val n2 = 21
+  try
+    val n1 = 4
+    n2 / n1
+  catch
+    case _ => 4


### PR DESCRIPTION
Fix #17187

The no-indent rewrite sometimes needs to add several `}` at the same position, to close nested constructs.

For example, it rewrites:
```scala
object A:
  object B:
    def foo = 42
```
Into:
```scala
object A {
  object B {
    def foo = 42
  }
}
```

We deal with end marker in the `indentedToBraces` method by checking the next token of the region. This also fixes the following error:

```scala
class A:
  def foo = 42

end A
```
Rewritten to
```scala
class A {
  def foo = 42
}

end A
```
Instead Of:
```scala
class A {
  def foo = 42

} // end A
```