### PR TITLE
Fix #11541: Specialize ClassTag[T] in exhaustivity check

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -798,6 +798,7 @@ class Definitions {
 
   @tu lazy val ReflectPackageClass: Symbol = requiredPackage("scala.reflect.package").moduleClass
   @tu lazy val ClassTagClass: ClassSymbol = requiredClass("scala.reflect.ClassTag")
+    @tu lazy val ClassTagClass_unapply: Symbol = ClassTagClass.requiredMethod("unapply")
   @tu lazy val ClassTagModule: Symbol = ClassTagClass.companionModule
     @tu lazy val ClassTagModule_apply: Symbol = ClassTagModule.requiredMethod(nme.apply)
 

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -602,8 +602,13 @@ object SpaceEngine {
 
   /** Whether the extractor covers the given type */
   def covers(unapp: TermRef, scrutineeTp: Type, argLen: Int)(using Context): Boolean =
-    SpaceEngine.isIrrefutable(unapp, argLen) || unapp.symbol == defn.TypeTest_unapply && {
+    SpaceEngine.isIrrefutable(unapp, argLen)
+    || unapp.symbol == defn.TypeTest_unapply && {
       val AppliedType(_, _ :: tp :: Nil) = unapp.prefix.widen.dealias: @unchecked
+      scrutineeTp <:< tp
+    }
+    || unapp.symbol == defn.ClassTagClass_unapply && {
+      val AppliedType(_, tp :: Nil) = unapp.prefix.widen.dealias: @unchecked
       scrutineeTp <:< tp
     }
 

--- a/tests/patmat/i11541.scala
+++ b/tests/patmat/i11541.scala
@@ -1,0 +1,13 @@
+import scala.reflect.ClassTag
+
+class Test:
+  type A
+
+  given ClassTag[A] = ???
+
+  var a: A | Null = null
+
+  a match { //WARNING: match may not be exhaustive. It would fail on pattern case: _: A
+    case null =>
+    case a: A =>
+  }


### PR DESCRIPTION
Fix #11541: Specialize `ClassTag[T]` in exhaustivity check