### PR TITLE
Change logic to find members of recursive types

### DIFF
--- a/tests/pos/i17380.scala
+++ b/tests/pos/i17380.scala
@@ -1,0 +1,3 @@
+class C { type T; type U }
+
+type X = C { type U = T; def u: U } { type T = String }


### PR DESCRIPTION
The previous logic used two boolean variables to selectively create defensive copies. It was quite complicated. The new logic is simpler and copies less.

 - It copies only if the same recursive type is accessed with two different prefixes. As long as the prefix stays the same,no confusion in the `substRecThis` is possible.
 - It avoids the openedTwice logic that causes defensive copies at all points in the future. It seems that trick is no longer necessary.

Fixes #17380 by avoiding infinite recursion due to defensive copies.