### PR TITLE
Avoid URL constructor deprecated on JDK20

### DIFF
--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -6,7 +6,7 @@ package dotty.tools.dotc.classpath
 import scala.language.unsafeNulls
 
 import java.io.{File => JFile}
-import java.net.URL
+import java.net.{URI, URL}
 import java.nio.file.{FileSystems, Files}
 
 import dotty.tools.dotc.classpath.PackageNameUtils.{packageContains, separatePkgAndClassNames}
@@ -194,7 +194,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
     if (inPackage.isRoot) ClassPathEntries(packages(inPackage), Nil)
     else ClassPathEntries(packages(inPackage), classes(inPackage))
 
-  def asURLs: Seq[URL] = Seq(new URL("jrt:/"))
+  def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
   // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
   // java models them as entries in the new "module path", we'll probably need to follow this.
   def asClassPathStrings: Seq[String] = Nil

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -2,12 +2,10 @@ package dotty.tools.dotc.classpath
 
 import scala.language.unsafeNulls
 
-import dotty.tools.io.ClassRepresentation
+import dotty.tools.io.{ClassPath, ClassRepresentation}
 import dotty.tools.io.{AbstractFile, VirtualDirectory}
 import FileUtils._
-import java.net.URL
-
-import dotty.tools.io.ClassPath
+import java.net.{URI, URL}
 
 case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath with DirectoryLookup[ClassFileEntryImpl] with NoSourcePaths {
   type F = AbstractFile
@@ -37,7 +35,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   def isPackage(f: AbstractFile): Boolean = f.isPackage
 
   // mimic the behavior of the old nsc.util.DirectoryClassPath
-  def asURLs: Seq[URL] = Seq(new URL(dir.name))
+  def asURLs: Seq[URL] = Seq(new URI(dir.name).toURL)
   def asClassPathStrings: Seq[String] = Seq(dir.path)
 
   override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl.apply

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -9,8 +9,7 @@ package io
 
 import scala.language.unsafeNulls
 
-import java.net.MalformedURLException
-import java.net.URL
+import java.net.{MalformedURLException, URI, URISyntaxException, URL}
 import java.util.regex.PatternSyntaxException
 
 import File.pathSeparator
@@ -182,8 +181,8 @@ object ClassPath {
   }
 
   def specToURL(spec: String): Option[URL] =
-    try Some(new URL(spec))
-    catch { case _: MalformedURLException => None }
+    try Some(new URI(spec).toURL)
+    catch case _: MalformedURLException | _: URISyntaxException => None
 
   def manifests: List[java.net.URL] = {
     import scala.jdk.CollectionConverters.EnumerationHasAsScala

--- a/compiler/src/dotty/tools/repl/AbstractFileClassLoader.scala
+++ b/compiler/src/dotty/tools/repl/AbstractFileClassLoader.scala
@@ -23,6 +23,9 @@ import java.util.Collections
 class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader) extends ClassLoader(parent):
   private def findAbstractFile(name: String) = root.lookupPath(name.split('/').toIndexedSeq, directory = false)
 
+  // on JDK 20 the URL constructor we're using is deprecated,
+  // but the recommended replacement, URL.of, doesn't exist on JDK 8
+  @annotation.nowarn("cat=deprecation")
   override protected def findResource(name: String) =
     findAbstractFile(name) match
       case null => null

--- a/project/DocumentationWebsite.scala
+++ b/project/DocumentationWebsite.scala
@@ -1,4 +1,5 @@
 import java.io.File
+import java.net.URI
 import java.nio.file.Paths
 import sbt._
 import Build._
@@ -48,7 +49,7 @@ object DocumentationWebsite {
     sbt.IO.touch(inkuireDestinationFile)
 
     def tryFetch(retries: Int, timeout: Duration): Unit = {
-      val downloadProcess = (new java.net.URL(inkuireLink) #> inkuireDestinationFile).run()
+      val downloadProcess = (new URI(inkuireLink).toURL #> inkuireDestinationFile).run()
       val result: Future[Int] = Future(blocking(downloadProcess.exitValue()))
       try {
         Await.result(result, timeout) match {


### PR DESCRIPTION
Forward ports tweaks from https://github.com/scala/scala/pull/10335