### PR TITLE
deps: bump jackson to 2.15.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
  *  to ensure the same version of the dependency is used in all projects
  */
 object Dependencies {
-  private val jacksonVersion = "2.13.3"
+  private val jacksonVersion = "2.15.1"
   val `jackson-databind` =
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   val `jackson-dataformat-yaml` =


### PR DESCRIPTION
If you're curious the release notes for this version can be found in
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.

The main reason for this change is that there are some CVEs attatched
to the 2.13.x series that are first fixed in later versions. You can see the
CVEs in the Security tab here on GitHub.

