### PR TITLE
Do not remove inline method implementations until PruneErasedDefs

### DIFF
--- a/compiler/src/dotty/tools/dotc/staging/CrossStageSafety.scala
+++ b/compiler/src/dotty/tools/dotc/staging/CrossStageSafety.scala
@@ -90,6 +90,9 @@ class CrossStageSafety extends TreeMapWithStages {
                 if level != 0 then cpy.Apply(tree)(cpy.TypeApply(tree.fun)(fun, transformedBody :: Nil), quotes :: Nil)
                 else tpd.Quote(transformedBody).select(nme.apply).appliedTo(quotes).withSpan(tree.span)
 
+      case _: DefDef if tree.symbol.isInlineMethod =>
+        tree
+
       case _ if !inQuoteOrSpliceScope =>
         checkAnnotations(tree) // Check quotes in annotations
         super.transform(tree)
@@ -117,8 +120,6 @@ class CrossStageSafety extends TreeMapWithStages {
             // propagate healed types
             tree1.withType(tree1.tpt.tpe.appliedTo(tree1.args.map(_.tpe)))
           case tree1 => tree1
-      case tree: DefDef if tree.symbol.is(Inline) && level > 0 =>
-        EmptyTree // Remove inline defs in quoted code. Already fully inlined.
       case tree: ValOrDefDef =>
         checkAnnotations(tree)
         healInfo(tree, tree.tpt.srcPos)

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -18,6 +18,7 @@ import NameKinds.OuterSelectName
 import StdNames._
 import TypeUtils.isErasedValueType
 import config.Feature
+import inlines.Inlines.inInlineMethod
 
 object FirstTransform {
   val name: String = "firstTransform"

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -103,9 +103,7 @@ class PickleQuotes extends MacroTransform {
           val pickled = PickleQuotes.pickle(quote1, quotes, contents)
           transform(pickled) // pickle quotes that are in the contents
         case tree: DefDef if !tree.rhs.isEmpty && tree.symbol.isInlineMethod =>
-          // Shrink size of the tree. The methods have already been inlined.
-          // TODO move to FirstTransform to trigger even without quotes
-          cpy.DefDef(tree)(rhs = defaultValue(tree.rhs.tpe))
+          tree
         case _ =>
           super.transform(tree)
   }

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -8,6 +8,7 @@ import dotty.tools.dotc.core.Decorators._
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.core.Types._
+import dotty.tools.dotc.inlines.Inlines
 import dotty.tools.dotc.util.SrcPos
 import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.dotc.staging.StagingLevel.*
@@ -56,7 +57,8 @@ class Staging extends MacroTransform {
           checker.transform(tree)
         case _ =>
       }
-
+    }
+    if !Inlines.inInlineMethod then
       tree match {
         case tree: RefTree =>
           assert(level != 0 || tree.symbol != defn.QuotedTypeModule_of,
@@ -72,7 +74,7 @@ class Staging extends MacroTransform {
         case _ =>
           // OK
       }
-    }
+  end checkPostCondition
 
   override def run(using Context): Unit =
     if (ctx.compilationUnit.needsStaging) super.run

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -110,6 +110,8 @@ class BootstrappedOnlyCompilationTests {
     aggregateTests(
       compileFilesInDir("tests/neg-macros", defaultOptions.and("-Xcheck-macros")),
       compileFile("tests/pos-macros/i9570.scala", defaultOptions.and("-Xfatal-warnings")),
+      compileFile("tests/pos-macros/macro-deprecation.scala", defaultOptions.and("-Xfatal-warnings", "-deprecation")),
+      compileFile("tests/pos-macros/macro-experimental.scala", defaultOptions.and("-Yno-experimental")),
     ).checkExpectedErrors()
   }
 

--- a/tests/pos-macros/macro-deprecation.scala
+++ b/tests/pos-macros/macro-deprecation.scala
@@ -1,0 +1,4 @@
+import scala.quoted.*
+
+inline def f = ${ impl } // error
+@deprecated def impl(using Quotes) = '{1}

--- a/tests/pos-macros/macro-experimental.scala
+++ b/tests/pos-macros/macro-experimental.scala
@@ -1,0 +1,5 @@
+import scala.quoted.*
+import scala.annotation.experimental
+
+inline def f = ${ impl } // error
+@experimental def impl(using Quotes) = '{1}


### PR DESCRIPTION
This way, the tree in the inline method will pass through all checks after first transform.