### PR TITLE
add styling to blockquote in content component

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/layout/content.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/content.css
@@ -215,6 +215,15 @@
   vertical-align: top;
 }
 
+/* content blockquote */
+#content blockquote {
+  color: var(--text-secondary);
+  border-left: 4px solid var(--border-default);
+  padding: 0 calc(2 * var(--base-spacing));
+  margin-inline-start: calc(2 * var(--base-spacing));
+  margin-inline-end: calc(2 * var(--base-spacing));
+}
+
 /* content link */
 #content a {
     color: var(--text-primary);


### PR DESCRIPTION
fixes #17421 

After:
![Screenshot 2023-05-05 at 12 51 05](https://user-images.githubusercontent.com/13436592/236439211-78bf59cf-b778-45cc-af00-2ed5f14b37c8.png)

@szymon-rd I was not sure who to assign to, or which branch to use