### PR TITLE
Avoid deprecated URL ctor in scaladoc

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/ExternalDocLink.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ExternalDocLink.scala
@@ -1,6 +1,6 @@
 package dotty.tools.scaladoc
 
-import java.net.URL
+import java.net.{URI, URL}
 import scala.util.matching._
 import scala.util.{ Try, Success, Failure }
 
@@ -30,7 +30,7 @@ object ExternalDocLink:
   def parseLegacy(mapping: String): Either[String, ExternalDocLink] =
     mapping.split("#").toList match
       case path :: apiUrl :: Nil => for {
-        url <- tryParse(mapping, "url")(URL(stripIndex(apiUrl)))
+        url <- tryParse(mapping, "url")(URI(stripIndex(apiUrl)).toURL)
       } yield ExternalDocLink(
         List(s"${Regex.quote(path)}.*".r),
         url,
@@ -42,7 +42,7 @@ object ExternalDocLink:
   def parse(mapping: String): Either[String, ExternalDocLink] =
 
     def parsePackageList(elements: List[String]) = elements match
-     case List(urlStr) => tryParse(mapping, "packageList")(Some(URL(urlStr)))
+     case List(urlStr) => tryParse(mapping, "packageList")(Some(URI(urlStr).toURL))
      case Nil => Right(None)
      case other => fail(mapping, s"Provided multiple package lists: $other")
 
@@ -57,7 +57,7 @@ object ExternalDocLink:
       case regexStr :: docToolStr :: urlStr :: rest =>
         for {
           regex <- tryParse(mapping, "regex")(regexStr.r)
-          url <- tryParse(mapping, "url")(URL(stripIndex(urlStr)))
+          url <- tryParse(mapping, "url")(URI(stripIndex(urlStr)).toURL)
           doctool <- doctoolByName(docToolStr)
           packageList <- parsePackageList(rest)
         } yield ExternalDocLink(

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Resources.scala
@@ -2,7 +2,7 @@ package dotty.tools.scaladoc
 package renderers
 
 import util.HTML._
-import java.net.URL
+import java.net.{URI, URL}
 import java.nio.file.Paths
 import java.nio.file.Path
 import java.nio.file.Files
@@ -565,4 +565,4 @@ trait Resources(using ctx: DocContext) extends Locations, Writer:
         case Resource.URL(url) =>
           Nil
         case Resource.URLToCopy(url, dest) =>
-          Seq(copy(new URL(url).openStream(), dest))
+          Seq(copy(URI(url).toURL.openStream(), dest))

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
@@ -3,8 +3,7 @@ package renderers
 
 import util.HTML._
 import scala.jdk.CollectionConverters._
-import java.net.URI
-import java.net.URL
+import java.net.{URI, URL}
 import dotty.tools.scaladoc.site._
 import scala.util.Try
 import org.jsoup.Jsoup
@@ -40,7 +39,7 @@ trait SiteRenderer(using DocContext) extends Locations:
 
     def processLocalLink(str: String): String =
       val staticSiteRootPath = content.ctx.root.toPath.toAbsolutePath
-      def asValidURL: Option[String] = Try(URL(str)).toOption.map(_ => str)
+      def asValidURL: Option[String] = Try(URI(str).toURL).toOption.map(_ => str)
       def asAsset: Option[String] = Option.when(
         Files.exists(staticSiteRootPath.resolve("_assets").resolve(str.stripPrefix("/")))
       )(


### PR DESCRIPTION
Follow-up to https://github.com/lampepfl/dotty/pull/17403 includes scaladoc.