### PR TITLE
Revert "Include top-level symbols from same file in outer ambiguity error"

### DIFF
--- a/tests/neg/ambiref.check
+++ b/tests/neg/ambiref.check
@@ -30,19 +30,3 @@
    |                and inherited subsequently in class E
    |
    | longer explanation available when compiling with `-explain`
--- [E049] Reference Error: tests/neg/ambiref.scala:43:10 ---------------------------------------------------------------
-43 |  println(global)    // error
-   |          ^^^^^^
-   |          Reference to global is ambiguous.
-   |          It is both defined in package <empty>
-   |          and inherited subsequently in object D
-   |
-   | longer explanation available when compiling with `-explain`
--- [E049] Reference Error: tests/neg/ambiref.scala:49:16 ---------------------------------------------------------------
-49 |    def t = new T { } // error
-   |                ^
-   |                Reference to T is ambiguous.
-   |                It is both defined in package p
-   |                and inherited subsequently in class C
-   |
-   | longer explanation available when compiling with `-explain`

--- a/tests/neg/ambiref.scala
+++ b/tests/neg/ambiref.scala
@@ -40,24 +40,4 @@ val global = 0
 class C:
   val global = 1
 object D extends C:
-  println(global)    // error
-
-package p:
-  class T
-  trait P { trait T }
-  class C extends P:
-    def t = new T { } // error
-
-package scala:
-  trait P { trait Option[+A] }
-  class C extends P:
-    def t = new Option[String] { } // OK, competing scala.Option is not defined in the same compilation unit
-
-object test5:
-  class Mu // generates a synthetic companion object with an apply method
-  trait A {
-    val Mu = 1
-  }
-  trait B extends A {
-    def t = Mu // don't warn about synthetic companion
-  }
+  println(global)    // OK, since global is defined in package

--- a/tests/pos-special/fatal-warnings/i9260.scala
+++ b/tests/pos-special/fatal-warnings/i9260.scala
@@ -10,7 +10,7 @@ end AstImpl
 
 object untpd extends AstImpl[Null]:
 
-  def DefDef(ast: this.Ast): DefDef = ast match
+  def DefDef(ast: Ast): DefDef = ast match
     case ast: DefDef => ast
 
 end untpd

--- a/tests/run/protectedacc.scala
+++ b/tests/run/protectedacc.scala
@@ -134,7 +134,7 @@ package p {
 
     abstract class X[T] extends PolyA[T] {
 
-      trait Inner extends this.B {
+      trait Inner extends B {
         def self: T;
         def self2: Node;
         def getB: Inner;


### PR DESCRIPTION
This reverts commit 7d4e103a941a30306ddde28a11f8bc3a8841acf8.

Reverts #17033
Closes #17433
