### PR TITLE
Backport "Patmat: Use less type variables in prefix inference"

### DIFF
--- a/tests/patmat/i12408.check
+++ b/tests/patmat/i12408.check
@@ -1,2 +1,2 @@
-13: Pattern Match Exhaustivity: X[<?>] & (X.this : X[T]).A(_), X[<?>] & (X.this : X[T]).C(_)
+13: Pattern Match Exhaustivity: A(_), C(_)
 21: Pattern Match

--- a/tests/pos/i16785.scala
+++ b/tests/pos/i16785.scala
@@ -1,0 +1,11 @@
+class VarImpl[Lbl, A]
+
+class Outer[|*|[_, _], Lbl1]:
+  type Var[A1] = VarImpl[Lbl1, A1]
+
+  sealed trait Foo[G]
+  case class Bar[T, U]()
+    extends Foo[Var[T] |*| Var[U]]
+
+  def go[X](scr: Foo[Var[X]]): Unit = scr match // was: compile hang
+    case Bar() => ()


### PR DESCRIPTION
Backports https://github.com/lampepfl/dotty/pull/16827

Solves https://github.com/lampepfl/dotty/issues/17368