### PR TITLE
fix(scaladocs): make sure scaladocs are aligned with actual behavior

### DIFF
--- a/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
@@ -44,7 +44,7 @@ sealed trait Plugin {
 trait StandardPlugin extends Plugin {
   /** Non-research plugins should override this method to return the phases
    *
-   *  @param options commandline options to the plugin, `-P:plugname:opt1,opt2` becomes List(opt1, opt2)
+   *  @param options commandline options to the plugin.
    *  @return a list of phases to be added to the phase plan
    */
   def init(options: List[String]): List[PluginPhase]

--- a/compiler/src/dotty/tools/dotc/plugins/Plugins.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugins.scala
@@ -116,8 +116,6 @@ trait Plugins {
 
   /** Add plugin phases to phase plan */
   def addPluginPhases(plan: List[List[Phase]])(using Context): List[List[Phase]] = {
-    // plugin-specific options.
-    // The user writes `-P:plugname:opt1,opt2`, but the plugin sees `List(opt1, opt2)`.
     def options(plugin: Plugin): List[String] = {
       def namec = plugin.name + ":"
       ctx.settings.pluginOptions.value filter (_ startsWith namec) map (_ stripPrefix namec)


### PR DESCRIPTION
This change just make sure the actual behavior is aligned with the comments about plugin options.

refs https://github.com/lampepfl/dotty/discussions/17238