### PR TITLE
Warn on unqualified top-level calls to Any or AnyRef methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -194,6 +194,8 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case MissingArgumentListID // errorNumber: 178
   case MatchTypeScrutineeCannotBeHigherKindedID // errorNumber: 179
   case AmbiguousExtensionMethodID // errorNumber 180
+  case CallToAnyRefMethodOnPredefID // errorNumber: 181
+  case CallToAnyRefMethodOnPackageObjectID // errorNumber: 182
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -194,8 +194,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case MissingArgumentListID // errorNumber: 178
   case MatchTypeScrutineeCannotBeHigherKindedID // errorNumber: 179
   case AmbiguousExtensionMethodID // errorNumber 180
-  case CallToAnyRefMethodOnPredefID // errorNumber: 181
-  case CallToAnyRefMethodOnPackageObjectID // errorNumber: 182
+  case UnqualifiedCallToAnyRefMethodID // errorNumber: 181
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2284,23 +2284,14 @@ class PureExpressionInStatementPosition(stat: untpd.Tree, val exprOwner: Symbol)
         |It can be removed without changing the semantics of the program. This may indicate an error."""
 }
 
-class CallToAnyRefMethodOnPredef(stat: untpd.Tree, method: Symbol)(using Context)
-  extends Message(CallToAnyRefMethodOnPredefID) {
+class UnqualifiedCallToAnyRefMethod(stat: untpd.Tree, method: Symbol)(using Context)
+  extends Message(UnqualifiedCallToAnyRefMethodID) {
   def kind = MessageKind.PotentialIssue
-  def msg(using Context) = i"Suspicious call to ${hl("Predef." + method.name)}"
+  def msg(using Context) = i"Suspicious top-level unqualified call to ${hl(method.name.toString)}"
   def explain(using Context) =
     i"""Top-level unqualified calls to ${hl("AnyRef")} or ${hl("Any")} methods such as ${hl(method.name.toString)} are
-       |resolved to calls on ${hl("Predef")}. This might not be what you intended."""
-}
-
-class CallToAnyRefMethodOnPackageObject(stat: untpd.Tree, method: Symbol)(using Context)
-  extends Message(CallToAnyRefMethodOnPackageObjectID) {
-  def kind = MessageKind.PotentialIssue
-  def msg(using Context) = i"Suspicious top-level call to ${hl("this." + method.name)}"
-  def explain(using Context) =
-    i"""Top-level calls to ${hl("AnyRef")} or ${hl("Any")} methods are resolved to calls on the
-       |synthetic package object generated for the current file. This might not be
-       |what you intended."""
+       |resolved to calls on ${hl("Predef")} or on imported methods. This might not be what
+       |you intended."""
 }
 
 class TraitCompanionWithMutableStatic()(using Context)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2284,6 +2284,25 @@ class PureExpressionInStatementPosition(stat: untpd.Tree, val exprOwner: Symbol)
         |It can be removed without changing the semantics of the program. This may indicate an error."""
 }
 
+class CallToAnyRefMethodOnPredef(stat: untpd.Tree, method: Symbol)(using Context)
+  extends Message(CallToAnyRefMethodOnPredefID) {
+  def kind = MessageKind.PotentialIssue
+  def msg(using Context) = i"Suspicious call to ${hl("Predef." + method.name)}"
+  def explain(using Context) =
+    i"""Top-level unqualified calls to ${hl("AnyRef")} or ${hl("Any")} methods such as ${hl(method.name.toString)} are
+       |resolved to calls on ${hl("Predef")}. This might not be what you intended."""
+}
+
+class CallToAnyRefMethodOnPackageObject(stat: untpd.Tree, method: Symbol)(using Context)
+  extends Message(CallToAnyRefMethodOnPackageObjectID) {
+  def kind = MessageKind.PotentialIssue
+  def msg(using Context) = i"Suspicious top-level call to ${hl("this." + method.name)}"
+  def explain(using Context) =
+    i"""Top-level calls to ${hl("AnyRef")} or ${hl("Any")} methods are resolved to calls on the
+       |synthetic package object generated for the current file. This might not be
+       |what you intended."""
+}
+
 class TraitCompanionWithMutableStatic()(using Context)
   extends SyntaxMsg(TraitCompanionWithMutableStaticID) {
   def msg(using Context) = i"Companion of traits cannot define mutable @static fields"

--- a/compiler/test/dotty/tools/utils.scala
+++ b/compiler/test/dotty/tools/utils.scala
@@ -17,8 +17,10 @@ import scala.util.control.{ControlThrowable, NonFatal}
 
 import dotc.config.CommandLineParser
 
+object Dummy
+
 def scripts(path: String): Array[File] = {
-  val dir = new File(this.getClass.getResource(path).getPath)
+  val dir = new File(Dummy.getClass.getResource(path).getPath)
   assert(dir.exists && dir.isDirectory, "Couldn't load scripts dir")
   dir.listFiles.filter { f =>
     val path = if f.isDirectory then f.getPath + "/" else f.getPath

--- a/tests/neg/i17266.check
+++ b/tests/neg/i17266.check
@@ -1,0 +1,84 @@
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:4:2 ------------------------------------------------------------
+4 |  synchronized { // error
+  |  ^^^^^^^^^^^^
+  |  Suspicious call to Predef.synchronized
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | Top-level unqualified calls to AnyRef or Any methods such as synchronized are
+  | resolved to calls on Predef. This might not be what you intended.
+   ---------------------------------------------------------------------------------------------------------------------
+-- [E182] Potential Issue Error: tests/neg/i17266.scala:9:7 ------------------------------------------------------------
+9 |  this.synchronized { // error
+  |  ^^^^^^^^^^^^^^^^^
+  |  Suspicious top-level call to this.synchronized
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | Top-level calls to AnyRef or Any methods are resolved to calls on the
+  | synthetic package object generated for the current file. This might not be
+  | what you intended.
+   ---------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:22:2 -----------------------------------------------------------
+22 |  wait() // error
+   |  ^^^^
+   |  Suspicious call to Predef.wait
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Top-level unqualified calls to AnyRef or Any methods such as wait are
+   | resolved to calls on Predef. This might not be what you intended.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E182] Potential Issue Error: tests/neg/i17266.scala:25:7 -----------------------------------------------------------
+25 |  this.wait() // error
+   |  ^^^^^^^^^
+   |  Suspicious top-level call to this.wait
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Top-level calls to AnyRef or Any methods are resolved to calls on the
+   | synthetic package object generated for the current file. This might not be
+   | what you intended.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:32:2 -----------------------------------------------------------
+32 |  wait(10) // error
+   |  ^^^^
+   |  Suspicious call to Predef.wait
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Top-level unqualified calls to AnyRef or Any methods such as wait are
+   | resolved to calls on Predef. This might not be what you intended.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E182] Potential Issue Error: tests/neg/i17266.scala:35:7 -----------------------------------------------------------
+35 |  this.wait(10) // error
+   |  ^^^^^^^^^
+   |  Suspicious top-level call to this.wait
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Top-level calls to AnyRef or Any methods are resolved to calls on the
+   | synthetic package object generated for the current file. This might not be
+   | what you intended.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:42:2 -----------------------------------------------------------
+42 |  hashCode() // error
+   |  ^^^^^^^^
+   |  Suspicious call to Predef.hashCode
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Top-level unqualified calls to AnyRef or Any methods such as hashCode are
+   | resolved to calls on Predef. This might not be what you intended.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E182] Potential Issue Error: tests/neg/i17266.scala:45:7 -----------------------------------------------------------
+45 |  this.hashCode() // error
+   |  ^^^^^^^^^^^^^
+   |  Suspicious top-level call to this.hashCode
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Top-level calls to AnyRef or Any methods are resolved to calls on the
+   | synthetic package object generated for the current file. This might not be
+   | what you intended.
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i17266.check
+++ b/tests/neg/i17266.check
@@ -1,84 +1,88 @@
 -- [E181] Potential Issue Error: tests/neg/i17266.scala:4:2 ------------------------------------------------------------
 4 |  synchronized { // error
   |  ^^^^^^^^^^^^
-  |  Suspicious call to Predef.synchronized
+  |  Suspicious top-level unqualified call to synchronized
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   | Top-level unqualified calls to AnyRef or Any methods such as synchronized are
-  | resolved to calls on Predef. This might not be what you intended.
+  | resolved to calls on Predef or on imported methods. This might not be what
+  | you intended.
    ---------------------------------------------------------------------------------------------------------------------
--- [E182] Potential Issue Error: tests/neg/i17266.scala:9:7 ------------------------------------------------------------
-9 |  this.synchronized { // error
-  |  ^^^^^^^^^^^^^^^^^
-  |  Suspicious top-level call to this.synchronized
-  |---------------------------------------------------------------------------------------------------------------------
-  | Explanation (enabled by `-explain`)
-  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  | Top-level calls to AnyRef or Any methods are resolved to calls on the
-  | synthetic package object generated for the current file. This might not be
-  | what you intended.
-   ---------------------------------------------------------------------------------------------------------------------
--- [E181] Potential Issue Error: tests/neg/i17266.scala:22:2 -----------------------------------------------------------
-22 |  wait() // error
-   |  ^^^^
-   |  Suspicious call to Predef.wait
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:17:2 -----------------------------------------------------------
+17 |  synchronized { // error
+   |  ^^^^^^^^^^^^
+   |  Suspicious top-level unqualified call to synchronized
    |--------------------------------------------------------------------------------------------------------------------
    | Explanation (enabled by `-explain`)
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   | Top-level unqualified calls to AnyRef or Any methods such as wait are
-   | resolved to calls on Predef. This might not be what you intended.
+   | Top-level unqualified calls to AnyRef or Any methods such as synchronized are
+   | resolved to calls on Predef or on imported methods. This might not be what
+   | you intended.
     --------------------------------------------------------------------------------------------------------------------
--- [E182] Potential Issue Error: tests/neg/i17266.scala:25:7 -----------------------------------------------------------
-25 |  this.wait() // error
-   |  ^^^^^^^^^
-   |  Suspicious top-level call to this.wait
-   |--------------------------------------------------------------------------------------------------------------------
-   | Explanation (enabled by `-explain`)
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   | Top-level calls to AnyRef or Any methods are resolved to calls on the
-   | synthetic package object generated for the current file. This might not be
-   | what you intended.
-    --------------------------------------------------------------------------------------------------------------------
--- [E181] Potential Issue Error: tests/neg/i17266.scala:32:2 -----------------------------------------------------------
-32 |  wait(10) // error
-   |  ^^^^
-   |  Suspicious call to Predef.wait
-   |--------------------------------------------------------------------------------------------------------------------
-   | Explanation (enabled by `-explain`)
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   | Top-level unqualified calls to AnyRef or Any methods such as wait are
-   | resolved to calls on Predef. This might not be what you intended.
-    --------------------------------------------------------------------------------------------------------------------
--- [E182] Potential Issue Error: tests/neg/i17266.scala:35:7 -----------------------------------------------------------
-35 |  this.wait(10) // error
-   |  ^^^^^^^^^
-   |  Suspicious top-level call to this.wait
-   |--------------------------------------------------------------------------------------------------------------------
-   | Explanation (enabled by `-explain`)
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   | Top-level calls to AnyRef or Any methods are resolved to calls on the
-   | synthetic package object generated for the current file. This might not be
-   | what you intended.
-    --------------------------------------------------------------------------------------------------------------------
--- [E181] Potential Issue Error: tests/neg/i17266.scala:42:2 -----------------------------------------------------------
-42 |  hashCode() // error
-   |  ^^^^^^^^
-   |  Suspicious call to Predef.hashCode
-   |--------------------------------------------------------------------------------------------------------------------
-   | Explanation (enabled by `-explain`)
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   | Top-level unqualified calls to AnyRef or Any methods such as hashCode are
-   | resolved to calls on Predef. This might not be what you intended.
-    --------------------------------------------------------------------------------------------------------------------
--- [E182] Potential Issue Error: tests/neg/i17266.scala:45:7 -----------------------------------------------------------
-45 |  this.hashCode() // error
-   |  ^^^^^^^^^^^^^
-   |  Suspicious top-level call to this.hashCode
-   |--------------------------------------------------------------------------------------------------------------------
-   | Explanation (enabled by `-explain`)
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   | Top-level calls to AnyRef or Any methods are resolved to calls on the
-   | synthetic package object generated for the current file. This might not be
-   | what you intended.
-    --------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:108:2 ----------------------------------------------------------
+108 |  wait() // error
+    |  ^^^^
+    |  Suspicious top-level unqualified call to wait
+    |-------------------------------------------------------------------------------------------------------------------
+    | Explanation (enabled by `-explain`)
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    | Top-level unqualified calls to AnyRef or Any methods such as wait are
+    | resolved to calls on Predef or on imported methods. This might not be what
+    | you intended.
+     -------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:115:2 ----------------------------------------------------------
+115 |  wait() // error
+    |  ^^^^
+    |  Suspicious top-level unqualified call to wait
+    |-------------------------------------------------------------------------------------------------------------------
+    | Explanation (enabled by `-explain`)
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    | Top-level unqualified calls to AnyRef or Any methods such as wait are
+    | resolved to calls on Predef or on imported methods. This might not be what
+    | you intended.
+     -------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:121:2 ----------------------------------------------------------
+121 |  wait(10) // error
+    |  ^^^^
+    |  Suspicious top-level unqualified call to wait
+    |-------------------------------------------------------------------------------------------------------------------
+    | Explanation (enabled by `-explain`)
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    | Top-level unqualified calls to AnyRef or Any methods such as wait are
+    | resolved to calls on Predef or on imported methods. This might not be what
+    | you intended.
+     -------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:128:2 ----------------------------------------------------------
+128 |  wait(10) // error
+    |  ^^^^
+    |  Suspicious top-level unqualified call to wait
+    |-------------------------------------------------------------------------------------------------------------------
+    | Explanation (enabled by `-explain`)
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    | Top-level unqualified calls to AnyRef or Any methods such as wait are
+    | resolved to calls on Predef or on imported methods. This might not be what
+    | you intended.
+     -------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:134:2 ----------------------------------------------------------
+134 |  hashCode() // error
+    |  ^^^^^^^^
+    |  Suspicious top-level unqualified call to hashCode
+    |-------------------------------------------------------------------------------------------------------------------
+    | Explanation (enabled by `-explain`)
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    | Top-level unqualified calls to AnyRef or Any methods such as hashCode are
+    | resolved to calls on Predef or on imported methods. This might not be what
+    | you intended.
+     -------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Error: tests/neg/i17266.scala:141:2 ----------------------------------------------------------
+141 |  hashCode() // error
+    |  ^^^^^^^^
+    |  Suspicious top-level unqualified call to hashCode
+    |-------------------------------------------------------------------------------------------------------------------
+    | Explanation (enabled by `-explain`)
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    | Top-level unqualified calls to AnyRef or Any methods such as hashCode are
+    | resolved to calls on Predef or on imported methods. This might not be what
+    | you intended.
+     -------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i17266.scala
+++ b/tests/neg/i17266.scala
@@ -6,7 +6,7 @@ def test1 =
   }
 
 def test2 =
-  this.synchronized { // error
+  this.synchronized { // not an error (should be?)
     println("hello")
   }
 
@@ -14,36 +14,131 @@ object MyLib
 
 def test3 =
   import MyLib.*
-  synchronized { // not an error (should be?)
+  synchronized { // error
     println("hello")
   }
 
 def test4 =
+  1.synchronized { // not an error (should be?)
+    println("hello")
+  }
+
+object Test4:
+  synchronized { // not an error
+    println("hello")
+  }
+
+object Test5:
+  def test5 =
+    synchronized { // not an error
+      println("hello")
+    }
+
+object Test6:
+  import MyLib.*
+  synchronized { // not an error
+    println("hello")
+  }
+
+object Test7:
+  import MyLib.*
+  def test7 =
+    synchronized { // not an error
+      println("hello")
+    }
+
+/*
+object Test7b:
+  def test8 =
+    import MyLib.*
+    synchronized { // already an error: Reference to synchronized is ambiguous.
+      println("hello")
+    }
+*/
+
+class Test8:
+  synchronized { // not an error
+    println("hello")
+  }
+
+class Test9:
+  def test5 =
+    synchronized { // not an error
+      println("hello")
+    }
+
+class Test10:
+  import MyLib.*
+  synchronized { // not an error
+    println("hello")
+  }
+
+class Test11:
+  import MyLib.*
+  def test7 =
+    synchronized { // not an error
+      println("hello")
+    }
+
+trait Test12:
+  synchronized { // not an error
+    println("hello")
+  }
+
+trait Test13:
+  def test5 =
+    synchronized { // not an error
+      println("hello")
+    }
+
+trait Test14:
+  import MyLib.*
+  synchronized { // not an error
+    println("hello")
+  }
+
+trait Test15:
+  import MyLib.*
+  def test7 =
+    synchronized { // not an error
+      println("hello")
+    }
+
+def test16 =
   wait() // error
 
-def test5 =
-  this.wait() // error
+def test17 =
+  this.wait() // not an error (should be?)
 
-def test6 =
+def test18 =
   import MyLib.*
-  wait() // not an error (should be?)
+  wait() // error
 
-def test7 =
+def test19 =
+  1.wait() // not an error (should be?)
+
+def test20 =
   wait(10) // error
 
-def test8 =
-  this.wait(10) // error
+def test21 =
+  this.wait(10) // not an error (should be?)
 
-def test9 =
+def test22 =
   import MyLib.*
-  wait(10) // not an error (should be?)
+  wait(10) // error
 
-def test10 =
+def test23 =
+  1.wait(10) // not an error (should be?)
+
+def test24 =
   hashCode() // error
 
-def test11 =
-  this.hashCode() // error
+def test25 =
+  this.hashCode() // not an error (should be?)
 
-def test12 =
+def test26 =
   import MyLib.*
-  hashCode() // not an error (should be?)
+  hashCode() // error
+
+def test27 =
+  1.hashCode()// not an error (should be? probably not)

--- a/tests/neg/i17266.scala
+++ b/tests/neg/i17266.scala
@@ -1,0 +1,49 @@
+// scalac: -Werror -explain
+
+def test1 =
+  synchronized { // error
+    println("hello")
+  }
+
+def test2 =
+  this.synchronized { // error
+    println("hello")
+  }
+
+object MyLib
+
+def test3 =
+  import MyLib.*
+  synchronized { // not an error (should be?)
+    println("hello")
+  }
+
+def test4 =
+  wait() // error
+
+def test5 =
+  this.wait() // error
+
+def test6 =
+  import MyLib.*
+  wait() // not an error (should be?)
+
+def test7 =
+  wait(10) // error
+
+def test8 =
+  this.wait(10) // error
+
+def test9 =
+  import MyLib.*
+  wait(10) // not an error (should be?)
+
+def test10 =
+  hashCode() // error
+
+def test11 =
+  this.hashCode() // error
+
+def test12 =
+  import MyLib.*
+  hashCode() // not an error (should be?)


### PR DESCRIPTION
Fixes #17266