### PR TITLE
Test require indent after colon at EOL in REPL

### DIFF
--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -347,6 +347,12 @@ class ReplCompilerTests extends ReplTest:
     assertEquals("java.lang.AssertionError: assertion failed", all.head)
   }
 
+  @Test def `i13097 expect lambda after colon` = contextually:
+    assert(ParseResult.isIncomplete("val x = List(42).foreach:"))
+
+  @Test def `i13097 expect template after colon` = contextually:
+    assert(ParseResult.isIncomplete("class C:"))
+
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");


### PR DESCRIPTION
Follow-up https://github.com/lampepfl/dotty/pull/16466

with test from https://github.com/lampepfl/dotty/pull/14092

which was sadly ignored.