### PR TITLE
deps: update various sbt plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,14 +8,14 @@ libraryDependencySchemes +=
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.20")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.13")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")


### PR DESCRIPTION
This updates the following:

- sbt-sonatype from 3.9.10 -> 3.9.20
- sbt-pgp (now under com.github.sbt) 2.0.0 -> 2.2.1
- ~sbt-pack from 0.13 -> 0.17~
- sbt-buildinfo from 0.9.0 -> 0.11.0
- sbt-mima-plugin from 1.1.0 -> 1.1.2

Note there are a couple others that are still outdated (sbt-scalajs, sbt-jmh), but they may require some more work, so I've purposefully left them out of here.

EDIT: I remeoved the sbt-pack update as there are some breaking changes in there that I'll need to address. I'll do that in a different pr.