### PR TITLE
deps: bump sbt-pack to latest 0.17

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1949,7 +1949,7 @@ object ScaladocConfigs {
   }
 
   lazy val DefaultGenerationConfig = Def.task {
-    def distLocation = (dist / pack).value
+    def distLocation = (dist / Compile / pack).value
     DefaultGenerationSettings.value
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.13")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.17")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 


### PR DESCRIPTION
This pr bumps sbt-pack to the latest 0.17 and also accounts for a breaking change that was introduced in
https://github.com/xerial/sbt-pack/pull/324 meaning that `pack` now must be scoped.