### PR TITLE
test: add in regression test for #7445

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -94,3 +94,6 @@ i4176-gadt.scala
 i13974a.scala
 
 java-inherited-type1
+
+# recursion limit exceeded
+i7445b.scala

--- a/tests/pos/i7445a.scala
+++ b/tests/pos/i7445a.scala
@@ -1,0 +1,10 @@
+// https://github.com/lampepfl/dotty/issues/7445
+
+object Main {
+  type O1[A] = {
+    type OutInner[X] = Unit
+    type Out = OutInner[A]
+  }
+
+  def f1: O1[Int]#Out = ???
+}

--- a/tests/pos/i7445b.scala
+++ b/tests/pos/i7445b.scala
@@ -1,0 +1,12 @@
+// https://github.com/lampepfl/dotty/issues/7445
+
+type O1[A] = {
+  type OutInner[Ts] <: Tuple = Ts match {
+    case EmptyTuple => EmptyTuple
+    case h *: t => h *: OutInner[t]
+  }
+
+  type Out = OutInner[A]
+}
+
+def f1: O1[(Int, Int)]#Out = ???


### PR DESCRIPTION
So this adds in a test that shows that the minimized version of the original issue is fixed, but the original report now fails the pickling tests. I've gone ahead and added a test for that as well, but added it to the excludes. I'll reopen the issue and mention this update.