### PR TITLE
test: add in a regression test for #7414

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -21,6 +21,7 @@ i15181.scala
 i15922.scala
 t5031_2.scala
 i16997.scala
+i7414.scala
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/tests/pos/i7414.scala
+++ b/tests/pos/i7414.scala
@@ -1,0 +1,12 @@
+// https://github.com/lampepfl/dotty/issues/7414
+
+object DepTest {
+  trait Trait {
+    case class Dependent()
+  }
+  object obj extends Trait
+  case class Dep[T <: Trait](t: T) {
+    def fun(q: t.Dependent): Unit = ???
+  }
+  Dep(obj).fun(obj.Dependent())
+}


### PR DESCRIPTION
While the original reported issue does now compile, the pickling tests
fail with:

```diff
- .fun:((q: DepTest.Dep[DepTest.obj.type]#t.Dependent): scala.Unit)>@tests/pos/i7414.scala<223..235>
+ .fun:((q: DepTest.obj.Dependent): scala.Unit)>@tests/pos/i7414.scala<223..235>
```
This adds in a test for this, but adds it to the excludes. I'm assuming
this was what was meant by this comment: https://github.com/lampepfl/dotty/issues/7414#issuecomment-1545331428.

Refs: #7414
