### PR TITLE
test: add in a regression test for #8742

### DIFF
--- a/tests/neg-custom-args/fatal-warnings/i8711.check
+++ b/tests/neg-custom-args/fatal-warnings/i8711.check
@@ -6,3 +6,7 @@
 12 |    case x: C => x // error
    |         ^^^^
    |         Unreachable case
+-- [E030] Match case Unreachable Error: tests/neg-custom-args/fatal-warnings/i8711.scala:17:9 --------------------------
+17 |    case x: (B | C) => x // error
+   |         ^^^^^^^^^^
+   |         Unreachable case

--- a/tests/neg-custom-args/fatal-warnings/i8711.scala
+++ b/tests/neg-custom-args/fatal-warnings/i8711.scala
@@ -12,4 +12,9 @@ object Test {
     case x: C => x // error
     case _ =>
   }
+
+  def baz(x: A) = x match {
+    case x: (B | C) => x // error
+    case _          =>
+  }
 }


### PR DESCRIPTION
There was also some other tests that were _very_ similar to this, so it
seemed like the logical place to also just include this one instead of
creating another file for it.

Closes #8742
