### PR TITLE
test: add in a regression test for #9270

### DIFF
--- a/compiler/test/dotc/run-test-recheck.excludes
+++ b/compiler/test/dotc/run-test-recheck.excludes
@@ -11,3 +11,6 @@ tagless.scala
 safeThrowsStrawman2.scala
 t7584.scala
 function-arity.scala
+
+# InvocationTargetException
+i9270.scala

--- a/tests/run/i9270.scala
+++ b/tests/run/i9270.scala
@@ -1,0 +1,9 @@
+// https://github.com/lampepfl/dotty/issues/9270
+class C:
+  object Foo extends Foo.Bar.Base:
+    object Bar:
+      class Base
+
+@main def Test() =
+  val c = new C
+  val x = new c.Foo.Bar.Base


### PR DESCRIPTION
Turns out this still fails, but only when ran in the test suite, not with a tool like scala-cli. I added it to the excludes.

Closes #9270