### PR TITLE
docs: remove empty "changes in type checking" page

### DIFF
--- a/docs/_docs/reference/changed-features/type-checking.md
+++ b/docs/_docs/reference/changed-features/type-checking.md
@@ -1,7 +1,0 @@
----
-layout: doc-page
-title: "Changes in Type Checking"
-nightlyOf: https://docs.scala-lang.org/scala3/reference/changed-features/type-checking.html
----
-
-*** **TO BE FILLED IN** ***

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -92,7 +92,6 @@ subsection:
           - page: reference/changed-features/operators.md
           - page: reference/changed-features/wildcards.md
           - page: reference/changed-features/imports.md
-          - page: reference/changed-features/type-checking.md
           - page: reference/changed-features/type-inference.md
           - page: reference/changed-features/implicit-resolution.md
           - page: reference/changed-features/implicit-conversions.md

--- a/project/resources/referenceReplacements/sidebar.yml
+++ b/project/resources/referenceReplacements/sidebar.yml
@@ -88,7 +88,6 @@ subsection:
       - page: reference/changed-features/operators.md
       - page: reference/changed-features/wildcards.md
       - page: reference/changed-features/imports.md
-      - page: reference/changed-features/type-checking.md
       - page: reference/changed-features/type-inference.md
       - page: reference/changed-features/implicit-resolution.md
       - page: reference/changed-features/implicit-conversions.md

--- a/project/scripts/expected-links/reference-expected-links.txt
+++ b/project/scripts/expected-links/reference-expected-links.txt
@@ -18,7 +18,6 @@
 ./changed-features/pattern-matching.html
 ./changed-features/structural-types-spec.html
 ./changed-features/structural-types.html
-./changed-features/type-checking.html
 ./changed-features/type-inference.html
 ./changed-features/vararg-splices.html
 ./changed-features/wildcards.html


### PR DESCRIPTION
This relates to https://github.com/lampepfl/dotty/issues/10759. Just as a general rule of thumb, I don't think we should have fully empty pages in documentation like this. It's not a great look to the outside world.

[skip community_build]

refs: https://github.com/lampepfl/dotty/issues/10759