### PR TITLE
test: add in a regression test for #11118

### DIFF
--- a/tests/neg/i11118.check
+++ b/tests/neg/i11118.check
@@ -1,0 +1,12 @@
+-- Warning: tests/neg/i11118.scala:2:12 --------------------------------------------------------------------------------
+2 |val (a,b) = (1,2,3) // error // warning
+  |            ^^^^^^^
+  |          pattern's type (Any, Any) does not match the right hand side expression's type (Int, Int, Int)
+  |
+  |          If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,
+  |          which may result in a MatchError at runtime.
+  |          This patch can be rewritten automatically under -rewrite -source 3.2-migration.
+-- Error: tests/neg/i11118.scala:2:4 -----------------------------------------------------------------------------------
+2 |val (a,b) = (1,2,3) // error // warning
+  |    ^
+  |    this case is unreachable since type (Int, Int, Int) is not a subclass of class Tuple2

--- a/tests/neg/i11118.scala
+++ b/tests/neg/i11118.scala
@@ -1,0 +1,2 @@
+// https://github.com/lampepfl/dotty/issues/11118
+val (a,b) = (1,2,3) // error // warning


### PR DESCRIPTION
This adds in a regression test showing that just like in Scala 2 a user
sees a warning about how the right hand side doesn't match the type of
the left.

closes #11118
