### PR TITLE
Remove unnecessary `tasty-inspector` dependency

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -926,7 +926,6 @@ object Build {
   lazy val `stdlib-bootstrapped` = project.in(file("stdlib-bootstrapped")).
     withCommonSettings(Bootstrapped).
     dependsOn(dottyCompiler(Bootstrapped) % "provided; compile->runtime; test->test").
-    dependsOn(`scala3-tasty-inspector` % "test->test").
     settings(commonBootstrappedSettings).
     settings(
       moduleName := "scala-library",


### PR DESCRIPTION
This dependency should have been added only to `stdlib-bootstrapped-tasty-tests`.