### PR TITLE
docs: minor fix in package object doc

### DIFF
--- a/docs/_docs/reference/dropped-features/package-objects.md
+++ b/docs/_docs/reference/dropped-features/package-objects.md
@@ -11,7 +11,7 @@ package object p {
   def b = ...
 }
 ```
-will be dropped. They are still available in Scala 3.0 and 3.1, but will be deprecated and removed afterwards.
+will be dropped. They are still available, but will be deprecated and removed afterwards.
 
 Package objects are no longer needed since all kinds of definitions can now be written at the top-level. Example:
 ```scala


### PR DESCRIPTION
Package objects are still available in scala 3.2 (and will be available in 3.3), so no need to write versions explicitly.