### PR TITLE
Two fixes to capture checking

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -976,8 +976,11 @@ class CheckCaptures extends Recheck, SymTransformer:
           recur(refs, Nil)
 
         private def healCaptureSet(cs: CaptureSet): Unit =
-          val toInclude = widenParamRefs(cs.elems.toList.filter(!isAllowed(_)).asInstanceOf)
-          toInclude.foreach(checkSubset(_, cs, tree.srcPos))
+          def avoidance(elems: List[CaptureRef])(using Context): Unit =
+            val toInclude = widenParamRefs(elems.filter(!isAllowed(_)).asInstanceOf)
+            //println(i"HEAL $cs by widening to $toInclude")
+            toInclude.foreach(checkSubset(_, cs, tree.srcPos))
+          cs.ensureWellformed(avoidance)
 
         private var allowed: SimpleIdentitySet[TermParamRef] = SimpleIdentitySet.empty
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3880,7 +3880,8 @@ object Types {
     /** Does one of the parameter types contain references to earlier parameters
      *  of this method type which cannot be eliminated by de-aliasing?
      */
-    def isParamDependent(using Context): Boolean = paramDependencyStatus == TrueDeps
+    def isParamDependent(using Context): Boolean =
+      paramDependencyStatus == TrueDeps || paramDependencyStatus == CaptureDeps
 
     /** Is there a dependency involving a reference in a capture set, but
      *  otherwise no true result dependency?

--- a/tests/neg-custom-args/captures/usingLogFile-alt.check
+++ b/tests/neg-custom-args/captures/usingLogFile-alt.check
@@ -1,0 +1,7 @@
+-- Error: tests/neg-custom-args/captures/usingLogFile-alt.scala:18:2 ---------------------------------------------------
+18 |  usingFile(  // error
+   |  ^^^^^^^^^
+   |  Sealed type variable T cannot  be instantiated to box () => Unit since
+   |  that type captures the root capability `cap`.
+   |  This is often caused by a local capability in the body of method usingFile
+   |  leaking as part of its result.

--- a/tests/neg-custom-args/captures/usingLogFile-alt.scala
+++ b/tests/neg-custom-args/captures/usingLogFile-alt.scala
@@ -1,0 +1,23 @@
+// Reported in issue #17517
+
+import language.experimental.captureChecking
+import java.io.*
+
+object Test:
+  class Logger(f: OutputStream^):
+    def log(msg: String): Unit = ???
+
+  def usingFile[sealed T](name: String, op: OutputStream^ => T): T =
+    val f = new FileOutputStream(name)
+    val result = op(f)
+    f.close()
+    result
+
+  def usingLogger[sealed T](f: OutputStream^)(op: Logger^{f} => T): T = ???
+
+  usingFile(  // error
+    "foo",
+    file => {
+      usingLogger(file)(l => () => l.log("test"))
+    }
+  )

--- a/tests/neg-custom-args/captures/usingLogFile.check
+++ b/tests/neg-custom-args/captures/usingLogFile.check
@@ -45,10 +45,3 @@
    |                that type captures the root capability `cap`.
    |                This is often caused by a local capability in the body of method usingFile
    |                leaking as part of its result.
--- Error: tests/neg-custom-args/captures/usingLogFile.scala:72:6 -------------------------------------------------------
-72 |      usingLogger(_, l => () => l.log("test"))) // error
-   |      ^^^^^^^^^^^
-   |      Sealed type variable T cannot  be instantiated to box () => Unit since
-   |      that type captures the root capability `cap`.
-   |      This is often caused by a local capability in the body of method usingLogger
-   |      leaking as part of its result.

--- a/tests/neg-custom-args/captures/usingLogFile.scala
+++ b/tests/neg-custom-args/captures/usingLogFile.scala
@@ -69,5 +69,5 @@ object Test4:
 
   def test =
     val later = usingFile("logfile",            // error
-      usingLogger(_, l => () => l.log("test"))) // error
+      usingLogger(_, l => () => l.log("test"))) // ok, since we can widen `l` to `file` instead of to `cap`
     later()

--- a/tests/pos-custom-args/captures/cc-dep-param.scala
+++ b/tests/pos-custom-args/captures/cc-dep-param.scala
@@ -1,0 +1,8 @@
+import language.experimental.captureChecking
+
+trait Foo[T]
+def test(): Unit =
+  val a: Foo[Int]^ = ???
+  val useA: () ->{a} Unit = ???
+  def foo[X](x: Foo[X]^, op: () ->{x} Unit): Unit = ???
+  foo(a, useA)


### PR DESCRIPTION
- It changes `isParamDependent` to consider `CaptureDependency` as well, so that when applying a capture dependent function the capture sets in the types of the remaining parameters will be correctly substituted. For example:
```scala
def foo[X](x: Foo[X]^, op: () ->{x} Unit): Unit = ???
foo(a, useA)
```
After rechecking `a` in the argument list, the expected type of the second argument, `useA`, should become `() -> {a} Unit`. This example previously does not work.

- It fixes #17517. It fixes the healing of capture sets, which happens at the end of the capture checking phase, in which we traverse the capture checked tree and try to heal the ill-formed capture sets in type arguments. Here we say a capture set `C` in a type argument is ill-formed if it contains `TermParamRef` bound by other lambdas. For example:
```scala
def usingLogger[sealed T](f: OutputStream^)(op: Logger^{f} => T): T = ???
usingLogger[() ->?1 Unit](file)(l => () => l.log("test"))
```
`l` will be propagated to `?1` as a result of capture checking, which makes `?1` ill-formed and we should widen `l` to `file`. The problem is that we heal the capture sets one-after-another but the healing of a later capture set may propagate more `TermParamRef`s to a healed one. For example:
```
usingFile[() ->?2 Unit](  // should be error
  "foo",
  file => {
    usingLogger[() ->?1 Unit](file)(l => () => l.log("test"))
  }
)
```
After capture checking both `?1` and `?2` will be `{l}`. When traversing the tree we first heal `?2`, wherein we widen `l` to `file`, but `file` is a `TermRef` here and we do nothing. Then, only later when we heal `?1`, we also widen `l` to `file` but this will end up propagating a `TermParamRef` of `file` to `?2`, which we should have widened as well. But `?2` is already healed and is not inspected again.

This PR solves this issue by installing a handler when healing the capture sets which will try to heal the new elements propagated later in the healing process.