### PR TITLE
Handle empty files and truncated YAML front matter

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/site/common.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/common.scala
@@ -63,11 +63,16 @@ def yamlParser(using ctx: StaticSiteContext): Parser = Parser.builder(defaultMar
 def loadTemplateFile(file: File, defaultTitle: Option[TemplateName] = None)(using ctx: StaticSiteContext): TemplateFile = {
   val lines = Files.readAllLines(file.toPath).asScala.toList
 
-  val (config, content) = if (lines.head == ConfigSeparator) {
+  val (config, content) = if (!lines.isEmpty && lines.head == ConfigSeparator) {
     // Taking the second occurrence of ConfigSeparator.
     // The rest may appear within the content.
-    val index = lines.drop(1).indexOf(ConfigSeparator) + 2
-    (lines.take(index), lines.drop(index))
+    val secondSeparatorIndex = lines.drop(1).indexOf(ConfigSeparator)
+    if secondSeparatorIndex != -1 then
+      (lines.take(secondSeparatorIndex + 2), lines.drop(secondSeparatorIndex + 2))
+    else
+      // If there is no second occurrence of ConfigSeparator, we assume that the
+      // whole file is config.
+      (lines.tail, Nil)
   } else (Nil, lines)
 
   val configParsed = yamlParser.parse(config.mkString(LineSeparator))

--- a/scaladoc/test-documentations/noConfigEnd/_docs/hello.md
+++ b/scaladoc/test-documentations/noConfigEnd/_docs/hello.md
@@ -1,0 +1,3 @@
+---
+title: My page
+foo: bar

--- a/scaladoc/test/dotty/tools/scaladoc/site/SiteGeneratationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SiteGeneratationTest.scala
@@ -96,6 +96,22 @@ class SiteGeneratationTest extends BaseHtmlTest:
   }
 
   @Test
+  def emptyPage() = withGeneratedSite(testDocPath.resolve("emptyPage")){
+    withHtmlFile("docs/hello.html") { content =>
+      // There should be no content as the page body is empty.
+      content.assertTextsIn("#content", Nil*)
+    }
+  }
+
+  @Test
+  def noConfigEnd() = withGeneratedSite(testDocPath.resolve("noConfigEnd")){
+    withHtmlFile("docs/hello.html") { content =>
+      // There should be no content as the page body is empty.
+      content.assertTextsIn("#content", Nil*)
+    }
+  }
+
+  @Test
   def staticLinking() = withGeneratedSite(testDocPath.resolve("static-links")){
 
     withHtmlFile("docs/Adoc.html"){ content  =>


### PR DESCRIPTION
Scaladoc crashes when a static file is empty:

```
[error] Caused by: java.util.NoSuchElementException: head of empty list
[error] 	at scala.collection.immutable.Nil$.head(List.scala:662)
[error] 	at scala.collection.immutable.Nil$.head(List.scala:661)
[error] 	at dotty.tools.scaladoc.site.common$package$.loadTemplateFile(common.scala:66)
[error] 	at dotty.tools.scaladoc.site.StaticSiteLoader.loadRecursively(StaticSiteLoader.scala:191)
[error] 	at dotty.tools.scaladoc.site.StaticSiteLoader.loadRecursively$$anonfun$1(StaticSiteLoader.scala:188)
```

See https://github.com/sbt/sbt/issues/7256 for more context.

This PR solves this issue, and also handles unended YAML front matter.