### PR TITLE
ClassfileParser: allow missing param names (for JDK 21)

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -758,10 +758,12 @@ class ClassfileParser(
         case tpnme.MethodParametersATTR =>
           val paramCount = in.nextByte
           for i <- 0 until paramCount do
-            val name = pool.getName(in.nextChar)
+            val index = in.nextChar
             val flags = in.nextChar
-            if (flags & JAVA_ACC_SYNTHETIC) == 0 then
-              res.namedParams += (i -> name.name)
+            if index != 0 then
+              val name = pool.getName(index)
+              if (flags & JAVA_ACC_SYNTHETIC) == 0 then
+                res.namedParams += (i -> name.name)
 
         case tpnme.AnnotationDefaultATTR =>
           sym.addAnnotation(Annotation(defn.AnnotationDefaultAnnot, Nil, sym.span))


### PR DESCRIPTION
this is a forward port of scala/scala#10397 (fixing scala/bug#12783, from which Scala 3 also suffers) — the same fix we'll be shipping in 2.12.18 and 2.13.11

I haven't included a unit test, because
* a similar change has already been well validated in a Scala 2 context
* without this change, the compiler can't compile anything at all on JDK 21
* we need the reference compiler to include this change before we can bootstrap on JDK 21 anyway

but I did manually test it locally, by bootstrapping on JDK 11, publishing the resulting compiler locally, and then launching the REPL and evaluating `2 + 2`

on 3.3.0-RC6, that fails with:

> error while loading AccessFlag,
> class file /modules/java.base/java/lang/reflect/AccessFlag.class is broken, reading aborted with class java.lang.RuntimeException
> bad constant pool index: 0 at pos: 5189
> error while loading ElementType,
> class file /modules/java.base/java/lang/annotation/ElementType.class is broken, reading aborted with class java.lang.RuntimeException
> bad constant pool index: 0 at pos: 1220
> 2 errors found

whereas with this change, it succeeds.
