### PR TITLE
Register `paramProxy` and `thisProxy` in `Quote` type

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -486,6 +486,7 @@ class Inliner(val call: tpd.Tree)(using Context):
   /** Register type of leaf node */
   private def registerLeaf(tree: Tree): Unit = tree match
     case _: This | _: Ident | _: TypeTree => registerTypes.traverse(tree.typeOpt)
+    case tree: Quote => registerTypes.traverse(tree.bodyType)
     case _ =>
 
   /** Make `tree` part of inlined expansion. This means its owner has to be changed

--- a/tests/pos-macros/i17434a/Macro.scala
+++ b/tests/pos-macros/i17434a/Macro.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+object SelectDynamicMacroImpl {
+  def selectImpl[E: Type](
+    ref: Expr[SQLSyntaxProvider[_]],
+    name: Expr[String]
+  )(using Quotes): Expr[SQLSyntax] = '{SQLSyntax("foo")}
+}

--- a/tests/pos-macros/i17434a/Test.scala
+++ b/tests/pos-macros/i17434a/Test.scala
@@ -1,0 +1,23 @@
+// test.scala
+import scala.language.dynamics
+
+trait SQLSyntaxProvider[A] extends Dynamic{
+  def field(name: String): SQLSyntax = ???
+
+  inline def selectDynamic(inline name: String): SQLSyntax =
+  select[A](this, name)
+
+  inline def select[E](ref: SQLSyntaxProvider[A], inline name: String): SQLSyntax =
+    ${ SelectDynamicMacroImpl.selectImpl[E]('ref, 'name) }
+}
+
+class SQLSyntax(value: String)
+trait SQLSyntaxSupport[A]
+case class ColumnSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](support: S) extends SQLSyntaxProvider[A]
+
+case class Account(id: Long, name: String)
+object Account extends SQLSyntaxSupport[Account]
+
+def Test() =
+  val p = ColumnSQLSyntaxProvider[Account.type, Account](Account)
+  assert(p.name == SQLSyntax("name"))

--- a/tests/pos-macros/i17434b/Macro.scala
+++ b/tests/pos-macros/i17434b/Macro.scala
@@ -1,0 +1,29 @@
+trait NameOf:
+  transparent inline def nameOf(inline expr: Any): String = ${NameOfImpl.nameOf('expr)}
+  transparent inline def nameOf[T](inline expr: T => Any): String = ${NameOfImpl.nameOf('expr)}
+object NameOf extends NameOf
+
+import scala.compiletime.*
+
+import scala.annotation.tailrec
+import scala.quoted.*
+
+object NameOfImpl {
+  def nameOf(expr: Expr[Any])(using Quotes): Expr[String] = {
+    import quotes.reflect.*
+    @tailrec def extract(tree: Tree): String = tree match {
+      case Ident(name) => name
+      case Select(_, name) => name
+      case Block(List(stmt), term) => extract(stmt)
+      case DefDef("$anonfun", _, _, Some(term)) => extract(term)
+      case Block(_, term) => extract(term)
+      case Apply(term, _) if term.symbol.fullName != "<special-ops>.throw" => extract(term)
+      case TypeApply(term, _) => extract(term)
+      case Inlined(_, _, term) => extract(term)
+      case Typed(term, _) => extract(term)
+      case _ => throw new MatchError(s"Unsupported expression: ${expr.show}")
+    }
+    val name = extract(expr.asTerm)
+    Expr(name)
+  }
+}

--- a/tests/pos-macros/i17434b/Test.scala
+++ b/tests/pos-macros/i17434b/Test.scala
@@ -1,0 +1,6 @@
+import NameOf._
+def test() =
+    def func1(x: Int): String = ???
+    val funcVal = func1 _
+    assert(nameOf(funcVal) == "funcVal")
+    assert(nameOf(func1 _) == "func1")

--- a/tests/pos-macros/i17434c/Macro.scala
+++ b/tests/pos-macros/i17434c/Macro.scala
@@ -1,0 +1,3 @@
+import scala.quoted.*
+inline def foo[T](expr: T => Any): Unit = ${impl('expr)}
+def impl(expr: Expr[Any])(using Quotes): Expr[Unit] = '{}

--- a/tests/pos-macros/i17434c/Test.scala
+++ b/tests/pos-macros/i17434c/Test.scala
@@ -1,0 +1,1 @@
+def test(f: Int => Any) = foo(f)

--- a/tests/pos-macros/i17434d/Macro.scala
+++ b/tests/pos-macros/i17434d/Macro.scala
@@ -1,0 +1,2 @@
+import scala.quoted.*
+def impl[E: Type](ref: Expr[Foo[_]])(using Quotes): Expr[Unit] = '{ }

--- a/tests/pos-macros/i17434d/Test.scala
+++ b/tests/pos-macros/i17434d/Test.scala
@@ -1,0 +1,4 @@
+trait Foo[A]:
+  inline def foo(): Unit = bar[this.type](this)
+  inline def bar[E](ref: Foo[A]): Unit = ${ impl[E]('ref) }
+def test(p: Foo[Int]) = p.foo()


### PR DESCRIPTION
Before 5ae7861eb246461bc0f970d0e446c2b080440d18 we used to find those types withing the `tpt`.

Fixes #17434