### PR TITLE
Make polymorphic functions more efficient and expressive

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1036,6 +1036,40 @@ object desugar {
     name
   }
 
+  /** Strip parens and empty blocks around the body of `tree`. */
+  def normalizePolyFunction(tree: PolyFunction)(using Context): PolyFunction =
+    def stripped(body: Tree): Tree = body match
+      case Parens(body1) =>
+        stripped(body1)
+      case Block(Nil, body1) =>
+        stripped(body1)
+      case _ => body
+    cpy.PolyFunction(tree)(tree.targs, stripped(tree.body)).asInstanceOf[PolyFunction]
+
+  /** Desugar [T_1, ..., T_M] => (P_1, ..., P_N) => R
+   *  Into    scala.PolyFunction { def apply[T_1, ..., T_M](x$1: P_1, ..., x$N: P_N): R }
+   */
+  def makePolyFunctionType(tree: PolyFunction)(using Context): RefinedTypeTree =
+    val PolyFunction(tparams: List[untpd.TypeDef] @unchecked, fun @ untpd.Function(vparamTypes, res)) = tree: @unchecked
+    val funFlags = fun match
+      case fun: FunctionWithMods =>
+        fun.mods.flags
+      case _ => EmptyFlags
+
+    // TODO: make use of this in the desugaring when pureFuns is enabled.
+    // val isImpure = funFlags.is(Impure)
+
+    // Function flags to be propagated to each parameter in the desugared method type.
+    val paramFlags = funFlags.toTermFlags & Given
+    val vparams = vparamTypes.zipWithIndex.map:
+      case (p: ValDef, _) => p.withAddedFlags(paramFlags)
+      case (p, n) => makeSyntheticParameter(n + 1, p).withAddedFlags(paramFlags)
+
+    RefinedTypeTree(ref(defn.PolyFunctionType), List(
+       DefDef(nme.apply, tparams :: vparams :: Nil, res, EmptyTree).withFlags(Synthetic)
+    )).withSpan(tree.span)
+  end makePolyFunctionType
+
   /** Invent a name for an anonympus given of type or template `impl`. */
   def inventGivenOrExtensionName(impl: Tree)(using Context): SimpleName =
     val str = impl match
@@ -1429,14 +1463,17 @@ object desugar {
   }
 
   /** Make closure corresponding to function.
-   *      params => body
+   *      [tparams] => params => body
    *  ==>
-   *      def $anonfun(params) = body
+   *      def $anonfun[tparams](params) = body
    *      Closure($anonfun)
    */
-  def makeClosure(params: List[ValDef], body: Tree, tpt: Tree | Null = null, span: Span)(using Context): Block =
+  def makeClosure(tparams: List[TypeDef], vparams: List[ValDef], body: Tree, tpt: Tree | Null = null, span: Span)(using Context): Block =
+    val paramss: List[ParamClause] =
+      if tparams.isEmpty then vparams :: Nil
+      else tparams :: vparams :: Nil
     Block(
-      DefDef(nme.ANON_FUN, params :: Nil, if (tpt == null) TypeTree() else tpt, body)
+      DefDef(nme.ANON_FUN, paramss, if (tpt == null) TypeTree() else tpt, body)
         .withSpan(span)
         .withMods(synthetic | Artifact),
       Closure(Nil, Ident(nme.ANON_FUN), EmptyTree))
@@ -1728,56 +1765,6 @@ object desugar {
       }
     }
 
-    def makePolyFunction(targs: List[Tree], body: Tree, pt: Type): Tree = body match {
-      case Parens(body1) =>
-        makePolyFunction(targs, body1, pt)
-      case Block(Nil, body1) =>
-        makePolyFunction(targs, body1, pt)
-      case Function(vargs, res) =>
-        assert(targs.nonEmpty)
-        // TODO: Figure out if we need a `PolyFunctionWithMods` instead.
-        val mods = body match {
-          case body: FunctionWithMods => body.mods
-          case _ => untpd.EmptyModifiers
-        }
-        val polyFunctionTpt = ref(defn.PolyFunctionType)
-        val applyTParams = targs.asInstanceOf[List[TypeDef]]
-        if (ctx.mode.is(Mode.Type)) {
-          // Desugar [T_1, ..., T_M] -> (P_1, ..., P_N) => R
-          // Into    scala.PolyFunction { def apply[T_1, ..., T_M](x$1: P_1, ..., x$N: P_N): R }
-
-          val applyVParams = vargs.zipWithIndex.map {
-            case (p: ValDef, _) => p.withAddedFlags(mods.flags)
-            case (p, n) => makeSyntheticParameter(n + 1, p).withAddedFlags(mods.flags.toTermFlags)
-          }
-          RefinedTypeTree(polyFunctionTpt, List(
-            DefDef(nme.apply, applyTParams :: applyVParams :: Nil, res, EmptyTree).withFlags(Synthetic)
-          ))
-        }
-        else {
-          // Desugar [T_1, ..., T_M] -> (x_1: P_1, ..., x_N: P_N) => body
-          // with pt [S_1, ..., S_M] -> (O_1, ..., O_N) => R
-          // Into    new scala.PolyFunction { def apply[T_1, ..., T_M](x_1: P_1, ..., x_N: P_N): R2 = body }
-          // where R2 is R, with all references to S_1..S_M replaced with T1..T_M.
-
-          def typeTree(tp: Type) = tp match
-            case RefinedType(parent, nme.apply, poly @ PolyType(_, mt: MethodType)) if parent.classSymbol eq defn.PolyFunctionClass =>
-              untpd.DependentTypeTree((tsyms, vsyms) =>
-                mt.resultType.substParams(mt, vsyms.map(_.termRef)).substParams(poly, tsyms.map(_.typeRef)))
-            case _ => TypeTree()
-
-          val applyVParams = vargs.asInstanceOf[List[ValDef]]
-            .map(varg => varg.withAddedFlags(mods.flags | Param))
-            New(Template(emptyConstructor, List(polyFunctionTpt), Nil, EmptyValDef,
-              List(DefDef(nme.apply, applyTParams :: applyVParams :: Nil, typeTree(pt), res))
-              ))
-        }
-      case _ =>
-        // may happen for erroneous input. An error will already have been reported.
-        assert(ctx.reporter.errorsReported)
-        EmptyTree
-    }
-
     // begin desugar
 
     // Special case for `Parens` desugaring: unlike all the desugarings below,
@@ -1790,8 +1777,6 @@ object desugar {
     }
 
     val desugared = tree match {
-      case PolyFunction(targs, body) =>
-        makePolyFunction(targs, body, pt) orElse tree
       case SymbolLit(str) =>
         Apply(
           ref(defn.ScalaSymbolClass.companionModule.termRef),

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1434,12 +1434,12 @@ object desugar {
    *      def $anonfun(params) = body
    *      Closure($anonfun)
    */
-  def makeClosure(params: List[ValDef], body: Tree, tpt: Tree | Null = null, isContextual: Boolean, span: Span)(using Context): Block =
+  def makeClosure(params: List[ValDef], body: Tree, tpt: Tree | Null = null, span: Span)(using Context): Block =
     Block(
       DefDef(nme.ANON_FUN, params :: Nil, if (tpt == null) TypeTree() else tpt, body)
         .withSpan(span)
         .withMods(synthetic | Artifact),
-      Closure(Nil, Ident(nme.ANON_FUN), if (isContextual) ContextualEmptyTree else EmptyTree))
+      Closure(Nil, Ident(nme.ANON_FUN), EmptyTree))
 
   /** If `nparams` == 1, expand partial function
    *

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -420,10 +420,7 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
     case Closure(_, meth, _) => true
     case Block(Nil, expr) => isContextualClosure(expr)
     case Block(DefDef(nme.ANON_FUN, params :: _, _, _) :: Nil, cl: Closure) =>
-      if params.isEmpty then
-        cl.tpt.eq(untpd.ContextualEmptyTree) || defn.isContextFunctionType(cl.tpt.typeOpt)
-      else
-        isUsingClause(params)
+      isUsingClause(params)
     case _ => false
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1192,7 +1192,6 @@ object Trees {
 
     @sharable val EmptyTree: Thicket = genericEmptyTree
     @sharable val EmptyValDef: ValDef = genericEmptyValDef
-    @sharable val ContextualEmptyTree: Thicket = new EmptyTree() // an empty tree marking a contextual closure
 
     // ----- Auxiliary creation methods ------------------
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -151,7 +151,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class CapturesAndResult(refs: List[Tree], parent: Tree)(implicit @constructorOnly src: SourceFile) extends TypTree
 
   /** Short-lived usage in typer, does not need copy/transform/fold infrastructure */
-  case class DependentTypeTree(tp: List[Symbol] => Type)(implicit @constructorOnly src: SourceFile) extends Tree
+  case class DependentTypeTree(tp: (List[TypeSymbol], List[TermSymbol]) => Type)(implicit @constructorOnly src: SourceFile) extends Tree
 
   @sharable object EmptyTypeIdent extends Ident(tpnme.EMPTY)(NoSource) with WithoutTypeOrPos[Untyped] {
     override def isEmpty: Boolean = true

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -236,10 +236,12 @@ object NameOps {
      */
     def isPlainFunction(using Context): Boolean = functionArity >= 0
 
-    /** Is a function name that contains `mustHave` as a substring */
-    private def isSpecificFunction(mustHave: String)(using Context): Boolean =
+    /** Is a function name that contains `mustHave` as a substring
+     *  and has arity `minArity` or greater.
+     */
+    private def isSpecificFunction(mustHave: String, minArity: Int = 0)(using Context): Boolean =
       val suffixStart = functionSuffixStart
-      isFunctionPrefix(suffixStart, mustHave) && funArity(suffixStart) >= 0
+      isFunctionPrefix(suffixStart, mustHave) && funArity(suffixStart) >= minArity
 
     def isContextFunction(using Context): Boolean = isSpecificFunction("Context")
     def isImpureFunction(using Context): Boolean = isSpecificFunction("Impure")

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1872,6 +1872,8 @@ object Types {
         if alwaysDependent || mt.isResultDependent then
           RefinedType(funType, nme.apply, mt)
         else funType
+      case poly @ PolyType(_, mt: MethodType) if !mt.isParamDependent =>
+        RefinedType(defn.PolyFunctionType, nme.apply, poly)
     }
 
     /** The signature of this type. This is by default NotAMethod,

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1511,6 +1511,7 @@ object Parsers {
             TermLambdaTypeTree(params.asInstanceOf[List[ValDef]], resultType)
           else if imods.isOneOf(Given | Impure) || erasedArgs.contains(true) then
             if imods.is(Given) && params.isEmpty then
+              imods &~= Given
               syntaxError(em"context function types require at least one parameter", paramSpan)
             FunctionWithMods(params, resultType, imods, erasedArgs.toList)
           else if !ctx.settings.YkindProjector.isDefault then

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -297,9 +297,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   protected def paramsText(lam: LambdaType): Text = {
     val erasedParams = lam.erasedParams
-    def paramText(name: Name, tp: Type, erased: Boolean) =
-      keywordText("erased ").provided(erased) ~ toText(name) ~ lambdaHash(lam) ~ toTextRHS(tp, isParameter = true)
-    Text(lam.paramNames.lazyZip(lam.paramInfos).lazyZip(erasedParams).map(paramText), ", ")
+    def paramText(ref: ParamRef, erased: Boolean) =
+      keywordText("erased ").provided(erased) ~ ParamRefNameString(ref) ~ lambdaHash(lam) ~ toTextRHS(ref.underlying, isParameter = true)
+    Text(lam.paramRefs.lazyZip(erasedParams).map(paramText), ", ")
   }
 
   protected def ParamRefNameString(name: Name): String = nameString(name)
@@ -363,7 +363,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
       case tp @ ConstantType(value) =>
         toText(value)
       case pref: TermParamRef =>
-        nameString(pref.binder.paramNames(pref.paramNum)) ~ lambdaHash(pref.binder)
+        ParamRefNameString(pref) ~ lambdaHash(pref.binder)
       case tp: RecThis =>
         val idx = openRecs.reverse.indexOf(tp.binder)
         if (idx >= 0) selfRecName(idx + 1)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -174,7 +174,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
       ~ " " ~ argText(args.last)
     }
 
-  private def toTextMethodAsFunction(info: Type, isPure: Boolean, refs: Text = Str("")): Text = info match
+  protected def toTextMethodAsFunction(info: Type, isPure: Boolean, refs: Text = Str("")): Text = info match
     case info: MethodType =>
       val capturesRoot = refs == rootSetText
       changePrec(GlobalPrec) {

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -196,6 +196,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case AmbiguousExtensionMethodID // errorNumber 180
   case UnqualifiedCallToAnyRefMethodID // errorNumber: 181
   case NotConstantID // errorNumber: 182
+  case ClosureCannotHaveInternalParameterDependenciesID // errorNumber: 183
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -51,6 +51,13 @@ object Message:
    */
   private class Seen(disambiguate: Boolean):
 
+    /** The set of lambdas that were opened at some point during printing. */
+    private val openedLambdas = new collection.mutable.HashSet[LambdaType]
+
+    /** Register that `tp` was opened during printing. */
+    def openLambda(tp: LambdaType): Unit =
+      openedLambdas += tp
+
     val seen = new collection.mutable.HashMap[SeenKey, List[Recorded]]:
       override def default(key: SeenKey) = Nil
 
@@ -89,8 +96,22 @@ object Message:
       val existing = seen(key)
       lazy val dealiased = followAlias(entry)
 
-      // alts: The alternatives in `existing` that are equal, or follow (an alias of) `entry`
-      var alts = existing.dropWhile(alt => dealiased ne followAlias(alt))
+      /** All lambda parameters with the same name are given the same superscript as
+       *  long as their corresponding binder has been printed.
+       *  See tests/neg/lambda-rename.scala for test cases.
+       */
+      def sameSuperscript(cur: Recorded, existing: Recorded) =
+        (cur eq existing) ||
+        (cur, existing).match
+          case (cur: ParamRef, existing: ParamRef) =>
+            (cur.paramName eq existing.paramName) &&
+            openedLambdas.contains(cur.binder) &&
+            openedLambdas.contains(existing.binder)
+          case _ =>
+            false
+
+      // The length of alts corresponds to the number of superscripts we need to print.
+      var alts = existing.dropWhile(alt => !sameSuperscript(dealiased, followAlias(alt)))
       if alts.isEmpty then
         alts = entry :: existing
         seen(key) = alts
@@ -208,10 +229,20 @@ object Message:
       case tp: SkolemType => seen.record(tp.repr.toString, isType = true, tp)
       case _ => super.toTextRef(tp)
 
+    override def toTextMethodAsFunction(info: Type, isPure: Boolean, refs: Text): Text =
+      info match
+        case info: LambdaType =>
+          seen.openLambda(info)
+        case _ =>
+      super.toTextMethodAsFunction(info, isPure, refs)
+
     override def toText(tp: Type): Text =
       if !tp.exists || tp.isErroneous then seen.nonSensical = true
       tp match
         case tp: TypeRef if useSourceModule(tp.symbol) => Str("object ") ~ super.toText(tp)
+        case tp: LambdaType =>
+          seen.openLambda(tp)
+          super.toText(tp)
         case _ => super.toText(tp)
 
     override def toText(sym: Symbol): Text =

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2920,3 +2920,10 @@ class MatchTypeScrutineeCannotBeHigherKinded(tp: Type)(using Context)
   extends TypeMsg(MatchTypeScrutineeCannotBeHigherKindedID) :
     def msg(using Context) = i"the scrutinee of a match type cannot be higher-kinded"
     def explain(using Context) = ""
+
+class ClosureCannotHaveInternalParameterDependencies(mt: Type)(using Context)
+  extends TypeMsg(ClosureCannotHaveInternalParameterDependenciesID):
+    def msg(using Context) =
+      i"""cannot turn method type $mt into closure
+         |because it has internal parameter dependencies"""
+    def explain(using Context) = ""

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -412,7 +412,7 @@ object Checking {
         case tree: RefTree =>
           checkRef(tree, tree.symbol)
           foldOver(x, tree)
-        case tree: This =>
+        case tree: This if tree.tpe.classSymbol == refineCls =>
           selfRef(tree)
         case tree: TypeTree =>
           val checkType = new TypeAccumulator[Unit] {

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -22,7 +22,11 @@ trait TypeAssigner {
    */
   def qualifyingClass(tree: untpd.Tree, qual: Name, packageOK: Boolean)(using Context): Symbol = {
     def qualifies(sym: Symbol) =
-      sym.isClass && (
+      sym.isClass &&
+      // `this` in a polymorphic function type never refers to the desugared refinement.
+      // In other refinements, `this` does refer to the refinement but is deprecated
+      // (see `Checking#checkRefinementNonCyclic`).
+      !(sym.isRefinementClass && sym.derivesFrom(defn.PolyFunctionClass)) && (
           qual.isEmpty ||
           sym.name == qual ||
           sym.is(Module) && sym.name.stripModuleClassSuffix == qual)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1323,14 +1323,14 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           (pt1.argInfos.init, typeTree(interpolateWildcards(pt1.argInfos.last.hiBound)))
         case RefinedType(parent, nme.apply, mt @ MethodTpe(_, formals, restpe))
         if (defn.isNonRefinedFunction(parent) || defn.isErasedFunctionType(parent)) && formals.length == defaultArity =>
-          (formals, untpd.DependentTypeTree(syms => restpe.substParams(mt, syms.map(_.termRef))))
+          (formals, untpd.DependentTypeTree((_, syms) => restpe.substParams(mt, syms.map(_.termRef))))
         case pt1 @ SAMType(mt @ MethodTpe(_, formals, _)) if !SAMType.isParamDependentRec(mt) =>
           val restpe = mt.resultType match
             case mt: MethodType => mt.toFunctionType(isJava = pt1.classSymbol.is(JavaDefined))
             case tp => tp
           (formals,
            if (mt.isResultDependent)
-             untpd.DependentTypeTree(syms => restpe.substParams(mt, syms.map(_.termRef)))
+             untpd.DependentTypeTree((_, syms) => restpe.substParams(mt, syms.map(_.termRef)))
            else
              typeTree(restpe))
         case _ =>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -526,6 +526,9 @@ object Build {
 
   // Settings shared between scala3-compiler and scala3-compiler-bootstrapped
   lazy val commonDottyCompilerSettings = Seq(
+       // Note: bench/profiles/projects.yml should be updated accordingly.
+       Compile / scalacOptions ++= Seq("-Yexplicit-nulls", "-Ysafe-init"),
+
       // Generate compiler.properties, used by sbt
       (Compile / resourceGenerators) += Def.task {
         import java.util._
@@ -803,9 +806,6 @@ object Build {
         "tasty-core"     -> (LocalProject("tasty-core-bootstrapped") / Compile / packageBin).value.getAbsolutePath,
       )
     },
-
-    // Note: bench/profiles/projects.yml should be updated accordingly.
-    Compile / scalacOptions ++= Seq("-Yexplicit-nulls", "-Ysafe-init"),
 
     repl := (Compile / console).value,
     Compile / console / scalacOptions := Nil, // reset so that we get stock REPL behaviour!  E.g. avoid -unchecked being enabled

--- a/tests/neg-custom-args/fatal-warnings/refinements-this.scala
+++ b/tests/neg-custom-args/fatal-warnings/refinements-this.scala
@@ -1,0 +1,3 @@
+class Outer:
+  type X = { type O = Outer.this.type } // ok
+  type Y = { type O = this.type } // error

--- a/tests/neg/lambda-rename.check
+++ b/tests/neg/lambda-rename.check
@@ -1,0 +1,34 @@
+-- [E007] Type Mismatch Error: tests/neg/lambda-rename.scala:4:33 ------------------------------------------------------
+4 |val a: (x: Int) => Bar[x.type] = ??? : ((x: Int) => Foo[x.type]) // error
+  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                                 Found:    (x: Int) => Foo[x.type]
+  |                                 Required: (x: Int) => Bar[x.type]
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/lambda-rename.scala:7:33 ------------------------------------------------------
+7 |val b: HK[[X] =>> Foo[(X, X)]] = ??? : HK[[X] =>> Bar[(X, X)]] // error
+  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                                 Found:    HK[[X] =>> Bar[(X, X)]]
+  |                                 Required: HK[[X] =>> Foo[(X, X)]]
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/lambda-rename.scala:10:33 -----------------------------------------------------
+10 |val c: HK[[X] =>> Foo[(X, X)]] = ??? : HK[[Y] =>> Foo[(X, X)]] // error
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 Found:    HK[[Y] =>> Foo[(X, X)]]
+   |                                 Required: HK[[X²] =>> Foo[(X², X²)]]
+   |
+   |                                 where:    X  is a class
+   |                                           X² is a type variable
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/lambda-rename.scala:12:33 -----------------------------------------------------
+12 |val d: HK[[Y] =>> Foo[(X, X)]] = ??? : HK[[X] =>> Foo[(X, X)]] // error
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 Found:    HK[[X] =>> Foo[(X, X)]]
+   |                                 Required: HK[[Y] =>> Foo[(X², X²)]]
+   |
+   |                                 where:    X  is a type variable
+   |                                           X² is a class
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/lambda-rename.scala
+++ b/tests/neg/lambda-rename.scala
@@ -1,0 +1,12 @@
+class Foo[T]
+class Bar[T]
+
+val a: (x: Int) => Bar[x.type] = ??? : ((x: Int) => Foo[x.type]) // error
+
+trait HK[F <: AnyKind]
+val b: HK[[X] =>> Foo[(X, X)]] = ??? : HK[[X] =>> Bar[(X, X)]] // error
+
+class X
+val c: HK[[X] =>> Foo[(X, X)]] = ??? : HK[[Y] =>> Foo[(X, X)]] // error
+
+val d: HK[[Y] =>> Foo[(X, X)]] = ??? : HK[[X] =>> Foo[(X, X)]] // error

--- a/tests/neg/polymorphic-functions.scala
+++ b/tests/neg/polymorphic-functions.scala
@@ -2,4 +2,6 @@ object Test {
   val pv0: [T] => List[T] = ???        // error
   val pv1: Any = [T] => Nil            // error
   val pv2: [T] => List[T] = [T] => Nil // error // error
+
+  val intraDep = [T] => (x: T, y: List[x.type]) => List(y) // error
 }

--- a/tests/neg/polymorphic-functions1.check
+++ b/tests/neg/polymorphic-functions1.check
@@ -1,7 +1,7 @@
--- [E007] Type Mismatch Error: tests/neg/polymorphic-functions1.scala:1:53 ---------------------------------------------
+-- [E007] Type Mismatch Error: tests/neg/polymorphic-functions1.scala:1:33 ---------------------------------------------
 1 |val f: [T] => (x: T) => x.type = [T] => (x: Int) => x // error
-  |                                                     ^
-  |                                                     Found:    [T] => (x: Int) => x.type
-  |                                                     Required: [T] => (x: T) => x.type
+  |                                 ^^^^^^^^^^^^^^^^^^^^
+  |                                 Found:    [T] => (x: Int) => x.type
+  |                                 Required: [T] => (x: T) => x.type
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg/polymorphic-functions1.check
+++ b/tests/neg/polymorphic-functions1.check
@@ -1,7 +1,7 @@
 -- [E007] Type Mismatch Error: tests/neg/polymorphic-functions1.scala:1:53 ---------------------------------------------
 1 |val f: [T] => (x: T) => x.type = [T] => (x: Int) => x // error
   |                                                     ^
-  |                                                     Found:    [T] => (x: Int) => Int
+  |                                                     Found:    [T] => (x: Int) => x.type
   |                                                     Required: [T] => (x: T) => x.type
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/pos/i16756.scala
+++ b/tests/pos/i16756.scala
@@ -1,0 +1,16 @@
+class DependentPoly {
+
+  sealed trait Col[V] {
+
+    trait Wrapper
+    val wrapper: Wrapper = ???
+  }
+
+  object Col1 extends Col[Int]
+
+  object Col2 extends Col[Double]
+
+  val polyFn: [C <: DependentPoly.this.Col[?]] => (x: C) => x.Wrapper =
+    [C <: Col[?]] => (x: C) => (x.wrapper: x.Wrapper)
+}
+

--- a/tests/pos/polymorphic-functions-this.scala
+++ b/tests/pos/polymorphic-functions-this.scala
@@ -4,3 +4,7 @@ trait Foo:
   val f: [T <: this.X] => (T, this.X) => (T, this.X) =
     [T <: this.X] => (x: T, y: this.X) => (x, y)
   f(x, x)
+
+  val g: [T <: this.type] => (T, this.type) => (T, this.type) =
+    [T <: this.type] => (x: T, y: this.type) => (x, y)
+  g(this, this)

--- a/tests/pos/polymorphic-functions-this.scala
+++ b/tests/pos/polymorphic-functions-this.scala
@@ -1,0 +1,6 @@
+trait Foo:
+  type X
+  def x: X
+  val f: [T <: this.X] => (T, this.X) => (T, this.X) =
+    [T <: this.X] => (x: T, y: this.X) => (x, y)
+  f(x, x)

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -85,6 +85,13 @@ object Test extends App {
   val v0a: String = v0
   assert(v0 == "foo")
 
+  // Used to fail with:    Found: ... => List[T]
+  //                    Expected: ... => List[x.type]
+  val md2: [T] => (x: T) => List[x.type] = [T] => (x: T) => List(x)
+  val x = 1
+  val v1 = md2(x)
+  val v1a: List[x.type] = v1
+
   // Contextual
   trait Show[T] { def show(t: T): String }
   implicit val si: Show[Int] =


### PR DESCRIPTION
This PR enhances polymorphic function types in two ways:
- Dependent result types can now be inferred from the expected type
- polymorphic lambdas are now implemented using JVM lambdas when possible instead of anonymous classes.

Additionally, we fix the logic for renaming bound variables when pretty-printing lambdas and fix the handling of `this` in refinements.