### PR TITLE
feat: hook up actions in sbt-bridge to start forwarding actionable diagnostics

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -140,7 +140,7 @@ final case class SbtCommunityProject(
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
     extraSbtArgs ++ sbtProps ++ List(
-      "-sbt-version", "1.8.2",
+      "-sbt-version", "1.9.0-RC3",
       "-Dsbt.supershell=false",
       s"-Ddotty.communitybuild.dir=$communitybuildDir",
       s"--addPluginSbtFile=$sbtPluginFilePath"

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -140,7 +140,7 @@ final case class SbtCommunityProject(
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
     extraSbtArgs ++ sbtProps ++ List(
-      "-sbt-version", "1.9.0-RC3",
+      "-sbt-version", "1.9.0",
       "-Dsbt.supershell=false",
       s"-Ddotty.communitybuild.dir=$communitybuildDir",
       s"--addPluginSbtFile=$sbtPluginFilePath"

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3059,8 +3059,7 @@ object Parsers {
       val mod = atSpan(in.skipToken()) { modOfToken(tok, name) }
 
       if mods.isOneOf(mod.flags) then
-        syntaxError(RepeatedModifier(mod.flags.flagsString), mod.span)
-
+        syntaxError(RepeatedModifier(mod.flags.flagsString, source, mod.span), mod.span)
       addMod(mods, mod)
     }
 

--- a/compiler/src/dotty/tools/dotc/reporting/CodeAction.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/CodeAction.scala
@@ -1,0 +1,9 @@
+package dotty.tools.dotc.reporting
+
+import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
+
+case class CodeAction(
+  title: String,
+  description: java.util.Optional[String],
+  patches: java.util.List[ActionPatch]
+)

--- a/compiler/src/dotty/tools/dotc/reporting/CodeAction.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/CodeAction.scala
@@ -2,6 +2,13 @@ package dotty.tools.dotc.reporting
 
 import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
 
+/** A representation of a code action / fix that can be used by tooling to
+  * apply a fix to their code.
+  *
+  * @param title The title of the fix, often showed to a user in their editor.
+  * @param description An optional description of the fix.
+  * @param patches The patches that this fix contains.
+  */
 case class CodeAction(
   title: String,
   description: java.util.Optional[String],

--- a/compiler/src/dotty/tools/dotc/reporting/CodeAction.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/CodeAction.scala
@@ -11,6 +11,6 @@ import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
   */
 case class CodeAction(
   title: String,
-  description: java.util.Optional[String],
-  patches: java.util.List[ActionPatch]
+  description: Option[String],
+  patches: List[ActionPatch]
 )

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -414,11 +414,10 @@ abstract class Message(val errorId: ErrorMessageID)(using Context) { self =>
    */
   def showAlways = false
 
-  /** A list of actions attatched to this message to address the issue this
+  /** A list of actions attached to this message to address the issue this
     * message represents.
     */
-  def actions(using Context): java.util.List[CodeAction] =
-    java.util.Collections.emptyList
+  def actions(using Context): List[CodeAction] = List.empty
 
   override def toString = msg
 }

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -414,6 +414,9 @@ abstract class Message(val errorId: ErrorMessageID)(using Context) { self =>
    */
   def showAlways = false
 
+  /** A list of actions attatched to this message to address the issue this
+    * message represents.
+    */
   def actions(using Context): java.util.List[CodeAction] =
     java.util.Collections.emptyList
 

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -10,7 +10,6 @@ import printing.Formatting.hl
 import config.SourceVersion
 
 import scala.language.unsafeNulls
-
 import scala.annotation.threadUnsafe
 
 /** ## Tips for error message generation
@@ -414,6 +413,9 @@ abstract class Message(val errorId: ErrorMessageID)(using Context) { self =>
    *  to only a single message of that class to be issued.
    */
   def showAlways = false
+
+  def actions(using Context): java.util.List[CodeAction] =
+    java.util.Collections.emptyList
 
   override def toString = msg
 }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -32,6 +32,7 @@ import cc.CaptureSet.IdentityCaptRefMap
 import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
 import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.SourcePosition
+import scala.jdk.CollectionConverters.*
 
 /**  Messages
   *  ========
@@ -1858,8 +1859,6 @@ class OnlyFunctionsCanBeFollowedByUnderscore(tp: Type, tree: untpd.PostfixOp)(us
 
   override def actions(using Context) =
     val untpd.PostfixOp(qual, Ident(nme.WILDCARD)) = tree: @unchecked
-    import scala.language.unsafeNulls
-    import scala.jdk.CollectionConverters.*
     List(
       CodeAction(title = "Rewrite to function value",
         description =  java.util.Optional.empty(),
@@ -1871,7 +1870,7 @@ class OnlyFunctionsCanBeFollowedByUnderscore(tp: Type, tree: untpd.PostfixOp)(us
     ).asJava
 }
 
-class MissingEmptyArgumentList(method: String)(using Context)
+class MissingEmptyArgumentList(method: String, tree: tpd.Tree)(using Context)
   extends SyntaxMsg(MissingEmptyArgumentListID) {
   def msg(using Context) = i"$method must be called with ${hl("()")} argument"
   def explain(using Context) = {
@@ -1886,6 +1885,16 @@ class MissingEmptyArgumentList(method: String)(using Context)
         |In Dotty, this idiom is an error. The application syntax has to follow exactly the parameter syntax.
         |Excluded from this rule are methods that are defined in Java or that override methods defined in Java."""
   }
+
+  override def actions(using Context) =
+    List(
+      CodeAction(title = "Insert ()",
+        description =  java.util.Optional.empty(),
+        patches = List(
+          ActionPatch(SourcePosition(tree.source, tree.span.endPos), "()"),
+        ).asJava
+      )
+    ).asJava
 }
 
 class DuplicateNamedTypeParameter(name: Name)(using Context)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -519,6 +519,7 @@ extends SyntaxMsg(RepeatedModifierID) {
   }
 
   override def actions(using Context) =
+    import scala.language.unsafeNulls
     List(
       CodeAction(title = s"""Remove repeated modifier: "$modifier"""",
         description =  java.util.Optional.empty(),
@@ -1869,6 +1870,7 @@ class OnlyFunctionsCanBeFollowedByUnderscore(tp: Type, tree: untpd.PostfixOp)(us
         |To convert to a function value, you need to explicitly write ${hl("() => x")}"""
 
   override def actions(using Context) =
+    import scala.language.unsafeNulls
     val untpd.PostfixOp(qual, Ident(nme.WILDCARD)) = tree: @unchecked
     List(
       CodeAction(title = "Rewrite to function value",
@@ -1898,6 +1900,7 @@ class MissingEmptyArgumentList(method: String, tree: tpd.Tree)(using Context)
   }
 
   override def actions(using Context) =
+    import scala.language.unsafeNulls
     List(
       CodeAction(title = "Insert ()",
         description =  java.util.Optional.empty(),

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -522,12 +522,12 @@ extends SyntaxMsg(RepeatedModifierID) {
     import scala.language.unsafeNulls
     List(
       CodeAction(title = s"""Remove repeated modifier: "$modifier"""",
-        description =  java.util.Optional.empty(),
+        description = None,
         patches = List(
           ActionPatch(SourcePosition(source, span), "")
-        ).asJava
+        )
       )
-    ).asJava
+    )
 }
 
 class InterpolatedStringError()(implicit ctx:Context)
@@ -1874,13 +1874,13 @@ class OnlyFunctionsCanBeFollowedByUnderscore(tp: Type, tree: untpd.PostfixOp)(us
     val untpd.PostfixOp(qual, Ident(nme.WILDCARD)) = tree: @unchecked
     List(
       CodeAction(title = "Rewrite to function value",
-        description =  java.util.Optional.empty(),
+        description = None,
         patches = List(
           ActionPatch(SourcePosition(tree.source, Span(tree.span.start)), "(() => "),
           ActionPatch(SourcePosition(tree.source, Span(qual.span.end, tree.span.end)), ")")
-        ).asJava
+        )
       )
-    ).asJava
+    )
 }
 
 class MissingEmptyArgumentList(method: String, tree: tpd.Tree)(using Context)
@@ -1903,12 +1903,12 @@ class MissingEmptyArgumentList(method: String, tree: tpd.Tree)(using Context)
     import scala.language.unsafeNulls
     List(
       CodeAction(title = "Insert ()",
-        description =  java.util.Optional.empty(),
+        description = None,
         patches = List(
           ActionPatch(SourcePosition(tree.source, tree.span.endPos), "()"),
-        ).asJava
+        )
       )
-    ).asJava
+    )
 }
 
 class DuplicateNamedTypeParameter(name: Name)(using Context)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -33,6 +33,7 @@ import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
 import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.SourcePosition
 import scala.jdk.CollectionConverters.*
+import dotty.tools.dotc.util.SourceFile
 
 /**  Messages
   *  ========
@@ -497,7 +498,7 @@ extends SyntaxMsg(ObjectMayNotHaveSelfTypeID) {
   }
 }
 
-class RepeatedModifier(modifier: String)(implicit ctx:Context)
+class RepeatedModifier(modifier: String, source: SourceFile, span: Span)(implicit ctx:Context)
 extends SyntaxMsg(RepeatedModifierID) {
   def msg(using Context) = i"""Repeated modifier $modifier"""
 
@@ -516,6 +517,16 @@ extends SyntaxMsg(RepeatedModifierID) {
         |
         |"""
   }
+
+  override def actions(using Context) =
+    List(
+      CodeAction(title = s"""Remove repeated modifier: "$modifier"""",
+        description =  java.util.Optional.empty(),
+        patches = List(
+          ActionPatch(SourcePosition(source, span), "")
+        ).asJava
+      )
+    ).asJava
 }
 
 class InterpolatedStringError()(implicit ctx:Context)

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -7,6 +7,7 @@ import core.Contexts._
 import collection.mutable
 import scala.annotation.tailrec
 import dotty.tools.dotc.reporting.Reporter
+import dotty.tools.dotc.util.SourcePosition;
 
 import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets.UTF_8
@@ -18,6 +19,8 @@ object Rewrites {
   private case class Patch(span: Span, replacement: String) {
     def delta = replacement.length - (span.end - span.start)
   }
+
+  case class ActionPatch(srcPos: SourcePosition, replacement: String)
 
   private class Patches(source: SourceFile) {
     private[Rewrites] val pbuf = new mutable.ListBuffer[Patch]()

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -20,6 +20,14 @@ object Rewrites {
     def delta = replacement.length - (span.end - span.start)
   }
 
+  /** A special type of Patch that instead of just a span, contains the
+    * full SourcePosition. This is useful when being used by
+    * [[dotty.tools.dotc.reporting.CodeAction]] or if the patch doesn't
+    * belong to the same file that the actual issue it's addressing is in.
+    *
+    * @param srcPos The SourcePosition of the patch.
+    * @param replacement The Replacement that should go in that position.
+    */
   case class ActionPatch(srcPos: SourcePosition, replacement: String)
 
   private class Patches(source: SourceFile) {

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -11,6 +11,7 @@ import dotty.tools.dotc.util.SourcePosition;
 
 import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets.UTF_8
+import dotty.tools.dotc.reporting.CodeAction
 
 /** Handles rewriting of Scala2 files to Dotty */
 object Rewrites {
@@ -99,6 +100,14 @@ object Rewrites {
       report.echo(s"[patched file ${source.file.path}]")
       rewrites.patched(source).writeBack()
     }
+
+  /** Given a CodeAction take the patches and apply them.
+   *
+   * @param action The CodeAction containing the patches
+   */
+  def applyAction(action: CodeAction)(using Context): Unit =
+    action.patches.foreach: actionPatch =>
+      patch(actionPatch.srcPos.span, actionPatch.replacement)
 }
 
 /** A completely encapsulated class representing rewrite state, used

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -55,7 +55,7 @@ object ErrorReporting {
     val meth = err.exprStr(methPart(tree))
     val info = if tree.symbol.exists then tree.symbol.info else mt
     if isCallableWithSingleEmptyArgumentList(info) then
-      report.error(MissingEmptyArgumentList(meth), tree.srcPos)
+      report.error(MissingEmptyArgumentList(meth, tree), tree.srcPos)
     else
       report.error(MissingArgumentList(meth, tree.symbol), tree.srcPos)
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2941,13 +2941,13 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       case closure(_, _, _) =>
       case _ =>
         val recovered = typed(qual)(using ctx.fresh.setExploreTyperState())
-        report.errorOrMigrationWarning(
-          OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen, tree), tree.srcPos, from = `3.0`
-        )
+        val msg = OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen, tree)
+        report.errorOrMigrationWarning(msg, tree.srcPos, from = `3.0`)
         if (migrateTo3) {
           // Under -rewrite, patch `x _` to `(() => x)`
-          patch(Span(tree.span.start), "(() => ")
-          patch(Span(qual.span.end, tree.span.end), ")")
+          msg.actions
+            .flatMap(_.patches)
+            .map(actionPatch => patch(actionPatch.srcPos.span, actionPatch.replacement))
           return typed(untpd.Function(Nil, qual), pt)
         }
     }
@@ -3951,10 +3951,17 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     def adaptNoArgsUnappliedMethod(wtp: MethodType, functionExpected: Boolean, arity: Int): Tree = {
       /** Is reference to this symbol `f` automatically expanded to `f()`? */
       def isAutoApplied(sym: Symbol): Boolean =
+        lazy val msg = MissingEmptyArgumentList(sym.show, tree)
+
         sym.isConstructor
         || sym.matchNullaryLoosely
-        || Feature.warnOnMigration(MissingEmptyArgumentList(sym.show, tree), tree.srcPos, version = `3.0`)
-           && { patch(tree.span.endPos, "()"); true }
+        || Feature.warnOnMigration(msg, tree.srcPos, version = `3.0`)
+          && { 
+            msg.actions
+              .flatMap(_.patches)
+              .map(actionPatch => patch(actionPatch.srcPos.span, actionPatch.replacement))
+            true
+          }
 
       /** If this is a selection prototype of the form `.apply(...): R`, return the nested
        *  function prototype `(...)R`. Otherwise `pt`.

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2941,7 +2941,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       case closure(_, _, _) =>
       case _ =>
         val recovered = typed(qual)(using ctx.fresh.setExploreTyperState())
-        report.errorOrMigrationWarning(OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen), tree.srcPos, from = `3.0`)
+        report.errorOrMigrationWarning(
+          OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen, tree), tree.srcPos, from = `3.0`
+        )
         if (migrateTo3) {
           // Under -rewrite, patch `x _` to `(() => x)`
           patch(Span(tree.span.start), "(() => ")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -54,6 +54,7 @@ import cc.CheckCaptures
 import config.Config
 
 import scala.annotation.constructorOnly
+import dotty.tools.dotc.rewrites.Rewrites
 
 object Typer {
 
@@ -2946,8 +2947,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         if (migrateTo3) {
           // Under -rewrite, patch `x _` to `(() => x)`
           msg.actions
-            .flatMap(_.patches)
-            .map(actionPatch => patch(actionPatch.srcPos.span, actionPatch.replacement))
+            .headOption
+            .foreach(Rewrites.applyAction)
           return typed(untpd.Function(Nil, qual), pt)
         }
     }
@@ -3958,8 +3959,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         || Feature.warnOnMigration(msg, tree.srcPos, version = `3.0`)
           && { 
             msg.actions
-              .flatMap(_.patches)
-              .map(actionPatch => patch(actionPatch.srcPos.span, actionPatch.replacement))
+              .headOption
+              .foreach(Rewrites.applyAction)
             true
           }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3953,7 +3953,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       def isAutoApplied(sym: Symbol): Boolean =
         sym.isConstructor
         || sym.matchNullaryLoosely
-        || Feature.warnOnMigration(MissingEmptyArgumentList(sym.show), tree.srcPos, version = `3.0`)
+        || Feature.warnOnMigration(MissingEmptyArgumentList(sym.show, tree), tree.srcPos, version = `3.0`)
            && { patch(tree.span.endPos, "()"); true }
 
       /** If this is a selection prototype of the form `.apply(...): R`, return the nested

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -30,6 +30,20 @@ class CodeActionTest extends DottyTest:
          |""".stripMargin
       )
 
+  @Test def insertBracesForEmptyArgument =
+    checkCodeAction(
+      """|object Test:
+         |  def foo(): Unit = ()
+         |  val x = foo
+         |""".stripMargin,
+      "Insert ()",
+      """|object Test:
+         |  def foo(): Unit = ()
+         |  val x = foo()
+         |""".stripMargin
+
+      )
+
   // Make sure we're not using the default reporter, which is the ConsoleReporter,
   // meaning they will get reported in the test run and that's it.
   private def newContext =
@@ -41,11 +55,11 @@ class CodeActionTest extends DottyTest:
     val source = SourceFile.virtual("test", code).content
     val runCtx = checkCompile("typer", code) { (_, _) => () }
     val diagnostics = runCtx.reporter.removeBufferedMessages
-    assertEquals(diagnostics.size, 1)
+    assertEquals(1, diagnostics.size)
 
     val diagnostic = diagnostics.head
     val actions = diagnostic.msg.actions.asScala.toList
-    assertEquals(actions.size, 1)
+    assertEquals(1, actions.size)
 
     // TODO account for more than 1 action
     val action = actions.head
@@ -80,4 +94,4 @@ class CodeActionTest extends DottyTest:
           assert(outNew == result.length, s"$outNew != ${result.length}")
 
     loop(patches, 0, 0)
-    assertEquals(result.mkString, expected)
+    assertEquals(expected, result.mkString)

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -44,6 +44,17 @@ class CodeActionTest extends DottyTest:
 
       )
 
+  @Test def removeRepeatModifier =
+    checkCodeAction(
+      """|final final class Test
+         |""".stripMargin,
+      """Remove repeated modifier: "final"""",
+      // TODO look into trying to remove the extra space that is left behind
+      """|final  class Test
+         |""".stripMargin
+
+      )
+
   // Make sure we're not using the default reporter, which is the ConsoleReporter,
   // meaning they will get reported in the test run and that's it.
   private def newContext =

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -1,0 +1,83 @@
+package dotty.tools.dotc.reporting
+
+import dotty.tools.DottyTest
+import dotty.tools.dotc.rewrites.Rewrites
+import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
+import dotty.tools.dotc.util.SourceFile
+
+import scala.annotation.tailrec
+import scala.jdk.CollectionConverters.*
+import scala.runtime.Scala3RunTime.assertFailed
+
+import org.junit.Assert._
+import org.junit.Test
+
+/** This is a test suite that is meant to test the actions attached to the
+  * diagnostic for a given code snippet.
+  */
+class CodeActionTest extends DottyTest:
+
+  @Test def convertToFunctionValue =
+    checkCodeAction(
+      """|object Test:
+         |  def x: Int = 3
+         |  val test = x _
+         |""".stripMargin,
+      "Rewrite to function value",
+      """|object Test:
+         |  def x: Int = 3
+         |  val test = (() => x)
+         |""".stripMargin
+      )
+
+  // Make sure we're not using the default reporter, which is the ConsoleReporter,
+  // meaning they will get reported in the test run and that's it.
+  private def newContext =
+    val rep = new StoreReporter(null) with UniqueMessagePositions with HideNonSensicalMessages
+    initialCtx.setReporter(rep).withoutColors
+
+  private def checkCodeAction(code: String, title: String, expected: String) =
+    ctx = newContext
+    val source = SourceFile.virtual("test", code).content
+    val runCtx = checkCompile("typer", code) { (_, _) => () }
+    val diagnostics = runCtx.reporter.removeBufferedMessages
+    assertEquals(diagnostics.size, 1)
+
+    val diagnostic = diagnostics.head
+    val actions = diagnostic.msg.actions.asScala.toList
+    assertEquals(actions.size, 1)
+
+    // TODO account for more than 1 action
+    val action = actions.head
+    assertEquals(action.title, title)
+    val patches = action.patches.asScala.toList
+    if patches.nonEmpty then
+      patches.reduceLeft: (p1, p2) =>
+        assert(p1.srcPos.span.end <= p2.srcPos.span.start, s"overlapping patches $p1 and $p2")
+        p2
+    else assertFailed("Expected a patch attatched to this action, but it was empty")
+
+    val delta = patches
+      .map: patch =>
+        patch.replacement.length - (patch.srcPos.end - patch.srcPos.start)
+      .sum
+
+    val result = new Array[Char](source.length + delta)
+
+    @tailrec def loop(ps: List[ActionPatch], inIdx: Int, outIdx: Int): Unit =
+      def copy(upTo: Int): Int =
+        val untouched = upTo - inIdx
+        System.arraycopy(source, inIdx, result, outIdx, untouched)
+        outIdx + untouched
+
+      ps match
+        case patch @ ActionPatch(srcPos, replacement) :: ps1 =>
+          val outNew = copy(srcPos.start)
+          replacement.copyToArray(result, outNew)
+          loop(ps1, srcPos.end, outNew + replacement.length)
+        case Nil =>
+          val outNew = copy(source.length)
+          assert(outNew == result.length, s"$outNew != ${result.length}")
+
+    loop(patches, 0, 0)
+    assertEquals(result.mkString, expected)

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -69,13 +69,13 @@ class CodeActionTest extends DottyTest:
     assertEquals(1, diagnostics.size)
 
     val diagnostic = diagnostics.head
-    val actions = diagnostic.msg.actions.asScala.toList
+    val actions = diagnostic.msg.actions.toList
     assertEquals(1, actions.size)
 
     // TODO account for more than 1 action
     val action = actions.head
     assertEquals(action.title, title)
-    val patches = action.patches.asScala.toList
+    val patches = action.patches.toList
     if patches.nonEmpty then
       patches.reduceLeft: (p1, p2) =>
         assert(p1.srcPos.span.end <= p2.srcPos.span.start, s"overlapping patches $p1 and $p2")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,6 @@ object Dependencies {
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % flexmarkVersion,
   )
 
-  val newCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.8.0"
+  val newCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.9.0-RC3"
   val oldCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.3.5"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,6 @@ object Dependencies {
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % flexmarkVersion,
   )
 
-  val newCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.9.0-RC3"
+  val newCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.9.0"
   val oldCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.3.5"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0-RC3
+sbt.version=1.9.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.0-RC3

--- a/sbt-bridge/src/dotty/tools/xsbt/Action.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/Action.java
@@ -1,0 +1,28 @@
+package dotty.tools.xsbt;
+
+import java.util.Optional;
+
+final public class Action implements xsbti.Action {
+  private final String _title;
+  private final Optional<String> _description;
+  private final WorkspaceEdit _edit;
+
+  public Action(String title, Optional<String> description, WorkspaceEdit edit) {
+    super();
+    this._title = title;
+    this._description = description;
+    this._edit = edit;
+  }
+
+  public String title() {
+    return _title;
+  }
+
+  public Optional<String> description() {
+    return _description;
+  }
+
+  public WorkspaceEdit edit() {
+    return _edit;
+  }
+}

--- a/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
@@ -3,11 +3,14 @@
  */
 package dotty.tools.xsbt;
 
+import java.util.List;
+
 import scala.Tuple2;
 import scala.collection.mutable.HashMap;
 
 import dotty.tools.dotc.core.Contexts.Context;
 import dotty.tools.dotc.reporting.AbstractReporter;
+import dotty.tools.dotc.reporting.CodeAction;
 import dotty.tools.dotc.reporting.Diagnostic;
 import dotty.tools.dotc.reporting.Message;
 import dotty.tools.dotc.util.SourceFile;
@@ -43,12 +46,13 @@ final public class DelegatingReporter extends AbstractReporter {
     messageBuilder.append(message.message());
     String diagnosticCode = String.valueOf(message.errorId().errorNumber());
     boolean shouldExplain = Diagnostic.shouldExplain(dia, ctx);
+    List<CodeAction> actions = message.actions(ctx);
     if (shouldExplain && !message.explanation().isEmpty()) {
       rendered.append(explanation(message, ctx));
       messageBuilder.append(System.lineSeparator()).append(explanation(message, ctx));
     }
 
-    delegate.log(new Problem(position, messageBuilder.toString(), severity, rendered.toString(), diagnosticCode));
+    delegate.log(new Problem(position, messageBuilder.toString(), severity, rendered.toString(), diagnosticCode, actions));
   }
 
   private static Severity severityOf(int level) {

--- a/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/DelegatingReporter.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import scala.Tuple2;
 import scala.collection.mutable.HashMap;
+import scala.jdk.javaapi.CollectionConverters;
 
 import dotty.tools.dotc.core.Contexts.Context;
 import dotty.tools.dotc.reporting.AbstractReporter;
@@ -46,7 +47,7 @@ final public class DelegatingReporter extends AbstractReporter {
     messageBuilder.append(message.message());
     String diagnosticCode = String.valueOf(message.errorId().errorNumber());
     boolean shouldExplain = Diagnostic.shouldExplain(dia, ctx);
-    List<CodeAction> actions = message.actions(ctx);
+    List<CodeAction> actions = CollectionConverters.asJava(message.actions(ctx));
     if (shouldExplain && !message.explanation().isEmpty()) {
       rendered.append(explanation(message, ctx));
       messageBuilder.append(System.lineSeparator()).append(explanation(message, ctx));

--- a/sbt-bridge/src/dotty/tools/xsbt/Problem.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/Problem.java
@@ -1,6 +1,13 @@
 package dotty.tools.xsbt;
 
+import java.util.List;
 import java.util.Optional;
+import static java.util.stream.Collectors.toList;
+
+import dotty.tools.dotc.reporting.CodeAction;
+import dotty.tools.dotc.rewrites.Rewrites.ActionPatch;
+import dotty.tools.dotc.util.SourcePosition;
+
 import xsbti.Position;
 import xsbti.Severity;
 
@@ -10,14 +17,16 @@ final public class Problem implements xsbti.Problem {
   private final Severity _severity;
   private final Optional<String> _rendered;
   private final String _diagnosticCode;
+  private final List<CodeAction> _actions;
 
-  public Problem(Position position, String message, Severity severity, String rendered, String diagnosticCode) {
+  public Problem(Position position, String message, Severity severity, String rendered, String diagnosticCode, List<CodeAction> actions) {
     super();
     this._position = position;
     this._message = message;
     this._severity = severity;
     this._rendered = Optional.of(rendered);
     this._diagnosticCode = diagnosticCode;
+    this._actions = actions;
   }
 
   public String category() {
@@ -53,6 +62,34 @@ final public class Problem implements xsbti.Problem {
       // contstruct it earlier, you'd end up with ClassNotFoundExceptions for
       // DiagnosticCode.
       return Optional.of(new DiagnosticCode(_diagnosticCode, Optional.empty()));
+    }
+  }
+
+  public List<xsbti.Action> actions() {
+    if (_actions.isEmpty()) {
+      return java.util.Collections.emptyList();
+    } else {
+      return _actions
+              .stream()
+              .map(action -> new Action(action.title(), action.description(), toWorkspaceEdit(action.patches())))
+              .collect(toList());
+    }
+  }
+
+  private static WorkspaceEdit toWorkspaceEdit(List<ActionPatch> patches) {
+    return new WorkspaceEdit(
+      patches
+        .stream()
+        .map(patch -> new TextEdit(positionOf(patch.srcPos()), patch.replacement()))
+        .collect(toList())
+    );
+  }
+
+  private static Position positionOf(SourcePosition pos) {
+    if (pos.exists()){
+      return new PositionBridge(pos, pos.source());
+    } else {
+      return PositionBridge.noPosition;
     }
   }
 

--- a/sbt-bridge/src/dotty/tools/xsbt/Problem.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/Problem.java
@@ -8,6 +8,9 @@ import dotty.tools.dotc.reporting.CodeAction;
 import dotty.tools.dotc.rewrites.Rewrites.ActionPatch;
 import dotty.tools.dotc.util.SourcePosition;
 
+import scala.jdk.javaapi.CollectionConverters;
+import scala.jdk.javaapi.OptionConverters;
+
 import xsbti.Position;
 import xsbti.Severity;
 
@@ -75,7 +78,7 @@ final public class Problem implements xsbti.Problem {
       // never getting called.
       return _actions
               .stream()
-              .map(action -> new Action(action.title(), action.description(), toWorkspaceEdit(action.patches())))
+              .map(action -> new Action(action.title(), OptionConverters.toJava(action.description()), toWorkspaceEdit(CollectionConverters.asJava(action.patches()))))
               .collect(toList());
     }
   }

--- a/sbt-bridge/src/dotty/tools/xsbt/Problem.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/Problem.java
@@ -69,6 +69,10 @@ final public class Problem implements xsbti.Problem {
     if (_actions.isEmpty()) {
       return java.util.Collections.emptyList();
     } else {
+      // Same as with diagnosticCode, we need to ensure we don't create the actual
+      // Action until we are here to ensure that when using an older version of sbt/zinc
+      // with the new versions of the compiler, this doesn't blow up because this is
+      // never getting called.
       return _actions
               .stream()
               .map(action -> new Action(action.title(), action.description(), toWorkspaceEdit(action.patches())))

--- a/sbt-bridge/src/dotty/tools/xsbt/TextEdit.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/TextEdit.java
@@ -1,0 +1,23 @@
+package dotty.tools.xsbt;
+
+import xsbti.Position;
+
+final public class TextEdit implements xsbti.TextEdit {
+  private final Position _position;
+  private final String _newText;
+
+  public TextEdit(Position position, String newText) {
+    super();
+    this._position = position;
+    this._newText = newText;
+  }
+
+  public Position position() {
+    return _position;
+  }
+
+  public String newText() {
+    return _newText;
+  }
+  
+}

--- a/sbt-bridge/src/dotty/tools/xsbt/WorkspaceEdit.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/WorkspaceEdit.java
@@ -1,0 +1,20 @@
+package dotty.tools.xsbt;
+
+import java.util.List;
+
+import xsbti.TextEdit;
+
+final public class WorkspaceEdit implements xsbti.WorkspaceEdit {
+
+  private final List<TextEdit> _changes;
+
+  public WorkspaceEdit(List<TextEdit> changes) {
+    super();
+    this._changes = changes;
+  }
+
+  public List<TextEdit> changes() {
+    return _changes;
+  }
+  
+}

--- a/sbt-test/compilerReporter/simple/Source.scala
+++ b/sbt-test/compilerReporter/simple/Source.scala
@@ -7,4 +7,7 @@ trait Wr {
 
 object Er {
   val a = er1
+
+  def f: Int = 1
+  val x = f _
 }

--- a/sbt-test/compilerReporter/simple/project/Reporter.scala
+++ b/sbt-test/compilerReporter/simple/project/Reporter.scala
@@ -27,27 +27,58 @@ object Reporter {
     check := (Compile / compile).failure.map(_ => {
       val problems = reporter.problems
       println(problems.toList)
-      assert(problems.size == 1)
 
-      // make sure position reported by zinc are proper
-      val mainProblem = problems.head
+      problems match {
+        case Array(err, warning) =>
+          // Checking the error reported
+          val eline = err.position().line()
+          assert(eline.isPresent() == true)
+          assert(eline.get() == 9)
 
-      val line = mainProblem.position().line()
-      assert(line.isPresent() == true)
-      assert(line.get() == 9)
+          val ediagnosticCode = err.diagnosticCode()
+          assert(ediagnosticCode.isPresent() == true)
+          val ecode = ediagnosticCode.get().code()
+          assert(ecode == "6")
 
-      val diagnosticCode = mainProblem.diagnosticCode()
-      assert(diagnosticCode.isPresent() == true)
-      val code = diagnosticCode.get()
-      assert(diagnosticCode.get().code() == "6")
+          val epointer = err.position().pointer()
+          assert(epointer.isPresent() == true)
+          assert(epointer.get() == 10)
 
-      val pointer = mainProblem.position().pointer()
-      assert(pointer.isPresent() == true)
-      assert(pointer.get() == 10)
+          assert(err.position.offset.isPresent)
 
-      assert(problems.forall(_.position.offset.isPresent))
+          assert(err.severity == Severity.Error) // not found: er1,
 
-      assert(problems.count(_.severity == Severity.Error) == 1) // not found: er1,
+          // Checking the warning reported
+   
+          val wline = warning.position().line()
+          assert(wline.isPresent() == true)
+          assert(wline.get() == 12)
+
+          val wdiagnosticCode = warning.diagnosticCode()
+          assert(wdiagnosticCode.isPresent() == true)
+          val wcode = wdiagnosticCode.get().code()
+          assert(wcode == "99")
+
+          val wpointer = warning.position().pointer()
+          assert(wpointer.isPresent() == true)
+          assert(wpointer.get() == 12)
+
+          assert(warning.position.offset.isPresent)
+
+          assert(warning.severity == Severity.Warn) // Only function types can be followed by _ but the current expression has type Int
+
+          //val actions = warning.actions()
+
+          //assert(actions.size == 1)
+
+          //val action = actions.head
+
+          //assert(action.title() == "wrong")
+
+        case somethingElse =>
+          assert(false, s"Only expected to have a single error and a single warning, but instead got: ${somethingElse.toString}")
+
+      }
     }).value
   )
 }

--- a/sbt-test/compilerReporter/simple/project/Reporter.scala
+++ b/sbt-test/compilerReporter/simple/project/Reporter.scala
@@ -2,6 +2,8 @@ import sbt._
 import Keys._
 import KeyRanks.DTask
 
+import scala.jdk.CollectionConverters.*
+
 object Reporter {
   import xsbti.{Reporter, Problem, Position, Severity}
 
@@ -67,13 +69,17 @@ object Reporter {
 
           assert(warning.severity == Severity.Warn) // Only function types can be followed by _ but the current expression has type Int
 
-          //val actions = warning.actions()
+          val actions = warning.actions().asScala.toList
 
-          //assert(actions.size == 1)
+          assert(actions.size == 1)
 
-          //val action = actions.head
+          val action = actions.head
 
-          //assert(action.title() == "wrong")
+          assert(action.title() == "Rewrite to function value")
+
+          val edits = action.edit().changes().asScala.toList
+
+          assert(edits.size == 2)
 
         case somethingElse =>
           assert(false, s"Only expected to have a single error and a single warning, but instead got: ${somethingElse.toString}")

--- a/tests/cmdTest-sbt-tests/sourcepath-with-inline-api-hash/project/build.properties
+++ b/tests/cmdTest-sbt-tests/sourcepath-with-inline-api-hash/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0-RC3
+sbt.version=1.9.0

--- a/tests/cmdTest-sbt-tests/sourcepath-with-inline-api-hash/project/build.properties
+++ b/tests/cmdTest-sbt-tests/sourcepath-with-inline-api-hash/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.0-RC3

--- a/tests/cmdTest-sbt-tests/sourcepath-with-inline/project/build.properties
+++ b/tests/cmdTest-sbt-tests/sourcepath-with-inline/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0-RC3
+sbt.version=1.9.0

--- a/tests/cmdTest-sbt-tests/sourcepath-with-inline/project/build.properties
+++ b/tests/cmdTest-sbt-tests/sourcepath-with-inline/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.0-RC3


### PR DESCRIPTION
There are still a few things I need to add/test fully before this is ready for a full review, but I thought I'd push it up just for others to take a look at or discuss if need be. The background for this is in [here](https://contributors.scala-lang.org/t/roadmap-for-actionable-diagnostics/6172/13), but this uses the POC that @smarter did at the tooling summit with the new structure that we agreed on. Some things I still need to test/work on:

- [x] doing a full e2e with Metals to ensure this is working
- [x] add in a new test suite that tests actions for a given piece of code. Right now I do an integration-like test in sbt-test just to ensure that the action is being forwarded, but I'd like to have a more robust test suite introduced so we can ensure that code snippets produce the expected actions and that the resulting code is what we'd expect.

So far this contains actions for:

- converting to a function value
- inserting parens for empty argument
- removing duplicated modifiers

refs: https://github.com/lampepfl/dotty/issues/17337