### PR TITLE
Fix superType of SuperType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3005,7 +3005,8 @@ object Types {
   abstract case class SuperType(thistpe: Type, supertpe: Type) extends CachedProxyType with SingletonType {
     override def underlying(using Context): Type = supertpe
     override def superType(using Context): Type =
-      thistpe.baseType(supertpe.typeSymbol)
+      if supertpe.typeSymbol.exists then thistpe.baseType(supertpe.typeSymbol)
+      else super.superType
     def derivedSuperType(thistpe: Type, supertpe: Type)(using Context): Type =
       if ((thistpe eq this.thistpe) && (supertpe eq this.supertpe)) this
       else SuperType(thistpe, supertpe)

--- a/tests/run/i17555.scala
+++ b/tests/run/i17555.scala
@@ -13,5 +13,5 @@ class D() extends A, Serializable {
 }
 
 @main def Test =
-  println(C())
-  println(D())
+  assert(C().toString == "B")
+  assert(D().toString == "B")

--- a/tests/run/i17555.scala
+++ b/tests/run/i17555.scala
@@ -1,0 +1,17 @@
+class Root {
+  override def toString() = "Root"
+}
+trait A extends Root with B {  }
+trait B {
+   override def toString() = "B"
+}
+case class C() extends A {
+  override def toString() = super.toString()
+}
+class D() extends A, Serializable {
+  override def toString() = super.toString()
+}
+
+@main def Test =
+  println(C())
+  println(D())


### PR DESCRIPTION
I am not quite sure about he previous definition of superType in SuperType. I believe it's probably needed for something. But it's clearly wrong if the `supertpe` argument does not have a symbol. We now fall back to the default 
```
   def superType = underlying
``` 
in this case.

Fixes #17555