### PR TITLE
Loading symbols from TASTy files directly

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
@@ -23,6 +23,12 @@ class PostProcessor(val frontendAccess: PostProcessorFrontendAccess, val bTypes:
 
   def postProcessAndSendToDisk(generatedDefs: GeneratedDefs): Unit = {
     val GeneratedDefs(classes, tasty) = generatedDefs
+    if !ctx.settings.YoutputOnlyTasty.value then
+      postProcessClassesAndSendToDisk(classes)
+    postProcessTastyAndSendToDisk(tasty)
+  }
+
+  private def postProcessClassesAndSendToDisk(classes: List[GeneratedClass]): Unit = {
     for (GeneratedClass(classNode, sourceFile, isArtifact, onFileCreated) <- classes) {
       val bytes =
         try
@@ -46,8 +52,10 @@ class PostProcessor(val frontendAccess: PostProcessorFrontendAccess, val bTypes:
         if clsFile != null then onFileCreated(clsFile)
       }
     }
+  }
 
-    for (GeneratedTasty(classNode, binaryGen) <- tasty){
+  private def postProcessTastyAndSendToDisk(tasty: List[GeneratedTasty]): Unit = {
+    for (GeneratedTasty(classNode, binaryGen) <- tasty) {
       classfileWriter.writeTasty(classNode.name.nn, binaryGen())
     }
   }

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -278,15 +278,17 @@ case class DirectoryClassPath(dir: JFile) extends JFileDirectoryLookup[ClassFile
 
   def findClassFile(className: String): Option[AbstractFile] = {
     val relativePath = FileUtils.dirPath(className)
-    val classFile = new JFile(dir, relativePath + ".class")
-    if (classFile.exists) {
-      Some(classFile.toPath.toPlainFile)
-    }
-    else None
+    val tastyFile = new JFile(dir, relativePath + ".tasty")
+    if tastyFile.exists then Some(tastyFile.toPath.toPlainFile)
+    else
+      val classFile = new JFile(dir, relativePath + ".class")
+      if classFile.exists then  Some(classFile.toPath.toPlainFile)
+      else None
   }
 
   protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
-  protected def isMatchingFile(f: JFile): Boolean = f.isClass
+  protected def isMatchingFile(f: JFile): Boolean =
+    f.isTasty || (f.isClass && f.classToTasty.isEmpty)
 
   private[dotty] def classes(inPackage: PackageName): Seq[ClassFileEntry] = files(inPackage)
 }

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -41,12 +41,17 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl.apply
 
   def findClassFile(className: String): Option[AbstractFile] = {
-    val relativePath = FileUtils.dirPath(className) + ".class"
-    Option(lookupPath(dir)(relativePath.split(java.io.File.separator).toIndexedSeq, directory = false))
+    val pathSeq = FileUtils.dirPath(className).split(java.io.File.separator)
+    val parentDir = lookupPath(dir)(pathSeq.init.toSeq, directory = true)
+    if parentDir == null then return None
+    else
+      Option(lookupPath(parentDir)(pathSeq.last + ".tasty" :: Nil, directory = false))
+        .orElse(Option(lookupPath(parentDir)(pathSeq.last + ".class" :: Nil, directory = false)))
   }
 
   private[dotty] def classes(inPackage: PackageName): Seq[ClassFileEntry] = files(inPackage)
 
   protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
-  protected def isMatchingFile(f: AbstractFile): Boolean = f.isClass
+  protected def isMatchingFile(f: AbstractFile): Boolean =
+    f.isTasty || (f.isClass && f.classToTasty.isEmpty)
 }

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -44,21 +44,21 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
     extends ZipArchiveFileLookup[ClassFileEntryImpl]
     with NoSourcePaths {
 
-    override def findClassFile(className: String): Option[AbstractFile] = {
-      val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
-      file(PackageName(pkg), simpleClassName + ".class").map(_.file)
-    }
+    override def findClassFile(className: String): Option[AbstractFile] =
+      findClass(className).map(_.file)
 
     // This method is performance sensitive as it is used by SBT's ExtractDependencies phase.
-    override def findClass(className: String): Option[ClassRepresentation] = {
+    override def findClass(className: String): Option[ClassFileEntryImpl] = {
       val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
-      file(PackageName(pkg), simpleClassName + ".class")
+      val binaries = files(PackageName(pkg), simpleClassName + ".tasty", simpleClassName + ".class")
+      binaries.find(_.file.isTasty).orElse(binaries.find(_.file.isClass))
     }
 
     override private[dotty] def classes(inPackage: PackageName): Seq[ClassFileEntry] = files(inPackage)
 
     override protected def createFileEntry(file: FileZipArchive#Entry): ClassFileEntryImpl = ClassFileEntryImpl(file)
-    override protected def isRequiredFileType(file: AbstractFile): Boolean = file.isClass
+    override protected def isRequiredFileType(file: AbstractFile): Boolean =
+      file.isTasty || (file.isClass && file.classToTasty.isEmpty)
   }
 
   /**

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -43,6 +43,15 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends Efficie
     }
     yield createFileEntry(entry)
 
+  protected def files(inPackage: PackageName, names: String*): Seq[FileEntryType] =
+    for {
+      dirEntry <- findDirEntry(inPackage).toSeq
+      name <- names
+      entry <- Option(dirEntry.lookupName(name, directory = false))
+      if isRequiredFileType(entry)
+    }
+    yield createFileEntry(entry)
+
   protected def file(inPackage: PackageName, name: String): Option[FileEntryType] =
     for {
       dirEntry <- findDirEntry(inPackage)

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -66,4 +66,7 @@ class JavaPlatform extends Platform {
 
   def newClassLoader(bin: AbstractFile)(using Context): SymbolLoader =
     new ClassfileLoader(bin)
+
+  def newTastyLoader(bin: AbstractFile)(using Context): SymbolLoader =
+    new TastyLoader(bin)
 }

--- a/compiler/src/dotty/tools/dotc/config/Platform.scala
+++ b/compiler/src/dotty/tools/dotc/config/Platform.scala
@@ -36,6 +36,9 @@ abstract class Platform {
   /** Create a new class loader to load class file `bin` */
   def newClassLoader(bin: AbstractFile)(using Context): SymbolLoader
 
+  /** Create a new TASTy loader to load class file `bin` */
+  def newTastyLoader(bin: AbstractFile)(using Context): SymbolLoader
+
   /** The given symbol is a method with the right name and signature to be a runnable program. */
   def isMainMethod(sym: Symbol)(using Context): Boolean
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -369,6 +369,7 @@ private sealed trait YSettings:
   val YnoExperimental: Setting[Boolean] = BooleanSetting("-Yno-experimental", "Disable experimental language features.")
   val YlegacyLazyVals: Setting[Boolean] = BooleanSetting("-Ylegacy-lazy-vals", "Use legacy (pre 3.3.0) implementation of lazy vals.")
   val Yscala2Stdlib: Setting[Boolean] = BooleanSetting("-Yscala2-stdlib", "Used when compiling the Scala 2 standard library.")
+  val YoutputOnlyTasty: Setting[Boolean] = BooleanSetting("-Youtput-only-tasty", "Used to only generate the TASTy file without the classfiles")
 
   val YprofileEnabled: Setting[Boolean] = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
   val YprofileDestination: Setting[String] = StringSetting("-Yprofile-destination", "file", "Where to send profiling output - specify a file, default is to the console.", "")

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -31,6 +31,7 @@ import io.AbstractFile
 import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos, EqHashMap}
 import scala.annotation.internal.sharable
 import config.Printers.typr
+import dotty.tools.dotc.classpath.FileUtils.isScalaBinary
 
 object Symbols {
 
@@ -151,7 +152,7 @@ object Symbols {
       * symbols defined by the user in a prior run of the REPL, that are still valid.
       */
     final def isDefinedInSource(using Context): Boolean =
-      span.exists && isValidInCurrentRun && associatedFileMatches(_.extension != "class")
+      span.exists && isValidInCurrentRun && associatedFileMatches(!_.isScalaBinary)
 
     /** Is symbol valid in current run? */
     final def isValidInCurrentRun(using Context): Boolean =
@@ -272,7 +273,7 @@ object Symbols {
     /** The class file from which this class was generated, null if not applicable. */
     final def binaryFile(using Context): AbstractFile | Null = {
       val file = associatedFile
-      if (file != null && file.extension == "class") file else null
+      if file != null && file.isScalaBinary then file else null
     }
 
     /** A trap to avoid calling x.symbol on something that is already a symbol.
@@ -285,7 +286,7 @@ object Symbols {
 
     final def source(using Context): SourceFile = {
       def valid(src: SourceFile): SourceFile =
-        if (src.exists && src.file.extension != "class") src
+        if (src.exists && !src.file.isScalaBinary) src
         else NoSource
 
       if (!denot.exists) NoSource
@@ -463,7 +464,7 @@ object Symbols {
       if !mySource.exists && !denot.is(Package) then
         // this allows sources to be added in annotations after `sourceOfClass` is first called
         val file = associatedFile
-        if file != null && file.extension != "class" then
+        if file != null && !file.isScalaBinary then
           mySource = ctx.getSource(file)
         else
           mySource = defn.patchSource(this)

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -26,6 +26,9 @@ import scala.util.control.NonFatal
 import dotty.tools.dotc.classpath.FileUtils.classToTasty
 
 object ClassfileParser {
+
+  import ClassfileConstants._
+
   /** Marker trait for unpicklers that can be embedded in classfiles. */
   trait Embedded
 
@@ -49,6 +52,177 @@ object ClassfileParser {
         if (parents eq parents1) tp else tp.copy(parentTypes = parents1)
       case _ =>
         mapOver(tp)
+    }
+  }
+
+  abstract class AbstractConstantPool(using in: DataReader) {
+    protected val len = in.nextChar
+    protected val starts = new Array[Int](len)
+    protected val values = new Array[AnyRef](len)
+    protected val internalized = new Array[NameOrString](len)
+
+    { var i = 1
+      while (i < starts.length) {
+        starts(i) = in.bp
+        i += 1
+        (in.nextByte.toInt: @switch) match {
+          case CONSTANT_UTF8 | CONSTANT_UNICODE =>
+            in.skip(in.nextChar)
+          case CONSTANT_CLASS | CONSTANT_STRING | CONSTANT_METHODTYPE =>
+            in.skip(2)
+          case CONSTANT_METHODHANDLE =>
+            in.skip(3)
+          case CONSTANT_FIELDREF | CONSTANT_METHODREF | CONSTANT_INTFMETHODREF
+             | CONSTANT_NAMEANDTYPE | CONSTANT_INTEGER | CONSTANT_FLOAT
+             | CONSTANT_INVOKEDYNAMIC =>
+            in.skip(4)
+          case CONSTANT_LONG | CONSTANT_DOUBLE =>
+            in.skip(8)
+            i += 1
+          case _ =>
+            errorBadTag(in.bp - 1)
+        }
+      }
+    }
+
+    /** Return the name found at given index. */
+    def getName(index: Int)(using in: DataReader): NameOrString = {
+      if (index <= 0 || len <= index)
+        errorBadIndex(index)
+
+      values(index) match {
+        case name: NameOrString => name
+        case null   =>
+          val start = starts(index)
+          if (in.getByte(start).toInt != CONSTANT_UTF8) errorBadTag(start)
+          val len   = in.getChar(start + 1).toInt
+          val name = new NameOrString(in.getUTF(start + 1, len + 2))
+          values(index) = name
+          name
+      }
+    }
+
+    /** Return the name found at given index in the constant pool, with '/' replaced by '.'. */
+    def getExternalName(index: Int)(using in: DataReader): NameOrString = {
+      if (index <= 0 || len <= index)
+        errorBadIndex(index)
+
+      if (internalized(index) == null)
+        internalized(index) = new NameOrString(getName(index).value.replace('/', '.'))
+
+      internalized(index)
+    }
+
+    def getClassSymbol(index: Int)(using ctx: Context, in: DataReader): Symbol
+
+    /** Return the external name of the class info structure found at 'index'.
+     *  Use 'getClassSymbol' if the class is sure to be a top-level class.
+     */
+    def getClassName(index: Int)(using in: DataReader): NameOrString = {
+      val start = starts(index)
+      if (in.getByte(start).toInt != CONSTANT_CLASS) errorBadTag(start)
+      getExternalName(in.getChar(start + 1))
+    }
+
+    /** Return the type of a class constant entry. Since
+     *  arrays are considered to be class types, they might
+     *  appear as entries in 'newarray' or 'cast' opcodes.
+     */
+    def getClassOrArrayType(index: Int)(using ctx: Context, in: DataReader): Type
+
+    def getType(index: Int, isVarargs: Boolean = false)(using Context, DataReader): Type
+
+    def getSuperClass(index: Int)(using Context, DataReader): Symbol = {
+      assert(index != 0, "attempt to parse java.lang.Object from classfile")
+      getClassSymbol(index)
+    }
+
+    def getConstant(index: Int)(using ctx: Context, in: DataReader): Constant = {
+      if (index <= 0 || len <= index) errorBadIndex(index)
+      var value = values(index)
+      if (value eq null) {
+        val start = starts(index)
+        value = (in.getByte(start).toInt: @switch) match {
+          case CONSTANT_STRING =>
+            Constant(getName(in.getChar(start + 1).toInt).value)
+          case CONSTANT_INTEGER =>
+            Constant(in.getInt(start + 1))
+          case CONSTANT_FLOAT =>
+            Constant(in.getFloat(start + 1))
+          case CONSTANT_LONG =>
+            Constant(in.getLong(start + 1))
+          case CONSTANT_DOUBLE =>
+            Constant(in.getDouble(start + 1))
+          case CONSTANT_CLASS =>
+            getClassOrArrayType(index).typeSymbol
+          case _ =>
+            errorBadTag(start)
+        }
+        values(index) = value
+      }
+      value match {
+        case ct: Constant  => ct
+        case cls: Symbol   => Constant(cls.typeRef)
+        case arr: Type     => Constant(arr)
+      }
+    }
+
+    private def getSubArray(bytes: Array[Byte]): Array[Byte] = {
+      val decodedLength = ByteCodecs.decode(bytes)
+      val arr           = new Array[Byte](decodedLength)
+      System.arraycopy(bytes, 0, arr, 0, decodedLength)
+      arr
+    }
+
+    def getBytes(index: Int)(using in: DataReader): Array[Byte] = {
+      if (index <= 0 || len <= index) errorBadIndex(index)
+      var value = values(index).asInstanceOf[Array[Byte]]
+      if (value eq null) {
+        val start = starts(index)
+        if (in.getByte(start).toInt != CONSTANT_UTF8) errorBadTag(start)
+        val len   = in.getChar(start + 1)
+        val bytes = new Array[Byte](len)
+        in.getBytes(start + 3, bytes)
+        value = getSubArray(bytes)
+        values(index) = value
+      }
+      value
+    }
+
+    def getBytes(indices: List[Int])(using in: DataReader): Array[Byte] = {
+      assert(!indices.isEmpty, indices)
+      var value = values(indices.head).asInstanceOf[Array[Byte]]
+      if (value eq null) {
+        val bytesBuffer = ArrayBuffer.empty[Byte]
+        for (index <- indices) {
+          if (index <= 0 || AbstractConstantPool.this.len <= index) errorBadIndex(index)
+          val start = starts(index)
+          if (in.getByte(start).toInt != CONSTANT_UTF8) errorBadTag(start)
+          val len = in.getChar(start + 1)
+          val buf = new Array[Byte](len)
+          in.getBytes(start + 3, buf)
+          bytesBuffer ++= buf
+        }
+        value = getSubArray(bytesBuffer.toArray)
+        values(indices.head) = value
+      }
+      value
+    }
+
+    /** Throws an exception signaling a bad constant index. */
+    protected def errorBadIndex(index: Int)(using in: DataReader) =
+      throw new RuntimeException("bad constant pool index: " + index + " at pos: " + in.bp)
+
+    /** Throws an exception signaling a bad tag at given address. */
+    protected def errorBadTag(start: Int)(using in: DataReader) =
+      throw new RuntimeException("bad constant pool tag " + in.getByte(start) + " at byte " + start)
+  }
+
+  protected class NameOrString(val value: String) {
+    private var _name: SimpleName = null
+    def name: SimpleName = {
+      if (_name eq null) _name = termName(value)
+      _name
     }
   }
 }
@@ -939,26 +1113,11 @@ class ClassfileParser(
       }
 
       if (scan(tpnme.TASTYATTR)) {
-        val attrLen = in.nextInt
-        val bytes = in.nextBytes(attrLen)
-        if (attrLen == 16) { // A tasty attribute with that has only a UUID (16 bytes) implies the existence of the .tasty file
-          classfile.classToTasty match
-            case None =>
-              report.error(em"Could not find TASTY for $classfile")
-            case Some(tastyFile) =>
-              val expectedUUID =
-                val reader = new TastyReader(bytes, 0, 16)
-                new UUID(reader.readUncompressedLong(), reader.readUncompressedLong())
-              val tastyUUID =
-                val tastyBytes: Array[Byte] = tastyFile.toByteArray
-                new TastyHeaderUnpickler(tastyBytes).readHeader()
-              if (expectedUUID != tastyUUID)
-                report.warning(s"$classfile is out of sync with its TASTy file. Loaded TASTy file. Try cleaning the project to fix this issue", NoSourcePosition)
-            return None
-        }
-        else
-          // Before 3.0.0 we had a mode where we could embed the TASTY bytes in the classfile. This has not been supported in any stable release.
-          report.error(s"Found a TASTY attribute with a length different from 16 in $classfile. This is likely a bug in the compiler. Please report.", NoSourcePosition)
+        val hint =
+          if classfile.classToTasty.isDefined then "This is likely a bug in the compiler. Please report."
+          else "This `.tasty` file is missing. Try cleaning the project to fix this issue."
+        report.error(s"Loading Scala 3 binary from $classfile. It should have been loaded from `.tasty` file. $hint", NoSourcePosition)
+        return None
       }
 
       if scan(tpnme.ScalaATTR) && !scalaUnpickleWhitelist.contains(classRoot.name)
@@ -1127,78 +1286,7 @@ class ClassfileParser(
   private def isStatic(flags: Int)      = (flags & JAVA_ACC_STATIC) != 0
   private def hasAnnotation(flags: Int) = (flags & JAVA_ACC_ANNOTATION) != 0
 
-  protected class NameOrString(val value: String) {
-    private var _name: SimpleName = null
-    def name: SimpleName = {
-      if (_name eq null) _name = termName(value)
-      _name
-    }
-  }
-
-  def getClassSymbol(name: SimpleName)(using Context): Symbol =
-    if (name.endsWith("$") && (name ne nme.nothingRuntimeClass) && (name ne nme.nullRuntimeClass))
-      // Null$ and Nothing$ ARE classes
-      requiredModule(name.dropRight(1))
-    else classNameToSymbol(name)
-
-  class ConstantPool(using in: DataReader) {
-    private val len = in.nextChar
-    private val starts = new Array[Int](len)
-    private val values = new Array[AnyRef](len)
-    private val internalized = new Array[NameOrString](len)
-
-    { var i = 1
-      while (i < starts.length) {
-        starts(i) = in.bp
-        i += 1
-        (in.nextByte.toInt: @switch) match {
-          case CONSTANT_UTF8 | CONSTANT_UNICODE =>
-            in.skip(in.nextChar)
-          case CONSTANT_CLASS | CONSTANT_STRING | CONSTANT_METHODTYPE =>
-            in.skip(2)
-          case CONSTANT_METHODHANDLE =>
-            in.skip(3)
-          case CONSTANT_FIELDREF | CONSTANT_METHODREF | CONSTANT_INTFMETHODREF
-             | CONSTANT_NAMEANDTYPE | CONSTANT_INTEGER | CONSTANT_FLOAT
-             | CONSTANT_INVOKEDYNAMIC =>
-            in.skip(4)
-          case CONSTANT_LONG | CONSTANT_DOUBLE =>
-            in.skip(8)
-            i += 1
-          case _ =>
-            errorBadTag(in.bp - 1)
-        }
-      }
-    }
-
-    /** Return the name found at given index. */
-    def getName(index: Int)(using in: DataReader): NameOrString = {
-      if (index <= 0 || len <= index)
-        errorBadIndex(index)
-
-      values(index) match {
-        case name: NameOrString => name
-        case null   =>
-          val start = starts(index)
-          if (in.getByte(start).toInt != CONSTANT_UTF8) errorBadTag(start)
-          val len   = in.getChar(start + 1).toInt
-          val name = new NameOrString(in.getUTF(start + 1, len + 2))
-          values(index) = name
-          name
-      }
-    }
-
-    /** Return the name found at given index in the constant pool, with '/' replaced by '.'. */
-    def getExternalName(index: Int)(using in: DataReader): NameOrString = {
-      if (index <= 0 || len <= index)
-        errorBadIndex(index)
-
-      if (internalized(index) == null)
-        internalized(index) = new NameOrString(getName(index).value.replace('/', '.'))
-
-      internalized(index)
-    }
-
+  class ConstantPool(using in: DataReader) extends AbstractConstantPool {
     def getClassSymbol(index: Int)(using ctx: Context, in: DataReader): Symbol = {
       if (index <= 0 || len <= index) errorBadIndex(index)
       var c = values(index).asInstanceOf[Symbol]
@@ -1212,19 +1300,6 @@ class ClassfileParser(
       c
     }
 
-    /** Return the external name of the class info structure found at 'index'.
-     *  Use 'getClassSymbol' if the class is sure to be a top-level class.
-     */
-    def getClassName(index: Int)(using in: DataReader): NameOrString = {
-      val start = starts(index)
-      if (in.getByte(start).toInt != CONSTANT_CLASS) errorBadTag(start)
-      getExternalName(in.getChar(start + 1))
-    }
-
-    /** Return the type of a class constant entry. Since
-     *  arrays are considered to be class types, they might
-     *  appear as entries in 'newarray' or 'cast' opcodes.
-     */
     def getClassOrArrayType(index: Int)(using ctx: Context, in: DataReader): Type = {
       if (index <= 0 || len <= index) errorBadIndex(index)
       val value = values(index)
@@ -1252,90 +1327,12 @@ class ClassfileParser(
 
     def getType(index: Int, isVarargs: Boolean = false)(using Context, DataReader): Type =
       sigToType(getExternalName(index).value, isVarargs = isVarargs)
-
-    def getSuperClass(index: Int)(using Context, DataReader): Symbol = {
-      assert(index != 0, "attempt to parse java.lang.Object from classfile")
-      getClassSymbol(index)
-    }
-
-    def getConstant(index: Int)(using ctx: Context, in: DataReader): Constant = {
-      if (index <= 0 || len <= index) errorBadIndex(index)
-      var value = values(index)
-      if (value eq null) {
-        val start = starts(index)
-        value = (in.getByte(start).toInt: @switch) match {
-          case CONSTANT_STRING =>
-            Constant(getName(in.getChar(start + 1).toInt).value)
-          case CONSTANT_INTEGER =>
-            Constant(in.getInt(start + 1))
-          case CONSTANT_FLOAT =>
-            Constant(in.getFloat(start + 1))
-          case CONSTANT_LONG =>
-            Constant(in.getLong(start + 1))
-          case CONSTANT_DOUBLE =>
-            Constant(in.getDouble(start + 1))
-          case CONSTANT_CLASS =>
-            getClassOrArrayType(index).typeSymbol
-          case _ =>
-            errorBadTag(start)
-        }
-        values(index) = value
-      }
-      value match {
-        case ct: Constant  => ct
-        case cls: Symbol   => Constant(cls.typeRef)
-        case arr: Type     => Constant(arr)
-      }
-    }
-
-    private def getSubArray(bytes: Array[Byte]): Array[Byte] = {
-      val decodedLength = ByteCodecs.decode(bytes)
-      val arr           = new Array[Byte](decodedLength)
-      System.arraycopy(bytes, 0, arr, 0, decodedLength)
-      arr
-    }
-
-    def getBytes(index: Int)(using in: DataReader): Array[Byte] = {
-      if (index <= 0 || len <= index) errorBadIndex(index)
-      var value = values(index).asInstanceOf[Array[Byte]]
-      if (value eq null) {
-        val start = starts(index)
-        if (in.getByte(start).toInt != CONSTANT_UTF8) errorBadTag(start)
-        val len   = in.getChar(start + 1)
-        val bytes = new Array[Byte](len)
-        in.getBytes(start + 3, bytes)
-        value = getSubArray(bytes)
-        values(index) = value
-      }
-      value
-    }
-
-    def getBytes(indices: List[Int])(using in: DataReader): Array[Byte] = {
-      assert(!indices.isEmpty, indices)
-      var value = values(indices.head).asInstanceOf[Array[Byte]]
-      if (value eq null) {
-        val bytesBuffer = ArrayBuffer.empty[Byte]
-        for (index <- indices) {
-          if (index <= 0 || ConstantPool.this.len <= index) errorBadIndex(index)
-          val start = starts(index)
-          if (in.getByte(start).toInt != CONSTANT_UTF8) errorBadTag(start)
-          val len = in.getChar(start + 1)
-          val buf = new Array[Byte](len)
-          in.getBytes(start + 3, buf)
-          bytesBuffer ++= buf
-        }
-        value = getSubArray(bytesBuffer.toArray)
-        values(indices.head) = value
-      }
-      value
-    }
-
-    /** Throws an exception signaling a bad constant index. */
-    private def errorBadIndex(index: Int)(using in: DataReader) =
-      throw new RuntimeException("bad constant pool index: " + index + " at pos: " + in.bp)
-
-    /** Throws an exception signaling a bad tag at given address. */
-    private def errorBadTag(start: Int)(using in: DataReader) =
-      throw new RuntimeException("bad constant pool tag " + in.getByte(start) + " at byte " + start)
   }
+
+  def getClassSymbol(name: SimpleName)(using Context): Symbol =
+    if (name.endsWith("$") && (name ne nme.nothingRuntimeClass) && (name ne nme.nullRuntimeClass))
+      // Null$ and Nothing$ ARE classes
+      requiredModule(name.dropRight(1))
+    else classNameToSymbol(name)
+
 }

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileTastyUUIDParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileTastyUUIDParser.scala
@@ -1,0 +1,116 @@
+package dotty.tools.dotc
+package core.classfile
+
+import scala.language.unsafeNulls
+
+import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.Decorators._
+import dotty.tools.dotc.core.Names._
+import dotty.tools.dotc.core.StdNames._
+import dotty.tools.dotc.core.Symbols._
+import dotty.tools.dotc.core.Types._
+import dotty.tools.dotc.util._
+import dotty.tools.io.AbstractFile
+import dotty.tools.tasty.TastyReader
+
+import java.io.IOException
+import java.lang.Integer.toHexString
+import java.util.UUID
+
+class ClassfileTastyUUIDParser(classfile: AbstractFile)(ictx: Context) {
+
+  import ClassfileConstants._
+
+  private var pool: ConstantPool = _              // the classfile's constant pool
+
+  def checkTastyUUID(tastyUUID: UUID)(using Context): Unit = try ctx.base.reusableDataReader.withInstance { reader =>
+    implicit val reader2 = reader.reset(classfile)
+    parseHeader()
+    this.pool = new ConstantPool
+    checkTastyAttr(tastyUUID)
+    this.pool =  null
+  }
+  catch {
+    case e: RuntimeException =>
+      if (ctx.debug) e.printStackTrace()
+      throw new IOException(
+        i"""class file ${classfile.canonicalPath} is broken, reading aborted with ${e.getClass}
+           |${Option(e.getMessage).getOrElse("")}""")
+  }
+
+  private def parseHeader()(using in: DataReader): Unit = {
+    val magic = in.nextInt
+    if (magic != JAVA_MAGIC)
+      throw new IOException(s"class file '${classfile}' has wrong magic number 0x${toHexString(magic)}, should be 0x${toHexString(JAVA_MAGIC)}")
+    val minorVersion = in.nextChar.toInt
+    val majorVersion = in.nextChar.toInt
+    if ((majorVersion < JAVA_MAJOR_VERSION) ||
+        ((majorVersion == JAVA_MAJOR_VERSION) &&
+         (minorVersion < JAVA_MINOR_VERSION)))
+      throw new IOException(
+        s"class file '${classfile}' has unknown version $majorVersion.$minorVersion, should be at least $JAVA_MAJOR_VERSION.$JAVA_MINOR_VERSION")
+  }
+
+  private def checkTastyAttr(tastyUUID: UUID)(using ctx: Context, in: DataReader): Unit = {
+    in.nextChar // jflags
+    in.nextChar // nameIdx
+    skipSuperclasses()
+    skipMembers() // fields
+    skipMembers() // methods
+    val attrs = in.nextChar
+    val attrbp = in.bp
+
+    def scan(target: TypeName): Boolean = {
+      in.bp = attrbp
+      var i = 0
+      while (i < attrs && pool.getName(in.nextChar).name.toTypeName != target) {
+        val attrLen = in.nextInt
+        in.skip(attrLen)
+        i += 1
+      }
+      i < attrs
+    }
+
+    if (scan(tpnme.TASTYATTR)) {
+      val attrLen = in.nextInt
+      val bytes = in.nextBytes(attrLen)
+      if (attrLen == 16) { // A tasty attribute with that has only a UUID (16 bytes) implies the existence of the .tasty file
+        val expectedUUID =
+          val reader = new TastyReader(bytes, 0, 16)
+          new UUID(reader.readUncompressedLong(), reader.readUncompressedLong())
+        if (expectedUUID != tastyUUID)
+          report.warning(s"$classfile is out of sync with its TASTy file. Loaded TASTy file. Try cleaning the project to fix this issue", NoSourcePosition)
+      }
+      else
+        // Before 3.0.0 we had a mode where we could embed the TASTY bytes in the classfile. This has not been supported in any stable release.
+        report.error(s"Found a TASTY attribute with a length different from 16 in $classfile. This is likely a bug in the compiler. Please report.", NoSourcePosition)
+    }
+
+  }
+
+  private def skipAttributes()(using in: DataReader): Unit = {
+    val attrCount = in.nextChar
+    for (i <- 0 until attrCount) {
+      in.skip(2); in.skip(in.nextInt)
+    }
+  }
+
+  private def skipMembers()(using in: DataReader): Unit = {
+    val memberCount = in.nextChar
+    for (i <- 0 until memberCount) {
+      in.skip(6); skipAttributes()
+    }
+  }
+
+  private def skipSuperclasses()(using in: DataReader): Unit = {
+    in.skip(2) // superclass
+    val ifaces = in.nextChar
+    in.skip(2 * ifaces)
+  }
+
+  class ConstantPool(using in: DataReader) extends ClassfileParser.AbstractConstantPool {
+    def getClassOrArrayType(index: Int)(using ctx: Context, in: DataReader): Type = throw new UnsupportedOperationException
+    def getClassSymbol(index: Int)(using ctx: Context, in: DataReader): Symbol = throw new UnsupportedOperationException
+    def getType(index: Int, isVarargs: Boolean)(using x$3: Context, x$4: DataReader): Type = throw new UnsupportedOperationException
+  }
+}

--- a/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala
@@ -62,8 +62,8 @@ class ReadTasty extends Phase {
       staticRef(className) match {
         case clsd: ClassDenotation =>
           clsd.infoOrCompleter match {
-            case info: ClassfileLoader =>
-              info.load(clsd) // sets cls.rootTreeOrProvider and cls.moduleClass.treeProvider as a side-effect
+            case info: TastyLoader =>
+              info.doComplete(clsd) // sets cls.rootTreeOrProvider and cls.moduleClass.treeProvider as a side-effect
             case _ =>
           }
           def moduleClass = clsd.owner.info.member(className.moduleClassName).symbol

--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -253,7 +253,7 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   /** Returns the sibling abstract file in the parent of this abstract file or directory.
    *  If there is no such file, returns `null`.
    */
-  def resolveSibling(name: String): AbstractFile =
+  def resolveSibling(name: String): AbstractFile | Null =
     container.lookupName(name, directory = false)
 
   private def fileOrSubdirectoryNamed(name: String, isDir: Boolean): AbstractFile =

--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -250,6 +250,12 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
     file
   }
 
+  /** Returns the sibling abstract file in the parent of this abstract file or directory.
+   *  If there is no such file, returns `null`.
+   */
+  def resolveSibling(name: String): AbstractFile =
+    container.lookupName(name, directory = false)
+
   private def fileOrSubdirectoryNamed(name: String, isDir: Boolean): AbstractFile =
     lookupName(name, isDir) match {
       case null =>

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -72,6 +72,8 @@ abstract class ZipArchive(override val jpath: JPath, release: Option[String]) ex
     // have to keep this name for compat with sbt's compiler-interface
     def getArchive: ZipFile = null
     override def underlyingSource: Option[ZipArchive] = Some(self)
+    override def resolveSibling(name: String): AbstractFile =
+      parent.lookupName(name, directory = false)
     override def toString: String = self.path + "(" + path + ")"
   }
 

--- a/sbt-test/tasty-compat/only-tasty/a/A.scala
+++ b/sbt-test/tasty-compat/only-tasty/a/A.scala
@@ -1,0 +1,5 @@
+package a
+
+object A:
+  def f(x: Int): Int = x + 1
+  inline def g(x: Int): Int = x + 1

--- a/sbt-test/tasty-compat/only-tasty/b/B.scala
+++ b/sbt-test/tasty-compat/only-tasty/b/B.scala
@@ -1,0 +1,5 @@
+package b
+
+object B:
+  def f(x: Int): Int = x + 2
+  inline def g(x: Int): Int = x + 2

--- a/sbt-test/tasty-compat/only-tasty/build.sbt
+++ b/sbt-test/tasty-compat/only-tasty/build.sbt
@@ -1,0 +1,16 @@
+lazy val a = project.in(file("a"))
+  .settings(
+    scalacOptions += "-Youtput-only-tasty",
+  )
+
+lazy val b = project.in(file("b"))
+  .settings(
+    scalacOptions += "-Youtput-only-tasty",
+    Compile / exportJars := true,
+  )
+
+lazy val c = project.in(file("c"))
+  .dependsOn(a, b)
+  .settings(
+    scalacOptions += "-Ycheck:all",
+  )

--- a/sbt-test/tasty-compat/only-tasty/c/C.scala
+++ b/sbt-test/tasty-compat/only-tasty/c/C.scala
@@ -1,0 +1,9 @@
+import a.A
+import b.B
+
+object C extends App {
+  assert(A.f(0) == 1)
+  assert(A.g(0) == 1)
+  assert(B.f(0) == 2)
+  assert(B.g(0) == 2)
+}

--- a/sbt-test/tasty-compat/only-tasty/project/DottyInjectedPlugin.scala
+++ b/sbt-test/tasty-compat/only-tasty/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/tasty-compat/only-tasty/project/build.properties
+++ b/sbt-test/tasty-compat/only-tasty/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.2

--- a/sbt-test/tasty-compat/only-tasty/test
+++ b/sbt-test/tasty-compat/only-tasty/test
@@ -1,0 +1,6 @@
+# compile library A
+> a/compile
+# compile library B
+> b/compile
+# compile library C, from source, against TASTy of A and B (where B loaded from jar)
+> c/compile

--- a/tests/run-custom-args/tasty-inspector/tastyPaths.check
+++ b/tests/run-custom-args/tasty-inspector/tastyPaths.check
@@ -1,2 +1,2 @@
-List(/tastyPaths/I8163.class)
+List(/tastyPaths/I8163.tasty)
 `reflect.SourceFile.current` cannot be called within the TASTy ispector


### PR DESCRIPTION
Before this PR we used to parse the classfiles first and when we found a classfile that has a `TASTY` attribute we switched and loaded the tasty. Now we find the `.tasty` files directly and load the symbols directly from them. We still load the class files to check that the UUID in that classfile matches the UUID in the TASTy file. 

When looking for classes in the classpath, we prioritize the TASTy files over classfiles. This implies that the symbol loader will receive the `.tasty` files for Scala 3 code and `.class` for Scala 2 and Java code.

A variant of the `ClassfileParser` called `ClassfileTastyUUIDParser` was added to have a way to check the UUID in the `TASTY` attribute of the classfile. The `ClassfileParser` could not be used directly because it eagerly tries to initialize parts of the symbols that are already loaded from the TASTy file, causing some conflicts.

Open question: should we only check the TASTy UUID under some flag to avoid loading both the `.tasty` and the `.class` files? The second commit introduces this check.
