### PR TITLE
Don't generate a super accessor for an inline method call

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -153,7 +153,9 @@ class SuperAccessors(thisPhase: DenotTransformer) {
         }
     }
 
-    val needAccessor = name.isTermName && (
+    val needAccessor =
+      name.isTermName                // Types don't need super accessors
+      && !sym.isInlineMethod && (    // Inline methods can't be overridden, don't need superaccessors
       clazz != currentClass || !validCurrentClass || mix.name.isEmpty && clazz.is(Trait))
 
     if (needAccessor) atPhase(thisPhase.next)(superAccessorCall(sel, mix.name))

--- a/tests/run/i17584.scala
+++ b/tests/run/i17584.scala
@@ -1,0 +1,9 @@
+trait A:
+  inline def g = 1
+trait B extends A:
+  def f = super.g
+class C extends B
+
+@main def Test =
+  val c = C()
+  assert(c.f == 1)


### PR DESCRIPTION
Inline methods cannot be overridden, so they don't need super accessors.

Fixes #17584