### PR TITLE
Ignore tests/pos-with-compiler-cc/dotc in VS Code search

### DIFF
--- a/.vscode-template/settings.json
+++ b/.vscode-template/settings.json
@@ -9,6 +9,7 @@
     "**/*.class": true,
     "**/*.tasty": true,
     "**/target/": true,
-    "community-build/community-projects": true
+    "community-build/community-projects": true,
+    "tests/pos-with-compiler-cc/dotc/**/*.scala": true
   }
 }


### PR DESCRIPTION
Since the addition of `tests/pos-with-compiler-cc/dotc`, I often lost time ending up in a `tests/pos-with-compiler-cc/dotc` file instead of the expected `compiler/src/dotty/tools/dotc` equivalent. I also often saw other contributors experiencing the same problem during sprees.

To solve this, I propose to exclude `tests/pos-with-compiler-cc/dotc` files from VS Code search by adding it to `search.exclude` list setting.

Before:

<img width="753" alt="image" src="https://github.com/lampepfl/dotty/assets/777748/30d23568-337b-4b8f-9305-9b779dc0d2ad">

After:

<img width="767" alt="image" src="https://github.com/lampepfl/dotty/assets/777748/6f933870-fedd-41ec-beb3-aa2411cf6869">

Note that to also exclude these files from full-text search, you also need to make sure this mysterious thing is checked:

![image](https://github.com/lampepfl/dotty/assets/777748/3be515e0-ea4b-4c93-a6b9-e4423594e336)

See also: https://stackoverflow.com/questions/29971600/choose-folders-to-be-ignored-during-search-in-vs-code.