### PR TITLE
docs: make sure references to feature requests mention discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,10 +1,10 @@
 ---
 name: "\U0001F389 Suggest a feature"
-about: Please create a feature request here https://github.com/lampepfl/dotty-feature-requests
+about: Please create a feature request here https://github.com/lampepfl/dotty/discussions/new?category=feature-requests
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-Please create a feature request here: [lampepfl/dotty-feature-requests](https://github.com/lampepfl/dotty-feature-requests).
+Please create a feature request in the [Dotty Discussions](https://github.com/lampepfl/dotty/discussions/new?category=feature-requests).

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -16,6 +16,11 @@ The issue supervisor is responsible for:
     - Attempting to reproduce the issue (or label “stat:cannot reproduce”)
     - Further minimizing the issue or asking the reporter of the issue to minimize it correctly (or label “stat:needs minimization”)
   - Identifying which issues are of considerable importance and bringing them to the attention of the team during the Dotty meeting, where they can be filtered and added to the [Future Versions](https://github.com/lampepfl/dotty/milestone/46) milestone.
+  - Identifying if a report is really a feature request and if so, converting it to
+    a [feature request discussion](https://github.com/lampepfl/dotty/discussions/categories/feature-requests).
+- Keeping an eye on new
+[discussions](https://github.com/lampepfl/dotty/discussions), making sure they
+don't go unanswered and also correctly labeling new feature requests.
 
 Other core teammates are responsible for providing information to the issue supervisor in a timely manner when it is requested if they have that information.
 
@@ -32,7 +37,6 @@ The issue supervisor schedule is maintained in the [Issue Supervisor Statistics 
 An issue supervisor needs to have all the accesses and privileges required to get their job done. This might include:
 
 - Admin rights in lampepfl/dotty repository
-- Admin rights in lampepfl/dotty-feature-requests repository
 - Permission to create new repositories in lampepfl organization (needed to fork repositories for the community build)
 - Access to the LAMP slack to be able to ask for help with the infrastructure, triaging and such
 


### PR DESCRIPTION
This accounts for the change where we now have feature requests being tracked in the [discussions](https://github.com/lampepfl/dotty/discussions/categories/feature-requests) tab under the feature requests label.

For context, the main reason for this is to ease the maintenance burden by further centralizing where things are located.
