### PR TITLE
Fix: Correct the navigation to anchor

### DIFF
--- a/scaladoc/resources/dotty_res/scripts/ux.js
+++ b/scaladoc/resources/dotty_res/scripts/ux.js
@@ -285,7 +285,7 @@ document
         getTocListElement(id).parentElement.classList.toggle("active");
       }
       if (lastEntry.isIntersecting) {
-        window.location.hash = "";
+        history.replaceState(null, "", window.location.pathname + window.location.search);
         removeAllHighlights();
         const id = getIdOfElement(lastEntry);
 

--- a/scaladoc/resources/dotty_res/scripts/ux.js
+++ b/scaladoc/resources/dotty_res/scripts/ux.js
@@ -285,7 +285,7 @@ document
         getTocListElement(id).parentElement.classList.toggle("active");
       }
       if (lastEntry.isIntersecting) {
-        history.replaceState(null, "", window.location.pathname + window.location.search);
+        history.replaceState(history.state, "", window.location.pathname + window.location.search);
         removeAllHighlights();
         const id = getIdOfElement(lastEntry);
 


### PR DESCRIPTION
The browser compatibility of [`location.hash`](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash) seems to be out of date. That's why in this fix, I suggest using [`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState).

## Before:

https://github.com/lampepfl/dotty/assets/44496264/a1399b0b-e4e8-4754-b146-661b59a01824

## After:

https://github.com/lampepfl/dotty/assets/44496264/22f38852-0cc5-48eb-a6e7-699f11628401

Fixes: #17182 