### PR TITLE
chore(community-build): update scala stdLib213 in community build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/dotty-staging/fastparse
 [submodule "community-build/community-projects/stdLib213"]
 	path = community-build/community-projects/stdLib213
-	url = https://github.com/dotty-staging/scala
+	url = https://github.com/dotty-staging/scala213
 [submodule "community-build/community-projects/sourcecode"]
 	path = community-build/community-projects/sourcecode
 	url = https://github.com/dotty-staging/sourcecode


### PR DESCRIPTION
Previously this was using a fork of
[`lampepfl/scala`](https://github.com/lampepfl/scala/tree/sharing-backend)
instead of a fork of actual `scala/scala`. This updates the community
build to run against a newly forked version of `scala/scala` instead of
the fork of a fork that is no longer used/maintained.
