### PR TITLE
chore(ci): add in cancellations for concurrent builds of the same branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ concurrency:
   # Taken from scalameta/metals
   # On main, we don't want any jobs cancelled so the sha is used to name the group
   # On PR branches, we cancel the job if new commits are pushed
-  # You can also bypass that making sure[no cancel] is in your pull request body
+  # You can also bypass that making sure [no cancel] is in your pull request body
   group: ${{
       ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags'))
         && format('contributor-pr-base-{0}', github.sha) 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,19 @@ on:
 env:
   DOTTY_CI_RUN: true
 
+concurrency:
+  # Taken from scalameta/metals
+  # On main, we don't want any jobs cancelled so the sha is used to name the group
+  # On PR branches, we cancel the job if new commits are pushed
+  # You can also bypass that making sure[no cancel] is in your pull request body
+  group: ${{
+      ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags'))
+        && format('contributor-pr-base-{0}', github.sha) 
+        || format('contributor-pr-{0}', github.ref))
+      && !contains(github.event.pull_request.body, '[no cancel]')
+    }}
+  cancel-in-progress: true
+
 # In this file, we set `--cpu-shares 4096` on every job. This might seem useless
 # since it means that every container has the same weight which should be
 # equivalent to doing nothing, but it turns out that OpenJDK computes

--- a/docs/_docs/contributing/sending-in-a-pr.md
+++ b/docs/_docs/contributing/sending-in-a-pr.md
@@ -114,6 +114,15 @@ Below are commonly used ones:
 | `[skip community_build_a]`| Skip the "a" community build    |
 | `[skip docs]`             | Skip the scaladoc tests         |
 
+#### Making sure every commit triggers a new run
+
+By default the Dotty CI will cancel your previous runs if you push a new commit.
+This helps make sure the CI keeps moving without getting stuck running a ton of
+jobs if you push multiple times in a row. _However_, there are times you may
+want to run every commit. To do this, make sure your PR body contains `[no
+cancel]`. This will ensure that there are no cancellations of your previous
+runs.
+
 ### 7: Create your PR!
 
 When the feature or fix is completed you should open a [Pull


### PR DESCRIPTION
I'd love to get others opinions on this.

This PR introduces a change to the CI that we use in Metals that has
really come in handy. The problem that this attempts to address is that
sometimes during the day the Dotty CI gets really backed up. Many times
when you look at why this is, it's because sometimes people push their
branch 2 or 3 times shortly after one another will small changes. This
then adds 3 full runs to CI when the vast majority of the time, the
latest one is the one they actually care about. What this change does is
cancels the previous one to run the latest. This _only_ does this on
PRs, not on the main branch.

EDIT:

Following the meeting I added in the ability to include a `[no cancel]` to your PR body. When this is included concurrent builds will be allowed.
