### PR TITLE
Revert "Inline _N case class product members under -Yscala2-stdlib"

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -664,8 +664,7 @@ object desugar {
     //       new C[...](p1, ..., pN)(moreParams)
     val (caseClassMeths, enumScaffolding) = {
       def syntheticProperty(name: TermName, tpt: Tree, rhs: Tree) =
-        val mods = if caseClassInScala2StdLib then synthetic | Inline else synthetic
-        DefDef(name, Nil, tpt, rhs).withMods(mods)
+        DefDef(name, Nil, tpt, rhs).withMods(synthetic)
 
       def productElemMeths =
         val caseParams = derivedVparamss.head.toArray

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -139,6 +139,12 @@ object MiMaFilters {
         // Companion module class: Missing type java.io.Serializable
         ProblemFilters.exclude[MissingTypesProblem]("scala.*$"),
 
+        // Case class product accessors
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.*._1"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.*._2"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.*._3"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.*._4"),
+
         // abstract method elemTag()scala.reflect.ClassTag in class scala.collection.mutable.ArraySeq does not have a correspondent in other version
         ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.collection.immutable.ArraySeq.elemTag"),
         ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.collection.mutable.ArraySeq.elemTag"),

--- a/stdlib-bootstrapped/test/Main.scala
+++ b/stdlib-bootstrapped/test/Main.scala
@@ -15,7 +15,6 @@ object HelloWorld:
 
     testScala2UnapplySignatures()
     testScala2ObjectParents()
-    testScala2ProductMembers()
   }
 
   def testScala2UnapplySignatures() = {
@@ -31,12 +30,4 @@ object HelloWorld:
   def testScala2ObjectParents() = {
     assert(!typeChecks("Either: scala.deriving.Mirror.Sum"))
     assert(!typeChecks("Either: scala.deriving.Mirror"))
-  }
-  def testScala2ProductMembers() = {
-    Some(1)._1
-    Right(1)._1
-    (1, 2)._1
-    (1, 2)._2
-    ::(1, Nil)._1
-    ::(1, Nil)._2
   }

--- a/stdlib-bootstrapped/test/Main.scala
+++ b/stdlib-bootstrapped/test/Main.scala
@@ -15,6 +15,7 @@ object HelloWorld:
 
     testScala2UnapplySignatures()
     testScala2ObjectParents()
+    testScala2CaseClassUnderscoreMembers()
   }
 
   def testScala2UnapplySignatures() = {
@@ -30,4 +31,9 @@ object HelloWorld:
   def testScala2ObjectParents() = {
     assert(!typeChecks("Either: scala.deriving.Mirror.Sum"))
     assert(!typeChecks("Either: scala.deriving.Mirror"))
+  }
+
+  def testScala2CaseClassUnderscoreMembers() = {
+    val some: Some[Int] = Some(1)
+    // FIXME: assert(!typeChecks("some._1"))
   }


### PR DESCRIPTION
These product members are only in the bytecode.

This reverts commit 8c58cbfe39f4ef99d8900849c73206b3944c4cd8.