### PR TITLE
deps: bump sbt plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,13 +8,13 @@ libraryDependencySchemes +=
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.20")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.17")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 


### PR DESCRIPTION
This bumps the following:

- sbt-sonatype from 3.9.20 -> 3.9.21
- sbt-jmh from 0.4.3 -> 0.4.5
