### PR TITLE
chore: remove unused semanticdb directory

### DIFF
--- a/semanticdb/project/build.properties
+++ b/semanticdb/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.8.2


### PR DESCRIPTION
From looking back it seems that what this directory used to contain was
removed in
https://github.com/lampepfl/dotty/commit/bd2f8a6a30f8c03d988aaf100f2dcb8e7986848e,
however the directory still remained. This PR just removes the leftover
`build.properties`, which keeps getting updated, but does nothing.
