### PR TITLE
Run all MatchType reduction under Mode.Type

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4943,7 +4943,7 @@ object Types {
         record("MatchType.reduce computed")
         if (myReduced != null) record("MatchType.reduce cache miss")
         myReduced =
-          trace(i"reduce match type $this $hashCode", matchTypes, show = true) {
+          trace(i"reduce match type $this $hashCode", matchTypes, show = true)(inMode(Mode.Type) {
             def matchCases(cmp: TrackingTypeComparer): Type =
               val saved = ctx.typerState.snapshot()
               try cmp.matchCases(scrutinee.normalized, cases)
@@ -4956,7 +4956,7 @@ object Types {
                   // instantiations during matchtype reduction
 
             TypeComparer.tracked(matchCases)
-          }
+          })
       myReduced.nn
     }
 

--- a/tests/pos/i16408.min1.scala
+++ b/tests/pos/i16408.min1.scala
@@ -1,0 +1,26 @@
+object Helpers:
+  type NodeFun[R] = Matchable // compiles without [R] parameter
+
+  type URIFun[R] = R match
+    case GetURI[u] => u & NodeFun[R]
+
+  private type GetURI[U] = RDF { type URI = U }
+end Helpers
+
+trait RDF:
+  type URI
+
+trait ROps[R <: RDF]:
+  def auth(uri: Helpers.URIFun[R]): String
+
+object TraitRDF extends RDF:
+  override type URI = TraitTypes.UriImpl
+
+  val rops = new ROps[TraitRDF.type] {
+    override def auth(uri: Helpers.URIFun[TraitRDF.type]): String = ???
+  }
+end TraitRDF
+
+object TraitTypes:
+  trait UriImpl // doesn't compile
+  // class UriImpl // compiles

--- a/tests/pos/i16408.min2.scala
+++ b/tests/pos/i16408.min2.scala
@@ -1,0 +1,22 @@
+object Helpers:
+  type NodeFun[R] = Matchable // compiles without [R] parameter
+
+  type URIFun[R] = R match
+    case RDF[u] => u & NodeFun[R]
+end Helpers
+
+trait RDF[URIParam]
+
+trait ROps[R <: RDF[?]]:
+  def auth(uri: Helpers.URIFun[R]): String
+
+object TraitRDF extends RDF[TraitTypes.UriImpl]:
+
+  val rops = new ROps[TraitRDF.type] {
+    override def auth(uri: Helpers.URIFun[TraitRDF.type]): String = ???
+  }
+end TraitRDF
+
+object TraitTypes:
+  trait UriImpl // doesn't compile
+  // class UriImpl // compiles

--- a/tests/pos/i16408.scala
+++ b/tests/pos/i16408.scala
@@ -1,0 +1,57 @@
+import scala.util.Try
+
+trait RDF:
+  rdf =>
+
+  type R = rdf.type
+  type Node <: Matchable
+  type URI <: Node
+
+  given rops: ROps[R]
+end RDF
+
+object RDF:
+  type Node[R <: RDF] = R match
+    case GetNode[n] => Matchable //n & rNode[R]
+
+  type URI[R <: RDF] <: Node[R] = R match
+    case GetURI[u] => u & Node[R]
+
+  private type GetNode[N] = RDF { type Node = N }
+  private type GetURI[U] = RDF { type URI = U }
+end RDF
+
+trait ROps[R <: RDF]:
+  def mkUri(str: String): Try[RDF.URI[R]]
+  def auth(uri: RDF.URI[R]): Try[String]
+
+object TraitTypes:
+  trait Node:
+    def value: String
+
+  trait Uri extends Node
+
+  def mkUri(u: String): Uri =
+    new Uri { def value = u }
+
+object TraitRDF extends RDF:
+  import TraitTypes as tz
+
+  override opaque type Node <: Matchable = tz.Node
+  override opaque type URI <: Node = tz.Uri
+
+  given rops: ROps[R] with
+    override def mkUri(str: String): Try[RDF.URI[R]] = Try(tz.mkUri(str))
+    override def auth(uri: RDF.URI[R]): Try[String] =
+      Try(java.net.URI.create(uri.value).getAuthority())
+
+end TraitRDF
+
+class Test[R <: RDF](using rops: ROps[R]):
+  import rops.given
+  lazy val uriT: Try[RDF.URI[R]] = rops.mkUri("https://bblfish.net/#i")
+  lazy val x: String = "uri authority=" + uriT.map(u => rops.auth(u))
+
+@main def run =
+  val test = Test[TraitRDF.type]
+  println(test.x)


### PR DESCRIPTION
Transcribing and paraphrasing from @smarter's comment in
https://github.com/lampepfl/dotty/issues/16408#issuecomment-1533347659 :

Type erasure assumes method signatures aren't simplified, since
simplification logic is implementation-defined.  For instance, some
intersection types can be simplified down, but intersection types and
their simplification can erase to different types - prefering classes
over traits, for instance (for Java interop, as it matches Java's
erasure).

Also note, simplify doesn't simplify intersections and unions in Type
mode.  But Match Types will cache their reduction without considering
the type mode as a cache input, thus the simplified reduction leaks even
when called in Type mode.

So we call simplified in Mode.Type, in both cases (another desire), so
only that result is cached instead.

Using normalise doesn't work because, for example, that doesn't
normalise match types that are applied type args (e.g. args of Pair).
And not caching the result of those reductions means that they'll get
repeat over and over.
