### PR TITLE
Cleanup quote pattern prototype

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -437,6 +437,6 @@ trait QuotesAndSplices {
       fun = unapplyFun.appliedToTypeTrees(typeBindingsTuple :: TypeTree(patType) :: Nil),
       implicits = quotedPattern :: Nil,
       patterns = splicePat :: Nil,
-      proto = quoteClass.typeRef.appliedTo(replaceBindings(quoted1.tpe) & quotedPt))
+      proto = quoteClass.typeRef.appliedTo(replaceBindings(quoted1.tpe)))
   }
 }


### PR DESCRIPTION
The `quotedPt` is used when typing the body of the quoted type. It does not need to appear in the prototype of the quote pattern `unapply`.