### PR TITLE
Fix pretty printer to handle using and erased modifier

### DIFF
--- a/tests/run-macros/term-show.check
+++ b/tests/run-macros/term-show.check
@@ -1,0 +1,21 @@
+{
+  class C() {
+    def a: scala.Int = 0
+    private[this] def b: scala.Int = 0
+    private[this] def c: scala.Int = 0
+    private[C] def d: scala.Int = 0
+    protected def e: scala.Int = 0
+    protected[this] def f: scala.Int = 0
+    protected[C] def g: scala.Int = 0
+  }
+  ()
+}
+@scala.annotation.internal.SourceFile("tests/run-macros/term-show/Test_2.scala") trait A() extends java.lang.Object {
+  def imp(x: scala.Int)(implicit str: scala.Predef.String): scala.Int
+  def use(`x₂`: scala.Int)(using `str₂`: scala.Predef.String): scala.Int
+  def era(`x₃`: scala.Int)(erased `str₃`: scala.Predef.String): scala.Int
+  def f1(x1: scala.Int, erased x2: scala.Int): scala.Int
+  def f2(erased `x1₂`: scala.Int, erased `x2₂`: scala.Int): scala.Int
+  def f3(using `x1₃`: scala.Int, erased `x2₃`: scala.Int): scala.Int
+  def f4(using erased `x1₄`: scala.Int, erased `x2₄`: scala.Int): scala.Int
+}

--- a/tests/run-macros/term-show/Macro_1.scala
+++ b/tests/run-macros/term-show/Macro_1.scala
@@ -5,4 +5,11 @@ object TypeToolbox {
   private def showImpl(using Quotes)(v: Expr[Any]): Expr[String] =
     import quotes.reflect.*
     Expr(v.show)
+
+  inline def showTree(inline className: String): String = ${ showTreeImpl('className) }
+  private def showTreeImpl(className: Expr[String])(using Quotes) : Expr[String] =
+    import quotes.reflect.*
+    val name = className.valueOrAbort
+    val res = Symbol.requiredClass(name).tree.show
+    Expr(res)
 }

--- a/tests/run-macros/term-show/Test_2.scala
+++ b/tests/run-macros/term-show/Test_2.scala
@@ -1,7 +1,19 @@
+import scala.language.experimental.erasedDefinitions
+
+trait A:
+  def imp(x: Int)(implicit str: String): Int
+  def use(x: Int)(using str: String): Int
+  def era(x: Int)(erased str: String): Int
+
+  def f1(x1: Int, erased x2: Int): Int
+  def f2(erased x1: Int, erased x2: Int): Int
+  def f3(using x1: Int, erased x2: Int): Int
+  def f4(using erased x1: Int, erased x2: Int): Int
+
 object Test {
   import TypeToolbox.*
   def main(args: Array[String]): Unit = {
-   assert(show {
+   println(show {
       class C {
         def a = 0
         private def b = 0
@@ -11,19 +23,8 @@ object Test {
         protected[this] def f = 0
         protected[C] def g = 0
       }
-    }
-    ==
-    """{
-      |  class C() {
-      |    def a: scala.Int = 0
-      |    private[this] def b: scala.Int = 0
-      |    private[this] def c: scala.Int = 0
-      |    private[C] def d: scala.Int = 0
-      |    protected def e: scala.Int = 0
-      |    protected[this] def f: scala.Int = 0
-      |    protected[C] def g: scala.Int = 0
-      |  }
-      |  ()
-      |}""".stripMargin)
+    })
+
+    println(showTree("A"))
   }
 }


### PR DESCRIPTION
The existing pretty printer doesn't handle using/erased keyword, making it a bit misleading when investigating code generated by macros.

This PR add support for those two modifiers