### PR TITLE
Fix #17577: scaladoc hangs with deep inheritance

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/api.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/api.scala
@@ -145,10 +145,10 @@ case class LinkToType(signature: Signature, dri: DRI, kind: Kind)
 case class HierarchyGraph(edges: Seq[(LinkToType, LinkToType)], sealedNodes: Set[LinkToType] = Set.empty):
   def vertecies: Seq[LinkToType] = edges.flatten((a, b) => Seq(a, b)).distinct
   def verteciesWithId: Map[LinkToType, Int] = vertecies.zipWithIndex.toMap
-  def +(edge: (LinkToType, LinkToType)): HierarchyGraph = HierarchyGraph((edges :+ edge).distinct)
-  def ++(edges: Seq[(LinkToType, LinkToType)]): HierarchyGraph = edges.foldLeft(this) {
-    case (acc, edge) => acc + edge
-  }
+  def +(edge: (LinkToType, LinkToType)): HierarchyGraph = this ++ Seq(edge)
+  def ++(edges: Seq[(LinkToType, LinkToType)]): HierarchyGraph = 
+    this.copy(edges = this.edges.view.concat(edges).distinct.toSeq)
+    
 object HierarchyGraph:
   def empty = HierarchyGraph(Seq.empty)
   def withEdges(edges: Seq[(LinkToType, LinkToType)]) = HierarchyGraph.empty ++ edges


### PR DESCRIPTION
This commit has a pair of fixes that bring the scaladoc build time for the repository mentioned in #17577 to a minute instead of hanging.

- Reimplement HierarchyGraph's `+` method in terms of `++` Previously, `++` was implemented in terms of `+`, but `+` called `distinct` resulting in poor performance. Now `distinct` is only called once for a `++` call.
- Get the distinct `LinkToType` values in `InheritanceInformationTransformer.apply`. Previously, `subtypes` could contain duplicates, causing redundant  calls to `getEdges`