### PR TITLE
Better error message for arity mismatch

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1739,10 +1739,12 @@ class NotAPath(tp: Type, usage: String)(using Context) extends TypeMsg(NotAPathI
         | - a reference to `this`, or
         | - a selection of an immutable path with an immutable value."""
 
-class WrongNumberOfParameters(expected: Int)(using Context)
+class WrongNumberOfParameters(expected: Int, found: Int, pt: Type, tree: tpd.Tree)(using Context)
   extends SyntaxMsg(WrongNumberOfParametersID) {
-  def msg(using Context) = s"Wrong number of parameters, expected: $expected"
-  def explain(using Context) = ""
+  def msg(using Context) = s"Wrong number of parameters, expected $expected, but found $found"
+    def explain(using Context) =
+    i"""|Expected pattern: $pt
+        |Found pattern   : ${tree.srcPos}"""
 }
 
 class DuplicatePrivateProtectedQualifier()(using Context)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1569,7 +1569,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     /** Returns the type and whether the parameter is erased */
     def protoFormal(i: Int): (Type, Boolean) =
       if (protoFormals.length == params.length) (protoFormals(i), isDefinedErased(i))
-      else (errorType(WrongNumberOfParameters(protoFormals.length), tree.srcPos), false)
+      else (errorType(WrongNumberOfParameters(protoFormals.length, params.length, pt, tree), tree.srcPos), false)
 
     /** Is `formal` a product type which is elementwise compatible with `params`? */
     def ptIsCorrectProduct(formal: Type) =


### PR DESCRIPTION
Currently, if we write:

```Scala
def add(x: Int, y: Int) = x + y

val a = List(1, 2, 3)
val b = a.map(add)
```
We get a pretty confusing error message:
```
-- [E086] Syntax Error: ----------------------------------------------------
  |val b = a.map(add)
  |              ^^^
  |              Wrong number of parameters, expected: 1
```

Now, with `-explained` enabled it's:

```
-- [E086] Syntax Error----------------------------------------------------------
  |val b = a.map(add)
  |              ^^^
  |              Wrong number of parameters, expected 1, but found 2
  |-----------------------------------------------------------------------------
  | Explanation (enabled by `-explain`)
  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  |
  | Expected pattern: Int => Int
  | Found pattern   : (x: Int, y: Int) => add(x, y)
   -----------------------------------------------------------------------------
```