### PR TITLE
Disallow `infix` objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -584,6 +584,8 @@ object Checking {
       report.error(ModifierNotAllowedForDefinition(Sealed), flagSourcePos(Sealed))
     if mods.is(Final, butNot = Synthetic) then
       report.warning(RedundantModifier(Final), flagSourcePos(Final))
+    if mods.is(Infix) then
+      report.error(ModifierNotAllowedForDefinition(Infix), flagSourcePos(Infix))
 
   /** Check the type signature of the symbol `M` defined by `tree` does not refer
    *  to a private type or value which is invisible at a point where `M` is still

--- a/tests/neg/i17738-infix-object/NestedInfixObject.scala
+++ b/tests/neg/i17738-infix-object/NestedInfixObject.scala
@@ -1,0 +1,2 @@
+object ToplevelObject:
+  infix object NestedInfixObject // error

--- a/tests/neg/i17738-infix-object/ToplevelInfixObject.scala
+++ b/tests/neg/i17738-infix-object/ToplevelInfixObject.scala
@@ -1,0 +1,1 @@
+infix object ToplevelInfixObject // error


### PR DESCRIPTION
Disallow `infix` objects by checking for the `infix` modifier in `Checking.scala`.

I also have another version of this PR that does these checks during parsing (kind of mirroring how `infix imports` and `infix exports` are rejected) but doing this in `Checking.scala` yields much nicer error messages for the end user, eg. when a user tries to compile code with `infix object Something` they will now see this:

```bash
-- [E156] Syntax Error: /home/aleksander/Repos/dotty/issues/issue17738/issue17738.scala:1:0 
1 |infix object Something
  |^^^^^
  |Modifier infix is not allowed for this definition
```

Part of #17738