### PR TITLE
Fix TastyFormat.MinorVersion

### DIFF
--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -290,7 +290,7 @@ object TastyFormat {
    *  compatibility, but remains backwards compatible, with all
    *  preceeding `MinorVersion`.
    */
-  final val MinorVersion: Int = 4
+  final val MinorVersion: Int = 3
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing


### PR DESCRIPTION
The build still uses
```scala
val baseVersion = "3.3.2-RC1"
```