### PR TITLE
Fix stdlib-bootstrapped private case class constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -696,12 +696,14 @@ object desugar {
             cpy.ValDef(vparam)(rhs = refOfDef(vparam)))
           val copyRestParamss = derivedVparamss.tail.nestedMap(vparam =>
             cpy.ValDef(vparam)(rhs = EmptyTree))
+          var flags = Synthetic | constr1.mods.flags & copiedAccessFlags
+          if ctx.settings.Yscala2Stdlib.value then flags &~= Private
           DefDef(
             nme.copy,
             joinParams(derivedTparams, copyFirstParams :: copyRestParamss),
             TypeTree(),
             creatorExpr
-          ).withMods(Modifiers(Synthetic | constr1.mods.flags & copiedAccessFlags, constr1.mods.privateWithin)) :: Nil
+          ).withMods(Modifiers(flags, constr1.mods.privateWithin)) :: Nil
         }
       }
 
@@ -755,7 +757,9 @@ object desugar {
           if (mods.is(Abstract)) Nil
           else {
             val appMods =
-              Modifiers(Synthetic | constr1.mods.flags & copiedAccessFlags).withPrivateWithin(constr1.mods.privateWithin)
+              var flags = Synthetic | constr1.mods.flags & copiedAccessFlags
+              if ctx.settings.Yscala2Stdlib.value then flags &~= Private
+              Modifiers(flags).withPrivateWithin(constr1.mods.privateWithin)
             val appParamss =
               derivedVparamss.nestedZipWithConserve(constrVparamss)((ap, cp) =>
                 ap.withMods(ap.mods | (cp.mods.flags & HasDefault)))

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -113,7 +113,6 @@ object MiMaFilters {
         "scala.collection.StringView.andThen", "scala.collection.StringView.compose",
         "scala.concurrent.BatchingExecutor#AbstractBatch.this",
         "scala.concurrent.Channel#LinkedList.this",
-        "scala.concurrent.duration.Deadline.apply", "scala.concurrent.duration.Deadline.copy", "scala.concurrent.duration.Deadline.copy$default$1",
         "scala.Enumeration#ValueOrdering.this",
         "scala.io.Source#RelaxedPosition.this",
         "scala.PartialFunction#OrElse.andThen", "scala.PartialFunction#OrElse.orElse",

--- a/project/TastyMiMaFilters.scala
+++ b/project/TastyMiMaFilters.scala
@@ -30,11 +30,6 @@ object TastyMiMaFilters {
     // Problem: ConstantType for `null` versus `scala.Null`
     ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.mutable.UnrolledBuffer.Unrolled.<init>$default$4"),
 
-    // Problem: Case class with private constructor
-    ProblemMatcher.make(ProblemKind.RestrictedVisibilityChange, "scala.concurrent.duration.Deadline.apply"),
-    ProblemMatcher.make(ProblemKind.RestrictedVisibilityChange, "scala.concurrent.duration.Deadline.copy"),
-    ProblemMatcher.make(ProblemKind.RestrictedVisibilityChange, "scala.concurrent.duration.Deadline.copy$default$1"),
-
     // Problem: Missing type arguments with higher-kinded types
     ProblemMatcher.make(ProblemKind.MissingTypeMember, "scala.collection.SortedSetFactoryDefaults._$5"),
     ProblemMatcher.make(ProblemKind.MissingTypeMember, "scala.collection.SortedMapFactoryDefaults._$6"),


### PR DESCRIPTION
In the Scala 2 the `apply` and `copy` of a private case class constructor are public in the pickles and bytecode.
