### PR TITLE
Suggest imports for the expected type of the underlying implicit not found error

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2848,10 +2848,17 @@ class MissingImplicitArgument(
             i"The following implicits in scope can be implicitly converted to ${pt.show}:" +
             ignoredConvertibleImplicits.map { imp => s"\n- ${imp.symbol.showDcl}"}.mkString
           )
+        def importSuggestionAddendum: String =
+          arg.tpe match
+            // If the failure was caused by an underlying NoMatchingImplicits, compute the addendum for its expected type
+            case noMatching: NoMatchingImplicits => // FIXME also handle SynthesisFailure
+              ctx.typer.importSuggestionAddendum(noMatching.expectedType)
+            case _ =>
+              ctx.typer.importSuggestionAddendum(pt)
         super.msgPostscript
         ++ ignoredInstanceNormalImport.map(hiddenImplicitNote)
             .orElse(noChainConversionsNote(ignoredConvertibleImplicits))
-            .getOrElse(ctx.typer.importSuggestionAddendum(pt))
+            .getOrElse(importSuggestionAddendum)
 
   def explain(using Context) = userDefinedImplicitNotFoundMessage(explain = true)
     .getOrElse("")

--- a/tests/neg/i8827a.check
+++ b/tests/neg/i8827a.check
@@ -1,0 +1,14 @@
+-- [E172] Type Error: tests/neg/i8827a.scala:16:26 ---------------------------------------------------------------------
+16 |  summon[Order[List[Foo]]] // error
+   |                          ^
+   | No given instance of type pkg.Order[List[pkg.Foo]] was found for parameter x of method summon in object Predef.
+   | I found:
+   |
+   |     pkg.Order.orderList[pkg.Foo](/* missing */summon[pkg.Order[pkg.Foo]])
+   |
+   | But no implicit values were found that match type pkg.Order[pkg.Foo].
+   |
+   | The following import might fix the problem:
+   |
+   |   import pkg.Implicits.orderFoo
+   |

--- a/tests/neg/i8827a.scala
+++ b/tests/neg/i8827a.scala
@@ -1,0 +1,16 @@
+package pkg
+
+trait Order[A]
+
+object Order {
+  implicit def orderList[A](implicit orderA: Order[A]): Order[List[A]] = ???
+}
+
+class Foo
+
+object Implicits {
+  implicit def orderFoo: Order[Foo] = ???
+}
+
+@main def main: Unit =
+  summon[Order[List[Foo]]] // error

--- a/tests/neg/i8827b.check
+++ b/tests/neg/i8827b.check
@@ -1,0 +1,14 @@
+-- [E172] Type Error: tests/neg/i8827b.scala:16:28 ---------------------------------------------------------------------
+16 |  summon[Order[Option[Foo]]] // error
+   |                            ^
+   |No given instance of type pkg.Order[Option[pkg.Foo]] was found for parameter x of method summon in object Predef.
+   |I found:
+   |
+   |    pkg.Order.given_Order_Option[pkg.Foo](/* missing */summon[pkg.Order[pkg.Foo]])
+   |
+   |But no implicit values were found that match type pkg.Order[pkg.Foo].
+   |
+   |The following import might fix the problem:
+   |
+   |  import pkg.Givens.orderFoo
+   |

--- a/tests/neg/i8827b.scala
+++ b/tests/neg/i8827b.scala
@@ -1,0 +1,16 @@
+package pkg
+
+trait Order[A]
+
+object Order {
+  given [A](using orderA: Order[A]): Order[Option[A]] = ???
+}
+
+class Foo
+
+object Givens {
+  given orderFoo: Order[Foo] = ???
+}
+
+@main def main: Unit =
+  summon[Order[Option[Foo]]] // error

--- a/tests/neg/missing-implicit3.check
+++ b/tests/neg/missing-implicit3.check
@@ -7,3 +7,8 @@
    |       ord.Ord.ordered[ord.Foo](/* missing */summon[ord.Foo => Comparable[? >: ord.Foo]])
    |
    |   But no implicit values were found that match type ord.Foo => Comparable[? >: ord.Foo].
+   |
+   |   The following import might make progress towards fixing the problem:
+   |
+   |     import scala.math.Ordered.orderingToOrdered
+   |


### PR DESCRIPTION
We used to suggest imports for the outermost type of a chain of implicits.
Now, we suggest imports for the `expectedType` of the underlying `NoMatchingImplicits`.

Fixes #8827