### PR TITLE
fix: report correct location on a repeat modifier

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3028,7 +3028,9 @@ object Parsers {
       val name = in.name
       val mod = atSpan(in.skipToken()) { modOfToken(tok, name) }
 
-      if (mods.isOneOf(mod.flags)) syntaxError(RepeatedModifier(mod.flags.flagsString))
+      if mods.isOneOf(mod.flags) then
+        syntaxError(RepeatedModifier(mod.flags.flagsString), mod.span)
+
       addMod(mods, mod)
     }
 

--- a/tests/neg/i17981.check
+++ b/tests/neg/i17981.check
@@ -1,0 +1,6 @@
+-- [E015] Syntax Error: tests/neg/i17981.scala:1:6 ---------------------------------------------------------------------
+1 |final final case class Foo() // error
+  |      ^^^^^
+  |      Repeated modifier final
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i17981.scala
+++ b/tests/neg/i17981.scala
@@ -1,0 +1,1 @@
+final final case class Foo() // error


### PR DESCRIPTION
Currently given the following code snippet:

```scala
final final case class Foo()
```

The error is reported on `Foo` and not on the repeated modifier. This changes the reporting to instead report on the repeated modifier `final`.

Fixes #17981