### PR TITLE
Add -Yprint-tasty compiler flag

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -353,6 +353,7 @@ private sealed trait YSettings:
   val YprintDebugOwners: Setting[Boolean] = BooleanSetting("-Yprint-debug-owners", "When printing trees, print owners of definitions.")
   val YprintLevel: Setting[Boolean] = BooleanSetting("-Yprint-level", "print nesting levels of symbols and type variables.")
   val YshowPrintErrors: Setting[Boolean] = BooleanSetting("-Yshow-print-errors", "Don't suppress exceptions thrown during tree printing.")
+  val YprintTasty: Setting[Boolean] = BooleanSetting("-Yprint-tasty", "Prints the generated TASTY to stdout.")
   val YtestPickler: Setting[Boolean] = BooleanSetting("-Ytest-pickler", "Self-test for pickling functionality; should be used with -Ystop-after:pickler.")
   val YcheckReentrant: Setting[Boolean] = BooleanSetting("-Ycheck-reentrant", "Check that compiled program does not contain vars that can be accessed from a global root.")
   val YdropComments: Setting[Boolean] = BooleanSetting("-Ydrop-docs", "Drop documentation when scanning source files.", aliases = List("-Ydrop-comments"))

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -116,9 +116,10 @@ class Pickler extends Phase {
             }
 
           // println(i"rawBytes = \n$rawBytes%\n%") // DEBUG
-          if pickling ne noPrinter then
+          if ctx.settings.YprintTasty.value || pickling != noPrinter then
             println(i"**** pickled info of $cls")
             println(TastyPrinter.showContents(pickled, ctx.settings.color.value == "never"))
+            println(i"**** end of pickled info of $cls")
           pickled
         }
       }


### PR DESCRIPTION
This flag provides a simple way to print the generated TASTy. Unlike `Printers.pickling`, this can be used on a release version of the compiler.