### PR TITLE
Refactor: Path validation and SiderbarParserTest

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
@@ -34,6 +34,14 @@ object Sidebar:
 
   private def toSidebar(r: RawInput, content: String | java.io.File)(using CompilerContext): Sidebar = r match
     case RawInput(title, page, index, subsection, dir, hidden) if page.nonEmpty && index.isEmpty && subsection.isEmpty() =>
+      val pagePath = content match 
+        case f: java.io.File => 
+          val pagePath = f.toPath()
+                          .getParent()
+                          .resolve(s"_docs/$page")
+          if !Files.exists(pagePath) then
+            report.error(s"Page $page does not exist.")               
+        case s: String => None
       Sidebar.Page(Option.when(title.nonEmpty)(title), page, hidden)
     case RawInput(title, page, index, subsection, dir, hidden) if page.isEmpty && (!subsection.isEmpty() || !index.isEmpty()) =>
       Sidebar.Category(Option.when(title.nonEmpty)(title), Option.when(index.nonEmpty)(index), subsection.asScala.map(toSidebar(_, content)).toList, Option.when(dir.nonEmpty)(dir))

--- a/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SidebarParserTest.scala
@@ -41,7 +41,6 @@ class SidebarParserTest:
   private val sidebarNoTitle =
     """index: index.md
       |subsection:
-      |  - title: My title
       |    page: my-page1.md
       |  - page: my-page2.md
       |  - page: my-page3/subsection
@@ -57,7 +56,7 @@ class SidebarParserTest:
       |    subsection:
       |      - page: my-page5/my-page5.md
       |  - subsection:
-      |        page: my-page7/my-page7.md
+      |      - page: my-page7/my-page7.md
       |  - index: my-page6/index.md
       |    subsection:
       |      - index: my-page6/my-page6/index.md
@@ -122,10 +121,9 @@ class SidebarParserTest:
     Console.withErr(new PrintStream(out)) {
       Sidebar.load(sidebarErrorNoPage)(using testContext)
     }
-    println(out.toString())
-    val error = out.toString().trim()
+    val errorPage = out.toString().trim()
 
-    assert(error.contains(msgNoPage) && error.contains(schemaMessage))
+    assert(errorPage.contains(msgNoPage) && errorPage.contains(schemaMessage))
 
 
   @Test
@@ -134,6 +132,6 @@ class SidebarParserTest:
     Console.withErr(new PrintStream(out)) {
       Sidebar.load(sidebarNoTitle)(using testContext)
     }
-    val error = out.toString().trim()
+    val errorTitle = out.toString().trim()
 
-    assert(error.contains(msgNoTitle) && error.contains(schemaMessage))
+    assert(errorTitle.contains(msgNoTitle) && errorTitle.contains(schemaMessage))


### PR DESCRIPTION
The goal of this PR is to re-add the path validation of the page in a sidebar.yaml and improve the Testcase in the `SidebarParserTest` by erasing the first title, so it's easier to understand the problem in it.

This PR is related to PRs: #17229 & #17959 

[test_windows_full]