### PR TITLE
fix: revert d53c237aafe098d2bed56fd522c7271410ff9dfd

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,19 +27,6 @@ on:
 env:
   DOTTY_CI_RUN: true
 
-concurrency:
-  # Taken from scalameta/metals
-  # On main, we don't want any jobs cancelled so the sha is used to name the group
-  # On PR branches, we cancel the job if new commits are pushed
-  # You can also bypass that making sure [no cancel] is in your pull request body
-  group: ${{
-      ((github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags'))
-        && format('contributor-pr-base-{0}', github.sha) 
-        || format('contributor-pr-{0}', github.ref))
-      && !contains(github.event.pull_request.body, '[no cancel]')
-    }}
-  cancel-in-progress: true
-
 # In this file, we set `--cpu-shares 4096` on every job. This might seem useless
 # since it means that every container has the same weight which should be
 # equivalent to doing nothing, but it turns out that OpenJDK computes

--- a/docs/_docs/contributing/sending-in-a-pr.md
+++ b/docs/_docs/contributing/sending-in-a-pr.md
@@ -130,16 +130,6 @@ parts of the CI that usually ony runs on nightly builds.
 | `[test_windows_full]`     | Execute unit tests on Windows                      |
 | `[test_non_bootstrapped]` | Execute unit tests using non-bootstrapped compiler |
 
-
-#### Making sure every commit triggers a new run
-
-By default the Dotty CI will cancel your previous runs if you push a new commit.
-This helps make sure the CI keeps moving without getting stuck running a ton of
-jobs if you push multiple times in a row. _However_, there are times you may
-want to run every commit. To do this, make sure your PR body contains `[no
-cancel]`. This will ensure that there are no cancellations of your previous
-runs.
-
 ### 7: Create your PR!
 
 When the feature or fix is completed you should open a [Pull


### PR DESCRIPTION
This seems to not be working as expected because `main` is also getting cancelled.