### PR TITLE
Add Ycheck to stdlib-bootstrapped

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SpecializeApplyMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeApplyMethods.scala
@@ -25,7 +25,7 @@ class SpecializeApplyMethods extends MiniPhase with InfoTransformer {
   override def description: String = SpecializeApplyMethods.description
 
   override def isEnabled(using Context): Boolean =
-    !ctx.settings.scalajs.value
+    !ctx.settings.scalajs.value && !ctx.settings.Yscala2Stdlib.value
 
   private def specApplySymbol(sym: Symbol, args: List[Type], ret: Type)(using Context): Symbol = {
     val name = nme.apply.specializedFunction(ret, args)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2714,6 +2714,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
          && !cls.isAllOf(PrivateLocal)
          && effectiveOwner.is(Trait)
          && !effectiveOwner.derivesFrom(defn.ObjectClass)
+         && !ctx.settings.Yscala2Stdlib.value // FIXME?: class PermutationsItr cannot be defined in universal trait SeqOps
       then
         report.error(em"$cls cannot be defined in universal $effectiveOwner", cdef.srcPos)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -940,6 +940,7 @@ object Build {
       },
       Compile / doc / scalacOptions += "-Ydocument-synthetic-types",
       scalacOptions += "-Yscala2-stdlib",
+      scalacOptions += "-Ycheck:all",
       scalacOptions -= "-Xfatal-warnings",
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),


### PR DESCRIPTION
Adding `-Ycheck` to stdlib-bootstrapped will tests the integrity of trees generated when compiling with the `-Yscala2-stdlib` flag.