### PR TITLE
Upgrade to sbt-tasty-mima 0.3.1.

### DIFF
--- a/project/TastyMiMaFilters.scala
+++ b/project/TastyMiMaFilters.scala
@@ -3,76 +3,17 @@ import tastymima.intf._
 
 object TastyMiMaFilters {
   val StdlibBootstrapped: java.util.List[ProblemMatcher] = asList(
-    // OK
-    ProblemMatcher.make(ProblemKind.MissingClass, "scala.*.<local child>"),
-
     // OK: constructors have a result type the return Unit instead of the class type
     ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.*.<init>"), // scala.math.Numeric.CharIsIntegral.<init>; before: (): scala.math.Numeric.CharIsIntegral; after: (): Unit
 
     // Probably OK
-    ProblemMatcher.make(ProblemKind.InternalError, "scala.*"),
-    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.*$extension"),
     ProblemMatcher.make(ProblemKind.IncompatibleSelfTypeChange, "scala.*"),
 
     // Probably OK: object singleton type
     ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.mutable.BitSet.bitSetFactory"),
 
-    // Probably OK: by-name arguments in signatures
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.App.delayedInit"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.Array.fill"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.*.fill"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.*.getOrElse"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.*.getOrElseUpdate"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.jdk.Accumulator.fill"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.Option.*"), // fold, toLeft, toRight, unless, when
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.Option.getOrElse"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.Option.orElse"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.Predef.*"), // assert, assume, require, Ensuring.ensuring
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.*.getOrElse"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.*.orElse"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.Try.apply"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.Using.apply"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.Using.resources"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.concurrent.Future.*"), // apply, delegate
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.Console.*"), // withErr, withIn, withOut
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.DelayedInit.delayedInit"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.io.Codec.wrap"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.PropertiesTrait.*"), // envOrElse, envOrSome, propOrElse, scalaPropOrElse
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.Either.cond"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.Either.filterOrElse"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.control.Breaks.*"), // breakable, TryBlock.catchBreak, tryBreakable
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.control.Exception.Catch.*"), // andFinally, apply,either, opt, withTry
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.control.Exception.*"), // failAsValue, Finally.and, ultimately
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.control.TailCalls.tailcall"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.util.DynamicVariable.withValue"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.FileProcessLogger.*"), // buffer, err, out
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.ProcessImpl.Spawn.apply"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.processInternal.*"), // onInterrupt, onIOInterrupt
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.ProcessLogger.*"), // buffer, err, out
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.PropImpl.or"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.ShutdownHookThread.apply"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.SystemProperties.*"), // exclusively, wrapAccess
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.immutable.LazyList.*"), // cons.apply, continually, Deferrer.#::, iterate, lazyAppendedAll, toDeferrer
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.immutable.Stream.*"), // append, cons.apply, continually, lazyAppendedAll, toDeferrer
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.Iterator.*"), // ++, concat, continually, GroupedIterator.withPadding
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.concurrent.BlockContext.*"), // blockOn, withBlockContext
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.ProcessBuilder.FileBuilder.#<<"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.ProcessBuilderImpl.FileImpl.#<<"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.ProcessBuilder.Sink.#<"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.ProcessBuilder.Source.#>"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.ProcessCreation.apply"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.concurrent.BatchingExecutorStatics.MissingParentBlockContext.blockOn"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.process.ProcessImpl.CompoundProcess.runInterruptible"),
-    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.util.hashing.Hashing.fromFunction"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.IterableOnceOps.aggregate"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.sys.package.addShutdownHook"),
-    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.mutable.HashTable.init"),
-
     // Probably OK: Case class with varargs
     ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.StringContext.parts"), // before: scala.<repeated>[Predef.String]; after: scala.collection.immutable.Seq[Predef.String] @scala.annotation.internal.Repeated
-
-    // Probably OK: default parameter
-    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.*$default$*"),
 
     // Problem: secondary constructors?
     ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.*.<init>"),
@@ -143,5 +84,71 @@ object TastyMiMaFilters {
     ProblemMatcher.make(ProblemKind.NewAbstractMember, "scala.collection.convert.impl.*_="),
     ProblemMatcher.make(ProblemKind.NewAbstractMember, "scala.math.ScalaNumericConversions.underlying"),
     ProblemMatcher.make(ProblemKind.NewAbstractMember, "scala.*.superscala$*$*$$*"),
+
+    ProblemMatcher.make(ProblemKind.InternalError, "scala.concurrent.duration.package.*"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.package.:+.unapply"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.package.+:.unapply"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.SortedMapOps.++"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.SortedMapOps.concat"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.SortedMapOps.map"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.SortedMapOps.+"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.SortedMapOps.collect"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.SortedMapOps.sortedMapFromIterable"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.SortedMapOps.flatMap"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.SortedMapOps.WithFilter.map"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.SortedMapOps.WithFilter.flatMap"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.StrictOptimizedSortedMapOps.collect"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.StrictOptimizedSortedMapOps.concat"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.StrictOptimizedSortedMapOps.map"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.StrictOptimizedSortedMapOps.+"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.StrictOptimizedSortedMapOps.flatMap"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.SortedSetFactoryDefaults.fromSpecific"),
+    ProblemMatcher.make(ProblemKind.InternalError, "scala.collection.SeqView.prependedAll"),
+    ProblemMatcher.make(ProblemKind.InternalError, "scala.collection.SeqView.appendedAll"),
+    ProblemMatcher.make(ProblemKind.InternalError, "scala.collection.SeqView.concat"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.SortedMapFactoryDefaults.fromSpecific"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.AnyStepper.ofParIntStepper"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.AnyStepper.ofParLongStepper"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.AnyStepper.ofParDoubleStepper"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.StepperShape.parUnbox"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.map"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.collect"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.diff"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.intersect"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.^"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.concat"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.fromBitMaskNoCopy"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.xor"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.BitSetOps.flatMap"),
+    ProblemMatcher.make(ProblemKind.NewAbstractMember, "scala.collection.BitSetOps.fromBitMaskNoCopy"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.runtime.Tuple2Zipped.Ops.zipped"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.runtime.Tuple3Zipped.Ops.zipped"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.immutable.SortedMapOps.updated"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.immutable.SortedMapOps.updatedWith"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.immutable.SortedMapOps.transform"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.immutable.SortedMapOps.+"),
+    ProblemMatcher.make(ProblemKind.NewAbstractMember, "scala.collection.immutable.SortedMapOps.updated"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.immutable.StrictOptimizedSortedMapOps.concat"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.immutable.BitSet.bitSetFactory"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.generic.IsMap.apply"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.convert.impl.BitSetStepper.from"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.convert.impl.*.semiclone"),
+    ProblemMatcher.make(ProblemKind.NewAbstractMember, "scala.collection.convert.impl.*.semiclone"),
+    ProblemMatcher.make(ProblemKind.FinalMember, "scala.collection.convert.AsJavaExtensions.*AsJava"),
+    ProblemMatcher.make(ProblemKind.FinalMember, "scala.collection.convert.AsScalaExtensions.*AsScala"),
+    ProblemMatcher.make(ProblemKind.FinalMember, "scala.collection.convert.StreamExtensions.*"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.convert.StreamExtensions.StepperHasParStream"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.convert.JavaCollectionWrappers.SetWrapper.iterator"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.*.stepper"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.*.valueStepper"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.*.keyStepper"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.*.efficientStepper"),
+    ProblemMatcher.make(ProblemKind.NewAbstractMember, "scala.jdk.Accumulator.efficientStepper"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.mutable.SortedMapOps.updated"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.mutable.UnrolledBuffer.classTagCompanion"),
+    ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.mutable.UnrolledBuffer.Unrolled.<init>$default$4"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.util.hashing.Hashing.fromFunction"),
+    ProblemMatcher.make(ProblemKind.RestrictedVisibilityChange, "scala.concurrent.duration.Deadline.copy$default$1"),
+    ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.concurrent.FailedNode.string"),
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,4 +20,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "0.3.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "0.3.1")


### PR DESCRIPTION
This allows to remove a number of wildcard problem filters, in particular about `InternalError`s. In exchange, it surfaces new problems, which are added as uncategorized for now.