### PR TITLE
Some stdlib bootstrapped patches

### DIFF
--- a/project/TastyMiMaFilters.scala
+++ b/project/TastyMiMaFilters.scala
@@ -144,9 +144,6 @@ object TastyMiMaFilters {
     ProblemMatcher.make(ProblemKind.MissingTermMember, "scala.collection.convert.impl.*StepperBase.semiclone"),
     ProblemMatcher.make(ProblemKind.NewAbstractMember, "scala.collection.convert.impl.*StepperBase.semiclone"),
 
-    // TASTy-MiMa bug? Wildcards in self type
-    ProblemMatcher.make(ProblemKind.MissingTypeMember, "scala.collection.generic.DefaultSerializable._$1"),
-
     // TASTy-MiMa bug? module classes
     ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.immutable.BitSet.bitSetFactory"), // The symbol scala.collection.immutable.BitSet.bitSetFactory has an incompatible type in current version: before: scala.collection.immutable.BitSet$; after: scala.collection.immutable.BitSet.type
     ProblemMatcher.make(ProblemKind.IncompatibleTypeChange, "scala.collection.mutable.BitSet.bitSetFactory"), // The symbol scala.collection.mutable.BitSet.bitSetFactory has an incompatible type in current version: before: scala.collection.mutable.BitSet$; after: scala.collection.mutable.BitSet.type

--- a/stdlib-bootstrapped/src/scala/collection/generic/DefaultSerializationProxy.scala
+++ b/stdlib-bootstrapped/src/scala/collection/generic/DefaultSerializationProxy.scala
@@ -1,0 +1,87 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.generic
+
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
+import scala.collection.{Factory, Iterable}
+import scala.collection.mutable.Builder
+
+/** The default serialization proxy for collection implementations.
+  *
+  * This class is `final` and requires an extra `Factory` object rather than leaving the details of creating a `Builder`
+  * to an abstract method that could be implemented by a subclass. This is necessary because the factory is needed
+  * for deserializing this class's private state, which happens before any subclass fields would be deserialized. Any
+  * additional state required to create the proper `Builder` needs to be captured by the `factory`.
+  */
+@SerialVersionUID(3L)
+final class DefaultSerializationProxy[A](factory: Factory[A, Any], @transient private[this] val coll: Iterable[A]) extends Serializable {
+
+  @transient protected var builder: Builder[A, Any] = _
+
+  private[this] def writeObject(out: ObjectOutputStream): Unit = {
+    out.defaultWriteObject()
+    val k = coll.knownSize
+    out.writeInt(k)
+    var count = 0
+    coll.foreach { x =>
+      out.writeObject(x)
+      count += 1
+    }
+    if(k >= 0) {
+      if(count != k) throw new IllegalStateException(s"Illegal size $count of collection, expected $k")
+    } else out.writeObject(SerializeEnd)
+  }
+
+  private[this] def readObject(in: ObjectInputStream): Unit = {
+    in.defaultReadObject()
+    builder = factory.newBuilder
+    val k = in.readInt()
+    if(k >= 0) {
+      builder.sizeHint(k)
+      var count = 0
+      while(count < k) {
+        builder += in.readObject().asInstanceOf[A]
+        count += 1
+      }
+    } else {
+      while (true) in.readObject match {
+        case SerializeEnd => return
+        case a => builder += a.asInstanceOf[A]
+      }
+    }
+  }
+
+  protected[this] def readResolve(): Any = builder.result()
+}
+
+@SerialVersionUID(3L)
+private[collection] case object SerializeEnd
+
+/** Mix-in trait to enable DefaultSerializationProxy for the standard collection types. Depending on the type
+  * it is mixed into, it will dynamically choose `iterableFactory`, `mapFactory`, `sortedIterableFactory` or
+  * `sortedMapFactory` for deserialization into the respective `CC` type. Override `writeReplace` or implement
+  * it directly without using this trait if you need a non-standard factory or if you want to use a different
+  * serialization scheme.
+  */
+trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[_] =>
+  protected[this] def writeReplace(): AnyRef = {
+    val f: Factory[Any, Any] = this match {
+      case it: scala.collection.SortedMap[_, _] => it.sortedMapFactory.sortedMapFactory[Any, Any](it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]
+      case it: scala.collection.Map[_, _] => it.mapFactory.mapFactory[Any, Any].asInstanceOf[Factory[Any, Any]]
+      case it: scala.collection.SortedSet[_] => it.sortedIterableFactory.evidenceIterableFactory[Any](it.ordering.asInstanceOf[Ordering[Any]])
+      case it => it.iterableFactory.iterableFactory
+    }
+    new DefaultSerializationProxy(f, this)
+  }
+}

--- a/stdlib-bootstrapped/src/scala/collection/generic/DefaultSerializationProxy.scala
+++ b/stdlib-bootstrapped/src/scala/collection/generic/DefaultSerializationProxy.scala
@@ -75,6 +75,7 @@ private[collection] case object SerializeEnd
   * serialization scheme.
   */
 trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[_] =>
+  type _$1 // FIXME: Use this: scala.collection.Iterable[Any] as self-type in Scala 2 stdlib
   protected[this] def writeReplace(): AnyRef = {
     val f: Factory[Any, Any] = this match {
       case it: scala.collection.SortedMap[_, _] => it.sortedMapFactory.sortedMapFactory[Any, Any](it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]


### PR DESCRIPTION
Scala 2 seems to create a type member `_$1` for the `_` in the self type of `DefaultSerializable`.

We could apply the following patch to Scala 2 to avoid this issue.

```diff
- trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[_] =>
+ trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[Any] =>
``
