### PR TITLE
Value parameter inference for polymorphic lambdas

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -150,8 +150,15 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   /** {x1, ..., xN} T   (only relevant under captureChecking) */
   case class CapturesAndResult(refs: List[Tree], parent: Tree)(implicit @constructorOnly src: SourceFile) extends TypTree
 
-  /** Short-lived usage in typer, does not need copy/transform/fold infrastructure */
-  case class DependentTypeTree(tp: (List[TypeSymbol], List[TermSymbol]) => Type)(implicit @constructorOnly src: SourceFile) extends Tree
+  /** A type tree appearing somewhere in the untyped DefDef of a lambda, it will be typed using `tpFun`.
+   *
+   *  @param isResult  Is this the result type of the lambda? This is handled specially in `Namer#valOrDefDefSig`.
+   *  @param tpFun     Compute the type of the type tree given the parameters of the lambda.
+   *                   A lambda has at most one type parameter list followed by exactly one term parameter list.
+   *
+   *  Note: This is only used briefly in Typer and does not need the copy/transform/fold infrastructure.
+   */
+  case class InLambdaTypeTree(isResult: Boolean, tpFun: (List[TypeSymbol], List[TermSymbol]) => Type)(implicit @constructorOnly src: SourceFile) extends Tree
 
   @sharable object EmptyTypeIdent extends Ident(tpnme.EMPTY)(NoSource) with WithoutTypeOrPos[Untyped] {
     override def isEmpty: Boolean = true

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1698,13 +1698,16 @@ class Namer { typer: Typer =>
         WildcardType
       case TypeTree() =>
         checkMembersOK(inferredType, mdef.srcPos)
-      case DependentTypeTree(tpFun) =>
+
+      // We cannot rely on `typedInLambdaTypeTree` since the computed type might not be fully-defined.
+      case InLambdaTypeTree(/*isResult =*/ true, tpFun) =>
         // A lambda has at most one type parameter list followed by exactly one term parameter list.
         val tpe = (paramss: @unchecked) match
           case TypeSymbols(tparams) :: TermSymbols(vparams) :: Nil => tpFun(tparams, vparams)
           case TermSymbols(vparams) :: Nil => tpFun(Nil, vparams)
         if (isFullyDefined(tpe, ForceDegree.none)) tpe
         else typedAheadExpr(mdef.rhs, tpe).tpe
+
       case TypedSplice(tpt: TypeTree) if !isFullyDefined(tpt.tpe, ForceDegree.none) =>
         mdef match {
           case mdef: DefDef if mdef.name == nme.ANON_FUN =>

--- a/tests/neg/polymorphic-functions2.scala
+++ b/tests/neg/polymorphic-functions2.scala
@@ -1,0 +1,6 @@
+val wrongLength1: [T, S] => (T, S) => T = [T] => (x, y) => x // error
+val wrongLength2: [T] => T => T = [T] => (x, x) => x // error
+
+val notSubType: [T] => T => T = [T <: Int] => x => x // error
+
+val notInScope: [T] => T => T = [S] => x => (x: T) // error

--- a/tests/run/polymorphic-functions.scala
+++ b/tests/run/polymorphic-functions.scala
@@ -106,4 +106,16 @@ object Test extends App {
   val tt2: [T] =>  T => T =  [T] => ((x: T) => x)
   val tt3: [T] =>  T => T =  [T] => { (x: T) => x }
   val tt4: [T] =>  T => T =  [T] => (x: T) => { x }
+
+  // Inferred parameter type
+  val i1a: [T] => T => T = [T] => x => x
+  val i2b: [T] => T => T = [S] => x => x
+  /// This does not work currently because subtyping of polymorphic functions is not implemented.
+  /// val i2c: [T <: Int] => T => T = [T] => x => x
+  val i3a: [T, S <: List[T]] => (T, S) => List[T] =
+    [T, S <: List[T]] => (x, y) => x :: y
+  val i3b: [T, S <: List[T]] => (T, S) => List[T] =
+    [S, T <: List[S]] => (x, y) => x :: y
+  val i4: [T, S <: List[T]] => (T, S) => List[T] =
+    [T, S <: List[T]] => (x, y: S) => x :: y
 }


### PR DESCRIPTION
## Release Notes

### Value parameter inference for polymorphic lambdas

It is now possible to write a polymorphic lambda without writing down the types of its value parameters as long as they can be inferred from the context, for example:
```scala
val f: [T] => T => String = [T] => (x: T) => x.toString
```
can now be written more concisely as:
```scala
val f: [T] => T => String = [T] => x => x.toString
```

## Detailed Description (not part of the release notes)
Just like

    val f: Int => Int = x => x

is inferred to

    val f: Int => Int = (x: Int) => x

we now accept

    val g: [T] => T => T = [S] => x => x

which is inferred to

    val g: [T] => T => T = [S] => (x: S) => x

This requires a substitution step which is tricky to do since we're operating with untyped trees at this point. We implement this by generalizing the existing `DependentTypeTree` mechanism (already used for computing dependent result types of lambdas) to also be usable in any other position inside the lambda.

We rename the tree to `InLambdaTypeTree` at the same time for clarity.

Note that this mechanism could also probably be used to allow closures with internal value parameter dependencies, but we don't attempt to support this here.