### PR TITLE
Experiment: Restrict type comparison of TermRef's with different symbols.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -324,7 +324,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                 && !sym1.is(Private)
                 && tp2.isPrefixDependentMemberRef
                 && isSubPrefix(tp1.prefix, tp2.prefix)
-                && tp1.signature == tp2.signature
+                && (tp1.isType || (tp1.isStable && tp2.isStable))
                 && !(sym1.isClass && sym2.isClass)  // class types don't subtype each other
                 ) ||
                 thirdTryNamed(tp2)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -324,7 +324,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                 && !sym1.is(Private)
                 && tp2.isPrefixDependentMemberRef
                 && isSubPrefix(tp1.prefix, tp2.prefix)
-                && (tp1.isType || (tp1.isStable && tp2.isStable))
+                && (tp1.signature == Signature.NotAMethod && tp2.signature == Signature.NotAMethod)
                 && !(sym1.isClass && sym2.isClass)  // class types don't subtype each other
                 ) ||
                 thirdTryNamed(tp2)


### PR DESCRIPTION
When comparing `p.x` and `q.y`, if they do not refer to the same symbol, we have to check that `x` and `y` would actually be in an overriding relationship in concrete values. For type refs, this is always the case. For term refs, we previously checked that the `signature`s were the same.

In this commit, we avoid the signature check and instead directly check for `isStable`. This is stricter: if a pair of types passes the `isStable` test, they would necessarily have passed the `signature` test; however, the converse is not true. In particular, methodic members will never be considered subtypes under the new test. I don't think this makes a difference in practice, because term refs to unstable members do not constitute real types that should be compared for subtyping in the first place. They are only used for computing references to such terms.

The new scheme brings subtyping closer to the spec, and should be clearer.