### PR TITLE
Fix variance checking in refinements

### DIFF
--- a/tests/neg/i18035.scala
+++ b/tests/neg/i18035.scala
@@ -1,0 +1,15 @@
+import reflect.Selectable.reflectiveSelectable
+
+class A[+Cov](f: Cov => Unit) {
+  def foo: { def apply(c: Cov): Unit } = // error
+    f
+}
+
+val aForString = new A[String](_.length)
+// => val aForString: A[String]
+
+val aForStringIsAForAny: A[Any] = aForString
+// => val aForStringIsAForAny: A[Any]
+
+val _ = aForStringIsAForAny.foo(123)
+// => java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String (java.lang.Integer and java.lang.String are in module java.base of loader 'bootstrap')


### PR DESCRIPTION
Do variance checks for parameters in method types and poly types of refinements.

Fixes #18035