### PR TITLE
Fix syntax and parsing of vararg patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2908,14 +2908,18 @@ object Parsers {
      */
     def pattern3(location: Location): Tree =
       val p = infixPattern()
-      if location.inArgs && followingIsVararg() then
+      if followingIsVararg() then
         val start = in.skipToken()
-        p match
-          case p @ Ident(name) if name.isVarPattern =>
-            Typed(p, atSpan(start) { Ident(tpnme.WILDCARD_STAR) })
-          case _ =>
-            syntaxError(em"`*` must follow pattern variable", start)
-            p
+        if location.inArgs then
+          p match
+            case p @ Ident(name) if name.isVarPattern =>
+              Typed(p, atSpan(start) { Ident(tpnme.WILDCARD_STAR) })
+            case _ =>
+              syntaxError(em"`*` must follow pattern variable", start)
+              p
+        else
+          syntaxError(em"bad use of `*` - sequence pattern not allowed here", start)
+          p
       else p
 
     /**  Pattern2    ::=  [id `@'] Pattern3

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1666,7 +1666,7 @@ object Parsers {
       if in.token == LPAREN then funParamClause() :: funParamClauses() else Nil
 
     /** InfixType ::= RefinedType {id [nl] RefinedType}
-     *             |  RefinedType `^`
+     *             |  RefinedType `^`   // under capture checking
      */
     def infixType(): Tree = infixTypeRest(refinedType())
 
@@ -2881,13 +2881,13 @@ object Parsers {
       if (isIdent(nme.raw.BAR)) { in.nextToken(); pattern1(location) :: patternAlts(location) }
       else Nil
 
-    /**  Pattern1     ::= PatVar Ascription
-     *                  | [‘-’] integerLiteral Ascription
-     *                  | [‘-’] floatingPointLiteral Ascription
+    /**  Pattern1     ::= PatVar `:` RefinedType
+     *                  | [‘-’] integerLiteral `:` RefinedType
+     *                  | [‘-’] floatingPointLiteral `:` RefinedType
      *                  | Pattern2
      */
     def pattern1(location: Location = Location.InPattern): Tree =
-      val p = pattern2()
+      val p = pattern2(location)
       if in.isColon then
         val isVariableOrNumber = isVarPattern(p) || p.isInstanceOf[Number]
         if !isVariableOrNumber then
@@ -2905,11 +2905,10 @@ object Parsers {
       else p
 
     /**  Pattern3    ::=  InfixPattern
-     *                 |  PatVar ‘*’
      */
-    def pattern3(): Tree =
+    def pattern3(location: Location): Tree =
       val p = infixPattern()
-      if followingIsVararg() then
+      if location.inArgs && followingIsVararg() then
         val start = in.skipToken()
         p match
           case p @ Ident(name) if name.isVarPattern =>
@@ -2921,10 +2920,10 @@ object Parsers {
 
     /**  Pattern2    ::=  [id `@'] Pattern3
      */
-    val pattern2: () => Tree = () => pattern3() match
+    val pattern2: Location => Tree = location => pattern3(location) match
       case p @ Ident(name) if in.token == AT =>
         val offset = in.skipToken()
-        pattern3() match {
+        pattern3(location) match {
           case pt @ Bind(nme.WILDCARD, pt1: Typed) if pt.mods.is(Given) =>
             atSpan(startOffset(p), 0) { Bind(name, pt1).withMods(pt.mods) }
           case Typed(Ident(nme.WILDCARD), pt @ Ident(tpnme.WILDCARD_STAR)) =>
@@ -2954,6 +2953,7 @@ object Parsers {
      *                    |  XmlPattern
      *                    |  `(' [Patterns] `)'
      *                    |  SimplePattern1 [TypeArgs] [ArgumentPatterns]
+     *                    |  ‘given’ RefinedType
      *  SimplePattern1   ::= SimpleRef
      *                    |  SimplePattern1 `.' id
      *  PatVar           ::= id
@@ -3597,7 +3597,7 @@ object Parsers {
      *  VarDcl  ::=  id {`,' id} `:' Type
      */
     def patDefOrDcl(start: Offset, mods: Modifiers): Tree = atSpan(start, nameStart) {
-      val first = pattern2()
+      val first = pattern2(Location.InPattern)
       var lhs = first match {
         case id: Ident if in.token == COMMA =>
           in.nextToken()

--- a/docs/_docs/internals/syntax.md
+++ b/docs/_docs/internals/syntax.md
@@ -317,7 +317,7 @@ Pattern1          ::=  PatVar ‘:’ RefinedType                               
                     |  [‘-’] integerLiteral ‘:’ RefinedType                     Typed(pat, tpe)
                     |  [‘-’] floatingPointLiteral ‘:’ RefinedType               Typed(pat, tpe)
                     |  Pattern2
-Pattern2          ::=  [id ‘@’] InfixPattern [‘*’]                              Bind(name, pat)
+Pattern2          ::=  [id ‘@’] InfixPattern                                    Bind(name, pat)
 InfixPattern      ::=  SimplePattern { id [nl] SimplePattern }                  InfixOp(pat, op, pat)
 SimplePattern     ::=  PatVar                                                   Ident(wildcard)
                     |  Literal                                                  Bind(name, Ident(wildcard))

--- a/docs/_docs/reference/syntax.md
+++ b/docs/_docs/reference/syntax.md
@@ -318,7 +318,7 @@ Pattern1          ::=  PatVar ‘:’ RefinedType
                     |  [‘-’] integerLiteral ‘:’ RefinedType
                     |  [‘-’] floatingPointLiteral ‘:’ RefinedType
                     |  Pattern2
-Pattern2          ::=  [id ‘@’] InfixPattern [‘*’]
+Pattern2          ::=  [id ‘@’] InfixPattern
 InfixPattern      ::=  SimplePattern { id [nl] SimplePattern }
 SimplePattern     ::=  PatVar
                     |  Literal

--- a/tests/neg/i17443.scala
+++ b/tests/neg/i17443.scala
@@ -1,0 +1,2 @@
+def run() =
+  val x = List(1) match { case (xs*) => xs } // error

--- a/tests/neg/i8715.check
+++ b/tests/neg/i8715.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i8715.scala:2:46 -----------------------------------------------------------------------------------
+2 |def Test = List(42) match { case List(xs @ (ys*)) => xs } // error
+  |                                              ^
+  |                                              bad use of `*` - sequence pattern not allowed here

--- a/tests/neg/i8715.scala
+++ b/tests/neg/i8715.scala
@@ -1,0 +1,2 @@
+@main
+def Test = List(42) match { case List(xs @ (ys*)) => xs } // error

--- a/tests/neg/t5702-neg-bad-and-wild.check
+++ b/tests/neg/t5702-neg-bad-and-wild.check
@@ -20,6 +20,10 @@
    |                  pattern expected
    |
    | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/t5702-neg-bad-and-wild.scala:16:16 -----------------------------------------------------------------
+16 |      case (1, x*) => // error: bad use of *
+   |                ^
+   |                bad use of `*` - sequence pattern not allowed here
 -- [E031] Syntax Error: tests/neg/t5702-neg-bad-and-wild.scala:17:18 ---------------------------------------------------
 17 |      case (1, x: _*) => // error: bad use of _* (sequence pattern not allowed)
    |                  ^
@@ -32,6 +36,10 @@
    |                 pattern expected
    |
    | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/t5702-neg-bad-and-wild.scala:25:14 -----------------------------------------------------------------
+25 |    val (b, _ * ) = (5,6) // error: bad use of `*`
+   |              ^
+   |              bad use of `*` - sequence pattern not allowed here
 -- [E161] Naming Error: tests/neg/t5702-neg-bad-and-wild.scala:24:10 ---------------------------------------------------
 24 |    val K(x) = k // error: x is already defined as value x
    |    ^^^^^^^^^^^^
@@ -66,14 +74,6 @@
 -- Warning: tests/neg/t5702-neg-bad-and-wild.scala:22:20 ---------------------------------------------------------------
 22 |    val K(x @ _*) = k
    |                    ^
-   |        pattern's type Int* does not match the right hand side expression's type Int
-   |
-   |        If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,
-   |        which may result in a MatchError at runtime.
-   |        This patch can be rewritten automatically under -rewrite -source 3.2-migration.
--- Warning: tests/neg/t5702-neg-bad-and-wild.scala:25:20 ---------------------------------------------------------------
-25 |    val (b, _ * ) = (5,6) // ok
-   |                    ^^^^^
    |        pattern's type Int* does not match the right hand side expression's type Int
    |
    |        If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,

--- a/tests/neg/t5702-neg-bad-and-wild.scala
+++ b/tests/neg/t5702-neg-bad-and-wild.scala
@@ -13,7 +13,7 @@ object Test {
       case List(1, _*3:) =>  // error // error
       case List(1, x*) => // ok
       case List(x*, 1) => // error: pattern expected
-      case (1, x*) => //ok
+      case (1, x*) => // error: bad use of *
       case (1, x: _*) => // error: bad use of _* (sequence pattern not allowed)
     }
 
@@ -22,7 +22,7 @@ object Test {
     val K(x @ _*) = k
     val K(ns @ _*, xx) = k // error: pattern expected // error
     val K(x) = k // error: x is already defined as value x
-    val (b, _ * ) = (5,6) // ok
+    val (b, _ * ) = (5,6) // error: bad use of `*`
 // no longer complains
 //bad-and-wild.scala:15: error: ')' expected but '}' found.
   }

--- a/tests/pos/i8715.scala
+++ b/tests/pos/i8715.scala
@@ -1,2 +1,0 @@
-@main
-def Test = List(42) match { case List(xs @ (ys*)) => xs }


### PR DESCRIPTION
Syntax: Remove outdated `*` after InfixPattern
Parsing: Only allow vararg `*` in ArgumentPatterns

Fixes #17443