### PR TITLE
Fix accessibleType for package object prefixes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1269,8 +1269,8 @@ object Denotations {
     def hasAltWith(p: SingleDenotation => Boolean): Boolean =
       denot1.hasAltWith(p) || denot2.hasAltWith(p)
     def accessibleFrom(pre: Type, superAccess: Boolean)(using Context): Denotation = {
-      val d1 = denot1 accessibleFrom (pre, superAccess)
-      val d2 = denot2 accessibleFrom (pre, superAccess)
+      val d1 = denot1.accessibleFrom(pre, superAccess)
+      val d2 = denot2.accessibleFrom(pre, superAccess)
       if (!d1.exists) d2
       else if (!d2.exists) d1
       else derivedUnionDenotation(d1, d2)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -77,21 +77,25 @@ trait TypeAssigner {
    *  (2) in Java compilation units, `Object` is replaced by `defn.FromJavaObjectType`
    */
   def accessibleType(tpe: Type, superAccess: Boolean)(using Context): Type =
-    tpe match
+    if ctx.isJava && tpe.isAnyRef then
+      defn.FromJavaObjectType
+    else tpe match
       case tpe: NamedType =>
-        val pre = tpe.prefix
-        val name = tpe.name
-        def postProcess(d: Denotation) =
-          if ctx.isJava && tpe.isAnyRef then defn.FromJavaObjectType
-          else TypeOps.makePackageObjPrefixExplicit(tpe withDenot d)
-        val d = tpe.denot.accessibleFrom(pre, superAccess)
-        if d.exists then postProcess(d)
+        val tpe1 = TypeOps.makePackageObjPrefixExplicit(tpe)
+        if tpe1 ne tpe then
+          accessibleType(tpe1, superAccess)
         else
-          // it could be that we found an inaccessible private member, but there is
-          // an inherited non-private member with the same name and signature.
-          val d2 = pre.nonPrivateMember(name).accessibleFrom(pre, superAccess)
-          if reallyExists(d2) then postProcess(d2)
-          else NoType
+          val pre = tpe.prefix
+          val name = tpe.name
+          val d = tpe.denot.accessibleFrom(pre, superAccess)
+          if d eq tpe.denot then tpe
+          else if d.exists then tpe.withDenot(d)
+          else
+            // it could be that we found an inaccessible private member, but there is
+            // an inherited non-private member with the same name and signature.
+            val d2 = pre.nonPrivateMember(name).accessibleFrom(pre, superAccess)
+            if reallyExists(d2) then tpe.withDenot(d2)
+            else NoType
       case tpe => tpe
 
   /** Try to make `tpe` accessible, emit error if not possible */

--- a/tests/pos/i15821.scala
+++ b/tests/pos/i15821.scala
@@ -1,0 +1,9 @@
+def main =
+  foo.bar(42)
+  foo.bar
+
+package object foo {
+  def bar[F[_]]: Unit = ???
+  def bar[F[_]](x: Int): Unit = ???
+  private[foo] def bar[F[_]](x: Int)(implicit dummy: DummyImplicit): Unit = ???
+}


### PR DESCRIPTION
Making a package object explicit re-computes the denotations of an overloaded method. So it should not be done after we have pruned down those denotations by an accessibility test. We now do it before checking accessibility.

Fixes #15821