### PR TITLE
On invalid prefix, throw a TypeError

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2751,7 +2751,8 @@ object Types {
         NamedType(prefix, name, d)
       }
       if (prefix eq this.prefix) this
-      else if !NamedType.validPrefix(prefix) then UnspecifiedErrorType
+      else if !NamedType.validPrefix(prefix) then
+        throw TypeError(em"invalid new prefix $prefix cannot replace ${this.prefix} in type $this")
       else if (lastDenotation == null) NamedType(prefix, designator)
       else designator match {
         case sym: Symbol =>
@@ -5400,6 +5401,9 @@ object Types {
     def explanation(using Context): String = msg.message
   }
 
+  /** Note: Make sure an errors is reported before construtcing this
+   *  as the type of a tree.
+   */
   object ErrorType:
     def apply(m: Message)(using Context): ErrorType =
       val et = new PreviousErrorType

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -699,7 +699,7 @@ class TreePickler(pickler: TastyPickler) {
         case ex: AssertionError =>
           println(i"error when pickling tree $tree")
           throw ex
-       case ex: MatchError =>
+        case ex: MatchError =>
           println(i"error when pickling tree $tree")
           throw ex
       }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -699,6 +699,9 @@ class TreePickler(pickler: TastyPickler) {
         case ex: AssertionError =>
           println(i"error when pickling tree $tree")
           throw ex
+       case ex: MatchError =>
+          println(i"error when pickling tree $tree")
+          throw ex
       }
   }
 

--- a/tests/neg/i12448.scala
+++ b/tests/neg/i12448.scala
@@ -1,5 +1,5 @@
 object Main {
   def mkArray[T <: A]: T#AType // error // error
-  mkArray[Array] // was: "assertion failed: invalid prefix HKTypeLambda..."
-  val x = mkArray[Array]
+  mkArray[Array] // was: "assertion failed: invalid prefix HKTypeLambda..." // error
+  val x = mkArray[Array] // error
 }

--- a/tests/neg/i16842.check
+++ b/tests/neg/i16842.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i16842.scala:24:7 ----------------------------------------------------------------------------------
+24 |  Liter(SemanticArray[SemanticInt.type], x) // error
+   |       ^
+   |       invalid new prefix (dim: Int): SemanticArray[SemanticInt.type] cannot replace ty.type in type ty.T

--- a/tests/neg/i16842.scala
+++ b/tests/neg/i16842.scala
@@ -21,5 +21,5 @@ def typecheckArrayLiter(
     a: ArrayLiter
 ): Liter[SemanticArray[SemanticType]] = {
   val x: List[Expr2[SemanticInt.type]] = List()
-  Liter(SemanticArray[SemanticInt.type], x) // error // error
+  Liter(SemanticArray[SemanticInt.type], x) // error
 }

--- a/tests/neg/i18058.check
+++ b/tests/neg/i18058.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i18058.scala:4:21 ----------------------------------------------------------------------------------
+4 |type G = (f: _ <: F) => f.A // error
+  |                     ^
+  |                     invalid new prefix  <: F cannot replace f.type in type f.A

--- a/tests/neg/i18058.scala
+++ b/tests/neg/i18058.scala
@@ -1,0 +1,4 @@
+trait F:
+  type A
+
+type G = (f: _ <: F) => f.A // error


### PR DESCRIPTION
Previously, the type was set to UnspecifiedErrorType. But that violates the rule that every ErrorType has to be reported. If that does not happen, crashes in pickler will result.

Fixes #18058 