### PR TITLE
Fix: Style for wiki syntax

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/DocRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/DocRenderer.scala
@@ -79,9 +79,9 @@ class DocRender(signatureRenderer: SignatureRenderer)(using DocContext):
     case UnorderedList(items) => ul(listItems(items))
     case OrderedList(items, style) => ol(listItems(items)) // TODO use style
     case Chain(items: Seq[Inline]) => span(items.map(renderElement))
-    case Italic(text) => span(cls:="italic")(renderElement(text))
+    case Italic(text) => em(renderElement(text))
     case Underline(text) => span(cls:="underline")(renderElement(text))
-    case Bold(text) => span(cls:="bold")(renderElement(text))
+    case Bold(text) => strong(renderElement(text))
     case Monospace(text) => code(renderElement(text))
     case Superscript(text) => span(cls:="superscript")(renderElement(text))  // TODO implement style
     case Subscript(text) => span(cls:="subscript")(renderElement(text))  // TODO implement style

--- a/scaladoc/src/dotty/tools/scaladoc/util/html.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/util/html.scala
@@ -51,6 +51,8 @@ object HTML:
 
   val div = Tag("div")
   val span = Tag("span")
+  val em = Tag("em")
+  val strong = Tag("strong")
   val a = Tag("a")
   val p = Tag("p")
   val h1 = Tag("h1")


### PR DESCRIPTION
The purpose of this PR is to correct the style of wiki syntax when the -comment-syntax:wiki option is enabled. There are 2 possibilities:

- First, change the tag (done in this PR): So when the correct syntax is called up, I change the tag to strong, em, etc... instead of using a span with a class.
- Second, change the CSS: We keep the span with a class and add the correct CSS associated with the class.

### Code:

<img width="399" alt="Screenshot 2023-06-27 at 16 01 31" src="https://github.com/lampepfl/dotty/assets/44496264/e75ba21f-03f5-40b2-8ce5-4356e9b933f4">

### Before:

<img width="1920" alt="Screenshot 2023-06-27 at 16 03 30" src="https://github.com/lampepfl/dotty/assets/44496264/958bd703-4570-402a-808c-5700a0a203fe">

### After:

<img width="1920" alt="Screenshot 2023-06-27 at 16 01 34" src="https://github.com/lampepfl/dotty/assets/44496264/35a3facb-1538-4fe0-b6ed-1bcda0e8f534">



Fix: #18051 