### PR TITLE
Curried methods are not valid SAM methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5536,6 +5536,7 @@ object Types {
         if (absMems.size == 1)
           absMems.head.info match {
             case mt: MethodType if !mt.isParamDependent &&
+                mt.resultType.isValueTypeOrWildcard &&
                 !defn.isContextFunctionType(mt.resultType) =>
               val cls = tp.classSymbol
 
@@ -5588,16 +5589,6 @@ object Types {
         else None
       }
       else None
-
-    def isSamCompatible(lhs: Type, rhs: Type)(using Context): Boolean = rhs match
-      case SAMType(mt) if !isParamDependentRec(mt) =>
-        lhs <:< mt.toFunctionType(isJava = rhs.classSymbol.is(JavaDefined))
-      case _ => false
-
-    def isParamDependentRec(mt: MethodType)(using Context): Boolean =
-      mt.isParamDependent || mt.resultType.match
-        case mt: MethodType => isParamDependentRec(mt)
-        case _              => false
   }
 
   // ----- TypeMaps --------------------------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -695,7 +695,9 @@ trait Applications extends Compatibility {
         val argtpe1 = argtpe.widen
 
         def SAMargOK =
-          defn.isFunctionType(argtpe1) && SAMType.isSamCompatible(argtpe, formal)
+          defn.isFunctionType(argtpe1) && formal.match
+            case SAMType(sam) => argtpe <:< sam.toFunctionType(isJava = formal.classSymbol.is(JavaDefined))
+            case _ => false
 
         isCompatible(argtpe, formal)
         // Only allow SAM-conversion to PartialFunction if implicit conversions

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1324,7 +1324,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         case RefinedType(parent, nme.apply, mt @ MethodTpe(_, formals, restpe))
         if (defn.isNonRefinedFunction(parent) || defn.isErasedFunctionType(parent)) && formals.length == defaultArity =>
           (formals, untpd.InLambdaTypeTree(isResult = true, (_, syms) => restpe.substParams(mt, syms.map(_.termRef))))
-        case pt1 @ SAMType(mt @ MethodTpe(_, formals, _)) if !SAMType.isParamDependentRec(mt) =>
+        case pt1 @ SAMType(mt @ MethodTpe(_, formals, _)) =>
           val restpe = mt.resultType match
             case mt: MethodType => mt.toFunctionType(isJava = pt1.classSymbol.is(JavaDefined))
             case tp => tp
@@ -4182,12 +4182,17 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       // convert function literal to SAM closure
       tree match {
         case closure(Nil, id @ Ident(nme.ANON_FUN), _)
-        if defn.isFunctionType(wtp) && !defn.isFunctionType(pt) && SAMType.isSamCompatible(wtp, pt) =>
-          // was ... && isFullyDefined(pt, ForceDegree.flipBottom)
-          // but this prevents case blocks from implementing polymorphic partial functions,
-          // since we do not know the result parameter a priori. Have to wait until the
-          // body is typechecked.
-          return toSAM(tree)
+        if defn.isFunctionType(wtp) && !defn.isFunctionType(pt) =>
+          pt match {
+            case SAMType(sam)
+            if wtp <:< sam.toFunctionType(isJava = pt.classSymbol.is(JavaDefined)) =>
+              // was ... && isFullyDefined(pt, ForceDegree.flipBottom)
+              // but this prevents case blocks from implementing polymorphic partial functions,
+              // since we do not know the result parameter a priori. Have to wait until the
+              // body is typechecked.
+              return toSAM(tree)
+            case _ =>
+          }
         case _ =>
       }
 

--- a/tests/neg/i17183b.scala
+++ b/tests/neg/i17183b.scala
@@ -6,4 +6,4 @@ trait MyFunc {
 
 case class Context(f: MyFunc)
 
-def test = Context(f = (_, _) => ???)
+def test = Context(f = (_, _) => ???) // error // error


### PR DESCRIPTION
This reverts most of #17740 and instead add a check on currying in SAMType. We could consider allowing curried methods in SAM types, but this would be a language change that requires a SIP, and the implementation would need an adaptation step in erasure since the invokedynamic method needs to have a compatible signature with the abstract method in the trait.