### PR TITLE
Faster scripted test

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,6 +11,7 @@ import complete.DefaultParsers._
 import pl.project13.scala.sbt.JmhPlugin
 import pl.project13.scala.sbt.JmhPlugin.JmhKeys.Jmh
 import sbt.Package.ManifestAttributes
+import sbt.PublishBinPlugin.autoImport._
 import sbt.plugins.SbtPlugin
 import sbt.ScriptedPlugin.autoImport._
 import xerial.sbt.pack.PackPlugin
@@ -1655,16 +1656,16 @@ object Build {
       },
       scriptedBufferLog := true,
       scripted := scripted.dependsOn(
-        (`scala3-sbt-bridge` / publishLocal),
-        (`scala3-interfaces` / publishLocal),
-        (`scala3-compiler-bootstrapped` / publishLocal),
-        (`scala3-library-bootstrapped` / publishLocal),
-        (`scala3-library-bootstrappedJS` / publishLocal),
-        (`tasty-core-bootstrapped` / publishLocal),
-        (`scala3-staging` / publishLocal),
-        (`scala3-tasty-inspector` / publishLocal),
-        (`scaladoc` / publishLocal),
-        (`scala3-bootstrapped` / publishLocal) // Needed because sbt currently hardcodes the dotty artifact
+        (`scala3-sbt-bridge` / publishLocalBin),
+        (`scala3-interfaces` / publishLocalBin),
+        (`scala3-compiler-bootstrapped` / publishLocalBin),
+        (`scala3-library-bootstrapped` / publishLocalBin),
+        (`scala3-library-bootstrappedJS` / publishLocalBin),
+        (`tasty-core-bootstrapped` / publishLocalBin),
+        (`scala3-staging` / publishLocalBin),
+        (`scala3-tasty-inspector` / publishLocalBin),
+        (`scaladoc` / publishLocalBin),
+        (`scala3-bootstrapped` / publishLocalBin) // Needed because sbt currently hardcodes the dotty artifact
       ).evaluated
     )
 

--- a/project/PublishBinPlugin.scala
+++ b/project/PublishBinPlugin.scala
@@ -1,0 +1,67 @@
+package sbt
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{ FileAlreadyExistsException, Files }
+
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import sbt.Keys._
+import sbt.internal.librarymanagement.{ IvySbt, IvyXml }
+
+/** This local plugin provides ways of publishing just the binary jar. */
+object PublishBinPlugin extends AutoPlugin {
+  override def trigger = allRequirements
+
+  object autoImport {
+    val publishLocalBin = taskKey[Unit]("")
+    val publishLocalBinConfig = taskKey[PublishConfiguration]("")
+  }
+  import autoImport._
+
+  private val dummyDoc = taskKey[File]("").withRank(Int.MaxValue)
+  override val globalSettings = Seq(publishLocalBin := (()))
+
+  override val projectSettings: Seq[Def.Setting[_]] = Def settings (
+    publishLocalBin := Classpaths.publishTask(publishLocalBinConfig).value,
+    publishLocalBinConfig := Classpaths.publishConfig(
+      false, // publishMavenStyle.value,
+      Classpaths.deliverPattern(crossTarget.value),
+      if (isSnapshot.value) "integration" else "release",
+      ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
+      (publishLocalBin / packagedArtifacts).value.toVector,
+      (publishLocalBin / checksums).value.toVector,
+      logging = ivyLoggingLevel.value,
+      overwrite = isSnapshot.value
+    ),
+    publishLocalBinConfig := publishLocalBinConfig
+      .dependsOn(
+        // Copied from sbt.internal.
+        Def.taskDyn {
+          val doGen = useCoursier.value
+          if (doGen)
+            Def.task {
+              val currentProject = {
+                val proj = csrProject.value
+                val publications = csrPublications.value
+                proj.withPublications(publications)
+              }
+              IvyXml.writeFiles(currentProject, None, ivySbt.value, streams.value.log)
+            } else
+            Def.task(())
+        }
+      )
+      .value,
+    dummyDoc := {
+      val dummyFile = streams.value.cacheDirectory / "doc.jar"
+      try {
+        Files.createDirectories(dummyFile.toPath.getParent)
+        Files.createFile(dummyFile.toPath)
+      } catch { case _: FileAlreadyExistsException => }
+      dummyFile
+    },
+    dummyDoc / packagedArtifact := (Compile / packageDoc / artifact).value -> dummyDoc.value,
+    publishLocalBin / packagedArtifacts :=
+      Classpaths
+        .packaged(Seq(Compile / packageBin, Compile / packageSrc, makePom, dummyDoc))
+        .value
+  )
+}


### PR DESCRIPTION
Problem
-------
edit-scripted cycle is painfully slow right now because `doc` is really slow (and or crashes after running out of memory), but scripted tests do not need scaladoc jars.

Solution
--------
This ports `PublishBinPlugin` from sbt/sbt (credits to @dwijnand https://github.com/sbt/sbt/pull/2725), which implements `publishLocalBin`, which skips scaladoc publishing, and makes edit-scripted cycle faster.