### PR TITLE
add test for issue #17997 affecting the global object initialization checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1021,7 +1021,16 @@ object Objects:
         ref match
         case Select(supert: Super, _) =>
           val SuperType(thisTp, superTp) = supert.tpe: @unchecked
-          val thisValue2 = extendTrace(ref) { resolveThis(thisTp.classSymbol.asClass, thisV, klass) }
+          val thisValue2 = extendTrace(ref) {
+            thisTp match
+              case thisTp: ThisType =>
+                evalType(thisTp, thisV, klass)
+              case AndType(thisTp: ThisType, _) =>
+                evalType(thisTp, thisV, klass)
+              case _ =>
+                report.warning("[Internal error] Unexpected type " + thisTp.show + ", trace:\n" + Trace.show, ref)
+                Bottom
+          }
           withTrace(trace2) { call(thisValue2, ref.symbol, args, thisTp, superTp) }
 
         case Select(qual, _) =>

--- a/tests/init-global/pos/i17997-2.scala
+++ b/tests/init-global/pos/i17997-2.scala
@@ -1,0 +1,23 @@
+abstract class FunSuite:
+  def foo(): Unit = println("FunSuite")
+
+  foo()
+
+trait MySelfType
+
+trait MyTrait extends FunSuite { this: MySelfType =>
+}
+
+abstract class MyAbstractClass extends FunSuite { this: MySelfType & MyTrait =>
+
+  override def foo() = {
+    println("MyAbstractClass")
+    super.foo()
+  }
+}
+
+final class MyFinalClass extends MyAbstractClass with MyTrait with MySelfType:
+  val n: Int = 100
+
+object Main:
+  (new MyFinalClass).foo()

--- a/tests/init-global/pos/i17997.scala
+++ b/tests/init-global/pos/i17997.scala
@@ -1,0 +1,23 @@
+abstract class FunSuite:
+  def foo(): Unit = println("FunSuite")
+
+  foo()
+
+trait MySelfType
+
+trait MyTrait extends FunSuite { this: MySelfType =>
+}
+
+abstract class MyAbstractClass extends FunSuite { this: MySelfType =>
+
+  override def foo() = {
+    println("MyAbstractClass")
+    super.foo()
+  }
+}
+
+final class MyFinalClass extends MyAbstractClass with MyTrait with MySelfType:
+  val n: Int = 100
+
+object Main:
+  (new MyFinalClass).foo()


### PR DESCRIPTION
Issue #17997 reported a minimized example that crashed the object instance initialization checker. That checker was fixed in #18069. However, a similar example also crashes the global object initialization checker. This PR adds a test that exhibits this crash in the global object initialization checker.