### PR TITLE
Avoid shadowing by private definitions in more situations

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -148,7 +148,7 @@ class ImportInfo(symf: Context ?=> Symbol,
     else
       for
         renamed <- reverseMapping.keys
-        denot <- pre.member(reverseMapping(renamed).nn).altsWith(_.isOneOf(GivenOrImplicitVal))
+        denot <- pre.implicitMembersNamed(reverseMapping(renamed).nn)
       yield
         val original = reverseMapping(renamed).nn
         val ref = TermRef(pre, original, denot)

--- a/tests/pos/i18135.scala
+++ b/tests/pos/i18135.scala
@@ -1,0 +1,26 @@
+class Conf
+
+class Bar(_conf: Conf) {
+  implicit val conf: Conf = _conf
+}
+
+class Foo(conf: Conf) extends Bar(conf)
+//class Foo(_conf: Conf) extends Bar(_conf)
+// using a different name fixes it
+
+class Test {
+  def test(foo: Foo) = {
+    import foo.*
+    //implicit val conf: Conf = foo.conf
+    // manually redefining it also fixes it
+    assert(conf != null)
+    assert(implicitly[Conf] != null)
+  }
+  def test2(foo: Foo) = {
+    import foo.conf
+    //implicit val conf: Conf = foo.conf
+    // manually redefining it also fixes it
+    assert(conf != null)
+    assert(implicitly[Conf] != null)
+  }
+}


### PR DESCRIPTION
There's a tricky case where when selecting a member we find a private definition first, which is not accessible, but which shadows another definition. We handled that case correctly on direct member selection, but not when a member was looked up in an import, nor when a member was searched in an implicit.

Fixes #18135 