### PR TITLE
Speedup bisection builds by skipping generation of scaladoc 

### DIFF
--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -238,7 +238,7 @@ class CommitBisect(validationScript: File, shouldFail: Boolean, bootstrapped: Bo
     val bisectRunScript = s"""
       |scalaVersion=$$(sbt "print ${scala3CompilerProject}/version" | tail -n1)
       |rm -r out
-      |sbt "clean; ${scala3Project}/publishLocal"
+      |sbt "clean; set every doc := new File(\"unused\"); set scaladoc/Compile/resourceGenerators := (\`${scala3Project}\`/Compile/resourceGenerators).value; ${scala3Project}/publishLocal"
       |${validationCommandStatusModifier}${validationScript.getAbsolutePath} "$$scalaVersion"
     """.stripMargin
     "git bisect start".!


### PR DESCRIPTION
Adds special mode for sbt builds enabled with `BISECTBUILD=yes` env variables. Under this mode scaladoc and static resources are not generated, though allowing to speedup local publishing by up to 50% (92s vs 189s previously). 
Flag would be used when bisecting projects.