### PR TITLE
Test stdlib-bootstrapped TASTy-MiMa in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,6 +255,11 @@ jobs:
         run: |
           ./project/scripts/sbt ";scala3-interfaces/mimaReportBinaryIssues ;scala3-library-bootstrapped/mimaReportBinaryIssues ;scala3-library-bootstrappedJS/mimaReportBinaryIssues; tasty-core-bootstrapped/mimaReportBinaryIssues; stdlib-bootstrapped/mimaReportBinaryIssues"
 
+      - name: TASTy MiMa
+        run: |
+          # This script cleans the compiler and recompiles it from scratch (keep as last run)
+          ./project/scripts/stdlib-bootstrapped-tasty-mima.sh
+
   community_build_a:
     runs-on: [self-hosted, Linux]
     container:

--- a/project/scripts/stdlib-bootstrapped-tasty-mima.sh
+++ b/project/scripts/stdlib-bootstrapped-tasty-mima.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eux
+
+source $(dirname $0)/cmdTestsCommon.inc.sh
+
+TASTY_FROMAT_FILE="tasty/src/dotty/tools/tasty/TastyFormat.scala"
+MINOR_TASTY_VERSION_SUPPORTED_BY_TASTY_MIMA=3
+MINOR_TASTY_VERSION=$(grep -oE 'val MinorVersion: Int = ([0-9]+)' $TASTY_FROMAT_FILE | grep -oE '[0-9]+')
+EXPERIMENTAL_TASTY_VERSION=$(grep -oE 'val ExperimentalVersion: Int = ([0-9]+)' $TASTY_FROMAT_FILE | grep -oE '[0-9]+')
+
+setTastyVersion() {
+  sed -i -E -e "s/val MinorVersion: Int = [0-9]+/val MinorVersion: Int = $1/" -e "s/val ExperimentalVersion: Int = [0-9]+/val ExperimentalVersion: Int = $2/" $TASTY_FROMAT_FILE
+}
+
+setTastyVersion $MINOR_TASTY_VERSION_SUPPORTED_BY_TASTY_MIMA 0
+
+# Run stdlib-bootstrapped/tastyMiMaReportIssues using a custom TASTy version.
+# We clean before to make sure all sources are recompiled using the new TASTY version.
+# We clean after to make sure no other test will use the TASTy generated with this version.
+"$SBT" "clean; stdlib-bootstrapped/clean; reload; stdlib-bootstrapped/tastyMiMaReportIssues; clean; stdlib-bootstrapped/clean"
+
+setTastyVersion $MINOR_TASTY_VERSION $EXPERIMENTAL_TASTY_VERSION


### PR DESCRIPTION
This addition does have some fragility with the current TASTy numbering scheme. The test script will change the TASTy version and recompile the compiler and library with this version to allow TASTy MiMa to read those files.

When we change to a new major version, there is the potential for this TASTy to not be readable from the latest release of TASTy MiMa. In that scenario, we would disable this test until a new version of TASTy MiMa is published.

Only test MiMa: [skip community_build] [skip docs] [skip test] [skip test_windows_fast] [skip test_sbt]