### PR TITLE
Fix flaky rewrites tests

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -80,7 +80,7 @@ class CompilationTests {
     aggregateTests(
       compileFile("tests/rewrites/rewrites.scala", scala2CompatMode.and("-rewrite", "-indent")),
       compileFile("tests/rewrites/rewrites3x.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
-      compileFile("tests/rewrites/rewrites3x.scala", defaultOptions.and("-rewrite", "-source", "future-migration", "-Xfatal-warnings")),
+      compileFile("tests/rewrites/rewrites3x-fatal-warnings.scala", defaultOptions.and("-rewrite", "-source", "future-migration", "-Xfatal-warnings")),
       compileFile("tests/rewrites/filtering-fors.scala", defaultOptions.and("-rewrite", "-source", "3.2-migration")),
       compileFile("tests/rewrites/refutable-pattern-bindings.scala", defaultOptions.and("-rewrite", "-source", "3.2-migration")),
       compileFile("tests/rewrites/i8982.scala", defaultOptions.and("-indent", "-rewrite")),

--- a/tests/rewrites/rewrites3x-fatal-warnings.scala
+++ b/tests/rewrites/rewrites3x-fatal-warnings.scala
@@ -1,0 +1,10 @@
+import scala.{collection => coll, runtime=>_, _}
+import coll._
+
+def f(xs: Int*) = xs.sum
+def test =
+  f(List(1, 2, 3): _*)
+
+def g = { implicit x: Int =>
+  x + 1
+}


### PR DESCRIPTION
Fixes https://github.com/lampepfl/dotty/issues/18164

As Vulpix runs tests in parallel, sometimes cleanup wasn't finished before another compilation started leading to throwing exception https://github.com/lampepfl/dotty/actions/runs/5482337258/jobs/9987578194#step:4:2966

This was probably the cause