### PR TITLE
Fix NoSuchElementException in scaladoc

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SectionRenderingExtension.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SectionRenderingExtension.scala
@@ -27,14 +27,15 @@ object SectionRenderingExtension extends HtmlRenderer.HtmlRendererExtension:
 
   case class AnchorLink(link: String) extends BlankLine(BasedSequence.EmptyBasedSequence())
   object SectionHandler extends CustomNodeRenderer[Section]:
-    val repeatedIds: mutable.Map[(NodeRendererContext, BasedSequence), Int] = mutable.Map()
+    val repeatedIds: mutable.Map[(NodeRendererContext, String), Int] = mutable.Map()
     val idGenerator = new HeaderIdGenerator.Factory().create()
     override def render(node: Section, c: NodeRendererContext, html: HtmlWriter): Unit =
       val Section(header, body) = node
-      val idSuffix = repeatedIds.getOrElseUpdate((c, header.getText), 0)
+      val headerText = header.getText.toString
+      val idSuffix = repeatedIds.getOrElseUpdate((c, headerText), 0)
       val ifSuffixStr = if(idSuffix == 0) then "" else idSuffix.toString
-      repeatedIds.update((c, header.getText), idSuffix + 1)
-      val id = idGenerator.getId(header.getText.append(ifSuffixStr))
+      repeatedIds.update((c, headerText), idSuffix + 1)
+      val id = idGenerator.getId(headerText + ifSuffixStr)
       val anchor = AnchorLink(s"#$id")
       val headerClass: String = header.getLevel match
         case 1 => "h500"

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SectionRenderingExtension.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SectionRenderingExtension.scala
@@ -33,7 +33,7 @@ object SectionRenderingExtension extends HtmlRenderer.HtmlRendererExtension:
       val Section(header, body) = node
       val idSuffix = repeatedIds.getOrElseUpdate((c, header.getText), 0)
       val ifSuffixStr = if(idSuffix == 0) then "" else idSuffix.toString
-      repeatedIds.update((c, header.getText), repeatedIds((c, header.getText)) + 1)
+      repeatedIds.update((c, header.getText), idSuffix + 1)
       val id = idGenerator.getId(header.getText.append(ifSuffixStr))
       val anchor = AnchorLink(s"#$id")
       val headerClass: String = header.getLevel match


### PR DESCRIPTION
This should fix the error causing recent fails of Nightly Dotty workflow.
However, I don't know why it fails so randomly. We might want to investigate and fix this properly.

Fixes #18143