### PR TITLE
Disallow naming the root package, except for selections

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1131,7 +1131,7 @@ object Parsers {
 
       if in.token == THIS then handleThis(EmptyTypeIdent)
       else if in.token == SUPER then handleSuper(EmptyTypeIdent)
-      else if in.lookahead.token == DOT then
+      else if in.token != INTERPOLATIONID && in.lookahead.token == DOT then
         val tok    = in.token
         val offset = in.offset
         val name   = ident()

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -583,8 +583,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         if foundUnderScala2.exists && !(foundUnderScala2 =:= found) then
           report.migrationWarning(
             em"""Name resolution will change.
-                | currently selected                          : $foundUnderScala2
-                | in the future, without -source 3.0-migration: $found""", tree.srcPos)
+              | currently selected                          : $foundUnderScala2
+              | in the future, without -source 3.0-migration: $found""", tree.srcPos)
           foundUnderScala2
         else found
       finally

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -569,7 +569,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     // optimization, it also avoids forcing imports thus potentially avoiding
     // cyclic references.
     if (name == nme.ROOTPKG)
-      return tree.withType(defn.RootPackage.termRef)
+      val tree2 = tree.withType(defn.RootPackage.termRef)
+      checkLegalValue(tree2, pt)
+      return tree2
 
     val rawType =
       val saved1 = unimported
@@ -581,13 +583,13 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         if foundUnderScala2.exists && !(foundUnderScala2 =:= found) then
           report.migrationWarning(
             em"""Name resolution will change.
-              | currently selected                          : $foundUnderScala2
-              | in the future, without -source 3.0-migration: $found""", tree.srcPos)
+                | currently selected                          : $foundUnderScala2
+                | in the future, without -source 3.0-migration: $found""", tree.srcPos)
           foundUnderScala2
         else found
       finally
-      	unimported = saved1
-      	foundUnderScala2 = saved2
+        unimported = saved1
+        foundUnderScala2 = saved2
 
     /** Normally, returns `ownType` except if `ownType` is a constructor proxy,
      *  and there is another shadowed type accessible with the same name that is not:

--- a/tests/neg/i18020.scala
+++ b/tests/neg/i18020.scala
@@ -1,0 +1,57 @@
+import _root_.scala.StringContext // ok
+
+class Test :
+  val Foo = 1
+  def foo0: Unit =
+    val x = new _root_.scala.StringContext() // ok
+    val y: Option[_root_.scala.Serializable] = None // ok
+    val z: _root_.scala.None.type = None
+    val w = _root_.scala.None
+    val (_root_, other) = (1, 2) // error
+    val (Test.this.Foo, 1) = ???
+    ??? match
+      case (Test.this.Foo, 1) => ()
+
+def foo3 =
+  val _root_ = "abc" // error
+
+def foo1: Unit =
+  val _root_: String = "abc" // error // error
+  // _root_: is, technically, a legal name
+  // so then it tries to construct the infix op pattern
+  // "_root_ String .." and then throws in a null when it fails
+  // to find an argument
+  // then Typer rejects "String" as an infix extractor (like ::)
+  // which is the second error
+
+def foo2: Unit = // error
+  val _root_ : String = "abc" // error
+
+// i17757
+def fooVal: Unit =
+  val _root_  = "abc" // error
+  println(_root_.length)  // error
+  println(_root_)  // error
+
+def barVal: Unit =
+  _root_  // error
+  _root_.scala  // error
+  println(_root_)  // error
+  println(_root_.scala)  // error
+
+// i18050
+package p {
+  package _root_ { // error
+    object X // error
+  }
+}
+
+// i12508
+package _root_ { // error
+  class C {
+    val _root_ = 42 // error
+  }
+}
+package _root_.p { // error
+  class C
+}

--- a/tests/neg/i18020.scala
+++ b/tests/neg/i18020.scala
@@ -46,7 +46,7 @@ package p {
   }
 }
 
-// i12508
+// scala/bug#12508
 package _root_ { // error
   class C {
     val _root_ = 42 // error
@@ -55,3 +55,8 @@ package _root_ { // error
 package _root_.p { // error
   class C
 }
+
+// from ScalaPB
+def fromScalaPb(x: Option[String]) = x match
+  case _root_.scala.Some(s) => s
+  case _                    => ""


### PR DESCRIPTION
References #18020, didn't actually fix that, because it addressed aspects of using `_root_` in definitions.  Adding more details to that ticket.
Fixes #17757
Fixes #18050
Includes the code in scala/bug#12508
