### PR TITLE
Improve parameter type inference error messaging

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -160,23 +160,27 @@ extends SyntaxMsg(CaseClassMissingParamListID) {
 
 class AnonymousFunctionMissingParamType(param: untpd.ValDef,
                                         tree: untpd.Function,
-                                        pt: Type)
+                                        inferredType: Type,
+                                        expectedType: Type,
+                                        )
                                         (using Context)
 extends TypeMsg(AnonymousFunctionMissingParamTypeID) {
   def msg(using Context) = {
     val ofFun =
       if param.name.is(WildcardParamName)
           || (MethodType.syntheticParamNames(tree.args.length + 1) contains param.name)
-      then i" of expanded function:\n$tree"
+      then i"\n\nIn expanded function:\n$tree"
       else ""
 
     val inferred =
-      if (pt == WildcardType) ""
-      else i"\nWhat I could infer was: $pt"
+      if (inferredType == WildcardType) ""
+      else i"\n\nPartially inferred type for the parameter: $inferredType"
 
-    i"""Missing parameter type
-        |
-        |I could not infer the type of the parameter ${param.name}$ofFun.$inferred"""
+    val expected =
+      if (expectedType == WildcardType) ""
+      else i"\n\nExpected type for the whole anonymous function: $expectedType"
+
+    i"Could not infer type for parameter ${param.name} of anonymous function$ofFun$inferred$expected"
   }
 
   def explain(using Context) = ""

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1620,7 +1620,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 else
                   inferredFromTarget(param, formal, calleeType, isErased, paramIndex).orElse(
                     if knownFormal then formal0
-                    else errorType(AnonymousFunctionMissingParamType(param, tree, formal), param.srcPos)
+                    else errorType(AnonymousFunctionMissingParamType(param, tree, inferredType = formal, expectedType = pt), param.srcPos)
                   )
               val paramTpt = untpd.TypedSplice(
                   (if knownFormal then InferredTypeTree() else untpd.TypeTree())
@@ -3957,7 +3957,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         sym.isConstructor
         || sym.matchNullaryLoosely
         || Feature.warnOnMigration(msg, tree.srcPos, version = `3.0`)
-          && { 
+          && {
             msg.actions
               .headOption
               .foreach(Rewrites.applyAction)

--- a/tests/neg/i11350.check
+++ b/tests/neg/i11350.check
@@ -1,14 +1,16 @@
 -- [E081] Type Error: tests/neg/i11350.scala:1:39 ----------------------------------------------------------------------
 1 |class A1[T](action: A1[T] ?=> String = "") // error
   |                                       ^
-  |                                       Missing parameter type
+  |                                       Could not infer type for parameter evidence$1 of anonymous function
   |
-  |                                       I could not infer the type of the parameter evidence$1.
-  |                                       What I could infer was: A1[<?>]
+  |                                       Partially inferred type for the parameter: A1[<?>]
+  |
+  |                                       Expected type for the whole anonymous function: (A1[<?>]) ?=> String
 -- [E081] Type Error: tests/neg/i11350.scala:2:39 ----------------------------------------------------------------------
 2 |class A2[T](action: A1[T] ?=> String = summon[A1[T]]) // error
   |                                       ^
-  |                                       Missing parameter type
+  |                                       Could not infer type for parameter evidence$2 of anonymous function
   |
-  |                                       I could not infer the type of the parameter evidence$2.
-  |                                       What I could infer was: A1[<?>]
+  |                                       Partially inferred type for the parameter: A1[<?>]
+  |
+  |                                       Expected type for the whole anonymous function: (A1[<?>]) ?=> String

--- a/tests/neg/i11561.check
+++ b/tests/neg/i11561.check
@@ -1,10 +1,12 @@
 -- [E081] Type Error: tests/neg/i11561.scala:2:32 ----------------------------------------------------------------------
 2 |  val updateText1 = copy(text = _) // error
   |                                ^
-  |                                Missing parameter type
+  |                                Could not infer type for parameter _$1 of anonymous function
   |
-  |                                I could not infer the type of the parameter _$1 of expanded function:
-  |                                _$1 => State.this.text = _$1.
+  |                                In expanded function:
+  |                                _$1 => State.this.text = _$1
+  |
+  |                                Expected type for the whole anonymous function: String
 -- [E052] Type Error: tests/neg/i11561.scala:3:30 ----------------------------------------------------------------------
 3 |  val updateText2 = copy(text = (_: String)) // error
   |                         ^^^^^^^^^^^^^^^^^^

--- a/tests/neg/i17183.check
+++ b/tests/neg/i17183.check
@@ -1,14 +1,18 @@
 -- [E081] Type Error: tests/neg/i17183.scala:11:24 ---------------------------------------------------------------------
 11 |def test = Context(f = (_, _) => ???) // error // error
    |                        ^
-   |                        Missing parameter type
+   |                        Could not infer type for parameter _$1 of anonymous function
    |
-   |                        I could not infer the type of the parameter _$1 of expanded function:
-   |                        (_$1, _$2) => ???.
+   |                        In expanded function:
+   |                        (_$1, _$2) => ???
+   |
+   |                        Expected type for the whole anonymous function: MyFunc
 -- [E081] Type Error: tests/neg/i17183.scala:11:27 ---------------------------------------------------------------------
 11 |def test = Context(f = (_, _) => ???) // error // error
    |                           ^
-   |                           Missing parameter type
+   |                           Could not infer type for parameter _$2 of anonymous function
    |
-   |                           I could not infer the type of the parameter _$2 of expanded function:
-   |                           (_$1, _$2) => ???.
+   |                           In expanded function:
+   |                           (_$1, _$2) => ???
+   |
+   |                           Expected type for the whole anonymous function: MyFunc


### PR DESCRIPTION
We fixed the issue, as well as hopefully improved the existing error


Done with @sankalpgambhir