### PR TITLE
Warn on use of inferred quote type variable bounds

### DIFF
--- a/tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.check
+++ b/tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.check
@@ -1,0 +1,49 @@
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:13:18 ----------------------------------
+13 |    case '{ $x: C[t] } => // error
+   |                  ^
+   |                  Type variable `t` has partially inferred bounds <: Int.
+   |
+   |                  Consider defining bounds explicitly:
+   |                    '{ type t <: Int; ... }
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:14:18 ----------------------------------
+14 |    case '{ $x: D[t] } => // error
+   |                  ^
+   |                  Type variable `t` has partially inferred bounds >: Null <: String.
+   |
+   |                  Consider defining bounds explicitly:
+   |                    '{ type t >: Null <: String; ... }
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:17:18 ----------------------------------
+17 |    case '{ $x: E[t, t] } => // error
+   |                  ^
+   |                  Type variable `t` has partially inferred bounds <: Int.
+   |
+   |                  Consider defining bounds explicitly:
+   |                    '{ type t <: Int; ... }
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:19:18 ----------------------------------
+19 |    case '{ $x: F[t, t] } => // error // error
+   |                  ^
+   |                  Type variable `t` has partially inferred bounds <: Int.
+   |
+   |                  Consider defining bounds explicitly:
+   |                    '{ type t <: Int; ... }
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:19:21 ----------------------------------
+19 |    case '{ $x: F[t, t] } => // error // error
+   |                     ^
+   |                     Ignored bound <: String
+   |
+   |                     Consider defining bounds explicitly:
+   |                       '{ type t <: Int & String; ... }
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:20:36 ----------------------------------
+20 |    case '{ type t <: Int; $x: F[t, t] } => // error
+   |                                    ^
+   |                                    Ignored bound <: String
+   |
+   |                                    Consider defining bounds explicitly:
+   |                                      '{ type t <: Int & String; ... }
+-- Error: tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala:26:17 ----------------------------------
+26 |    case '[ F[t, t] ] => // error // will have a second error with SIP-53
+   |                 ^
+   |                 Ignored bound <: String
+   |
+   |                 Consider defining bounds explicitly:
+   |                   '[ type t <: Int & String; ... ]

--- a/tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala
+++ b/tests/neg-custom-args/fatal-warnings/quote-type-var-with-bounds.scala
@@ -1,0 +1,26 @@
+// scalac: -deprecation
+
+import scala.quoted.*
+
+class C[T <: Int]
+class D[T >: Null <: String]
+class E[T <: Int, U <: Int]
+class F[T <: Int, U <: String]
+
+def test[T: Type](e: Expr[Any])(using Quotes) =
+  e match
+    case '{ $x: t } =>
+    case '{ $x: C[t] } => // error
+    case '{ $x: D[t] } => // error
+    case '{ type t <: Int; $x: C[t] } =>
+
+    case '{ $x: E[t, t] } => // error
+
+    case '{ $x: F[t, t] } => // error // error
+    case '{ type t <: Int; $x: F[t, t] } => // error
+
+  Type.of[T] match
+    case '[ C[t] ] => // will have an error with SIP-53
+    case '[ D[t] ] => // will have an error with SIP-53
+    case '[ E[t, t] ] => // will have an error with SIP-53
+    case '[ F[t, t] ] => // error // will have a second error with SIP-53

--- a/tests/neg-macros/quote-type-variable-no-inference-2.check
+++ b/tests/neg-macros/quote-type-variable-no-inference-2.check
@@ -1,12 +1,19 @@
--- Warning: tests/neg-macros/quote-type-variable-no-inference-2.scala:5:22 ---------------------------------------------
-5 |    case '{ $_ : F[t, t]; () } => // warn // error
+-- Deprecation Warning: tests/neg-macros/quote-type-variable-no-inference-2.scala:7:19 ---------------------------------
+7 |    case '{ $_ : F[t, t]; () } => // warn // error
+  |                   ^
+  |                   Type variable `t` has partially inferred bounds <: Int.
+  |
+  |                   Consider defining bounds explicitly:
+  |                     '{ type t <: Int; ... }
+-- Warning: tests/neg-macros/quote-type-variable-no-inference-2.scala:7:22 ---------------------------------------------
+7 |    case '{ $_ : F[t, t]; () } => // warn // error
   |                      ^
   |                      Ignored bound <: Double
   |
   |                      Consider defining bounds explicitly:
   |                        '{ type t <: Int & Double; ... }
--- [E057] Type Mismatch Error: tests/neg-macros/quote-type-variable-no-inference-2.scala:5:12 --------------------------
-5 |    case '{ $_ : F[t, t]; () } => // warn // error
+-- [E057] Type Mismatch Error: tests/neg-macros/quote-type-variable-no-inference-2.scala:7:12 --------------------------
+7 |    case '{ $_ : F[t, t]; () } => // warn // error
   |            ^
   |            Type argument t does not conform to upper bound Double in inferred type F[t, t]
   |

--- a/tests/neg-macros/quote-type-variable-no-inference-2.scala
+++ b/tests/neg-macros/quote-type-variable-no-inference-2.scala
@@ -1,3 +1,5 @@
+// scalac: -deprecation
+
 import scala.quoted.*
 
 def test2(x: Expr[Any])(using Quotes) =


### PR DESCRIPTION
This kind of inference is not reliable. We can only consider the bounds from type constructor where the type variable is defined but any other constraints are ignored. Therefore it is not possible to properly infer the type bounds of the type variable.

The solution is simple, write the bounds explicitly and just check that those bounds conform to the use site of the type variable. Unfortunately, this does not work yet with type quote pattern as we do not have [SIP-53](https://docs.scala-lang.org/sips/quote-pattern-type-variable-syntax.html) yet. But in that case, we can also provide better warnings that mention the future support for the patterns they are trying to write.