### PR TITLE
Do not beta-reduce/eta-expand pattern splices with contextual function types

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3173,6 +3173,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               && xtree.isTerm
               && !untpd.isContextualClosure(xtree)
               && !ctx.mode.is(Mode.Pattern)
+              && !xtree.isInstanceOf[SplicePattern]
               && !ctx.isAfterTyper
               && !ctx.isInlineContext
             then
@@ -3957,7 +3958,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         sym.isConstructor
         || sym.matchNullaryLoosely
         || Feature.warnOnMigration(msg, tree.srcPos, version = `3.0`)
-          && { 
+          && {
             msg.actions
               .headOption
               .foreach(Rewrites.applyAction)
@@ -4021,6 +4022,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           && pt != SingletonTypeProto
           && pt != AssignProto
           && !ctx.mode.is(Mode.Pattern)
+          && !tree.isInstanceOf[SplicePattern]
           && !ctx.isAfterTyper
           && !ctx.isInlineContext
       then

--- a/tests/pos-macros/i18197a.scala
+++ b/tests/pos-macros/i18197a.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+def readPathMacro[A: Type, B: Type](expr: Expr[Any])(using Quotes) =
+  expr match
+    case '{ foo($y) } => y: Expr[Int ?=> Int]
+
+def foo(x: Int ?=> Int): Any = ???

--- a/tests/pos-macros/i18197b/Macro.scala
+++ b/tests/pos-macros/i18197b/Macro.scala
@@ -1,0 +1,18 @@
+import scala.quoted.*
+
+object ReproMacro {
+  inline def readPath[A, B](inline config: Config[A, B]) = ${ readPathMacro[A, B]('config) }
+
+  def readPathMacro[A: Type, B: Type](expr: Expr[Config[A, B]])(using Quotes) = {
+    import quotes.reflect.report
+
+    expr match {
+      case '{ Field.const[a, b, tpe]($selector) } =>
+        val selector2: Expr[Selector ?=> a => tpe] = selector
+        report.info(s"Matched!")
+        '{}
+      case other =>
+        report.errorAndAbort("woops, I did not match")
+    }
+  }
+}

--- a/tests/pos-macros/i18197b/Test.scala
+++ b/tests/pos-macros/i18197b/Test.scala
@@ -1,0 +1,19 @@
+trait Selector {
+  extension [A](self: A) def at[B <: A]: B
+}
+
+trait Config[A, B]
+
+object Field {
+  def const[A, B, FieldTpe](selector: Selector ?=> A => FieldTpe): Config[A, B] = ???
+}
+
+final case class Example(int: Int)
+
+@main def main = {
+  // compiles just fine
+  ReproMacro.readPath[Example, Example](Field.const(_.int))
+
+  // doesn't compile
+  ReproMacro.readPath[Example, Example](Field.const(_.int.at[Int]))
+}


### PR DESCRIPTION
The change in `typedUnnamed` fixes beta-reduction on the type that eliminated the implicit argument. Then the second fix in `adaptNoArgsOther` ensures that we do not transform `${x}` into `(ev ?=> ${x}.apply(x))`.

Fixes #18197