### PR TITLE
Fix ignored type variable bound warning in type quote pattern

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1010,7 +1010,7 @@ object desugar {
    *  if the type has a pattern variable name
    */
   def quotedPatternTypeDef(tree: TypeDef)(using Context): TypeDef = {
-    assert(ctx.mode.is(Mode.QuotedPattern))
+    assert(ctx.mode.isQuotedPattern)
     if tree.name.isVarPattern && !tree.isBackquoted then
       val patternTypeAnnot = New(ref(defn.QuotedRuntimePatterns_patternTypeAnnot.typeRef)).withSpan(tree.span)
       val mods = tree.mods.withAddedAnnotation(patternTypeAnnot)
@@ -1359,7 +1359,7 @@ object desugar {
       case tree: ValDef => valDef(tree)
       case tree: TypeDef =>
         if (tree.isClassDef) classDef(tree)
-        else if (ctx.mode.is(Mode.QuotedPattern)) quotedPatternTypeDef(tree)
+        else if (ctx.mode.isQuotedPattern) quotedPatternTypeDef(tree)
         else tree
       case tree: DefDef =>
         if (tree.name.isConstructorName) tree // was already handled by enclosing classDef

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -10,6 +10,9 @@ case class Mode(val bits: Int) extends AnyVal {
 
   def isExpr: Boolean = (this & PatternOrTypeBits) == None
 
+  /** Are we in the body of quoted pattern? */
+  def isQuotedPattern: Boolean = (this & QuotedPatternBits) != None
+
   override def toString: String =
     (0 until 31).filter(i => (bits & (1 << i)) != 0).map(modeName).mkString("Mode(", ",", ")")
 
@@ -68,6 +71,9 @@ object Mode {
    *  the printing.
    */
   val Printing: Mode = newMode(10, "Printing")
+
+  /** Are we in a quote the body of quoted type pattern? */
+  val QuotedTypePattern: Mode = newMode(11, "QuotedTypePattern")
 
   /** We are currently in a `viewExists` check. In that case, ambiguous
    *  implicits checks are disabled and we succeed with the first implicit
@@ -128,8 +134,10 @@ object Mode {
   /** Are we trying to find a hidden implicit? */
   val FindHiddenImplicits: Mode = newMode(24, "FindHiddenImplicits")
 
-  /** Are we in a quote in a pattern? */
-  val QuotedPattern: Mode = newMode(25, "QuotedPattern")
+  /** Are we in a quote the body of quoted expression pattern? */
+  val QuotedExprPattern: Mode = newMode(25, "QuotedExprPattern")
+
+  val QuotedPatternBits: Mode = QuotedExprPattern | QuotedTypePattern
 
   /** Are we typechecking the rhs of an extension method? */
   val InExtensionMethod: Mode = newMode(26, "InExtensionMethod")

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -707,7 +707,7 @@ object TreeChecker {
       super.typedQuotePattern(tree, pt)
 
     override def typedSplicePattern(tree: untpd.SplicePattern, pt: Type)(using Context): Tree =
-      assert(ctx.mode.is(Mode.QuotedPattern))
+      assert(ctx.mode.isQuotedPattern)
       def isAppliedIdent(rhs: untpd.Tree): Boolean = rhs match
         case _: Ident => true
         case rhs: GenericApply => isAppliedIdent(rhs.fun)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -560,7 +560,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         return tree.withType(defn.AnyType)
       if untpd.isVarPattern(tree) && name.isTermName then
         return typed(desugar.patternVar(tree), pt)
-    else if ctx.mode.is(Mode.QuotedPattern) then
+    else if ctx.mode.isQuotedPattern then
       if untpd.isVarPattern(tree) && name.isTypeName then
         return typedQuotedTypeVar(tree, pt)
     end if
@@ -964,7 +964,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         // so the expected type is the union `Seq[T] | Array[_ <: T]`.
         val ptArg =
           // FIXME(#8680): Quoted patterns do not support Array repeated arguments
-          if ctx.mode.is(Mode.QuotedPattern) then
+          if ctx.mode.isQuotedPattern then
             pt.translateFromRepeated(toArray = false, translateWildcard = true)
           else
             pt.translateFromRepeated(toArray = false, translateWildcard = true)
@@ -2225,7 +2225,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           val (desugaredArg, argPt) =
             if ctx.mode.is(Mode.Pattern) then
               (if (untpd.isVarPattern(arg)) desugar.patternVar(arg) else arg, tparamBounds)
-            else if ctx.mode.is(Mode.QuotedPattern) then
+            else if ctx.mode.isQuotedPattern then
               (arg, tparamBounds)
             else
               (arg, WildcardType)
@@ -3957,7 +3957,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         sym.isConstructor
         || sym.matchNullaryLoosely
         || Feature.warnOnMigration(msg, tree.srcPos, version = `3.0`)
-          && { 
+          && {
             msg.actions
               .headOption
               .foreach(Rewrites.applyAction)
@@ -4274,7 +4274,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               tree.tpe.EtaExpand(tp.typeParamSymbols)
           tree.withType(tp1)
         }
-      if (ctx.mode.is(Mode.Pattern) || ctx.mode.is(Mode.QuotedPattern) || tree1.tpe <:< pt) tree1
+      if (ctx.mode.is(Mode.Pattern) || ctx.mode.isQuotedPattern || tree1.tpe <:< pt) tree1
       else err.typeMismatch(tree1, pt)
     }
 

--- a/tests/neg-macros/quote-type-variable-no-inference-2.check
+++ b/tests/neg-macros/quote-type-variable-no-inference-2.check
@@ -1,0 +1,13 @@
+-- Warning: tests/neg-macros/quote-type-variable-no-inference-2.scala:5:22 ---------------------------------------------
+5 |    case '{ $_ : F[t, t]; () } => // warn // error
+  |                      ^
+  |                      Ignored bound <: Double
+  |
+  |                      Consider defining bounds explicitly:
+  |                        '{ type t <: Int & Double; ... }
+-- [E057] Type Mismatch Error: tests/neg-macros/quote-type-variable-no-inference-2.scala:5:12 --------------------------
+5 |    case '{ $_ : F[t, t]; () } => // warn // error
+  |            ^
+  |            Type argument t does not conform to upper bound Double in inferred type F[t, t]
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-macros/quote-type-variable-no-inference-2.scala
+++ b/tests/neg-macros/quote-type-variable-no-inference-2.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+def test2(x: Expr[Any])(using Quotes) =
+  x match
+    case '{ $_ : F[t, t]; () } => // warn // error
+    case '{ type u <: Int & Double; $_ : F[u, u] } =>
+
+type F[X <: Int, Y <: Double]

--- a/tests/neg-macros/quote-type-variable-no-inference-3.check
+++ b/tests/neg-macros/quote-type-variable-no-inference-3.check
@@ -1,0 +1,20 @@
+-- Warning: tests/neg-macros/quote-type-variable-no-inference-3.scala:5:22 ---------------------------------------------
+5 |    case '{ $_ : F[t, t]; () } => // warn // error
+  |                      ^
+  |                      Ignored bound <: Comparable[U]
+  |
+  |                      Consider defining bounds explicitly:
+  |                        '{ type t <: Comparable[U]; ... }
+-- Warning: tests/neg-macros/quote-type-variable-no-inference-3.scala:6:49 ---------------------------------------------
+6 |    case '{ type u <: Comparable[`u`]; $_ : F[u, u] } =>
+  |                                                 ^
+  |                                                 Ignored bound <: Comparable[Any]
+  |
+  |                                                 Consider defining bounds explicitly:
+  |                                                   '{ type u <: Comparable[u] & Comparable[Any]; ... }
+-- [E057] Type Mismatch Error: tests/neg-macros/quote-type-variable-no-inference-3.scala:5:12 --------------------------
+5 |    case '{ $_ : F[t, t]; () } => // warn // error
+  |            ^
+  |            Type argument t does not conform to upper bound Comparable[t] in inferred type F[t, t]
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-macros/quote-type-variable-no-inference-3.scala
+++ b/tests/neg-macros/quote-type-variable-no-inference-3.scala
@@ -1,0 +1,8 @@
+import scala.quoted.*
+
+def test2(x: Expr[Any])(using Quotes) =
+  x match
+    case '{ $_ : F[t, t]; () } => // warn // error
+    case '{ type u <: Comparable[`u`]; $_ : F[u, u] } =>
+
+type F[T, U <: Comparable[U]]

--- a/tests/neg-macros/quote-type-variable-no-inference.check
+++ b/tests/neg-macros/quote-type-variable-no-inference.check
@@ -3,7 +3,8 @@
   |                 ^
   |                 Ignored bound <: Double
   |
-  |                 Consider defining bounds explicitly `'{ type t <: Int & Double; ... }`
+  |                 Consider defining bounds explicitly:
+  |                   '[ type t <: Int & Double; ... ]
 -- [E057] Type Mismatch Error: tests/neg-macros/quote-type-variable-no-inference.scala:5:9 -----------------------------
 5 |    case '[ F[t, t] ] => // warn // error // error
   |         ^


### PR DESCRIPTION
See the diff in tests/neg-macros/quote-type-variable-no-inference.check