### PR TITLE
allow nullability flow typing even in presence of pattern match

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -445,7 +445,7 @@ object Nullables:
                 else candidates -= name
               case None =>
             traverseChildren(tree)
-          case _: (If | WhileDo | Typed) =>
+          case _: (If | WhileDo | Typed | Match | CaseDef) =>
             traverseChildren(tree)      // assignments to candidate variables are OK here ...
           case _ =>
             reachable = Set.empty       // ... but not here

--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -445,7 +445,7 @@ object Nullables:
                 else candidates -= name
               case None =>
             traverseChildren(tree)
-          case _: (If | WhileDo | Typed | Match | CaseDef) =>
+          case _: (If | WhileDo | Typed | Match | CaseDef | untpd.ParsedTry) =>
             traverseChildren(tree)      // assignments to candidate variables are OK here ...
           case _ =>
             reachable = Set.empty       // ... but not here

--- a/tests/explicit-nulls/pos/match-flow-typing.scala
+++ b/tests/explicit-nulls/pos/match-flow-typing.scala
@@ -1,0 +1,8 @@
+def m(): String = {
+  var x: String|Null = "foo"
+  1 match {
+    case 1 => x = x
+  }
+  if(x == null) "foo"
+  else x
+}

--- a/tests/explicit-nulls/pos/match-flow-typing.scala
+++ b/tests/explicit-nulls/pos/match-flow-typing.scala
@@ -6,3 +6,16 @@ def m(): String = {
   if(x == null) "foo"
   else x
 }
+
+def m2(): String = {
+  var x: String|Null = "foo"
+  try {
+    x = x
+  } catch {
+    case e => x = x
+  } finally {
+    x = x
+  }
+  if(x == null) "foo"
+  else x
+}


### PR DESCRIPTION
Nullability flow typing is conservatively disabled for mutable variables to which a write occurs nested inside a Tree other than some known ones, such as If and WhileDo. This is to prevent flow-sensitive reasoning for variables that are captured and written to in a closure. Pattern matches do not create a closure. This change enables nullability flow typing even for mutable variables that are written to inside a pattern match.