### PR TITLE
Fix spurious subtype check pruning when both sides have unions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3014,7 +3014,9 @@ object TypeComparer {
 
     object Repr:
       extension (s: Repr)
-        inline def combinedWith(that: Repr): Repr = s min that
+        def combinedWith(that: => Repr): Repr =
+          if s == Uncovered then Uncovered
+          else s min that
 
     inline def bothHaveOr(s1: Repr, s2: Repr): Boolean = ~((s1 | s2) & NotHasOr) != 0
     inline def bothCovered(s1: Repr, s2: Repr): Boolean = (s1 & s2 & IsCovered) != 0

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3016,7 +3016,7 @@ object TypeComparer {
       extension (s: Repr)
         inline def combinedWith(that: Repr): Repr = s min that
 
-    inline def bothHaveOr(s1: Repr, s2: Repr): Boolean = ~(s1 | s2 & NotHasOr) != 0
+    inline def bothHaveOr(s1: Repr, s2: Repr): Boolean = ~((s1 | s2) & NotHasOr) != 0
     inline def bothCovered(s1: Repr, s2: Repr): Boolean = (s1 & s2 & IsCovered) != 0
   end CoveredStatus
   type CoveredStatus = CoveredStatus.Repr

--- a/tests/pos/i17465.scala
+++ b/tests/pos/i17465.scala
@@ -1,0 +1,45 @@
+def test1[A, B]: Unit = {
+  def f[T](x: T{ def *(y: Int): T }): T = ???
+  def test = f[scala.collection.StringOps | String]("Hello")
+  locally:
+    val test1 : (scala.collection.StringOps | String) { def *(y: Int): (scala.collection.StringOps | String) } = ???
+    val test2 : (scala.collection.StringOps | String) { def *(y: Int): (scala.collection.StringOps | String) } = test1
+
+  locally:
+    val test1 : (Int | String) { def foo(x: Int): Int } = ???
+    val test2 : (Int | String) { def foo(x: Int): Int } = test1
+
+  locally:
+    val test1 : ((Int | String) & Any) { def foo(): Int } = ???
+    val test2 : ((Int | String) & Any) { def foo(): Int } = test1
+
+  locally:
+    val test1 : Int { def foo(): Int } = ???
+    val test2 : Int { def foo(): Int } = test1
+
+  locally:
+    val test1 : (Int | String) { def foo(): Int } = ???
+    val test2 : (Int | String) & Any = test1
+
+  locally:
+    val test1 : (Int | B) { def *(y: Int): Int } = ???
+    val test2 : (Int | B) { def *(y: Int): Int } = test1
+
+  locally:
+    val test1 : (Int | String) = ???
+    val test2 : (Int | String) = test1
+
+  type Foo = Int | String
+  locally:
+    val test1 : Foo { type T = Int } = ???
+    val test2 : (Int | String) = test1
+}
+
+def test2: Unit = {
+  import reflect.Selectable.reflectiveSelectable
+
+  trait A[T](x: T{ def *(y: Int): T }):
+    def f: T = x * 2
+
+  class B extends A("Hello")
+}


### PR DESCRIPTION
Fixes #17465.

In TypeComparer, `fourthTry` calls `isNewSubType` and `isCovered` to detect the subtype queries that have been covered by previous attempts and prune them. However, the pruning is spurious when both sides contain union types, as exemplified by the following subtype trace before the PR:
```
==> isSubType (test1 : (Int | String){def foo(x: Int): Int}) <:< Int | String?
  ==> isSubType (Int | String){def foo(x: Int): Int} <:< Int | String?
    ==> isSubType (Int | String){def foo(x: Int): Int} <:< Int?
    <== isSubType (Int | String){def foo(x: Int): Int} <:< Int = false
    ==> isSubType (Int | String){def foo(x: Int): Int} <:< String?
      ==> isSubType (Int | String){def foo(x: Int): Int} <:< String?
      <== isSubType (Int | String){def foo(x: Int): Int} <:< String = false
    <== isSubType (Int | String){def foo(x: Int): Int} <:< String = false
    // (1): follow-up subtype checks are pruned here by isNewSubType
  <== isSubType (Int | String){def foo(x: Int): Int} <:< Int | String = false
<== isSubType (test1 : (Int | String){def foo(x: Int): Int}) <:< Int | String = false
```
At `(1)`, the pruning condition is met, and follow-up recursions are skipped. However, in this case, only after `(1)` are the refinement on LHS dropped and the subtype between two identical OrTypes are accepted. The pruning is spurious.

This PR tempers the pruning conditions specified in `isCovered` and `isNewSubType` to fix these false negatives.