### PR TITLE
Fix typo: suports -> supports

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
@@ -142,7 +142,7 @@ object Scaladoc:
       )
 
       if other.nonEmpty then report.warning(
-        s"scaladoc suports only .tasty and .jar files, following files will be ignored: ${other.mkString(", ")}"
+        s"scaladoc supports only .tasty and .jar files, following files will be ignored: ${other.mkString(", ")}"
       )
 
       def defaultDest(): File =


### PR DESCRIPTION
Also a question:
Will scaladoc support `.scala` files in foreseeable future? Scala 2 scaladoc does support that, so actually I am wondering why dottydoc does not... AFAIK it only supports tasty and jar files.