### PR TITLE
Make check flags for `newMethod`, `newVal` and `newBind` in Quotes API less restrictive

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2888,11 +2888,12 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def Transparent: Flags = dotc.core.Flags.Transparent
 
       // Keep: aligned with Quotes's `newMethod` doc
-      private[QuotesImpl] def validMethodFlags: Flags = Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | AbsOverride | Synthetic | Artifact | ExtensionMethod | Exported | Erased | Infix | Invisible | JavaStatic
+      private[QuotesImpl] def validMethodFlags: Flags = Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | AbsOverride | JavaStatic | Synthetic | Artifact // Flags that could be allowed: Synthetic | ExtensionMethod | Exported | Erased | Infix | Invisible
       // Keep: aligned with Quotes's `newVal` doc
-      private[QuotesImpl] def validValFlags: Flags = Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | AbsOverride | Synthetic | Artifact | Erased | Invisible | JavaStatic
+      private[QuotesImpl] def validValFlags: Flags = Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | AbsOverride | JavaStatic | Synthetic | Artifact // Flags that could be added: Synthetic | Erased | Invisible
+
       // Keep: aligned with Quotes's `newBind` doc
-      private[QuotesImpl] def validBindFlags: Flags = Case | Implicit | Given | Erased
+      private[QuotesImpl] def validBindFlags: Flags = Case // Flags that could be allowed: Implicit | Given | Erased
     end Flags
 
     given FlagsMethods: FlagsMethods with

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2888,11 +2888,11 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def Transparent: Flags = dotc.core.Flags.Transparent
 
       // Keep: aligned with Quotes's `newMethod` doc
-      private[QuotesImpl] def validMethodFlags: Flags = Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | AbsOverride | JavaStatic // Flags that could be allowed: Synthetic | ExtensionMethod | Exported | Erased | Infix | Invisible
+      private[QuotesImpl] def validMethodFlags: Flags = Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | AbsOverride | Synthetic | Artifact | ExtensionMethod | Exported | Erased | Infix | Invisible | JavaStatic
       // Keep: aligned with Quotes's `newVal` doc
-      private[QuotesImpl] def validValFlags: Flags = Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | AbsOverride | JavaStatic // Flags that could be added: Synthetic | Erased | Invisible
+      private[QuotesImpl] def validValFlags: Flags = Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | AbsOverride | Synthetic | Artifact | Erased | Invisible | JavaStatic
       // Keep: aligned with Quotes's `newBind` doc
-      private[QuotesImpl] def validBindFlags: Flags = Case // Flags that could be allowed: Implicit | Given | Erased
+      private[QuotesImpl] def validBindFlags: Flags = Case | Implicit | Given | Erased
     end Flags
 
     given FlagsMethods: FlagsMethods with

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3785,7 +3785,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       *  @param parent The owner of the method
       *  @param name The name of the method
       *  @param tpe The type of the method (MethodType, PolyType, ByNameType)
-      *  @param flags extra flags to with which the symbol should be constructed. `Method` flag will be added. Can be `Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | JavaStatic`
+      *  @param flags extra flags to with which the symbol should be constructed. `Method` flag will be added. Can be `Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | AbsOverride | Synthetic | Artifact | ExtensionMethod | Exported | Erased | Infix | Invisible | JavaStatic`
       *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
       */
       // Keep: `flags` doc aligned with QuotesImpl's `validMethodFlags`
@@ -3802,7 +3802,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       *  @param parent The owner of the val/var/lazy val
       *  @param name The name of the val/var/lazy val
       *  @param tpe The type of the val/var/lazy val
-      *  @param flags extra flags to with which the symbol should be constructed. Can be `Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | JavaStatic`
+      *  @param flags extra flags to with which the symbol should be constructed. Can be `Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | AbsOverride | Synthetic | Artifact | Erased | Invisible | JavaStatic`
       *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
       *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
       *        direct or indirect children of the reflection context's owner.
@@ -3818,7 +3818,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       *
       *  @param parent The owner of the binding
       *  @param name The name of the binding
-      *  @param flags extra flags to with which the symbol should be constructed. `Case` flag will be added. Can be `Case`
+      *  @param flags extra flags to with which the symbol should be constructed. `Case` flag will be added. Can be `Case | Implicit | Given | Erased`
       *  @param tpe The type of the binding
       *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
       *        direct or indirect children of the reflection context's owner.

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -3785,7 +3785,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       *  @param parent The owner of the method
       *  @param name The name of the method
       *  @param tpe The type of the method (MethodType, PolyType, ByNameType)
-      *  @param flags extra flags to with which the symbol should be constructed. `Method` flag will be added. Can be `Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | AbsOverride | Synthetic | Artifact | ExtensionMethod | Exported | Erased | Infix | Invisible | JavaStatic`
+      *  @param flags extra flags to with which the symbol should be constructed. `Method` flag will be added. Can be `Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | JavaStatic | Synthetic | Artifact`
       *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
       */
       // Keep: `flags` doc aligned with QuotesImpl's `validMethodFlags`
@@ -3802,7 +3802,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       *  @param parent The owner of the val/var/lazy val
       *  @param name The name of the val/var/lazy val
       *  @param tpe The type of the val/var/lazy val
-      *  @param flags extra flags to with which the symbol should be constructed. Can be `Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | AbsOverride | Synthetic | Artifact | Erased | Invisible | JavaStatic`
+      *  @param flags extra flags to with which the symbol should be constructed. Can be `Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | JavaStatic | Synthetic | Artifact`
       *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
       *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
       *        direct or indirect children of the reflection context's owner.
@@ -3818,7 +3818,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       *
       *  @param parent The owner of the binding
       *  @param name The name of the binding
-      *  @param flags extra flags to with which the symbol should be constructed. `Case` flag will be added. Can be `Case | Implicit | Given | Erased`
+      *  @param flags extra flags to with which the symbol should be constructed. `Case` flag will be added. Can be `Case`
       *  @param tpe The type of the binding
       *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
       *        direct or indirect children of the reflection context's owner.


### PR DESCRIPTION
Fixes #17764

Allows `Flags.Artifact` and `Flags.Synthetic` and the other ["flags that could be allowed"](https://github.com/lampepfl/dotty/blob/3.3.1-RC1/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala#L2880-L2885) as they are valid flags and there is no reason to forbid them.