### PR TITLE
Restore `Scanner.commentSpans` 

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -233,6 +233,10 @@ object Scanners {
     /** Return a list of all the comment positions */
     def commentSpans: List[Span] = commentPosBuf.toList
 
+    /** Return a list of all the comment positions */
+    @deprecated("Use `comments` to get rich information source comments", since = "3.3.1")
+    def commentSpans: List[Span] = comments.map(_.span)
+
     private def addComment(comment: Comment): Unit = {
       val lookahead = lookaheadReader()
       def nextPos: Int = (lookahead.getc(): @switch) match {


### PR DESCRIPTION
Restores `Scanner.commentSpans` method removed in #17528 to preserve the source compatibility of the public compiler API. 
The restored method is now marked as deprecated, allowing to remove it in some future, non-lts, major release.
The public API was used in mpollmeier/scala-repl-pp and regression was discvered in Open CB:  https://github.com/VirtusLab/community-build3/actions/runs/5557868276/jobs/10155544164