### PR TITLE
Heal stage inconsistent prefixes of type projections

### DIFF
--- a/compiler/src/dotty/tools/dotc/staging/HealType.scala
+++ b/compiler/src/dotty/tools/dotc/staging/HealType.scala
@@ -46,7 +46,7 @@ class HealType(pos: SrcPos)(using Context) extends TypeMap {
       case prefix: TermRef if tp.symbol.isTypeSplice =>
         checkNotWildcardSplice(tp)
         if level == 0 then tp else getTagRef(prefix)
-      case _: NamedType | _: ThisType | NoPrefix =>
+      case _: TermRef | _: ThisType | NoPrefix =>
         if levelInconsistentRootOfPath(tp).exists then
           tryHeal(tp)
         else

--- a/tests/pos-macros/i17293.scala
+++ b/tests/pos-macros/i17293.scala
@@ -1,0 +1,12 @@
+import scala.quoted.*
+
+trait OuterTrait {
+  trait X
+}
+
+def exampleMacro[T <: OuterTrait: Type](expr: Expr[T])(using Quotes): Expr[OuterTrait#X] = {
+  '{
+    val prefix: T = ${ expr }
+    new prefix.X {}
+  }
+}

--- a/tests/pos-macros/i17293b.scala
+++ b/tests/pos-macros/i17293b.scala
@@ -1,0 +1,12 @@
+import scala.quoted.*
+
+trait OuterTrait { self =>
+  trait X
+
+  def exampleMacro[T <: self.type: Type](expr: Expr[T])(using Quotes): Expr[self.X] = {
+    '{
+      val prefix: T = ${ expr }
+      new prefix.X {}
+    }
+  }
+}


### PR DESCRIPTION
If the prefix of a `TypeRef` is a `TypeRef` we just `mapOver`.

Fixes #17293