### PR TITLE
Allow eta-expansion of inline defs

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3976,12 +3976,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
       // Reasons NOT to eta expand:
       //  - we reference a constructor
-      //  - we reference a typelevel method
       //  - we are in a pattern
       //  - the current tree is a synthetic apply which is not expandable (eta-expasion would simply undo that)
       if arity >= 0
          && !tree.symbol.isConstructor
-         && !tree.symbol.isAllOf(InlineMethod)
          && !ctx.mode.is(Mode.Pattern)
          && !(isSyntheticApply(tree) && !functionExpected)
       then

--- a/tests/neg/i12207.scala
+++ b/tests/neg/i12207.scala
@@ -5,4 +5,4 @@ extension [T](t: T) inline def pi[P <: Tuple](using P): T = ???
 inline def env[P <: Tuple, T](op: P ?=> T): P ?=> T = op
 
 @main def Test =
-  env { pi[String] } // error // error
+  env { pi[String] } // error

--- a/tests/neg/i7459.scala
+++ b/tests/neg/i7459.scala
@@ -2,7 +2,7 @@ object Foo {
   inline def summon[T](x: T): T =  x match {
     case t: T => t
   }
-  println(summon)  // error
+  println(summon)
 }
 
 import scala.deriving.*

--- a/tests/pos/inline-eta.scala
+++ b/tests/pos/inline-eta.scala
@@ -1,0 +1,9 @@
+class Foo(x: Int)
+
+object A:
+  inline def bar(x: Int): Int = x
+  val g1 = bar
+  val g2: Int => Int = bar
+
+  def foo(xs: List[Int]) =
+    xs.map(Foo.apply) // use the `inline def apply` constructor proxy


### PR DESCRIPTION
The fact that this wasn't allowed before seems to be a bug and not an intentional restriction: the check was originally introduced in a019a4e4532ae086c2d223186580c898023bb5e4 for "typelevel methods" which are only vaguely related to today's inline methods.