### PR TITLE
Reduce IO calls in extractDependencies

### DIFF
--- a/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
@@ -20,6 +20,10 @@ object FileUtils {
     def isClass: Boolean = !file.isDirectory && file.hasExtension("class") && !file.name.endsWith("$class.class")
       // FIXME: drop last condition when we stop being compatible with Scala 2.11
 
+    def isClassExtension: Boolean = file.hasExtension("class")
+
+    def isTastyExtension: Boolean = file.hasExtension("tasty")
+
     def isTasty: Boolean = !file.isDirectory && file.hasExtension("tasty")
 
     def isScalaBinary: Boolean = file.isClass || file.isTasty

--- a/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
@@ -17,14 +17,14 @@ object FileUtils {
   extension (file: AbstractFile) {
     def isPackage: Boolean = file.isDirectory && mayBeValidPackage(file.name)
 
-    def isClass: Boolean = !file.isDirectory && file.hasExtension("class") && !file.name.endsWith("$class.class")
+    def isClass: Boolean = !file.isDirectory && hasClassExtension && !file.name.endsWith("$class.class")
       // FIXME: drop last condition when we stop being compatible with Scala 2.11
 
-    def isClassExtension: Boolean = file.hasExtension("class")
+    def hasClassExtension: Boolean = file.hasExtension("class")
 
-    def isTastyExtension: Boolean = file.hasExtension("tasty")
+    def hasTastyExtension: Boolean = file.hasExtension("tasty")
 
-    def isTasty: Boolean = !file.isDirectory && file.hasExtension("tasty")
+    def isTasty: Boolean = !file.isDirectory && hasTastyExtension
 
     def isScalaBinary: Boolean = file.isClass || file.isTasty
 

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -274,9 +274,10 @@ object Contexts {
 
     def getSiblingClassfile(tastyFile: AbstractFile): AbstractFile =
       base.siblingClassfiles.getOrElseUpdate(tastyFile, {
-        val classfile0 = tastyFile.resolveSibling(tastyFile.name.stripSuffix(".tasty") + ".class")
+        val className = tastyFile.name.stripSuffix(".tasty")
+        val classfile0 = tastyFile.resolveSibling(className + ".class")
         if classfile0 == null then
-          val classfile = tastyFile.resolveSibling(tastyFile.name.stripSuffix(".tasty") + "$.class")
+          val classfile = tastyFile.resolveSibling(className + "$.class")
           if classfile == null then
             NoAbstractFile
           else

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -277,11 +277,7 @@ object Contexts {
         val className = tastyFile.name.stripSuffix(".tasty")
         val classfile0 = tastyFile.resolveSibling(className + ".class")
         if classfile0 == null then
-          val classfile = tastyFile.resolveSibling(className + "$.class")
-          if classfile == null then
-            NoAbstractFile
-          else
-            classfile
+          NoAbstractFile
         else
           classfile0
       })

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -272,16 +272,6 @@ object Contexts {
     /** AbstractFile with given path, memoized */
     def getFile(name: String): AbstractFile = getFile(name.toTermName)
 
-    def getSiblingClassfile(tastyFile: AbstractFile): AbstractFile =
-      base.siblingClassfiles.getOrElseUpdate(tastyFile, {
-        val className = tastyFile.name.stripSuffix(".tasty")
-        val classfile0 = tastyFile.resolveSibling(className + ".class")
-        if classfile0 == null then
-          NoAbstractFile
-        else
-          classfile0
-      })
-
     private var related: SimpleIdentityMap[Phase | SourceFile, Context] | Null = null
 
     private def lookup(key: Phase | SourceFile): Context | Null =
@@ -958,7 +948,6 @@ object Contexts {
     /** Sources and Files that were loaded */
     val sources: util.HashMap[AbstractFile, SourceFile] = util.HashMap[AbstractFile, SourceFile]()
     val files: util.HashMap[TermName, AbstractFile] = util.HashMap()
-    val siblingClassfiles: util.HashMap[AbstractFile, AbstractFile] = util.HashMap()
 
     // Types state
     /** A table for hash consing unique types */
@@ -1063,7 +1052,6 @@ object Contexts {
       errorTypeMsg.clear()
       sources.clear()
       files.clear()
-      siblingClassfiles.clear()
       comparers.clear()  // forces re-evaluation of top and bottom classes in TypeComparer
 
     // Test that access is single threaded

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -272,6 +272,19 @@ object Contexts {
     /** AbstractFile with given path, memoized */
     def getFile(name: String): AbstractFile = getFile(name.toTermName)
 
+    def getSiblingClassfile(tastyFile: AbstractFile): AbstractFile =
+      base.siblingClassfiles.getOrElseUpdate(tastyFile, {
+        val classfile0 = tastyFile.resolveSibling(tastyFile.name.stripSuffix(".tasty") + ".class")
+        if classfile0 == null then
+          val classfile = tastyFile.resolveSibling(tastyFile.name.stripSuffix(".tasty") + "$.class")
+          if classfile == null then
+            NoAbstractFile
+          else
+            classfile
+        else
+          classfile0
+      })
+
     private var related: SimpleIdentityMap[Phase | SourceFile, Context] | Null = null
 
     private def lookup(key: Phase | SourceFile): Context | Null =
@@ -948,6 +961,7 @@ object Contexts {
     /** Sources and Files that were loaded */
     val sources: util.HashMap[AbstractFile, SourceFile] = util.HashMap[AbstractFile, SourceFile]()
     val files: util.HashMap[TermName, AbstractFile] = util.HashMap()
+    val siblingClassfiles: util.HashMap[AbstractFile, AbstractFile] = util.HashMap()
 
     // Types state
     /** A table for hash consing unique types */
@@ -1052,6 +1066,7 @@ object Contexts {
       errorTypeMsg.clear()
       sources.clear()
       files.clear()
+      siblingClassfiles.clear()
       comparers.clear()  // forces re-evaluation of top and bottom classes in TypeComparer
 
     // Test that access is single threaded

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -432,10 +432,9 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
 
 
   private def checkTastyUUID(tastyFile: AbstractFile, tastyBytes: Array[Byte])(using Context): Unit =
-    var classfile = tastyFile.resolveSibling(tastyFile.name.stripSuffix(".tasty") + ".class")
-    if classfile == null then
-      classfile = tastyFile.resolveSibling(tastyFile.name.stripSuffix(".tasty") + "$.class")
-    if classfile != null then
+    import dotty.tools.io.NoAbstractFile
+    val classfile = ctx.getSiblingClassfile(tastyFile)
+    if classfile != NoAbstractFile then
       val tastyUUID = new TastyHeaderUnpickler(tastyBytes).readHeader()
       new ClassfileTastyUUIDParser(classfile)(ctx).checkTastyUUID(tastyUUID)
     else

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -432,9 +432,10 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
 
 
   private def checkTastyUUID(tastyFile: AbstractFile, tastyBytes: Array[Byte])(using Context): Unit =
-    import dotty.tools.io.NoAbstractFile
-    val classfile = ctx.getSiblingClassfile(tastyFile)
-    if classfile != NoAbstractFile then
+    val classfile =
+      val className = tastyFile.name.stripSuffix(".tasty")
+      tastyFile.resolveSibling(className + ".class")
+    if classfile != null then
       val tastyUUID = new TastyHeaderUnpickler(tastyBytes).readHeader()
       new ClassfileTastyUUIDParser(classfile)(ctx).checkTastyUUID(tastyUUID)
     else

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -21,7 +21,7 @@ import dotty.tools.dotc.core.Types._
 import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.dotc.util.{SrcPos, NoSourcePosition}
 import dotty.tools.io
-import dotty.tools.io.{AbstractFile, PlainFile, ZipArchive}
+import dotty.tools.io.{AbstractFile, PlainFile, ZipArchive, NoAbstractFile}
 import xsbti.UseScope
 import xsbti.api.DependencyContext
 import xsbti.api.DependencyContext._
@@ -462,8 +462,8 @@ class DependencyRecorder {
       // Cannot ignore inheritance relationship coming from the same source (see sbt/zinc#417)
       def allowLocal = dep.context == DependencyByInheritance || dep.context == LocalDependencyByInheritance
       if depFile.isTastyExtension then
-        val depClassFile = depFile.resolveSibling(depFile.name.stripSuffix(".tasty") + ".class")
-        if depClassFile != null then
+        val depClassFile = ctx.getSiblingClassfile(depFile)
+        if depClassFile != NoAbstractFile then
           // did not find associated class file, e.g. for a TASTy-only classpath.
           // The file that Zinc recieves with binaryDependency is used to lookup any either any
           // generated non-local classes or produced xsbti.API associated with the file.

--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -97,8 +97,10 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   /** Returns the path of this abstract file in a canonical form. */
   def canonicalPath: String = if (jpath == null) path else jpath.normalize.toString
 
-  /** Checks extension case insensitively. */
+  /** Checks extension case insensitively. TODO: change to enum */
   def hasExtension(other: String): Boolean = extension == other.toLowerCase
+
+  /** Returns the extension of this abstract file. TODO: store as an enum to avoid costly comparisons */
   val extension: String = Path.extension(name)
 
   /** The absolute file, if this is a relative file. */

--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -253,7 +253,7 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   /** Returns the sibling abstract file in the parent of this abstract file or directory.
    *  If there is no such file, returns `null`.
    */
-  def resolveSibling(name: String): AbstractFile | Null =
+  final def resolveSibling(name: String): AbstractFile | Null =
     container.lookupName(name, directory = false)
 
   private def fileOrSubdirectoryNamed(name: String, isDir: Boolean): AbstractFile =

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -102,8 +102,15 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
    */
   def lookupName(name: String, directory: Boolean): AbstractFile = {
     val child = givenPath / name
-    if ((child.isDirectory && directory) || (child.isFile && !directory)) new PlainFile(child)
-    else null
+    if directory then
+      if child.isDirectory /* IO! */ then
+        new PlainFile(child)
+      else
+        null
+    else if child.isFile /* IO! */ then
+      new PlainFile(child)
+    else
+      null
   }
 
   /** Does this abstract file denote an existing file? */

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -113,6 +113,11 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
       null
   }
 
+  final def fakeSibling(name: String): AbstractFile = {
+    val child = givenPath.parent / name
+    new PlainFile(child)
+  }
+
   /** Does this abstract file denote an existing file? */
   def create(): Unit = if (!exists) givenPath.createFile()
 

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -113,11 +113,6 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
       null
   }
 
-  final def fakeSibling(name: String): AbstractFile = {
-    val child = givenPath.parent / name
-    new PlainFile(child)
-  }
-
   /** Does this abstract file denote an existing file? */
   def create(): Unit = if (!exists) givenPath.createFile()
 

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -72,8 +72,7 @@ abstract class ZipArchive(override val jpath: JPath, release: Option[String]) ex
     // have to keep this name for compat with sbt's compiler-interface
     def getArchive: ZipFile = null
     override def underlyingSource: Option[ZipArchive] = Some(self)
-    override def resolveSibling(name: String): AbstractFile =
-      parent.lookupName(name, directory = false)
+    override def container: Entry = parent
     override def toString: String = self.path + "(" + path + ")"
   }
 


### PR DESCRIPTION
fix two hotspots in extractDependencies - checking if `depFile` is a class, (does file IO on `isDirectory`), and resolving sibling class file of a TASTy file (more file IO).

To fix this, only check the file extension, and also avoid unnecessary resolving of sibling `.class` file (always failing) when we have a `.scala` file as the associated file.

Second we can cache the associated class file of a TASTy file.

before:
<img width="1668" alt="Screenshot 2023-08-02 at 12 08 42" src="https://github.com/lampepfl/dotty/assets/13436592/67fd2f36-e8e4-442a-891b-42de156b37f9">


after:
<img width="1668" alt="Screenshot 2023-08-02 at 13 43 15" src="https://github.com/lampepfl/dotty/assets/13436592/2e832f83-7f34-4042-bb8f-70627c389aeb">

as you can see `recordClassDependency` after optimisation is now completely dominated by calling to zinc
