### PR TITLE
don't disable all scalacOptions, only Ysafe-init and Xcheck-macros

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -372,7 +372,7 @@ object projects:
     sbtTestCommand = """set deriving/scalacOptions -= "-Xfatal-warnings"; set typeable/scalacOptions -= "-Xfatal-warnings"; test""",
       // selectively disable -Xfatal-warnings due to deprecations
     sbtDocCommand = forceDoc("typeable", "deriving", "data"),
-    scalacOptions = Nil // disable -Ysafe-init, due to -Xfatal-warnings
+    scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Ysafe-init"), // due to -Xfatal-warnings
   )
 
   lazy val xmlInterpolator = SbtCommunityProject(
@@ -682,7 +682,7 @@ object projects:
     sbtTestCommand = "runCommunityBuild",
     sbtPublishCommand = "publishLocal",
     dependencies = List(scalatest),
-    scalacOptions = List("-language:implicitConversions"), // disabled -Ysafe-init, due to bug in macro
+    scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Xcheck-macros") :+ "-language:implicitConversions", // disabled -Xcheck-macros, due to bug in macro
   )
 
   lazy val onnxScala = SbtCommunityProject(


### PR DESCRIPTION
In the community build runner, comments for the shapeless and protoquill projects say to disable the Ysafe-init and Xcheck-macros options, but the implementation disables all scalacOptions. This change makes the implementation match the comments.

Also, the comment for protoquill incorrectly stated that Ysafe-init needs to be disabled due to a buggy macro. The project works fine with Ysafe-init, but the buggy macro requires Xcheck-macros disabled.