### PR TITLE
Fix how an inferred type var affects match analysis

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -323,13 +323,19 @@ trait ConstraintHandling {
           finally
             homogenizeArgs = saved
         //println(i"narrow bounds for $param from $oldBounds to $narrowedBounds")
-        val c1 = constraint.updateEntry(param, narrowedBounds)
-        (c1 eq constraint)
-        || {
-          constraint = c1
-          val TypeBounds(lo, hi) = constraint.entry(param): @unchecked
-          isSub(lo, hi)
-        }
+        val lo2 = narrowedBounds.loBound
+        val hi2 = narrowedBounds.hiBound
+        if lo2 == hi2 && !narrowedBounds.existsPart(_ eq param, StopAt.Static) then
+          constraint = constraint.replace(param, if isUpper then lo2 else hi2)
+          true
+        else
+          val c1 = constraint.updateEntry(param, narrowedBounds)
+          (c1 eq constraint)
+          || {
+            constraint = c1
+            val TypeBounds(lo, hi) = constraint.entry(param): @unchecked
+            isSub(lo, hi)
+          }
   end addOneBound
 
   protected def addBoundTransitively(param: TypeParamRef, rawBound: Type, isUpper: Boolean)(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -180,9 +180,9 @@ sealed trait GadtState {
         def substDependentSyms(tp: Type, isUpper: Boolean)(using Context): Type = {
           def loop(tp: Type) = substDependentSyms(tp, isUpper)
           tp match
-            case tp @ AndType(tp1, tp2) if !isUpper =>
+            case tp @ AndType(tp1, tp2) =>
               tp.derivedAndType(loop(tp1), loop(tp2))
-            case tp @ OrType(tp1, tp2) if isUpper =>
+            case tp @ OrType(tp1, tp2) =>
               tp.derivedOrType(loop(tp1), loop(tp2))
             case tp: NamedType =>
               params.indexOf(tp.symbol) match

--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -277,8 +277,8 @@ trait PatternTypeConstrainer { self: TypeComparer =>
                   val TypeBounds(loS, hiS) = argS.bounds
                   val TypeBounds(loP, hiP) = argP.bounds
                   var res = true
-                  if variance <  1 then res &&= isSubType(loS, hiP)
                   if variance > -1 then res &&= isSubType(loP, hiS)
+                  if variance <  1 then res &&= isSubType(loS, hiP)
                   res
                 else true
               }

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -244,14 +244,12 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
   protected def recur(tp1: Type, tp2: Type): Boolean = trace(s"isSubType ${traceInfo(tp1, tp2)}${approx.show}", subtyping) {
 
     def monitoredIsSubType = {
+      //if ctx.settings.YnoDeepSubtypes.value then throw new StackOverflowError("deep subtype")
+      assert(!ctx.settings.YnoDeepSubtypes.value)
       if (pendingSubTypes == null) {
         pendingSubTypes = util.HashSet[(Type, Type)]()
         report.log(s"!!! deep subtype recursion involving ${tp1.show} <:< ${tp2.show}, constraint = ${state.constraint.show}")
         report.log(s"!!! constraint = ${constraint.show}")
-        //if (ctx.settings.YnoDeepSubtypes.value) {
-        //  new Error("deep subtype").printStackTrace()
-        //}
-        assert(!ctx.settings.YnoDeepSubtypes.value)
         if (Config.traceDeepSubTypeRecursions && !this.isInstanceOf[ExplainingTypeComparer])
           report.log(explained(_.isSubType(tp1, tp2, approx)))
       }

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -417,9 +417,7 @@ object Inferencing {
         if safeToInstantiate then tvar.instantiate(fromBelow = v == -1)
         else {
           val bounds = TypeComparer.fullBounds(tvar.origin)
-          if (bounds.hi frozen_<:< bounds.lo) || bounds.hi.classSymbol.is(Final) then
-            tvar.instantiate(fromBelow = false)
-          else {
+          {
             // We do not add the created symbols to GADT constraint immediately, since they may have inter-dependencies.
             // Instead, we simultaneously add them later on.
             val wildCard = newPatternBoundSymbol(UniqueName.fresh(tvar.origin.paramName), bounds, span, addToGadt = false)

--- a/tests/patmat/i17118.scala
+++ b/tests/patmat/i17118.scala
@@ -1,0 +1,8 @@
+class Foo
+
+sealed trait T[U]
+final case class G[A <: Foo](i: A) extends T[A]
+
+class Test:
+  def f[X](t1: T[X]): X = t1 match
+    case G(i) => i

--- a/tests/pos/creative-gadt-constraints5a.scala
+++ b/tests/pos/creative-gadt-constraints5a.scala
@@ -1,0 +1,6 @@
+sealed trait SUB[A, +B]
+final case class Refl[T]() extends SUB[T, T]
+
+class Test:
+  def t1[A, B, C](sub: SUB[A | B, C]) = sub match
+    case Refl() => // C >: A | B


### PR DESCRIPTION
This patch is to fix #17118.

The issue is that, during typing, the type var `?A` in `case G[?A](i)`,
originally refers to the parameter `A`, which is bound by `Foo`.  Then
it is instantiated to `X`, which isn't bound.  So then match analysis
thinks that the case only covers `G[X]` values, leaving `G[Foo]` values
unconvered.

The solution involves instead of instantiating `?A` to `X`,
instantiating it to a fresh pattern bound symbol (`A$1`), with bounds
`>: X <: Foo & X`, which preserves the needed upper-bound.

The other changes are in order to make that work, in particular make
pos/creative-gadt-constraints5a (which is a part of
neg/creative-gadt-constraints) compile without blowing up isSubType.