### PR TITLE
Refactor dependent function refinement logic

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -954,7 +954,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   def isStructuralTermSelectOrApply(tree: Tree)(using Context): Boolean = {
     def isStructuralTermSelect(tree: Select) =
       def hasRefinement(qualtpe: Type): Boolean = qualtpe.dealias match
-        case defn.PolyFunctionOf(_) =>
+        case defn.FunctionOf(_) =>
           false
         case RefinedType(parent, rname, rinfo) =>
           rname == tree.name || hasRefinement(parent)

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -881,7 +881,7 @@ object CaptureSet:
           ++ (recur(rinfo.resType)                             // add capture set of result
           -- CaptureSet(rinfo.paramRefs.filter(_.isTracked)*)) // but disregard bound parameters
         case tpd @ AppliedType(tycon, args) =>
-          if followResult && defn.isNonRefinedFunction(tpd) then
+          if followResult && defn.isFunctionNType(tpd) then
             recur(args.last)
               // must be (pure) FunctionN type since ImpureFunctions have already
               // been eliminated in selector's dealias. Use capture set of result.

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -49,7 +49,7 @@ extends tpd.TreeTraverser:
     def recur(tp: Type): Type = tp.dealias match
       case tp @ CapturingType(parent, refs) if !tp.isBoxed =>
         tp.boxed
-      case tp1 @ AppliedType(tycon, args) if defn.isNonRefinedFunction(tp1) =>
+      case tp1 @ AppliedType(tycon, args) if defn.isFunctionNType(tp1) =>
         val res = args.last
         val boxedRes = recur(res)
         if boxedRes eq res then tp
@@ -129,7 +129,7 @@ extends tpd.TreeTraverser:
           apply(parent)
         case tp @ AppliedType(tycon, args) =>
           val tycon1 = this(tycon)
-          if defn.isNonRefinedFunction(tp) then
+          if defn.isFunctionNType(tp) then
             // Convert toplevel generic function types to dependent functions
             if !defn.isFunctionSymbol(tp.typeSymbol) && (tp.dealias ne tp) then
               // This type is a function after dealiasing, so we dealias and recurse.
@@ -197,7 +197,7 @@ extends tpd.TreeTraverser:
       val mt = ContextualMethodType(paramName :: Nil)(
         _ => paramType :: Nil,
         mt => if isLast then res else expandThrowsAlias(res, mt :: encl))
-      val fntpe = defn.PolyFunctionOf(mt)
+      val fntpe = mt.toFunctionType()
       if !encl.isEmpty && isLast then
         val cs = CaptureSet(encl.map(_.paramRefs.head)*)
         CapturingType(fntpe, cs, boxed = false)

--- a/compiler/src/dotty/tools/dotc/cc/Synthetics.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Synthetics.scala
@@ -174,9 +174,9 @@ object Synthetics:
       val (et: ExprType) = symd.info: @unchecked
       val (enclThis: ThisType) = symd.owner.thisType: @unchecked
       def mapFinalResult(tp: Type, f: Type => Type): Type =
-        val defn.FunctionOf(args, res, isContextual) = tp: @unchecked
+        val defn.FunctionNOf(args, res, isContextual) = tp: @unchecked
         if defn.isFunctionNType(res) then
-          defn.FunctionOf(args, mapFinalResult(res, f), isContextual)
+          defn.FunctionNOf(args, mapFinalResult(res, f), isContextual)
         else
           f(tp)
       val resType1 =

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -567,7 +567,7 @@ object TypeErasure {
         functionType(info.resultType)
       case info: MethodType =>
         assert(!info.resultType.isInstanceOf[MethodicType])
-        defn.FunctionType(n = info.erasedParams.count(_ == false))
+        defn.FunctionType(n = info.nonErasedParamCount)
     }
     erasure(functionType(applyInfo))
 }
@@ -933,7 +933,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
       case tp: TermRef =>
         sigName(underlyingOfTermRef(tp))
       case ExprType(rt) =>
-        sigName(defn.FunctionOf(Nil, rt))
+        sigName(defn.FunctionNOf(Nil, rt))
       case tp: TypeVar if !tp.isInstantiated =>
         tpnme.Uninstantiated
       case tp @ defn.PolyFunctionOf(_) =>

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -297,10 +297,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
     "(" ~ toTextRef(tp) ~ " : " ~ toTextGlobal(tp.underlying) ~ ")"
 
   protected def paramsText(lam: LambdaType): Text = {
-    val erasedParams = lam.erasedParams
-    def paramText(ref: ParamRef, erased: Boolean) =
+    def paramText(ref: ParamRef) =
+      val erased = ref.underlying.hasAnnotation(defn.ErasedParamAnnot)
       keywordText("erased ").provided(erased) ~ ParamRefNameString(ref) ~ lambdaHash(lam) ~ toTextRHS(ref.underlying, isParameter = true)
-    Text(lam.paramRefs.lazyZip(erasedParams).map(paramText), ", ")
+    Text(lam.paramRefs.map(paramText), ", ")
   }
 
   protected def ParamRefNameString(name: Name): String = nameString(name)

--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -129,25 +129,25 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
           assert(ctx.typer.isInstanceOf[Erasure.Typer])
           ctx.typer.typed(untpd.cpy.Apply(ref)(ref, args), member.info.finalResultType)
         else
-          val defn.ContextFunctionType(argTypes, resType, erasedParams) = tp: @unchecked
-          val anonFun = newAnonFun(ctx.owner,
-            MethodType(
-              argTypes.zip(erasedParams.padTo(argTypes.length, false))
-                      .flatMap((t, e) => if e then None else Some(t)),
-              resType),
-            coord = ctx.owner.coord)
+          val mtWithoutErasedParams = atPhase(erasurePhase) {
+            tp.dealias match
+              case defn.FunctionOf(mt: MethodType) =>
+                val paramInfos = mt.paramInfos.zip(mt.erasedParams).collect { case (param, false) => param }
+                mt.derivedLambdaType(paramInfos = paramInfos)
+          }
+          val anonFun = newAnonFun(ctx.owner, mtWithoutErasedParams, coord = ctx.owner.coord)
           anonFun.info = transformInfo(anonFun, anonFun.info)
 
           def lambdaBody(refss: List[List[Tree]]) =
             val refs :: Nil = refss: @unchecked
             val expandedRefs = refs.map(_.withSpan(ctx.owner.span.endPos)) match
               case (bunchedParam @ Ident(nme.ALLARGS)) :: Nil =>
-                argTypes.indices.toList.map(n =>
+                mtWithoutErasedParams.paramInfos.indices.toList.map(n =>
                   bunchedParam
                     .select(nme.primitive.arrayApply)
                     .appliedTo(Literal(Constant(n))))
               case refs1 => refs1
-            expand(args ::: expandedRefs, resType, n - 1)(using ctx.withOwner(anonFun))
+            expand(args ::: expandedRefs, mtWithoutErasedParams.resType, n - 1)(using ctx.withOwner(anonFun))
 
           val unadapted = Closure(anonFun, lambdaBody)
           cpy.Block(unadapted)(unadapted.stats,

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -326,7 +326,7 @@ object PickleQuotes {
               defn.QuotedExprClass.typeRef.appliedTo(defn.AnyType)),
             args =>
               val cases = holeContents.zipWithIndex.map { case (splice, idx) =>
-                val defn.FunctionOf(argTypes, defn.FunctionOf(quotesType :: _, _, _), _) = splice.tpe: @unchecked
+                val defn.FunctionNOf(argTypes, defn.FunctionNOf(quotesType :: _, _, _), _) = splice.tpe: @unchecked
                 val rhs = {
                   val spliceArgs = argTypes.zipWithIndex.map { (argType, i) =>
                     args(1).select(nme.apply).appliedTo(Literal(Constant(i))).asInstance(argType)

--- a/compiler/src/dotty/tools/dotc/transform/SpecializeFunctions.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeFunctions.scala
@@ -88,7 +88,7 @@ class SpecializeFunctions extends MiniPhase {
                   // Need to cast to regular function, since specialized apply methods
                   // are not members of ContextFunction0. The cast will be eliminated in
                   // erasure.
-                  qual.cast(defn.FunctionOf(Nil, res))
+                  qual.cast(defn.FunctionNOf(Nil, res))
                 case _ =>
                   qual
               qual1.select(specializedApply)

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -749,9 +749,9 @@ object TreeChecker {
         if isTerm then defn.QuotedExprClass.typeRef.appliedTo(tree1.typeOpt)
         else defn.QuotedTypeClass.typeRef.appliedTo(tree1.typeOpt)
       val contextualResult =
-        defn.FunctionOf(List(defn.QuotesClass.typeRef), expectedResultType, isContextual = true)
+        defn.FunctionNOf(List(defn.QuotesClass.typeRef), expectedResultType, isContextual = true)
       val expectedContentType =
-        defn.FunctionOf(argQuotedTypes, contextualResult)
+        defn.FunctionNOf(argQuotedTypes, contextualResult)
       assert(content.typeOpt =:= expectedContentType, i"unexpected content of hole\nexpected: ${expectedContentType}\nwas: ${content.typeOpt}")
 
       tree1

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1724,7 +1724,7 @@ trait Applications extends Compatibility {
           def apply(t: Type) = t match {
             case t @ AppliedType(tycon, args) =>
               def mapArg(arg: Type, tparam: TypeParamInfo) =
-                if (variance > 0 && tparam.paramVarianceSign < 0) defn.FunctionOf(arg :: Nil, defn.UnitType)
+                if (variance > 0 && tparam.paramVarianceSign < 0) defn.FunctionNOf(arg :: Nil, defn.UnitType)
                 else arg
               mapOver(t.derivedAppliedType(tycon, args.zipWithConserve(tycon.typeParams)(mapArg)))
             case _ => mapOver(t)
@@ -1951,7 +1951,7 @@ trait Applications extends Compatibility {
     /** The shape of given tree as a type; cannot handle named arguments. */
     def typeShape(tree: untpd.Tree): Type = tree match {
       case untpd.Function(args, body) =>
-        defn.FunctionOf(
+        defn.FunctionNOf(
           args.map(Function.const(defn.AnyType)), typeShape(body),
           isContextual = untpd.isContextualClosure(tree))
       case Match(EmptyTree, _) =>
@@ -1991,8 +1991,8 @@ trait Applications extends Compatibility {
         def paramCount(ref: TermRef) =
           val formals = ref.widen.firstParamTypes
           if formals.length > idx then
-            formals(idx) match
-              case defn.FunctionOf(args, _, _) => args.length
+            formals(idx).dealias match
+              case defn.FunctionNOf(args, _, _) => args.length
               case _ => -1
           else -1
 
@@ -2077,8 +2077,8 @@ trait Applications extends Compatibility {
           else resolveMapped(alts1, _.widen.appliedTo(targs1.tpes), pt1)
 
       case pt =>
-        val compat0 = pt match
-          case defn.FunctionOf(args, resType, _) =>
+        val compat0 = pt.dealias match
+          case defn.FunctionNOf(args, resType, _) =>
             narrowByTypes(alts, args, resType)
           case _ =>
             Nil
@@ -2243,7 +2243,7 @@ trait Applications extends Compatibility {
         val formalsForArg: List[Type] = altFormals.map(_.head)
         def argTypesOfFormal(formal: Type): List[Type] =
           formal.dealias match {
-            case defn.FunctionOf(args, result, isImplicit) => args
+            case defn.FunctionOf(mt: MethodType) if !mt.isResultDependent => mt.paramInfos // TODO handle result-dependent functions?
             case defn.PartialFunctionOf(arg, result) => arg :: Nil
             case _ => Nil
           }
@@ -2266,7 +2266,7 @@ trait Applications extends Compatibility {
               false
           val commonFormal =
             if (isPartial) defn.PartialFunctionOf(commonParamTypes.head, WildcardType)
-            else defn.FunctionOf(commonParamTypes, WildcardType, isContextual = untpd.isContextualClosure(arg))
+            else defn.FunctionNOf(commonParamTypes, WildcardType, isContextual = untpd.isContextualClosure(arg))
           overload.println(i"pretype arg $arg with expected type $commonFormal")
           if (commonParamTypes.forall(isFullyDefined(_, ForceDegree.flipBottom)))
             withMode(Mode.ImplicitsEnabled) {

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -166,8 +166,9 @@ object ErrorReporting {
       val normTp = normalize(tree.tpe, pt)
       val normPt = normalize(pt, pt)
 
-      def contextFunctionCount(tp: Type): Int = tp.stripped match
-        case defn.ContextFunctionType(_, restp, _) => 1 + contextFunctionCount(restp)
+      def contextFunctionCount(tp: Type): Int = tp.stripped.dealias match
+        // TODO handle result-dependent functions?
+        case defn.FunctionOf(mt) if mt.isContextualMethod && !mt.isResultDependent => 1 + contextFunctionCount(mt.resType)
         case _ => 0
       def strippedTpCount = contextFunctionCount(tree.tpe) - contextFunctionCount(normTp)
       def strippedPtCount = contextFunctionCount(pt) - contextFunctionCount(normPt)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1892,10 +1892,12 @@ class Namer { typer: Typer =>
     def expectedDefaultArgType =
       val originalTp = defaultParamType
       val approxTp = wildApprox(originalTp)
-      approxTp.stripPoly match
-        case atp @ defn.ContextFunctionType(_, resType, _)
-        if !defn.isNonRefinedFunction(atp) // in this case `resType` is lying, gives us only the non-dependent upper bound
-            || resType.existsPart(_.isInstanceOf[WildcardType], StopAt.Static, forceLazy = false) =>
+      approxTp.dealias.stripPoly match
+        case defn.FunctionOf(mt)
+        if mt.isContextualMethod && (
+           mt.isResultDependent || // in this case `resType` is lying, gives us only the non-dependent upper bound
+           mt.resType.existsPart(_.isInstanceOf[WildcardType], StopAt.Static, forceLazy = false)
+        ) =>
           originalTp
         case _ =>
           approxTp

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -383,9 +383,9 @@ object ProtoTypes {
     def allArgTypesAreCurrent()(using Context): Boolean =
       state.typedArg.size == args.length
 
-    private def isUndefined(tp: Type): Boolean = tp match {
+    private def isUndefined(tp: Type): Boolean = tp.dealias match {
       case _: WildcardType => true
-      case defn.FunctionOf(args, result, _) => args.exists(isUndefined) || isUndefined(result)
+      case defn.FunctionNOf(args, result, _) => args.exists(isUndefined) || isUndefined(result)
       case _ => false
     }
 
@@ -424,7 +424,7 @@ object ProtoTypes {
               case ValDef(_, tpt, _) if !tpt.isEmpty => typer.typedType(tpt).typeOpt
               case _ => WildcardType
             }
-            targ = arg.withType(defn.FunctionOf(paramTypes, WildcardType))
+            targ = arg.withType(defn.FunctionNOf(paramTypes, WildcardType))
           case Some(_) if !force =>
             targ = arg.withType(WildcardType)
           case _ =>
@@ -845,9 +845,9 @@ object ProtoTypes {
               tp
             case pt: ApplyingProto =>
               if (rt eq mt.resultType) tp
-              else mt.derivedLambdaType(mt.paramNames, mt.paramInfos, rt)
+              else mt.derivedLambdaType(resType = rt)
             case _ =>
-              val ft = defn.FunctionOf(mt.paramInfos, rt)
+              val ft = mt.derivedLambdaType(resType = rt).toFunctionType()
               if mt.paramInfos.nonEmpty || (ft frozen_<:< pt) then ft else rt
           }
         }

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -122,7 +122,7 @@ trait QuotesAndSplices {
       for arg <- typedArgs if arg.symbol.is(Mutable) do // TODO support these patterns. Possibly using scala.quoted.util.Var
         report.error("References to `var`s cannot be used in higher-order pattern", arg.srcPos)
       val argTypes = typedArgs.map(_.tpe.widenTermRefExpr)
-      val patType = if tree.args.isEmpty then pt else defn.FunctionOf(argTypes, pt)
+      val patType = if tree.args.isEmpty then pt else defn.FunctionNOf(argTypes, pt)
       val pat = typedPattern(tree.body, defn.QuotedExprClass.typeRef.appliedTo(patType))(using quotePatternSpliceContext)
       val baseType = pat.tpe.baseType(defn.QuotedExprClass)
       val argType = if baseType.exists then baseType.argTypesHi.head else defn.NothingType
@@ -148,7 +148,7 @@ trait QuotesAndSplices {
     if isInBraces then // ${x}(...) match an application
       val typedArgs = args.map(arg => typedExpr(arg))
       val argTypes = typedArgs.map(_.tpe.widenTermRefExpr)
-      val splice1 = typedSplicePattern(splice, defn.FunctionOf(argTypes, pt))
+      val splice1 = typedSplicePattern(splice, defn.FunctionNOf(argTypes, pt))
       untpd.cpy.Apply(tree)(splice1.select(nme.apply), typedArgs).withType(pt)
     else // $x(...) higher-order quasipattern
       if args.isEmpty then

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -105,7 +105,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       case AppliedType(_, funArgs @ fun :: tupled :: Nil) =>
         def functionTypeEqual(baseFun: Type, actualArgs: List[Type],
             actualRet: Type, expected: Type) =
-          expected =:= defn.FunctionOf(actualArgs, actualRet,
+          expected =:= defn.FunctionNOf(actualArgs, actualRet,
             defn.isContextFunctionType(baseFun))
         val arity: Int =
           if defn.isFunctionNType(fun) then

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1814,9 +1814,9 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
                 case PolyType(_, _, mt1) => mt1.hasErasedParams
             case _ => false
         def isDependentFunctionType: Boolean =
-          val tpNoRefinement = self.dropDependentRefinement
-          tpNoRefinement != self
-          && dotc.core.Symbols.defn.isNonRefinedFunction(tpNoRefinement)
+          self match
+            case dotc.core.Symbols.defn.FunctionOf(mt) => mt.isResultDependent
+            case _ => false
         def isTupleN: Boolean =
           dotc.core.Symbols.defn.isTupleNType(self)
         def select(sym: Symbol): TypeRepr = self.select(sym)

--- a/tests/neg-custom-args/captures/byname.check
+++ b/tests/neg-custom-args/captures/byname.check
@@ -2,7 +2,7 @@
 10 |  h(f2()) // error
    |    ^^^^
    |    Found:    (x$0: Int) ->{cap1} Int
-   |    Required: (x$0: Int) ->{cap2} Int
+   |    Required: Int ->{cap2} Int
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/byname.scala:19:5 ----------------------------------------

--- a/tests/pos-macros/erasedArgs/Macro_1.scala
+++ b/tests/pos-macros/erasedArgs/Macro_1.scala
@@ -1,0 +1,7 @@
+import scala.quoted._
+import scala.language.experimental.erasedDefinitions
+
+transparent inline def mcr: Any = ${ mcrImpl(1, 2d, "abc") }
+
+def mcrImpl(x: Int, erased y: Double, z: String)(using Quotes): Expr[String] =
+  Expr(x.toString() + z)

--- a/tests/pos-macros/erasedArgs/Test_2.scala
+++ b/tests/pos-macros/erasedArgs/Test_2.scala
@@ -1,0 +1,1 @@
+def test: "1abc" = mcr


### PR DESCRIPTION
This fixes inconsistencies with refined dependent function types and poly functions representing methods with erased parameters.

<del>This PR has many commits on purpose. These changes proved to be extremely fragile. Therefore it was decided that it would be better to do smaller incremental changes to be able to pinpoint any undetected regression in the future.</del>

The first commits reflect the code to split the logic into base abstractions for function types. These aim to remove ad-hoc behavior of function-type extractors and homogenize them. Once this was done, we moved towards representing function types homogeneously using `MethodType`s as their base representation. This representation is more robust as it forces us to consider dependent function types explicitly. Finally, some fixes were made where we did not handle function types correctly. Some todos are left where we could generalize to dependent function types, but this could go out of the bounds of the current spec for dependent function types (to be followed-up).
