### PR TITLE
Add -semanticdb-text compiler option

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -54,6 +54,7 @@ trait AllScalaSettings extends CommonScalaSettings, PluginSettings, VerboseSetti
 
   /* Path related settings */
   val semanticdbTarget: Setting[String] = PathSetting("-semanticdb-target", "Specify an alternative output directory for SemanticDB files.", "")
+  val semanticdbText: Setting[Boolean] = BooleanSetting("-semanticdb-text", "Specifies whether to include source code in SemanticDB files or not.")
 
   val source: Setting[String] = ChoiceSetting("-source", "source version", "source version", ScalaSettings.supportedSourceVersions, SourceVersion.defaultSourceVersion.toString, aliases = List("--source"))
   val uniqid: Setting[Boolean] = BooleanSetting("-uniqid", "Uniquely tag all identifiers in debugging output.", aliases = List("--unique-id"))

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -483,6 +483,9 @@ object ExtractSemanticDB:
       .filterNot(_.isEmpty)
       .map(Paths.get(_))
 
+  private def semanticdbText(using Context): Boolean =
+    ctx.settings.semanticdbText.value
+
   private def outputDirectory(using Context): AbstractFile = ctx.settings.outputDir.value
 
   def write(
@@ -503,7 +506,7 @@ object ExtractSemanticDB:
       schema = Schema.SEMANTICDB4,
       language = Language.SCALA,
       uri = Tools.mkURIstring(Paths.get(relPath)),
-      text = "",
+      text = if semanticdbText then String(source.content) else "",
       md5 = internal.MD5.compute(String(source.content)),
       symbols = symbolInfos,
       occurrences = occurrences,


### PR DESCRIPTION
This PR add the `-semanticdb-text`  compiler option that enables text ouput into semanticdb files.

Discussion: [Support text inclusion in semanticdb output](https://github.com/lampepfl/dotty/discussions/18306)