### PR TITLE
Add actionable item to PatternMatchExhaustivity diagnostic

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -844,10 +844,12 @@ extends Message(LossyWideningConstantConversionID):
                 |Write `.to$targetType` instead."""
   def explain(using Context) = ""
 
-class PatternMatchExhaustivity(uncoveredFn: => String, hasMore: Boolean)(using Context)
+class PatternMatchExhaustivity(val uncovered: Seq[String], tree: untpd.Match)(using Context)
 extends Message(PatternMatchExhaustivityID) {
   def kind = MessageKind.PatternMatchExhaustivity
-  lazy val uncovered = uncoveredFn
+
+  private val hasMore = uncovered.lengthCompare(6) > 0
+
   def msg(using Context) =
     val addendum = if hasMore then "(More unmatched cases are elided)" else ""
     i"""|${hl("match")} may not be exhaustive.
@@ -862,6 +864,26 @@ extends Message(PatternMatchExhaustivityID) {
         | - If an extractor always return ${hl("Some(...)")}, write ${hl("Some[X]")} for its return type
         | - Add a ${hl("case _ => ...")} at the end to match all remaining cases
         |"""
+
+  override def actions(using Context) =
+    import scala.language.unsafeNulls
+    val endPos = tree.cases.lastOption.map(_.endPos).getOrElse(tree.selector.endPos)
+    val startColumn = tree.cases.lastOption.map(_.startPos.startColumn).getOrElse(tree.selector.startPos.startColumn + 2)
+    val pathes = List(
+          ActionPatch(endPos, uncovered.map(c=> indent(s"case $c => ???", startColumn)).mkString("\n", "\n", "")),
+        )
+    List(
+      CodeAction(title = s"Insert missing cases (${uncovered.size})",
+        description = None,
+        patches = pathes
+      )
+    )
+
+
+  private def indent(text:String, margin: Int): String = {
+    import scala.language.unsafeNulls
+    " " * margin + text
+  }
 }
 
 class UncheckedTypePattern(msgFn: => String)(using Context)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -844,11 +844,12 @@ extends Message(LossyWideningConstantConversionID):
                 |Write `.to$targetType` instead."""
   def explain(using Context) = ""
 
-class PatternMatchExhaustivity(val uncovered: Seq[String], tree: untpd.Match)(using Context)
+class PatternMatchExhaustivity(uncoveredCases: Seq[String], tree: untpd.Match)(using Context)
 extends Message(PatternMatchExhaustivityID) {
   def kind = MessageKind.PatternMatchExhaustivity
 
-  private val hasMore = uncovered.lengthCompare(6) > 0
+  private val hasMore = uncoveredCases.lengthCompare(6) > 0
+  val uncovered = uncoveredCases.take(6).mkString(", ")
 
   def msg(using Context) =
     val addendum = if hasMore then "(More unmatched cases are elided)" else ""
@@ -870,10 +871,10 @@ extends Message(PatternMatchExhaustivityID) {
     val endPos = tree.cases.lastOption.map(_.endPos).getOrElse(tree.selector.endPos)
     val startColumn = tree.cases.lastOption.map(_.startPos.startColumn).getOrElse(tree.selector.startPos.startColumn + 2)
     val pathes = List(
-          ActionPatch(endPos, uncovered.map(c=> indent(s"case $c => ???", startColumn)).mkString("\n", "\n", "")),
+          ActionPatch(endPos, uncoveredCases.map(c=> indent(s"case $c => ???", startColumn)).mkString("\n", "\n", "")),
         )
     List(
-      CodeAction(title = s"Insert missing cases (${uncovered.size})",
+      CodeAction(title = s"Insert missing cases (${uncoveredCases.size})",
         description = None,
         patches = pathes
       )

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -868,11 +868,19 @@ extends Message(PatternMatchExhaustivityID) {
 
   override def actions(using Context) =
     import scala.language.unsafeNulls
-    val endPos = tree.cases.lastOption.map(_.endPos).getOrElse(tree.selector.endPos)
-    val startColumn = tree.cases.lastOption.map(_.startPos.startColumn).getOrElse(tree.selector.startPos.startColumn + 2)
+    val endPos = tree.cases.lastOption.map(_.endPos)
+      .getOrElse(tree.selector.endPos)
+    val startColumn = tree.cases.lastOption
+      .map(_.startPos.startColumn)
+      .getOrElse(tree.selector.startPos.startColumn + 2)
+
     val pathes = List(
-          ActionPatch(endPos, uncoveredCases.map(c=> indent(s"case $c => ???", startColumn)).mkString("\n", "\n", "")),
-        )
+      ActionPatch(
+        srcPos = endPos, 
+        replacement = uncoveredCases.map(c => indent(s"case $c => ???", startColumn))
+          .mkString("\n", "\n", "")
+      ),
+    )
     List(
       CodeAction(title = s"Insert missing cases (${uncoveredCases.size})",
         description = None,

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -790,8 +790,7 @@ object SpaceEngine {
 
     def doShow(s: Space, flattenList: Boolean = false): String = s match {
       case Empty => "empty"
-      case Typ(ConstantType(const : Constant), _) if const.tag == StringTag => "\"" + const.value + "\""
-      case Typ(ConstantType(const : Constant), _) => "" + const.value 
+      case Typ(c: ConstantType, _) => c.value.show
       case Typ(tp: TermRef, _) =>
         if (flattenList && tp <:< defn.NilType) ""
         else tp.symbol.showName

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -775,7 +775,7 @@ object SpaceEngine {
     checkConstraint(genConstraint(sp))(using ctx.fresh.setNewTyperState())
   }
 
-  def showSpaces(ss: Seq[Space])(using Context): String = ss.map(show).mkString(", ")
+  def showSpaces(ss: Seq[Space])(using Context): Seq[String] = ss.map(show)
 
   /** Display spaces */
   def show(s: Space)(using Context): String = {
@@ -900,9 +900,8 @@ object SpaceEngine {
 
 
     if uncovered.nonEmpty then
-      val hasMore = uncovered.lengthCompare(6) > 0
-      val deduped = dedup(uncovered.take(6))
-      report.warning(PatternMatchExhaustivity(showSpaces(deduped), hasMore), m.selector)
+      val deduped = dedup(uncovered)
+      report.warning(PatternMatchExhaustivity(showSpaces(deduped), m), m.selector)
   }
 
   private def redundancyCheckable(sel: Tree)(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -790,7 +790,8 @@ object SpaceEngine {
 
     def doShow(s: Space, flattenList: Boolean = false): String = s match {
       case Empty => "empty"
-      case Typ(c: ConstantType, _) => "" + c.value.value
+      case Typ(ConstantType(const : Constant), _) if const.tag == StringTag => "\"" + const.value + "\""
+      case Typ(ConstantType(const : Constant), _) => "" + const.value 
       case Typ(tp: TermRef, _) =>
         if (flattenList && tp <:< defn.NilType) ""
         else tp.symbol.showName

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -100,6 +100,25 @@ class CodeActionTest extends DottyTest:
          afterPhase = "patternMatcher"
       )
 
+  @Test def insertMissingCasesForUnionIntType =
+    checkCodeAction(
+      code =
+        """object Test:
+           |  def foo(text: 1 | 2) = text match {
+           |    case 2 => ???
+           |  }
+           |""".stripMargin,
+         title = "Insert missing cases (1)",
+      expected =
+        """object Test:
+           |  def foo(text: 1 | 2) = text match {
+           |    case 2 => ???
+           |    case 1 => ???
+           |  }
+           |""".stripMargin,
+         afterPhase = "patternMatcher"
+      )
+
   // Make sure we're not using the default reporter, which is the ConsoleReporter,
   // meaning they will get reported in the test run and that's it.
   private def newContext =

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -56,26 +56,28 @@ class CodeActionTest extends DottyTest:
 
   @Test def insertMissingCases =
     checkCodeAction(
-      code = """|enum Tree:
-         |  case Node(l: Tree, r: Tree)
-         |  case Leaf(v: String)
-         |
-         |object Test:
-         |  def foo(tree: Tree) = tree match {
-         |    case Tree.Node(_, _) => ???
-         |  }
-         |""".stripMargin,
+      code =
+        """|enum Tree:
+           |  case Node(l: Tree, r: Tree)
+           |  case Leaf(v: String)
+           |
+           |object Test:
+           |  def foo(tree: Tree) = tree match {
+           |    case Tree.Node(_, _) => ???
+           |  }
+           |""".stripMargin,
          title = "Insert missing cases (1)",
-      expected = """|enum Tree:
-         |  case Node(l: Tree, r: Tree)
-         |  case Leaf(v: String)
-         |
-         |object Test:
-         |  def foo(tree: Tree) = tree match {
-         |    case Tree.Node(_, _) => ???
-         |    case Tree.Leaf(_) => ???
-         |  }
-         |""".stripMargin,
+      expected =
+        """|enum Tree:
+           |  case Node(l: Tree, r: Tree)
+           |  case Leaf(v: String)
+           |
+           |object Test:
+           |  def foo(tree: Tree) = tree match {
+           |    case Tree.Node(_, _) => ???
+           |    case Tree.Leaf(_) => ???
+           |  }
+           |""".stripMargin,
          afterPhase = "patternMatcher"
       )
 

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -119,6 +119,23 @@ class CodeActionTest extends DottyTest:
          afterPhase = "patternMatcher"
       )
 
+  @Test def insertMissingCasesUsingBracelessSyntax =
+    checkCodeAction(
+      code =
+        """object Test:
+           |  def foo(text: 1 | 2) = text match
+           |    case 2 => ???
+           |""".stripMargin,
+         title = "Insert missing cases (1)",
+      expected =
+        """object Test:
+           |  def foo(text: 1 | 2) = text match
+           |    case 2 => ???
+           |    case 1 => ???
+           |""".stripMargin,
+         afterPhase = "patternMatcher"
+      )
+
   // Make sure we're not using the default reporter, which is the ConsoleReporter,
   // meaning they will get reported in the test run and that's it.
   private def newContext =

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -81,6 +81,25 @@ class CodeActionTest extends DottyTest:
          afterPhase = "patternMatcher"
       )
 
+  @Test def insertMissingCasesForUnionStringType =
+    checkCodeAction(
+      code =
+        """object Test:
+           |  def foo(text: "Alice" | "Bob") = text match {
+           |    case "Alice" => ???
+           |  }
+           |""".stripMargin,
+         title = "Insert missing cases (1)",
+      expected =
+        """object Test:
+           |  def foo(text: "Alice" | "Bob") = text match {
+           |    case "Alice" => ???
+           |    case "Bob" => ???
+           |  }
+           |""".stripMargin,
+         afterPhase = "patternMatcher"
+      )
+
   // Make sure we're not using the default reporter, which is the ConsoleReporter,
   // meaning they will get reported in the test run and that's it.
   private def newContext =

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -75,7 +75,7 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
 
     // Here we add extra information that we should know about the error message
     val extra = dia.msg match {
-      case pm: PatternMatchExhaustivity => s": ${pm.uncovered}"
+      case pm: PatternMatchExhaustivity => s": ${pm.uncovered.mkString("\n")}"
       case _ => ""
     }
 

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -75,7 +75,7 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
 
     // Here we add extra information that we should know about the error message
     val extra = dia.msg match {
-      case pm: PatternMatchExhaustivity => s": ${pm.uncovered.mkString("\n")}"
+      case pm: PatternMatchExhaustivity => s": ${pm.uncovered}"
       case _ => ""
     }
 


### PR DESCRIPTION
The purpose of this PR is to add an actionable item for non-exhaustive pattern match diagnostic, so that people can auto insert missing cases. 

Relates to https://github.com/scalameta/metals-feature-requests/issues/350