### PR TITLE
Support completions for extension definition parameter

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -136,11 +136,9 @@ object Completion {
    */
   def pathBeforeDesugaring(path: List[Tree], pos: SourcePosition)(using Context): List[Tree] =
     val hasUntypedTree = path.headOption.forall(NavigateAST.untypedPath(_, exactMatch = true).nonEmpty)
-    if hasUntypedTree then
-      path
-    else
-      NavigateAST.untypedPath(pos.span).collect:
-        case tree: untpd.Tree => tree
+    if hasUntypedTree then path
+    else NavigateAST.untypedPath(pos.span).collect:
+      case tree: untpd.Tree => tree
 
   private def computeCompletions(pos: SourcePosition, path: List[Tree])(using Context): (Int, List[Completion]) = {
     val path0 = pathBeforeDesugaring(path, pos)

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -154,12 +154,11 @@ object Completion:
 
     val completer = new Completer(mode, prefix, pos)
 
-    val completions = path0 match
-      case untpd.Select(qual, _) :: _ :: untpd.ExtMethods(_, _) :: _ =>
-        val tpdQual = ctx.typer.typedExpr(qual)
-        completer.selectionCompletions(tpdQual)
-      case _ => tpdPath match
+    val adjustedPath: List[Tree] = path0 match
+      case (sel: untpd.Select) :: _ :: untpd.ExtMethods(_, _) :: _ => List(ctx.typer.typedExpr(sel))
+      case _                                                       => tpdPath
 
+    val completions = adjustedPath match
         // Ignore synthetic select from `This` because in code it was `Ident`
         // See example in dotty.tools.languageserver.CompletionTest.syntheticThis
         case Select(qual @ This(_), _) :: _ if qual.span.isSynthetic  => completer.scopeCompletions

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -94,7 +94,7 @@ object Completion:
    * Inspect `path` to determine the completion prefix. Only symbols whose name start with the
    * returned prefix should be considered.
    */
-  def completionPrefix(path: List[untpd.Tree],  pos: SourcePosition)(using Context): String =
+  def completionPrefix(path: List[untpd.Tree], pos: SourcePosition)(using Context): String =
     path match
       case (sel: untpd.ImportSelector) :: _ =>
         completionPrefix(sel.imported :: Nil, pos)

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -251,10 +251,11 @@ class ReplDriver(settings: Array[String],
       given state: State = newRun(state0)
       compiler
         .typeCheck(expr, errorsAllowed = true)
-        .map { tree =>
+        .map { (untpdTree, tpdTree) =>
           val file = SourceFile.virtual("<completions>", expr, maybeIncomplete = true)
           val unit = CompilationUnit(file)(using state.context)
-          unit.tpdTree = tree
+          unit.untpdTree = untpdTree
+          unit.tpdTree = tpdTree
           given Context = state.context.fresh.setCompilationUnit(unit)
           val srcPos = SourcePosition(file, Span(cursor))
           val completions = try Completion.completions(srcPos)._2 catch case NonFatal(_) => Nil

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -32,6 +32,11 @@ class TabcompleteTests extends ReplTest {
     assertEquals(List("apply"), comp)
   }
 
+  @Test def tabCompleteInExtensionDefinition = initially {
+    val comp = tabComplete("extension (x: Lis")
+    assertEquals(List("List"), comp)
+  }
+
   @Test def tabCompleteTwiceIn = {
     val src1 = "class Foo { def bar(xs: List[Int]) = xs.map"
     val src2 = "class Foo { def bar(xs: List[Int]) = xs.mapC"

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1528,4 +1528,13 @@ class CompletionTest {
         )
       )
   }
+
+  @Test def desugaredErrorStatement: Unit =
+    code"""|trait Foo
+           |object T:
+           |  extension (x: Fo$m1)
+           |"""
+      .completion(m1, Set(
+          ("Foo",Class,"Foo")
+      ))
 }

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1523,10 +1523,7 @@ class CompletionTest {
           |object Test:
           |  def foo: ArrayBuffer[Fo${m1}] = ???
           """
-      .completion(m1, Set(
-          ("Foo",Class,"Foo")
-        )
-      )
+      .completion(m1, Set(("Foo",Class,"Foo")))
   }
 
   @Test def extensionDefinitionCompletions: Unit =
@@ -1534,7 +1531,21 @@ class CompletionTest {
            |object T:
            |  extension (x: Fo$m1)
            |"""
-      .completion(m1, Set(
-          ("Foo",Class,"Foo")
-      ))
+      .completion(m1, Set(("Foo",Class,"Foo")))
+
+  @Test def selectDynamic: Unit =
+    code"""|import scala.language.dynamics
+           |class Foo extends Dynamic {
+           |  def banana: Int = 42
+           |  def selectDynamic(field: String): Foo = this
+           |  def applyDynamicNamed(name: String)(arg: (String, Int)): Foo = this
+           |  def updateDynamic(name: String)(value: Int): Foo = this
+           |}
+           |object Test:
+           |  val x = new Foo()
+           |  x.sele$m1
+           |  x.bana$m2
+           |"""
+      .completion(m1, Set(("selectDynamic", Method, "(field: String): Foo")))
+      .completion(m2, Set(("banana", Method, "=> Int")))
 }

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1533,6 +1533,16 @@ class CompletionTest {
            |"""
       .completion(m1, Set(("Foo",Class,"Foo")))
 
+  @Test def extensionDefinitionCompletionsSelect: Unit =
+    code"""|object Test:
+           |  class TestSelect()
+           |object T:
+           |  extension (x: Test.TestSel$m1)
+           |"""
+      .completion(m1, Set(
+        ("TestSelect", Module, "Test.TestSelect"), ("TestSelect", Class, "Test.TestSelect")
+      ))
+
   @Test def selectDynamic: Unit =
     code"""|import scala.language.dynamics
            |class Foo extends Dynamic {

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1529,7 +1529,7 @@ class CompletionTest {
       )
   }
 
-  @Test def desugaredErrorStatement: Unit =
+  @Test def extensionDefinitionCompletions: Unit =
     code"""|trait Foo
            |object T:
            |  extension (x: Fo$m1)

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1543,6 +1543,39 @@ class CompletionTest {
         ("TestSelect", Module, "Test.TestSelect"), ("TestSelect", Class, "Test.TestSelect")
       ))
 
+  @Test def extensionDefinitionCompletionsSelectNested: Unit =
+    code"""|object Test:
+           |  object Test2:
+           |    class TestSelect()
+           |object T:
+           |  extension (x: Test.Test2.TestSel$m1)
+           |"""
+      .completion(m1, Set(
+        ("TestSelect", Module, "Test.Test2.TestSelect"), ("TestSelect", Class, "Test.Test2.TestSelect")
+      ))
+
+  @Test def extensionDefinitionCompletionsSelectInside: Unit =
+    code"""|object Test:
+           |  object Test2:
+           |    class TestSelect()
+           |object T:
+           |  extension (x: Test.Te$m1.TestSelect)
+           |"""
+      .completion(m1, Set(("Test2", Module, "Test.Test2")))
+
+  @Test def extensionDefinitionCompletionsTypeParam: Unit =
+    code"""|object T:
+           |  extension [TypeParam](x: TypePar$m1)
+           |"""
+      .completion(m1, Set(("TypeParam", Field, "T.TypeParam")))
+
+
+  @Test def typeParamCompletions: Unit =
+    code"""|object T:
+           |  def xxx[TTT](x: TT$m1)
+           |"""
+      .completion(m1, Set(("TTT", Field, "T.TTT")))
+
   @Test def selectDynamic: Unit =
     code"""|import scala.language.dynamics
            |class Foo extends Dynamic {

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -63,7 +63,6 @@ class Completions(
       case Literal(Constant(_: String)) :: _ => Mode.Term // literal completions
       case _ => mode
 
-
   private lazy val shouldAddSnippet =
     path match
       /* In case of `method@@()` we should not add snippets and the path
@@ -113,7 +112,6 @@ class Completions(
     else !completionMode.is(Mode.Term)
     end if
   end includeSymbol
-
 
   def completions(): (List[CompletionValue], SymbolSearch.Result) =
     val (advanced, exclusive) = advancedCompletions(path, pos, completionPos)
@@ -242,9 +240,8 @@ class Completions(
     def companionSynthetic = sym.companion.exists && sym.companion.is(Synthetic)
     // find the apply completion that would need a snippet
     val methodSymbols =
-      if shouldAddSnippet &&
-        (sym.is(Flags.Module) || sym.isClass && !sym.is(Flags.Trait)) &&
-          !sym.is(Flags.JavaDefined) && completionMode.is(Mode.Term)
+      if shouldAddSnippet && completionMode.is(Mode.Term) &&
+        (sym.is(Flags.Module) || sym.isClass && !sym.is(Flags.Trait)) && !sym.is(Flags.JavaDefined)
       then
         val info =
           /* Companion will be added even for normal classes now,

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -57,7 +57,7 @@ class Completions(
   val coursierComplete = new CoursierComplete(BuildInfo.scalaVersion)
 
   private lazy val completionMode =
-    val adjustedPath = Completion.pathBeforeDesugaring(path, pos)
+    val adjustedPath = Completion.resolveTypedOrUntypedPath(path, pos)
     val mode = Completion.completionMode(adjustedPath, pos)
     path match
       case Literal(Constant(_: String)) :: _ => Mode.Term // literal completions

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -125,7 +125,7 @@ class Completions(
   end CursorPos
 
   private lazy val cursorPos =
-    calculateTypeInstanceAndNewPositions(path)
+    calculateTypeInstanceAndNewPositions(Completion.pathBeforeDesugaring(path, pos))
 
   private def calculateTypeInstanceAndNewPositions(
       path: List[Tree]

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -106,10 +106,8 @@ class Completions(
       else false
 
     if generalExclude then false
-    else if completionMode.is(Mode.ImportOrExport) then true
-    else if completionMode.is(Mode.Term) && isWildcardParam(sym) then false
-    else if completionMode.is(Mode.Term) && (sym.isTerm || sym.is(Package)) then true
-    else !completionMode.is(Mode.Term)
+    else if completionMode.is(Mode.Type) then true
+    else !isWildcardParam(sym) && (sym.isTerm || sym.is(Package))
     end if
   end includeSymbol
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -669,14 +669,12 @@ class CompletionSuite extends BaseCompletionSuite:
     check(
       s"""|object Main {
           |  Option(1) match {
-          |    case _: S@@
+          |    case _: Som@@
           |}
           |""".stripMargin,
       """|Some[?] scala
-         |ScalaReflectionException scala
-         |Seq[A] scala.collection.immutable
          |""".stripMargin,
-      topLines = Some(3)
+      topLines = Some(1)
     )
 
   @Test def adt3 =
@@ -695,9 +693,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |""".stripMargin,
       """|NotString: Int
          |Number: Regex
-         |Nil scala.collection.immutable
          |""".stripMargin,
-      topLines = Option(3)
+      topLines = Some(2)
     )
 
   @Test def adt4 =
@@ -705,29 +702,12 @@ class CompletionSuite extends BaseCompletionSuite:
       s"""|object Main {
           |  val Number = "".r
           |  "" match {
-          |    case _: N@@
+          |    case _: Numb@@
           |}
           |""".stripMargin,
       """|Number: Regex
-         |NoSuchElementException java.util
-         |NoSuchFieldError java.lang
          |""".stripMargin,
-      topLines = Option(3)
-    )
-
-  @Test def adt5 =
-    check(
-      s"""|object Main {
-          |  val Number = "".r
-          |  "" match {
-          |    case _: N@@
-          |}
-          |""".stripMargin,
-      """|Number: Regex
-         |NoSuchElementException java.util
-         |NoSuchFieldError java.lang
-         |""".stripMargin,
-      topLines = Option(3)
+      topLines = Some(1)
     )
 
   @Test def `no-methods-on-case-type` =

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1331,6 +1331,16 @@ class CompletionSuite extends BaseCompletionSuite:
 
   @Test def `extension-definition-scope` =
     check(
+      """|trait Foo
+         |object T:
+         |  extension (x: Fo@@)
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-symbol-search` =
+    check(
       """|object T:
          |  extension (x: ListBuffe@@)
          |""".stripMargin,
@@ -1339,11 +1349,102 @@ class CompletionSuite extends BaseCompletionSuite:
          |""".stripMargin,
     )
 
-  @Test def `extension-definition-symbol-search` =
+  @Test def `extension-definition-type-parameter` =
     check(
       """|trait Foo
          |object T:
-         |  extension (x: Fo@@)
+         |  extension [A <: Fo@@]
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-type-parameter-symbol-search` =
+    check(
+      """|object T:
+         |  extension [A <: ListBuffe@@]
+         |""".stripMargin,
+      """|ListBuffer[T] - scala.collection.mutable
+         |ListBuffer - scala.collection.mutable
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-using-param-clause` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension (using Fo@@)
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+
+  @Test def `extension-definition-mix-1` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension (x: Int)(using Fo@@)
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-mix-2` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension (using Fo@@)(x: Int)(using Foo)
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-mix-3` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension (using Foo)(x: Int)(using Fo@@)
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-mix-4` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension [A](x: Fo@@)
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-mix-5` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension [A](using Fo@@)(x: Int)
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-mix-6` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension [A](using Foo)(x: Fo@@)
+         |""".stripMargin,
+      """|Foo test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-mix-7` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension [A](using Foo)(x: Fo@@)(using Fo@@)
          |""".stripMargin,
       """|Foo test
          |""".stripMargin

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1442,3 +1442,14 @@ class CompletionSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
+
+  @Test def `no-square-brackets` =
+    checkEdit(
+      """|object O:
+         |  val a = List.appl@@
+         |""".stripMargin,
+      """|object O:
+         |  val a = List.apply($0)
+         |""".stripMargin,
+    )
+

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -673,8 +673,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |}
           |""".stripMargin,
       """|Some[?] scala
-         |SafeVarargs java.lang
          |ScalaReflectionException scala
+         |Seq[A] scala.collection.immutable
          |""".stripMargin,
       topLines = Some(3)
     )
@@ -709,8 +709,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |}
           |""".stripMargin,
       """|Number: Regex
-         |NegativeArraySizeException java.lang
-         |NoClassDefFoundError java.lang
+         |NoSuchElementException java.util
+         |NoSuchFieldError java.lang
          |""".stripMargin,
       topLines = Option(3)
     )
@@ -724,10 +724,22 @@ class CompletionSuite extends BaseCompletionSuite:
           |}
           |""".stripMargin,
       """|Number: Regex
-         |NegativeArraySizeException java.lang
-         |NoClassDefFoundError java.lang
+         |NoSuchElementException java.util
+         |NoSuchFieldError java.lang
          |""".stripMargin,
       topLines = Option(3)
+    )
+
+  @Test def `no-methods-on-case-type` =
+    check(
+      s"""|object Main {
+          |  val Number = "".r
+          |  "" match {
+          |    case _: NotImpl@@
+          |}
+          |""".stripMargin,
+      """|NotImplementedError scala
+         |""".stripMargin,
     )
 
   @Test def underscore =
@@ -1344,7 +1356,7 @@ class CompletionSuite extends BaseCompletionSuite:
       """|object T:
          |  extension (x: ListBuffe@@)
          |""".stripMargin,
-      """|ListBuffer[T] - scala.collection.mutable
+      """|ListBuffer[A] - scala.collection.mutable
          |ListBuffer - scala.collection.mutable
          |""".stripMargin,
     )
@@ -1364,7 +1376,7 @@ class CompletionSuite extends BaseCompletionSuite:
       """|object T:
          |  extension [A <: ListBuffe@@]
          |""".stripMargin,
-      """|ListBuffer[T] - scala.collection.mutable
+      """|ListBuffer[A] - scala.collection.mutable
          |ListBuffer - scala.collection.mutable
          |""".stripMargin
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1442,6 +1442,39 @@ class CompletionSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
+  @Test def `extension-definition-select` =
+    check(
+      """|object Test:
+         |  class TestSelect()
+         |object T:
+         |  extension (x: Test.TestSel@@)
+         |""".stripMargin,
+      """|TestSelect test.Test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-select-mix-1` =
+    check(
+      """|object Test:
+         |  class TestSelect()
+         |object T:
+         |  extension (using Int)(x: Test.TestSel@@)
+         |""".stripMargin,
+      """|TestSelect test.Test
+         |""".stripMargin
+    )
+
+  @Test def `extension-definition-select-mix-2` =
+    check(
+      """|object Test:
+         |  class TestSelect[T]()
+         |object T:
+         |  extension [T](x: Test.TestSel@@)
+         |""".stripMargin,
+      """|TestSelect[T] test.Test
+         |TestSelect test.Test
+         |""".stripMargin
+    )
 
   @Test def `no-square-brackets` =
     checkEdit(

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -539,7 +539,7 @@ class CompletionSuite extends BaseCompletionSuite:
           |  new Foo().bana@@
           |}
           |""".stripMargin,
-      "selectDynamic(field: String): Foo"
+      "banana: Int"
     )
 
   @Test def dynamic2 =
@@ -549,7 +549,7 @@ class CompletionSuite extends BaseCompletionSuite:
           |  val x = new Foo().foo.bana@@
           |}
           |""".stripMargin,
-      "selectDynamic(field: String): Foo"
+      "banana: Int"
     )
 
   @Test def dynamic3 =
@@ -560,7 +560,7 @@ class CompletionSuite extends BaseCompletionSuite:
           |  (foo.bar = 42).bana@@
           |}
           |""".stripMargin,
-      "selectDynamic(field: String): Foo"
+      "banana: Int"
     )
 
   @Test def dynamic4 =
@@ -570,7 +570,7 @@ class CompletionSuite extends BaseCompletionSuite:
           |  val foo = new Foo().foo(x = 42).bana@@
           |}
           |""".stripMargin,
-      "selectDynamic(field: String): Foo"
+      "banana: Int"
     )
 
   @Test def dynamic5 =

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1326,6 +1326,26 @@ class CompletionSuite extends BaseCompletionSuite:
       """|AClass[A <: Int] test.O
          |AClass test.O
          |AbstractTypeClassManifest - scala.reflect.ClassManifestFactory
+         """.stripMargin
+    )
+
+  @Test def `extension-definition-scope` =
+    check(
+      """|object T:
+         |  extension (x: ListBuffe@@)
+         |""".stripMargin,
+      """|ListBuffer[T] - scala.collection.mutable
+         |ListBuffer - scala.collection.mutable
+         |""".stripMargin,
+    )
+
+  @Test def `extension-definition-symbol-search` =
+    check(
+      """|trait Foo
+         |object T:
+         |  extension (x: Fo@@)
+         |""".stripMargin,
+      """|Foo test
          |""".stripMargin
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -673,8 +673,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |}
           |""".stripMargin,
       """|Some[?] scala
-         |Seq scala.collection.immutable
-         |Set scala.collection.immutable
+         |SafeVarargs java.lang
+         |ScalaReflectionException scala
          |""".stripMargin,
       topLines = Some(3)
     )
@@ -709,8 +709,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |}
           |""".stripMargin,
       """|Number: Regex
-         |Nil scala.collection.immutable
-         |NoManifest scala.reflect
+         |NegativeArraySizeException java.lang
+         |NoClassDefFoundError java.lang
          |""".stripMargin,
       topLines = Option(3)
     )
@@ -724,8 +724,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |}
           |""".stripMargin,
       """|Number: Regex
-         |Nil scala.collection.immutable
-         |NoManifest scala.reflect
+         |NegativeArraySizeException java.lang
+         |NoClassDefFoundError java.lang
          |""".stripMargin,
       topLines = Option(3)
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1436,7 +1436,7 @@ class CompletionSuite extends BaseCompletionSuite:
     check(
       """|trait Foo
          |object T:
-         |  extension [A](using Foo)(x: Fo@@)(using Fo@@)
+         |  extension [A](using Foo)(x: Fo@@)(using Foo)
          |""".stripMargin,
       """|Foo test
          |""".stripMargin

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
@@ -293,7 +293,6 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
-  // Ignore for Scala 3, since we don't provide completions for null
   @Test def `match-typed` =
     checkEdit(
       """|object Main {
@@ -305,11 +304,12 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
       """|import java.util.ArrayDeque
          |object Main {
          |  def foo(): Unit = null match {
-         |    case x: ArrayDeque =>
+         |    case x: ArrayDeque[$0] =>
          |  }
          |}
          |""".stripMargin,
-      filter = _.contains("java.util")
+      filter = _.contains("java.util"),
+      assertSingleItem = false,
     )
 
   @Test def `type` =


### PR DESCRIPTION
Extension methods are extended into normal definitions.
Because of that typed trees don't include any information about the extension method definition parameter:
```scala
extension (x: In@@)
```
In order to add completions, we check if there is an exact path to the untyped tree, and if not, we fall back to it. There may also be more possible cases like that, but I can't think of any at the moment.