### PR TITLE
Issue "positional after named argument" errors

### DIFF
--- a/tests/neg/i18122.check
+++ b/tests/neg/i18122.check
@@ -1,0 +1,52 @@
+-- Error: tests/neg/i18122.scala:10:16 ---------------------------------------------------------------------------------
+10 |    foo1(y = 1, 2, x = 3) // error: positional after named
+   |                ^
+   |                positional after named argument
+-- Error: tests/neg/i18122.scala:11:16 ---------------------------------------------------------------------------------
+11 |    foo2(y = 1, 2, x = 3) // error: positional after named
+   |                ^
+   |                positional after named argument
+-- Error: tests/neg/i18122.scala:12:16 ---------------------------------------------------------------------------------
+12 |    foo1(y = 1, 2, z = 3) // error: positional after named
+   |                ^
+   |                positional after named argument
+-- Error: tests/neg/i18122.scala:13:16 ---------------------------------------------------------------------------------
+13 |    foo2(y = 1, 2, z = 3) // error: positional after named
+   |                ^
+   |                positional after named argument
+-- Error: tests/neg/i18122.scala:14:16 ---------------------------------------------------------------------------------
+14 |    foo1(y = 1, 2) // error: positional after named
+   |                ^
+   |                positional after named argument
+-- Error: tests/neg/i18122.scala:15:16 ---------------------------------------------------------------------------------
+15 |    foo2(y = 1, 2) // error: positional after named
+   |                ^
+   |                positional after named argument
+-- [E171] Type Error: tests/neg/i18122.scala:17:8 ----------------------------------------------------------------------
+17 |    bar1() // error: missing arg
+   |    ^^^^^^
+   |    missing argument for parameter x of method bar1 in object Test: (x: Int, ys: Int*): Unit
+-- [E171] Type Error: tests/neg/i18122.scala:23:8 ----------------------------------------------------------------------
+23 |    bar1(ys = 1) // error: missing arg
+   |    ^^^^^^^^^^^^
+   |    missing argument for parameter x of method bar1 in object Test: (x: Int, ys: Int*): Unit
+-- Error: tests/neg/i18122.scala:43:16 ---------------------------------------------------------------------------------
+43 |    bar1(x = 1, 2, ys = 3)  // error: positional after named
+   |                ^
+   |                positional after named argument
+-- Error: tests/neg/i18122.scala:44:18 ---------------------------------------------------------------------------------
+44 |    bar1(1, 2, ys = 3)      // error: parameter ys is already instantiated
+   |               ^^^^^^
+   |               parameter ys of method bar1 in object Test: (x: Int, ys: Int*): Unit is already instantiated
+-- Error: tests/neg/i18122.scala:45:16 ---------------------------------------------------------------------------------
+45 |    bar2(x = 1, 2, ys = 3)  // error: positional after named
+   |                ^
+   |                positional after named argument
+-- Error: tests/neg/i18122.scala:46:17 ---------------------------------------------------------------------------------
+46 |    bar1(ys = 1, 2, x = 3)  // error: positional after named
+   |                 ^
+   |                 positional after named argument
+-- Error: tests/neg/i18122.scala:47:17 ---------------------------------------------------------------------------------
+47 |    bar2(ys = 1, 2, x = 3)  // error: positional after named
+   |                 ^
+   |                 positional after named argument

--- a/tests/neg/i18122.scala
+++ b/tests/neg/i18122.scala
@@ -1,0 +1,49 @@
+object Test {
+  def foo1(x: Int, y: Int, z: Int) = println((x, y, z))
+  def foo2(x: Int = 0, y: Int, z: Int) = println((x, y, z))
+  def bar1(x: Int, ys: Int*) = println((x, ys))
+  def bar2(x: Int = 0, ys: Int*) = println((x, ys))
+
+  def main(args: Array[String]) = {
+    foo1(1, y = 2, 3)
+    foo2(1, y = 2, 3)
+    foo1(y = 1, 2, x = 3) // error: positional after named
+    foo2(y = 1, 2, x = 3) // error: positional after named
+    foo1(y = 1, 2, z = 3) // error: positional after named
+    foo2(y = 1, 2, z = 3) // error: positional after named
+    foo1(y = 1, 2) // error: positional after named
+    foo2(y = 1, 2) // error: positional after named
+
+    bar1() // error: missing arg
+    bar2()
+    bar1(1)
+    bar2(1)
+    bar1(x = 1)
+    bar2(x = 1)
+    bar1(ys = 1) // error: missing arg
+    bar2(ys = 1)
+    bar1(1, 2)
+    bar2(1, 2)
+    bar1(1, ys = 2)
+    bar2(1, ys = 2)
+    bar1(x = 1, 2)
+    bar2(x = 1, 2)
+    bar1(x = 1, ys = 2)
+    bar2(x = 1, ys = 2)
+    bar1(ys = 1, x = 2)
+    bar2(ys = 1, x = 2)
+    bar1(1, 2, 3)
+    bar2(1, 2, 3)
+    bar1(1, ys = 2, 3)
+    bar2(1, ys = 2, 3)
+    bar1(x = 1, 2, 3)
+    bar2(x = 1, 2, 3)
+    bar1(x = 1, ys = 2, 3)
+    bar2(x = 1, ys = 2, 3)
+    bar1(x = 1, 2, ys = 3)  // error: positional after named
+    bar1(1, 2, ys = 3)      // error: parameter ys is already instantiated
+    bar2(x = 1, 2, ys = 3)  // error: positional after named
+    bar1(ys = 1, 2, x = 3)  // error: positional after named
+    bar2(ys = 1, 2, x = 3)  // error: positional after named
+  }
+}

--- a/tests/pos-with-compiler-cc/dotc/transform/PickleQuotes.scala
+++ b/tests/pos-with-compiler-cc/dotc/transform/PickleQuotes.scala
@@ -134,7 +134,7 @@ class PickleQuotes extends MacroTransform {
               contents += content
             val holeType =
               if isTerm then getTermHoleType(tree.tpe) else getTypeHoleType(tree.tpe)
-            val hole = cpy.Hole(tree)(content = EmptyTree, TypeTree(holeType))
+            val hole = cpy.Hole(tree)(content = EmptyTree, tpt = TypeTree(holeType))
             if isTerm then Inlined(EmptyTree, Nil, hole).withSpan(tree.span) else hole
           case tree: DefTree =>
             val newAnnotations = tree.symbol.annotations.mapconserve { annot =>


### PR DESCRIPTION
Issue "positional after named argument" errors if a positional argument follows a named argument and one of the following is true:

 - There is a formal argument before the argument position that has not yet been instantiated with a previous actual argument, (either named or positional), or
 - The formal parameter at the argument position is also mentioned in a subsequent named parameter.

This brings the behavior largely in line with Scala 2.

Fixes #18122 