### PR TITLE
Remove unnecessary guard in TreeMap

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1596,6 +1596,9 @@ object Trees {
             case tree @ TypeDef(name, rhs) =>
               cpy.TypeDef(tree)(name, transform(rhs))
             case tree @ Template(constr, parents, self, _) if tree.derived.isEmpty =>
+              // Currently we do not have cases where we expect `tree.derived` to contain trees for typed trees.
+              // If it is the case we will fall in `transformMoreCases` and throw an exception there.
+              // In the future we might keep the `derived` clause after typing, in that case we might want to start handling it here.
               cpy.Template(tree)(transformSub(constr), transform(tree.parents), Nil, transformSub(self), transformStats(tree.body, tree.symbol))
             case Import(expr, selectors) =>
               cpy.Import(tree)(transform(expr), selectors)


### PR DESCRIPTION
This guard was added in fb09e828e2a9cd1320d036e3916555b08fbde52b but does not seem to be necessary. Note that `UntypedTreeMap` handles the case `DerivingTemplate` explicitly.