### PR TITLE
Fix #17115: Try to normalize while computing `typeSize`.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6459,7 +6459,9 @@ object Types {
         seen += tp
         tp match {
           case tp: AppliedType =>
-            foldOver(n + 1, tp)
+            val tpNorm = tp.tryNormalize
+            if tpNorm.exists then apply(n, tpNorm)
+            else foldOver(n + 1, tp)
           case tp: RefinedType =>
             foldOver(n + 1, tp)
           case tp: TypeRef if tp.info.isTypeAlias =>

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -56,6 +56,7 @@ i15827.scala
 i17149.scala
 tuple-fold.scala
 mt-redux-norm.perspective.scala
+i18211.scala
 
 # Opaque type
 i5720.scala

--- a/tests/pos/i17115.scala
+++ b/tests/pos/i17115.scala
@@ -1,0 +1,9 @@
+trait A[T <: Tuple] { val x: Int }
+given empty: A[EmptyTuple] with { val x = 1 }
+given inductive[Tup <: NonEmptyTuple](using A[Tuple.Tail[Tup]]): A[Tup] with { val x = summon[A[Tuple.Tail[Tup]]].x + 1 }
+
+object Test:
+  def main(args: Array[String]): Unit =
+    println(summon[A[(String, String, String)]].x) //this line is fine
+    println(summon[A[(String, String, String, String)]].x) //this line gives error
+end Test

--- a/tests/pos/i18211.scala
+++ b/tests/pos/i18211.scala
@@ -1,0 +1,39 @@
+import scala.compiletime.ops.int.*
+
+type AnyInt[A <: Int] <: Int = A match {
+  case _ => A
+}
+
+type IndexOf[A, T <: Tuple] <: Int = T match {
+  case EmptyTuple => -1
+  case A *: t     => 0
+  case _ *: t =>
+    IndexOf[A, t] match {
+      case -1        => -1
+      case AnyInt[a] => S[a]
+    }
+}
+
+type Indexes[A, T <: Tuple]
+object Indexes {
+  given of[A, T <: Tuple](using IndexOf[A, T] >= 0 =:= true)(using
+      index: ValueOf[IndexOf[A, T]],
+      next: Indexes[A, Tuple.Drop[T, S[IndexOf[A, T]]]]
+  ): Indexes[A, T] = ???
+
+  given empty[A, T <: Tuple](using IndexOf[A, T] =:= -1): Indexes[A, T] = ???
+}
+
+class GetAll[A]:
+  def apply[T <: Tuple](t: T)(using indexes: Indexes[A, T]): List[A] = ???
+
+def getAll[A]: GetAll[A] = new GetAll[A]
+
+def test =
+  // the code here is trying to get all values from a tuple that has type [X] as a list
+
+  // this works if there are only two strings in the tuple
+  getAll[String](("str1", 1, "str2", false))
+
+  //but this not compiles if there are more than two strings in the tuple
+  getAll[String](("str1", 1, "str2", false, "str3"))


### PR DESCRIPTION
@odersky at https://github.com/lampepfl/dotty/issues/17115#issuecomment-1471554060 you raised concerns with using `simplified`. This is a solution with `tryNormalize` instead, but buried inside `typeSize`. Is that acceptable?