### PR TITLE
ExtractDependencies uses more efficient caching

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -20,7 +20,6 @@ import annotation.{tailrec, constructorOnly}
 import ast.tpd._
 import Synthesizer._
 import sbt.ExtractDependencies.*
-import sbt.ClassDependency
 import xsbti.api.DependencyContext._
 
 /** Synthesize terms for special classes */

--- a/compiler/src/dotty/tools/dotc/util/EqHashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/EqHashMap.scala
@@ -58,6 +58,22 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
     used += 1
     if used > limit then growTable()
 
+  override def getOrElseUpdate(key: Key, value: => Value): Value =
+    // created by blending lookup and update, avoid having to recompute hash and probe
+    Stats.record(statsItem("lookup-or-update"))
+    var idx = firstIndex(key)
+    var k = keyAt(idx)
+    while k != null do
+      if isEqual(k, key) then return valueAt(idx)
+      idx = nextIndex(idx)
+      k = keyAt(idx)
+    val v = value
+    setKey(idx, key)
+    setValue(idx, v)
+    used += 1
+    if used > limit then growTable()
+    v
+
   private def addOld(key: Key, value: Value): Unit =
     Stats.record(statsItem("re-enter"))
     var idx = firstIndex(key)

--- a/compiler/src/dotty/tools/dotc/util/EqHashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/EqHashSet.scala
@@ -15,7 +15,7 @@ object EqHashSet:
  *                           initial size of the table will be the smallest power of two
  *                           that is equal or greater than the given `initialCapacity`.
  *                           Minimum value is 4.
-*  @param  capacityMultiple The minimum multiple of capacity relative to used elements.
+ *  @param  capacityMultiple The minimum multiple of capacity relative to used elements.
  *                           The hash table will be re-sized once the number of elements
  *                           multiplied by capacityMultiple exceeds the current size of the hash table.
  *                           However, a table of size up to DenseLimit will be re-sized only

--- a/compiler/src/dotty/tools/dotc/util/EqHashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/EqHashSet.scala
@@ -2,10 +2,10 @@ package dotty.tools.dotc.util
 
 import dotty.tools.uncheckedNN
 
-object HashSet:
+object EqHashSet:
 
-  def from[T](xs: IterableOnce[T]): HashSet[T] =
-    val set = new HashSet[T]()
+  def from[T](xs: IterableOnce[T]): EqHashSet[T] =
+    val set = new EqHashSet[T]()
     set ++= xs
     set
 
@@ -21,30 +21,26 @@ object HashSet:
  *                           However, a table of size up to DenseLimit will be re-sized only
  *                           once the number of elements reaches the table's size.
  */
-class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends GenericHashSet[T](initialCapacity, capacityMultiple) {
+class EqHashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends GenericHashSet[T](initialCapacity, capacityMultiple) {
   import GenericHashSet.DenseLimit
 
-  /** Hashcode, by default a processed `x.hashCode`, can be overridden */
-  protected def hash(key: T): Int =
-    val h = key.hashCode
-    // Part of the MurmurHash3 32 bit finalizer
-    val i = (h ^ (h >>> 16)) * 0x85EBCA6B
-    val j = (i ^ (i >>> 13)) & 0x7FFFFFFF
-    if j==0 then 0x41081989 else j
+  /** System's identity hashcode left shifted by 1 */
+  final def hash(key: T): Int =
+    System.identityHashCode(key) << 1
 
-  /** Hashcode, by default `equals`, can be overridden */
-  protected def isEqual(x: T, y: T): Boolean = x.equals(y)
+  /** reference equality */
+  final def isEqual(x: T, y: T): Boolean = x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
 
   /** Turn hashcode `x` into a table index */
-  protected def index(x: Int): Int = x & (table.length - 1)
+  private def index(x: Int): Int = x & (table.length - 1)
 
-  protected def firstIndex(x: T) = if isDense then 0 else index(hash(x))
-  protected def nextIndex(idx: Int) =
+  private def firstIndex(x: T) = if isDense then 0 else index(hash(x))
+  private def nextIndex(idx: Int) =
     Stats.record(statsItem("miss"))
     index(idx + 1)
 
-  protected def entryAt(idx: Int): T | Null = table(idx).asInstanceOf[T | Null]
-  protected def setEntry(idx: Int, x: T) = table(idx) = x.asInstanceOf[AnyRef | Null]
+  private def entryAt(idx: Int): T | Null = table(idx).asInstanceOf[T | Null]
+  private def setEntry(idx: Int, x: T) = table(idx) = x.asInstanceOf[AnyRef | Null]
 
   override def lookup(x: T): T | Null =
     Stats.record(statsItem("lookup"))
@@ -57,12 +53,24 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Ge
     null
 
   /** Add entry at `x` at index `idx` */
-  protected def addEntryAt(idx: Int, x: T): T =
+  private def addEntryAt(idx: Int, x: T): T =
     Stats.record(statsItem("addEntryAt"))
     setEntry(idx, x)
     used += 1
     if used > limit then growTable()
     x
+
+  /** attempts to put `x` in the Set, if it was not entered before, return true, else return false. */
+  override def add(x: T): Boolean =
+    Stats.record(statsItem("enter"))
+    var idx = firstIndex(x)
+    var e: T | Null = entryAt(idx)
+    while e != null do
+      if isEqual(e.uncheckedNN, x) then return false // already entered
+      idx = nextIndex(idx)
+      e = entryAt(idx)
+    addEntryAt(idx, x)
+    true // first entry
 
   override def put(x: T): T =
     Stats.record(statsItem("put"))
@@ -125,7 +133,4 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Ge
         val e: T | Null = oldTable(idx).asInstanceOf[T | Null]
         if e != null then addOld(e.uncheckedNN)
         idx += 1
-
-  override def iterator: Iterator[T] = new EntryIterator():
-    def entry(idx: Int) = entryAt(idx)
 }

--- a/compiler/src/dotty/tools/dotc/util/EqHashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/EqHashSet.scala
@@ -85,36 +85,6 @@ class EqHashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends 
 
   override def +=(x: T): Unit = put(x)
 
-  override def remove(x: T): Boolean =
-    Stats.record(statsItem("remove"))
-    var idx = firstIndex(x)
-    var e: T | Null = entryAt(idx)
-    while e != null do
-      if isEqual(e.uncheckedNN, x) then
-        var hole = idx
-        while
-          idx = nextIndex(idx)
-          e = entryAt(idx)
-          e != null
-        do
-          val eidx = index(hash(e.uncheckedNN))
-          if isDense
-            || index(eidx - (hole + 1)) > index(idx - (hole + 1))
-               // entry `e` at `idx` can move unless `index(hash(e))` is in
-               // the (ring-)interval [hole + 1 .. idx]
-          then
-            setEntry(hole, e.uncheckedNN)
-            hole = idx
-        table(hole) = null
-        used -= 1
-        return true
-      idx = nextIndex(idx)
-      e = entryAt(idx)
-    false
-
-  override def -=(x: T): Unit =
-    remove(x)
-
   private def addOld(x: T) =
     Stats.record(statsItem("re-enter"))
     var idx = firstIndex(x)

--- a/compiler/src/dotty/tools/dotc/util/GenericHashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashSet.scala
@@ -36,8 +36,7 @@ abstract class GenericHashSet[T](initialCapacity: Int = 8, capacityMultiple: Int
 
   private def roundToPower(n: Int) =
     if n < 4 then 4
-    else if Integer.bitCount(n) == 1 then n
-    else 1 << (32 - Integer.numberOfLeadingZeros(n))
+    else 1 << (32 - Integer.numberOfLeadingZeros(n - 1))
 
   def clear(resetToInitial: Boolean): Unit =
     used = 0
@@ -49,10 +48,10 @@ abstract class GenericHashSet[T](initialCapacity: Int = 8, capacityMultiple: Int
 
   protected def isDense = limit < DenseLimit
 
-  /** Hashcode, by default a processed `x.hashCode`, can be overridden */
+  /** Hashcode, to be implemented in subclass */
   protected def hash(key: T): Int
 
-  /** Hashcode, by default `equals`, can be overridden */
+  /** Equality, to be implemented in subclass */
   protected def isEqual(x: T, y: T): Boolean
 
   /** Turn hashcode `x` into a table index */

--- a/compiler/src/dotty/tools/dotc/util/GenericHashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/GenericHashSet.scala
@@ -2,12 +2,12 @@ package dotty.tools.dotc.util
 
 import dotty.tools.uncheckedNN
 
-object HashSet:
+object GenericHashSet:
 
-  def from[T](xs: IterableOnce[T]): HashSet[T] =
-    val set = new HashSet[T]()
-    set ++= xs
-    set
+  /** The number of elements up to which dense packing is used.
+   *  If the number of elements reaches `DenseLimit` a hash table is used instead
+   */
+  inline val DenseLimit = 8
 
 /** A hash set that allows some privileged protected access to its internals
  *  @param  initialCapacity  Indicates the initial number of slots in the hash table.
@@ -21,32 +21,54 @@ object HashSet:
  *                           However, a table of size up to DenseLimit will be re-sized only
  *                           once the number of elements reaches the table's size.
  */
-class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends GenericHashSet[T](initialCapacity, capacityMultiple) {
+abstract class GenericHashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends MutableSet[T] {
   import GenericHashSet.DenseLimit
 
+  protected var used: Int = _
+  protected var limit: Int = _
+  protected var table: Array[AnyRef | Null] = _
+
+  clear()
+
+  private def allocate(capacity: Int) =
+    table = new Array[AnyRef | Null](capacity)
+    limit = if capacity <= DenseLimit then capacity - 1 else capacity / capacityMultiple
+
+  private def roundToPower(n: Int) =
+    if n < 4 then 4
+    else if Integer.bitCount(n) == 1 then n
+    else 1 << (32 - Integer.numberOfLeadingZeros(n))
+
+  def clear(resetToInitial: Boolean): Unit =
+    used = 0
+    if resetToInitial then allocate(roundToPower(initialCapacity))
+    else java.util.Arrays.fill(table, null)
+
+  /** The number of elements in the set */
+  def size: Int = used
+
+  protected def isDense = limit < DenseLimit
+
   /** Hashcode, by default a processed `x.hashCode`, can be overridden */
-  protected def hash(key: T): Int =
-    val h = key.hashCode
-    // Part of the MurmurHash3 32 bit finalizer
-    val i = (h ^ (h >>> 16)) * 0x85EBCA6B
-    val j = (i ^ (i >>> 13)) & 0x7FFFFFFF
-    if j==0 then 0x41081989 else j
+  protected def hash(key: T): Int
 
   /** Hashcode, by default `equals`, can be overridden */
-  protected def isEqual(x: T, y: T): Boolean = x.equals(y)
+  protected def isEqual(x: T, y: T): Boolean
 
   /** Turn hashcode `x` into a table index */
-  protected def index(x: Int): Int = x & (table.length - 1)
+  private def index(x: Int): Int = x & (table.length - 1)
 
-  protected def firstIndex(x: T) = if isDense then 0 else index(hash(x))
-  protected def nextIndex(idx: Int) =
+  protected def currentTable: Array[AnyRef | Null] = table
+
+  private def firstIndex(x: T) = if isDense then 0 else index(hash(x))
+  private def nextIndex(idx: Int) =
     Stats.record(statsItem("miss"))
     index(idx + 1)
 
-  protected def entryAt(idx: Int): T | Null = table(idx).asInstanceOf[T | Null]
-  protected def setEntry(idx: Int, x: T) = table(idx) = x.asInstanceOf[AnyRef | Null]
+  private def entryAt(idx: Int): T | Null = table(idx).asInstanceOf[T | Null]
+  private def setEntry(idx: Int, x: T) = table(idx) = x.asInstanceOf[AnyRef | Null]
 
-  override def lookup(x: T): T | Null =
+  def lookup(x: T): T | Null =
     Stats.record(statsItem("lookup"))
     var idx = firstIndex(x)
     var e: T | Null = entryAt(idx)
@@ -57,14 +79,26 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Ge
     null
 
   /** Add entry at `x` at index `idx` */
-  protected def addEntryAt(idx: Int, x: T): T =
+  private def addEntryAt(idx: Int, x: T): T =
     Stats.record(statsItem("addEntryAt"))
     setEntry(idx, x)
     used += 1
     if used > limit then growTable()
     x
 
-  override def put(x: T): T =
+  /** attempts to put `x` in the Set, if it was not entered before, return true, else return false. */
+  override def add(x: T): Boolean =
+    Stats.record(statsItem("enter"))
+    var idx = firstIndex(x)
+    var e: T | Null = entryAt(idx)
+    while e != null do
+      if isEqual(e.uncheckedNN, x) then return false // already entered
+      idx = nextIndex(idx)
+      e = entryAt(idx)
+    addEntryAt(idx, x)
+    true // first entry
+
+  def put(x: T): T =
     Stats.record(statsItem("put"))
     var idx = firstIndex(x)
     var e: T | Null = entryAt(idx)
@@ -75,9 +109,9 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Ge
       e = entryAt(idx)
     addEntryAt(idx, x)
 
-  override def +=(x: T): Unit = put(x)
+  def +=(x: T): Unit = put(x)
 
-  override def remove(x: T): Boolean =
+  def remove(x: T): Boolean =
     Stats.record(statsItem("remove"))
     var idx = firstIndex(x)
     var e: T | Null = entryAt(idx)
@@ -104,7 +138,7 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Ge
       e = entryAt(idx)
     false
 
-  override def -=(x: T): Unit =
+  def -=(x: T): Unit =
     remove(x)
 
   private def addOld(x: T) =
@@ -116,7 +150,7 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Ge
       e = entryAt(idx)
     setEntry(idx, x)
 
-  override def copyFrom(oldTable: Array[AnyRef | Null]): Unit =
+  def copyFrom(oldTable: Array[AnyRef | Null]): Unit =
     if isDense then
       Array.copy(oldTable, 0, table, 0, oldTable.length)
     else
@@ -126,6 +160,32 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Ge
         if e != null then addOld(e.uncheckedNN)
         idx += 1
 
-  override def iterator: Iterator[T] = new EntryIterator():
+  protected def growTable(): Unit =
+    val oldTable = table
+    val newLength =
+      if oldTable.length == DenseLimit then DenseLimit * 2 * roundToPower(capacityMultiple)
+      else table.length * 2
+    allocate(newLength)
+    copyFrom(oldTable)
+
+  abstract class EntryIterator extends Iterator[T]:
+    def entry(idx: Int): T | Null
+    private var idx = 0
+    def hasNext =
+      while idx < table.length && table(idx) == null do idx += 1
+      idx < table.length
+    def next() =
+      require(hasNext)
+      try entry(idx).uncheckedNN finally idx += 1
+
+  def iterator: Iterator[T] = new EntryIterator():
     def entry(idx: Int) = entryAt(idx)
+
+  override def toString: String =
+    iterator.mkString("HashSet(", ", ", ")")
+
+  protected def statsItem(op: String) =
+    val prefix = if isDense then "HashSet(dense)." else "HashSet."
+    val suffix = getClass.getSimpleName
+    s"$prefix$op $suffix"
 }

--- a/compiler/src/dotty/tools/dotc/util/HashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashMap.scala
@@ -63,6 +63,22 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
     used += 1
     if used > limit then growTable()
 
+  override def getOrElseUpdate(key: Key, value: => Value): Value =
+    // created by blending lookup and update, avoid having to recompute hash and probe
+    Stats.record(statsItem("lookup-or-update"))
+    var idx = firstIndex(key)
+    var k = keyAt(idx)
+    while k != null do
+      if isEqual(k, key) then return valueAt(idx)
+      idx = nextIndex(idx)
+      k = keyAt(idx)
+    val v = value
+    setKey(idx, key)
+    setValue(idx, v)
+    used += 1
+    if used > limit then growTable()
+    v
+
   private def addOld(key: Key, value: Value): Unit =
     Stats.record(statsItem("re-enter"))
     var idx = firstIndex(key)

--- a/compiler/src/dotty/tools/dotc/util/MutableSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/MutableSet.scala
@@ -7,6 +7,13 @@ abstract class MutableSet[T] extends ReadOnlySet[T]:
   /** Add element `x` to the set */
   def +=(x: T): Unit
 
+  /** attempts to put `x` in the Set, if it was not entered before, return true, else return false.
+   *  Overridden in GenericHashSet.
+   */
+  def add(x: T): Boolean =
+    if lookup(x) == null then { this += x; true }
+    else false
+
   /** Like `+=` but return existing element equal to `x` of it exists,
    *  `x` itself otherwise.
    */

--- a/compiler/test/dotty/tools/dotc/util/EqHashMapTest.scala
+++ b/compiler/test/dotty/tools/dotc/util/EqHashMapTest.scala
@@ -1,0 +1,115 @@
+package dotty.tools.dotc.util
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class EqHashMapTest:
+
+  var counter = 0
+
+  // basic identity hash, and reference equality, but with a counter for ordering
+  class Id:
+    val count = { counter += 1; counter }
+
+  val id1, id2, id3 = Id()
+
+  given Ordering[Id] = Ordering.by(_.count)
+
+  @Test
+  def invariant: Unit =
+    assert((id1 ne id2) && (id1 ne id3) && (id2 ne id3))
+
+  @Test
+  def newEmpty: Unit =
+    val m = EqHashMap[Id, Int]()
+    assert(m.size == 0)
+    assert(m.iterator.toList == Nil)
+
+  @Test
+  def update: Unit =
+    val m = EqHashMap[Id, Int]()
+    assert(m.size == 0 && !m.contains(id1))
+    m.update(id1, 1)
+    assert(m.size == 1 && m(id1) == 1)
+    m.update(id1, 2) // replace value
+    assert(m.size == 1 && m(id1) == 2)
+    m.update(id3, 3) // new key
+    assert(m.size == 2 && m(id1) == 2 && m(id3) == 3)
+
+  @Test
+  def getOrElseUpdate: Unit =
+    val m = EqHashMap[Id, Int]()
+    // add id1
+    assert(m.size == 0 && !m.contains(id1))
+    val added = m.getOrElseUpdate(id1, 1)
+    assert(added == 1 && m.size == 1 && m(id1) == 1)
+    // try add id1 again
+    val addedAgain = m.getOrElseUpdate(id1, 23)
+    assert(addedAgain != 23 && m.size == 1 && m(id1) == 1) // no change
+
+  private def fullMap() =
+    val m = EqHashMap[Id, Int]()
+    m.update(id1, 1)
+    m.update(id2, 2)
+    m
+
+  @Test
+  def remove: Unit =
+    val m = fullMap()
+    // remove id2
+    m.remove(id2)
+    assert(m.size == 1)
+    assert(m.contains(id1) && !m.contains(id2))
+    // remove id1
+    m -= id1
+    assert(m.size == 0)
+    assert(!m.contains(id1) && !m.contains(id2))
+
+  @Test
+  def lookup: Unit =
+    val m = fullMap()
+    assert(m.lookup(id1) == 1)
+    assert(m.lookup(id2) == 2)
+    assert(m.lookup(id3) == null)
+
+  @Test
+  def iterator: Unit =
+    val m = fullMap()
+    assert(m.iterator.toList.sorted == List(id1 -> 1,id2 -> 2))
+
+  @Test
+  def clear: Unit =
+    locally:
+      val s1 = fullMap()
+      s1.clear()
+      assert(s1.size == 0)
+    locally:
+      val s2 = fullMap()
+      s2.clear(resetToInitial = false)
+      assert(s2.size == 0)
+
+  // basic structural equality and hash code
+  class I32(val x: Int):
+    override def hashCode(): Int = x
+    override def equals(that: Any): Boolean = that match
+      case that: I32 => this.x == that.x
+      case _ => false
+
+  /** the hash set is based on reference equality, i.e. does not use universal equality */
+  @Test
+  def referenceEquality: Unit =
+    val i1, i2 = I32(1) // different instances
+
+    assert(i1.equals(i2)) // structural equality
+    assert(i1 ne i2) // reference inequality
+
+    val m = locally:
+      val m = EqHashMap[I32, Int]()
+      m(i1) = 23
+      m(i2) = 29
+      m
+
+    assert(m.size == 2 && m(i1) == 23 && m(i2) == 29)
+    assert(m.keysIterator.toSet == Set(i1)) // scala.Set delegates to universal equality
+  end referenceEquality
+

--- a/compiler/test/dotty/tools/dotc/util/EqHashSetTest.scala
+++ b/compiler/test/dotty/tools/dotc/util/EqHashSetTest.scala
@@ -1,0 +1,119 @@
+package dotty.tools.dotc.util
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class EqHashSetTest:
+
+  var counter = 0
+
+  // basic identity hash, and reference equality, but with a counter for ordering
+  class Id:
+    val count = { counter += 1; counter }
+
+  val id1, id2, id3 = Id()
+
+  given Ordering[Id] = Ordering.by(_.count)
+
+  @Test
+  def invariant: Unit =
+    assert((id1 ne id2) && (id1 ne id3) && (id2 ne id3))
+
+  @Test
+  def newEmpty: Unit =
+    val s = EqHashSet[Id]()
+    assert(s.size == 0)
+    assert(s.iterator.toList == Nil)
+
+  @Test
+  def put: Unit =
+    val s = EqHashSet[Id]()
+    // put id1
+    assert(s.size == 0 && !s.contains(id1))
+    s += id1
+    assert(s.size == 1 && s.contains(id1))
+    // put id2
+    assert(!s.contains(id2))
+    s.put(id2)
+    assert(s.size == 2 && s.contains(id1) && s.contains(id2))
+    // put id3
+    s ++= List(id3)
+    assert(s.size == 3 && s.contains(id1) && s.contains(id2) && s.contains(id3))
+
+  @Test
+  def add: Unit =
+    val s = EqHashSet[Id]()
+    // add id1
+    assert(s.size == 0 && !s.contains(id1))
+    val added = s.add(id1)
+    assert(added && s.size == 1 && s.contains(id1))
+    // try add id1 again
+    val addedAgain = s.add(id1)
+    assert(!addedAgain && s.size == 1 && s.contains(id1)) // no change
+
+  @Test
+  def construct: Unit =
+    val s = EqHashSet.from(List(id1,id2,id3))
+    assert(s.size == 3)
+    assert(s.contains(id1) && s.contains(id2) && s.contains(id3))
+
+  @Test
+  def remove: Unit =
+    val s = EqHashSet.from(List(id1,id2,id3))
+    // remove id2
+    s.remove(id2)
+    assert(s.size == 2)
+    assert(s.contains(id1) && !s.contains(id2) && s.contains(id3))
+    // remove id1
+    s -= id1
+    assert(s.size == 1)
+    assert(!s.contains(id1) && !s.contains(id2) && s.contains(id3))
+    // remove id3
+    s --= List(id3)
+    assert(s.size == 0)
+    assert(!s.contains(id1) && !s.contains(id2) && !s.contains(id3))
+
+  @Test
+  def lookup: Unit =
+    val s = EqHashSet.from(List(id1, id2))
+    assert(s.lookup(id1) eq id1)
+    assert(s.lookup(id2) eq id2)
+    assert(s.lookup(id3) eq null)
+
+  @Test
+  def iterator: Unit =
+    val s = EqHashSet.from(List(id1,id2,id3))
+    assert(s.iterator.toList.sorted == List(id1,id2,id3))
+
+  @Test
+  def clear: Unit =
+    locally:
+      val s1 = EqHashSet.from(List(id1,id2,id3))
+      s1.clear()
+      assert(s1.size == 0)
+    locally:
+      val s2 = EqHashSet.from(List(id1,id2,id3))
+      s2.clear(resetToInitial = false)
+      assert(s2.size == 0)
+
+  // basic structural equality and hash code
+  class I32(val x: Int):
+    override def hashCode(): Int = x
+    override def equals(that: Any): Boolean = that match
+      case that: I32 => this.x == that.x
+      case _ => false
+
+  /** the hash map is based on reference equality, i.e. does not use universal equality */
+  @Test
+  def referenceEquality: Unit =
+    val i1, i2 = I32(1) // different instances
+
+    assert(i1.equals(i2)) // structural equality
+    assert(i1 ne i2) // reference inequality
+
+    val s = EqHashSet.from(List(i1,i2))
+
+    assert(s.size == 2 && s.contains(i1) && s.contains(i2))
+    assert(s.iterator.toSet == Set(i1)) // scala.Set delegates to universal equality
+  end referenceEquality
+

--- a/compiler/test/dotty/tools/dotc/util/HashMapTest.scala
+++ b/compiler/test/dotty/tools/dotc/util/HashMapTest.scala
@@ -1,0 +1,137 @@
+package dotty.tools.dotc.util
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class HashMapTest:
+
+  var counter = 0
+
+  // structural hash and equality, but with a counter for ordering
+  class Id(val count: Int = { counter += 1; counter }):
+    override def hashCode(): Int = count
+    override def equals(that: Any): Boolean = that match
+      case that: Id => this.count == that.count
+      case _ => false
+    def makeCopy: Id = new Id(count)
+
+  val id1, id2, id3 = Id()
+
+  given Ordering[Id] = Ordering.by(_.count)
+
+  @Test
+  def invariant: Unit =
+    assert((id1 ne id2) && (id1 ne id3) && (id2 ne id3))
+    assert(id1 != id2 && id1 != id3 && id2 != id3)
+
+  @Test
+  def newEmpty: Unit =
+    val m = HashMap[Id, Int]()
+    assert(m.size == 0)
+    assert(m.iterator.toList == Nil)
+
+  @Test
+  def update: Unit =
+    val m = HashMap[Id, Int]()
+    assert(m.size == 0 && !m.contains(id1))
+    m.update(id1, 1)
+    assert(m.size == 1 && m(id1) == 1)
+    m.update(id1, 2) // replace value
+    assert(m.size == 1 && m(id1) == 2)
+    m.update(id3, 3) // new key
+    assert(m.size == 2 && m(id1) == 2 && m(id3) == 3)
+
+  @Test
+  def getOrElseUpdate: Unit =
+    val m = HashMap[Id, Int]()
+    // add id1
+    assert(m.size == 0 && !m.contains(id1))
+    val added = m.getOrElseUpdate(id1, 1)
+    assert(added == 1 && m.size == 1 && m(id1) == 1)
+    // try add id1 again
+    val addedAgain = m.getOrElseUpdate(id1, 23)
+    assert(addedAgain != 23 && m.size == 1 && m(id1) == 1) // no change
+
+  class StatefulHash:
+    var hashCount = 0
+    override def hashCode(): Int = { hashCount += 1; super.hashCode() }
+
+  @Test
+  def getOrElseUpdate_hashesAtMostOnce: Unit =
+    locally:
+      val sh1 = StatefulHash()
+      val m = HashMap[StatefulHash, Int]() // will be a dense map with default size
+      val added = m.getOrElseUpdate(sh1, 1)
+      assert(sh1.hashCount == 0) // no hashing at all for dense maps
+    locally:
+      val sh1 = StatefulHash()
+      val m = HashMap[StatefulHash, Int](64) // not dense
+      val added = m.getOrElseUpdate(sh1, 1)
+      assert(sh1.hashCount == 1) // would be 2 if for example getOrElseUpdate was implemented as lookup + update
+
+  private def fullMap() =
+    val m = HashMap[Id, Int]()
+    m.update(id1, 1)
+    m.update(id2, 2)
+    m
+
+  @Test
+  def remove: Unit =
+    val m = fullMap()
+    // remove id2
+    m.remove(id2)
+    assert(m.size == 1)
+    assert(m.contains(id1) && !m.contains(id2))
+    // remove id1
+    m -= id1
+    assert(m.size == 0)
+    assert(!m.contains(id1) && !m.contains(id2))
+
+  @Test
+  def lookup: Unit =
+    val m = fullMap()
+    assert(m.lookup(id1) == 1)
+    assert(m.lookup(id2) == 2)
+    assert(m.lookup(id3) == null)
+
+  @Test
+  def iterator: Unit =
+    val m = fullMap()
+    assert(m.iterator.toList.sorted == List(id1 -> 1,id2 -> 2))
+
+  @Test
+  def clear: Unit =
+    locally:
+      val s1 = fullMap()
+      s1.clear()
+      assert(s1.size == 0)
+    locally:
+      val s2 = fullMap()
+      s2.clear(resetToInitial = false)
+      assert(s2.size == 0)
+
+  // basic structural equality and hash code
+  class I32(val x: Int):
+    override def hashCode(): Int = x
+    override def equals(that: Any): Boolean = that match
+      case that: I32 => this.x == that.x
+      case _ => false
+
+  /** the hash map is based on universal equality, i.e. does not use reference equality */
+  @Test
+  def universalEquality: Unit =
+    val id2_2 = id2.makeCopy
+
+    assert(id2.equals(id2_2)) // structural equality
+    assert(id2 ne id2_2) // reference inequality
+
+    val m = locally:
+      val m = HashMap[Id, Int]()
+      m(id2) = 23
+      m(id2_2) = 29
+      m
+
+    assert(m.size == 1 && m(id2) == 29 && m(id2_2) == 29)
+    assert(m.keysIterator.toList.head eq id2) // does not replace id2 with id2_2
+  end universalEquality
+

--- a/compiler/test/dotty/tools/dotc/util/HashSetTest.scala
+++ b/compiler/test/dotty/tools/dotc/util/HashSetTest.scala
@@ -1,0 +1,117 @@
+package dotty.tools.dotc.util
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class HashSetTest:
+
+  var counter = 0
+
+  // structural hash and equality, with a counter for ordering
+  class Id(val count: Int = { counter += 1; counter }):
+    override def hashCode: Int = count
+    override def equals(that: Any): Boolean = that match
+      case that: Id => this.count == that.count
+      case _ => false
+    def makeCopy: Id = new Id(count)
+
+  val id1, id2, id3 = Id()
+
+  given Ordering[Id] = Ordering.by(_.count)
+
+  @Test
+  def invariant: Unit =
+    assert((id1 ne id2) && (id1 ne id3) && (id2 ne id3))
+    assert(id1 != id2 && id1 != id3 && id2 != id3)
+
+  @Test
+  def newEmpty: Unit =
+    val s = HashSet[Id]()
+    assert(s.size == 0)
+    assert(s.iterator.toList == Nil)
+
+  @Test
+  def put: Unit =
+    val s = HashSet[Id]()
+    // put id1
+    assert(s.size == 0 && !s.contains(id1))
+    s += id1
+    assert(s.size == 1 && s.contains(id1))
+    // put id2
+    assert(!s.contains(id2))
+    s.put(id2)
+    assert(s.size == 2 && s.contains(id1) && s.contains(id2))
+    // put id3
+    s ++= List(id3)
+    assert(s.size == 3 && s.contains(id1) && s.contains(id2) && s.contains(id3))
+
+  @Test
+  def add: Unit =
+    val s = HashSet[Id]()
+    // add id1
+    assert(s.size == 0 && !s.contains(id1))
+    val added = s.add(id1)
+    assert(added && s.size == 1 && s.contains(id1))
+    // try add id1 again
+    val addedAgain = s.add(id1)
+    assert(!addedAgain && s.size == 1 && s.contains(id1)) // no change
+
+  @Test
+  def construct: Unit =
+    val s = HashSet.from(List(id1,id2,id3))
+    assert(s.size == 3)
+    assert(s.contains(id1) && s.contains(id2) && s.contains(id3))
+
+  @Test
+  def remove: Unit =
+    val s = HashSet.from(List(id1,id2,id3))
+    // remove id2
+    s.remove(id2)
+    assert(s.size == 2)
+    assert(s.contains(id1) && !s.contains(id2) && s.contains(id3))
+    // remove id1
+    s -= id1
+    assert(s.size == 1)
+    assert(!s.contains(id1) && !s.contains(id2) && s.contains(id3))
+    // remove id3
+    s --= List(id3)
+    assert(s.size == 0)
+    assert(!s.contains(id1) && !s.contains(id2) && !s.contains(id3))
+
+  @Test
+  def lookup: Unit =
+    val s = HashSet.from(List(id1, id2))
+    assert(s.lookup(id1) eq id1)
+    assert(s.lookup(id2) eq id2)
+    assert(s.lookup(id3) eq null)
+
+  @Test
+  def iterator: Unit =
+    val s = HashSet.from(List(id1,id2,id3))
+    assert(s.iterator.toList.sorted == List(id1,id2,id3))
+
+  @Test
+  def clear: Unit =
+    locally:
+      val s1 = HashSet.from(List(id1,id2,id3))
+      s1.clear()
+      assert(s1.size == 0)
+    locally:
+      val s2 = HashSet.from(List(id1,id2,id3))
+      s2.clear(resetToInitial = false)
+      assert(s2.size == 0)
+
+  /** the hash set is based on universal equality, i.e. does not use reference equality */
+  @Test
+  def universalEquality: Unit =
+    val id2_2 = id2.makeCopy
+
+    assert(id2.equals(id2_2)) // structural equality
+    assert(id2 ne id2_2) // reference inequality
+
+    val s = HashSet.from(List(id2,id2_2))
+
+    assert(s.size == 1 && s.contains(id2) && s.contains(id2_2))
+    assert(s.iterator.toList == List(id2)) // single element
+  end universalEquality
+


### PR DESCRIPTION
alternative to https://github.com/lampepfl/dotty/pull/18219

reduces allocations in the phase by 77% (on `scala3-compiler-bootstrapped`), allocations in the whole compilation pipeline are reduced from about 12% to 4% contributed by this phase.

Reduced allocations come from:
- reusing a single set for the `seen` cache.
- use linear probe maps (dotty.tools.dotc.util) avoiding allocation of nodes
- no `ClassDependency` allocation each time a dependency exists (many are likely duplicated)

performance is also improved due to less expensive hashing (`EqHashMap`), and introduction of `EqHashSet`, also reducing number of times we hash (`add` method on HashSet, and optimised `getOrElseUpdate`). Probably also from reduced heap pressure of allocating.

heap before:

<img width="1671" alt="Screenshot 2023-08-15 at 17 34 39" src="https://github.com/lampepfl/dotty/assets/13436592/1097a20f-4dde-49e7-bbae-d98c1d621c18">

heap after:

<img width="1671" alt="Screenshot 2023-08-15 at 17 35 04" src="https://github.com/lampepfl/dotty/assets/13436592/fcaacf8f-4a87-472b-a482-aa3cdcc9d328">

As you can see now the majority of allocation is by Zinc (MappedFileConverter)