### PR TITLE
Improve non-static macro implementation error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -31,6 +31,7 @@ import dotty.tools.dotc.quoted.{PickledQuotes, QuoteUtils}
 
 import scala.quoted.Quotes
 import scala.quoted.runtime.impl._
+import dotty.tools.dotc.core.NameKinds
 
 /** Utility class to splice quoted expressions */
 object Splicer {
@@ -214,6 +215,13 @@ object Splicer {
             report.error("Macro cannot be implemented with an `inline` method", fn.srcPos)
           args.flatten.foreach(checkIfValidArgument)
 
+        case Call(fn, args) if fn.symbol.name.is(NameKinds.InlineAccessorName) =>
+          // TODO suggest use of @binaryAPI one we have the annotation
+          report.error(
+            i"""Macro implementation is not statically accessible.
+              |
+              |Non-static inline accessor was generated in ${fn.symbol.owner}
+              |""".stripMargin, tree.srcPos)
         case _ =>
           report.error(
             """Malformed macro.

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -216,7 +216,7 @@ object Splicer {
           args.flatten.foreach(checkIfValidArgument)
 
         case Call(fn, args) if fn.symbol.name.is(NameKinds.InlineAccessorName) =>
-          // TODO suggest use of @binaryAPI one we have the annotation
+          // TODO suggest use of @binaryAPI once we have the annotation
           report.error(
             i"""Macro implementation is not statically accessible.
               |

--- a/tests/neg-macros/i15413.check
+++ b/tests/neg-macros/i15413.check
@@ -1,0 +1,6 @@
+-- Error: tests/neg-macros/i15413.scala:4:22 ---------------------------------------------------------------------------
+4 |  inline def foo = ${ Macro.fooImpl } // error
+  |                      ^^^^^^^^^^^^^
+  |                      Macro implementation is not statically accessible.
+  |
+  |                      Non-static inline accessor was generated in class Macro

--- a/tests/neg-macros/i15413.scala
+++ b/tests/neg-macros/i15413.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+class Macro:
+  inline def foo = ${ Macro.fooImpl } // error
+
+object Macro:
+  private def fooImpl(using Quotes) = '{}


### PR DESCRIPTION
If non-static inline accessor is generated we do not we can tell the user why they cannot access the macro implementation this way.

Currently we do not have a clean way to fix this code, but in the future [SIP-58](https://github.com/scala/improvement-proposals/pull/58) would introduce a way to not generate this accessor.

Fixes #15413