### PR TITLE
Fix failing bounds check on default getter

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -333,7 +333,7 @@ object Applications {
       // it's crucial that the type tree is not copied directly as argument to
       // `cpy$default$1`. If it was, the variable `X'` would already be interpolated
       // when typing the default argument, which is too early.
-      spliceMeth(meth, fn).appliedToTypes(targs.tpes)
+      spliceMeth(meth, fn).appliedToTypeTrees(targs.map(targ => TypeTree(targ.tpe).withSpan(targ.span)))
     case _ => meth
   }
 

--- a/tests/pos/i18253.orig.scala
+++ b/tests/pos/i18253.orig.scala
@@ -1,0 +1,15 @@
+import compiletime.ops.int.Max
+
+trait DFSInt[W <: Int]
+trait Candidate[R]:
+  type OutW <: Int
+object Candidate:
+  given [W <: Int, R <: DFSInt[W]]: Candidate[R] with
+    type OutW = W
+
+def foo[R](rhs: R)(using icR: Candidate[R]): DFSInt[Max[8, icR.OutW]] = ???
+
+object Test:
+  def check[A](a: A, clue: Int = 1): Unit = ???
+  val x: DFSInt[8] = ???
+  check(foo(x))

--- a/tests/pos/i18253.scala
+++ b/tests/pos/i18253.scala
@@ -1,0 +1,14 @@
+import scala.compiletime.ops.int.Max
+
+trait Foo[A]
+trait Bar[B]:
+  type Out <: Int
+object Bar:
+  given inst[C <: Int]: Bar[C] with
+    type Out = C
+
+class Test:
+  def mkFoo(using bx: Bar[2]): Foo[Max[1, bx.Out]] = ???
+  def check[Y](yy: Y, clue: Int = 1): Unit = ()
+
+  def test: Unit = check(mkFoo)


### PR DESCRIPTION
The type arguments on the default argument had the wrong span, which
means that they were getting bounds checked.  This is in contrast to the
other type arguments (the ones on check itself), which aren't
bounds checked  - by not passing the isZeroExtent guard in
checkInferredWellFormed.
