### PR TITLE
Only lift inner expressions when lifting repeated `Typed` arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -76,10 +76,11 @@ abstract class Lifter {
       tree
   }
 
-  /** Lift a function argument, stripping any NamedArg wrapper */
+  /** Lift a function argument, stripping any NamedArg wrapper and repeated Typed trees */
   private def liftArg(defs: mutable.ListBuffer[Tree], arg: Tree, prefix: TermName = EmptyTermName)(using Context): Tree =
     arg match {
       case arg @ NamedArg(name, arg1) => cpy.NamedArg(arg)(name, lift(defs, arg1, prefix))
+      case arg @ Typed(arg1, tpt) if tpt.typeOpt.isRepeatedParam => cpy.Typed(arg)(lift(defs, arg1, prefix), tpt)
       case arg => lift(defs, arg, prefix)
     }
 

--- a/tests/coverage/run/i16940/i16940.scala
+++ b/tests/coverage/run/i16940/i16940.scala
@@ -1,6 +1,3 @@
-// scalac: -coverage-out:coverage
-// scalajs: --skip
-
 import concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.*
 import scala.concurrent.duration.*

--- a/tests/coverage/run/i16940/i16940.scoverage.check
+++ b/tests/coverage/run/i16940/i16940.scoverage.check
@@ -1,0 +1,343 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+353
+552
+18
+result
+Apply
+false
+0
+false
+Await.result(\n    Future.sequence(Seq(brokenSynchronizedBlock(false), brokenSynchronizedBlock(true)))\n      .map { result =>\n        println(test)\n        assert(test == 2)\n      },\n    3.seconds\n  )
+
+1
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+371
+533
+19
+map
+Apply
+false
+0
+false
+Future.sequence(Seq(brokenSynchronizedBlock(false), brokenSynchronizedBlock(true)))\n      .map { result =>\n        println(test)\n        assert(test == 2)\n      }
+
+2
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+371
+454
+19
+sequence
+Apply
+false
+0
+false
+Future.sequence(Seq(brokenSynchronizedBlock(false), brokenSynchronizedBlock(true)))
+
+3
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+387
+453
+19
+apply
+Apply
+false
+0
+false
+Seq(brokenSynchronizedBlock(false), brokenSynchronizedBlock(true))
+
+4
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+387
+390
+19
+Seq
+Ident
+false
+0
+false
+Seq
+
+5
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+391
+421
+19
+brokenSynchronizedBlock
+Apply
+false
+0
+false
+brokenSynchronizedBlock(false)
+
+6
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+423
+452
+19
+brokenSynchronizedBlock
+Apply
+false
+0
+false
+brokenSynchronizedBlock(true)
+
+7
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+$anonfun
+486
+499
+21
+println
+Apply
+false
+0
+false
+println(test)
+
+8
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+$anonfun
+508
+525
+22
+assertFailed
+Apply
+false
+0
+false
+assert(test == 2)
+
+9
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+$anonfun
+508
+525
+22
+assertFailed
+Apply
+true
+0
+false
+assert(test == 2)
+
+10
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+$anonfun
+508
+525
+22
+<none>
+Literal
+true
+0
+false
+assert(test == 2)
+
+11
+i16940/i16940.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+539
+548
+24
+seconds
+Select
+false
+0
+false
+3.seconds
+
+12
+i16940/i16940.scala
+<empty>
+i16940$package$
+Object
+<empty>.i16940$package$
+brokenSynchronizedBlock
+189
+323
+6
+apply
+Apply
+false
+0
+false
+Future {\n  if (option) {\n    Thread.sleep(500)\n  }\n  synchronized {\n    val tmp = test\n    Thread.sleep(1000)\n    test = tmp + 1\n  }\n}
+
+13
+i16940/i16940.scala
+<empty>
+i16940$package$
+Object
+<empty>.i16940$package$
+brokenSynchronizedBlock
+218
+235
+8
+sleep
+Apply
+false
+0
+false
+Thread.sleep(500)
+
+14
+i16940/i16940.scala
+<empty>
+i16940$package$
+Object
+<empty>.i16940$package$
+brokenSynchronizedBlock
+212
+239
+7
+<none>
+Block
+true
+0
+false
+{\n    Thread.sleep(500)\n  }
+
+15
+i16940/i16940.scala
+<empty>
+i16940$package$
+Object
+<empty>.i16940$package$
+brokenSynchronizedBlock
+239
+239
+9
+<none>
+Literal
+true
+0
+false
+
+
+16
+i16940/i16940.scala
+<empty>
+i16940$package$
+Object
+<empty>.i16940$package$
+brokenSynchronizedBlock
+242
+321
+10
+synchronized
+Apply
+false
+0
+false
+synchronized {\n    val tmp = test\n    Thread.sleep(1000)\n    test = tmp + 1\n  }
+
+17
+i16940/i16940.scala
+<empty>
+i16940$package$
+Object
+<empty>.i16940$package$
+brokenSynchronizedBlock
+280
+298
+12
+sleep
+Apply
+false
+0
+false
+Thread.sleep(1000)
+
+18
+i16940/i16940.scala
+<empty>
+i16940$package$
+Object
+<empty>.i16940$package$
+brokenSynchronizedBlock
+128
+155
+6
+brokenSynchronizedBlock
+DefDef
+false
+0
+false
+def brokenSynchronizedBlock
+

--- a/tests/coverage/run/i18233-min/i18233-min.scala
+++ b/tests/coverage/run/i18233-min/i18233-min.scala
@@ -1,0 +1,13 @@
+def aList =
+  List(Array[String]()*)
+
+def arr =
+  Array("abc", "def")
+
+def anotherList =
+  List(arr*)
+
+object Test extends App {
+  println(aList)
+  println(anotherList)
+}

--- a/tests/coverage/run/i18233-min/i18233-min.scoverage.check
+++ b/tests/coverage/run/i18233-min/i18233-min.scoverage.check
@@ -1,0 +1,258 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+i18233-min/i18233-min.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+131
+145
+10
+println
+Apply
+false
+0
+false
+println(aList)
+
+1
+i18233-min/i18233-min.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+139
+144
+10
+aList
+Ident
+false
+0
+false
+aList
+
+2
+i18233-min/i18233-min.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+148
+168
+11
+println
+Apply
+false
+0
+false
+println(anotherList)
+
+3
+i18233-min/i18233-min.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+156
+167
+11
+anotherList
+Ident
+false
+0
+false
+anotherList
+
+4
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+aList
+14
+36
+1
+apply
+Apply
+false
+0
+false
+List(Array[String]()*)
+
+5
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+aList
+14
+18
+1
+List
+Ident
+false
+0
+false
+List
+
+6
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+aList
+19
+34
+1
+apply
+Apply
+false
+0
+false
+Array[String]()
+
+7
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+aList
+0
+9
+0
+aList
+DefDef
+false
+0
+false
+def aList
+
+8
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+arr
+50
+69
+4
+apply
+Apply
+false
+0
+false
+Array("abc", "def")
+
+9
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+arr
+38
+45
+3
+arr
+DefDef
+false
+0
+false
+def arr
+
+10
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+anotherList
+91
+101
+7
+apply
+Apply
+false
+0
+false
+List(arr*)
+
+11
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+anotherList
+91
+95
+7
+List
+Ident
+false
+0
+false
+List
+
+12
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+anotherList
+96
+99
+7
+arr
+Ident
+false
+0
+false
+arr
+
+13
+i18233-min/i18233-min.scala
+<empty>
+i18233-min$package$
+Object
+<empty>.i18233-min$package$
+anotherList
+71
+86
+6
+anotherList
+DefDef
+false
+0
+false
+def anotherList
+

--- a/tests/coverage/run/i18233/i18233.scala
+++ b/tests/coverage/run/i18233/i18233.scala
@@ -1,0 +1,9 @@
+enum Foo:
+  case Bar, Baz
+
+object Foo:
+  def render = List(values.tail*).mkString
+
+object Test extends App {
+  println(Foo.render)
+}

--- a/tests/coverage/run/i18233/i18233.scoverage.check
+++ b/tests/coverage/run/i18233/i18233.scoverage.check
@@ -1,0 +1,156 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+i18233/i18233.scala
+<empty>
+Foo$
+Object
+<empty>.Foo$
+render
+54
+72
+4
+apply
+Apply
+false
+0
+false
+List(values.tail*)
+
+1
+i18233/i18233.scala
+<empty>
+Foo$
+Object
+<empty>.Foo$
+render
+54
+58
+4
+List
+Ident
+false
+0
+false
+List
+
+2
+i18233/i18233.scala
+<empty>
+Foo$
+Object
+<empty>.Foo$
+render
+59
+65
+4
+refArrayOps
+Apply
+false
+0
+false
+values
+
+3
+i18233/i18233.scala
+<empty>
+Foo$
+Object
+<empty>.Foo$
+render
+59
+70
+4
+tail
+Select
+false
+0
+false
+values.tail
+
+4
+i18233/i18233.scala
+<empty>
+Foo$
+Object
+<empty>.Foo$
+render
+54
+81
+4
+mkString
+Select
+false
+0
+false
+List(values.tail*).mkString
+
+5
+i18233/i18233.scala
+<empty>
+Foo$
+Object
+<empty>.Foo$
+render
+41
+51
+4
+render
+DefDef
+false
+0
+false
+def render
+
+6
+i18233/i18233.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+111
+130
+7
+println
+Apply
+false
+0
+false
+println(Foo.render)
+
+7
+i18233/i18233.scala
+<empty>
+Test$
+Object
+<empty>.Test$
+<init>
+119
+129
+7
+render
+Select
+false
+0
+false
+Foo.render
+


### PR DESCRIPTION
closes lampepfl#18233