### PR TITLE
Fix macros with erased arguments

### DIFF
--- a/tests/pos-macros/erasedArgs/Macro_1.scala
+++ b/tests/pos-macros/erasedArgs/Macro_1.scala
@@ -1,0 +1,7 @@
+import scala.quoted._
+import scala.language.experimental.erasedDefinitions
+
+transparent inline def mcr: Any = ${ mcrImpl(1, 2d, "abc") }
+
+def mcrImpl(x: Int, erased y: Double, z: String)(using Quotes): Expr[String] =
+  Expr(x.toString() + z)

--- a/tests/pos-macros/erasedArgs/Test_2.scala
+++ b/tests/pos-macros/erasedArgs/Test_2.scala
@@ -1,0 +1,1 @@
+def test: "1abc" = mcr


### PR DESCRIPTION
The interpreter was dropping all arguments in the list if one of them was erased. Now we filter out only the erased arguments.


Part of #18305