### PR TITLE
Fix MT separate compilation bug (bis)

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1452,7 +1452,13 @@ class TreeUnpickler(reader: TastyReader,
               val args = until(end)(readTpt())
               val tree = untpd.AppliedTypeTree(tycon, args)
               val ownType = ctx.typeAssigner.processAppliedType(tree, tycon.tpe.safeAppliedTo(args.tpes))
-              tree.withType(postProcessFunction(ownType))
+              val tp = postProcessFunction(ownType)
+              // Much like in the MATCHtpt case,
+              // normalize the type to avoid differences in the type of trees,
+              // (between joint compilation and separate compilation)
+              // which affects how types are compared in subtyping.
+              val tpn = tp.normalized
+              tree.withType(tpn)
             case ANNOTATEDtpt =>
               Annotated(readTpt(), readTree())
             case LAMBDAtpt =>

--- a/tests/pos/i18261.bis.min/Main_0.scala
+++ b/tests/pos/i18261.bis.min/Main_0.scala
@@ -1,0 +1,7 @@
+trait VAL
+
+type Foo[T, M] = M match { case VAL => T }
+
+class Cand[A]
+object Cand:
+  given inst[X, Y <: Foo[X, VAL]]: Cand[Y] = new Cand[Y]

--- a/tests/pos/i18261.bis.min/Test_1.scala
+++ b/tests/pos/i18261.bis.min/Test_1.scala
@@ -1,0 +1,4 @@
+class Test:
+  def test: Unit =
+    summon[Cand[Int]]
+    summon[Cand[Long]]

--- a/tests/pos/i18261.bis/DFBits_0.scala
+++ b/tests/pos/i18261.bis/DFBits_0.scala
@@ -1,0 +1,7 @@
+trait DFBits[W <: Int]
+
+trait Candidate[R]:
+  type OutW <: Int
+object Candidate:
+  given [W <: Int, R <: Foo[DFBits[W], VAL]]: Candidate[R] with
+    type OutW = W

--- a/tests/pos/i18261.bis/Foo_0.scala
+++ b/tests/pos/i18261.bis/Foo_0.scala
@@ -1,0 +1,4 @@
+trait VAL
+
+type Foo[T, M] = M match
+  case VAL => T

--- a/tests/pos/i18261.bis/Test_1.scala
+++ b/tests/pos/i18261.bis/Test_1.scala
@@ -1,0 +1,5 @@
+def baz[L](lhs: L)(using icL: Candidate[L]): DFBits[Int] = ???
+object Test:
+  val x: DFBits[8] = ???
+  val z: DFBits[Int] = baz(x)
+  summon[Candidate[z.type]]


### PR DESCRIPTION
Like I said in #18398, there are several factors involved, and I'd be happy to fix one or more of those causes, in alternative to hot-fixing specific tasty trees.