### PR TITLE
Tweak selection from self types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -854,9 +854,14 @@ object Types {
             // is made to save execution time in the common case. See i9844.scala for test cases.
             def qualifies(sd: SingleDenotation) =
               !sd.symbol.is(Private) || sd.symbol.owner == tp.cls
-            d match
+            d.match
               case d: SingleDenotation => if qualifies(d) then d else NoDenotation
               case d => d.filterWithPredicate(qualifies)
+            .orElse:
+              // Only inaccessible private symbols were found. But there could still be
+              // shadowed non-private symbols, so as a fallback search for those.
+              // Test case is i18361.scala.
+              findMember(name, pre, required, excluded | Private)
           else d
         else
           // There is a special case to handle:

--- a/tests/pos/i18361.scala
+++ b/tests/pos/i18361.scala
@@ -1,0 +1,15 @@
+package test1:
+  class Service(val name: String)
+  class CrudService(name: String) extends Service(name)
+
+  trait Foo { self: CrudService =>
+    val x = self.name
+  }
+
+package test2:
+  abstract class Service[F[_]](val name: String)
+  abstract class CrudService[F[_]](name: String) extends Service[F](name)
+
+  trait Foo[F[_]] { self: CrudService[?] =>
+    val x = self.name
+  }


### PR DESCRIPTION
Previously, we rejected the case where a symbol of a self type selection was private if it was not of the enclosing class. But that symbol could shadow a non-private symbol in a base class, so have to treat that case as well.

Fixes #18351