### PR TITLE
Fix i18518

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1419,7 +1419,11 @@ object Parsers {
     private def getFunction(tree: Tree): Option[Function] = tree match {
       case Parens(tree1) => getFunction(tree1)
       case Block(Nil, tree1) => getFunction(tree1)
-      case Function(_, _: CapturesAndResult) => None
+      case Function(_, _: CapturesAndResult) =>
+        // A function tree like this will be desugared
+        // into a capturing type in the typer,
+        // so None is returned.
+        None
       case t: Function => Some(t)
       case _ => None
     }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1419,6 +1419,7 @@ object Parsers {
     private def getFunction(tree: Tree): Option[Function] = tree match {
       case Parens(tree1) => getFunction(tree1)
       case Block(Nil, tree1) => getFunction(tree1)
+      case Function(_, _: CapturesAndResult) => None
       case t: Function => Some(t)
       case _ => None
     }

--- a/tests/neg-custom-args/captures/i18518.scala
+++ b/tests/neg-custom-args/captures/i18518.scala
@@ -1,0 +1,5 @@
+import language.experimental.captureChecking
+type Foo1 = [R] -> (x: Unit) ->{} Unit  // error
+type Foo2 = [R] -> (x: Unit) ->{cap} Unit  // error
+type Foo3 = (c: Int^) -> [R] -> (x: Unit) ->{c} Unit  // error
+type Foo4 = (c: Int^) -> [R] -> (x0: Unit) -> (x: Unit) ->{c} Unit


### PR DESCRIPTION
Fix #18518.

It is an implementation restriction that a value parameter has to follow a type abstraction. So `[X] -> T ->{x} U` should be rejected as a capturing type follows the type abstraction,but it wasn't. This PR refines the check in `Parsers.scala` to reject this case properly.