### PR TITLE
Fix incorrect comment parser used in nightly scaladoc

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2207,8 +2207,7 @@ object ScaladocConfigs {
     val stdLibRoot = projectRoot.relativize(managedSources.toPath.normalize())
     val docRootFile = stdLibRoot.resolve("rootdoc.txt")
 
-    val dottyManagesSources =
-      (`scala3-library-bootstrapped`/Compile/sourceDirectory).value
+    val dottyManagesSources = (`scala3-library-bootstrapped`/Compile/baseDirectory).value
 
     val tastyCoreSources = projectRoot.relativize((`tasty-core-bootstrapped`/Compile/scalaSource).value.toPath().normalize())
 


### PR DESCRIPTION
Previously a `sourceDirectory` sbt task would resolve to `library/src/main` which would usually be correct, but in the case of scala3-library, we have the sources directly under `library/src`. This lead to the fact that the incorrectly set `-comment-syntax` option could never match against the prefix for markdown, and would use the wiki syntax for all scala3-library sources.
Fixes #18511