### PR TITLE
Use the unwidened type when casting structural calls

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -969,16 +969,11 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
       !tree.symbol.exists
       && tree.isTerm
       && hasRefinement(tree.qualifier.tpe)
-    def loop(tree: Tree): Boolean = tree match
-      case TypeApply(fun, _) =>
-        loop(fun)
-      case Apply(fun, _) =>
-        loop(fun)
+    funPart(tree) match
       case tree: Select =>
         isStructuralTermSelect(tree)
       case _ =>
         false
-    loop(tree)
   }
 
   /** Return a pair consisting of (supercall, rest)

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -242,7 +242,7 @@ trait Dynamic {
 
     fun.tpe.widen match {
       case tpe: ValueType =>
-        structuralCall(nme.selectDynamic, Nil).maybeBoxingCast(fun.tpe)
+        structuralCall(nme.selectDynamic, Nil).maybeBoxingCast(fun.tpe.widenExpr)
 
       case tpe: MethodType =>
         def isDependentMethod(tpe: Type): Boolean = tpe match {

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -235,14 +235,14 @@ trait Dynamic {
           if ValueClasses.isDerivedValueClass(tpe.classSymbol) && qual.tpe <:< defn.ReflectSelectableTypeRef then
             val genericUnderlying = ValueClasses.valueClassUnbox(tpe.classSymbol.asClass)
             val underlying = tpe.select(genericUnderlying).widen.resultType
-            New(tpe, tree.cast(underlying) :: Nil)
+            New(tpe.widen, tree.cast(underlying) :: Nil)
           else
             tree
         maybeBoxed.cast(tpe)
 
     fun.tpe.widen match {
       case tpe: ValueType =>
-        structuralCall(nme.selectDynamic, Nil).maybeBoxingCast(tpe)
+        structuralCall(nme.selectDynamic, Nil).maybeBoxingCast(fun.tpe)
 
       case tpe: MethodType =>
         def isDependentMethod(tpe: Type): Boolean = tpe match {

--- a/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
@@ -181,7 +181,7 @@ object HoverProvider:
             findRefinement(parent)
           case _ => None
 
-      val refTpe = sel.tpe.metalsDealias match
+      val refTpe = sel.tpe.widen.metalsDealias match
         case r: RefinedType => Some(r)
         case t: (TermRef | TypeProxy) => Some(t.termSymbol.info.metalsDealias)
         case _ => None

--- a/tests/pos/i18263.orig.scala
+++ b/tests/pos/i18263.orig.scala
@@ -1,0 +1,16 @@
+sealed trait Scope
+sealed trait Domain extends Scope
+object Domain extends Domain
+
+trait Baz[T]
+def baz(using ck: Scope): Baz[ck.type] = ???
+
+class Foo extends scala.reflect.Selectable:
+  type TScope = Domain
+  final protected given TScope = Domain
+
+object ID:
+  val internal1 = new Foo:
+    val ii = new Foo:
+      val x = baz
+  val z = internal1.ii.x //error

--- a/tests/pos/i18263.scala
+++ b/tests/pos/i18263.scala
@@ -1,0 +1,15 @@
+final class Bar
+final class Inv[T]
+class Foo extends scala.reflect.Selectable:
+  type Boo = Bar
+  final given boo1: Boo = new Bar
+
+class Test:
+  def mkInv(using bar: Bar): Inv[bar.type] = new Inv()
+
+  def test: Unit =
+    val foo1     /* : Foo { val foo2: { z1 => Foo { val inv1: Inv[(z1.boo1 : z1.Boo)] }}} */ = new Foo:
+      val foo2   /* :                 { z1 => Foo { val inv1: Inv[(z1.boo1 : z1.Boo)] }}  */ = new Foo:
+        val inv1 /* :                                         Inv[(   boo1 :    Boo)]     */ = mkInv /* (this.boo1) */
+    val inv2 = foo1.foo2.inv1 // error
+    ()


### PR DESCRIPTION
So if the call is to a stable val, the call will have a stable type.
