### PR TITLE
A more robust scheme for resetting denotations after Recheck

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -168,10 +168,10 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
    */
   var pureFunsImportEncountered = false
 
-  /** Will be set to true if any of the compiled compilation units contains
-   *  a captureChecking language import.
+  /** Will be set to true if experimental.captureChecking is enabled
+   *  or any of the compiled compilation units contains a captureChecking language import.
    */
-  var ccImportEncountered = false
+  var ccEnabledSomewhere = Feature.enabledBySetting(Feature.captureChecking)(using ictx)
 
   private var myEnrichedErrorMessage = false
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -29,7 +29,7 @@ object CheckCaptures:
 
   class Pre extends PreRecheck, SymTransformer:
 
-    override def isEnabled(using Context) = true
+    override def isRunnable(using Context) = super.isRunnable && Feature.ccEnabledSomewhere
 
   	/**  - Reset `private` flags of parameter accessors so that we can refine them
      *     in Setup if they have non-empty capture sets.
@@ -190,7 +190,8 @@ class CheckCaptures extends Recheck, SymTransformer:
   import CheckCaptures.*
 
   def phaseName: String = "cc"
-  override def isEnabled(using Context) = true
+
+  override def isRunnable(using Context) = super.isRunnable && Feature.ccEnabledSomewhere
 
   def newRechecker()(using Context) = CaptureChecker(ctx)
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -42,7 +42,7 @@ object CheckCaptures:
         if sym.isAllOf(PrivateParamAccessor) && !sym.hasAnnotation(defn.ConstructorOnlyAnnot) then
           sym.copySymDenotation(initFlags = sym.flags &~ Private | Recheck.ResetPrivate)
         else if Synthetics.needsTransform(sym) then
-          Synthetics.transform(sym, toCC = true)
+          Synthetics.transform(sym)
         else sym
       else sym
   end Pre
@@ -203,11 +203,7 @@ class CheckCaptures extends Recheck, SymTransformer:
   override def run(using Context): Unit =
     if Feature.ccEnabled then
       super.run
-
-  override def transformSym(sym: SymDenotation)(using Context): SymDenotation =
-    if Synthetics.needsTransform(sym) then Synthetics.transform(sym, toCC = false)
-    else super.transformSym(sym)
-
+      
   override def printingContext(ctx: Context) = ctx.withProperty(ccStateKey, Some(new CCState))
 
   class CaptureChecker(ictx: Context) extends Rechecker(ictx):

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -34,14 +34,17 @@ object CheckCaptures:
   	/**  - Reset `private` flags of parameter accessors so that we can refine them
      *     in Setup if they have non-empty capture sets.
      *   - Special handling of some symbols defined for case classes.
+     *  Enabled only until recheck is finished, and provided some compilation unit
+     *  is CC-enabled.
      */
     def transformSym(sym: SymDenotation)(using Context): SymDenotation =
-      if sym.isAllOf(PrivateParamAccessor) && !sym.hasAnnotation(defn.ConstructorOnlyAnnot) then
-        sym.copySymDenotation(initFlags = sym.flags &~ Private | Recheck.ResetPrivate)
-      else if Synthetics.needsTransform(sym) then
-        Synthetics.transform(sym, toCC = true)
-      else
-        sym
+      if !pastRecheck && Feature.ccEnabledSomewhere then
+        if sym.isAllOf(PrivateParamAccessor) && !sym.hasAnnotation(defn.ConstructorOnlyAnnot) then
+          sym.copySymDenotation(initFlags = sym.flags &~ Private | Recheck.ResetPrivate)
+        else if Synthetics.needsTransform(sym) then
+          Synthetics.transform(sym, toCC = true)
+        else sym
+      else sym
   end Pre
 
   enum EnvKind:

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -306,7 +306,7 @@ extends tpd.TreeTraverser:
 
   /** Update info of `sym` for CheckCaptures phase only */
   private def updateInfo(sym: Symbol, info: Type)(using Context) =
-    sym.updateInfoBetween(preRecheckPhase, thisPhase, info, newOwnerFor(sym))
+    sym.updateInfo(preRecheckPhase, info, newOwnerFor(sym))
     sym.namedType match
       case ref: CaptureRef => ref.invalidateCaches()
       case _ =>

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -103,8 +103,8 @@ object Feature:
 
   /** Is captureChecking enabled for any of the currently compiled compilation units? */
   def ccEnabledSomewhere(using Context) =
-    enabledBySetting(captureChecking)
-    || ctx.run != null && ctx.run.nn.ccImportEncountered
+    if ctx.run != null then ctx.run.nn.ccEnabledSomewhere
+    else enabledBySetting(captureChecking)
 
   def sourceVersionSetting(using Context): SourceVersion =
     SourceVersion.valueOf(ctx.settings.source.value)
@@ -174,7 +174,7 @@ object Feature:
       true
     else if fullFeatureName == captureChecking then
       ctx.compilationUnit.needsCaptureChecking = true
-      if ctx.run != null then ctx.run.nn.ccImportEncountered = true
+      if ctx.run != null then ctx.run.nn.ccEnabledSomewhere = true
       true
     else
       false

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -299,12 +299,23 @@ object Phases {
      */
     def phaseName: String
 
+    /** This property is queried when phases are first assembled.
+     *  If it is false, the phase will be dropped from the set of phases to traverse.
+     */
+    def isEnabled(using Context): Boolean = true
+
+    /** This property is queried before a phase is run.
+     *  If it is false, the phase is skipped.
+     */
     def isRunnable(using Context): Boolean =
       !ctx.reporter.hasErrors
         // TODO: This might test an unintended condition.
         // To find out whether any errors have been reported during this
         // run one calls `errorsReported`, not `hasErrors`.
         // But maybe changing this would prevent useful phases from running?
+
+    /** True for all phases except NoPhase */
+    def exists: Boolean = true
 
     /** If set, allow missing or superfluous arguments in applications
      *  and type applications.
@@ -359,10 +370,6 @@ object Phases {
 
     /** Can this transform change the base types of a type? */
     def changesBaseTypes: Boolean = changesParents
-
-    def isEnabled(using Context): Boolean = true
-
-    def exists: Boolean = true
 
     def initContext(ctx: FreshContext): Unit = ()
 

--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -22,7 +22,10 @@ abstract class TypeError(using creationContext: Context) extends Exception(""):
    *  This is expensive and only useful for debugging purposes.
    */
   def computeStackTrace: Boolean =
-    ctx.debug || (cyclicErrors != noPrinter && this.isInstanceOf[CyclicReference] && !(ctx.mode is Mode.CheckCyclic))
+    ctx.debug
+    || (cyclicErrors != noPrinter && this.isInstanceOf[CyclicReference] && !(ctx.mode is Mode.CheckCyclic))
+    || ctx.settings.YdebugTypeError.value
+    || ctx.settings.YdebugError.value
 
   override def fillInStackTrace(): Throwable =
     if computeStackTrace then super.fillInStackTrace().nn

--- a/compiler/src/dotty/tools/dotc/transform/PreRecheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PreRecheck.scala
@@ -14,6 +14,8 @@ abstract class PreRecheck extends Phase, DenotTransformer:
 
   override def changesBaseTypes: Boolean = true
 
+  var pastRecheck = false
+
   def run(using Context): Unit = ()
 
   override def isCheckable = false

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -48,26 +48,19 @@ object Recheck:
 
   extension (sym: Symbol)
 
-    /** Update symbol's info to newInfo from prevPhase.next to lastPhase.
+    /** Update symbol's info to newInfo after `prevPhase`.
      *  Also update owner to newOwnerOrNull if it is not null.
-     *  Reset to previous info and owner for phases after lastPhase.
+     *  The update is valid until after Recheck. After that the symbol's denotation
+     *  is reset to what it was before PreRecheck.
      */
-    def updateInfoBetween(prevPhase: DenotTransformer, lastPhase: DenotTransformer, newInfo: Type, newOwnerOrNull: Symbol | Null = null)(using Context): Unit =
+    def updateInfo(prevPhase: DenotTransformer, newInfo: Type, newOwnerOrNull: Symbol | Null = null)(using Context): Unit =
       val newOwner = if newOwnerOrNull == null then sym.owner else newOwnerOrNull
       if (sym.info ne newInfo) || (sym.owner ne newOwner)  then
         val flags = sym.flags
         sym.copySymDenotation(
-            initFlags =
-              if flags.isAllOf(ResetPrivateParamAccessor)
-              then flags &~ ResetPrivate | Private
-              else flags
-          ).installAfter(lastPhase) // reset
-        sym.copySymDenotation(
             owner = newOwner,
             info = newInfo,
-            initFlags =
-              if newInfo.isInstanceOf[LazyType] then flags &~ Touched
-              else flags
+            initFlags = if newInfo.isInstanceOf[LazyType] then flags &~ Touched else flags
           ).installAfter(prevPhase)
 
     /** Does symbol have a new denotation valid from phase.next that is different
@@ -158,15 +151,19 @@ abstract class Recheck extends Phase, SymTransformer:
     // One failing test is pos/i583a.scala
 
   /** Change any `ResetPrivate` flags back to `Private` */
-  def transformSym(sym: SymDenotation)(using Context): SymDenotation =
-    if sym.isAllOf(Recheck.ResetPrivateParamAccessor) then
-      sym.copySymDenotation(initFlags = sym.flags &~ Recheck.ResetPrivate | Private)
-    else sym
+  def transformSym(symd: SymDenotation)(using Context): SymDenotation =
+    val sym = symd.symbol
+    if sym.isUpdatedAfter(preRecheckPhase) then atPhase(preRecheckPhase)(sym.denot)
+    else symd
 
   def run(using Context): Unit =
     val rechecker = newRechecker()
     rechecker.checkUnit(ctx.compilationUnit)
     rechecker.reset()
+
+  override def runOn(units: List[CompilationUnit])(using runCtx: Context): List[CompilationUnit] =
+    try super.runOn(units)
+    finally preRecheckPhase.pastRecheck = true
 
   def newRechecker()(using Context): Rechecker
 
@@ -197,6 +194,7 @@ abstract class Recheck extends Phase, SymTransformer:
     def reset()(using Context): Unit =
       for (ref, mbr) <- prevSelDenots.iterator do
         ref.withDenot(mbr)
+      preRecheckPhase
 
     /** Constant-folded rechecked type `tp` of tree `tree` */
     protected def constFold(tree: Tree, tp: Type)(using Context): Type =

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -153,7 +153,8 @@ abstract class Recheck extends Phase, SymTransformer:
   /** Change any `ResetPrivate` flags back to `Private` */
   def transformSym(symd: SymDenotation)(using Context): SymDenotation =
     val sym = symd.symbol
-    if sym.isUpdatedAfter(preRecheckPhase) then atPhase(preRecheckPhase)(sym.denot)
+    if sym.isUpdatedAfter(preRecheckPhase)
+    then atPhase(preRecheckPhase)(sym.denot.copySymDenotation())
     else symd
 
   def run(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -194,7 +194,6 @@ abstract class Recheck extends Phase, SymTransformer:
     def reset()(using Context): Unit =
       for (ref, mbr) <- prevSelDenots.iterator do
         ref.withDenot(mbr)
-      preRecheckPhase
 
     /** Constant-folded rechecked type `tp` of tree `tree` */
     protected def constFold(tree: Tree, tp: Type)(using Context): Type =


### PR DESCRIPTION
The new scheme works also for arbitrary denotation changes in PreRecheck.

Furthermore, recheck denot transformers are not run after Recheck has ended. This
means that effectively only symbols touched by the Rechecker are transformed and
reset again afterwards.
