### PR TITLE
use directives instead of scalac options in tests

### DIFF
--- a/compiler/test-resources/repl/i13208.scala
+++ b/compiler/test-resources/repl/i13208.scala
@@ -1,4 +1,4 @@
-// scalac: -source:future -deprecation
+//> using options -source:future -deprecation
 scala> type M[X] = X match { case Int => String case _ => Int }
 scala> type N[X] = X match { case List[_] => Int }
 1 warning found

--- a/compiler/test-resources/repl/rewrite-messages
+++ b/compiler/test-resources/repl/rewrite-messages
@@ -1,4 +1,4 @@
-// scalac: -source:future-migration -deprecation -Werror
+//> using options -source:future-migration -deprecation -Werror
 scala> import scala.util._
 -- Error: ----------------------------------------------------------------------
 1 | import scala.util._

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -69,7 +69,7 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
 
     val expectedOutput = lines.filter(nonBlank)
     val actualOutput = {
-      val opts = toolArgsFor(ToolName.Scalac)(lines.take(1))
+      val opts = toolArgsFor(ToolName.Scalac, scriptFile.map(_.toString))(lines.take(1))
       val (optsLine, inputLines) = if opts.isEmpty then ("", lines) else (lines.head, lines.drop(1))
       resetToInitial(opts)
 

--- a/tests/disabled/macro/pos/t8013/inpervolated_2.scala
+++ b/tests/disabled/macro/pos/t8013/inpervolated_2.scala
@@ -1,6 +1,4 @@
-/*
- * scalac: -Xfatal-warnings -Xlint
- */
+//> using options -Xfatal-warnings -Xlint
 package t8013
 
 // unsuspecting user of perverse macro

--- a/tests/pos-macros/i18409.scala
+++ b/tests/pos-macros/i18409.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Wunused:all
+//> using options -Werror -Wunused:all
 
 import scala.quoted.*
 


### PR DESCRIPTION
- update remaining `// scalac:` to `//> using options` in tests
- throw error when using old syntax in tests

fixes `scalac:` portion of #18149
still to do:
- rewrite `// test: -jvm 15+` to use a directive
- support `// scalajs: --skip` with a directive or similar

once this is done, we can remove the `toolArg` regex