### PR TITLE
Convert List.apply into `::` chains

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -60,7 +60,7 @@ abstract class AccessProxies {
   def addAccessorDefs(cls: Symbol, body: List[Tree])(using Context): List[Tree] = {
     val accDefs = accessorDefs(cls).toList
     transforms.println(i"add accessors for $cls: $accDefs%, %")
-    if (accDefs.isEmpty) body else body ++ accDefs
+    if (accDefs.isEmpty) body else body ::: accDefs
   }
 
   trait Insert {

--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -91,13 +91,13 @@ object BetaReduce:
       case _ => None
     tree match
       case Apply(Select(fn, nme.apply), args) if defn.isFunctionNType(fn.tpe) =>
-        recur(fn, List(args)) match
+        recur(fn, args :: Nil) match
           case Some(reduced) =>
             seq(bindingsBuf.result(), reduced).withSpan(tree.span)
           case None =>
             tree
       case Apply(TypeApply(Select(fn, nme.apply), targs), args) if fn.tpe.typeSymbol eq dotc.core.Symbols.defn.PolyFunctionClass =>
-        recur(fn, List(targs, args)) match
+        recur(fn, targs :: args :: Nil) match
           case Some(reduced) =>
             seq(bindingsBuf.result(), reduced).withSpan(tree.span)
           case None =>

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -561,13 +561,13 @@ object CheckUnused:
         else
           Nil
       val warnings =
-        val unsorted = sortedImp ++
-          sortedLocalDefs ++
-          sortedExplicitParams ++
-          sortedImplicitParams ++
-          sortedPrivateDefs ++
-          sortedPatVars ++
-          unsetLocalDefs ++
+        val unsorted = sortedImp :::
+          sortedLocalDefs :::
+          sortedExplicitParams :::
+          sortedImplicitParams :::
+          sortedPrivateDefs :::
+          sortedPatVars :::
+          unsetLocalDefs :::
           unsetPrivateDefs
 
         unsorted.sortBy { s =>

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -561,11 +561,19 @@ object CheckUnused:
         else
           Nil
       val warnings =
-        List(sortedImp, sortedLocalDefs, sortedExplicitParams, sortedImplicitParams,
-                  sortedPrivateDefs, sortedPatVars, unsetLocalDefs, unsetPrivateDefs).flatten.sortBy { s =>
-        val pos = s.pos.sourcePos
-        (pos.line, pos.column)
-      }
+        val unsorted = sortedImp ++
+          sortedLocalDefs ++
+          sortedExplicitParams ++
+          sortedImplicitParams ++
+          sortedPrivateDefs ++
+          sortedPatVars ++
+          unsetLocalDefs ++
+          unsetPrivateDefs
+
+        unsorted.sortBy { s =>
+          val pos = s.pos.sourcePos
+          (pos.line, pos.column)
+        }
       UnusedResult(warnings.toSet)
     end getUnused
     //============================ HELPERS ====================================
@@ -705,7 +713,7 @@ object CheckUnused:
         sym.everySymbol.exists(usedDef.apply)
 
       private def everySymbol(using Context): List[Symbol] =
-        List(sym, sym.companionClass, sym.companionModule, sym.moduleClass).filter(_.exists)
+        (sym :: sym.companionClass :: sym.companionModule :: sym.moduleClass :: Nil).filter(_.exists)
 
       /** A function is overriden. Either has `override flags` or parent has a matching member (type and name) */
       private def isOverriden(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -58,8 +58,8 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
           tp.derivedLambdaType(resType = addConstrParams(restpe))
         case _ =>
           tp.derivedLambdaType(
-            paramNames = tp.paramNames ++ (nameParamName :: ordinalParamName :: Nil),
-            paramInfos = tp.paramInfos ++ (defn.StringType :: defn.IntType :: Nil))
+            paramNames = tp.paramNames ::: (nameParamName :: ordinalParamName :: Nil),
+            paramInfos = tp.paramInfos ::: (defn.StringType :: defn.IntType :: Nil))
       }
   }
 
@@ -81,7 +81,7 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
       case app @ Apply(fn, args0) if fn.symbol.owner == targetCls =>
         if args0.nonEmpty && targetCls == defn.JavaEnumClass then
           report.error(em"the constructor of java.lang.Enum cannot be called explicitly", app.sourcePos)
-        cpy.Apply(app)(fn, args0 ++ args)
+        cpy.Apply(app)(fn, args0 ::: args)
       case p => p
     }
 
@@ -92,7 +92,7 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
       val tree1 = cpy.DefDef(tree)(
         paramss = tree.paramss.init
           :+ (tree.paramss.last.asInstanceOf[List[ValDef]]
-              ++ addedParams(sym, isLocal=false, Param)))
+              ::: addedParams(sym, isLocal=false, Param)))
       sym.setParamssFromDefs(tree1.paramss)
       tree1
     else tree
@@ -167,7 +167,7 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
       val addedForwarders = addedEnumForwarders(cls)
       cpy.Template(templ)(
         parents = addEnumConstrArgs(defn.JavaEnumClass, templ.parents, addedSyms.map(ref)),
-        body = params ++ addedDefs ++ addedForwarders ++ rest)
+        body = params ::: addedDefs ::: addedForwarders ::: rest)
     else if isJavaEnumValueImpl(cls) then
       def creatorParamRef(name: TermName) =
         ref(cls.owner.paramSymss.head.find(_.name == name).get)

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -58,8 +58,8 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
           tp.derivedLambdaType(resType = addConstrParams(restpe))
         case _ =>
           tp.derivedLambdaType(
-            paramNames = tp.paramNames ++ List(nameParamName, ordinalParamName),
-            paramInfos = tp.paramInfos ++ List(defn.StringType, defn.IntType))
+            paramNames = tp.paramNames ++ (nameParamName :: ordinalParamName :: Nil),
+            paramInfos = tp.paramInfos ++ (defn.StringType :: defn.IntType :: Nil))
       }
   }
 
@@ -70,7 +70,7 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
     val flags = flag | Synthetic | (if isLocal then Private | Deferred else EmptyFlags)
     val nameParam = newSymbol(owner, nameParamName, flags, defn.StringType, coord = owner.span)
     val ordinalParam = newSymbol(owner, ordinalParamName, flags, defn.IntType, coord = owner.span)
-    List(ValDef(nameParam), ValDef(ordinalParam))
+    ValDef(nameParam) :: ValDef(ordinalParam) :: Nil
   }
 
   /** Add arguments `args` to the parent constructor application in `parents` that invokes
@@ -173,9 +173,9 @@ class CompleteJavaEnums extends MiniPhase with InfoTransformer { thisPhase =>
         ref(cls.owner.paramSymss.head.find(_.name == name).get)
       val args =
         if cls.owner.isAllOf(EnumCase) then
-          List(Literal(Constant(cls.owner.name.toString)), Literal(Constant(ordinalFor(cls.owner))))
+          Literal(Constant(cls.owner.name.toString)) :: Literal(Constant(ordinalFor(cls.owner))) :: Nil
         else
-          List(creatorParamRef(nme.nameDollar), creatorParamRef(nme.ordinalDollar_))
+          creatorParamRef(nme.nameDollar) :: creatorParamRef(nme.ordinalDollar_) :: Nil
       cpy.Template(templ)(
         parents = addEnumConstrArgs(cls.owner.owner.linkedClass, templ.parents, args),
       )

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -859,9 +859,9 @@ object Erasure {
             case Block(stats, expr) =>
               cpy.Block(fun1)(stats, app(expr))
             case Apply(fun2, SeqLiteral(prevArgs, argTpt) :: _) if bunchArgs =>
-              mkApply(fun2, JavaSeqLiteral(prevArgs ++ args1, argTpt) :: Nil)
+              mkApply(fun2, JavaSeqLiteral(prevArgs ::: args1, argTpt) :: Nil)
             case Apply(fun2, prevArgs) =>
-              mkApply(fun2, prevArgs ++ args1)
+              mkApply(fun2, prevArgs ::: args1)
             case _ if bunchArgs =>
               mkApply(fun1, JavaSeqLiteral(args1, TypeTree(defn.ObjectType)) :: Nil)
             case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -69,8 +69,8 @@ class ExpandSAMs extends MiniPhase:
           val tpe1 = collectAndStripRefinements(tpe)
           val Seq(samDenot) = tpe1.possibleSamMethods
           cpy.Block(tree)(stats,
-            AnonClass(List(tpe1),
-              List(samDenot.symbol.asTerm.name -> fn.symbol.asTerm),
+            AnonClass(tpe1 :: Nil,
+              samDenot.symbol.asTerm.name -> fn.symbol.asTerm :: Nil,
               refinements.toList
             )
           )
@@ -134,9 +134,9 @@ class ExpandSAMs extends MiniPhase:
     val pfRHS = partialFunRHS(anon.rhs)
     val anonSym = anon.symbol
     val anonTpe = anon.tpe.widen
-    val parents = List(
-      defn.AbstractPartialFunctionClass.typeRef.appliedTo(anonTpe.firstParamTypes.head, anonTpe.resultType),
-      defn.SerializableType)
+    val parents =
+      defn.AbstractPartialFunctionClass.typeRef.appliedTo(anonTpe.firstParamTypes.head, anonTpe.resultType) ::
+      defn.SerializableType :: Nil
 
     AnonClass(anonSym.owner, parents, tree.span) { pfSym =>
       def overrideSym(sym: Symbol) = sym.copy(

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -87,9 +87,9 @@ class ExtensionMethods extends MiniPhase with DenotTransformer with FullParamete
           val underlying = valueErasure(underlyingOfValueClass(valueClass))
           val evt = ErasedValueType(valueClass.typeRef, underlying)
           val u2evtSym = newSymbol(moduleSym, nme.U2EVT, Synthetic | Method,
-            MethodType(List(nme.x_0), List(underlying), evt))
+            MethodType(nme.x_0 :: Nil, underlying :: Nil, evt))
           val evt2uSym = newSymbol(moduleSym, nme.EVT2U, Synthetic | Method,
-            MethodType(List(nme.x_0), List(evt), underlying))
+            MethodType(nme.x_0 :: Nil, evt :: Nil, underlying))
           enterInModuleClass(u2evtSym)
           enterInModuleClass(evt2uSym)
 

--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -118,9 +118,9 @@ trait FullParameterization {
 
     info match {
       case info: PolyType =>
-        PolyType(info.paramNames ++ ctnames)(
+        PolyType(info.paramNames ::: ctnames)(
           pt =>
-            (info.paramInfos.map(mapClassParams(_, pt).bounds) ++
+            (info.paramInfos.map(mapClassParams(_, pt).bounds) :::
              mappedClassBounds(pt)).mapConserve(_.subst(info, pt).bounds),
           pt => resultType(mapClassParams(_, pt)).subst(info, pt))
       case _ =>
@@ -164,7 +164,7 @@ trait FullParameterization {
             val base = thisArg.tpe.baseType(origClass)
             assert(base.exists)
             ref(rewired.termRef)
-              .appliedToTypeTrees(targs ++ base.argInfos.map(TypeTree(_)))
+              .appliedToTypeTrees(targs ::: base.argInfos.map(TypeTree(_)))
               .appliedTo(thisArg)
           } else EmptyTree
         }
@@ -204,7 +204,7 @@ trait FullParameterization {
 
       new TreeTypeMap(
         typeMap = rewireType(_)
-          .subst(origLeadingTypeParamSyms ++ origOtherParamSyms, (trefs ++ argRefs).tpes)
+          .subst(origLeadingTypeParamSyms ::: origOtherParamSyms, (trefs ::: argRefs).tpes)
           .substThisUnlessStatic(origClass, thisRef.tpe),
         treeMap = {
           case tree: This if tree.symbol == origClass => thisRef

--- a/compiler/src/dotty/tools/dotc/transform/FunctionXXLForwarders.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FunctionXXLForwarders.scala
@@ -36,7 +36,7 @@ class FunctionXXLForwarders extends MiniPhase with IdentityDenotTransformer {
       var idx = -1
       val argss = receiver.tpe.widenDealias.paramInfoss.map(_.map { param =>
         idx += 1
-        argsApply.appliedToTermArgs(List(Literal(Constant(idx)))).cast(param)
+        argsApply.appliedToTermArgs(Literal(Constant(idx)) :: Nil).cast(param)
       })
       ref(receiver.symbol).appliedToArgss(argss).cast(defn.ObjectType)
     }
@@ -51,8 +51,8 @@ class FunctionXXLForwarders extends MiniPhase with IdentityDenotTransformer {
            ddef.symbol.allOverriddenSymbols.exists(sym => defn.isXXLFunctionClass(sym.owner))
       }
       yield {
-        val xsType = defn.ArrayType.appliedTo(List(defn.ObjectType))
-        val methType = MethodType(List(nme.args))(_ => List(xsType), _ => defn.ObjectType)
+        val xsType = defn.ArrayType.appliedTo(defn.ObjectType :: Nil)
+        val methType = MethodType(nme.args :: Nil)(_ => xsType :: Nil, _ => defn.ObjectType)
         val meth = newSymbol(ddef.symbol.owner, nme.apply, Synthetic | Method, methType)
         DefDef(meth, paramss => forwarderRhs(ddef, paramss.head.head))
       }

--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -76,7 +76,7 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
 
       /** The parameter references defined by the constructor info */
       def allParamRefs(tp: Type): List[ParamRef] = tp match {
-        case tp: LambdaType => tp.paramRefs ++ allParamRefs(tp.resultType)
+        case tp: LambdaType => tp.paramRefs ::: allParamRefs(tp.resultType)
         case _              => Nil
       }
 
@@ -236,7 +236,7 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
               cpy.TypeDef(tdef)(
                   rhs = cpy.Template(impl)(
                       parents = hoistedSuperCall :: others,
-                      body = hoistedBody ++ staticSuperArgDefs)) ::
+                      body = hoistedBody ::: staticSuperArgDefs)) ::
               enclSuperArgDefs)
         }
       case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
@@ -27,18 +27,17 @@ class Instrumentation extends MiniPhase { thisPhase =>
   override def isEnabled(using Context) =
     ctx.settings.Yinstrument.value
 
-  private val collectionNamesOfInterest = List(
-    "map", "flatMap", "filter", "filterNot", "withFilter", "collect", "flatten", "foldLeft", "foldRight", "take",
-    "reverse", "zip", "++", ":::", ":+", "distinct", "dropRight", "takeRight", "groupBy", "groupMap", "init", "inits",
-    "interect", "mkString", "partition", "reverse_:::", "scanLeft", "scanRight",
-    "sortBy", "sortWith", "sorted", "span", "splitAt", "takeWhile", "transpose", "unzip", "unzip3",
-    "updated", "zipAll", "zipWithIndex",
-    "mapConserve", "mapconserve", "filterConserve", "zipWithConserve", "mapWithIndexConserve"
-  )
+  private val collectionNamesOfInterest =
+    "map" :: "flatMap" :: "filter" :: "filterNot" :: "withFilter" :: "collect" :: "flatten" :: "foldLeft" :: "foldRight" :: "take" ::
+    "reverse" :: "zip" :: "++" :: ":::" :: ":+" :: "distinct" :: "dropRight" :: "takeRight" :: "groupBy" :: "groupMap" :: "init" :: "inits" ::
+    "interect" :: "mkString" :: "partition" :: "reverse_:::" :: "scanLeft" :: "scanRight" ::
+    "sortBy" :: "sortWith" :: "sorted" :: "span" :: "splitAt" :: "takeWhile" :: "transpose" :: "unzip" :: "unzip3" ::
+    "updated" :: "zipAll" :: "zipWithIndex" ::
+    "mapConserve" :: "mapconserve" :: "filterConserve" :: "zipWithConserve" :: "mapWithIndexConserve" :: Nil
 
-  private val namesOfInterest = collectionNamesOfInterest ++ List(
-    "::", "+=", "toString", "newArray", "box", "toCharArray", "termName", "typeName",
-    "slice", "staticRef", "requiredClass")
+  private val namesOfInterest = collectionNamesOfInterest ++ (
+    "::" :: "+=" :: "toString" :: "newArray" :: "box" :: "toCharArray" :: "termName" :: "typeName" ::
+    "slice" :: "staticRef" :: "requiredClass" :: Nil)
 
   private var namesToRecord: Set[Name] = _
   private var collectionNamesToRecord: Set[Name] = _

--- a/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Instrumentation.scala
@@ -35,7 +35,7 @@ class Instrumentation extends MiniPhase { thisPhase =>
     "updated" :: "zipAll" :: "zipWithIndex" ::
     "mapConserve" :: "mapconserve" :: "filterConserve" :: "zipWithConserve" :: "mapWithIndexConserve" :: Nil
 
-  private val namesOfInterest = collectionNamesOfInterest ++ (
+  private val namesOfInterest = collectionNamesOfInterest ::: (
     "::" :: "+=" :: "toString" :: "newArray" :: "box" :: "toCharArray" :: "termName" :: "typeName" ::
     "slice" :: "staticRef" :: "requiredClass" :: Nil)
 

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -85,8 +85,8 @@ object LambdaLift:
       case MethodTpe(pnames, ptypes, restpe) =>
         val ps = proxies(local)
         MethodType(
-          ps.map(_.name.asTermName) ++ pnames,
-          ps.map(_.info) ++ ptypes,
+          ps.map(_.name.asTermName) ::: pnames,
+          ps.map(_.info) ::: ptypes,
           restpe)
       case info => info
     }
@@ -169,7 +169,7 @@ object LambdaLift:
 
     def addFreeArgs(sym: Symbol, args: List[Tree])(using Context): List[Tree] =
       val fvs = deps.freeVars(sym)
-      if fvs.nonEmpty then fvs.toList.map(proxyRef(_)) ++ args else args
+      if fvs.nonEmpty then fvs.toList.map(proxyRef(_)) ::: args else args
 
     def addFreeParams(tree: Tree, proxies: List[Symbol])(using Context): Tree = proxies match {
       case Nil => tree
@@ -192,12 +192,12 @@ object LambdaLift:
         tree match {
           case tree: DefDef =>
             cpy.DefDef(tree)(
-                paramss = tree.termParamss.map(freeParamDefs ++ _),
+                paramss = tree.termParamss.map(freeParamDefs ::: _),
                 rhs =
                   if (sym.isPrimaryConstructor && !sym.owner.is(Trait)) copyParams(tree.rhs)
                   else tree.rhs)
           case tree: Template =>
-            cpy.Template(tree)(body = freeParamDefs ++ tree.body)
+            cpy.Template(tree)(body = freeParamDefs ::: tree.body)
         }
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -227,7 +227,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
       Block(stats.init, stats.last),
       unitLiteral
     )
-    DefDef(sym.asTerm, Block(List(init), targetRef.ensureApplied))
+    DefDef(sym.asTerm, Block(init :: Nil, targetRef.ensureApplied))
   }
 
   /** Create thread-unsafe lazy accessor for not-nullable types  equivalent to such code
@@ -249,7 +249,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
       Block(stats.init, stats.last),
       unitLiteral
     )
-    DefDef(sym.asTerm, Block(List(init), targetRef.ensureApplied))
+    DefDef(sym.asTerm, Block(init :: Nil, targetRef.ensureApplied))
   }
 
   def transformMemberDefThreadUnsafe(x: ValOrDefDef)(using Context): Thicket = {
@@ -567,13 +567,13 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
       CaseDef(
         Bind(caseSymbol, ref(caseSymbol)),
         EmptyTree,
-        Block(List(triggerRetry), Throw(ref(caseSymbol)))
+        Block(triggerRetry :: Nil, Throw(ref(caseSymbol)))
       )
     }
 
     val initialize = If(
       casFlag.appliedTo(thiz, offset, flagRef, computeState, fieldId),
-      Try(compute, List(retryCase), EmptyTree),
+      Try(compute, retryCase :: Nil, EmptyTree),
       unitLiteral
     )
 
@@ -587,7 +587,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
       )
     )
 
-    val loop = WhileDo(EmptyTree, Block(List(flagDef, stateDef), condition))
+    val loop = WhileDo(EmptyTree, Block(flagDef :: stateDef :: Nil, condition))
     DefDef(methodSymbol, loop)
   }
 
@@ -634,7 +634,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
         flag = ValDef(flagSymbol, Literal(Constant(0L)))
         val fieldTree = thizClass.select(lazyNme.RLazyVals.getDeclaredField).appliedTo(Literal(Constant(flagName.toString)))
         val offsetTree = ValDef(offsetSymbol.nn, getOffsetStatic.appliedTo(fieldTree))
-        appendOffsetDefs += (claz -> new OffsetInfo(List(offsetTree), ord))
+        appendOffsetDefs += (claz -> new OffsetInfo(offsetTree :: Nil, ord))
     }
 
     val containerName = LazyLocalName.fresh(x.name.asTermName)

--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -32,13 +32,13 @@ class MacroAnnotations:
    */
   def expandAnnotations(tree: MemberDef)(using Context): List[DefTree] =
     if !hasMacroAnnotation(tree.symbol) then
-      List(tree)
+      tree :: Nil
     else if tree.symbol.is(Module) && !tree.symbol.isClass then
       // only class is transformed
-      List(tree)
+      tree :: Nil
     else if tree.symbol.isType && !tree.symbol.isClass then
       report.error("macro annotations are not supported on type", tree)
-      List(tree)
+      tree :: Nil
     else
       debug.println(i"Expanding macro annotations of:\n$tree")
 
@@ -63,7 +63,7 @@ class MacroAnnotations:
                   case ex: scala.quoted.runtime.StopMacroExpansion =>
                     if !ctx.reporter.hasErrors then
                       report.error("Macro expansion was aborted by the macro without any errors reported. Macros should issue errors to end-users when aborting a macro expansion with StopMacroExpansion.", annot.tree)
-                    List(tree)
+                    tree :: Nil
                   case Interpreter.MissingClassDefinedInCurrentRun(sym) =>
                     Interpreter.suspendOnMissing(sym, annot.tree)
                   case NonFatal(ex) =>
@@ -75,7 +75,7 @@ class MacroAnnotations:
                           |    ${stack.mkString("\n    ")}
                           |"""
                     report.error(msg, annot.tree)
-                    List(tree)
+                    tree :: Nil
                   case _ =>
                     throw ex0
           transformedTrees.span(_.symbol != tree.symbol) match

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -273,7 +273,7 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
             else if (getter.is(Lazy, butNot = Module))
               transformFollowing(superRef(getter).appliedToNone)
             else if (getter.is(Module))
-              New(getter.info.resultType, List(This(cls)))
+              New(getter.info.resultType, This(cls) :: Nil)
             else
               Underscore(getter.info.resultType)
           // transformFollowing call is needed to make memoize & lazy vals run

--- a/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
@@ -14,7 +14,7 @@ class MixinOps(cls: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
   val superCls: Symbol = cls.superClass
   val mixins: List[ClassSymbol] = cls.mixins
 
-  lazy val JUnit4Annotations: List[Symbol] = List("Test", "Ignore", "Before", "After", "BeforeClass", "AfterClass").
+  lazy val JUnit4Annotations: List[Symbol] = ("Test" :: "Ignore" :: "Before" :: "After" :: "BeforeClass" :: "AfterClass" :: Nil).
     map(n => getClassIfDefined("org.junit." + n)).
     filter(_.exists)
 

--- a/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
@@ -69,7 +69,7 @@ class MoveStatics extends MiniPhase with SymTransformer {
             case _ => false
           }
 
-          rebuild(companion, companionTmpl.body ++ staticDefs) :: rebuild(module, remainingDefs) :: Nil
+          rebuild(companion, companionTmpl.body ::: staticDefs) :: rebuild(module, remainingDefs) :: Nil
         }
       }
       val newPairs =
@@ -81,7 +81,7 @@ class MoveStatics extends MiniPhase with SymTransformer {
               rebuild(classDef, tmpl.body) :: Nil
             }
             else move(classes.head, classes.tail.head)
-      Trees.flatten(newPairs.toList.flatten ++ others)
+      Trees.flatten(newPairs.toList.flatten ::: others)
     }
     else trees
 }

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1042,10 +1042,9 @@ object PatternMatcher {
       case _ =>
     end checkSwitch
 
-    val optimizations: List[(String, Plan => Plan)] = List(
-      "mergeTests" -> mergeTests,
-      "inlineVars" -> inlineVars
-    )
+    val optimizations: List[(String, Plan => Plan)] =
+      "mergeTests" -> mergeTests ::
+      "inlineVars" -> inlineVars :: Nil
 
     /** Translate pattern match to sequence of tests. */
     def translateMatch(tree: Match): Tree = {

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -235,7 +235,7 @@ object PickleQuotes {
       val typeName = body.tpe.typeSymbol.name
       val literalValue =
         if lit.const.tag == Constants.NullTag || lit.const.tag == Constants.UnitTag then Nil
-        else List(body)
+        else body :: Nil
       val constModule = lit.const.tag match
         case Constants.BooleanTag => defn. Quotes_reflect_BooleanConstant
         case Constants.ByteTag => defn. Quotes_reflect_ByteConstant
@@ -321,8 +321,8 @@ object PickleQuotes {
         else
           Lambda(
             MethodType(
-              List(nme.idx, nme.contents, nme.quotes).map(name => UniqueName.fresh(name).toTermName),
-              List(defn.IntType, defn.SeqType.appliedTo(defn.AnyType), defn.QuotesClass.typeRef),
+              (nme.idx :: nme.contents :: nme.quotes :: Nil).map(name => UniqueName.fresh(name).toTermName),
+              defn.IntType :: defn.SeqType.appliedTo(defn.AnyType) :: defn.QuotesClass.typeRef :: Nil,
               defn.QuotedExprClass.typeRef.appliedTo(defn.AnyType)),
             args =>
               val cases = holeContents.zipWithIndex.map { case (splice, idx) =>
@@ -352,8 +352,8 @@ object PickleQuotes {
         if quote.isTypeQuote then defn.QuoteUnpickler_unpickleTypeV2
         else defn.QuoteUnpickler_unpickleExprV2
       val unpickleArgs =
-        if quote.isTypeQuote then List(pickledQuoteStrings, types)
-        else List(pickledQuoteStrings, types, termHoles)
+        if quote.isTypeQuote then pickledQuoteStrings :: types :: Nil
+        else pickledQuoteStrings :: types :: termHoles :: Nil
       quotes
         .asInstance(defn.QuoteUnpicklerClass.typeRef)
         .select(unpickleMeth).appliedToType(bodyType)

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -167,7 +167,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
               if cls.isOneOf(GivenOrImplicit) then
                 sym.updateAnnotationsAfter(thisPhase,
                   atPhase(thisPhase)(cls.annotationsCarrying(Set(defn.CompanionMethodMetaAnnot)))
-                    ++ sym.annotations)
+                    ::: sym.annotations)
           else
             if sym.is(Param) then
               sym.keepAnnotationsCarrying(thisPhase, Set(defn.ParamMetaAnnot), orNoneOf = defn.NonBeanMetaAnnots)
@@ -220,7 +220,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
         def decompose(tree: TypeApply): (Tree, List[Tree]) = tree.fun match {
           case fun: TypeApply =>
             val (tycon, args) = decompose(fun)
-            (tycon, args ++ tree.args)
+            (tycon, args ::: tree.args)
           case _ =>
             (tree.fun, tree.args)
         }

--- a/compiler/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -59,7 +59,7 @@ class SelectStatic extends MiniPhase with IdentityDenotTransformer {
     val tree1 =
       if isStaticRef && !tree.qualifier.symbol.isAllOf(JavaModule) && !tree.qualifier.isType then
         if isStaticOwnerRef(tree.qualifier) then ref(sym)
-        else Block(List(tree.qualifier), ref(sym))
+        else Block(tree.qualifier :: Nil, ref(sym))
       else tree
 
     normalize(tree1)

--- a/compiler/src/dotty/tools/dotc/transform/Splicing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicing.scala
@@ -178,7 +178,7 @@ class Splicing extends MacroTransform:
       val bindingsTypes = bindings.map(_.termRef.widenTermRefExpr)
       val methType = MethodType(bindingsTypes, newTree.tpe)
       val meth = newSymbol(spliceOwner, nme.ANON_FUN, Synthetic | Method, methType)
-      val ddef = DefDef(meth, List(bindings), newTree.tpe, newTree.changeOwner(ctx.owner, meth))
+      val ddef = DefDef(meth, bindings :: Nil, newTree.tpe, newTree.changeOwner(ctx.owner, meth))
       val fnType = defn.FunctionType(bindings.size, isContextual = false).appliedTo(bindingsTypes :+ newTree.tpe)
       val closure = Block(ddef :: Nil, Closure(Nil, ref(meth), TypeTree(fnType)))
       tpd.Hole(true, holeIdx, refs, closure, tpe)
@@ -348,7 +348,7 @@ class Splicing extends MacroTransform:
     private def spliced(tpe: Type)(body: Context ?=> Tree)(using Context): Tree =
       val exprTpe = defn.QuotedExprClass.typeRef.appliedTo(tpe)
       val closure =
-        val methTpe = ContextualMethodType(List(defn.QuotesClass.typeRef), exprTpe)
+        val methTpe = ContextualMethodType(defn.QuotesClass.typeRef :: Nil, exprTpe)
         val meth = newSymbol(ctx.owner, nme.ANON_FUN, Synthetic | Method, methTpe)
         Closure(meth, argss => {
           withCurrentQuote(argss.head.head) {

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -749,7 +749,7 @@ object TreeChecker {
         if isTerm then defn.QuotedExprClass.typeRef.appliedTo(tree1.typeOpt)
         else defn.QuotedTypeClass.typeRef.appliedTo(tree1.typeOpt)
       val contextualResult =
-        defn.FunctionOf(List(defn.QuotesClass.typeRef), expectedResultType, isContextual = true)
+        defn.FunctionOf(defn.QuotesClass.typeRef :: Nil, expectedResultType, isContextual = true)
       val expectedContentType =
         defn.FunctionOf(argQuotedTypes, contextualResult)
       assert(content.typeOpt =:= expectedContentType, i"unexpected content of hole\nexpected: ${expectedContentType}\nwas: ${content.typeOpt}")

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -187,7 +187,7 @@ object TypeTestsCasts {
         def isPrimitive(tp: Type) = tp.classSymbol.isPrimitiveValueClass
 
         def derivedTree(expr1: Tree, sym: Symbol, tp: Type) =
-          cpy.TypeApply(tree)(expr1.select(sym).withSpan(expr.span), List(TypeTree(tp)))
+          cpy.TypeApply(tree)(expr1.select(sym).withSpan(expr.span), TypeTree(tp) :: Nil)
 
         def inMatch =
           tree.fun.symbol == defn.Any_typeTest ||  // new scheme

--- a/compiler/src/dotty/tools/dotc/transform/VCInlineMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/VCInlineMethods.scala
@@ -76,7 +76,7 @@ class VCInlineMethods extends MiniPhase with IdentityDenotTransformer {
               TypeTree(tparam.typeRef.asSeenFrom(ev.tpe, origCls)))
             transformFollowing(
               ref(extensionMeth)
-              .appliedToTypeTrees(mtArgs ++ ctArgs)
+              .appliedToTypeTrees(mtArgs ::: ctArgs)
               .appliedTo(ev)
               .appliedToArgss(mArgss))
           }

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1253,9 +1253,9 @@ object Objects:
   def patternMatch(scrutinee: Value, cases: List[CaseDef], thisV: ThisValue, klass: ClassSymbol): Contextual[Value] =
     // expected member types for `unapplySeq`
     def lengthType = ExprType(defn.IntType)
-    def lengthCompareType = MethodType(List(defn.IntType), defn.IntType)
-    def applyType(elemTp: Type) = MethodType(List(defn.IntType), elemTp)
-    def dropType(elemTp: Type) = MethodType(List(defn.IntType), defn.CollectionSeqType.appliedTo(elemTp))
+    def lengthCompareType = MethodType(defn.IntType :: Nil, defn.IntType)
+    def applyType(elemTp: Type) = MethodType(defn.IntType :: Nil, elemTp)
+    def dropType(elemTp: Type) = MethodType(defn.IntType :: Nil, defn.CollectionSeqType.appliedTo(elemTp))
     def toSeqType(elemTp: Type) = ExprType(defn.CollectionSeqType.appliedTo(elemTp))
 
     def getMemberMethod(receiver: Type, name: TermName, tp: Type): Denotation =

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -466,7 +466,7 @@ object Semantic:
 
       case (RefSet(refs1), RefSet(refs2)) =>
         val diff = refs2.filter(ref => refs1.forall(_ != ref))
-        RefSet(refs1 ++ diff)
+        RefSet(refs1 ::: diff)
 
     /** Conservatively approximate the value with `Cold` or `Hot` */
     def widenArg: Contextual[Value] =

--- a/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/StringInterpolatorOpt.scala
@@ -117,7 +117,7 @@ class StringInterpolatorOpt extends MiniPhase:
     // Perform format checking and normalization, then make it StringOps(fmt).format(args1) with tweaked args
     def transformF(fun: Tree, args: Tree): Tree =
       val (fmt, args1) = FormatInterpolatorTransform.checked(fun, args)
-      resolveConstructor(defn.StringOps.typeRef, List(fmt))
+      resolveConstructor(defn.StringOps.typeRef, fmt :: Nil)
         .select(nme.format)
         .appliedTo(args1)
     // Starting with Scala 2.13, s and raw are macros in the standard
@@ -135,7 +135,7 @@ class StringInterpolatorOpt extends MiniPhase:
       evalOnce(pre) { sc =>
         val parts = sc.select(defn.StringContext_parts)
         ref(defn.StringContextModule_standardInterpolator)
-          .appliedToTermArgs(List(process, args, parts))
+          .appliedToTermArgs(process :: args :: parts :: Nil)
       }
     end transformS
     // begin transformApply

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -171,7 +171,7 @@ object SpaceEngine {
       LazyList(spaces: _*).flatMap(flatten)
 
     case _ =>
-      List(space)
+      space :: Nil
   }
 
   /** Is `a` a subspace of `b`? Equivalent to `simplify(simplify(a) - simplify(b)) == Empty`, but faster */
@@ -556,7 +556,7 @@ object SpaceEngine {
 
     val sig =
       if (resTp.isRef(defn.BooleanClass))
-        List()
+        Nil
       else {
         val isUnapplySeq = unappSym.name == nme.unapplySeq
 
@@ -619,8 +619,8 @@ object SpaceEngine {
           case tp if tpB <:< tp                              => tpB
           case tp if !TypeComparer.provablyDisjoint(tp, tpB) => AndType(tp, tpB)
 
-      case OrType(tp1, tp2)                            => List(tp1, tp2)
-      case tp if tp.isRef(defn.BooleanClass)           => List(ConstantType(Constant(true)), ConstantType(Constant(false)))
+      case OrType(tp1, tp2)                            => tp1 :: tp2 :: Nil
+      case tp if tp.isRef(defn.BooleanClass)           => ConstantType(Constant(true)) :: ConstantType(Constant(false)) :: Nil
       case tp if tp.isRef(defn.UnitClass)              => ConstantType(Constant(())) :: Nil
       case tp @ NamedType(Parts(parts), _)             => parts.map(tp.derivedSelect)
       case _: SingletonType                            => ListOfNoType
@@ -637,11 +637,11 @@ object SpaceEngine {
       case tp if tp.isDecomposableToChildren =>
         def getChildren(sym: Symbol): List[Symbol] =
           sym.children.flatMap { child =>
-            if child eq sym then List(sym) // i3145: sealed trait Baz, val x = new Baz {}, Baz.children returns Baz...
+            if child eq sym then sym :: Nil // i3145: sealed trait Baz, val x = new Baz {}, Baz.children returns Baz...
             else if tp.classSymbol == defn.TupleClass || tp.classSymbol == defn.NonEmptyTupleClass then
-              List(child) // TupleN and TupleXXL classes are used for Tuple, but they aren't Tuple's children
+              child :: Nil // TupleN and TupleXXL classes are used for Tuple, but they aren't Tuple's children
             else if (child.is(Private) || child.is(Sealed)) && child.isOneOf(AbstractOrTrait) then getChildren(child)
-            else List(child)
+            else child :: Nil
           }
         val children = getChildren(tp.classSymbol)
         debug.println(i"candidates for $tp : $children")
@@ -683,7 +683,7 @@ object SpaceEngine {
       val cls = tp.classSymbol
       tp.hasSimpleKind && cls.is(Sealed) && cls.isOneOf(AbstractOrTrait) && !cls.hasAnonymousChild && cls.children.nonEmpty
 
-  val ListOfNoType    = List(NoType)
+  val ListOfNoType    = NoType :: Nil
   val ListOfTypNoType = ListOfNoType.map(Typ(_, decomposed = true))
 
   object Parts:

--- a/compiler/src/dotty/tools/dotc/transform/sjs/ExplicitJSClasses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/ExplicitJSClasses.scala
@@ -528,17 +528,17 @@ class ExplicitJSClasses extends MiniPhase with InfoTransformer { thisPhase =>
 
       val jsclassVal = myState.localClass2jsclassVal(sym)
       if (myState.notYetReferencedLocalClasses.remove(cls)) {
-        Thicket(List(tree, ValDef(jsclassVal, rhs)))
+        Thicket(tree :: ValDef(jsclassVal, rhs) :: Nil)
       } else {
         /* We are using `jsclassVal` inside the definition of the class.
          * We need to declare it as var before and initialize it after the class definition.
          */
         jsclassVal.setFlag(Mutable)
-        Thicket(List(
-            ValDef(jsclassVal, Literal(Constant(null))),
-            tree,
-            Assign(ref(jsclassVal), rhs)
-        ))
+        Thicket(
+            ValDef(jsclassVal, Literal(Constant(null))) ::
+            tree ::
+            Assign(ref(jsclassVal), rhs) :: Nil
+        )
       }
     } else {
       tree

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
@@ -155,7 +155,7 @@ class JUnitBootstrappers extends MiniPhase {
     val owner = testClass.owner
     val moduleSym = newCompleteModuleSymbol(owner, bootstrapperName,
       Synthetic, Synthetic,
-      List(defn.ObjectType, junitdefn.BootstrapperType), newScope,
+      defn.ObjectType :: junitdefn.BootstrapperType :: Nil, newScope,
       coord = testClass.span, assocFile = testClass.assocFile).entered
     val classSym = moduleSym.moduleClass.asClass
 
@@ -163,15 +163,14 @@ class JUnitBootstrappers extends MiniPhase {
 
     val testMethods = annotatedMethods(testClass, junitdefn.TestAnnotClass)
 
-    val defs = List(
-      genCallOnModule(classSym, junitNme.beforeClass, testClass.companionModule, junitdefn.BeforeClassAnnotClass),
-      genCallOnModule(classSym, junitNme.afterClass, testClass.companionModule, junitdefn.AfterClassAnnotClass),
-      genCallOnParam(classSym, junitNme.before, testClass, junitdefn.BeforeAnnotClass),
-      genCallOnParam(classSym, junitNme.after, testClass, junitdefn.AfterAnnotClass),
-      genTests(classSym, testMethods),
-      genInvokeTest(classSym, testClass, testMethods),
-      genNewInstance(classSym, testClass)
-    )
+    val defs =
+      genCallOnModule(classSym, junitNme.beforeClass, testClass.companionModule, junitdefn.BeforeClassAnnotClass) ::
+      genCallOnModule(classSym, junitNme.afterClass, testClass.companionModule, junitdefn.AfterClassAnnotClass) ::
+      genCallOnParam(classSym, junitNme.before, testClass, junitdefn.BeforeAnnotClass) ::
+      genCallOnParam(classSym, junitNme.after, testClass, junitdefn.AfterAnnotClass) ::
+      genTests(classSym, testMethods) ::
+      genInvokeTest(classSym, testClass, testMethods) ::
+      genNewInstance(classSym, testClass) :: Nil
 
     sbt.APIUtils.registerDummyClass(classSym)
 
@@ -245,7 +244,7 @@ class JUnitBootstrappers extends MiniPhase {
         }
 
         val reifiedAnnot = resolveConstructor(junitdefn.TestAnnotType, mappedArguments)
-        New(junitdefn.TestMetadataType, List(name, ignored, reifiedAnnot))
+        New(junitdefn.TestMetadataType, name :: ignored :: reifiedAnnot :: Nil)
       }
       JavaSeqLiteral(metadata, TypeTree(junitdefn.TestMetadataType))
     })
@@ -255,7 +254,7 @@ class JUnitBootstrappers extends MiniPhase {
     val junitdefn = jsdefn.junit
 
     val sym = newSymbol(owner, junitNme.invokeTest, Synthetic | Method,
-      MethodType(List(junitNme.instance, junitNme.name), List(defn.ObjectType, defn.StringType), junitdefn.FutureType)).entered
+      MethodType(junitNme.instance :: junitNme.name :: Nil, defn.ObjectType :: defn.StringType ::Nil, junitdefn.FutureType)).entered
 
     DefDef(sym, { (paramRefss: List[List[Tree]]) =>
       val List(List(instanceParamRef, nameParamRef)) = paramRefss

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSExports.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSExports.scala
@@ -173,7 +173,7 @@ object PrepJSExports {
     }
 
     val allExportInfos = for {
-      annot <- directAnnots ++ unitAnnots
+      annot <- directAnnots ::: unitAnnots
     } yield {
       val isExportAll = annot.symbol == JSExportAllAnnot
       val isTopLevelExport = annot.symbol == JSExportTopLevelAnnot

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
@@ -318,14 +318,14 @@ class PrepJSInterop extends MacroTransform with IdentityDenotTransformer { thisP
           val enclosingClass = currentOwner.enclosingClass
 
           // new DynamicImportThunk { def apply(): Any = body }
-          val dynamicImportThunkAnonClass = AnonClass(currentOwner, List(jsdefn.DynamicImportThunkType), span) { cls =>
+          val dynamicImportThunkAnonClass = AnonClass(currentOwner, jsdefn.DynamicImportThunkType :: Nil, span) { cls =>
             val applySym = newSymbol(cls, nme.apply, Method, MethodType(Nil, Nil, defn.AnyType), coord = span).entered
             val transformedBody = enterDynamicImportEnclosingClass(enclosingClass) {
               transform(body)
             }
             val newBody = transformedBody.changeOwnerAfter(currentOwner, applySym, thisPhase)
             val applyDefDef = DefDef(applySym, newBody)
-            List(applyDefDef)
+            applyDefDef :: Nil
           }
 
           // runtime.DynamicImport[A](new ...)


### PR DESCRIPTION
Reasoning:
Varargs in Scala use intermediate collections as shown in this example:
```scala
def foo = List("", "", "")
def bar = "" :: "" :: "" :: Nil
```

compiling with `-Xprint:repeatableAnnotations` gives:
```scala
def foo(): scala.collection.immutable.List =
  List().apply(scala.runtime.ScalaRunTime.wrapRefArray(["","","" : String]))
    .asInstanceOf[scala.collection.immutable.List]
def bar(): scala.collection.immutable.List = Nil().::("").::("").::("")
```

I want to avoid instantiating that extra `Array` and wrapping it into an `ArraySeq` to then create a `List`.