### PR TITLE
fix regression: inline match crash when rhs uses private inlined methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -455,7 +455,7 @@ object Trees {
         val point = span.point
         if name.toTermName == nme.ERROR then
           Span(point)
-        else if qualifier.span.start > span.point then // right associative
+        else if qualifier.span.exists && qualifier.span.start > span.point then // right associative
           val realName = name.stripModuleClassSuffix.lastPart
           Span(span.start, span.start + realName.length, point)
         else

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -38,6 +38,7 @@ class CompilationTests {
       compileFilesInDir("tests/pos-custom-args/captures", defaultOptions.and("-language:experimental.captureChecking")),
       compileFile("tests/pos-special/utf8encoded.scala", defaultOptions.and("-encoding", "UTF8")),
       compileFile("tests/pos-special/utf16encoded.scala", defaultOptions.and("-encoding", "UTF16")),
+      compileDir("tests/pos-special/i18589", defaultOptions.and("-Ysafe-init").without("-Ycheck:all")),
       // Run tests for legacy lazy vals
       compileFilesInDir("tests/pos", defaultOptions.and("-Ysafe-init", "-Ylegacy-lazy-vals", "-Ycheck-constraint-deps"), FileFilter.include(TestSources.posLazyValsAllowlist)),
       compileDir("tests/pos-special/java-param-names", defaultOptions.withJavacOnlyOptions("-parameters")),

--- a/tests/pos-special/i18589/core_0.scala
+++ b/tests/pos-special/i18589/core_0.scala
@@ -1,0 +1,17 @@
+import scala.deriving.Mirror
+
+trait NamedCodec[A, R]
+
+object NamedCodecPlatform {
+
+  final class Builder[R]() {
+    inline def of[T](using m: Mirror.Of[T]): NamedCodec[T, R] =
+      inline m match {
+        case s: Mirror.SumOf[T]     => sumInst(s)
+        case _: Mirror.ProductOf[T] => productInst
+      }
+
+    private inline def productInst[T]: NamedCodec[T, R] = ???
+    private inline def sumInst[T](m: Mirror.SumOf[T]): NamedCodec[T, R] = ???
+  }
+}

--- a/tests/pos-special/i18589/test_1.scala
+++ b/tests/pos-special/i18589/test_1.scala
@@ -1,0 +1,8 @@
+enum Data {
+  case A, B, C
+}
+
+@main def Test = {
+  val builder: NamedCodecPlatform.Builder[Any] = ???
+  builder.of[Data]
+}


### PR DESCRIPTION
resolves: https://github.com/lampepfl/dotty/issues/18589