### PR TITLE
Add attributes section to TASTy and use it for Stdlib TASTy

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -308,8 +308,8 @@ object Flags {
    */
   val (_, StableRealizable @ _, _) = newFlags(24, "<stable>")
 
-  /** A case parameter accessor */
-  val (_, CaseAccessor @ _, _) = newFlags(25, "<caseaccessor>")
+  /** A case parameter accessor / an unpickled Scala 2 TASTy (only for Scala 2 stdlib) */
+  val (_, CaseAccessor @ _, Scala2Tasty @ _) = newFlags(25, "<caseaccessor>", "<scala-2-tasty>")
 
   /** A Scala 2x super accessor / an unpickled Scala 2.x class */
   val (SuperParamAliasOrScala2x @ _, SuperParamAlias @ _, Scala2x @ _) = newFlags(26, "<super-param-alias>", "<scala-2.x>")

--- a/compiler/src/dotty/tools/dotc/core/tasty/AttributePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/AttributePickler.scala
@@ -1,0 +1,26 @@
+package dotty.tools.dotc.core.tasty
+
+import dotty.tools.dotc.ast.{tpd, untpd}
+
+import dotty.tools.tasty.TastyBuffer
+import dotty.tools.tasty.TastyFormat, TastyFormat.AttributesSection
+
+import java.nio.charset.StandardCharsets
+
+object AttributePickler:
+
+  def pickleAttributes(
+    attributes: Attributes,
+    pickler: TastyPickler,
+    buf: TastyBuffer
+  ): Unit =
+    if attributes.scala2StandardLibrary || attributes.explicitNulls then // or any other attribute is set
+      pickler.newSection(AttributesSection, buf)
+      // Pickle attributes
+      if attributes.scala2StandardLibrary then buf.writeNat(TastyFormat.SCALA2STANDARDLIBRARYattr)
+      if attributes.explicitNulls then buf.writeNat(TastyFormat.EXPLICITNULLSattr)
+    end if
+
+  end pickleAttributes
+
+end AttributePickler

--- a/compiler/src/dotty/tools/dotc/core/tasty/AttributeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/AttributeUnpickler.scala
@@ -1,0 +1,33 @@
+package dotty.tools.dotc
+package core.tasty
+
+import scala.language.unsafeNulls
+
+import dotty.tools.tasty.{TastyFormat, TastyReader, TastyBuffer}
+
+import java.nio.charset.StandardCharsets
+
+class AttributeUnpickler(reader: TastyReader):
+  import reader._
+
+  lazy val attributeTags: List[Int] =
+    val listBuilder = List.newBuilder[Int]
+    while !isAtEnd do listBuilder += readNat()
+    listBuilder.result()
+
+  lazy val attributes: Attributes = {
+    var scala2StandardLibrary = false
+    var explicitNulls = false
+    for attributeTag <- attributeTags do
+      attributeTag match
+        case TastyFormat.SCALA2STANDARDLIBRARYattr => scala2StandardLibrary = true
+        case TastyFormat.EXPLICITNULLSattr => explicitNulls = true
+        case attribute =>
+          assert(false, "Unexpected attribute value: " + attribute)
+    Attributes(
+      scala2StandardLibrary,
+      explicitNulls,
+    )
+  }
+
+end AttributeUnpickler

--- a/compiler/src/dotty/tools/dotc/core/tasty/Attributes.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/Attributes.scala
@@ -1,0 +1,6 @@
+package dotty.tools.dotc.core.tasty
+
+class Attributes(
+  val scala2StandardLibrary: Boolean,
+  val explicitNulls: Boolean,
+)

--- a/compiler/src/dotty/tools/dotc/core/tasty/ScratchData.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/ScratchData.scala
@@ -10,6 +10,7 @@ class ScratchData:
   val pickledIndices = new mutable.BitSet
 
   val commentBuffer = new TastyBuffer(5000)
+  val attributeBuffer = new TastyBuffer(32)
 
   def reset() =
     assert(delta ne delta1)
@@ -17,4 +18,5 @@ class ScratchData:
     positionBuffer.reset()
     pickledIndices.clear()
     commentBuffer.reset()
+    attributeBuffer.reset()
 

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -77,7 +77,7 @@ class ExtensionMethods extends MiniPhase with DenotTransformer with FullParamete
 
           // Create extension methods, except if the class comes from Scala 2
           // because it adds extension methods before pickling.
-          if (!(valueClass.is(Scala2x)))
+          if !valueClass.is(Scala2x, butNot = Scala2Tasty) then
             for (decl <- valueClass.classInfo.decls)
               if isMethodWithExtension(decl) then
                 enterInModuleClass(createExtensionMethod(decl, moduleClassSym.symbol))

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -108,6 +108,12 @@ class Pickler extends Phase {
                 pickler, treePkl.buf.addrOfTree, treePkl.docString, tree,
                 scratch.commentBuffer)
 
+          val attributes = Attributes(
+            scala2StandardLibrary = ctx.settings.YcompileScala2Library.value,
+            explicitNulls = ctx.settings.YexplicitNulls.value,
+          )
+          AttributePickler.pickleAttributes(attributes, pickler, scratch.attributeBuffer)
+
           val pickled = pickler.assembleParts()
 
           def rawBytes = // not needed right now, but useful to print raw format.

--- a/scala2-library-tasty-tests/src/Main.scala
+++ b/scala2-library-tasty-tests/src/Main.scala
@@ -17,6 +17,7 @@ object HelloWorld:
     testScala2ObjectParents()
     testScala2CaseClassUnderscoreMembers()
     testScalaNumberUnderlying()
+    testArrayOps()
     scala.collection.mutable.UnrolledBufferTest.test()
   }
 
@@ -68,3 +69,9 @@ object HelloWorld:
     val _: Object = MyNumber2(BigInt(1)).underlying
     val _: Object = (MyNumber2(BigInt(1)): ScalaNumber).underlying
   }
+
+  def testArrayOps() = {
+    new collection.ArrayOps[String](Array[String]("foo")).exists(x => true)
+  }
+
+end HelloWorld

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -265,8 +265,15 @@ All elements of a position section are serialized as Ints
 
 Standard Section: "Comments" Comment*
 ```none
-  Comment       = Length Bytes LongInt      // Raw comment's bytes encoded as UTF-8, followed by the comment's coordinates.
+  Comment       = UTF8 LongInt              // Raw comment's bytes encoded as UTF-8, followed by the comment's coordinates.
 ```
+
+Standard Section: "Attributes" Attribute*
+```none
+  Attribute     = SCALA2STANDARDLIBRARYattr
+                  EXPLICITNULLSattr
+```
+
 **************************************************************************************/
 
 object TastyFormat {
@@ -361,6 +368,7 @@ object TastyFormat {
   final val ASTsSection = "ASTs"
   final val PositionsSection = "Positions"
   final val CommentsSection = "Comments"
+  final val AttributesSection = "Attributes"
 
   /** Tags used to serialize names, should update [[TastyFormat$.nameTagToString]] if a new constant is added */
   class NameTags {
@@ -597,6 +605,12 @@ object TastyFormat {
   final val firstNatASTTreeTag = IDENT
   final val firstLengthTreeTag = PACKAGE
 
+
+  // Attributes tags
+
+  final val SCALA2STANDARDLIBRARYattr = 1
+  final val EXPLICITNULLSattr = 2
+
   /** Useful for debugging */
   def isLegalTag(tag: Int): Boolean =
     firstSimpleTreeTag <= tag && tag <= SPLITCLAUSE ||
@@ -810,6 +824,11 @@ object TastyFormat {
     case PROTECTEDqualified => "PROTECTEDqualified"
     case EXPLICITtpt => "EXPLICITtpt"
     case HOLE => "HOLE"
+  }
+
+  def attributeTagToString(tag: Int): String = tag match {
+    case SCALA2STANDARDLIBRARYattr => "SCALA2STANDARDLIBRARYattr"
+    case EXPLICITNULLSattr => "EXPLICITNULLSattr"
   }
 
   /** @return If non-negative, the number of leading references (represented as nats) of a length/trees entry.


### PR DESCRIPTION
The `Attributes` section contains a list `Attribute` tags.

At this point, the only Scala 2 TASTy is the one from the standard library. To know that a TASTy contains the definitions of the standard library, we add the `SCALA2STANDARDLIBRARYattr` attribute to the TASTy file. We mark all unpickled classes from those TASTy files with `Scala2x | Scala2Tasty`.

Attributes will also be used to mark files that were compiled with explicit nulls using the `EXPLICITNULLSattr` attribute.