### PR TITLE
Make direct tuple assignment work by default in 3.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2725,7 +2725,7 @@ object Parsers {
       atSpan(startOffset(pat), accept(LARROW)) {
         val checkMode =
           if casePat then GenCheckMode.FilterAlways
-          else if sourceVersion.isAtLeast(`future`) then GenCheckMode.Check
+          else if sourceVersion.isAtLeast(`3.4`) then GenCheckMode.Check
           else if sourceVersion.isAtLeast(`3.2`) then GenCheckMode.CheckAndFilter
           else GenCheckMode.FilterNow  // filter on source version < 3.2, for backward compat
         GenFrom(pat, subExpr(), checkMode)


### PR DESCRIPTION
As described in https://contributors.scala-lang.org/t/make-tuple-unpack-feature-from-source-future-become-default/6238, this PR enables direct tuple assignment in for comprehensions on Scala 3.4.

```scala
  // With ZIO assignment separately:
  def y =
    for
      x <- ZIO.fromOption(Some(1, 2))
      (a, b) = x
    yield (a, b)

  println(runZIO(y))

  // With ZIO direct assignment (doesn't work unless using "-source:future"):
  def z =
    for
      (a, b) <- ZIO.fromOption(Some(1, 2))
    yield (a, b)
```

This behavior was available previously only thru `-source:future` and better-monadic-for lib.

I might need some guidance to change the test cases to address this.

Addresses #16334 