### PR TITLE
error when reading class file with unknown newer jdk version

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
@@ -11,6 +11,7 @@ object ClassfileConstants {
   inline val JAVA_MINOR_VERSION = 3
 
   inline val JAVA8_MAJOR_VERSION = 52
+  inline val JAVA_LATEST_MAJOR_VERSION = 65
 
   /** (see http://java.sun.com/docs/books/jvms/second_edition/jvms-clarify.html)
    *

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileConstants.scala
@@ -11,7 +11,6 @@ object ClassfileConstants {
   inline val JAVA_MINOR_VERSION = 3
 
   inline val JAVA8_MAJOR_VERSION = 52
-  inline val JAVA_LATEST_MAJOR_VERSION = 65
 
   /** (see http://java.sun.com/docs/books/jvms/second_edition/jvms-clarify.html)
    *

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -29,6 +29,28 @@ import scala.compiletime.uninitialized
 
 object ClassfileParser {
 
+  object Header:
+    opaque type Version = Long
+
+    object Version:
+      val Unknown: Version = -1L
+
+      def brokenVersionAddendum(classfileVersion: Version)(using Context): String =
+        if classfileVersion.exists then
+          val (maj, min) = (classfileVersion.majorVersion, classfileVersion.minorVersion)
+          val scalaVersion = config.Properties.versionNumberString
+          i""" (version $maj.$min),
+            |  please check the JDK compatibility of your Scala version ($scalaVersion)"""
+        else
+          ""
+
+      def apply(major: Int, minor: Int): Version =
+        (major.toLong << 32) | (minor.toLong & 0xFFFFFFFFL)
+      extension (version: Version)
+        def exists: Boolean = version != Unknown
+        def majorVersion: Int = (version >> 32).toInt
+        def minorVersion: Int = (version & 0xFFFFFFFFL).toInt
+
   import ClassfileConstants._
 
   /** Marker trait for unpicklers that can be embedded in classfiles. */
@@ -57,7 +79,7 @@ object ClassfileParser {
     }
   }
 
-  private[classfile] def parseHeader(classfile: AbstractFile)(using in: DataReader): Unit = {
+  private[classfile] def parseHeader(classfile: AbstractFile)(using in: DataReader): Header.Version = {
     val magic = in.nextInt
     if (magic != JAVA_MAGIC)
       throw new IOException(s"class file '${classfile}' has wrong magic number 0x${toHexString(magic)}, should be 0x${toHexString(JAVA_MAGIC)}")
@@ -68,9 +90,7 @@ object ClassfileParser {
          (minorVersion < JAVA_MINOR_VERSION)))
       throw new IOException(
         s"class file '${classfile}' has unknown version $majorVersion.$minorVersion, should be at least $JAVA_MAJOR_VERSION.$JAVA_MINOR_VERSION")
-    if majorVersion > JAVA_LATEST_MAJOR_VERSION then
-      throw new IOException(
-        s"class file '${classfile}' has unknown version $majorVersion.$minorVersion, and was compiled by a newer JDK than supported by this Scala version, please update to a newer Scala version.")
+    Header.Version(majorVersion, minorVersion)
   }
 
   abstract class AbstractConstantPool(using in: DataReader) {
@@ -263,6 +283,7 @@ class ClassfileParser(
   protected var classTParams: Map[Name, Symbol] = Map()
 
   private var Scala2UnpicklingMode = Mode.Scala2Unpickling
+  private var classfileVersion: Header.Version = Header.Version.Unknown
 
   classRoot.info = NoLoader().withDecls(instanceScope)
   moduleRoot.info = NoLoader().withDecls(staticScope).withSourceModule(staticModule)
@@ -275,7 +296,7 @@ class ClassfileParser(
   def run()(using Context): Option[Embedded] = try ctx.base.reusableDataReader.withInstance { reader =>
     implicit val reader2 = reader.reset(classfile)
     report.debuglog("[class] >> " + classRoot.fullName)
-    parseHeader(classfile)
+    classfileVersion = parseHeader(classfile)
     this.pool = new ConstantPool
     val res = parseClass()
     this.pool =  null
@@ -284,9 +305,11 @@ class ClassfileParser(
   catch {
     case e: RuntimeException =>
       if (ctx.debug) e.printStackTrace()
+      val addendum = Header.Version.brokenVersionAddendum(classfileVersion)
       throw new IOException(
-        i"""class file ${classfile.canonicalPath} is broken, reading aborted with ${e.getClass}
-           |${Option(e.getMessage).getOrElse("")}""")
+        i"""  class file ${classfile.canonicalPath} is broken$addendum,
+          |  reading aborted with ${e.getClass}:
+          |  ${Option(e.getMessage).getOrElse("")}""")
   }
 
   /** Return the class symbol of the given name. */

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -57,6 +57,22 @@ object ClassfileParser {
     }
   }
 
+  private[classfile] def parseHeader(classfile: AbstractFile)(using in: DataReader): Unit = {
+    val magic = in.nextInt
+    if (magic != JAVA_MAGIC)
+      throw new IOException(s"class file '${classfile}' has wrong magic number 0x${toHexString(magic)}, should be 0x${toHexString(JAVA_MAGIC)}")
+    val minorVersion = in.nextChar.toInt
+    val majorVersion = in.nextChar.toInt
+    if ((majorVersion < JAVA_MAJOR_VERSION) ||
+        ((majorVersion == JAVA_MAJOR_VERSION) &&
+         (minorVersion < JAVA_MINOR_VERSION)))
+      throw new IOException(
+        s"class file '${classfile}' has unknown version $majorVersion.$minorVersion, should be at least $JAVA_MAJOR_VERSION.$JAVA_MINOR_VERSION")
+    if majorVersion > JAVA_LATEST_MAJOR_VERSION then
+      throw new IOException(
+        s"class file '${classfile}' has unknown version $majorVersion.$minorVersion, and was compiled by a newer JDK than supported by this Scala version, please update to a newer Scala version.")
+  }
+
   abstract class AbstractConstantPool(using in: DataReader) {
     protected val len = in.nextChar
     protected val starts = new Array[Int](len)
@@ -259,7 +275,7 @@ class ClassfileParser(
   def run()(using Context): Option[Embedded] = try ctx.base.reusableDataReader.withInstance { reader =>
     implicit val reader2 = reader.reset(classfile)
     report.debuglog("[class] >> " + classRoot.fullName)
-    parseHeader()
+    parseHeader(classfile)
     this.pool = new ConstantPool
     val res = parseClass()
     this.pool =  null
@@ -271,19 +287,6 @@ class ClassfileParser(
       throw new IOException(
         i"""class file ${classfile.canonicalPath} is broken, reading aborted with ${e.getClass}
            |${Option(e.getMessage).getOrElse("")}""")
-  }
-
-  private def parseHeader()(using in: DataReader): Unit = {
-    val magic = in.nextInt
-    if (magic != JAVA_MAGIC)
-      throw new IOException(s"class file '${classfile}' has wrong magic number 0x${toHexString(magic)}, should be 0x${toHexString(JAVA_MAGIC)}")
-    val minorVersion = in.nextChar.toInt
-    val majorVersion = in.nextChar.toInt
-    if ((majorVersion < JAVA_MAJOR_VERSION) ||
-        ((majorVersion == JAVA_MAJOR_VERSION) &&
-         (minorVersion < JAVA_MINOR_VERSION)))
-      throw new IOException(
-        s"class file '${classfile}' has unknown version $majorVersion.$minorVersion, should be at least $JAVA_MAJOR_VERSION.$JAVA_MINOR_VERSION")
   }
 
   /** Return the class symbol of the given name. */

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileTastyUUIDParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileTastyUUIDParser.scala
@@ -26,7 +26,7 @@ class ClassfileTastyUUIDParser(classfile: AbstractFile)(ictx: Context) {
 
   def checkTastyUUID(tastyUUID: UUID)(using Context): Unit = try ctx.base.reusableDataReader.withInstance { reader =>
     implicit val reader2 = reader.reset(classfile)
-    parseHeader()
+    ClassfileParser.parseHeader(classfile)
     this.pool = new ConstantPool
     checkTastyAttr(tastyUUID)
     this.pool =  null
@@ -37,19 +37,6 @@ class ClassfileTastyUUIDParser(classfile: AbstractFile)(ictx: Context) {
       throw new IOException(
         i"""class file ${classfile.canonicalPath} is broken, reading aborted with ${e.getClass}
            |${Option(e.getMessage).getOrElse("")}""")
-  }
-
-  private def parseHeader()(using in: DataReader): Unit = {
-    val magic = in.nextInt
-    if (magic != JAVA_MAGIC)
-      throw new IOException(s"class file '${classfile}' has wrong magic number 0x${toHexString(magic)}, should be 0x${toHexString(JAVA_MAGIC)}")
-    val minorVersion = in.nextChar.toInt
-    val majorVersion = in.nextChar.toInt
-    if ((majorVersion < JAVA_MAJOR_VERSION) ||
-        ((majorVersion == JAVA_MAJOR_VERSION) &&
-         (minorVersion < JAVA_MINOR_VERSION)))
-      throw new IOException(
-        s"class file '${classfile}' has unknown version $majorVersion.$minorVersion, should be at least $JAVA_MAJOR_VERSION.$JAVA_MINOR_VERSION")
   }
 
   private def checkTastyAttr(tastyUUID: UUID)(using ctx: Context, in: DataReader): Unit = {


### PR DESCRIPTION
when reading a classfile causes a runtime exception, report the version of the classfile, and request that the user checks JDK compatibility.

Considerations:
- should we test this?

currently we have no process for testing latest JDK, currently we still only test with JDK 16 and 8

fixes #18573