### PR TITLE
Fix crash in global object initialization checker when select target has no source

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -766,8 +766,11 @@ object Objects:
       val target = if needResolve then resolve(ref.klass, field) else field
       if target.is(Flags.Lazy) then
         given Env.Data = Env.emptyEnv(target.owner.asInstanceOf[ClassSymbol].primaryConstructor)
-        val rhs = target.defTree.asInstanceOf[ValDef].rhs
-        eval(rhs, ref, target.owner.asClass, cacheResult = true)
+        if target.hasSource then
+          val rhs = target.defTree.asInstanceOf[ValDef].rhs
+          eval(rhs, ref, target.owner.asClass, cacheResult = true)
+        else
+          Bottom
       else if target.exists then
         if target.isOneOf(Flags.Mutable) then
           if ref.hasVar(target) then


### PR DESCRIPTION
This fixes a bug in the global object initialization checker that results in a crash that occurs when building the `akka` community project with `-Ysafe-init-global` flag.