### PR TITLE
Bring back experimental.relaxedExtensionImports language import

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -90,6 +90,14 @@ object language:
      */
     @compileTimeOnly("`into` can only be used at compile time in import statements")
     object into
+
+    /** Was needed to add support for relaxed imports of extension methods.
+      * The language import is no longer needed as this is now a standard feature since SIP was accepted.
+      * @see [[http://dotty.epfl.ch/docs/reference/contextual/extension-methods]]
+      */
+    @compileTimeOnly("`relaxedExtensionImports` can only be used at compile time in import statements")
+    @deprecated("The experimental.relaxedExtensionImports language import is no longer needed since the feature is now standard", since = "3.4")
+    object relaxedExtensionImports
   end experimental
 
   /** The deprecated object contains features that are no longer officially suypported in Scala.


### PR DESCRIPTION
This is to keep MiMa happy.

Not sure what the policy should be. At some point we might want to simply drop the import since it no longer does anything, but maybe we should wait a bit with it?