### PR TITLE
Fix the tparam bounds of exported inherited classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -594,7 +594,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
             if (base.typeSymbol == cls2) return true
           }
           else if tp1.typeParams.nonEmpty && !tp1.isAnyKind then
-            return recur(tp1, EtaExpansion(tp2))
+            return recur(tp1, tp2.etaExpand)
         fourthTry
     }
 
@@ -734,7 +734,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           case _ =>
             val tparams1 = tp1.typeParams
             if (tparams1.nonEmpty)
-              return recur(tp1.etaExpand(tparams1), tp2) || fourthTry
+              return recur(tp1.etaExpand, tp2) || fourthTry
             tp2 match {
               case EtaExpansion(tycon2: TypeRef) if tycon2.symbol.isClass && tycon2.symbol.is(JavaDefined) =>
                 recur(tp1, tycon2) || fourthTry
@@ -2820,7 +2820,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         tp.symbol match
           case cls: ClassSymbol =>
             if cls == defn.SingletonClass then defn.AnyType
-            else if cls.typeParams.nonEmpty then EtaExpansion(tp)
+            else if cls.typeParams.nonEmpty then tp.etaExpand
             else tp
           case sym =>
             if !ctx.erasedTypes && sym == defn.FromJavaObjectSymbol then defn.AnyType

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -850,7 +850,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         }
         else if args.nonEmpty then
           tycon.safeAppliedTo(EtaExpandIfHK(sym.typeParams, args.map(translateTempPoly)))
-        else if (sym.typeParams.nonEmpty) tycon.etaExpand(sym.typeParams)
+        else if (sym.typeParams.nonEmpty) tycon.etaExpand
         else tycon
       case TYPEBOUNDStpe =>
         val lo = readTypeRef()

--- a/compiler/src/dotty/tools/dotc/typer/Deriving.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Deriving.scala
@@ -165,7 +165,7 @@ trait Deriving {
           // case (a) ... see description above
           val derivedParams = clsParams.dropRight(instanceArity)
           val instanceType =
-            if (instanceArity == clsArity) clsType.etaExpand(clsParams)
+            if (instanceArity == clsArity) clsType.etaExpand
             else {
               val derivedParamTypes = derivedParams.map(_.typeRef)
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1200,7 +1200,7 @@ class Namer { typer: Typer =>
               val forwarderName = checkNoConflict(alias.toTypeName, isPrivate = false, span)
               var target = pathType.select(sym)
               if target.typeParams.nonEmpty then
-                target = target.etaExpandWithAsf
+                target = target.etaExpand
               newSymbol(
                 cls, forwarderName,
                 MandatoryExportTypeFlags | (sym.flags & RetainedExportTypeFlags),

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1199,22 +1199,8 @@ class Namer { typer: Typer =>
             if mbr.isType then
               val forwarderName = checkNoConflict(alias.toTypeName, isPrivate = false, span)
               var target = pathType.select(sym)
-              val tparams = target.typeParams
-              if tparams.nonEmpty then
-                // like `target = target.etaExpand(target.typeParams)`
-                // except call `asSeenFrom` to fix class type parameter bounds
-                // e.g. in pos/i18569:
-                // `Test#F` should have `M2.A` or `Test.A` as bounds, not `M1#A`.
-                target = HKTypeLambda(tparams.map(_.paramName))(
-                  tl => tparams.map {
-                    case p: Symbol =>
-                      val info = p.info.asSeenFrom(pathType, sym.owner)
-                      HKTypeLambda.toPInfo(tl.integrate(tparams, info))
-                    case p =>
-                      val info = p.paramInfo
-                      HKTypeLambda.toPInfo(tl.integrate(tparams, info))
-                  },
-                  tl => tl.integrate(tparams, target.appliedTo(tparams.map(_.paramRef))))
+              if target.typeParams.nonEmpty then
+                target = target.etaExpandWithAsf(pathType, sym.owner)
               newSymbol(
                 cls, forwarderName,
                 MandatoryExportTypeFlags | (sym.flags & RetainedExportTypeFlags),

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1200,7 +1200,7 @@ class Namer { typer: Typer =>
               val forwarderName = checkNoConflict(alias.toTypeName, isPrivate = false, span)
               var target = pathType.select(sym)
               if target.typeParams.nonEmpty then
-                target = target.etaExpandWithAsf(pathType, sym.owner)
+                target = target.etaExpandWithAsf
               newSymbol(
                 cls, forwarderName,
                 MandatoryExportTypeFlags | (sym.flags & RetainedExportTypeFlags),

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -377,7 +377,7 @@ object RefChecks {
      */
     def checkOverride(checkSubType: (Type, Type) => Context ?=> Boolean, member: Symbol, other: Symbol): Unit =
       def memberTp(self: Type) =
-        if (member.isClass) TypeAlias(member.typeRef.etaExpand(member.typeParams))
+        if (member.isClass) TypeAlias(member.typeRef.etaExpand)
         else self.memberInfo(member)
       def otherTp(self: Type) =
         self.memberInfo(other)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4283,7 +4283,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             tree1.withType(tp1)
           else
             // Eta-expand higher-kinded type
-            val tp1 = tree.tpe.etaExpand(tp.typeParamSymbols)
+            val tp1 = tree.tpe.etaExpand
             tree.withType(tp1)
         }
       if (ctx.mode.is(Mode.Pattern) || ctx.mode.isQuotedPattern || tree1.tpe <:< pt) tree1

--- a/tests/neg/i7820.check
+++ b/tests/neg/i7820.check
@@ -1,0 +1,34 @@
+-- [E046] Cyclic Error: tests/neg/i7820.scala:1:23 ---------------------------------------------------------------------
+1 |trait A1 { type F[X <: F[_, _], Y] }  // error: cyclic reference involving type F
+  |                       ^
+  |                       Cyclic reference involving type F
+  |
+  |                        Run with -explain-cyclic for more details.
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E046] Cyclic Error: tests/neg/i7820.scala:2:23 ---------------------------------------------------------------------
+2 |trait A2 { type F[X <: F, Y] }        // error: cyclic reference involving type F
+  |                       ^
+  |                       Cyclic reference involving type F
+  |
+  |                        Run with -explain-cyclic for more details.
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E046] Cyclic Error: tests/neg/i7820.scala:3:23 ---------------------------------------------------------------------
+3 |trait A3 { type F[X >: F, Y] }        // error: cyclic reference involving type F
+  |                       ^
+  |                       Cyclic reference involving type F
+  |
+  |                        Run with -explain-cyclic for more details.
+  |
+  | longer explanation available when compiling with `-explain`
+-- Warning: tests/neg/i7820.scala:1:25 ---------------------------------------------------------------------------------
+1 |trait A1 { type F[X <: F[_, _], Y] }  // error: cyclic reference involving type F
+  |                         ^
+  |                         `_` is deprecated for wildcard arguments of types: use `?` instead
+  |                         This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+-- Warning: tests/neg/i7820.scala:1:28 ---------------------------------------------------------------------------------
+1 |trait A1 { type F[X <: F[_, _], Y] }  // error: cyclic reference involving type F
+  |                            ^
+  |                            `_` is deprecated for wildcard arguments of types: use `?` instead
+  |                            This construct can be rewritten automatically under -rewrite -source 3.4-migration.

--- a/tests/neg/i7820.scala
+++ b/tests/neg/i7820.scala
@@ -1,3 +1,3 @@
 trait A1 { type F[X <: F[_, _], Y] }  // error: cyclic reference involving type F
-trait A2 { type F[X <: F, Y] }        // error: cyclic reference involving type F // error
-trait A3 { type F[X >: F, Y] }        // error: cyclic reference involving type F // error
+trait A2 { type F[X <: F, Y] }        // error: cyclic reference involving type F
+trait A3 { type F[X >: F, Y] }        // error: cyclic reference involving type F

--- a/tests/pos/i18569.reg1.scala
+++ b/tests/pos/i18569.reg1.scala
@@ -1,0 +1,11 @@
+// Minimisation of the CI failure
+// in scala-parallel-collections
+// to do with how EtaExpansion is used
+// by typeOfNew when typing a New tree
+
+trait Foo[+A]:
+  class Bar[B >: A]
+
+class Test:
+  def t1[X](foo: Foo[X]): Unit =
+    val bar = new foo.Bar()

--- a/tests/pos/i18569.scala
+++ b/tests/pos/i18569.scala
@@ -1,0 +1,11 @@
+trait M1:
+  trait A
+  trait F[T <: A]
+  type G[T <: A] = F[T]
+
+object M2 extends M1
+
+trait Test:
+  export M2.*
+  def y: F[A]
+  def z: G[A]


### PR DESCRIPTION
When trying to export M2.F, seeing M1#F from the prefix M2 doesn't
change the bounds of F's T type parameter, which still refers to
M1.this.A, rather than M2.A.  So, we run asSeenFrom against that info,
when eta-expanding the class into a hk type lambda.
