### PR TITLE
fix scala 2 macros in traits with type parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1030,7 +1030,7 @@ object SymDenotations {
 
     /** Is this a Scala 2 macro defined */
     final def isScala2MacroInScala3(using Context): Boolean =
-      is(Macro, butNot = Inline) && is(Erased)
+      is(Macro, butNot = Inline) && flagsUNSAFE.is(Erased) // flag is set initially for macros - we check if it's a scala 2 macro before completing the type constructor so do not force the info to check the flag
       // Consider the macros of StringContext as plain Scala 2 macros when
       // compiling the standard library with Dotty.
       // This should be removed on Scala 3.x

--- a/tests/pos-macros/i16630.scala
+++ b/tests/pos-macros/i16630.scala
@@ -1,0 +1,14 @@
+import scala.language.experimental.macros
+import scala.quoted.{Quotes, Expr, Type}
+
+trait TraitWithTypeParam[A]:
+  inline def foo: Option[A] = ${ MacrosImpl.fooImpl[A] }
+  def foo: Option[A] = macro MacrosImpl.compatFooImpl[A]
+
+object MacrosImpl:
+  def fooImpl[A: Type](using quotes: Quotes): Expr[Option[A]] = ???
+  def compatFooImpl[A: c.WeakTypeTag](c: Context): c.Tree = ???
+
+trait Context:
+  type WeakTypeTag[A]
+  type Tree


### PR DESCRIPTION
Fixes https://github.com/lampepfl/dotty/issues/16630

This PR fixes the above issue which affects cross scala2/3 projects that use a common macro library as per https://docs.scala-lang.org/scala3/guides/migration/tutorial-macro-mixing.html , e.g. scala-logging is blocked from fixing this issue https://github.com/lightbend-labs/scala-logging/issues/317

The fix makes the scala 2 macro check read the Erased flag from the initial flags rather than completing the RHS first.  This will work in the case of scala 2 macros because the erased flag is explicitly added rather than being in the source code.  However it relies on using an "UNSAFE" value.

More background on my investigation:

1. The scala 2 macros are identified by being flagged as Macro and Erased
https://github.com/lampepfl/dotty/blob/f2aa33c3643655fd9a48a1e448d7d79e6e52ea79/compiler/src/dotty/tools/dotc/ast/Desugar.scala#L275
3. Namer.completeConstructor indexes the constructor and then other statements (the macros here) and then completes the constructor symbol.
https://github.com/lampepfl/dotty/blob/7c0a848d0ed6330873a39129e6d02da169150fa7/compiler/src/dotty/tools/dotc/typer/Namer.scala#L1458-L1461
5. When we index a statement, we check it's not a scala 2 macro so that we don't enter it into the symbol table for the scope.
https://github.com/lampepfl/dotty/blob/7c0a848d0ed6330873a39129e6d02da169150fa7/compiler/src/dotty/tools/dotc/typer/Namer.scala#L307-L308
7. However, although the Erased flag is actually set in the SymDenotation at init time, Erased is not in the AfterLoadFlags that are in Flags.scala, meaning that ensureCompleted() is called on the SymDenotation in order to populate the final flag set.
https://github.com/lampepfl/dotty/blob/e1a136a0076e260d1e12ca397f0a2816cbdc9015/compiler/src/dotty/tools/dotc/core/SymDenotations.scala#L128
9. Since we are still only  part way through the process of completing the constructor, I don't think it's correct to try to complete the scala 2 macro yet.  It actually fails because the type parameter A in the (trait?) definition does not have the actual type A as an attachment yet.
https://github.com/lampepfl/dotty/blob/9464bf008694506250f3fd061d7de27f1dea5d38/compiler/src/dotty/tools/dotc/typer/Typer.scala#L2133

I think the fix without any restructuring must be to check the Erased flag without needing to call ensureCompleted on the symbol, but I'm not sure if there's a better way to identify scala 2 macros at this point in the code.

I managed to get it to compile by any of these:

- hacking Namer.completeConstructor to ensure the constructor symbol is completed before indexing the rest of the statements, but that seems backwards.
i.e. add `symbolOfTree(constr).ensureCompleted()` between these two lines
https://github.com/lampepfl/dotty/blob/7c0a848d0ed6330873a39129e6d02da169150fa7/compiler/src/dotty/tools/dotc/typer/Namer.scala#L1458-L1459
- adding Erased to Flags.FromStartFlags but I think this is missing for a good reason - things can become Erased later in the process.
https://github.com/lampepfl/dotty/blob/6ff1774363208cfdd7e4d7f4eac60aad68c52cb1/compiler/src/dotty/tools/dotc/core/Flags.scala#L466
- This PR implementation.

I have added a minimal test to the macros suite, which now passes.   I managed to make something that detects the bug and doesn't depend on scala-reflect library, however beyond compiling we don't know if it actually did something useful.  Tips on making a better test case would be appreciated!

Any tips or corrections would be useful