### PR TITLE
Fix warning underlining in global init checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Trace.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Trace.scala
@@ -77,7 +77,7 @@ object Trace:
    *  pos.source must exist
    */
   private def positionMarker(pos: SourcePosition): String =
-    val trimmed = pos.lineContent.takeWhile(c => c.isWhitespace).length
+    val trimmed = pos.source.lineContent(pos.start).takeWhile(c => c.isWhitespace).length
     val padding = pos.startColumnPadding.substring(trimmed).nn + "   "
     val carets =
       if (pos.startLine == pos.endLine)

--- a/tests/init-global/neg/line-spacing.check
+++ b/tests/init-global/neg/line-spacing.check
@@ -1,0 +1,13 @@
+-- Error: tests/init-global/neg/line-spacing.scala:4:7 -----------------------------------------------------------------
+3 |    B
+4 |      .s.length // error
+  |    ^
+  |    Access uninitialized field value s. Call trace: 
+  |    -> object B {	[ line-spacing.scala:7 ]
+  |       ^
+  |    -> val s: String = s"${A.a}a"	[ line-spacing.scala:8 ]
+  |                           ^^^
+  |    -> def a: Int =	[ line-spacing.scala:2 ]
+  |       ^
+  |    -> .s.length // error	[ line-spacing.scala:4 ]
+  |       ^

--- a/tests/init-global/neg/line-spacing.scala
+++ b/tests/init-global/neg/line-spacing.scala
@@ -1,0 +1,12 @@
+object A {
+  def a: Int =
+    B
+      .s.length // error
+}
+
+object B {
+  val s: String = s"${A.a}a"
+}
+
+@main
+def Test = print(A.a)

--- a/tests/init-global/neg/line-spacing.scala
+++ b/tests/init-global/neg/line-spacing.scala
@@ -7,6 +7,3 @@ object A {
 object B {
   val s: String = s"${A.a}a"
 }
-
-@main
-def Test = print(A.a)


### PR DESCRIPTION
Fixes the placement of the caret when the global init checker reports warnings for multi-line statements.