### PR TITLE
Support implicit arguments before extractor method

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1304,7 +1304,7 @@ object Objects:
           case _ => List()
 
         val implicitValuesAfterScrtinee = evalArgs(implicits.map(Arg.apply), thisV, klass)
-        val unapplyRes = call(receiver, funRef.symbol, TraceValue(scrutinee, summon[Trace]) :: (implicitValuesBeforeScrutinee(fun) ++ implicitValuesAfterScrtinee), funRef.prefix, superType = NoType, needResolve = true)
+        val unapplyRes = call(receiver, funRef.symbol, implicitValuesBeforeScrutinee(fun) ++ (TraceValue(scrutinee, summon[Trace]) :: implicitValuesAfterScrtinee), funRef.prefix, superType = NoType, needResolve = true)
 
         if fun.symbol.name == nme.unapplySeq then
           var resultTp = unapplyResTp

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1303,7 +1303,7 @@ object Objects:
             implicitArgsBeforeScrutinee(f) ++ evalArgs(implicitArgs.map(Arg.apply), thisV, klass)
           case _ => List()
 
-        val implicitArgsAfterScrtinee = evalArgs(implicits.map(Arg.apply), thisV, klass)
+        val implicitArgsAfterScrutinee = evalArgs(implicits.map(Arg.apply), thisV, klass)
         val args = implicitArgsBeforeScrutinee(fun) ++ (TraceValue(scrutinee, summon[Trace]) :: implicitArgsAfterScrtinee)
         val unapplyRes = call(receiver, funRef.symbol, args, funRef.prefix, superType = NoType, needResolve = true)
 

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1298,13 +1298,14 @@ object Objects:
           case select: Select =>
             eval(select.qualifier, thisV, klass)
 
-        def implicitValuesBeforeScrutinee(fun: Tree): Contextual[List[ArgInfo]] = fun match
+        def implicitArgsBeforeScrutinee(fun: Tree): Contextual[List[ArgInfo]] = fun match
           case Apply(f, implicitArgs) =>
-            implicitValuesBeforeScrutinee(f) ++ evalArgs(implicitArgs.map(Arg.apply), thisV, klass)
+            implicitArgsBeforeScrutinee(f) ++ evalArgs(implicitArgs.map(Arg.apply), thisV, klass)
           case _ => List()
 
-        val implicitValuesAfterScrtinee = evalArgs(implicits.map(Arg.apply), thisV, klass)
-        val unapplyRes = call(receiver, funRef.symbol, implicitValuesBeforeScrutinee(fun) ++ (TraceValue(scrutinee, summon[Trace]) :: implicitValuesAfterScrtinee), funRef.prefix, superType = NoType, needResolve = true)
+        val implicitArgsAfterScrtinee = evalArgs(implicits.map(Arg.apply), thisV, klass)
+        val args = implicitArgsBeforeScrutinee(fun) ++ (TraceValue(scrutinee, summon[Trace]) :: implicitArgsAfterScrtinee)
+        val unapplyRes = call(receiver, funRef.symbol, args, funRef.prefix, superType = NoType, needResolve = true)
 
         if fun.symbol.name == nme.unapplySeq then
           var resultTp = unapplyResTp

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1304,7 +1304,7 @@ object Objects:
           case _ => List()
 
         val implicitArgsAfterScrutinee = evalArgs(implicits.map(Arg.apply), thisV, klass)
-        val args = implicitArgsBeforeScrutinee(fun) ++ (TraceValue(scrutinee, summon[Trace]) :: implicitArgsAfterScrtinee)
+        val args = implicitArgsBeforeScrutinee(fun) ++ (TraceValue(scrutinee, summon[Trace]) :: implicitArgsAfterScrutinee)
         val unapplyRes = call(receiver, funRef.symbol, args, funRef.prefix, superType = NoType, needResolve = true)
 
         if fun.symbol.name == nme.unapplySeq then

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1298,9 +1298,13 @@ object Objects:
           case select: Select =>
             eval(select.qualifier, thisV, klass)
 
-        val implicitValues = evalArgs(implicits.map(Arg.apply), thisV, klass)
-        // TODO: implicit values may appear before and/or after the scrutinee parameter.
-        val unapplyRes = call(receiver, funRef.symbol, TraceValue(scrutinee, summon[Trace]) :: implicitValues, funRef.prefix, superType = NoType, needResolve = true)
+        def implicitValuesBeforeScrutinee(fun: Tree): Contextual[List[ArgInfo]] = fun match
+          case Apply(f, implicitArgs) =>
+            implicitValuesBeforeScrutinee(f) ++ evalArgs(implicitArgs.map(Arg.apply), thisV, klass)
+          case _ => List()
+
+        val implicitValuesAfterScrtinee = evalArgs(implicits.map(Arg.apply), thisV, klass)
+        val unapplyRes = call(receiver, funRef.symbol, TraceValue(scrutinee, summon[Trace]) :: (implicitValuesBeforeScrutinee(fun) ++ implicitValuesAfterScrtinee), funRef.prefix, superType = NoType, needResolve = true)
 
         if fun.symbol.name == nme.unapplySeq then
           var resultTp = unapplyResTp

--- a/tests/init-global/neg/unapply-implicit-arg.scala
+++ b/tests/init-global/neg/unapply-implicit-arg.scala
@@ -1,0 +1,11 @@
+class Foo
+
+object Bar {
+  def unapply(using Foo)(pair: (Int, Int))(using Foo): Option[Int] =
+    if pair._1 == 0 then Some(pair._1) else Some(pair._2)
+  given Foo = new Foo
+  val i1: Int = 0
+  val i2: Int = (i1, i2) match // error
+    case Bar(i) => i
+    case _ => 0
+}

--- a/tests/init-global/neg/unapply-implicit-arg2.scala
+++ b/tests/init-global/neg/unapply-implicit-arg2.scala
@@ -4,11 +4,11 @@ object Bar {
     def m2(i: Int) = i+2
   }
   def unapply(using f1: Foo)(i: Int): Option[Int] =
-    if i == 0 then Some(f1.m1(i)) else Some(f1.m2(i))
+    if i == 0 then Some(f1.m1(i1)) else Some(f1.m2(i2)) // error
 
   given Foo = new Foo
   val i1: Int = 0
-  val i2: Int = i2 match // error
+  val i2: Int = i1 match
     case Bar(i) => i
     case _ => 0
 }

--- a/tests/init-global/neg/unapply-implicit-arg3.scala
+++ b/tests/init-global/neg/unapply-implicit-arg3.scala
@@ -1,14 +1,14 @@
 object Bar {
   class Foo {
-    def m1(i: Int) = i+1
-    def m2(i: Int) = i+2
+    def m1(i: Int) = i + i1
+    def m2(i: Int) = i + i2 // error
   }
   def unapply(using f1: Foo)(i: Int): Option[Int] =
     if i == 0 then Some(f1.m1(i)) else Some(f1.m2(i))
 
   given Foo = new Foo
   val i1: Int = 0
-  val i2: Int = i2 match // error
+  val i2: Int = i1 match
     case Bar(i) => i
     case _ => 0
 }

--- a/tests/init-global/neg/unapplySeq-implicit-arg.scala
+++ b/tests/init-global/neg/unapplySeq-implicit-arg.scala
@@ -1,0 +1,11 @@
+class Foo
+
+object Bar {
+  def unapplySeq(using Foo)(using Foo)(pair: (Int, Int))(using Foo): Option[Seq[Int]] =
+    if pair._1 == 0 then Some(Seq(pair._1)) else Some(Seq(pair._2))
+  given Foo = new Foo
+  val i1: Int = 0
+  val i2: Int = (i1, i2) match // error
+    case Bar(i) => i
+    case _ => 0
+}

--- a/tests/init-global/neg/unapplySeq-implicit-arg.scala
+++ b/tests/init-global/neg/unapplySeq-implicit-arg.scala
@@ -1,11 +1,14 @@
-class Foo
-
 object Bar {
-  def unapplySeq(using Foo)(using Foo)(pair: (Int, Int))(using Foo): Option[Seq[Int]] =
-    if pair._1 == 0 then Some(Seq(pair._1)) else Some(Seq(pair._2))
+  class Foo {
+    def m1(seq: Seq[Int]) = 1 +: seq
+    def m2(seq: Seq[Int]) = 2 +: seq
+  }
+  def unapplySeq(using f1: Foo)(seqi: Seq[Int]): Option[Seq[Int]] =
+    if seqi(0) == 0 then Some(f1.m1(seqi)) else Some(f1.m2(seqi))
+
   given Foo = new Foo
   val i1: Int = 0
-  val i2: Int = (i1, i2) match // error
+  val i2: Int = Seq(i2) match // error
     case Bar(i) => i
     case _ => 0
 }

--- a/tests/init-global/neg/unapplySeq-implicit-arg2.scala
+++ b/tests/init-global/neg/unapplySeq-implicit-arg2.scala
@@ -1,0 +1,10 @@
+object Bar {
+  class Foo
+  def unapplySeq(using f1: Foo)(using f2: Foo)(seqi: Seq[Int])(using Foo): Option[Seq[Int]] =
+    Some(i1 +: seqi) // error
+  given Foo = new Foo
+  val i1: Int = Seq(0) match {
+    case Bar(i) => i
+    case _ => 0
+  }
+}

--- a/tests/init-global/neg/unapplySeq-implicit-arg3.scala
+++ b/tests/init-global/neg/unapplySeq-implicit-arg3.scala
@@ -1,0 +1,12 @@
+object Bar {
+  class Foo {
+    def m(seq: Seq[Int]) = i1 +: seq // error
+  }
+  def unapplySeq(using f1: Foo)(seqi: Seq[Int])(using Foo): Option[Seq[Int]] =
+    Some(f1.m(seqi))
+  given Foo = new Foo
+  val i1: Int = Seq(0) match {
+    case Bar(i, _) => i
+    case _ => 0
+  }
+}

--- a/tests/init-global/pos/unapply-implicit-arg-pos.scala
+++ b/tests/init-global/pos/unapply-implicit-arg-pos.scala
@@ -1,11 +1,14 @@
-class Foo
-
 object Bar {
-  def unapply(using Foo)(using Foo)(pair: (Int, Int))(using Foo): Option[Int] =
-    if pair._1 == 0 then Some(pair._1) else Some(pair._2)
+  class Foo {
+    def m1(i: Int) = i + i1
+    def m2(i: Int) = i + 2
+  }
+  def unapply(using f1: Foo)(using f2: Foo)(i: Int)(using f3: Foo): Option[Int] =
+    if i == 0 then Some(f1.m1(i1) + f3.m1(i1)) else Some(f2.m2(i) + f3.m2(i))
+
   given Foo = new Foo
   val i1: Int = 0
-  val i2: Int = (i1, i1) match
+  val i2: Int = i1 match
     case Bar(i) => i
     case _ => 0
 }

--- a/tests/init-global/pos/unapply-implicit-arg-pos.scala
+++ b/tests/init-global/pos/unapply-implicit-arg-pos.scala
@@ -1,0 +1,11 @@
+class Foo
+
+object Bar {
+  def unapply(using Foo)(using Foo)(pair: (Int, Int))(using Foo): Option[Int] =
+    if pair._1 == 0 then Some(pair._1) else Some(pair._2)
+  given Foo = new Foo
+  val i1: Int = 0
+  val i2: Int = (i1, i1) match
+    case Bar(i) => i
+    case _ => 0
+}

--- a/tests/init-global/pos/unapplySeq-implicit-arg-pos.scala
+++ b/tests/init-global/pos/unapplySeq-implicit-arg-pos.scala
@@ -1,0 +1,11 @@
+class Foo
+
+object Bar {
+  def unapplySeq(using Foo)(using Foo)(pair: (Int, Int))(using Foo): Option[Seq[Int]] =
+    if pair._1 == 0 then Some(Seq(pair._1)) else Some(Seq(pair._2))
+  given Foo = new Foo
+  val i1: Int = 0
+  val i2: Int = (i1, i1) match
+    case Bar(i) => i
+    case _ => 0
+}

--- a/tests/init-global/pos/unapplySeq-implicit-arg-pos.scala
+++ b/tests/init-global/pos/unapplySeq-implicit-arg-pos.scala
@@ -1,11 +1,14 @@
-class Foo
-
 object Bar {
-  def unapplySeq(using Foo)(using Foo)(pair: (Int, Int))(using Foo): Option[Seq[Int]] =
-    if pair._1 == 0 then Some(Seq(pair._1)) else Some(Seq(pair._2))
+  class Foo {
+    def m1(seq: Seq[Int]) = 0 +: seq
+    def m2(seq: Seq[Int]) = i1 +: seq
+  }
+  def unapplySeq(using f1: Foo)(using f2: Foo)(seqi: Seq[Int])(using f3: Foo): Option[Seq[Int]] =
+    if seqi(0) == 0 then Some(f1.m1(seqi)) else Some(f2.m2(seqi))
+
   given Foo = new Foo
   val i1: Int = 0
-  val i2: Int = (i1, i1) match
+  val i2: Int = Seq(i1) match
     case Bar(i) => i
     case _ => 0
 }


### PR DESCRIPTION
Currently the global object initialization checker crashes when encountering implicit arguments in extractor methods that are before scrutinee. This PR fixes the issue and adds tests with implicit arguments before scrutinee for `unapply` and `unapplySeq` respectively.