### PR TITLE
Remove double tests of `tests/pos`

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -34,7 +34,6 @@ class CompilationTests {
       compileFilesInDir("tests/pos", defaultOptions.and("-Ysafe-init")),
       compileFilesInDir("tests/pos-deep-subtype", allowDeepSubtypes),
       compileFilesInDir("tests/pos-special/sourcepath/outer", defaultOptions.and("-sourcepath", "tests/pos-special/sourcepath")),
-      compileFilesInDir("tests/pos", defaultOptions.and("-Xlint:private-shadow", "-Xlint:type-parameter-shadow")),
       compileFile("tests/pos-special/sourcepath/outer/nested/Test4.scala", defaultOptions.and("-sourcepath", "tests/pos-special/sourcepath")),
       compileFilesInDir("tests/pos-scala2", defaultOptions.and("-source", "3.0-migration")),
       compileFilesInDir("tests/pos-custom-args/captures", defaultOptions.and("-language:experimental.captureChecking")),


### PR DESCRIPTION
We should not tests all `tests/pos` files twice with another set of flags. Furthermore, in all our tests the result of adding the flags is not checked in any meaningful way. The only tests for this flag (tests/neg-custom-args/fatal-warnings/i17612b/i17612b.scala) does add the flag explicitly and checks the result already.

See https://github.com/lampepfl/dotty/commit/46f2db6af69063d09538f0da1a3a9c5ba5f871d1