### PR TITLE
Properly format enclosing class of private access error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -876,7 +876,7 @@ extends Message(PatternMatchExhaustivityID) {
 
     val pathes = List(
       ActionPatch(
-        srcPos = endPos, 
+        srcPos = endPos,
         replacement = uncoveredCases.map(c => indent(s"case $c => ???", startColumn))
           .mkString("\n", "\n", "")
       ),
@@ -2984,7 +2984,7 @@ extends ReferenceMsg(CannotBeAccessedID):
         i"${if (sym.owner == pre.typeSymbol) sym.show else sym.showLocated} cannot"
       case _ =>
         i"none of the overloaded alternatives named $name can"
-    val where = if (ctx.owner.exists) s" from ${ctx.owner.enclosingClass}" else ""
+    val where = if (ctx.owner.exists) i" from ${ctx.owner.enclosingClass}" else ""
     val whyNot = new StringBuffer
     alts.foreach(_.isAccessibleFrom(pre, superAccess, whyNot))
     i"$whatCanNot be accessed as a member of $pre$where.$whyNot"

--- a/tests/neg/i12573.check
+++ b/tests/neg/i12573.check
@@ -4,6 +4,6 @@
    |         value getDFType is not a member of DFBits[(8 : Int)].
    |         Extension methods were tried, but the search failed with:
    |
-   |             method getDFType cannot be accessed as a member of DFType.type from module class i12573$package$.
+   |             method getDFType cannot be accessed as a member of DFType.type from package object i12573$package.
    |              Access to protected method getDFType not permitted because enclosing package object i12573$package
    |              is not a subclass of object DFType where target is defined

--- a/tests/neg/i18686.check
+++ b/tests/neg/i18686.check
@@ -1,0 +1,4 @@
+-- [E173] Reference Error: tests/neg/i18686.scala:7:16 -----------------------------------------------------------------
+7 |    println(Foo.Bar) // error
+  |            ^^^^^^^
+  |            value Bar cannot be accessed as a member of Foo.type from object Main.

--- a/tests/neg/i18686.scala
+++ b/tests/neg/i18686.scala
@@ -1,0 +1,9 @@
+object Foo:
+  private val Bar: Int = 3
+end Foo
+
+object Main:
+  def main(args: Array[String]): Unit =
+    println(Foo.Bar) // error
+  end main
+end Main


### PR DESCRIPTION
Before, the error message showed `module class XYZ$`. Now it shows `object XYZ`.

This does not fix the issue #18686, it only improves a bit the current error message.