### PR TITLE
Improve assertion error message for `Apply` and `TypeApply`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -45,19 +45,21 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def Apply(fn: Tree, args: List[Tree])(using Context): Apply = fn match
     case Block(Nil, expr) =>
       Apply(expr, args)
-    case _: RefTree | _: GenericApply | _: Inlined | _: Hole =>
-      ta.assignType(untpd.Apply(fn, args), fn, args)
     case _ =>
-      assert(ctx.reporter.errorsReported)
+      assert(
+        fn.isInstanceOf[RefTree | GenericApply | Inlined | Hole] || ctx.reporter.errorsReported,
+        s"Illegal Apply function prefix: $fn"
+      )
       ta.assignType(untpd.Apply(fn, args), fn, args)
 
   def TypeApply(fn: Tree, args: List[Tree])(using Context): TypeApply = fn match
     case Block(Nil, expr) =>
       TypeApply(expr, args)
-    case _: RefTree | _: GenericApply =>
-      ta.assignType(untpd.TypeApply(fn, args), fn, args)
     case _ =>
-      assert(ctx.reporter.errorsReported)
+      assert(
+        fn.isInstanceOf[RefTree | GenericApply] || ctx.reporter.errorsReported,
+        s"Illegal TypeApply function prefix: $fn"
+      )
       ta.assignType(untpd.TypeApply(fn, args), fn, args)
 
   def Literal(const: Constant)(using Context): Literal =


### PR DESCRIPTION
<del>
These are valid prefixes for a TypeApply in the same way they are for an Apply.

See https://github.com/lampepfl/dotty/issues/16861#issuecomment-1763200624
</del>