### PR TITLE
Fix import suggestion error logging

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -195,7 +195,7 @@ trait ImportSuggestions:
       && {
         val task = new TimerTask:
           def run() =
-            println(i"Cancelling test of $ref when making suggestions for error in ${ctx.source}")
+            implicits.println(i"Cancelling test of $ref when making suggestions for error in ${ctx.source}")
             ctx.run.nn.isCancelled = true
         val span = ctx.owner.srcPos.span
         val (expectedType, argument, kind) = pt match


### PR DESCRIPTION
This was printing the extra debug information when testing `tests/neg-deep-subtype/i1650.scala`.