### PR TITLE
Keep qualifier of Ident when selecting setter

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1121,7 +1121,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               case fn @ Ident(name: TermName) =>
                 // We need to make sure that the prefix of this extension getter is
                 // retained when we transform it into a setter. Otherwise, we could
-                // end up resoving an unrelated setter from another extension. We
+                // end up resolving an unrelated setter from another extension. We
                 // transform the `Ident` into a `Select` to ensure that the prefix
                 // is retained with a `TypedSplice` (see `case Select` bellow).
                 // See tests/pos/i18713.scala for an example.

--- a/tests/pos/i18713.scala
+++ b/tests/pos/i18713.scala
@@ -1,0 +1,18 @@
+import language.experimental.relaxedExtensionImports
+
+class A
+object AA:
+  extension (a: A)
+    def f = ???
+    def f_=(x: String) = ???
+
+object BB:
+  extension (b: Long)
+    def f = ???
+    def f_=(x: String) = ???
+
+def test(a: A) =
+  import AA.*
+  import BB.*
+  a.f
+  a.f = "aa"


### PR DESCRIPTION
We already keep the qualifier as a typed splice if the prefix is an explicit Select.

Fixes #18713