### PR TITLE
Sync `main` with `language-reference-stable`

### DIFF
--- a/changelogs/3.3.0-RC1.md
+++ b/changelogs/3.3.0-RC1.md
@@ -1,0 +1,225 @@
+# Highlights of the release
+
+- Stabilize new lazy vals [#16614](https://github.com/lampepfl/dotty/pull/16614)
+- Experimental Macro annotations  [#16392](https://github.com/lampepfl/dotty/pull/16392) [#16454](https://github.com/lampepfl/dotty/pull/16454) [#16534](https://github.com/lampepfl/dotty/pull/16534)
+- Fix stability check for inline parameters [#15511](https://github.com/lampepfl/dotty/pull/15511)
+- Make `fewerBraces` a standard feature [#16297](https://github.com/lampepfl/dotty/pull/16297)
+- Add new front-end phase for unused entities and add support for unused imports [#16157](https://github.com/lampepfl/dotty/pull/16157)
+- Implement -Wvalue-discard warning [#15975](https://github.com/lampepfl/dotty/pull/15975)
+- Introduce boundary/break control abstraction. [#16612](https://github.com/lampepfl/dotty/pull/16612)
+
+# Other changes and fixes
+
+## Annotations
+
+- Support use-site meta-annotations [#16445](https://github.com/lampepfl/dotty/pull/16445)
+
+## Desugaring
+
+- Reuse typed prefix for `applyDynamic` and `applyDynamicNamed` [#16552](https://github.com/lampepfl/dotty/pull/16552)
+- Fix object selftype match error [#16441](https://github.com/lampepfl/dotty/pull/16441)
+
+## Erasure
+
+- Dealias before checking for outer references in types [#16525](https://github.com/lampepfl/dotty/pull/16525)
+- Fix generic signature for type params bounded by primitive [#16442](https://github.com/lampepfl/dotty/pull/16442)
+- Avoid EmptyScope.cloneScope crashing, eg on missing references [#16314](https://github.com/lampepfl/dotty/pull/16314)
+
+## GADTs
+
+- Inline GADT state restoring in TypeComparer [#16564](https://github.com/lampepfl/dotty/pull/16564)
+- Add extension/conversion to GADT selection healing [#16638](https://github.com/lampepfl/dotty/pull/16638)
+
+## Incremental compilation
+
+- Unpickle arguments of parent constructors in Templates lazily [#16688](https://github.com/lampepfl/dotty/pull/16688)
+
+## Initialization
+
+- Fix #16438: Supply dummy args for erroneous parent call in init check [#16448](https://github.com/lampepfl/dotty/pull/16448)
+
+## Inline
+
+- Dealias in ConstantValue, for inline if cond [#16652](https://github.com/lampepfl/dotty/pull/16652)
+- Set Span for top level annotations generated in PostTyper [#16378](https://github.com/lampepfl/dotty/pull/16378)
+- Interpolate any type vars from comparing against SelectionProto [#16348](https://github.com/lampepfl/dotty/pull/16348)
+- Handle binding of beta reduced inlined lambdas  [#16377](https://github.com/lampepfl/dotty/pull/16377)
+- Do not add dummy RHS to abstract inline methods [#16510](https://github.com/lampepfl/dotty/pull/16510)
+- Warn on inline given aliases with functions as RHS [#16499](https://github.com/lampepfl/dotty/pull/16499)
+- Support inline overrides in value classes [#16523](https://github.com/lampepfl/dotty/pull/16523)
+
+## Java interop
+
+- Represent Java annotations as interfaces so they can be extended, and disallow various misuses of them [#16260](https://github.com/lampepfl/dotty/pull/16260)
+
+## Opaque Types
+
+- Delay opaque alias checking until PostTyper [#16644](https://github.com/lampepfl/dotty/pull/16644)
+
+## Overloading
+
+- Handle context function arguments in overloading resolution [#16511](https://github.com/lampepfl/dotty/pull/16511)
+
+## Parser
+
+- Improve support for Unicode supplementary characters in identifiers and string interpolation (as in Scala 2) [#16278](https://github.com/lampepfl/dotty/pull/16278)
+- Require indent after colon at EOL [#16466](https://github.com/lampepfl/dotty/pull/16466)
+- Help givens return refined types [#16293](https://github.com/lampepfl/dotty/pull/16293)
+
+## Pattern Matching
+
+- Tweak AvoidMap's derivedSelect [#16563](https://github.com/lampepfl/dotty/pull/16563)
+- Space: Use RHS of & when refining subtypes [#16573](https://github.com/lampepfl/dotty/pull/16573)
+- Freeze constraints in a condition check of maximiseType [#16526](https://github.com/lampepfl/dotty/pull/16526)
+- Restrict syntax of typed patterns [#16150](https://github.com/lampepfl/dotty/pull/16150)
+- Test case to show that #16252 works with transparent [#16262](https://github.com/lampepfl/dotty/pull/16262)
+- Support inline unapplySeq and with leading given parameters [#16358](https://github.com/lampepfl/dotty/pull/16358)
+- Handle sealed prefixes in exh checking [#16621](https://github.com/lampepfl/dotty/pull/16621)
+- Detect irrefutable quoted patterns [#16674](https://github.com/lampepfl/dotty/pull/16674)
+
+## Pickling
+
+- Allow case classes with up to 254 parameters [#16501](https://github.com/lampepfl/dotty/pull/16501)
+- Correctly unpickle Scala 2 private case classes in traits [#16519](https://github.com/lampepfl/dotty/pull/16519)
+
+## Polyfunctions
+
+- Fix #9996: Crash with function accepting polymorphic function type with singleton result [#16327](https://github.com/lampepfl/dotty/pull/16327)
+
+## Quotes
+
+- Remove contents of inline methods [#16345](https://github.com/lampepfl/dotty/pull/16345)
+- Fix errors in explicit type annotations in inline match cases [#16257](https://github.com/lampepfl/dotty/pull/16257)
+- Handle macro annotation suspends and crashes [#16509](https://github.com/lampepfl/dotty/pull/16509)
+- Fix macro annotations `spliceOwner` [#16513](https://github.com/lampepfl/dotty/pull/16513)
+
+## REPL
+
+- REPL: Fix crash when printing instances of value classes [#16393](https://github.com/lampepfl/dotty/pull/16393)
+- Attempt to fix completion crash [#16267](https://github.com/lampepfl/dotty/pull/16267)
+- Fix REPL shadowing bug [#16389](https://github.com/lampepfl/dotty/pull/16389)
+- Open up for extensibility [#16276](https://github.com/lampepfl/dotty/pull/16276)
+- Don't crash if completions throw [#16687](https://github.com/lampepfl/dotty/pull/16687)
+
+## Reflection
+
+- Fix reflect typeMembers to return all members [#15033](https://github.com/lampepfl/dotty/pull/15033)
+- Deprecate reflect Flags.Static [#16568](https://github.com/lampepfl/dotty/pull/16568)
+
+## Reporting
+
+- Suppress follow-on errors for erroneous import qualifiers [#16658](https://github.com/lampepfl/dotty/pull/16658)
+- Fix order in which errors are reported for assignment to val [#16660](https://github.com/lampepfl/dotty/pull/16660)
+- Fix class name in error message [#16635](https://github.com/lampepfl/dotty/pull/16635)
+- Make refined type printing more source compatible [#16303](https://github.com/lampepfl/dotty/pull/16303)
+- Add error hint on local inline def used in quotes [#16572](https://github.com/lampepfl/dotty/pull/16572)
+- Fix Text wrapping [#16277](https://github.com/lampepfl/dotty/pull/16277)
+- Fix -Wunused:import registering constructor `<init>` instead of its owner (also fix false positive for enum) [#16661](https://github.com/lampepfl/dotty/pull/16661)
+- Fix #16675 : -Wunused false positive on case class generated method, due to flags used to distinguish case accessors. [#16683](https://github.com/lampepfl/dotty/pull/16683)
+- Fix #16680 by registering Ident not containing a symbol [#16689](https://github.com/lampepfl/dotty/pull/16689)
+- Fix #16682: CheckUnused missed some used symbols [#16690](https://github.com/lampepfl/dotty/pull/16690)
+- Fix the non-miniphase tree traverser [#16684](https://github.com/lampepfl/dotty/pull/16684)
+
+## Scala-JS
+
+- Fix #14289: Accept Ident refs to `js.native` in native member rhs. [#16185](https://github.com/lampepfl/dotty/pull/16185)
+
+## Standard Library
+
+- Add `CanEqual` instance for `Map` [#15886](https://github.com/lampepfl/dotty/pull/15886)
+- Refine `Tuple.Append` return type [#16140](https://github.com/lampepfl/dotty/pull/16140)
+
+## TASTy format
+
+- Make it a fatal error if erasure cannot resolve a type [#16373](https://github.com/lampepfl/dotty/pull/16373)
+
+## Tooling
+
+- Add -Yimports compiler flag [#16218](https://github.com/lampepfl/dotty/pull/16218)
+- Allow BooleanSettings to be set with a colon [#16425](https://github.com/lampepfl/dotty/pull/16425)
+
+## Transform
+
+- Avoid stackoverflow in ExplicitOuter [#16381](https://github.com/lampepfl/dotty/pull/16381)
+- Make lazy vals run on non-fallback graal image - remove dynamic reflection [#16346](https://github.com/lampepfl/dotty/pull/16346)
+- Patch to avoid crash in #16351 [#16354](https://github.com/lampepfl/dotty/pull/16354)
+- Don't treat package object's `<init>` methods as package members [#16667](https://github.com/lampepfl/dotty/pull/16667)
+- Space: Refine isSubspace property & an example [#16574](https://github.com/lampepfl/dotty/pull/16574)
+
+## Typer
+
+- Drop requirement that self types are closed [#16648](https://github.com/lampepfl/dotty/pull/16648)
+- Disallow constructor params from appearing in parent types for soundness [#16664](https://github.com/lampepfl/dotty/pull/16664)
+- Don't search implicit arguments in singleton type prefix [#16490](https://github.com/lampepfl/dotty/pull/16490)
+- Don't rely on isProvisional to determine whether atoms computed [#16489](https://github.com/lampepfl/dotty/pull/16489)
+- Support signature polymorphic methods (`MethodHandle` and `VarHandle`) [#16225](https://github.com/lampepfl/dotty/pull/16225)
+- Prefer parameterless alternatives during ambiguous overload resolution [#16315](https://github.com/lampepfl/dotty/pull/16315)
+- Fix calculation to drop transparent classes [#16344](https://github.com/lampepfl/dotty/pull/16344)
+- Test case for issue 16311 [#16317](https://github.com/lampepfl/dotty/pull/16317)
+- Skip caching provisional OrType atoms [#16295](https://github.com/lampepfl/dotty/pull/16295)
+- Avoid cyclic references due to experimental check when inlining [#16195](https://github.com/lampepfl/dotty/pull/16195)
+- Track type variable dependencies to guide instantiation decisions [#16042](https://github.com/lampepfl/dotty/pull/16042)
+- Two fixes to constraint solving [#16353](https://github.com/lampepfl/dotty/pull/16353)
+- Fix regression in cyclic constraint handling [#16514](https://github.com/lampepfl/dotty/pull/16514)
+- Sharpen range approximation for applied types with capture set ranges [#16261](https://github.com/lampepfl/dotty/pull/16261)
+- Cut the Gordian Knot: Don't widen unions to transparent [#15642](https://github.com/lampepfl/dotty/pull/15642)
+- Fix widening logic to keep instantiation within bounds [#16417](https://github.com/lampepfl/dotty/pull/16417)
+- Skip ambiguous reference error when symbols are aliases [#16401](https://github.com/lampepfl/dotty/pull/16401)
+- Avoid incorrect simplifications when updating bounds in the constraint [#16410](https://github.com/lampepfl/dotty/pull/16410)
+- Take `@targetName` into account when resolving extension methods [#16487](https://github.com/lampepfl/dotty/pull/16487)
+- Improve ClassTag handling to avoid invalid ClassTag generation and inference failure [#16492](https://github.com/lampepfl/dotty/pull/16492)
+- Fix extracting the elemType of a union of arrays [#16569](https://github.com/lampepfl/dotty/pull/16569)
+- Make sure annotations are typed in expression contexts [#16699](https://github.com/lampepfl/dotty/pull/16699)
+- Throw a type error when using hk-types in unions or intersections [#16712](https://github.com/lampepfl/dotty/pull/16712)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.2.2..3.3.0-RC1` these are:
+
+```
+   225 Martin Odersky
+    73 Dale Wijnand
+    58 Szymon Rodziewicz
+    54 Nicolas Stucki
+    48 Kamil Szewczyk
+    48 Paul Coral
+    30 Paweł Marks
+    28 Florian3k
+    28 Yichen Xu
+    14 Guillaume Martres
+     8 Fengyun Liu
+     8 Michał Pałka
+     7 Chris Birchall
+     7 rochala
+     6 Kacper Korban
+     6 Sébastien Doeraene
+     6 jdudrak
+     5 Seth Tisue
+     5 Som Snytt
+     5 nizhikov
+     4 Filip Zybała
+     4 Jan Chyb
+     4 Michael Pollmeier
+     4 Natsu Kagami
+     3 Jamie Thompson
+     2 Alex
+     2 Anatolii Kmetiuk
+     2 Dmitrii Naumenko
+     2 Lukas Rytz
+     2 adampauls
+     2 yoshinorin
+     1 Alexander Slesarenko
+     1 Chris Kipp
+     1 Guillaume Raffin
+     1 Jakub Kozłowski
+     1 Jan-Pieter van den Heuvel
+     1 Julien Richard-Foy
+     1 Kenji Yoshida
+     1 Philippus
+     1 Szymon R
+     1 Tim Spence
+     1 s.bazarsadaev
+
+```

--- a/changelogs/3.3.0-RC2.md
+++ b/changelogs/3.3.0-RC2.md
@@ -1,0 +1,229 @@
+This release is nearly identical to 3.3.0-RC1. The only difference is that 3.3.0-RC1 generated output with incorrect TASTy version.
+
+The following changelog is identical to the changelog of 3.3.0-RC1.
+
+# Highlights of the release
+
+- Stabilize new lazy vals [#16614](https://github.com/lampepfl/dotty/pull/16614)
+- Experimental Macro annotations  [#16392](https://github.com/lampepfl/dotty/pull/16392) [#16454](https://github.com/lampepfl/dotty/pull/16454) [#16534](https://github.com/lampepfl/dotty/pull/16534)
+- Fix stability check for inline parameters [#15511](https://github.com/lampepfl/dotty/pull/15511)
+- Make `fewerBraces` a standard feature [#16297](https://github.com/lampepfl/dotty/pull/16297)
+- Add new front-end phase for unused entities and add support for unused imports [#16157](https://github.com/lampepfl/dotty/pull/16157)
+- Implement -Wvalue-discard warning [#15975](https://github.com/lampepfl/dotty/pull/15975)
+- Introduce boundary/break control abstraction. [#16612](https://github.com/lampepfl/dotty/pull/16612)
+
+# Other changes and fixes
+
+## Annotations
+
+- Support use-site meta-annotations [#16445](https://github.com/lampepfl/dotty/pull/16445)
+
+## Desugaring
+
+- Reuse typed prefix for `applyDynamic` and `applyDynamicNamed` [#16552](https://github.com/lampepfl/dotty/pull/16552)
+- Fix object selftype match error [#16441](https://github.com/lampepfl/dotty/pull/16441)
+
+## Erasure
+
+- Dealias before checking for outer references in types [#16525](https://github.com/lampepfl/dotty/pull/16525)
+- Fix generic signature for type params bounded by primitive [#16442](https://github.com/lampepfl/dotty/pull/16442)
+- Avoid EmptyScope.cloneScope crashing, eg on missing references [#16314](https://github.com/lampepfl/dotty/pull/16314)
+
+## GADTs
+
+- Inline GADT state restoring in TypeComparer [#16564](https://github.com/lampepfl/dotty/pull/16564)
+- Add extension/conversion to GADT selection healing [#16638](https://github.com/lampepfl/dotty/pull/16638)
+
+## Incremental compilation
+
+- Unpickle arguments of parent constructors in Templates lazily [#16688](https://github.com/lampepfl/dotty/pull/16688)
+
+## Initialization
+
+- Fix #16438: Supply dummy args for erroneous parent call in init check [#16448](https://github.com/lampepfl/dotty/pull/16448)
+
+## Inline
+
+- Dealias in ConstantValue, for inline if cond [#16652](https://github.com/lampepfl/dotty/pull/16652)
+- Set Span for top level annotations generated in PostTyper [#16378](https://github.com/lampepfl/dotty/pull/16378)
+- Interpolate any type vars from comparing against SelectionProto [#16348](https://github.com/lampepfl/dotty/pull/16348)
+- Handle binding of beta reduced inlined lambdas  [#16377](https://github.com/lampepfl/dotty/pull/16377)
+- Do not add dummy RHS to abstract inline methods [#16510](https://github.com/lampepfl/dotty/pull/16510)
+- Warn on inline given aliases with functions as RHS [#16499](https://github.com/lampepfl/dotty/pull/16499)
+- Support inline overrides in value classes [#16523](https://github.com/lampepfl/dotty/pull/16523)
+
+## Java interop
+
+- Represent Java annotations as interfaces so they can be extended, and disallow various misuses of them [#16260](https://github.com/lampepfl/dotty/pull/16260)
+
+## Opaque Types
+
+- Delay opaque alias checking until PostTyper [#16644](https://github.com/lampepfl/dotty/pull/16644)
+
+## Overloading
+
+- Handle context function arguments in overloading resolution [#16511](https://github.com/lampepfl/dotty/pull/16511)
+
+## Parser
+
+- Improve support for Unicode supplementary characters in identifiers and string interpolation (as in Scala 2) [#16278](https://github.com/lampepfl/dotty/pull/16278)
+- Require indent after colon at EOL [#16466](https://github.com/lampepfl/dotty/pull/16466)
+- Help givens return refined types [#16293](https://github.com/lampepfl/dotty/pull/16293)
+
+## Pattern Matching
+
+- Tweak AvoidMap's derivedSelect [#16563](https://github.com/lampepfl/dotty/pull/16563)
+- Space: Use RHS of & when refining subtypes [#16573](https://github.com/lampepfl/dotty/pull/16573)
+- Freeze constraints in a condition check of maximiseType [#16526](https://github.com/lampepfl/dotty/pull/16526)
+- Restrict syntax of typed patterns [#16150](https://github.com/lampepfl/dotty/pull/16150)
+- Test case to show that #16252 works with transparent [#16262](https://github.com/lampepfl/dotty/pull/16262)
+- Support inline unapplySeq and with leading given parameters [#16358](https://github.com/lampepfl/dotty/pull/16358)
+- Handle sealed prefixes in exh checking [#16621](https://github.com/lampepfl/dotty/pull/16621)
+- Detect irrefutable quoted patterns [#16674](https://github.com/lampepfl/dotty/pull/16674)
+
+## Pickling
+
+- Allow case classes with up to 254 parameters [#16501](https://github.com/lampepfl/dotty/pull/16501)
+- Correctly unpickle Scala 2 private case classes in traits [#16519](https://github.com/lampepfl/dotty/pull/16519)
+
+## Polyfunctions
+
+- Fix #9996: Crash with function accepting polymorphic function type with singleton result [#16327](https://github.com/lampepfl/dotty/pull/16327)
+
+## Quotes
+
+- Remove contents of inline methods [#16345](https://github.com/lampepfl/dotty/pull/16345)
+- Fix errors in explicit type annotations in inline match cases [#16257](https://github.com/lampepfl/dotty/pull/16257)
+- Handle macro annotation suspends and crashes [#16509](https://github.com/lampepfl/dotty/pull/16509)
+- Fix macro annotations `spliceOwner` [#16513](https://github.com/lampepfl/dotty/pull/16513)
+
+## REPL
+
+- REPL: Fix crash when printing instances of value classes [#16393](https://github.com/lampepfl/dotty/pull/16393)
+- Attempt to fix completion crash [#16267](https://github.com/lampepfl/dotty/pull/16267)
+- Fix REPL shadowing bug [#16389](https://github.com/lampepfl/dotty/pull/16389)
+- Open up for extensibility [#16276](https://github.com/lampepfl/dotty/pull/16276)
+- Don't crash if completions throw [#16687](https://github.com/lampepfl/dotty/pull/16687)
+
+## Reflection
+
+- Fix reflect typeMembers to return all members [#15033](https://github.com/lampepfl/dotty/pull/15033)
+- Deprecate reflect Flags.Static [#16568](https://github.com/lampepfl/dotty/pull/16568)
+
+## Reporting
+
+- Suppress follow-on errors for erroneous import qualifiers [#16658](https://github.com/lampepfl/dotty/pull/16658)
+- Fix order in which errors are reported for assignment to val [#16660](https://github.com/lampepfl/dotty/pull/16660)
+- Fix class name in error message [#16635](https://github.com/lampepfl/dotty/pull/16635)
+- Make refined type printing more source compatible [#16303](https://github.com/lampepfl/dotty/pull/16303)
+- Add error hint on local inline def used in quotes [#16572](https://github.com/lampepfl/dotty/pull/16572)
+- Fix Text wrapping [#16277](https://github.com/lampepfl/dotty/pull/16277)
+- Fix -Wunused:import registering constructor `<init>` instead of its owner (also fix false positive for enum) [#16661](https://github.com/lampepfl/dotty/pull/16661)
+- Fix #16675 : -Wunused false positive on case class generated method, due to flags used to distinguish case accessors. [#16683](https://github.com/lampepfl/dotty/pull/16683)
+- Fix #16680 by registering Ident not containing a symbol [#16689](https://github.com/lampepfl/dotty/pull/16689)
+- Fix #16682: CheckUnused missed some used symbols [#16690](https://github.com/lampepfl/dotty/pull/16690)
+- Fix the non-miniphase tree traverser [#16684](https://github.com/lampepfl/dotty/pull/16684)
+
+## Scala-JS
+
+- Fix #14289: Accept Ident refs to `js.native` in native member rhs. [#16185](https://github.com/lampepfl/dotty/pull/16185)
+
+## Standard Library
+
+- Add `CanEqual` instance for `Map` [#15886](https://github.com/lampepfl/dotty/pull/15886)
+- Refine `Tuple.Append` return type [#16140](https://github.com/lampepfl/dotty/pull/16140)
+
+## TASTy format
+
+- Make it a fatal error if erasure cannot resolve a type [#16373](https://github.com/lampepfl/dotty/pull/16373)
+
+## Tooling
+
+- Add -Yimports compiler flag [#16218](https://github.com/lampepfl/dotty/pull/16218)
+- Allow BooleanSettings to be set with a colon [#16425](https://github.com/lampepfl/dotty/pull/16425)
+
+## Transform
+
+- Avoid stackoverflow in ExplicitOuter [#16381](https://github.com/lampepfl/dotty/pull/16381)
+- Make lazy vals run on non-fallback graal image - remove dynamic reflection [#16346](https://github.com/lampepfl/dotty/pull/16346)
+- Patch to avoid crash in #16351 [#16354](https://github.com/lampepfl/dotty/pull/16354)
+- Don't treat package object's `<init>` methods as package members [#16667](https://github.com/lampepfl/dotty/pull/16667)
+- Space: Refine isSubspace property & an example [#16574](https://github.com/lampepfl/dotty/pull/16574)
+
+## Typer
+
+- Drop requirement that self types are closed [#16648](https://github.com/lampepfl/dotty/pull/16648)
+- Disallow constructor params from appearing in parent types for soundness [#16664](https://github.com/lampepfl/dotty/pull/16664)
+- Don't search implicit arguments in singleton type prefix [#16490](https://github.com/lampepfl/dotty/pull/16490)
+- Don't rely on isProvisional to determine whether atoms computed [#16489](https://github.com/lampepfl/dotty/pull/16489)
+- Support signature polymorphic methods (`MethodHandle` and `VarHandle`) [#16225](https://github.com/lampepfl/dotty/pull/16225)
+- Prefer parameterless alternatives during ambiguous overload resolution [#16315](https://github.com/lampepfl/dotty/pull/16315)
+- Fix calculation to drop transparent classes [#16344](https://github.com/lampepfl/dotty/pull/16344)
+- Test case for issue 16311 [#16317](https://github.com/lampepfl/dotty/pull/16317)
+- Skip caching provisional OrType atoms [#16295](https://github.com/lampepfl/dotty/pull/16295)
+- Avoid cyclic references due to experimental check when inlining [#16195](https://github.com/lampepfl/dotty/pull/16195)
+- Track type variable dependencies to guide instantiation decisions [#16042](https://github.com/lampepfl/dotty/pull/16042)
+- Two fixes to constraint solving [#16353](https://github.com/lampepfl/dotty/pull/16353)
+- Fix regression in cyclic constraint handling [#16514](https://github.com/lampepfl/dotty/pull/16514)
+- Sharpen range approximation for applied types with capture set ranges [#16261](https://github.com/lampepfl/dotty/pull/16261)
+- Cut the Gordian Knot: Don't widen unions to transparent [#15642](https://github.com/lampepfl/dotty/pull/15642)
+- Fix widening logic to keep instantiation within bounds [#16417](https://github.com/lampepfl/dotty/pull/16417)
+- Skip ambiguous reference error when symbols are aliases [#16401](https://github.com/lampepfl/dotty/pull/16401)
+- Avoid incorrect simplifications when updating bounds in the constraint [#16410](https://github.com/lampepfl/dotty/pull/16410)
+- Take `@targetName` into account when resolving extension methods [#16487](https://github.com/lampepfl/dotty/pull/16487)
+- Improve ClassTag handling to avoid invalid ClassTag generation and inference failure [#16492](https://github.com/lampepfl/dotty/pull/16492)
+- Fix extracting the elemType of a union of arrays [#16569](https://github.com/lampepfl/dotty/pull/16569)
+- Make sure annotations are typed in expression contexts [#16699](https://github.com/lampepfl/dotty/pull/16699)
+- Throw a type error when using hk-types in unions or intersections [#16712](https://github.com/lampepfl/dotty/pull/16712)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.2.2..3.3.0-RC1` these are:
+
+```
+   225 Martin Odersky
+    73 Dale Wijnand
+    58 Szymon Rodziewicz
+    54 Nicolas Stucki
+    48 Kamil Szewczyk
+    48 Paul Coral
+    30 Paweł Marks
+    28 Florian3k
+    28 Yichen Xu
+    14 Guillaume Martres
+     8 Fengyun Liu
+     8 Michał Pałka
+     7 Chris Birchall
+     7 rochala
+     6 Kacper Korban
+     6 Sébastien Doeraene
+     6 jdudrak
+     5 Seth Tisue
+     5 Som Snytt
+     5 nizhikov
+     4 Filip Zybała
+     4 Jan Chyb
+     4 Michael Pollmeier
+     4 Natsu Kagami
+     3 Jamie Thompson
+     2 Alex
+     2 Anatolii Kmetiuk
+     2 Dmitrii Naumenko
+     2 Lukas Rytz
+     2 adampauls
+     2 yoshinorin
+     1 Alexander Slesarenko
+     1 Chris Kipp
+     1 Guillaume Raffin
+     1 Jakub Kozłowski
+     1 Jan-Pieter van den Heuvel
+     1 Julien Richard-Foy
+     1 Kenji Yoshida
+     1 Philippus
+     1 Szymon R
+     1 Tim Spence
+     1 s.bazarsadaev
+
+```

--- a/changelogs/3.3.0-RC3.md
+++ b/changelogs/3.3.0-RC3.md
@@ -1,0 +1,23 @@
+# Backported fixes
+
+- Added jpath check to `ClassLikeSupport` getParentsAsTreeSymbolTuples [#16759](https://github.com/lampepfl/dotty/pull/16759)
+- Split out immutable GadtConstraint [#16602](https://github.com/lampepfl/dotty/pull/16602)
+- Avoid bidirectional GADT typebounds from fullBounds [#15683](https://github.com/lampepfl/dotty/pull/15683)
+- Fix static lazy field holder for GraalVM  [#16800](https://github.com/lampepfl/dotty/pull/16800)
+- Add support for disabling redirected output in the REPL driver for usage in worksheets in the Scala Plugin for IntelliJ IDEA [#16810](https://github.com/lampepfl/dotty/pull/16810)
+- Add missing criterion to subtype check [#16889](https://github.com/lampepfl/dotty/pull/16889)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.0-RC2..3.3.0-RC3` these are:
+
+```
+     7 Dale Wijnand
+     5 Szymon Rodziewicz
+     2 Paweł Marks
+     2 Vasil Vasilev
+     1 Martin Odersky
+     1 Mohammad Yousuf Minhaj Zia
+```

--- a/changelogs/3.3.0-RC4.md
+++ b/changelogs/3.3.0-RC4.md
@@ -1,0 +1,35 @@
+# Backported fixes
+
+- Fix HK quoted pattern type variables [#16907](https//github.com/lampepfl/dotty/pull/16907)
+- Fix caching issue caused by incorrect isProvisional check [#16989](https://github.com/lampepfl/dotty/pull/16989)
+- Fix race condition in new LazyVals [#16975](https://github.com/lampepfl/dotty/pull/16975)
+- Fix "-Wunused: False positive on parameterless enum member" [#16927](https://github.com/lampepfl/dotty/pull/16927)
+- Register usage of symbols in non-inferred type trees in CheckUnused [#16939](https://github.com/lampepfl/dotty/pull/16939)
+- Traverse annotations instead of just registering in -W [#16956](https://github.com/lampepfl/dotty/pull/16956)
+- Ignore parameter of accessors in -Wunused [#16957](https://github.com/lampepfl/dotty/pull/16957)
+- Improve override detection in CheckUnused [#16965](https://github.com/lampepfl/dotty/pull/16965)
+- WUnused: Fix unused warning in synthetic symbols [#17020](https://github.com/lampepfl/dotty/pull/17020)
+- Fix WUnused with idents in derived code [#17095](https//github.com/lampepfl/dotty/pull/17095)
+- WUnused: Fix for symbols with synthetic names and unused transparent inlines [#17061](https//github.com/lampepfl/dotty/pull/17061)
+- Skip extension method params in WUnused [#17178](https//github.com/lampepfl/dotty/pull/17178)
+- Fix wunused false positive when deriving alias type [#17157](https//github.com/lampepfl/dotty/pull/17157)
+- Fix WUnused for accessible symbols that are renamed [#17177](https//github.com/lampepfl/dotty/pull/17177)
+- Fix WUnused false positive in for [#17176](https//github.com/lampepfl/dotty/pull/17176)
+- Make CheckUnused run both after Typer and Inlining [#17206](https//github.com/lampepfl/dotty/pull/17206)
+- Disable WUnused for params of non-private defs [#17223](https//github.com/lampepfl/dotty/pull/17223)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.0-RC3..3.3.0-RC4` these are:
+
+```
+    41 Szymon Rodziewicz
+     4 Paul Coral
+     3 Paweł Marks
+     1 Guillaume Martres
+     1 Kacper Korban
+     1 Nicolas Stucki
+
+```

--- a/changelogs/3.3.0-RC5.md
+++ b/changelogs/3.3.0-RC5.md
@@ -1,0 +1,22 @@
+# Backported fixes
+
+- Remove experimental from `Mirror#fromProductTyped` [#16829](https//github.com/lampepfl/dotty/pull/16829)
+- Wunused: Check if symbol exists before `isValidMemberDef` check [#17316](https://github.com/lampepfl/dotty/pull/17316)
+- Wunused: Include import selector bounds in unused checks [#17323](https://github.com/lampepfl/dotty/pull/17323)
+- Fix compiler crash in WUnused  [#17340](https://github.com/lampepfl/dotty/pull/17340)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.0-RC4..3.3.0-RC5` these are:
+
+```
+     2 Kacper Korban
+     2 Michael Pilquist
+     2 Paweł Marks
+     2 Szymon Rodziewicz
+     1 Matt Bovel
+
+
+```

--- a/changelogs/3.3.0-RC6.md
+++ b/changelogs/3.3.0-RC6.md
@@ -1,0 +1,18 @@
+# Backported fixes
+
+- Patmat: Use less type variables in prefix inference [#16827](https//github.com/lampepfl/dotty/pull/16827)
+- Just warn on type ascription on a pattern [#17454](https://github.com/lampepfl/dotty/pull/17454)
+- Fix #17187: allow patches with same span [#17366](https://github.com/lampepfl/dotty/pull/17366)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.0-RC5..3.3.0-RC6` these are:
+
+```
+     2  Adrien Piquerez
+     2  Michał Pałka
+     2  Paweł Marks
+     1  Dale Wijnand
+```

--- a/changelogs/3.3.0.md
+++ b/changelogs/3.3.0.md
@@ -1,0 +1,268 @@
+# Highlights of the release
+
+- Stabilize new lazy vals [#16614](https://github.com/lampepfl/dotty/pull/16614)
+- Experimental Macro annotations  [#16392](https://github.com/lampepfl/dotty/pull/16392) [#16454](https://github.com/lampepfl/dotty/pull/16454) [#16534](https://github.com/lampepfl/dotty/pull/16534)
+- Fix stability check for inline parameters [#15511](https://github.com/lampepfl/dotty/pull/15511)
+- Make `fewerBraces` a standard feature [#16297](https://github.com/lampepfl/dotty/pull/16297)
+- Add new front-end phase for unused entities and add support for unused imports [#16157](https://github.com/lampepfl/dotty/pull/16157)
+- Implement -Wvalue-discard warning [#15975](https://github.com/lampepfl/dotty/pull/15975)
+- Introduce boundary/break control abstraction. [#16612](https://github.com/lampepfl/dotty/pull/16612)
+
+# Other changes and fixes
+
+## Annotations
+
+- Support use-site meta-annotations [#16445](https://github.com/lampepfl/dotty/pull/16445)
+
+## Desugaring
+
+- Reuse typed prefix for `applyDynamic` and `applyDynamicNamed` [#16552](https://github.com/lampepfl/dotty/pull/16552)
+- Fix object selftype match error [#16441](https://github.com/lampepfl/dotty/pull/16441)
+
+## Erasure
+
+- Dealias before checking for outer references in types [#16525](https://github.com/lampepfl/dotty/pull/16525)
+- Fix generic signature for type params bounded by primitive [#16442](https://github.com/lampepfl/dotty/pull/16442)
+- Avoid EmptyScope.cloneScope crashing, eg on missing references [#16314](https://github.com/lampepfl/dotty/pull/16314)
+
+## GADTs
+
+- Inline GADT state restoring in TypeComparer [#16564](https://github.com/lampepfl/dotty/pull/16564)
+- Add extension/conversion to GADT selection healing [#16638](https://github.com/lampepfl/dotty/pull/16638)
+- Split out immutable GadtConstraint [#16602](https://github.com/lampepfl/dotty/pull/16602)
+- Avoid bidirectional GADT typebounds from fullBounds [#15683](https://github.com/lampepfl/dotty/pull/15683)
+
+## Incremental compilation
+
+- Unpickle arguments of parent constructors in Templates lazily [#16688](https://github.com/lampepfl/dotty/pull/16688)
+
+## Initialization
+
+- Fix #16438: Supply dummy args for erroneous parent call in init check [#16448](https://github.com/lampepfl/dotty/pull/16448)
+
+## Inline
+
+- Dealias in ConstantValue, for inline if cond [#16652](https://github.com/lampepfl/dotty/pull/16652)
+- Set Span for top level annotations generated in PostTyper [#16378](https://github.com/lampepfl/dotty/pull/16378)
+- Interpolate any type vars from comparing against SelectionProto [#16348](https://github.com/lampepfl/dotty/pull/16348)
+- Handle binding of beta reduced inlined lambdas  [#16377](https://github.com/lampepfl/dotty/pull/16377)
+- Do not add dummy RHS to abstract inline methods [#16510](https://github.com/lampepfl/dotty/pull/16510)
+- Warn on inline given aliases with functions as RHS [#16499](https://github.com/lampepfl/dotty/pull/16499)
+- Support inline overrides in value classes [#16523](https://github.com/lampepfl/dotty/pull/16523)
+
+## Java interop
+
+- Represent Java annotations as interfaces so they can be extended, and disallow various misuses of them [#16260](https://github.com/lampepfl/dotty/pull/16260)
+
+## Linting
+
+- Fix -Wunused:import registering constructor `<init>` instead of its owner (also fix false positive for enum) [#16661](https://github.com/lampepfl/dotty/pull/16661)
+- Fix #16675 : -Wunused false positive on case class generated method, due to flags used to distinguish case accessors. [#16683](https://github.com/lampepfl/dotty/pull/16683)
+- Fix #16682: CheckUnused missed some used symbols [#16690](https://github.com/lampepfl/dotty/pull/16690)
+- Fix "-Wunused: False positive on parameterless enum member" [#16927](https://github.com/lampepfl/dotty/pull/16927)
+- Register usage of symbols in non-inferred type trees in CheckUnused [#16939](https://github.com/lampepfl/dotty/pull/16939)
+- Traverse annotations instead of just registering in -Wunused [#16956](https://github.com/lampepfl/dotty/pull/16956)
+- Ignore parameter of accessors in -Wunused [#16957](https://github.com/lampepfl/dotty/pull/16957)
+- Ignore parameter of accessors in -Wunused [#16957](https://github.com/lampepfl/dotty/pull/16957)
+- Improve override detection in CheckUnused [#16965](https://github.com/lampepfl/dotty/pull/16965)
+- WUnused: Fix unused warning in synthetic symbols [#17020](https://github.com/lampepfl/dotty/pull/17020)
+- Fix WUnused with idents in derived code [#17095](https//github.com/lampepfl/dotty/pull/17095)
+- WUnused: Fix for symbols with synthetic names and unused transparent inlines [#17061](https//github.com/lampepfl/dotty/pull/17061)
+- Skip extension method params in WUnused [#17178](https//github.com/lampepfl/dotty/pull/17178)
+- Fix wunused false positive when deriving alias type [#17157](https//github.com/lampepfl/dotty/pull/17157)
+- Fix WUnused for accessible symbols that are renamed [#17177](https//github.com/lampepfl/dotty/pull/17177)
+- Fix WUnused false positive in for [#17176](https//github.com/lampepfl/dotty/pull/17176)
+- Make CheckUnused run both after Typer and Inlining [#17206](https//github.com/lampepfl/dotty/pull/17206)
+- Disable WUnused for params of non-private defs [#17223](https//github.com/lampepfl/dotty/pull/17223)
+- Wunused: Check if symbol exists before `isValidMemberDef` check [#17316](https://github.com/lampepfl/dotty/pull/17316)
+- Wunused: Include import selector bounds in unused checks [#17323](https://github.com/lampepfl/dotty/pull/17323)
+- Fix compiler crash in WUnused  [#17340](https://github.com/lampepfl/dotty/pull/17340)
+
+## Opaque Types
+
+- Delay opaque alias checking until PostTyper [#16644](https://github.com/lampepfl/dotty/pull/16644)
+
+## Overloading
+
+- Handle context function arguments in overloading resolution [#16511](https://github.com/lampepfl/dotty/pull/16511)
+
+## Parser
+
+- Improve support for Unicode supplementary characters in identifiers and string interpolation (as in Scala 2) [#16278](https://github.com/lampepfl/dotty/pull/16278)
+- Require indent after colon at EOL [#16466](https://github.com/lampepfl/dotty/pull/16466)
+- Help givens return refined types [#16293](https://github.com/lampepfl/dotty/pull/16293)
+
+## Pattern Matching
+
+- Tweak AvoidMap's derivedSelect [#16563](https://github.com/lampepfl/dotty/pull/16563)
+- Space: Use RHS of & when refining subtypes [#16573](https://github.com/lampepfl/dotty/pull/16573)
+- Freeze constraints in a condition check of maximiseType [#16526](https://github.com/lampepfl/dotty/pull/16526)
+- Restrict syntax of typed patterns [#16150](https://github.com/lampepfl/dotty/pull/16150)
+- Test case to show that #16252 works with transparent [#16262](https://github.com/lampepfl/dotty/pull/16262)
+- Support inline unapplySeq and with leading given parameters [#16358](https://github.com/lampepfl/dotty/pull/16358)
+- Handle sealed prefixes in exh checking [#16621](https://github.com/lampepfl/dotty/pull/16621)
+- Detect irrefutable quoted patterns [#16674](https://github.com/lampepfl/dotty/pull/16674)
+- Patmat: Use less type variables in prefix inference [#16827](https//github.com/lampepfl/dotty/pull/16827)
+
+## Pickling
+
+- Allow case classes with up to 254 parameters [#16501](https://github.com/lampepfl/dotty/pull/16501)
+- Correctly unpickle Scala 2 private case classes in traits [#16519](https://github.com/lampepfl/dotty/pull/16519)
+
+## Polyfunctions
+
+- Fix #9996: Crash with function accepting polymorphic function type with singleton result [#16327](https://github.com/lampepfl/dotty/pull/16327)
+
+## Quotes
+
+- Remove contents of inline methods [#16345](https://github.com/lampepfl/dotty/pull/16345)
+- Fix errors in explicit type annotations in inline match cases [#16257](https://github.com/lampepfl/dotty/pull/16257)
+- Handle macro annotation suspends and crashes [#16509](https://github.com/lampepfl/dotty/pull/16509)
+- Fix macro annotations `spliceOwner` [#16513](https://github.com/lampepfl/dotty/pull/16513)
+- Fix HK quoted pattern type variables [#16907](https//github.com/lampepfl/dotty/pull/16907)
+
+## REPL
+
+- REPL: Fix crash when printing instances of value classes [#16393](https://github.com/lampepfl/dotty/pull/16393)
+- Attempt to fix completion crash [#16267](https://github.com/lampepfl/dotty/pull/16267)
+- Fix REPL shadowing bug [#16389](https://github.com/lampepfl/dotty/pull/16389)
+- Open up for extensibility [#16276](https://github.com/lampepfl/dotty/pull/16276)
+- Don't crash if completions throw [#16687](https://github.com/lampepfl/dotty/pull/16687)
+
+## Reflection
+
+- Fix reflect typeMembers to return all members [#15033](https://github.com/lampepfl/dotty/pull/15033)
+- Deprecate reflect Flags.Static [#16568](https://github.com/lampepfl/dotty/pull/16568)
+
+## Reporting
+
+- Suppress follow-on errors for erroneous import qualifiers [#16658](https://github.com/lampepfl/dotty/pull/16658)
+- Fix order in which errors are reported for assignment to val [#16660](https://github.com/lampepfl/dotty/pull/16660)
+- Fix class name in error message [#16635](https://github.com/lampepfl/dotty/pull/16635)
+- Make refined type printing more source compatible [#16303](https://github.com/lampepfl/dotty/pull/16303)
+- Add error hint on local inline def used in quotes [#16572](https://github.com/lampepfl/dotty/pull/16572)
+- Fix Text wrapping [#16277](https://github.com/lampepfl/dotty/pull/16277)
+- Fix #16680 by registering Ident not containing a symbol [#16689](https://github.com/lampepfl/dotty/pull/16689)
+- Fix the non-miniphase tree traverser [#16684](https://github.com/lampepfl/dotty/pull/16684)
+- Just warn on type ascription on a pattern [#17454](https://github.com/lampepfl/dotty/pull/17454)
+
+## Scala-JS
+
+- Fix #14289: Accept Ident refs to `js.native` in native member rhs. [#16185](https://github.com/lampepfl/dotty/pull/16185)
+
+## Scaladoc
+
+- Added jpath check to `ClassLikeSupport` getParentsAsTreeSymbolTuples [#16759](https://github.com/lampepfl/dotty/pull/16759)
+
+## Standard Library
+
+- Add `CanEqual` instance for `Map` [#15886](https://github.com/lampepfl/dotty/pull/15886)
+- Refine `Tuple.Append` return type [#16140](https://github.com/lampepfl/dotty/pull/16140)
+- Remove experimental from `Mirror#fromProductTyped` [#16829](https//github.com/lampepfl/dotty/pull/16829)
+
+## TASTy format
+
+- Make it a fatal error if erasure cannot resolve a type [#16373](https://github.com/lampepfl/dotty/pull/16373)
+
+## Tooling
+
+- Add -Yimports compiler flag [#16218](https://github.com/lampepfl/dotty/pull/16218)
+- Allow BooleanSettings to be set with a colon [#16425](https://github.com/lampepfl/dotty/pull/16425)
+- Add support for disabling redirected output in the REPL driver for usage in worksheets in the Scala Plugin for IntelliJ IDEA [#16810](https://github.com/lampepfl/dotty/pull/16810)
+- Fix #17187: allow patches with same span [#17366](https://github.com/lampepfl/dotty/pull/17366)
+
+## Transform
+
+- Avoid stackoverflow in ExplicitOuter [#16381](https://github.com/lampepfl/dotty/pull/16381)
+- Make lazy vals run on non-fallback graal image - remove dynamic reflection [#16346](https://github.com/lampepfl/dotty/pull/16346)
+- Patch to avoid crash in #16351 [#16354](https://github.com/lampepfl/dotty/pull/16354)
+- Don't treat package object's `<init>` methods as package members [#16667](https://github.com/lampepfl/dotty/pull/16667)
+- Space: Refine isSubspace property & an example [#16574](https://github.com/lampepfl/dotty/pull/16574)
+- Fix static lazy field holder for GraalVM  [#16800](https://github.com/lampepfl/dotty/pull/16800)
+- Fix race condition in new LazyVals [#16975](https://github.com/lampepfl/dotty/pull/16975)
+
+## Typer
+
+- Drop requirement that self types are closed [#16648](https://github.com/lampepfl/dotty/pull/16648)
+- Disallow constructor params from appearing in parent types for soundness [#16664](https://github.com/lampepfl/dotty/pull/16664)
+- Don't search implicit arguments in singleton type prefix [#16490](https://github.com/lampepfl/dotty/pull/16490)
+- Don't rely on isProvisional to determine whether atoms computed [#16489](https://github.com/lampepfl/dotty/pull/16489)
+- Support signature polymorphic methods (`MethodHandle` and `VarHandle`) [#16225](https://github.com/lampepfl/dotty/pull/16225)
+- Prefer parameterless alternatives during ambiguous overload resolution [#16315](https://github.com/lampepfl/dotty/pull/16315)
+- Fix calculation to drop transparent classes [#16344](https://github.com/lampepfl/dotty/pull/16344)
+- Test case for issue 16311 [#16317](https://github.com/lampepfl/dotty/pull/16317)
+- Skip caching provisional OrType atoms [#16295](https://github.com/lampepfl/dotty/pull/16295)
+- Avoid cyclic references due to experimental check when inlining [#16195](https://github.com/lampepfl/dotty/pull/16195)
+- Track type variable dependencies to guide instantiation decisions [#16042](https://github.com/lampepfl/dotty/pull/16042)
+- Two fixes to constraint solving [#16353](https://github.com/lampepfl/dotty/pull/16353)
+- Fix regression in cyclic constraint handling [#16514](https://github.com/lampepfl/dotty/pull/16514)
+- Sharpen range approximation for applied types with capture set ranges [#16261](https://github.com/lampepfl/dotty/pull/16261)
+- Cut the Gordian Knot: Don't widen unions to transparent [#15642](https://github.com/lampepfl/dotty/pull/15642)
+- Fix widening logic to keep instantiation within bounds [#16417](https://github.com/lampepfl/dotty/pull/16417)
+- Skip ambiguous reference error when symbols are aliases [#16401](https://github.com/lampepfl/dotty/pull/16401)
+- Avoid incorrect simplifications when updating bounds in the constraint [#16410](https://github.com/lampepfl/dotty/pull/16410)
+- Take `@targetName` into account when resolving extension methods [#16487](https://github.com/lampepfl/dotty/pull/16487)
+- Improve ClassTag handling to avoid invalid ClassTag generation and inference failure [#16492](https://github.com/lampepfl/dotty/pull/16492)
+- Fix extracting the elemType of a union of arrays [#16569](https://github.com/lampepfl/dotty/pull/16569)
+- Make sure annotations are typed in expression contexts [#16699](https://github.com/lampepfl/dotty/pull/16699)
+- Throw a type error when using hk-types in unions or intersections [#16712](https://github.com/lampepfl/dotty/pull/16712)
+- Add missing criterion to subtype check [#16889](https://github.com/lampepfl/dotty/pull/16889)
+- Fix caching issue caused by incorrect isProvisional check [#16989](https://github.com/lampepfl/dotty/pull/16989)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.2.2..3.3.0` these are:
+
+```
+   226 Martin Odersky
+   106 Szymon Rodziewicz
+    81 Dale Wijnand
+    56 Nicolas Stucki
+    52 Paul Coral
+    48 Kamil Szewczyk
+    45 Paweł Marks
+    28 Florian3k
+    28 Yichen Xu
+    15 Guillaume Martres
+    10 Michał Pałka
+     9 Kacper Korban
+     8 Fengyun Liu
+     7 Chris Birchall
+     7 rochala
+     6 Sébastien Doeraene
+     6 jdudrak
+     5 Seth Tisue
+     5 Som Snytt
+     5 nizhikov
+     4 Filip Zybała
+     4 Jan Chyb
+     4 Michael Pollmeier
+     4 Natsu Kagami
+     3 Anatolii Kmetiuk
+     3 Jamie Thompson
+     2 Adrien Piquerez
+     2 Alex
+     2 Dmitrii Naumenko
+     2 Lukas Rytz
+     2 Michael Pilquist
+     2 Vasil Vasilev
+     2 adampauls
+     2 yoshinorin
+     1 Alexander Slesarenko
+     1 Chris Kipp
+     1 Guillaume Raffin
+     1 Jakub Kozłowski
+     1 Jan-Pieter van den Heuvel
+     1 Julien Richard-Foy
+     1 Kenji Yoshida
+     1 Matt Bovel
+     1 Mohammad Yousuf Minhaj Zia
+     1 Philippus
+     1 Szymon R
+     1 Tim Spence
+     1 s.bazarsadaev
+
+
+```

--- a/changelogs/3.3.1-RC1.md
+++ b/changelogs/3.3.1-RC1.md
@@ -1,0 +1,288 @@
+# Highlights of the release
+
+- Support records in JavaParsers [#16762](https://github.com/lampepfl/dotty/pull/16762)
+- Port JVM backend refactor from Scala 2 [#15322](https://github.com/lampepfl/dotty/pull/15322)
+
+# Other changes and fixes
+
+## Backend
+
+- Disallow mixins where super calls bind to vals [#16908](https://github.com/lampepfl/dotty/pull/16908)
+- Fix #15107: Avoid re-emitting a LineNumber after only LabelNodes. [#16813](https://github.com/lampepfl/dotty/pull/16813)
+
+## Coverage
+
+- Fix #17042: Preserve the shape of secondary ctors in instrumentCoverage. [#17111](https://github.com/lampepfl/dotty/pull/17111)
+
+## Default parameters
+
+- Dupe fix when finding default arg getters [#17058](https://github.com/lampepfl/dotty/pull/17058)
+
+## Documentation
+
+- Fix: ensure syntax blocks for ebnf are marked as such [#16837](https://github.com/lampepfl/dotty/pull/16837)
+
+## Erasure
+
+- Handle `@companionClass` and `@companionMethod` meta-annotations [#17091](https://github.com/lampepfl/dotty/pull/17091)
+
+## Extension Methods
+
+- Support extension methods imported from different objects [#17050](https://github.com/lampepfl/dotty/pull/17050)
+
+## GADTs
+
+- Fix tuple member selection so it works with GADT healing [#16766](https://github.com/lampepfl/dotty/pull/16766)
+- Fix upper bound constraints, that are higher-kinded [#16744](https://github.com/lampepfl/dotty/pull/16744)
+- Split out immutable GadtConstraint [#16602](https://github.com/lampepfl/dotty/pull/16602)
+
+## Implicits
+
+- Improve subtyping check for not yet eta-expanded higher kinded types [#17139](https://github.com/lampepfl/dotty/pull/17139)
+- Harden tpd.Apply/TypeApply in case of errors [#16887](https://github.com/lampepfl/dotty/pull/16887)
+- Try to be more subtle when inferring type parameters of class parents [#16896](https://github.com/lampepfl/dotty/pull/16896)
+- Include `P` in the implicit scope of `P.this.type` [#17088](https://github.com/lampepfl/dotty/pull/17088)
+
+## Incremental Compilation
+
+- Fix under-compilation when the method type in a SAM changes [#16996](https://github.com/lampepfl/dotty/pull/16996)
+
+## Infrastructure
+
+- Set reference version to 3.3.0-RC6 [#17504](https://github.com/lampepfl/dotty/pull/17504)
+- Fix #17119: Download Coursier from GitHub directly [#17141](https://github.com/lampepfl/dotty/pull/17141)
+
+## Inline
+
+- Remove NamedArg from inlined arguments [#17228](https://github.com/lampepfl/dotty/pull/17228)
+- Don't generate a Select for a TermRef with NoPrefix [#16754](https://github.com/lampepfl/dotty/pull/16754)
+- Prepare bodies of inline forwarders eagerly [#16757](https://github.com/lampepfl/dotty/pull/16757)
+- Do not remove inline method implementations until PruneErasedDefs [#17408](https://github.com/lampepfl/dotty/pull/17408)
+
+## Java Interop
+
+- ClassfileParser: allow missing param names (for JDK 21) [#17536](https://github.com/lampepfl/dotty/pull/17536)
+
+## Linting
+
+- Improve -Wunused: locals, privates with unset vars warning #16639 [#17160](https://github.com/lampepfl/dotty/pull/17160)
+- Fix wunused false positive when deriving alias type [#17157](https://github.com/lampepfl/dotty/pull/17157)
+- Port `-Wnonunit-statement` setting for dotty [#16936](https://github.com/lampepfl/dotty/pull/16936)
+
+## Match Types
+
+- Normalize match type usage during implicit lookup [#17457](https://github.com/lampepfl/dotty/pull/17457)
+- Fix #13757: Explicitly disallow higher-kinded scrutinees of match types. [#17322](https://github.com/lampepfl/dotty/pull/17322)
+- Fix match type reduction with wildcard type arguments [#17065](https://github.com/lampepfl/dotty/pull/17065)
+- Fix check whether classtag can be generated for match types [#16708](https://github.com/lampepfl/dotty/pull/16708)
+
+## Parser
+
+- Allow lines starting with `.` to fall outside previous indentation widths [#17056](https://github.com/lampepfl/dotty/pull/17056)
+
+## Pattern Matching
+
+- Fix #11541: Specialize ClassTag[T] in exhaustivity check [#17385](https://github.com/lampepfl/dotty/pull/17385)
+- Check outer class prefixes in type projections when pattern matching [#17136](https://github.com/lampepfl/dotty/pull/17136)
+- Make unchecked cases non-`@unchecked` and non-unreachable [#16958](https://github.com/lampepfl/dotty/pull/16958)
+- Fix #16899: Better handle X instanceOf P where X is T1 | T2 [#17382](https://github.com/lampepfl/dotty/pull/17382)
+
+## Pickling
+
+- ClassfileParser: Avoid cycle when accessing companion in inner class lookup [#16882](https://github.com/lampepfl/dotty/pull/16882)
+
+## Polyfunctions
+
+- Fix type aliases in beta-reduction of polyfunctions [#17054](https://github.com/lampepfl/dotty/pull/17054)
+
+## Quotes
+
+- Register `paramProxy` and `thisProxy` in `Quote` type [#17541](https://github.com/lampepfl/dotty/pull/17541)
+- Only check newVal/newMethod privateWithin on -Xcheck-macros [#17437](https://github.com/lampepfl/dotty/pull/17437)
+- Unencode quote and splice trees [#17342](https://github.com/lampepfl/dotty/pull/17342)
+- Correctly type Expr.ofTupleFromSeq for arity > 22 [#17261](https://github.com/lampepfl/dotty/pull/17261)
+- Use TermRef to distinguish distinct Type[T] instances  [#17205](https://github.com/lampepfl/dotty/pull/17205)
+- Check level consistency of SingletonTypeTree as a type [#17209](https://github.com/lampepfl/dotty/pull/17209)
+- Fix splice type variable pattern detection [#17048](https://github.com/lampepfl/dotty/pull/17048)
+- Avoid creation of `@SplicedType` quote local refrences [#17051](https://github.com/lampepfl/dotty/pull/17051)
+- Dealias type references when healing types in quotes [#17049](https://github.com/lampepfl/dotty/pull/17049)
+- Replace quoted type variables in signature of HOAS pattern result  [#16951](https://github.com/lampepfl/dotty/pull/16951)
+- Beta-reduce directly applied PolymorphicFunction [#16623](https://github.com/lampepfl/dotty/pull/16623)
+- Use `Object.toString` for `quoted.{Expr, Type}` [#16663](https://github.com/lampepfl/dotty/pull/16663)
+- Fix Splicer.isEscapedVariable [#16838](https://github.com/lampepfl/dotty/pull/16838)
+- Fix references to class members defined in quotes [#17107](https://github.com/lampepfl/dotty/pull/17107)
+- Handle pickled forward references in pickled expressions [#16855](https://github.com/lampepfl/dotty/pull/16855)
+- Fix #16615 - crashes of path dependent types in spliced Type.of [#16773](https://github.com/lampepfl/dotty/pull/16773)
+- Disallow local term references in staged types [#16362](https://github.com/lampepfl/dotty/pull/16362)
+- Refactor level checking / type healing logic [#17082](https://github.com/lampepfl/dotty/pull/17082)
+- Dealias quoted types when staging [#17059](https://github.com/lampepfl/dotty/pull/17059)
+- Fix quotes with references to path dependent types [#17081](https://github.com/lampepfl/dotty/pull/17081)
+- Make arguments order in quote hole deterministic [#17405](https://github.com/lampepfl/dotty/pull/17405)
+- Only transform the body of the quote with QuoteTransformer [#17451](https://github.com/lampepfl/dotty/pull/17451)
+- Place staged type captures in Quote AST [#17424](https://github.com/lampepfl/dotty/pull/17424)
+- Add SplicePattern AST to parse and type quote pattern splices [#17396](https://github.com/lampepfl/dotty/pull/17396)
+
+## Reflection
+
+- -Xcheck-macros: add hint when a symbol in created twice [#16733](https://github.com/lampepfl/dotty/pull/16733)
+- Assert that symbols created using reflect API have correct privateWithin symbols [#17352](https://github.com/lampepfl/dotty/pull/17352)
+- Fix reflect.LambdaType type test [#16972](https://github.com/lampepfl/dotty/pull/16972)
+- Improve `New`/`Select` -Ycheck message [#16746](https://github.com/lampepfl/dotty/pull/16746)
+- Improve error message for CyclicReference in macros [#16749](https://github.com/lampepfl/dotty/pull/16749)
+- Add reflect `defn.FunctionClass` overloads [#16849](https://github.com/lampepfl/dotty/pull/16849)
+
+## REPL
+
+- Always load REPL classes in macros including the output directory [#16866](https://github.com/lampepfl/dotty/pull/16866)
+
+## Reporting
+
+- Improve missing argument list error [#17126](https://github.com/lampepfl/dotty/pull/17126)
+- Improve implicit parameter error message with aliases [#17125](https://github.com/lampepfl/dotty/pull/17125)
+- Improve "constructor proxy shadows outer" handling [#17154](https://github.com/lampepfl/dotty/pull/17154)
+- Clarify ambiguous reference error message [#16137](https://github.com/lampepfl/dotty/pull/16137)
+- Hint about forbidden combination of implicit values and conversions [#16735](https://github.com/lampepfl/dotty/pull/16735)
+- Attach explanation message to diagnostic message [#16787](https://github.com/lampepfl/dotty/pull/16787)
+- Propagate implicit search errors from implicit macros [#16840](https://github.com/lampepfl/dotty/pull/16840)
+- Detail UnapplyInvalidReturnType error message [#17167](https://github.com/lampepfl/dotty/pull/17167)
+- Add way to debug -Xcheck-macros tree checking [#16973](https://github.com/lampepfl/dotty/pull/16973)
+- Enrich and finesse compiler crash reporting [#17031](https://github.com/lampepfl/dotty/pull/17031)
+- Allow @implicitNotFound messages as explanations [#16893](https://github.com/lampepfl/dotty/pull/16893)
+- Include top-level symbols from same file in outer ambiguity error [#17033](https://github.com/lampepfl/dotty/pull/17033)
+- Do not issue deprecation warnings when declaring deprecated case classes [#17165](https://github.com/lampepfl/dotty/pull/17165)
+
+## Scala-JS
+
+- Fix #17344: Make implicit references to this above dynamic imports explicit. [#17357](https://github.com/lampepfl/dotty/pull/17357)
+- Fix #12621: Better error message for JS trait ctor param. [#16811](https://github.com/lampepfl/dotty/pull/16811)
+- Fix #16801: Handle Closure's of s.r.FunctionXXL. [#16809](https://github.com/lampepfl/dotty/pull/16809)
+- Fix #17549: Unify how Memoize and Constructors decide what fields need storing. [#17560](https://github.com/lampepfl/dotty/pull/17560)
+
+## Scaladoc
+
+- Feat: Add a blog configuration with yaml [#17214](https://github.com/lampepfl/dotty/pull/17214)
+- Don't render the "$" for module [#17302](https://github.com/lampepfl/dotty/pull/17302)
+- Fix: Add scrollbar to the sidebar [#17203](https://github.com/lampepfl/dotty/pull/17203)
+- Scaladoc: fix crash when processing extends call [#17260](https://github.com/lampepfl/dotty/pull/17260)
+- Fix: Modify the CSS so that the logo of the generated documentation is adaptive [#17172](https://github.com/lampepfl/dotty/pull/17172)
+- Fix: Remove the duplicate parameter when generating the scaladoc. [#17097](https://github.com/lampepfl/dotty/pull/17097)
+- Fix: padding top in mobile version [#17019](https://github.com/lampepfl/dotty/pull/17019)
+- Fix: tap target of the menu in Mobile version [#17018](https://github.com/lampepfl/dotty/pull/17018)
+- Scaladoc: Fix expand icon not changing on anchor link [#17053](https://github.com/lampepfl/dotty/pull/17053)
+- Scaladoc: fix inkuire generation for PolyTypes [#17129](https://github.com/lampepfl/dotty/pull/17129)
+- Re port scroll bar [#17463](https://github.com/lampepfl/dotty/pull/17463)
+- Handle empty files and truncated YAML front matter [#17527](https://github.com/lampepfl/dotty/pull/17527)
+
+## SemanticDB
+
+- Make sure symbol exists before calling owner [#16860](https://github.com/lampepfl/dotty/pull/16860)
+- Support LambdaType (convert from HKTypeLambda) [#16056](https://github.com/lampepfl/dotty/pull/16056)
+
+## Specification
+
+- Apply `class-shadowing.md` to the Spec [#16839](https://github.com/lampepfl/dotty/pull/16839)
+- Adding base for future Spec into the compiler repo [#16825](https://github.com/lampepfl/dotty/pull/16825)
+
+## Standard Library
+
+- Optimization: avoid NotGiven allocations [#17090](https://github.com/lampepfl/dotty/pull/17090)
+
+## Tooling
+
+- Disable `ExtractSemanticDB` phase when writing to output directory defined as JAR. [#16790](https://github.com/lampepfl/dotty/pull/16790)
+- Print owner of bind symbol with -Yprint-debug-owners [#16854](https://github.com/lampepfl/dotty/pull/16854)
+- Small fixes to allow using Metals with scaladoc with sbt [#16816](https://github.com/lampepfl/dotty/pull/16816)
+
+## Transform
+
+- Move CrossVersionChecks before FirstTransform [#17301](https://github.com/lampepfl/dotty/pull/17301)
+- Fix needsOuterIfReferenced [#17159](https://github.com/lampepfl/dotty/pull/17159)
+- Drop incorrect super accessor in trait subclass [#17062](https://github.com/lampepfl/dotty/pull/17062)
+- Generate toString only for synthetic companions of case classes [#16890](https://github.com/lampepfl/dotty/pull/16890)
+- Check trait constructor for accessibility even if not called at Typer [#17094](https://github.com/lampepfl/dotty/pull/17094)
+- Fix #17435: A simpler fix [#17436](https://github.com/lampepfl/dotty/pull/17436)
+
+## Typer
+
+- Preserve type bounds for inlined definitions in posttyper [#17190](https://github.com/lampepfl/dotty/pull/17190)
+- Change logic to find members of recursive types [#17386](https://github.com/lampepfl/dotty/pull/17386)
+- Recognize named arguments in isFunctionWithUnknownParamType [#17161](https://github.com/lampepfl/dotty/pull/17161)
+- Better comparisons for type projections [#17092](https://github.com/lampepfl/dotty/pull/17092)
+- Allow selectDynamic and applyDynamic to be extension methods [#17106](https://github.com/lampepfl/dotty/pull/17106)
+- Fix use of accessibleFrom when finding default arg getters [#16977](https://github.com/lampepfl/dotty/pull/16977)
+- Map class literal constant types [#16988](https://github.com/lampepfl/dotty/pull/16988)
+- Always use adapted type in withDenotation [#16901](https://github.com/lampepfl/dotty/pull/16901)
+- Restrict captureWildcards to only be used if needed [#16799](https://github.com/lampepfl/dotty/pull/16799)
+- Don't capture wildcards if in closure or by-name [#16732](https://github.com/lampepfl/dotty/pull/16732)
+- Infer: Don't minimise to Nothing if there's an upper bound [#16786](https://github.com/lampepfl/dotty/pull/16786)
+- Perform Matchable check only if type test is needed [#16824](https://github.com/lampepfl/dotty/pull/16824)
+- Don't eta expand unary varargs methods [#16892](https://github.com/lampepfl/dotty/pull/16892)
+- Fix beta-reduction with `Nothing` and `null` args [#16938](https://github.com/lampepfl/dotty/pull/16938)
+- Generate kind-correct wildcards when selecting from a wildcard [#17025](https://github.com/lampepfl/dotty/pull/17025)
+- Fix #16405 ctd - wildcards prematurely resolving to Nothing [#16764](https://github.com/lampepfl/dotty/pull/16764)
+- Test: add regression test for #7790 [#17473](https://github.com/lampepfl/dotty/pull/17473)
+- Properly handle `AnyVal`s as refinement members of `Selectable`s  [#16286](https://github.com/lampepfl/dotty/pull/16286)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.0..3.3.1-RC1` these are:
+
+```
+   148 Nicolas Stucki
+    65 Martin Odersky
+    51 Szymon Rodziewicz
+    49 Dale Wijnand
+    49 Quentin Bernet
+    38 Chris Kipp
+    19 David Hua
+    18 Lucas
+    18 ysthakur
+    15 Fengyun Liu
+    15 Paweł Marks
+    14 Guillaume Martres
+    14 Jamie Thompson
+    11 Sébastien Doeraene
+     9 Timothée Andres
+     8 Kacper Korban
+     7 Matt Bovel
+     7 Som Snytt
+     6 Julien Richard-Foy
+     6 Lucas Leblanc
+     5 Michał Pałka
+     4 Anatolii Kmetiuk
+     4 Guillaume Raffin
+     4 Paul Coral
+     4 Wojciech Mazur
+     4 Yichen Xu
+     3 Decel
+     3 Jan Chyb
+     2 Adrien Piquerez
+     2 Arman Bilge
+     2 Carl
+     2 Florian3k
+     2 Kenji Yoshida
+     2 Michael Pilquist
+     2 Natsu Kagami
+     2 Seth Tisue
+     2 Tomasz Godzik
+     2 Vasil Vasilev
+     2 Yadu Krishnan
+     1 Bersier
+     1 Flavio Brasil
+     1 Jan-Pieter van den Heuvel
+     1 Lukas Rytz
+     1 Miles Yucht
+     1 Mohammad Yousuf Minhaj Zia
+     1 Ondra Pelech
+     1 Philippus
+     1 Rikito Taniguchi
+     1 Simon R
+     1 brandonspark
+     1 github-actions[bot]
+     1 liang3zy22
+     1 s.bazarsadaev
+     1 Łukasz Wroński
+
+```

--- a/changelogs/3.3.1-RC2.md
+++ b/changelogs/3.3.1-RC2.md
@@ -1,0 +1,16 @@
+# Backported fixes
+
+- Dealias types in `New`` before matching quotes [#17615](https://github.com/lampepfl/dotty/pull/17615)
+- Fix `accessibleType` for package object prefixes [#18057](https://github.com/lampepfl/dotty/pull/18057)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.1-RC1..3.3.1-RC2` these are:
+
+```
+     2 Martin Odersky
+     2 Paweł Marks
+     1 Nicolas Stucki
+```

--- a/changelogs/3.3.1-RC3.md
+++ b/changelogs/3.3.1-RC3.md
@@ -1,0 +1,15 @@
+# Backported fixes
+
+- Add clause for protected visibility from package objects [#18134](https://github.com/lampepfl/dotty/pull/18134)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.1-RC2..3.3.1-RC3` these are:
+
+```
+     2 Paweł Marks
+     1 Martin Odersky
+
+```

--- a/changelogs/3.3.1-RC3.md
+++ b/changelogs/3.3.1-RC3.md
@@ -10,6 +10,6 @@ According to `git shortlog -sn --no-merges 3.3.1-RC2..3.3.1-RC3` these are:
 
 ```
      2 Paweł Marks
-     1 Martin Odersky
+     1 Nicolas Stucki
 
 ```

--- a/changelogs/3.3.1-RC4.md
+++ b/changelogs/3.3.1-RC4.md
@@ -1,0 +1,15 @@
+# Backported fixes
+
+- Revert "Include top-level symbols from same file in outer ambiguity error" [#17438](https://github.com/lampepfl/dotty/pull/17438)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.1-RC3..3.3.1-RC4` these are:
+
+```
+     2 Paweł Marks
+     1 Nicolas Stucki
+
+```

--- a/changelogs/3.3.1-RC5.md
+++ b/changelogs/3.3.1-RC5.md
@@ -1,0 +1,22 @@
+# Backported fixes
+
+- Heal stage inconsistent prefixes of type projections [#18239](https://github.com/lampepfl/dotty/pull/18239)
+- Fix regression #17245: Overloaded methods with ClassTags [#18286](http://github.com/lampepfl/dotty/pull/18286)
+- Disallow taking singleton types of packages again [#18232](http://github.com/lampepfl/dotty/pull/18232)
+- A slightly more conservative version of #14218 [#18352](http://github.com/lampepfl/dotty/pull/18352)
+- Record failures to adapt application arguments [#18269](http://github.com/lampepfl/dotty/pull/18269)
+- Fix regression in exhaustivity of HK types [#18303](http://github.com/lampepfl/dotty/pull/18303)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.1-RC4..3.3.1-RC5` these are:
+
+```
+     5 Dale Wijnand
+     2 Martin Odersky
+     2 Paweł Marks
+     1 Jan Chyb
+     1 Nicolas Stucki
+```

--- a/changelogs/3.3.1-RC6.md
+++ b/changelogs/3.3.1-RC6.md
@@ -1,0 +1,17 @@
+# Backported fixes
+
+- Refine `infoDependsOnPrefix` [#18204](https://github.com/lampepfl/dotty/pull/18204)
+- FDo not compute `protoFormal` if `param.tpt` is empty [#18288](http://github.com/lampepfl/dotty/pull/18288)
+- Revert "Normalize match type usage during implicit lookup" [#18440](http://github.com/lampepfl/dotty/pull/18440)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.1-RC4..3.3.1-RC5` these are:
+
+```
+     3	Paweł Marks
+     2	Martin Odersky
+     1	Nicolas Stucki
+```

--- a/changelogs/3.3.1-RC6.md
+++ b/changelogs/3.3.1-RC6.md
@@ -1,14 +1,14 @@
 # Backported fixes
 
 - Refine `infoDependsOnPrefix` [#18204](https://github.com/lampepfl/dotty/pull/18204)
-- FDo not compute `protoFormal` if `param.tpt` is empty [#18288](http://github.com/lampepfl/dotty/pull/18288)
+- Do not compute `protoFormal` if `param.tpt` is empty [#18288](http://github.com/lampepfl/dotty/pull/18288)
 - Revert "Normalize match type usage during implicit lookup" [#18440](http://github.com/lampepfl/dotty/pull/18440)
 
 # Contributors
 
 Thank you to all the contributors who made this release possible 🎉
 
-According to `git shortlog -sn --no-merges 3.3.1-RC4..3.3.1-RC5` these are:
+According to `git shortlog -sn --no-merges 3.3.1-RC5..3.3.1-RC6` these are:
 
 ```
      3	Paweł Marks

--- a/changelogs/3.3.1-RC7.md
+++ b/changelogs/3.3.1-RC7.md
@@ -1,0 +1,16 @@
+# Backported fixes
+
+- Tweak selection from self types [#18467](https://github.com/lampepfl/dotty/pull/18467)
+- Revert "Add reflect `defn.FunctionClass` overloads" [#18473](http://github.com/lampepfl/dotty/pull/18473)
+
+# Contributors
+
+Thank you to all the contributors who made this release possible 🎉
+
+According to `git shortlog -sn --no-merges 3.3.1-RC6..3.3.1-RC7` these are:
+
+```
+     3	Paweł Marks
+     1	Martin Odersky
+
+```

--- a/changelogs/3.3.1.md
+++ b/changelogs/3.3.1.md
@@ -42,7 +42,6 @@
 - Harden tpd.Apply/TypeApply in case of errors [#16887](https://github.com/lampepfl/dotty/pull/16887)
 - Try to be more subtle when inferring type parameters of class parents [#16896](https://github.com/lampepfl/dotty/pull/16896)
 - Include `P` in the implicit scope of `P.this.type` [#17088](https://github.com/lampepfl/dotty/pull/17088)
-- Do not compute `protoFormal` if `param.tpt` is empty [#18288](http://github.com/lampepfl/dotty/pull/18288)
 
 ## Incremental Compilation
 
@@ -72,6 +71,7 @@
 
 ## Match Types
 
+- Normalize match type usage during implicit lookup [#17457](https://github.com/lampepfl/dotty/pull/17457)
 - Fix #13757: Explicitly disallow higher-kinded scrutinees of match types. [#17322](https://github.com/lampepfl/dotty/pull/17322)
 - Fix match type reduction with wildcard type arguments [#17065](https://github.com/lampepfl/dotty/pull/17065)
 - Fix check whether classtag can be generated for match types [#16708](https://github.com/lampepfl/dotty/pull/16708)
@@ -86,7 +86,6 @@
 - Check outer class prefixes in type projections when pattern matching [#17136](https://github.com/lampepfl/dotty/pull/17136)
 - Make unchecked cases non-`@unchecked` and non-unreachable [#16958](https://github.com/lampepfl/dotty/pull/16958)
 - Fix #16899: Better handle X instanceOf P where X is T1 | T2 [#17382](https://github.com/lampepfl/dotty/pull/17382)
-- Fix regression in exhaustivity of HK types [#18303](http://github.com/lampepfl/dotty/pull/18303)
 
 ## Pickling
 
@@ -122,7 +121,6 @@
 - Only transform the body of the quote with QuoteTransformer [#17451](https://github.com/lampepfl/dotty/pull/17451)
 - Place staged type captures in Quote AST [#17424](https://github.com/lampepfl/dotty/pull/17424)
 - Add SplicePattern AST to parse and type quote pattern splices [#17396](https://github.com/lampepfl/dotty/pull/17396)
-- Dealias types in `New`` before matching quotes [#17615](https://github.com/lampepfl/dotty/pull/17615)
 
 ## Reflection
 
@@ -131,6 +129,7 @@
 - Fix reflect.LambdaType type test [#16972](https://github.com/lampepfl/dotty/pull/16972)
 - Improve `New`/`Select` -Ycheck message [#16746](https://github.com/lampepfl/dotty/pull/16746)
 - Improve error message for CyclicReference in macros [#16749](https://github.com/lampepfl/dotty/pull/16749)
+- Add reflect `defn.FunctionClass` overloads [#16849](https://github.com/lampepfl/dotty/pull/16849)
 
 ## REPL
 
@@ -223,77 +222,66 @@
 - Fix #16405 ctd - wildcards prematurely resolving to Nothing [#16764](https://github.com/lampepfl/dotty/pull/16764)
 - Test: add regression test for #7790 [#17473](https://github.com/lampepfl/dotty/pull/17473)
 - Properly handle `AnyVal`s as refinement members of `Selectable`s  [#16286](https://github.com/lampepfl/dotty/pull/16286)
-- Fix `accessibleType` for package object prefixes [#18057](https://github.com/lampepfl/dotty/pull/18057)
-- Add clause for protected visibility from package objects [#18134](https://github.com/lampepfl/dotty/pull/18134)
-- Revert "Include top-level symbols from same file in outer ambiguity error" [#17438](https://github.com/lampepfl/dotty/pull/17438)
-- Heal stage inconsistent prefixes of type projections [#18239](https://github.com/lampepfl/dotty/pull/18239)
-- Fix regression #17245: Overloaded methods with ClassTags [#18286](http://github.com/lampepfl/dotty/pull/18286)
-- Disallow taking singleton types of packages again [#18232](http://github.com/lampepfl/dotty/pull/18232)
-- A slightly more conservative version of #14218 [#18352](http://github.com/lampepfl/dotty/pull/18352)
-- Record failures to adapt application arguments [#18269](http://github.com/lampepfl/dotty/pull/18269)
-- Refine `infoDependsOnPrefix` [#18204](httpsF://github.com/lampepfl/dotty/pull/18204)
-- Tweak selection from self types [#18467](https://github.com/lampepfl/dotty/pull/18467)
 
 # Contributors
 
 Thank you to all the contributors who made this release possible 🎉
 
-According to `git shortlog -sn --no-merges 3.3.0..3.3.1-RC1` these are:
+According to `git shortlog -sn --no-merges 3.3.0..3.3.1` these are:
 
 ```
-   148 Nicolas Stucki
-    65 Martin Odersky
-    51 Szymon Rodziewicz
-    49 Dale Wijnand
-    49 Quentin Bernet
-    38 Chris Kipp
-    19 David Hua
-    18 Lucas
-    18 ysthakur
-    15 Fengyun Liu
-    15 Paweł Marks
-    14 Guillaume Martres
-    14 Jamie Thompson
-    11 Sébastien Doeraene
-     9 Timothée Andres
-     8 Kacper Korban
-     7 Matt Bovel
-     7 Som Snytt
-     6 Julien Richard-Foy
-     6 Lucas Leblanc
-     5 Michał Pałka
-     4 Anatolii Kmetiuk
-     4 Guillaume Raffin
-     4 Paul Coral
-     4 Wojciech Mazur
-     4 Yichen Xu
-     3 Decel
-     3 Jan Chyb
-     2 Adrien Piquerez
-     2 Arman Bilge
-     2 Carl
-     2 Florian3k
-     2 Kenji Yoshida
-     2 Michael Pilquist
-     2 Natsu Kagami
-     2 Seth Tisue
-     2 Tomasz Godzik
-     2 Vasil Vasilev
-     2 Yadu Krishnan
-     1 Bersier
-     1 Flavio Brasil
-     1 Jan-Pieter van den Heuvel
-     1 Lukas Rytz
-     1 Miles Yucht
-     1 Mohammad Yousuf Minhaj Zia
-     1 Ondra Pelech
-     1 Philippus
-     1 Rikito Taniguchi
-     1 Simon R
-     1 brandonspark
-     1 github-actions[bot]
-     1 liang3zy22
-     1 s.bazarsadaev
-     1 Łukasz Wroński
-
+   152	Nicolas Stucki
+    73	Martin Odersky
+    54	Dale Wijnand
+    51	Szymon Rodziewicz
+    49	Quentin Bernet
+    38	Chris Kipp
+    31	Paweł Marks
+    19	David Hua
+    18	Lucas
+    18	ysthakur
+    15	Fengyun Liu
+    14	Guillaume Martres
+    14	Jamie Thompson
+    11	Sébastien Doeraene
+     9	Timothée Andres
+     8	Kacper Korban
+     7	Matt Bovel
+     7	Som Snytt
+     6	Julien Richard-Foy
+     6	Lucas Leblanc
+     5	Michał Pałka
+     4	Anatolii Kmetiuk
+     4	Guillaume Raffin
+     4	Jan Chyb
+     4	Paul Coral
+     4	Wojciech Mazur
+     4	Yichen Xu
+     3	Decel
+     2	Adrien Piquerez
+     2	Arman Bilge
+     2	Carl
+     2	Florian3k
+     2	Kenji Yoshida
+     2	Michael Pilquist
+     2	Natsu Kagami
+     2	Seth Tisue
+     2	Tomasz Godzik
+     2	Vasil Vasilev
+     2	Yadu Krishnan
+     1	Bersier
+     1	Flavio Brasil
+     1	Jan-Pieter van den Heuvel
+     1	Lukas Rytz
+     1	Miles Yucht
+     1	Mohammad Yousuf Minhaj Zia
+     1	Ondra Pelech
+     1	Philippus
+     1	Rikito Taniguchi
+     1	Simon R
+     1	brandonspark
+     1	github-actions[bot]
+     1	liang3zy22
+     1	s.bazarsadaev
+     1	Łukasz Wroński
 ```

--- a/docs/_docs/reference/experimental/erased-defs.md
+++ b/docs/_docs/reference/experimental/erased-defs.md
@@ -161,8 +161,8 @@ object Machine:
   //                    State must be Off
 ```
 
-Note that in [Inline](../metaprogramming/inline.md) we discussed `erasedValue` and inline
-matches. `erasedValue` is implemented with `erased`, so the state machine above
+Note that in [Compile-time operations](../metaprogramming/compiletime-ops.md#erasedvalue) we discussed `erasedValue` and inline
+matches. `erasedValue` is internally implemented with `erased` (and is not experimental), so the state machine above
 can be encoded as follows:
 
 ```scala

--- a/docs/_docs/reference/language-versions/source-compatibility.md
+++ b/docs/_docs/reference/language-versions/source-compatibility.md
@@ -23,6 +23,9 @@ The default Scala language syntax version currently supported by the Dotty compi
 - [`3.2-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/2-migration$.html): the same as `3.2`, but in conjunction with `-rewrite`, offer code rewrites from Scala `3.0/3.1` to `3.2`.
 - [`future`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future$.html): A preview of changes that will be introduced in `3.x` versions after `3.2`.
 Some Scala 2 specific idioms are dropped in this version. The feature set supported by this version may grow over time as features become stabilised for preview.
+- [`3.3`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/3$.html): the same as `3.2`, but in addition:
+  -[Fewer braces syntax](https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html#optional-braces-for-method-arguments-1) is enabled by default.
+- [`3.3-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/3-migration$.html): the same as `3.3`
 
 - [`future-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future-migration$.html): Same as `future` but with additional helpers to migrate from `3.2`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
 

--- a/docs/_docs/reference/language-versions/source-compatibility.md
+++ b/docs/_docs/reference/language-versions/source-compatibility.md
@@ -21,12 +21,11 @@ The default Scala language syntax version currently supported by the Dotty compi
   - [stricter pattern bindings](https://docs.scala-lang.org/scala3/reference/changed-features/pattern-bindings.html) are now enabled (part of `future` in earlier `3.x` releases), producing warnings for refutable patterns. These warnings can be silenced to achieve the same runtime behavior, but in `future` they become errors and refutable patterns will not compile.
   - [Nonlocal returns](https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html) now produce a warning upon usage (they are still an error under `future`).
 - [`3.2-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/2-migration$.html): the same as `3.2`, but in conjunction with `-rewrite`, offer code rewrites from Scala `3.0/3.1` to `3.2`.
-- [`future`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future$.html): A preview of changes that will be introduced in `3.x` versions after `3.2`.
-Some Scala 2 specific idioms are dropped in this version. The feature set supported by this version may grow over time as features become stabilised for preview.
 - [`3.3`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/3$.html): the same as `3.2`, but in addition:
   -[Fewer braces syntax](https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html#optional-braces-for-method-arguments-1) is enabled by default.
 - [`3.3-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/3-migration$.html): the same as `3.3`
-
+- [`future`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future$.html): A preview of changes that will be introduced in `3.x` versions after `3.3`.
+Some Scala 2 specific idioms are dropped in this version. The feature set supported by this version may grow over time as features become stabilised for preview.
 - [`future-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future-migration$.html): Same as `future` but with additional helpers to migrate from `3.3`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
 
 There are two ways to specify a language version :

--- a/docs/_docs/reference/language-versions/source-compatibility.md
+++ b/docs/_docs/reference/language-versions/source-compatibility.md
@@ -27,7 +27,7 @@ Some Scala 2 specific idioms are dropped in this version. The feature set suppor
   -[Fewer braces syntax](https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html#optional-braces-for-method-arguments-1) is enabled by default.
 - [`3.3-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/3-migration$.html): the same as `3.3`
 
-- [`future-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future-migration$.html): Same as `future` but with additional helpers to migrate from `3.2`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
+- [`future-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future-migration$.html): Same as `future` but with additional helpers to migrate from `3.3`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
 
 There are two ways to specify a language version :
 

--- a/docs/_docs/reference/language-versions/source-compatibility.md
+++ b/docs/_docs/reference/language-versions/source-compatibility.md
@@ -17,16 +17,16 @@ The default Scala language syntax version currently supported by the Dotty compi
     - in conjunction with `-rewrite`, offer code rewrites from Scala 2.13 to 3.0.
 
 - [`3.0`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/0$.html), [`3.1`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/1$.html): the default set of features included in scala versions `3.0.0` to `3.1.3`.
+- [`3.2-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/2-migration$.html): the same as `3.2`, but in conjunction with `-rewrite`, offer code rewrites from Scala `3.0/3.1` to `3.2`.
 - [`3.2`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/2$.html): the same as `3.0` and `3.1`, but in addition:
   - [stricter pattern bindings](https://docs.scala-lang.org/scala3/reference/changed-features/pattern-bindings.html) are now enabled (part of `future` in earlier `3.x` releases), producing warnings for refutable patterns. These warnings can be silenced to achieve the same runtime behavior, but in `future` they become errors and refutable patterns will not compile.
   - [Nonlocal returns](https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html) now produce a warning upon usage (they are still an error under `future`).
-- [`3.2-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/2-migration$.html): the same as `3.2`, but in conjunction with `-rewrite`, offer code rewrites from Scala `3.0/3.1` to `3.2`.
-- [`3.3`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/3$.html): the same as `3.2`, but in addition:
-  -[Fewer braces syntax](https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html#optional-braces-for-method-arguments-1) is enabled by default.
 - [`3.3-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/3-migration$.html): the same as `3.3`
+- [`3.3`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$3/3$.html): the same as `3.2`, but in addition:
+  - [Fewer braces syntax](https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html#optional-braces-for-method-arguments-1) is enabled by default.
+- [`future-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future-migration$.html): Same as `future` but with additional helpers to migrate from `3.3`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
 - [`future`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future$.html): A preview of changes that will be introduced in `3.x` versions after `3.3`.
 Some Scala 2 specific idioms are dropped in this version. The feature set supported by this version may grow over time as features become stabilised for preview.
-- [`future-migration`](https://scala-lang.org/api/3.x/scala/runtime/stdLibPatches/language$$future-migration$.html): Same as `future` but with additional helpers to migrate from `3.3`. Similarly to the helpers available under `3.0-migration`, these include migration warnings and optional rewrites.
 
 There are two ways to specify a language version :
 

--- a/docs/_docs/reference/other-new-features/indentation.md
+++ b/docs/_docs/reference/other-new-features/indentation.md
@@ -274,7 +274,8 @@ Indentation can be mixed freely with braces `{...}`, as well as brackets `[...]`
 For instance, consider:
 ```scala
 {
-  val x = f(x: Int, y =>
+  val x = 4
+  f(x: Int, y =>
     x * (
       y + 1
     ) +
@@ -283,13 +284,13 @@ For instance, consider:
   )
 }
 ```
- - Here, the indentation width of the region enclosed by the braces is 3 (i.e. the indentation width of the
+ - Here, the indentation width of the region enclosed by the braces is 2 (i.e. the indentation width of the
 statement starting with `val`).
- - The indentation width of the region in parentheses that follows `f` is also 3, since the opening
+ - The indentation width of the region in parentheses that follows `f` is also 2, since the opening
    parenthesis is not at the end of a line.
- - The indentation width of the region in parentheses around `y + 1` is 9
+ - The indentation width of the region in parentheses around `y + 1` is 6
    (i.e. the indentation width of `y + 1`).
- - Finally, the indentation width of the last region in parentheses starting with `(x` is 6 (i.e. the indentation width of the indented region following the `=>`.
+ - Finally, the indentation width of the last region in parentheses starting with `(x` is 4 (i.e. the indentation width of the indented region following the `=>`.
 
 ## Special Treatment of Case Clauses
 

--- a/docs/_docs/reference/other-new-features/open-classes.md
+++ b/docs/_docs/reference/other-new-features/open-classes.md
@@ -77,4 +77,4 @@ A class that is neither `abstract` nor `open` is similar to a `sealed` class: it
 
 ## Migration
 
-`open` is a new modifier in Scala 3. To allow cross compilation between Scala 2.13 and Scala 3.0 without warnings, the feature warning for ad-hoc extensions is produced only under `-source future`. It will be produced by default from Scala 3.1 on.
+`open` is a new modifier in Scala 3. To allow cross compilation between Scala 2.13 and Scala 3.0 without warnings, the feature warning for ad-hoc extensions is produced only under `-source future`. It will be produced by default [from Scala 3.4 on](https://github.com/lampepfl/dotty/issues/16334).


### PR DESCRIPTION
Replaces #17614

This PR is semi-automatically generated to synchronize `language-reference-stable` with `main`.

It takes all commits from the first branch that are not present on the second and filters out all that were backported from `main` or have more than one parent. Then it examines changes introduced by each commit.

Changes are divided into three groups:
- safe - those affect files in `changelogs`, `docs`, `scaladoc`, and `scaladoc-testcases` directories or any `**.md` file.
- potentially safe - affect files in `project` direcotry
- unsafe - all other modifications

Commits only having safe changes were cherry-picked. Those having any potentially safe changes and those that contained both safe and unsafe changes were examined individually. Other commits were skipped.

Running a script and answering about each questionable commit took less than 10 minutes, and as a result, we have no conflicts. Working on #17614 would have required hours of fixing dozens of conflicts resulting from merging changes cherry-picked from the `main` branch. It could also have led to subtle problems. 

If there is no problem with this approach, I'll modify the script slightly and make it a part of a CI instead of the current step that tries to merge the documentation branch to `main` after every change.