### PR TITLE
Tweak convertible implicits fix

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -850,7 +850,7 @@ trait Implicits:
     && !to.isError
     && !ctx.isAfterTyper
     && ctx.mode.is(Mode.ImplicitsEnabled)
-    && from.widen.isValueType
+    && from.isValueType
     && (  from.isValueSubType(to)
        || inferView(dummyTreeOfType(from), to)
             (using ctx.fresh.addMode(Mode.ImplicitExploration).setExploreTyperState()).isSuccess
@@ -982,7 +982,7 @@ trait Implicits:
             .filter { imp =>
               !isImplicitDefConversion(imp.underlying)
                 && imp.symbol != defn.Predef_conforms
-                && viewExists(imp, fail.expectedType)
+                && viewExists(imp.underlying.resultType, fail.expectedType)
             }
         else
           Nil

--- a/tests/neg/i16453b1.check
+++ b/tests/neg/i16453b1.check
@@ -1,0 +1,8 @@
+-- [E172] Type Error: tests/neg/i16453b1.scala:11:19 -------------------------------------------------------------------
+11 |  val ko = get[Int] // error
+   |                   ^
+   |No given instance of type Ctx => Option[Int] was found for parameter fn of method get
+   |
+   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
+   |The following implicits in scope can be implicitly converted to Ctx => Option[Int]:
+   |- final lazy given val foo: Ctx => Int

--- a/tests/neg/i16453b1.scala
+++ b/tests/neg/i16453b1.scala
@@ -1,0 +1,12 @@
+import scala.language.implicitConversions
+
+sealed trait Ctx
+given ct[T]: Conversion[Ctx => T, Ctx => Option[T]] = fn => fn.andThen(Option.apply)
+
+def get[T](using fn: Ctx => Option[T]): Option[T] = ???
+
+def Test = {
+  given foo: (Ctx => Int) = _ => 42
+  val ok = get[Int](using summon[Ctx => Int])
+  val ko = get[Int] // error
+}

--- a/tests/neg/i16453b2.check
+++ b/tests/neg/i16453b2.check
@@ -1,0 +1,8 @@
+-- [E172] Type Error: tests/neg/i16453b2.scala:11:19 -------------------------------------------------------------------
+11 |  val ko = get[Int] // error
+   |                   ^
+   |No given instance of type Ctx => Option[Int] was found for parameter fn of method get
+   |
+   |Note: implicit conversions are not automatically applied to arguments of using clauses. You will have to pass the argument explicitly.
+   |The following implicits in scope can be implicitly converted to Ctx => Option[Int]:
+   |- final given def foo2[A]: Ctx => Int

--- a/tests/neg/i16453b2.scala
+++ b/tests/neg/i16453b2.scala
@@ -1,0 +1,12 @@
+import scala.language.implicitConversions
+
+sealed trait Ctx
+given ct[T]: Conversion[Ctx => T, Ctx => Option[T]] = fn => fn.andThen(Option.apply)
+
+def get[T](using fn: Ctx => Option[T]): Option[T] = ???
+
+def Test = {
+  given foo2[A]: (Ctx => Int) = _ => 42
+  val ok = get[Int](using summon[Ctx => Int])
+  val ko = get[Int] // error
+}


### PR DESCRIPTION
Rather than widen in viewExists, widen earlier, past type lambda
parameters.  This allows `foo2` in `i16453b2` from being listed as a
possible implicit, as appropriate.
