### PR TITLE
Use setting to enable Scala2 library TASTy in scala3-bootstrapped

### DIFF
--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -82,6 +82,9 @@ object Properties {
   /** scala-library jar */
   def scalaLibrary: String = sys.props("dotty.tests.classes.scalaLibrary")
 
+  /** scala-library TASTy jar */
+  def scalaLibraryTasty: Option[String] = sys.props.get("dotty.tests.tasties.scalaLibrary")
+
   /** scala-asm jar */
   def scalaAsm: String = sys.props("dotty.tests.classes.scalaAsm")
 

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -25,12 +25,14 @@ object TestConfiguration {
     "-Xverify-signatures"
   )
 
-  val basicClasspath = mkClasspath(List(
+  val basicClasspath = mkClasspath(
+    Properties.scalaLibraryTasty.toList ::: List(
     Properties.scalaLibrary,
     Properties.dottyLibrary
   ))
 
-  val withCompilerClasspath = mkClasspath(List(
+  val withCompilerClasspath = mkClasspath(
+    Properties.scalaLibraryTasty.toList ::: List(
     Properties.scalaLibrary,
     Properties.scalaAsm,
     Properties.jlineTerminal,


### PR DESCRIPTION
Enabling this setting will add the Scala2 library TASTy JAR from `scala2-library-tasty` to the Scala3 bootstrapped classpath. It can be used to compile using `scala3-bootstrapped/scalac` or run any tests in `scala3-bootstrapped`.

Example usage:
```
sbt> set ThisBuild/Build.useScala2LibraryTasty := true
sbt> scala3-bootstrapped/scalac
sbt> scala3-bootstrapped/testCompilation
```