### PR TITLE
Fix `callTrace` of inlined methods

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,6 +209,10 @@ jobs:
         run: sbt ";dist/pack ;scala3-bootstrapped/compile ;scala3-bootstrapped/test"
         shell: cmd
 
+      - name: Test with Scala 2 library TASTy
+        run: sbt ";set ThisBuild/Build.useScala2LibraryTasty := true ;scala3-bootstrapped/testCompilation i5" # only test a subset of test to avoid doubling the CI execution time
+        shell: cmd
+
       - name: Scala.js Test
         run: sbt ";sjsJUnitTests/test ;set sjsJUnitTests/scalaJSLinkerConfig ~= switchToESModules ;sjsJUnitTests/test ;sjsCompilerTests/test"
         shell: cmd

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -31,7 +31,7 @@ object Trees {
 
   /** Property key for backquoted identifiers and definitions */
   val Backquoted: Property.StickyKey[Unit] = Property.StickyKey()
-  
+
   val SyntheticUnit: Property.StickyKey[Unit] = Property.StickyKey()
 
   /** Trees take a parameter indicating what the type of their `tpe` field
@@ -661,7 +661,8 @@ object Trees {
    *
    *  @param  call      Info about the original call that was inlined
    *                    Until PostTyper, this is the full call, afterwards only
-   *                    a reference to the toplevel class from which the call was inlined.
+   *                    a reference to the method or the top-level class from
+   *                    which the call was inlined.
    *  @param  bindings  Bindings for proxies to be used in the inlined code
    *  @param  expansion The inlined tree, minus bindings.
    *

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -299,20 +299,6 @@ object Inlines:
     (new Reposition).transform(tree)
   end reposition
 
-  /** Leave only a call trace consisting of
-   *  - a reference to the top-level class from which the call was inlined,
-   *  - the call's position
-   *  in the call field of an Inlined node.
-   *  The trace has enough info to completely reconstruct positions.
-   *  Note: For macros it returns a Select and for other inline methods it returns an Ident (this distinction is only temporary to be able to run YCheckPositions)
-   */
-  def inlineCallTrace(callSym: Symbol, pos: SourcePosition)(using Context): Tree = {
-    assert(ctx.source == pos.source)
-    val topLevelCls = callSym.topLevelClass
-    if (callSym.is(Macro)) ref(topLevelCls.owner).select(topLevelCls.name)(using ctx.withOwner(topLevelCls.owner)).withSpan(pos.span)
-    else Ident(topLevelCls.typeRef).withSpan(pos.span)
-  }
-
   private object Intrinsics:
     import dotty.tools.dotc.reporting.Diagnostic.Error
     private enum ErrorKind:

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -304,7 +304,7 @@ object PickleQuotes {
     def pickleAsTasty() = {
       val body1 =
         if body.isType then body
-        else Inlined(Inlines.inlineCallTrace(ctx.owner, quote.sourcePos), Nil, body)
+        else Inlined(ref(ctx.owner.topLevelClass.typeRef).withSpan(quote.span), Nil, body)
       val pickleQuote = PickledQuotes.pickleQuote(body1)
       val pickledQuoteStrings = pickleQuote match
         case x :: Nil => Literal(Constant(x))

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -367,7 +367,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           val pos = call.sourcePos
           CrossVersionChecks.checkExperimentalRef(call.symbol, pos)
           withMode(Mode.InlinedCall)(transform(call))
-          val callTrace = Inlines.inlineCallTrace(call.symbol, pos)(using ctx.withSource(pos.source))
+          val callTrace = ref(call.symbol)(using ctx.withSource(pos.source)).withSpan(pos.span)
           cpy.Inlined(tree)(callTrace, transformSub(bindings), transform(expansion)(using inlineContext(tree)))
         case templ: Template =>
           withNoCheckNews(templ.parents.flatMap(newPart)) {


### PR DESCRIPTION
We need to keep the reference to the called method, not only the symbol
of the to level class. This is important for the traces of the `assert`
method that is defined in a different file. This might also be useful
for macro annotations.

This is also a solution to the awkward Select vs. Ident distinction to
identify macros in `YCheckPositions`.
