### PR TITLE
fix(#18265): crash on extension method without type nor RHS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2577,6 +2577,8 @@ object Parsers {
       parents match {
         case parent :: Nil if !in.isNestedStart =>
           reposition(if (parent.isType) ensureApplied(wrapNew(parent)) else parent)
+        case tkn if in.token == INDENT =>
+          New(templateBodyOpt(emptyConstructor, parents, Nil))
         case _ =>
           New(reposition(templateBodyOpt(emptyConstructor, parents, Nil)))
       }

--- a/tests/neg/i18265.check
+++ b/tests/neg/i18265.check
@@ -1,0 +1,6 @@
+-- [E019] Syntax Error: tests/neg/i18265.scala:5:13 --------------------------------------------------------------------
+5 |    def twice // error
+  |             ^
+  |             Missing return type
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i18265.scala
+++ b/tests/neg/i18265.scala
@@ -1,0 +1,5 @@
+trait Foo
+
+val foo = new Foo:
+  extension (s: String)
+    def twice // error

--- a/tests/semanticdb/expect/StructuralTypes.expect.scala
+++ b/tests/semanticdb/expect/StructuralTypes.expect.scala
@@ -16,7 +16,7 @@ object StructuralTypes/*<-example::StructuralTypes.*/:
 
   val V/*<-example::StructuralTypes.V.*/: Object/*->java::lang::Object#*/ {
     def scalameta/*<-local4*/: String/*->scala::Predef.String#*/
-  } = /*<-local6*/new:
-    def scalameta/*<-local5*/ = "4.0"
+  } = new:
+    /*<-local6*/def scalameta/*<-local5*/ = "4.0"
   V/*->example::StructuralTypes.V.*/.scalameta/*->scala::reflect::Selectable#selectDynamic().*/
 end StructuralTypes/*->example::StructuralTypes.*/

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3472,7 +3472,7 @@ Occurrences:
 [16:9..16:15): Object -> java/lang/Object#
 [17:8..17:17): scalameta <- local4
 [17:19..17:25): String -> scala/Predef.String#
-[18:6..18:6): <- local6
+[19:4..19:4): <- local6
 [19:8..19:17): scalameta <- local5
 [20:2..20:3): V -> example/StructuralTypes.V.
 [20:4..20:13): scalameta -> scala/reflect/Selectable#selectDynamic().


### PR DESCRIPTION
close #18265 
This commit fixes a bug that causes Scala compiler to crash due to position error when an extension method followed by a newline has neither type annotation nor `= <expr>`.

This commit is based on https://github.com/lampepfl/dotty/pull/18445.

Co-Authored-By: @hamzaremmal