### PR TITLE
bugfix: [metals] Case completions for tuple type

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
@@ -97,25 +97,26 @@ object CaseKeywordCompletion:
         selectorSym
       )
     then
-      val label =
-        if patternOnly.isEmpty then s"case ${parents.selector.show} =>"
-        else parents.selector.show
-      List(
-        CompletionValue.CaseKeyword(
-          selectorSym,
-          label,
-          Some(
-            if patternOnly.isEmpty then
+      if patternOnly.isEmpty then
+        val selectorTpe = parents.selector.show
+        val tpeLabel =
+          if !selectorTpe.contains("x$1") then selectorTpe
+          else selector.symbol.info.show
+        val label = s"case ${tpeLabel} =>"
+        List(
+          CompletionValue.CaseKeyword(
+            selectorSym,
+            label,
+            Some(
               if config.isCompletionSnippetsEnabled() then "case ($0) =>"
               else "case () =>"
-            else if config.isCompletionSnippetsEnabled() then "($0)"
-            else "()"
-          ),
-          Nil,
-          range = Some(completionPos.toEditRange),
-          command = config.parameterHintsCommand().asScala
+            ),
+            Nil,
+            range = Some(completionPos.toEditRange),
+            command = config.parameterHintsCommand().asScala,
+          )
         )
-      )
+      else Nil
     else
       val result = ListBuffer.empty[SymbolImport]
       val isVisited = mutable.Set.empty[Symbol]

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionCaseSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionCaseSuite.scala
@@ -698,3 +698,27 @@ class CompletionCaseSuite extends BaseCompletionSuite:
          |case Dog => test.O.Animal
          |""".stripMargin,
     )
+  @Test def `for-comp` =
+    check(
+      """|object A {
+         |  val a = for {
+         |    foo <- List("a", "b", "c")
+         |    abc = println("Print!")
+         |  } yield bar@@
+         |
+         |}
+         |""".stripMargin,
+      "",
+    )
+
+  @Test def `lambda-case-tuple` =
+    check(
+      """|object A {
+         |  val a = List((1,2)).foreach {
+         |    case (a,b) => println(a)
+         |    case@@
+         |  }
+         |}
+         |""".stripMargin,
+      "case (Int, Int) => scala",
+    )


### PR DESCRIPTION
We shouldn't show case completions for tuple type if query doesn't match label. Also, sometimes label contained x$1 symbol (eg. (x$1: (Int, Int)) @unchecked scala, which we don't want to show to the user.

Connected to https://github.com/scalameta/metals/pull/5292