### PR TITLE
Retract SynthesizeExtMethodReceiver mode when when going deeper in overloading resolution

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2219,7 +2219,8 @@ trait Applications extends Compatibility {
     }
     val mapped = reverseMapping.map(_._1)
     overload.println(i"resolve mapped: ${mapped.map(_.widen)}%, % with $pt")
-    resolveOverloaded(mapped, pt).map(reverseMapping.toMap)
+    resolveOverloaded(mapped, pt)(using ctx.retractMode(Mode.SynthesizeExtMethodReceiver))
+      .map(reverseMapping.toMap)
 
   /** Try to typecheck any arguments in `pt` that are function values missing a
    *  parameter type. If the formal parameter types corresponding to a closure argument

--- a/tests/pos/i18744.scala
+++ b/tests/pos/i18744.scala
@@ -1,0 +1,13 @@
+package dotty.tools.dotc.typer
+
+object Color:
+  def apply(): Int = ???
+
+extension (u: Unit)
+  def foo(that: String, f: Int => Int): Int = ???
+  def foo(that: Long, f: Int => Int): Int = ???
+
+def test =
+  val c = Color()
+  ().foo("", (_: Int) => c)
+  ().foo("", (_: Int) => Color())

--- a/tests/pos/i18745.scala
+++ b/tests/pos/i18745.scala
@@ -1,0 +1,14 @@
+object Color:
+  def apply(i: Int): Int = i
+
+type Plane
+
+object Plane:
+  extension (plane: Plane)
+    def zipWith(that: String, f: Int => Int): Int = ???
+    def zipWith(that: Int, f: Int => Int): Int = ???
+
+import Plane.zipWith
+
+def test(p: Plane) =
+  p.zipWith("", (_: Int) => Color(25))


### PR DESCRIPTION
Retract SynthesizeExtMethodReceiver mode when going deeper in overloding resolution

The SynthesizeExtMethodReceiver mode is supposed to be turned on only for the direct application of of a synthesized receiver to the qualifier of an extension method selection. Previously its lifetime was accidentally extended when overloading resolution looked at subsequent parameter lists because the first one was not enough to disambiguate.

Fixes #18745
Fixes #18744