### PR TITLE
Properly handle by-name function types in REPL

### DIFF
--- a/compiler/test-resources/repl/i18756
+++ b/compiler/test-resources/repl/i18756
@@ -1,0 +1,5 @@
+scala> def f: ( => Int) => Int = i => i ; f(1)
+def f: (=> Int) => Int
+val res0: Int = 1
+scala> f(1)
+val res1: Int = 1

--- a/compiler/test-resources/repl/i18756b
+++ b/compiler/test-resources/repl/i18756b
@@ -1,0 +1,5 @@
+scala> def f: ( => Int) => ( => Int) => Int = i => j => i + j; f(1)(2)
+def f: (=> Int) => (=> Int) => Int
+val res0: Int = 3
+scala> f(1)(2)
+val res1: Int = 3


### PR DESCRIPTION
Fixes #18756

The fix is to transform term references to the `apply` method of the by-name function type. We transform  `((=> T1) => R)#apply`  into  `((() ?=> T1) => R)#apply`.

I have not figured out why this seems to only affect the REPL.