### PR TITLE
Identify structural trees on Match Type qualifiers

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -992,6 +992,8 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
       def hasRefinement(qualtpe: Type): Boolean = qualtpe.dealias match
         case defn.PolyFunctionOf(_) =>
           false
+        case tp: MatchType =>
+          hasRefinement(tp.tryNormalize)
         case RefinedType(parent, rname, rinfo) =>
           rname == tree.name || hasRefinement(parent)
         case tp: TypeProxy =>

--- a/tests/neg/i17192.5.scala
+++ b/tests/neg/i17192.5.scala
@@ -1,6 +1,7 @@
 class Ifce[BT <: Boolean]:
   type RT = BT match
-    case true => this.type { val v1: Int }
+    case true  => this.type { val v1: Int }
+    case false => this.type
   def cast: RT = this.asInstanceOf[RT]
 
 class Test:

--- a/tests/neg/i17192.5.scala
+++ b/tests/neg/i17192.5.scala
@@ -1,0 +1,12 @@
+class Ifce[BT <: Boolean]:
+  type RT = BT match
+    case true => this.type { val v1: Int }
+  def cast: RT = this.asInstanceOf[RT]
+
+class Test:
+  def t1: Unit =
+    val full1 = new Ifce[true]().cast
+    val v1 = full1.v1 // error
+//           ^^^^^
+//           Found:    (full1 : Ifce[(true : Boolean)]#RT)
+//           Required: Selectable | Dynamic

--- a/tests/pos/i17192.scala
+++ b/tests/pos/i17192.scala
@@ -1,0 +1,11 @@
+class Ifce[BT <: Boolean] extends Selectable:
+  type RT = BT match
+    case true  => this.type { val v1: Int }
+    case false => this.type
+  def cast : RT = this.asInstanceOf[RT]
+  def selectDynamic(key: String): Any = ???
+
+class Test:
+  def t1: Unit =
+    val full = (new Ifce[true]).cast
+    val v1 = full.v1


### PR DESCRIPTION
Without this change, selecting `v1` on a type `Ifce[(true :
Boolean)]#RT` which widens to a MatchType wouldn't be identified as a
structural tree, which later breaks Erasure.
