### PR TITLE
Use dedicated equals method for univerval equality of chars

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1684,7 +1684,7 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
         val equalsMethod: Symbol = {
           if (l.tpe <:< defn.BoxedNumberClass.info) {
             if (r.tpe <:< defn.BoxedNumberClass.info) defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumNum)
-            else if (r.tpe <:< defn.BoxedCharClass.info) NoSymbol // ctx.requiredMethod(BoxesRunTimeTypeRef, nme.equalsNumChar) // this method is private
+            else if (r.tpe <:< defn.BoxedCharClass.info) defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumChar)
             else defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumObject)
           } else defn.BoxesRunTimeModule_externalEquals
         }

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -2845,7 +2845,7 @@ class JSCodeGen()(using genCtx: Context) {
   private lazy val externalEqualsNumNum: Symbol =
     defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumNum)
   private lazy val externalEqualsNumChar: Symbol =
-    NoSymbol // requiredMethod(BoxesRunTimeTypeRef, nme.equalsNumChar) // this method is private
+    defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumChar)
   private lazy val externalEqualsNumObject: Symbol =
     defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumObject)
   private lazy val externalEquals: Symbol =
@@ -2885,7 +2885,7 @@ class JSCodeGen()(using genCtx: Context) {
         val ptfm = ctx.platform
         if (lsym.derivesFrom(defn.BoxedNumberClass)) {
           if (rsym.derivesFrom(defn.BoxedNumberClass)) externalEqualsNumNum
-          else if (rsym.derivesFrom(defn.BoxedCharClass)) externalEqualsNumObject // will be externalEqualsNumChar in 2.12, SI-9030
+          else if (rsym.derivesFrom(defn.BoxedCharClass)) externalEqualsNumChar
           else externalEqualsNumObject
         } else externalEquals
       }

--- a/tests/pos-with-compiler-cc/backend/jvm/BCodeBodyBuilder.scala
+++ b/tests/pos-with-compiler-cc/backend/jvm/BCodeBodyBuilder.scala
@@ -1622,7 +1622,7 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
         val equalsMethod: Symbol = {
           if (l.tpe <:< defn.BoxedNumberClass.info) {
             if (r.tpe <:< defn.BoxedNumberClass.info) defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumNum)
-            else if (r.tpe <:< defn.BoxedCharClass.info) NoSymbol // ctx.requiredMethod(BoxesRunTimeTypeRef, nme.equalsNumChar) // this method is private
+            else if (r.tpe <:< defn.BoxedCharClass.info) defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumChar)
             else defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumObject)
           } else defn.BoxesRunTimeModule_externalEquals
         }

--- a/tests/pos-with-compiler-cc/backend/sjs/JSCodeGen.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSCodeGen.scala
@@ -2846,7 +2846,7 @@ class JSCodeGen()(using genCtx: DetachedContext) {
   private lazy val externalEqualsNumNum: Symbol =
     defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumNum)
   private lazy val externalEqualsNumChar: Symbol =
-    NoSymbol // requiredMethod(BoxesRunTimeTypeRef, nme.equalsNumChar) // this method is private
+    defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumChar)
   private lazy val externalEqualsNumObject: Symbol =
     defn.BoxesRunTimeModule.requiredMethod(nme.equalsNumObject)
   private lazy val externalEquals: Symbol =
@@ -2886,7 +2886,7 @@ class JSCodeGen()(using genCtx: DetachedContext) {
         val ptfm = ctx.platform
         if (lsym.derivesFrom(defn.BoxedNumberClass)) {
           if (rsym.derivesFrom(defn.BoxedNumberClass)) externalEqualsNumNum
-          else if (rsym.derivesFrom(defn.BoxedCharClass)) externalEqualsNumObject // will be externalEqualsNumChar in 2.12, SI-9030
+          else if (rsym.derivesFrom(defn.BoxedCharClass)) externalEqualsNumChar
           else externalEqualsNumObject
         } else externalEquals
       }


### PR DESCRIPTION
 Uses `BoxesRunTime.equalsNumChar` instead of `BoxesRunTime.equalsNumObject` for boxed Char universal equality checks. This method was private in Scala 2.11, but is available since 2.12 allowing us to better optimize universal equality checks made with `Char` 
 
 Change was reflected in both JVM and JS backend (also the test sources)