### PR TITLE
Allow inferred parameter types always, when eta-expanding

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4167,11 +4167,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           val funExpected = functionExpected
           val arity =
             if funExpected then
-              if !isFullyDefined(pt, ForceDegree.none) && isFullyDefined(wtp, ForceDegree.none) then
-                // if method type is fully defined, but expected type is not,
-                // prioritize method parameter types as parameter types of the eta-expanded closure
-                0
-              else defn.functionArity(ptNorm)
+              defn.functionArity(ptNorm)
             else
               val nparams = wtp.paramInfos.length
               if nparams > 1

--- a/tests/neg/i5976.scala
+++ b/tests/neg/i5976.scala
@@ -1,6 +1,6 @@
 object Test {
   def f(i: => Int) = i + i
-  val res = List(42).map(f) // error
+  val res = List(42).map(f)
 
   val g: (=> Int) => Int = f
   val h: Int => Int = g // error

--- a/tests/pos/i18453.scala
+++ b/tests/pos/i18453.scala
@@ -1,0 +1,8 @@
+trait Box[T]
+
+class Test:
+  def f[A, B](c: A => A & B)(using ba: Box[A]): Unit = ???
+
+  def g[X, Y](using bx: Box[X]): Unit =
+    def d(t: X): X & Y = t.asInstanceOf[X & Y]
+    f(d)

--- a/tests/pos/i18453.workaround.scala
+++ b/tests/pos/i18453.workaround.scala
@@ -1,0 +1,8 @@
+trait Box[T]
+
+class Test:
+  def f[A, B](c: A => A & B)(using ba: Box[A]): Unit = ???
+
+  def g[X, Y](using bx: Box[X]): Unit =
+    def d(t: X): X & Y = t.asInstanceOf[X & Y]
+    f(u => d(u))

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -1070,7 +1070,7 @@ Language => Scala
 Symbols => 181 entries
 Occurrences => 159 entries
 Diagnostics => 1 entries
-Synthetics => 6 entries
+Synthetics => 5 entries
 
 Symbols:
 _empty_/Enums. => final object Enums extends Object { self: Enums.type => +30 decls }
@@ -1253,7 +1253,7 @@ _empty_/Enums.unwrap().(ev) => implicit given param ev: <:<[A, Option[B]]
 _empty_/Enums.unwrap().(opt) => param opt: Option[A]
 _empty_/Enums.unwrap().[A] => typeparam A 
 _empty_/Enums.unwrap().[B] => typeparam B 
-local0 => param x: Option[B]
+local0 => param x: A
 
 Occurrences:
 [0:7..0:12): Enums <- _empty_/Enums.
@@ -1421,7 +1421,6 @@ Diagnostics:
 
 Synthetics:
 [52:9..52:13):Refl => *.unapply[Option[B]]
-[52:31..52:50):identity[Option[B]] => *[Function1[A, Option[B]]]
 [54:14..54:18):Some => *.apply[Some[Int]]
 [54:14..54:34):Some(Some(1)).unwrap => *(given_<:<_T_T[Option[Int]])
 [54:19..54:23):Some => *.apply[Int]


### PR DESCRIPTION
Rather than drawing an exemption based on fully defined types, report
the right function arity.  This leads eta-expansion to leave off the
type, so then the parameter type is inferred.  In the test case
pos/i18453 this leads to the type var ?A being instantiated to X, rather
than ?A & ?B being constrained against X & Y, which leads to ?A being
instantiated to X & Y - and then failing to find a Box[X & Y] in scope.
