### PR TITLE
Add workflow adding to backport project

### DIFF
--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -1,0 +1,24 @@
+name: Add to backporting project
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  add-to-backporting-project:
+    if: "github.event.pull_request.merged == true
+         && github.event.pull_request.base.ref == 'main'
+         && !contains(github.event.pull_request.body, '[Next only]')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: coursier/cache-action@v6
+      - uses: VirtusLab/scala-cli-setup@v0.2
+      - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.event.pull_request.number }}
+        env:
+          GRAPHQL_API_TOKEN: ${{ secrets.GRAPHQL_API_TOKEN }}
+

--- a/project/scripts/addToBackportingProject.scala
+++ b/project/scripts/addToBackportingProject.scala
@@ -8,6 +8,9 @@ import sttp.client4.*
 lazy val apiToken =
   System.getenv("GRAPHQL_API_TOKEN")
 
+val PROJECT_ID: String = "PVT_kwDOACj3ec4AWSoi"
+val FIELD_ID: String = "PVTF_lADOACj3ec4AWSoizgO7uJ4"
+
 case class ID(value: String) derives WrapperVariable
 
 @main def run(number: Int) =
@@ -19,7 +22,7 @@ def getPrData(number: Int): (ID, String) =
   val res = query"""
     |query getPR {
     |  repository(owner: "lampepfl", name:"dotty") {
-    |    pullRequest(number: 17570) {
+    |    pullRequest(number: $number) {
     |      id
     |      mergedAt
     |    }
@@ -36,9 +39,9 @@ def timestampItem(id: ID, date: String) =
   query"""
     |mutation editField {
     |  updateProjectV2ItemFieldValue(input: {
-    |    projectId: "PVT_kwDOACj3ec4AWSoi",
+    |    projectId: $PROJECT_ID,
     |    itemId: $id,
-    |    fieldId: "PVTF_lADOACj3ec4AWSoizgO7uJ4",
+    |    fieldId: $FIELD_ID,
     |    value: { text: $date }
     |  }) {
     |    projectV2Item {
@@ -56,7 +59,7 @@ def addItem(id: ID) =
   val res = query"""
     |mutation addItem {
     |  addProjectV2ItemById(input: {
-    |    projectId: "PVT_kwDOACj3ec4AWSoi",
+    |    projectId: $PROJECT_ID,
     |    contentId: $id
     |  }) {
     |    item {

--- a/project/scripts/addToBackportingProject.scala
+++ b/project/scripts/addToBackportingProject.scala
@@ -1,0 +1,72 @@
+//> using scala 3.3.1
+//> using toolkit 0.2.1
+//> using lib pro.kordyjan::pytanie:0.1.6
+
+import pytanie.*
+import sttp.client4.*
+
+lazy val apiToken =
+  System.getenv("GRAPHQL_API_TOKEN")
+
+case class ID(value: String) derives WrapperVariable
+
+@main def run(number: Int) =
+  val (id, date) = getPrData(number)
+  val newId = addItem(id)
+  timestampItem(newId, date)
+
+def getPrData(number: Int): (ID, String) =
+  val res = query"""
+    |query getPR {
+    |  repository(owner: "lampepfl", name:"dotty") {
+    |    pullRequest(number: 17570) {
+    |      id
+    |      mergedAt
+    |    }
+    |  }
+    |}
+    """.send(
+      uri"https://api.github.com/graphql",
+      "Kordyjan",
+      apiToken
+    )
+  (ID(res.repository.pullRequest.id), res.repository.pullRequest.mergedAt)
+
+def timestampItem(id: ID, date: String) =
+  query"""
+    |mutation editField {
+    |  updateProjectV2ItemFieldValue(input: {
+    |    projectId: "PVT_kwDOACj3ec4AWSoi",
+    |    itemId: $id,
+    |    fieldId: "PVTF_lADOACj3ec4AWSoizgO7uJ4",
+    |    value: { text: $date }
+    |  }) {
+    |    projectV2Item {
+    |      updatedAt
+    |    }
+    |  }
+    |}
+    """.send(
+      uri"https://api.github.com/graphql",
+      "Kordyjan",
+      apiToken
+    )
+
+def addItem(id: ID) =
+  val res = query"""
+    |mutation addItem {
+    |  addProjectV2ItemById(input: {
+    |    projectId: "PVT_kwDOACj3ec4AWSoi",
+    |    contentId: $id
+    |  }) {
+    |    item {
+    |      id
+    |    }
+    |  }
+    |}
+    """.send(
+      uri"https://api.github.com/graphql",
+      "Kordyjan",
+      apiToken
+    )
+  ID(res.addProjectV2ItemById.item.id)


### PR DESCRIPTION
This adds a simple workflow that will add each PR merged to `main` to the lts-backporting project.

The workflow can be skipped by using a following tag (used here intentionally):

[Next only]