### PR TITLE
Better error messages for missing commas and more

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -997,6 +997,8 @@ object Parsers {
       leadingOperandTokens.contains(in.lookahead.token)
       || in.postfixOpsEnabled
       || in.lookahead.token == COLONop
+      || in.lookahead.token == EOF     // important for REPL completions
+      || ctx.mode.is(Mode.Interactive) // in interactive mode the next tokens might be missing
 
   /* --------- OPERAND/OPERATOR STACK --------------------------------------- */
 

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -221,10 +221,13 @@ object Tokens extends TokensCommon {
 
   final val openParensTokens = BitSet(LBRACE, LPAREN, LBRACKET)
 
-  final val canStartExprTokens3: TokenSet =
-      atomicExprTokens
+  final val canStartInfixExprTokens =
+    atomicExprTokens
     | openParensTokens
-    | BitSet(INDENT, QUOTE, IF, WHILE, FOR, NEW, TRY, THROW)
+    | BitSet(QUOTE, NEW)
+
+  final val canStartExprTokens3: TokenSet =
+    canStartInfixExprTokens | BitSet(INDENT, IF, WHILE, FOR, TRY, THROW)
 
   final val canStartExprTokens2: TokenSet = canStartExprTokens3 | BitSet(DO)
 
@@ -232,6 +235,8 @@ object Tokens extends TokensCommon {
     THIS, SUPER, USCORE, LPAREN, LBRACE, AT)
 
   final val canStartTypeTokens: TokenSet = canStartInfixTypeTokens | BitSet(LBRACE)
+
+  final val canStartPatternTokens = atomicExprTokens | openParensTokens | BitSet(USCORE, QUOTE)
 
   final val templateIntroTokens: TokenSet = BitSet(CLASS, TRAIT, OBJECT, ENUM, CASECLASS, CASEOBJECT)
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1187,7 +1187,7 @@ extends ReferenceMsg(ForwardReferenceExtendsOverDefinitionID) {
         |"""
 }
 
-class ExpectedTokenButFound(expected: Token, found: Token)(using Context)
+class ExpectedTokenButFound(expected: Token, found: Token, prefix: String = "")(using Context)
 extends SyntaxMsg(ExpectedTokenButFoundID) {
 
   private def foundText = Tokens.showToken(found)
@@ -1196,7 +1196,7 @@ extends SyntaxMsg(ExpectedTokenButFoundID) {
     val expectedText =
       if (Tokens.isIdentifier(expected)) "an identifier"
       else Tokens.showToken(expected)
-    i"""${expectedText} expected, but ${foundText} found"""
+    i"""$prefix$expectedText expected, but $foundText found"""
 
   def explain(using Context) =
     if (Tokens.isIdentifier(expected) && Tokens.isKeyword(found))

--- a/tests/neg/cc-only-defs.scala
+++ b/tests/neg/cc-only-defs.scala
@@ -7,5 +7,5 @@ trait Test {
 
   val b: ImpureFunction1[Int, Int] // now OK
 
-  val a: {z} String // error
-}  // error
+  val a: {z} String // error // error
+}

--- a/tests/neg/i14564.check
+++ b/tests/neg/i14564.check
@@ -1,17 +1,4 @@
--- [E018] Syntax Error: tests/neg/i14564.scala:5:28 --------------------------------------------------------------------
-5 |def test = sum"${ List(42)* }" // error // error
-  |                            ^
-  |                            expression expected but [31m'}'[0m found
-  |
-  | longer explanation available when compiling with `-explain`
--- [E008] Not Found Error: tests/neg/i14564.scala:5:26 -----------------------------------------------------------------
-5 |def test = sum"${ List(42)* }" // error // error
-  |                  ^^^^^^^^^
-  |                  value * is not a member of List[Int], but could be made available as an extension method.
-  |
-  |                  One of the following imports might make progress towards fixing the problem:
-  |
-  |                    import scala.math.Fractional.Implicits.infixFractionalOps
-  |                    import scala.math.Integral.Implicits.infixIntegralOps
-  |                    import scala.math.Numeric.Implicits.infixNumericOps
-  |
+-- Error: tests/neg/i14564.scala:5:26 ----------------------------------------------------------------------------------
+5 |def test = sum"${ List(42)* }" // error
+  |                          ^
+  |                          spread operator `*` not allowed here; must come last in a parameter list

--- a/tests/neg/i14564.scala
+++ b/tests/neg/i14564.scala
@@ -2,5 +2,5 @@ import language.postfixOps as _
 
 extension (sc: StringContext) def sum(xs: Int*): String = xs.sum.toString
 
-def test = sum"${ List(42)* }" // error // error
+def test = sum"${ List(42)* }" // error
 

--- a/tests/neg/i18020.scala
+++ b/tests/neg/i18020.scala
@@ -16,7 +16,7 @@ def foo3 =
   val _root_ = "abc" // error
 
 def foo1: Unit =
-  val _root_: String = "abc" // error // error
+  val _root_: String = "abc" // error
   // _root_: is, technically, a legal name
   // so then it tries to construct the infix op pattern
   // "_root_ String .." and then throws in a null when it fails

--- a/tests/neg/i18734.check
+++ b/tests/neg/i18734.check
@@ -1,0 +1,28 @@
+-- [E040] Syntax Error: tests/neg/i18734.scala:7:8 ---------------------------------------------------------------------
+7 |  Foo(1 2) // error
+  |        ^
+  |        ',' or ')' expected, but integer literal found
+-- [E040] Syntax Error: tests/neg/i18734.scala:9:8 ---------------------------------------------------------------------
+9 |  Foo(x y) // error
+  |        ^
+  |        ',' or ')' expected, but identifier found
+-- [E040] Syntax Error: tests/neg/i18734.scala:11:8 --------------------------------------------------------------------
+11 |  Foo(1 b = 2) // error
+   |        ^
+   |        ',' or ')' expected, but identifier found
+-- [E040] Syntax Error: tests/neg/i18734.scala:16:4 --------------------------------------------------------------------
+16 |    b = 2 // error
+   |    ^
+   |    ',' or ')' expected, but identifier found
+-- [E040] Syntax Error: tests/neg/i18734.scala:19:32 -------------------------------------------------------------------
+19 |  val f: (Int, Int) => Int = (x y) => x + y // error
+   |                                ^
+   |                                ',' or ')' expected, but identifier found
+-- [E040] Syntax Error: tests/neg/i18734.scala:23:10 -------------------------------------------------------------------
+23 |  bar[Int String](1 2) // error // error
+   |          ^^^^^^
+   |          ',' or ']' expected, but identifier found
+-- [E040] Syntax Error: tests/neg/i18734.scala:23:20 -------------------------------------------------------------------
+23 |  bar[Int String](1 2) // error // error
+   |                    ^
+   |                    ',' or ')' expected, but integer literal found

--- a/tests/neg/i18734.scala
+++ b/tests/neg/i18734.scala
@@ -1,0 +1,25 @@
+case class Foo(a: Int, b: Int)
+
+object Bar:
+  val x = 1
+  val y = 2
+
+  Foo(1 2) // error
+
+  Foo(x y) // error
+
+  Foo(1 b = 2) // error
+
+  // Or
+  Foo(
+    a = 1
+    b = 2 // error
+  )
+
+  val f: (Int, Int) => Int = (x y) => x + y // error
+
+  def bar[X, Y](x: X, y: Y) = ???
+
+  bar[Int String](1 2) // error // error
+
+

--- a/tests/neg/i4453.scala
+++ b/tests/neg/i4453.scala
@@ -1,2 +1,2 @@
-class x0 { var x0 == _ * // error: _* can be used only for last argument // error: == cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method
-// error '=' expected, but eof found
+class x0 { var x0 == _ * // error spread operator `*` not allowed here // error '=' expected
+  // error: == cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method

--- a/tests/neg/i5498-postfixOps.check
+++ b/tests/neg/i5498-postfixOps.check
@@ -4,13 +4,25 @@
   |          expression expected but [31mend of statement[0m found
   |
   | longer explanation available when compiling with `-explain`
--- [E018] Syntax Error: tests/neg/i5498-postfixOps.scala:6:37 ----------------------------------------------------------
-6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error
-  |                                     ^
-  |                                     expression expected but [31m')'[0m found
-  |
-  | longer explanation available when compiling with `-explain`
+-- [E040] Syntax Error: tests/neg/i5498-postfixOps.scala:6:29 ----------------------------------------------------------
+6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error // error (type error) // error (type error)
+  |                             ^^^^^^^^
+  |                             ')' expected, but identifier found
 -- [E172] Type Error: tests/neg/i5498-postfixOps.scala:6:0 -------------------------------------------------------------
-6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error
+6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error // error (type error) // error (type error)
   |^
   |No given instance of type scala.concurrent.duration.DurationConversions.Classifier[Null] was found for parameter ev of method second in trait DurationConversions
+-- [E007] Type Mismatch Error: tests/neg/i5498-postfixOps.scala:6:24 ---------------------------------------------------
+6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error // error (type error) // error (type error)
+  |                        ^
+  |                        Found:    (1 : Int)
+  |                        Required: Boolean
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i5498-postfixOps.scala:6:26 ---------------------------------------------------
+6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error // error (type error) // error (type error)
+  |                          ^
+  |                          Found:    (2 : Int)
+  |                          Required: Boolean
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i5498-postfixOps.check
+++ b/tests/neg/i5498-postfixOps.check
@@ -7,7 +7,7 @@
 -- [E040] Syntax Error: tests/neg/i5498-postfixOps.scala:6:29 ----------------------------------------------------------
 6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error // error (type error) // error (type error)
   |                             ^^^^^^^^
-  |                             ')' expected, but identifier found
+  |                             ',' or ')' expected, but identifier found
 -- [E172] Type Error: tests/neg/i5498-postfixOps.scala:6:0 -------------------------------------------------------------
 6 |  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error // error (type error) // error (type error)
   |^

--- a/tests/neg/i5498-postfixOps.scala
+++ b/tests/neg/i5498-postfixOps.scala
@@ -3,5 +3,5 @@ import scala.concurrent.duration.*
 def test() = {
   1 second // error: usage of postfix operator
 
-  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error
+  Seq(1, 2).filter(List(1,2) contains) // error: usage of postfix operator // error // error (type error) // error (type error)
 }

--- a/tests/neg/i6059.scala
+++ b/tests/neg/i6059.scala
@@ -1,3 +1,3 @@
 def I0(I1: Int ) = I1
-val I1 = I0(I0 i2) => // error
+val I1 = I0(I0 i2) => // error // error
   true

--- a/tests/neg/syntax-error-recovery.check
+++ b/tests/neg/syntax-error-recovery.check
@@ -9,7 +9,7 @@
 -- [E040] Syntax Error: tests/neg/syntax-error-recovery.scala:19:4 -----------------------------------------------------
 19 |    if x == 0 then println(bar) // error
    |    ^^
-   |    ')' expected, but 'if' found
+   |    ',' or ')' expected, but 'if' found
 -- [E040] Syntax Error: tests/neg/syntax-error-recovery.scala:23:12 ----------------------------------------------------
 23 |    if x < 0) then // error
    |            ^
@@ -25,7 +25,7 @@
 -- [E040] Syntax Error: tests/neg/syntax-error-recovery.scala:48:4 -----------------------------------------------------
 48 |    if x == 0 then println(bar) // error
    |    ^^
-   |    ')' expected, but 'if' found
+   |    ',' or ')' expected, but 'if' found
 -- [E040] Syntax Error: tests/neg/syntax-error-recovery.scala:52:12 ----------------------------------------------------
 52 |    if x < 0) then // error
    |            ^

--- a/tests/neg/t11900.check
+++ b/tests/neg/t11900.check
@@ -10,9 +10,7 @@
 52 |    println("b"),   // error: weird comma
    |                ^
    |                end of statement expected but ',' found
--- [E032] Syntax Error: tests/neg/t11900.scala:64:8 --------------------------------------------------------------------
+-- Error: tests/neg/t11900.scala:64:7 ----------------------------------------------------------------------------------
 64 |      _*, // error
-   |        ^
-   |        pattern expected
-   |
-   | longer explanation available when compiling with `-explain`
+   |       ^
+   |       spread operator `*` not allowed here; must come last in a parameter list

--- a/tests/neg/t1625.check
+++ b/tests/neg/t1625.check
@@ -1,8 +1,8 @@
--- [E040] Syntax Error: tests/neg/t1625.scala:2:20 ---------------------------------------------------------------------
+-- Error: tests/neg/t1625.scala:2:19 -----------------------------------------------------------------------------------
 2 |  def foo(x: String*, y: String*, c: String*): Int // error: an identifier expected, but ',' found // error: an identifier expected, but ',' found
-  |                    ^
-  |                    an identifier expected, but ',' found
--- [E040] Syntax Error: tests/neg/t1625.scala:2:32 ---------------------------------------------------------------------
+  |                   ^
+  |                   spread operator `*` not allowed here; must come last in a parameter list
+-- Error: tests/neg/t1625.scala:2:31 -----------------------------------------------------------------------------------
 2 |  def foo(x: String*, y: String*, c: String*): Int // error: an identifier expected, but ',' found // error: an identifier expected, but ',' found
-  |                                ^
-  |                                an identifier expected, but ',' found
+  |                               ^
+  |                               spread operator `*` not allowed here; must come last in a parameter list

--- a/tests/neg/t1625b.scala
+++ b/tests/neg/t1625b.scala
@@ -1,3 +1,3 @@
 object T5 {
-  case class Abc(x: String*, c: String*) // error: identifier expected but `,` found
+  case class Abc(x: String*, c: String*) // error: varargs parameter must come last
 }

--- a/tests/neg/t5702-neg-bad-and-wild.check
+++ b/tests/neg/t5702-neg-bad-and-wild.check
@@ -14,12 +14,10 @@
 13 |      case List(1, _*3:) =>  // error // error
    |                       ^
    |                       an identifier expected, but ')' found
--- [E032] Syntax Error: tests/neg/t5702-neg-bad-and-wild.scala:15:18 ---------------------------------------------------
+-- Error: tests/neg/t5702-neg-bad-and-wild.scala:15:17 -----------------------------------------------------------------
 15 |      case List(x*, 1) => // error: pattern expected
-   |                  ^
-   |                  pattern expected
-   |
-   | longer explanation available when compiling with `-explain`
+   |                 ^
+   |                 spread operator `*` not allowed here; must come last in a parameter list
 -- Error: tests/neg/t5702-neg-bad-and-wild.scala:16:16 -----------------------------------------------------------------
 16 |      case (1, x*) => // error: bad use of *
    |                ^
@@ -30,12 +28,10 @@
    |                  * can be used only for last argument
    |
    | longer explanation available when compiling with `-explain`
--- [E032] Syntax Error: tests/neg/t5702-neg-bad-and-wild.scala:23:17 ---------------------------------------------------
+-- Error: tests/neg/t5702-neg-bad-and-wild.scala:23:16 -----------------------------------------------------------------
 23 |    val K(ns @ _*, xx) = k // error: pattern expected
-   |                 ^
-   |                 pattern expected
-   |
-   | longer explanation available when compiling with `-explain`
+   |                ^
+   |                spread operator `*` not allowed here; must come last in a parameter list
 -- Error: tests/neg/t5702-neg-bad-and-wild.scala:25:14 -----------------------------------------------------------------
 25 |    val (b, _ * ) = (5,6) // error: bad use of `*`
    |              ^

--- a/tests/neg/t5702-neg-bad-brace.check
+++ b/tests/neg/t5702-neg-bad-brace.check
@@ -1,9 +1,7 @@
--- [E032] Syntax Error: tests/neg/t5702-neg-bad-brace.scala:8:21 -------------------------------------------------------
+-- Error: tests/neg/t5702-neg-bad-brace.scala:8:20 ---------------------------------------------------------------------
 8 |      case List(1, _*} => // error: pattern expected
-  |                     ^
-  |                     pattern expected
-  |
-  | longer explanation available when compiling with `-explain`
+  |                    ^
+  |                    spread operator `*` not allowed here; must come last in a parameter list
 -- [E040] Syntax Error: tests/neg/t5702-neg-bad-brace.scala:11:0 -------------------------------------------------------
 11 |} // error: eof expected, but '}' found
    |^


### PR DESCRIPTION
Three measures:

 1. Classify an id as infix operator only if following can start an operand
 2. Detect and report spread operators in illegal positions
 3. Mention `,` in addition to `)` or `]` in error messages when a `,` could have been missing

Fixes #18734

