### PR TITLE
Detect case where two alternatives are the same after widening ExprTypes

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1780,14 +1780,21 @@ trait Applications extends Compatibility {
       def winsType2 = isAsSpecific(alt2, tp2, alt1, tp1)
 
       overload.println(i"compare($alt1, $alt2)? $tp1 $tp2 $ownerScore $winsType1 $winsType2")
-      if (ownerScore == 1)
-        if (winsType1 || !winsType2) 1 else 0
-      else if (ownerScore == -1)
-        if (winsType2 || !winsType1) -1 else 0
-      else if (winsType1)
-        if (winsType2) 0 else 1
+      if winsType1 && winsType2
+          && alt1.widenExpr =:= alt2.widenExpr
+          && alt1.widenExpr.isStable
+      then
+        // alternatives are the same after following ExprTypes, pick one of them
+        // (prefer the one that is not a method, but that's arbitrary).
+        if alt1.widenExpr =:= alt2 then -1 else 1
+      else if ownerScore == 1 then
+        if winsType1 || !winsType2 then 1 else 0
+      else if ownerScore == -1 then
+        if winsType2 || !winsType1 then -1 else 0
+      else if winsType1 then
+        if winsType2 then 0 else 1
       else
-        if (winsType2) -1 else 0
+        if winsType2 then -1 else 0
     }
 
     if alt1.symbol.is(ConstructorProxy) && !alt2.symbol.is(ConstructorProxy) then -1

--- a/tests/pos/i18768.scala
+++ b/tests/pos/i18768.scala
@@ -1,0 +1,14 @@
+object Module:
+  object Exportee:
+
+    opaque type Id = Long
+
+    def apply(): Id = ???
+
+    extension (e: Id)
+      def updated: Id = ???
+
+
+object Client:
+  export Module.*
+  val x = Exportee().updated


### PR DESCRIPTION
In implicit or extension method search we might get two alternatives that are different but that point to the same singleton type after widening ExprTypes. In that case we can arbitrarily pick one of them instead of declaring an ambiguity.

Fixes #18768