### PR TITLE
Improve error message about missing type of context function parameter

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -7,7 +7,7 @@ import Contexts._
 import Decorators._, Symbols._, Names._, NameOps._, Types._, Flags._, Phases._
 import Denotations.SingleDenotation
 import SymDenotations.SymDenotation
-import NameKinds.WildcardParamName
+import NameKinds.{WildcardParamName, ContextFunctionParamName}
 import parsing.Scanners.Token
 import parsing.Tokens
 import printing.Highlighting._
@@ -166,21 +166,24 @@ class AnonymousFunctionMissingParamType(param: untpd.ValDef,
                                         (using Context)
 extends TypeMsg(AnonymousFunctionMissingParamTypeID) {
   def msg(using Context) = {
-    val ofFun =
+    val paramDescription =
       if param.name.is(WildcardParamName)
-          || (MethodType.syntheticParamNames(tree.args.length + 1) contains param.name)
-      then i"\n\nIn expanded function:\n$tree"
+          || param.name.is(ContextFunctionParamName)
+          || MethodType.syntheticParamNames(tree.args.length + 1).contains(param.name)
+      then i"\nin expanded function:\n  $tree"
       else ""
 
     val inferred =
-      if (inferredType == WildcardType) ""
-      else i"\n\nPartially inferred type for the parameter: $inferredType"
+      if inferredType == WildcardType then ""
+      else i"\nWhat I could infer was: $inferredType"
 
     val expected =
-      if (expectedType == WildcardType) ""
-      else i"\n\nExpected type for the whole anonymous function: $expectedType"
+      if expectedType == WildcardType then ""
+      else i"\nExpected type for the whole anonymous function:\n  $expectedType"
 
-    i"Could not infer type for parameter ${param.name} of anonymous function$ofFun$inferred$expected"
+    i"""Missing parameter type
+       |
+       |I could not infer the type of the parameter ${param.name}$paramDescription$inferred$expected"""
   }
 
   def explain(using Context) = ""

--- a/tests/neg/i11350.check
+++ b/tests/neg/i11350.check
@@ -1,16 +1,22 @@
 -- [E081] Type Error: tests/neg/i11350.scala:1:39 ----------------------------------------------------------------------
 1 |class A1[T](action: A1[T] ?=> String = "") // error
   |                                       ^
-  |                                       Could not infer type for parameter contextual$1 of anonymous function
+  |                                       Missing parameter type
   |
-  |                                       Partially inferred type for the parameter: A1[<?>]
-  |
-  |                                       Expected type for the whole anonymous function: (A1[<?>]) ?=> String
+  |                                       I could not infer the type of the parameter contextual$1
+  |                                       in expanded function:
+  |                                         contextual$1 ?=> ""
+  |                                       What I could infer was: A1[<?>]
+  |                                       Expected type for the whole anonymous function:
+  |                                         (A1[<?>]) ?=> String
 -- [E081] Type Error: tests/neg/i11350.scala:2:39 ----------------------------------------------------------------------
 2 |class A2[T](action: A1[T] ?=> String = summon[A1[T]]) // error
   |                                       ^
-  |                                       Could not infer type for parameter contextual$2 of anonymous function
+  |                                       Missing parameter type
   |
-  |                                       Partially inferred type for the parameter: A1[<?>]
-  |
-  |                                       Expected type for the whole anonymous function: (A1[<?>]) ?=> String
+  |                                       I could not infer the type of the parameter contextual$2
+  |                                       in expanded function:
+  |                                         contextual$2 ?=> summon[A1[T]]
+  |                                       What I could infer was: A1[<?>]
+  |                                       Expected type for the whole anonymous function:
+  |                                         (A1[<?>]) ?=> String

--- a/tests/neg/i11561.check
+++ b/tests/neg/i11561.check
@@ -1,12 +1,13 @@
 -- [E081] Type Error: tests/neg/i11561.scala:2:32 ----------------------------------------------------------------------
 2 |  val updateText1 = copy(text = _) // error
   |                                ^
-  |                                Could not infer type for parameter _$1 of anonymous function
+  |                                Missing parameter type
   |
-  |                                In expanded function:
-  |                                _$1 => State.this.text = _$1
-  |
-  |                                Expected type for the whole anonymous function: String
+  |                                I could not infer the type of the parameter _$1
+  |                                in expanded function:
+  |                                  _$1 => State.this.text = _$1
+  |                                Expected type for the whole anonymous function:
+  |                                  String
 -- [E052] Type Error: tests/neg/i11561.scala:3:30 ----------------------------------------------------------------------
 3 |  val updateText2 = copy(text = (_: String)) // error
   |                         ^^^^^^^^^^^^^^^^^^

--- a/tests/neg/i17183.check
+++ b/tests/neg/i17183.check
@@ -1,18 +1,20 @@
 -- [E081] Type Error: tests/neg/i17183.scala:11:24 ---------------------------------------------------------------------
 11 |def test = Context(f = (_, _) => ???) // error // error
    |                        ^
-   |                        Could not infer type for parameter _$1 of anonymous function
+   |                        Missing parameter type
    |
-   |                        In expanded function:
-   |                        (_$1, _$2) => ???
-   |
-   |                        Expected type for the whole anonymous function: MyFunc
+   |                        I could not infer the type of the parameter _$1
+   |                        in expanded function:
+   |                          (_$1, _$2) => ???
+   |                        Expected type for the whole anonymous function:
+   |                          MyFunc
 -- [E081] Type Error: tests/neg/i17183.scala:11:27 ---------------------------------------------------------------------
 11 |def test = Context(f = (_, _) => ???) // error // error
    |                           ^
-   |                           Could not infer type for parameter _$2 of anonymous function
+   |                           Missing parameter type
    |
-   |                           In expanded function:
-   |                           (_$1, _$2) => ???
-   |
-   |                           Expected type for the whole anonymous function: MyFunc
+   |                           I could not infer the type of the parameter _$2
+   |                           in expanded function:
+   |                             (_$1, _$2) => ???
+   |                           Expected type for the whole anonymous function:
+   |                             MyFunc

--- a/tests/neg/i18188.check
+++ b/tests/neg/i18188.check
@@ -1,0 +1,11 @@
+-- [E081] Type Error: tests/neg/i18188.scala:3:39 ----------------------------------------------------------------------
+3 |class A1[T](action: A1[T] ?=> String = "") // error
+  |                                       ^
+  |                                       Missing parameter type
+  |
+  |                                       I could not infer the type of the parameter contextual$1
+  |                                       in expanded function:
+  |                                         contextual$1 ?=> ""
+  |                                       What I could infer was: dotty.tools.dotc.typer.A1[<?>]
+  |                                       Expected type for the whole anonymous function:
+  |                                         (dotty.tools.dotc.typer.A1[<?>]) ?=> String

--- a/tests/neg/i18188.scala
+++ b/tests/neg/i18188.scala
@@ -1,0 +1,3 @@
+package dotty.tools.dotc.typer
+
+class A1[T](action: A1[T] ?=> String = "") // error


### PR DESCRIPTION
Also, change formatting of msg closer to what it was before. I find that more legible.