### PR TITLE
Allow inner classes of universal traits

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2785,11 +2785,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       checkDerivedValueClass(cls, body1)
 
       val effectiveOwner = cls.owner.skipWeakOwner
-      if !cls.isRefinementClass
-         && !cls.isAllOf(PrivateLocal)
+      if cls.is(ModuleClass)
          && effectiveOwner.is(Trait)
          && !effectiveOwner.derivesFrom(defn.ObjectClass)
-         && !ctx.settings.YcompileScala2Library.value // FIXME?: class PermutationsItr cannot be defined in universal trait SeqOps
       then
         report.error(em"$cls cannot be defined in universal $effectiveOwner", cdef.srcPos)
 

--- a/tests/neg/inner-classes-of-universal-traits.scala
+++ b/tests/neg/inner-classes-of-universal-traits.scala
@@ -1,0 +1,8 @@
+trait Outer extends Any {
+  trait Inner1
+  trait Inner2 extends Any
+  class Inner3
+  class Inner4(a: Int) extends AnyVal // error
+  case class Inner5(a: Int) // error
+  object Inner6 // error
+}

--- a/tests/pos-special/stdlib/collection/IndexedSeq.scala
+++ b/tests/pos-special/stdlib/collection/IndexedSeq.scala
@@ -33,7 +33,7 @@ trait IndexedSeq[+A] extends Seq[A]
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](immutable.IndexedSeq)
 
 /** Base trait for indexed Seq operations */
-trait IndexedSeqOps[+A, +CC[_], +C] extends AnyRef with SeqOps[A, CC, C] { self =>
+trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
 
   def iterator: Iterator[A] = view.iterator
 

--- a/tests/pos-special/stdlib/collection/Seq.scala
+++ b/tests/pos-special/stdlib/collection/Seq.scala
@@ -77,13 +77,7 @@ object Seq extends SeqFactory.Delegate[Seq](immutable.Seq)
   * @define coll sequence
   * @define Coll `Seq`
   */
-trait SeqOps[+A, +CC[_], +C] extends AnyRef
-  // CC TODO: Our treechecker disallows classes in universal traits, but the typer accepts
-  // them. Since SeqOps contains nested classes, I changed it to be no longer a universal trait.
-  // Alternatively we could
-  //  - Change TreeChecker to accept this
-  //  - Move nested classes out of the trait
-  with IterableOps[A, CC, C] { self =>
+trait SeqOps[+A, +CC[_], +C] extends Any with IterableOps[A, CC, C] { self =>
 
   override def view: SeqView[A] = new SeqView.Id[A](this)
 


### PR DESCRIPTION
Just forbid inner objects. This aligns with Scala 2 and allows us to keep Seq's definition as in Scala 2 when porting or capture checking the standard library.
