### PR TITLE
Tweak approximation of type variables when computing default types

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1896,7 +1896,10 @@ class Namer { typer: Typer =>
      */
     def expectedDefaultArgType =
       val originalTp = defaultParamType
-      val approxTp = wildApprox(originalTp)
+      val approxTp = withMode(Mode.TypevarsMissContext):
+        // assert TypevarsMissContext so that TyperState does not leak into approximation
+        // We approximate precisely because we want to unlink the type variable. Test case is i18795.scala.
+        wildApprox(originalTp)
       approxTp.stripPoly match
         case atp @ defn.ContextFunctionType(_, resType)
         if !defn.isNonRefinedFunction(atp) // in this case `resType` is lying, gives us only the non-dependent upper bound

--- a/tests/pos/i18795.scala
+++ b/tests/pos/i18795.scala
@@ -1,0 +1,15 @@
+package example
+
+object Main extends App with Test {
+  load("")()
+}
+
+trait Test {
+
+  def load[T](
+    doLoad: T
+  )(
+    description: T => Option[String] = (x: T) => None // <--- compile error here
+  ): Unit = ???
+
+}


### PR DESCRIPTION
Tweak approximation of type variables when computing the expected types of default arguments.

Fixes #18795