### PR TITLE
Remove `stdlib213` from community build tests

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -358,14 +358,6 @@ object projects:
     // sbtDocCommand = "dotty-community-build/doc"
   )
 
-  lazy val stdLib213 = SbtCommunityProject(
-    project       = "stdLib213",
-    extraSbtArgs  = List("-Dscala.build.compileWithDotty=true"),
-    sbtTestCommand   = """set Global / fatalWarnings := false; library/compile""",
-    sbtPublishCommand = """set Global / fatalWarnings := false; set library/Compile/packageDoc/publishArtifact := false; library/publishLocal""",
-    // sbtDocCommand = "library/doc" // Does no compile? No idea :/
-  )
-
   lazy val shapeless3 = SbtCommunityProject(
     project = "shapeless-3",
     sbtTestCommand = "testJVM; testJS",
@@ -793,7 +785,6 @@ def allProjects = List(
   projects.scalaPB,
   projects.minitest,
   projects.fastparse,
-  projects.stdLib213,
   projects.shapeless3,
   projects.xmlInterpolator,
   projects.effpi,

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -95,7 +95,6 @@ class CommunityBuildTestC:
   @Test def sourcecode = projects.sourcecode.run()
   @Test def specs2 = projects.specs2.run()
 
-  @Test def stdLib213 = projects.stdLib213.run()
   @Test def ujson = projects.ujson.run()
   @Test def upickle = projects.upickle.run()
   @Test def utest = projects.utest.run()


### PR DESCRIPTION
This test exists for historical reasons. Now we compile the Scala 2 library in the `scala2-library-bootstrapped` project. This one checks that it compiles (with `-Ycheck:all`) and is used to package the TASTy files in the `scala2-library-tasty` project. Furthermore, now there is a `scala/scala` test that checks that the library can be compiled with Scala 3.

This test is fundamentally broken but we have not noticed it because we do not use `-Ycheck:all`. The reason is that when we compile `scala.Predef` we get a conflict with `scala.runtime.stdLibPatches.Predef` when we patch the symbols. This also surfaced in #18738.