### PR TITLE
Deprecation warnings for old syntax: `private[this]`

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -362,7 +362,7 @@ object projects:
     project = "shapeless-3",
     sbtTestCommand = "testJVM; testJS",
     sbtDocCommand = forceDoc("typeable", "deriving"),
-    scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Ysafe-init"), // due to -Xfatal-warnings
+    scalacOptions = "-source" :: "3.3" :: SbtCommunityProject.scalacOptions.filter(_ != "-Ysafe-init"), // due to -Xfatal-warnings
   )
 
   lazy val xmlInterpolator = SbtCommunityProject(

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -160,7 +160,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    *  every time we compare components of the previous pair of types.
    *  This type is used for capture conversion in `isSubArgs`.
    */
-  private [this] var leftRoot: Type | Null = null
+  private var leftRoot: Type | Null = null
 
   /** Are we forbidden from recording GADT constraints? */
   private var frozenGadt = false

--- a/compiler/src/dotty/tools/dotc/core/classfile/ReusableDataReader.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ReusableDataReader.scala
@@ -9,10 +9,10 @@ import java.io.{DataInputStream, InputStream}
 import java.nio.{BufferUnderflowException, ByteBuffer}
 
 final class ReusableDataReader() extends DataReader {
-  private[this] var data = new Array[Byte](32768)
-  private[this] var bb: ByteBuffer = ByteBuffer.wrap(data)
-  private[this] var size = 0
-  private[this] val reader: DataInputStream = {
+  private var data = new Array[Byte](32768)
+  private var bb: ByteBuffer = ByteBuffer.wrap(data)
+  private var size = 0
+  private val reader: DataInputStream = {
     val stream = new InputStream {
       override def read(): Int = try {
         bb.get & 0xff

--- a/compiler/src/dotty/tools/dotc/reporting/WConf.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/WConf.scala
@@ -117,7 +117,7 @@ object WConf:
       else Right(WConf(configs))
 
 class Suppression(val annotPos: SourcePosition, filters: List[MessageFilter], val start: Int, end: Int, val verbose: Boolean):
-  private[this] var _used = false
+  private var _used = false
   def used: Boolean = _used
   def markUsed(): Unit = { _used = true }
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Access.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Access.scala
@@ -50,8 +50,8 @@ final case class AccessMessage(
     sealedValue: dotty.tools.dotc.semanticdb.AccessMessage.SealedValue = dotty.tools.dotc.semanticdb.AccessMessage.SealedValue.Empty
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (sealedValue.privateAccess.isDefined) {
         val __value = sealedValue.privateAccess.get
@@ -379,8 +379,8 @@ final case class PrivateWithinAccess(
     symbol: _root_.scala.Predef.String = ""
     )  extends dotty.tools.dotc.semanticdb.Access.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -539,8 +539,8 @@ final case class ProtectedWithinAccess(
     symbol: _root_.scala.Predef.String = ""
     )  extends dotty.tools.dotc.semanticdb.Access.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Annotation.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Annotation.scala
@@ -13,8 +13,8 @@ final case class Annotation(
     tpe: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.Annotation._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Constant.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Constant.scala
@@ -58,8 +58,8 @@ final case class ConstantMessage(
     sealedValue: dotty.tools.dotc.semanticdb.ConstantMessage.SealedValue = dotty.tools.dotc.semanticdb.ConstantMessage.SealedValue.Empty
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (sealedValue.unitConstant.isDefined) {
         val __value = sealedValue.unitConstant.get
@@ -442,8 +442,8 @@ final case class BooleanConstant(
     value: _root_.scala.Boolean = false
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -520,8 +520,8 @@ final case class ByteConstant(
     value: _root_.scala.Int = 0
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -598,8 +598,8 @@ final case class ShortConstant(
     value: _root_.scala.Int = 0
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -676,8 +676,8 @@ final case class CharConstant(
     value: _root_.scala.Int = 0
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -754,8 +754,8 @@ final case class IntConstant(
     value: _root_.scala.Int = 0
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -832,8 +832,8 @@ final case class LongConstant(
     value: _root_.scala.Long = 0L
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -910,8 +910,8 @@ final case class FloatConstant(
     value: _root_.scala.Float = 0.0f
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -988,8 +988,8 @@ final case class DoubleConstant(
     value: _root_.scala.Double = 0.0
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -1066,8 +1066,8 @@ final case class StringConstant(
     value: _root_.scala.Predef.String = ""
     )  extends dotty.tools.dotc.semanticdb.Constant.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Diagnostic.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Diagnostic.scala
@@ -15,8 +15,8 @@ final case class Diagnostic(
     message: _root_.scala.Predef.String = ""
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (range.isDefined) {
         val __value = range.get

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Documentation.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Documentation.scala
@@ -14,8 +14,8 @@ final case class Documentation(
     format: dotty.tools.dotc.semanticdb.Documentation.Format = dotty.tools.dotc.semanticdb.Documentation.Format.HTML
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Location.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Location.scala
@@ -14,8 +14,8 @@ final case class Location(
     range: _root_.scala.Option[dotty.tools.dotc.semanticdb.Range] = _root_.scala.None
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Range.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Range.scala
@@ -16,8 +16,8 @@ final case class Range(
     endCharacter: _root_.scala.Int = 0
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Scope.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Scope.scala
@@ -14,8 +14,8 @@ final case class Scope(
     hardlinks: _root_.scala.Seq[dotty.tools.dotc.semanticdb.SymbolInformation] = _root_.scala.Seq.empty
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       symlinks.foreach { __item =>
         val __value = __item

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Signature.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Signature.scala
@@ -44,8 +44,8 @@ final case class SignatureMessage(
     sealedValue: dotty.tools.dotc.semanticdb.SignatureMessage.SealedValue = dotty.tools.dotc.semanticdb.SignatureMessage.SealedValue.Empty
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (sealedValue.classSignature.isDefined) {
         val __value = sealedValue.classSignature.get
@@ -222,8 +222,8 @@ final case class ClassSignature(
     declarations: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None
     )  extends dotty.tools.dotc.semanticdb.Signature.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (typeParameters.isDefined) {
         val __value = typeParameters.get
@@ -372,8 +372,8 @@ final case class MethodSignature(
     returnType: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.MethodSignature._typemapper_returnType.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Signature.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (typeParameters.isDefined) {
         val __value = typeParameters.get
@@ -499,8 +499,8 @@ final case class TypeSignature(
     upperBound: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.TypeSignature._typemapper_upperBound.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Signature.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (typeParameters.isDefined) {
         val __value = typeParameters.get
@@ -628,8 +628,8 @@ final case class ValueSignature(
     tpe: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.ValueSignature._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Signature.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/SymbolInformation.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/SymbolInformation.scala
@@ -22,8 +22,8 @@ final case class SymbolInformation(
     documentation: _root_.scala.Option[dotty.tools.dotc.semanticdb.Documentation] = _root_.scala.None
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/SymbolOccurrence.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/SymbolOccurrence.scala
@@ -15,8 +15,8 @@ final case class SymbolOccurrence(
     role: dotty.tools.dotc.semanticdb.SymbolOccurrence.Role = dotty.tools.dotc.semanticdb.SymbolOccurrence.Role.UNKNOWN_ROLE
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (range.isDefined) {
         val __value = range.get

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Synthetic.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Synthetic.scala
@@ -14,8 +14,8 @@ final case class Synthetic(
     tree: dotty.tools.dotc.semanticdb.Tree = dotty.tools.dotc.semanticdb.Synthetic._typemapper_tree.toCustom(dotty.tools.dotc.semanticdb.TreeMessage.defaultInstance)
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (range.isDefined) {
         val __value = range.get

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/TextDocument.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/TextDocument.scala
@@ -21,8 +21,8 @@ final case class TextDocument(
     synthetics: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Synthetic] = _root_.scala.Seq.empty
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/TextDocuments.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/TextDocuments.scala
@@ -13,8 +13,8 @@ final case class TextDocuments(
     documents: _root_.scala.Seq[dotty.tools.dotc.semanticdb.TextDocument] = _root_.scala.Seq.empty
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       documents.foreach { __item =>
         val __value = __item

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Tree.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Tree.scala
@@ -52,8 +52,8 @@ final case class TreeMessage(
     sealedValue: dotty.tools.dotc.semanticdb.TreeMessage.SealedValue = dotty.tools.dotc.semanticdb.TreeMessage.SealedValue.Empty
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (sealedValue.applyTree.isDefined) {
         val __value = sealedValue.applyTree.get
@@ -324,8 +324,8 @@ final case class ApplyTree(
     arguments: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Tree] = _root_.scala.Seq.empty
     )  extends dotty.tools.dotc.semanticdb.Tree.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -431,8 +431,8 @@ final case class FunctionTree(
     body: dotty.tools.dotc.semanticdb.Tree = dotty.tools.dotc.semanticdb.FunctionTree._typemapper_body.toCustom(dotty.tools.dotc.semanticdb.TreeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Tree.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       parameters.foreach { __item =>
         val __value = __item
@@ -535,8 +535,8 @@ final case class IdTree(
     symbol: _root_.scala.Predef.String = ""
     )  extends dotty.tools.dotc.semanticdb.Tree.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -613,8 +613,8 @@ final case class LiteralTree(
     constant: dotty.tools.dotc.semanticdb.Constant = dotty.tools.dotc.semanticdb.LiteralTree._typemapper_constant.toCustom(dotty.tools.dotc.semanticdb.ConstantMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Tree.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -696,8 +696,8 @@ final case class MacroExpansionTree(
     tpe: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.MacroExpansionTree._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Tree.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -804,8 +804,8 @@ final case class OriginalTree(
     range: _root_.scala.Option[dotty.tools.dotc.semanticdb.Range] = _root_.scala.None
     )  extends dotty.tools.dotc.semanticdb.Tree.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (range.isDefined) {
         val __value = range.get
@@ -882,8 +882,8 @@ final case class SelectTree(
     id: _root_.scala.Option[dotty.tools.dotc.semanticdb.IdTree] = _root_.scala.None
     )  extends dotty.tools.dotc.semanticdb.Tree.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -986,8 +986,8 @@ final case class TypeApplyTree(
     typeArguments: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type] = _root_.scala.Seq.empty
     )  extends dotty.tools.dotc.semanticdb.Tree.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {

--- a/compiler/src/dotty/tools/dotc/semanticdb/generated/Type.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/generated/Type.scala
@@ -68,8 +68,8 @@ final case class TypeMessage(
     sealedValue: dotty.tools.dotc.semanticdb.TypeMessage.SealedValue = dotty.tools.dotc.semanticdb.TypeMessage.SealedValue.Empty
     )  extends SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (sealedValue.typeRef.isDefined) {
         val __value = sealedValue.typeRef.get
@@ -533,8 +533,8 @@ final case class TypeRef(
     typeArguments: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type] = _root_.scala.Seq.empty
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -662,8 +662,8 @@ final case class SingleType(
     symbol: _root_.scala.Predef.String = ""
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -766,8 +766,8 @@ final case class ThisType(
     symbol: _root_.scala.Predef.String = ""
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -845,8 +845,8 @@ final case class SuperType(
     symbol: _root_.scala.Predef.String = ""
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -949,8 +949,8 @@ final case class ConstantType(
     constant: dotty.tools.dotc.semanticdb.Constant = dotty.tools.dotc.semanticdb.ConstantType._typemapper_constant.toCustom(dotty.tools.dotc.semanticdb.ConstantMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -1031,8 +1031,8 @@ final case class IntersectionType(
     types: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type] = _root_.scala.Seq.empty
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       types.foreach { __item =>
         val __value = dotty.tools.dotc.semanticdb.IntersectionType._typemapper_types.toBase(__item)
@@ -1111,8 +1111,8 @@ final case class UnionType(
     types: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type] = _root_.scala.Seq.empty
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       types.foreach { __item =>
         val __value = dotty.tools.dotc.semanticdb.UnionType._typemapper_types.toBase(__item)
@@ -1191,8 +1191,8 @@ final case class WithType(
     types: _root_.scala.Seq[dotty.tools.dotc.semanticdb.Type] = _root_.scala.Seq.empty
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       types.foreach { __item =>
         val __value = dotty.tools.dotc.semanticdb.WithType._typemapper_types.toBase(__item)
@@ -1272,8 +1272,8 @@ final case class StructuralType(
     declarations: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -1376,8 +1376,8 @@ final case class AnnotatedType(
     tpe: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.AnnotatedType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       annotations.foreach { __item =>
         val __value = __item
@@ -1481,8 +1481,8 @@ final case class ExistentialType(
     declarations: _root_.scala.Option[dotty.tools.dotc.semanticdb.Scope] = _root_.scala.None
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -1585,8 +1585,8 @@ final case class UniversalType(
     tpe: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.UniversalType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (typeParameters.isDefined) {
         val __value = typeParameters.get
@@ -1688,8 +1688,8 @@ final case class ByNameType(
     tpe: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.ByNameType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -1770,8 +1770,8 @@ final case class RepeatedType(
     tpe: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.RepeatedType._typemapper_tpe.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -1853,8 +1853,8 @@ final case class MatchType(
     cases: _root_.scala.Seq[dotty.tools.dotc.semanticdb.MatchType.CaseType] = _root_.scala.Seq.empty
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
 
       {
@@ -1944,8 +1944,8 @@ object MatchType  extends SemanticdbGeneratedMessageCompanion[dotty.tools.dotc.s
       body: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.MatchType.CaseType._typemapper_body.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
       )  extends SemanticdbGeneratedMessage  derives CanEqual {
       @transient @sharable
-      private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-      private[this] def __computeSerializedSize(): _root_.scala.Int = {
+      private var __serializedSizeMemoized: _root_.scala.Int = 0
+      private def __computeSerializedSize(): _root_.scala.Int = {
         var __size = 0
 
         {
@@ -2067,8 +2067,8 @@ final case class LambdaType(
     returnType: dotty.tools.dotc.semanticdb.Type = dotty.tools.dotc.semanticdb.LambdaType._typemapper_returnType.toCustom(dotty.tools.dotc.semanticdb.TypeMessage.defaultInstance)
     )  extends dotty.tools.dotc.semanticdb.Type.NonEmpty with SemanticdbGeneratedMessage  derives CanEqual {
     @transient @sharable
-    private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
-    private[this] def __computeSerializedSize(): _root_.scala.Int = {
+    private var __serializedSizeMemoized: _root_.scala.Int = 0
+    private def __computeSerializedSize(): _root_.scala.Int = {
       var __size = 0
       if (parameters.isDefined) {
         val __value = parameters.get

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -90,7 +90,7 @@ object Splicer {
   /** Checks that no symbol that was generated within the macro expansion has an out of scope reference */
   def checkEscapedVariables(tree: Tree, expansionOwner: Symbol)(using Context): tree.type =
     new TreeTraverser {
-      private[this] var locals = Set.empty[Symbol]
+      private var locals = Set.empty[Symbol]
       private def markSymbol(sym: Symbol)(using Context): Unit =
           locals = locals + sym
       private def markDef(tree: Tree)(using Context): Unit = tree match {

--- a/compiler/src/dotty/tools/dotc/util/Chars.scala
+++ b/compiler/src/dotty/tools/dotc/util/Chars.scala
@@ -28,7 +28,7 @@ object Chars:
     if (0 <= num && num < base) num else -1
   }
   /** Buffer for creating '\ u XXXX' strings. */
-  private[this] val char2uescapeArray = Array[Char]('\\', 'u', 0, 0, 0, 0)
+  private val char2uescapeArray = Array[Char]('\\', 'u', 0, 0, 0, 0)
 
   /** Convert a character to a backslash-u escape */
   def char2uescape(c: Char): String = {

--- a/compiler/src/dotty/tools/dotc/util/ReusableInstance.scala
+++ b/compiler/src/dotty/tools/dotc/util/ReusableInstance.scala
@@ -15,8 +15,8 @@ import scala.util.chaining.*
   * Ported from scala.reflect.internal.util.ReusableInstance
   */
 final class ReusableInstance[T <: AnyRef] private (make: => T) {
-  private[this] val cache = new ArrayBuffer[T](ReusableInstance.InitialSize).tap(_.addOne(make))
-  private[this] var taken = 0
+  private val cache = new ArrayBuffer[T](ReusableInstance.InitialSize).tap(_.addOne(make))
+  private var taken = 0
 
   inline def withInstance[R](action: T => R): R ={
     if (taken == cache.size)

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -214,7 +214,7 @@ final class FileZipArchive(jpath: JPath, release: Option[String]) extends ZipArc
     case _                 => false
   }
 
-  private[this] var closeables: List[java.io.Closeable] = Nil
+  private var closeables: List[java.io.Closeable] = Nil
   override def close(): Unit = {
     closeables.foreach(_.close)
     closeables = Nil
@@ -281,7 +281,7 @@ final class ManifestResources(val url: URL) extends ZipArchive(null, None) {
     }
   }
 
-  private[this] var closeables: List[java.io.Closeable] = Nil
+  private var closeables: List[java.io.Closeable] = Nil
   override def close(): Unit = {
     closeables.foreach(_.close())
     closeables = Nil

--- a/compiler/src/dotty/tools/runner/ScalaClassLoader.scala
+++ b/compiler/src/dotty/tools/runner/ScalaClassLoader.scala
@@ -64,7 +64,7 @@ object ScalaClassLoader {
   def fromURLsParallelCapable(urls: Seq[URL], parent: ClassLoader | Null = null): URLClassLoader =
     new URLClassLoader(urls.toArray, if parent == null then bootClassLoader else parent)
 
-  @sharable private[this] val bootClassLoader: ClassLoader =
+  @sharable private val bootClassLoader: ClassLoader =
     if scala.util.Properties.isJavaAtLeast("9") then
       try
         ClassLoader.getSystemClassLoader.getParent

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -52,7 +52,7 @@ object SourceCode {
     if (flags.is(Flags.Param)) flagList += "param"
     if (flags.is(Flags.ParamAccessor)) flagList += "paramAccessor"
     if (flags.is(Flags.Private)) flagList += "private"
-    if (flags.is(Flags.PrivateLocal)) flagList += "private[this]"
+    if (flags.is(Flags.PrivateLocal)) flagList += "private"
     if (flags.is(Flags.Protected)) flagList += "protected"
     if (flags.is(Flags.Scala2x)) flagList += "scala2x"
     if (flags.is(Flags.Sealed)) flagList += "sealed"
@@ -67,9 +67,9 @@ object SourceCode {
     import syntaxHighlight.*
     import quotes.reflect.*
 
-    private[this] val sb: StringBuilder = new StringBuilder
+    private val sb: StringBuilder = new StringBuilder
 
-    private[this] var indent: Int = 0
+    private var indent: Int = 0
     private def indented(printIndented: => Unit): Unit = {
       indent += 1
       printIndented
@@ -1441,8 +1441,8 @@ object SourceCode {
 
     private def escapedString(str: String): String = str flatMap escapedChar
 
-    private[this] val names = collection.mutable.Map.empty[Symbol, String]
-    private[this] val namesIndex = collection.mutable.Map.empty[String, Int]
+    private val names = collection.mutable.Map.empty[Symbol, String]
+    private val namesIndex = collection.mutable.Map.empty[String, Int]
 
     private def splicedName(sym: Symbol): Option[String] = {
       if sym.owner.isClassDef then None

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -61,6 +61,7 @@ class CompilationTests {
       compileFile("tests/rewrites/rewrites3x.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
       compileFile("tests/rewrites/rewrites3x-fatal-warnings.scala", defaultOptions.and("-rewrite", "-source", "future-migration", "-Xfatal-warnings")),
       compileFile("tests/rewrites/with-type-operator.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
+      compileFile("tests/rewrites/private-this.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
       compileFile("tests/rewrites/filtering-fors.scala", defaultOptions.and("-rewrite", "-source", "3.2-migration")),
       compileFile("tests/rewrites/refutable-pattern-bindings.scala", defaultOptions.and("-rewrite", "-source", "3.2-migration")),
       compileFile("tests/rewrites/i8982.scala", defaultOptions.and("-indent", "-rewrite")),

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -54,14 +54,14 @@ class DottyLanguageServer extends LanguageServer
   import lsp4j.jsonrpc.messages.{Either => JEither}
   import lsp4j._
 
-  private[this] var rootUri: String = _
+  private var rootUri: String = _
 
-  private[this] var myClient: DottyClient = _
+  private var myClient: DottyClient = _
   def client: DottyClient = myClient
 
-  private[this] var myDrivers: mutable.Map[ProjectConfig, InteractiveDriver] = _
+  private var myDrivers: mutable.Map[ProjectConfig, InteractiveDriver] = _
 
-  private[this] var myDependentProjects: mutable.Map[ProjectConfig, mutable.Set[ProjectConfig]] = _
+  private var myDependentProjects: mutable.Map[ProjectConfig, mutable.Set[ProjectConfig]] = _
 
   def drivers: Map[ProjectConfig, InteractiveDriver] = thisServer.synchronized {
     if myDrivers == null then

--- a/language-server/src/dotty/tools/languageserver/worksheet/Evaluator.scala
+++ b/language-server/src/dotty/tools/languageserver/worksheet/Evaluator.scala
@@ -23,7 +23,7 @@ private object Evaluator {
    * The most recent Evaluator that was used. It can be reused if the user classpath hasn't changed
    * between two calls.
    */
-  private[this] var previousEvaluator: Option[(String, Evaluator)] = None
+  private var previousEvaluator: Option[(String, Evaluator)] = None
 
   /**
    * Get a (possibly reused) Evaluator and set cancel checker.

--- a/language-server/src/dotty/tools/languageserver/worksheet/InputStreamConsumer.scala
+++ b/language-server/src/dotty/tools/languageserver/worksheet/InputStreamConsumer.scala
@@ -4,7 +4,7 @@ import java.io.{InputStream, IOException}
 import java.util.Scanner
 
 class InputStreamConsumer(in: InputStream) {
-  private[this] val scanner =
+  private val scanner =
     new Scanner(in).useDelimiter(InputStreamConsumer.delimiter)
 
   /** Finds and returns the next complete token from this input stream.

--- a/language-server/test/dotty/tools/languageserver/util/Code.scala
+++ b/language-server/test/dotty/tools/languageserver/util/Code.scala
@@ -190,7 +190,7 @@ object Code {
   }
 
   object Project {
-    private[this] val count = new java.util.concurrent.atomic.AtomicInteger()
+    private val count = new java.util.concurrent.atomic.AtomicInteger()
     private def freshName: String = s"project${count.incrementAndGet()}"
 
     /**

--- a/language-server/test/dotty/tools/languageserver/util/CodeRange.scala
+++ b/language-server/test/dotty/tools/languageserver/util/CodeRange.scala
@@ -14,7 +14,7 @@ import PositionContext._
  * @param end   The end marker.
  */
 case class CodeRange(start: CodeMarker, end: CodeMarker) {
-  private[this] var checked = false
+  private var checked = false
   def check(): PosCtx[Unit] = {
     if (!checked) {
       assert(start.file == end.file, s"$start and $end where not in the same file")

--- a/language-server/test/dotty/tools/languageserver/util/PositionContext.scala
+++ b/language-server/test/dotty/tools/languageserver/util/PositionContext.scala
@@ -4,8 +4,8 @@ import dotty.tools.languageserver.util.embedded.CodeMarker
 import dotty.tools.languageserver.util.server.TestFile
 
 class PositionContext(positionMap: Map[CodeMarker, (TestFile, Int, Int)]) {
-  private[this] var lastKey: CodeMarker = _
-  private[this] var lastValue: (TestFile, Int, Int) = _
+  private var lastKey: CodeMarker = _
+  private var lastValue: (TestFile, Int, Int) = _
   def positionOf(pos: CodeMarker): (TestFile, Int, Int) = {
     if (lastKey eq pos) lastValue
     else {

--- a/language-server/test/dotty/tools/languageserver/util/server/TestClient.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestClient.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable.Buffer
 class TestClient extends DottyClient {
 
   class Log[T] {
-    private[this] val log = Buffer.empty[T]
+    private val log = Buffer.empty[T]
 
     def +=(elem: T): this.type = { log += elem; this }
     def get: List[T] = log.toList

--- a/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestServer.scala
@@ -21,7 +21,7 @@ class TestServer(testFolder: Path, projects: List[Project]) {
 
   init()
 
-  private[this] def init(): InitializeResult = {
+  private def init(): InitializeResult = {
     var compiledProjects: Set[Project] = Set.empty
 
     /** Compile the dependencies of the given project, and then the project. */

--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -25,12 +25,12 @@ object LazyVals {
       throwInitializationException()
   }
 
-  private[this] val base: Int = {
+  private val base: Int = {
     val processors = java.lang.Runtime.getRuntime.nn.availableProcessors()
     8 * processors * processors
   }
 
-  private[this] val monitors: Array[Object] =
+  private val monitors: Array[Object] =
     Array.tabulate(base)(_ => new Object)
 
   private def getMonitor(obj: Object, fieldId: Int = 0) = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -579,6 +579,9 @@ object Build {
        // Note: bench/profiles/projects.yml should be updated accordingly.
        Compile / scalacOptions ++= Seq("-Yexplicit-nulls", "-Ysafe-init"),
 
+      // Use source 3.3 to avoid fatal migration warnings on scalajs-ir
+      scalacOptions ++= Seq("-source", "3.3"),
+
       // Generate compiler.properties, used by sbt
       (Compile / resourceGenerators) += Def.task {
         import java.util._

--- a/sbt-test/compilerReporter/i14576/build.sbt
+++ b/sbt-test/compilerReporter/i14576/build.sbt
@@ -10,7 +10,7 @@ lazy val resetMessages = taskKey[Unit]("empties the messages list")
 
 lazy val root = (project in file("."))
   .settings(
-    scalacOptions += "-source:future",
+    scalacOptions += "-source:future-migration",
     extraAppenders := { s => Seq(ConsoleAppender(FakePrintWriter)) },
     assertFeatureSummary := {
       assert {
@@ -24,7 +24,7 @@ lazy val root = (project in file("."))
     },
     assertDeprecationSummary := {
       assert {
-        FakePrintWriter.messages.exists(_.contains("there were 3 deprecation warnings; re-run with -deprecation for details"))
+        FakePrintWriter.messages.exists(_.contains("there were 2 deprecation warnings; re-run with -deprecation for details"))
       }
     },
     assertNoDeprecationSummary := {

--- a/scaladoc-testcases/src/example/level2/Documentation.scala
+++ b/scaladoc-testcases/src/example/level2/Documentation.scala
@@ -163,7 +163,7 @@ abstract class Documentation[T, A <: Int, B >: String, -X, +Y](c1: String, val c
   def table(foo: String) = ???
 
   protected[example] val valWithScopeModifier = ???
-  protected[this] val valWithScopeModifierThis = ???
+  protected val valWithScopeModifierThis = ???
 
   var iAmAVar = ???
 }

--- a/scaladoc-testcases/src/tests/visibility.scala
+++ b/scaladoc-testcases/src/tests/visibility.scala
@@ -1,6 +1,8 @@
 package tests
 package visibility
 
+import scala.language.`3.3` // to avoid migration warnings/errors of private[this]
+
 private object PrivateTopLevelObject //unexpected
 
 private[tests] object PrivateInOuterPackageTopLevelObject //unexpected

--- a/staging/src/scala/quoted/staging/Compiler.scala
+++ b/staging/src/scala/quoted/staging/Compiler.scala
@@ -26,9 +26,9 @@ object Compiler:
   def make(appClassloader: ClassLoader)(implicit settings: Settings): Compiler =
     new Compiler:
 
-      private[this] val driver: QuoteDriver = new QuoteDriver(appClassloader)
+      private val driver: QuoteDriver = new QuoteDriver(appClassloader)
 
-      private[this] var running = false
+      private var running = false
 
       def run[T](exprBuilder: Quotes => Expr[T]): T = synchronized {
         try

--- a/staging/src/scala/quoted/staging/QuoteCompiler.scala
+++ b/staging/src/scala/quoted/staging/QuoteCompiler.scala
@@ -33,7 +33,7 @@ import scala.quoted.{Expr, Quotes, Type}
 private class QuoteCompiler extends Compiler:
 
   /** Either `Left` with name of the classfile generated or `Right` with the value contained in the expression */
-  private[this] var result: Either[String, Any] = null
+  private var result: Either[String, Any] = null
 
   override protected def frontendPhases: List[List[Phase]] =
     List(List(new QuotedFrontend))

--- a/staging/src/scala/quoted/staging/QuoteDriver.scala
+++ b/staging/src/scala/quoted/staging/QuoteDriver.scala
@@ -21,7 +21,7 @@ import scala.annotation.tailrec
 private class QuoteDriver(appClassloader: ClassLoader) extends Driver:
   import tpd._
 
-  private[this] val contextBase: ContextBase = new ContextBase
+  private val contextBase: ContextBase = new ContextBase
 
   def run[T](exprBuilder: Quotes => Expr[T], settings: Compiler.Settings): T =
     val outDir: AbstractFile =

--- a/tests/init/neg/function11.scala
+++ b/tests/init/neg/function11.scala
@@ -1,5 +1,5 @@
 final class Capture {
-  private[this] var m: Boolean = false
+  private var m: Boolean = false
 
   (0 to 10).foreach { i =>      // error
     f()
@@ -14,7 +14,7 @@ final class Capture {
 }
 
 final class Capture2 {
-  private[this] var m: Boolean = false
+  private var m: Boolean = false
 
   (0 to 10).foreach { i =>
     f()

--- a/tests/neg-custom-args/captures/leaking-iterators.scala
+++ b/tests/neg-custom-args/captures/leaking-iterators.scala
@@ -36,7 +36,7 @@ trait Iterator[+A] extends IterableOnce[A]:
   def ++[B >: A](xs: IterableOnce[B]^): Iterator[B]^{this, xs}
 end Iterator
 
-private[this] final class ConcatIteratorCell[A](head: => IterableOnce[A]^):
+private final class ConcatIteratorCell[A](head: => IterableOnce[A]^):
   def headIterator: Iterator[A]^{this} = head.iterator
 
 def usingLogFile[sealed R](op: FileOutputStream^ => R): R =

--- a/tests/neg-scalajs/js-native-members.check
+++ b/tests/neg-scalajs/js-native-members.check
@@ -1,3 +1,33 @@
+-- Warning: tests/neg-scalajs/js-native-members.scala:24:16 ------------------------------------------------------------
+24 |  private[this] def this(x: Int) = this() // ok
+   |                ^
+   |                The [this] qualifier will be deprecated in the future; it should be dropped.
+   |                See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+   |                This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+-- Warning: tests/neg-scalajs/js-native-members.scala:28:16 ------------------------------------------------------------
+28 |  private[this] val a: Int = js.native // error
+   |                ^
+   |                The [this] qualifier will be deprecated in the future; it should be dropped.
+   |                See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+   |                This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+-- Warning: tests/neg-scalajs/js-native-members.scala:32:16 ------------------------------------------------------------
+32 |  private[this] var d: Int = js.native // error
+   |                ^
+   |                The [this] qualifier will be deprecated in the future; it should be dropped.
+   |                See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+   |                This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+-- Warning: tests/neg-scalajs/js-native-members.scala:36:16 ------------------------------------------------------------
+36 |  private[this] def g(): Int = js.native // error
+   |                ^
+   |                The [this] qualifier will be deprecated in the future; it should be dropped.
+   |                See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+   |                This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+-- Warning: tests/neg-scalajs/js-native-members.scala:49:25 ------------------------------------------------------------
+49 |  class X3 private[this] () extends js.Object { // ok
+   |                         ^
+   |                         The [this] qualifier will be deprecated in the future; it should be dropped.
+   |                         See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+   |                         This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 -- Error: tests/neg-scalajs/js-native-members.scala:9:24 ---------------------------------------------------------------
 9 |  def this(z: String) = this(z.length, z) // error
   |                        ^^^^^^^^^^^^^^^^^

--- a/tests/neg-scalajs/js-non-native-members-qualified-private.check
+++ b/tests/neg-scalajs/js-non-native-members-qualified-private.check
@@ -1,3 +1,9 @@
+-- Warning: tests/neg-scalajs/js-non-native-members-qualified-private.scala:52:28 --------------------------------------
+52 |      class B private[this] () extends js.Object // ok
+   |                            ^
+   |                          The [this] qualifier will be deprecated in the future; it should be dropped.
+   |                          See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+   |                          This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 -- Error: tests/neg-scalajs/js-non-native-members-qualified-private.scala:6:32 -----------------------------------------
 6 |        private[Enclosing1] def foo(i: Int): Int = i // error
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/neg/i15503c.scala
+++ b/tests/neg/i15503c.scala
@@ -1,4 +1,4 @@
-//> using options -Xfatal-warnings -Wunused:privates
+//> using options -Xfatal-warnings -Wunused:privates -source:3.3
 trait C
 class A:
   self: C => // OK

--- a/tests/neg/i16639a.scala
+++ b/tests/neg/i16639a.scala
@@ -1,4 +1,4 @@
-//> using options -Xfatal-warnings -Wunused:all
+//> using options -Xfatal-warnings -Wunused:all -source:3.3
 //
 class Bippy(a: Int, b: Int) {
   private def this(c: Int) = this(c, c)           // warn /Dotty:NoWarn

--- a/tests/neg/i17612a.scala
+++ b/tests/neg/i17612a.scala
@@ -1,4 +1,4 @@
-//> using options -Xfatal-warnings -Xlint:private-shadow
+//> using options -Xfatal-warnings -Xlint:private-shadow -source:3.3
 
 object i17612a:
 	class Base(var x: Int, val y: Int, var z: Int):

--- a/tests/neg/i17612b/i17612b.scala
+++ b/tests/neg/i17612b/i17612b.scala
@@ -1,4 +1,4 @@
-//> using options -Xfatal-warnings -Xlint:private-shadow
+//> using options -Xfatal-warnings -Xlint:private-shadow -source:3.3
 
 object i17612b:
 

--- a/tests/neg/nonunit-statement.scala
+++ b/tests/neg/nonunit-statement.scala
@@ -1,4 +1,4 @@
-//> using options -Xfatal-warnings -Wnonunit-statement -Wvalue-discard
+//> using options -Xfatal-warnings -Wnonunit-statement -Wvalue-discard -source:3.3
 import collection.ArrayOps
 import collection.mutable.{ArrayBuilder, LinkedHashSet, ListBuffer}
 import concurrent._

--- a/tests/neg/private-this-3.4.check
+++ b/tests/neg/private-this-3.4.check
@@ -1,0 +1,12 @@
+-- Error: tests/neg/private-this-3.4.scala:6:16 ------------------------------------------------------------------------
+6 |  private[this] def foo: Int = ??? // error: migration warning
+  |                ^
+  |                The [this] qualifier will be deprecated in the future; it should be dropped.
+  |                See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+  |                This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+-- Error: tests/neg/private-this-3.4.scala:7:18 ------------------------------------------------------------------------
+7 |  protected[this] def bar: Int = ??? // error: migration warning
+  |                  ^
+  |                  The [this] qualifier will be deprecated in the future; it should be dropped.
+  |                  See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+  |                  This construct can be rewritten automatically under -rewrite -source 3.4-migration.

--- a/tests/neg/private-this-3.4.scala
+++ b/tests/neg/private-this-3.4.scala
@@ -1,0 +1,7 @@
+//> using options -Werror
+
+import scala.language.`3.4`
+
+class Foo:
+  private[this] def foo: Int = ??? // error: migration warning
+  protected[this] def bar: Int = ??? // error: migration warning

--- a/tests/neg/private-this-future-migration.scala
+++ b/tests/neg/private-this-future-migration.scala
@@ -1,0 +1,7 @@
+//> using options -Werror
+
+import scala.language.`future-migration`
+
+class Foo:
+  private[this] def foo: Int = ??? // error: migration warning
+  protected[this] def bar: Int = ??? // error: migration warning

--- a/tests/neg/private-this-future.scala
+++ b/tests/neg/private-this-future.scala
@@ -1,0 +1,5 @@
+import scala.language.future
+
+class Foo:
+  private[this] def foo: Int = ??? // error
+  protected[this] def bar: Int = ??? // error

--- a/tests/pos/i6290.scala
+++ b/tests/pos/i6290.scala
@@ -1,4 +1,4 @@
-//> using options -Xfatal-warnings -deprecation -feature
+//> using options -Xfatal-warnings -deprecation -feature -source:3.3
 
 class TC { type T }
 

--- a/tests/pos/private-this-future-migration.scala
+++ b/tests/pos/private-this-future-migration.scala
@@ -1,0 +1,5 @@
+import scala.language.`future-migration`
+
+class Foo:
+  private[this] def foo: Int = ??? // warn
+  protected[this] def bar: Int = ??? // warn

--- a/tests/pos/private-this.scala
+++ b/tests/pos/private-this.scala
@@ -1,0 +1,3 @@
+class Foo:
+  private[this] def foo: Int = ???
+  protected[this] def bar: Int = ???

--- a/tests/rewrites/private-this.check
+++ b/tests/rewrites/private-this.check
@@ -1,0 +1,12 @@
+class Foo:
+  private def foo1: Int = ???
+  private def foo2: Int = ???
+  private def foo3: Int = ???
+  private def foo4: Int = ???
+  private  def foo5: Int = ???
+
+  protected def bar1: Int = ???
+  protected def bar2: Int = ???
+  protected def bar3: Int = ???
+  protected def bar4: Int = ???
+  protected  def bar5: Int = ???

--- a/tests/rewrites/private-this.scala
+++ b/tests/rewrites/private-this.scala
@@ -1,0 +1,12 @@
+class Foo:
+  private[this] def foo1: Int = ???
+  private[ this] def foo2: Int = ???
+  private[this ] def foo3: Int = ???
+  private[ this ] def foo4: Int = ???
+  private [this] def foo5: Int = ???
+
+  protected[this] def bar1: Int = ???
+  protected[ this] def bar2: Int = ???
+  protected[this ] def bar3: Int = ???
+  protected[ this ] def bar4: Int = ???
+  protected [this] def bar5: Int = ???

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -8,7 +8,7 @@ Text => empty
 Language => Scala
 Symbols => 9 entries
 Occurrences => 19 entries
-Diagnostics => 2 entries
+Diagnostics => 4 entries
 
 Symbols:
 example/Access# => class Access extends Object { self: Access => +8 decls }
@@ -44,7 +44,13 @@ Occurrences:
 
 Diagnostics:
 [3:14..3:16): [warning] unused private member
+[4:16..4:16): [warning] The [this] qualifier will be deprecated in the future; it should be dropped.
+See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 [4:20..4:22): [warning] unused private member
+[7:18..7:18): [warning] The [this] qualifier will be deprecated in the future; it should be dropped.
+See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 
 expect/Advanced.scala
 ---------------------
@@ -559,7 +565,7 @@ Text => empty
 Language => Scala
 Symbols => 108 entries
 Occurrences => 127 entries
-Diagnostics => 4 entries
+Diagnostics => 6 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -803,7 +809,13 @@ Occurrences:
 
 Diagnostics:
 [18:9..18:10): [warning] unused explicit parameter
+[20:23..20:23): [warning] The [this] qualifier will be deprecated in the future; it should be dropped.
+See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 [20:27..20:28): [warning] unused explicit parameter
+[22:23..22:23): [warning] The [this] qualifier will be deprecated in the future; it should be dropped.
+See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 [22:27..22:28): [warning] unused explicit parameter
 [24:10..24:11): [warning] unused explicit parameter
 
@@ -3914,7 +3926,7 @@ Text => empty
 Language => Scala
 Symbols => 42 entries
 Occurrences => 129 entries
-Diagnostics => 1 entries
+Diagnostics => 5 entries
 
 Symbols:
 example/ValUsages. => final object ValUsages extends Object { self: ValUsages.type => +2 decls }
@@ -4093,6 +4105,18 @@ Occurrences:
 
 Diagnostics:
 [2:20..2:21): [warning] unused explicit parameter
+[5:16..5:16): [warning] The [this] qualifier will be deprecated in the future; it should be dropped.
+See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+[7:16..7:16): [warning] The [this] qualifier will be deprecated in the future; it should be dropped.
+See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+[12:16..12:16): [warning] The [this] qualifier will be deprecated in the future; it should be dropped.
+See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+[13:16..13:16): [warning] The [this] qualifier will be deprecated in the future; it should be dropped.
+See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 
 expect/Vararg.scala
 -------------------


### PR DESCRIPTION
This is the first part of  #18863

* In `3.4` we emit the deprecation warning and enable the patch with -rewrite.
* In `future` we emit we make this syntax an error

```scala
//> using options -source future
private[this] def foo: Int = ??? // error
```
```diff
//> using options -rewrite -source 3.4-migration
- private[this] def foo: Int = ???
+ private def foo: Int = ???
```