### PR TITLE
Increase PC timeout

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
@@ -54,7 +54,7 @@ abstract class BasePCSuite extends PcAssertions:
       .newInstance("", myclasspath.asJava, scalacOpts.asJava)
 
   protected def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl().copy(snippetAutoIndent = false, timeoutDelay = if isDebug then 3600 else 5)
+    PresentationCompilerConfigImpl().copy(snippetAutoIndent = false, timeoutDelay = if isDebug then 3600 else 10)
 
   private def inspectDialect(filename: String, code: String) =
     val file = tmp.resolve(filename)


### PR DESCRIPTION
Dotty CI was flaky and could fail because of Presentation Compiler initialisation timeout.

https://github.com/lampepfl/dotty/actions/runs/6717768764/job/18256242542
https://github.com/lampepfl/dotty/actions/runs/6721566887/job/18267570899

I've doubled it.