### PR TITLE
Fix i18629

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1418,7 +1418,7 @@ object Objects:
       val applyDenot = getMemberMethod(scrutineeType, nme.apply, applyType(elemType))
       val applyRes = call(scrutinee, applyDenot.symbol, TraceValue(Bottom, summon[Trace]) :: Nil, scrutineeType, superType = NoType, needResolve = true)
 
-      if isWildcardStarArg(pats.last) then
+      if isWildcardStarArgList(pats) then
         if pats.size == 1 then
           // call .toSeq
           val toSeqDenot = scrutineeType.member(nme.toSeq).suchThat(_.info.isParameterless)
@@ -1433,7 +1433,8 @@ object Objects:
         end if
       else
         // no patterns like `xs*`
-      for pat <- pats do evalPattern(applyRes, pat)
+        for pat <- pats do evalPattern(applyRes, pat)
+      end if
     end evalSeqPatterns
 
 

--- a/tests/init-global/pos/i18629.scala
+++ b/tests/init-global/pos/i18629.scala
@@ -1,5 +1,6 @@
 object Foo {
   val bar = List() match {
     case List() => ???
+    case _ => ???
   }
 }

--- a/tests/init-global/pos/i18629.scala
+++ b/tests/init-global/pos/i18629.scala
@@ -1,0 +1,5 @@
+object Foo {
+  val bar = List() match {
+    case List() => ???
+  }
+}


### PR DESCRIPTION
This PR fixes the minimized test of #18629 that could previously crash the global initialization checker because of empty patterns when matching against `List()`.