### PR TITLE
Fix #18407: Ignore Quote/Slice in init checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -1383,11 +1383,11 @@ object Semantic:
       case tpl: Template =>
         init(tpl, thisV, klass)
 
-      case _: Import | _: Export =>
+      case _: Import | _: Export | _: Quote | _: Splice | _: QuotePattern | _: SplicePattern =>
         Hot
 
       case _ =>
-        report.warning("[Internal error] unexpected tree" + Trace.show, expr)
+        report.warning("[Internal error] unexpected tree: " + expr.getClass + ", trace:\n" + Trace.show, expr)
         Hot
 
   /** Handle semantics of leaf nodes

--- a/tests/init/pos/i18407/base_0.scala
+++ b/tests/init/pos/i18407/base_0.scala
@@ -1,0 +1,4 @@
+// base_0.scala
+trait BaseTest extends AnyFreeSpecLike {
+  "empty-test" - {}    // ok if we comment out this line
+}

--- a/tests/init/pos/i18407/macros_0.scala
+++ b/tests/init/pos/i18407/macros_0.scala
@@ -1,0 +1,37 @@
+// macros_0.scala
+object source {
+  import scala.quoted._
+
+  class Position()
+
+  object Position {
+    def withPosition[T](
+        fun: Expr[Position => T]
+    )(using quotes: Quotes, typeOfT: Type[T]): Expr[T] = {
+      '{
+        ${ fun }.apply(new source.Position())
+      }
+    }
+  }
+}
+
+trait AnyFreeSpecLike {
+  import scala.language.implicitConversions
+
+  protected final class FreeSpecStringWrapper(
+      string: String,
+      pos: source.Position
+  ) {
+    def -(fun: => Unit): Unit = fun
+  }
+
+  inline implicit def convertToFreeSpecStringWrapper(
+      s: String
+  ): FreeSpecStringWrapper = {
+    ${
+      source.Position.withPosition[FreeSpecStringWrapper]('{
+        (pos: source.Position) => new FreeSpecStringWrapper(s, pos)
+      })
+    }
+  }
+}

--- a/tests/init/pos/i18407/test_1.scala
+++ b/tests/init/pos/i18407/test_1.scala
@@ -1,0 +1,4 @@
+class MyTest extends BaseTest {
+    "empty-test" - {}
+    private val myObject = new {}
+}


### PR DESCRIPTION
Fix #18407: Ignore Quote/Slice in init checker

We should never be able to encounter them in usage of macros --- because macros will expand to normal trees without quote and splices.

The particular test case is actually problematic: The macro did not expand in `base_0.scala`.