### PR TITLE
Admit parametric aliases of classes in parent typing

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -746,7 +746,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           case _ =>
             val tparams1 = tp1.typeParams
             if (tparams1.nonEmpty)
-              return recur(tp1.EtaExpand(tparams1), tp2) || fourthTry
+              return recur(tp1.etaExpand(tparams1), tp2) || fourthTry
             tp2 match {
               case EtaExpansion(tycon2: TypeRef) if tycon2.symbol.isClass && tycon2.symbol.is(JavaDefined) =>
                 recur(tp1, tycon2) || fourthTry

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -832,7 +832,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         }
         else if args.nonEmpty then
           tycon.safeAppliedTo(EtaExpandIfHK(sym.typeParams, args.map(translateTempPoly)))
-        else if (sym.typeParams.nonEmpty) tycon.EtaExpand(sym.typeParams)
+        else if (sym.typeParams.nonEmpty) tycon.etaExpand(sym.typeParams)
         else tycon
       case TYPEBOUNDStpe =>
         val lo = readTypeRef()

--- a/compiler/src/dotty/tools/dotc/typer/Deriving.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Deriving.scala
@@ -165,7 +165,7 @@ trait Deriving {
           // case (a) ... see description above
           val derivedParams = clsParams.dropRight(instanceArity)
           val instanceType =
-            if (instanceArity == clsArity) clsType.EtaExpand(clsParams)
+            if (instanceArity == clsArity) clsType.etaExpand(clsParams)
             else {
               val derivedParamTypes = derivedParams.map(_.typeRef)
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1197,7 +1197,7 @@ class Namer { typer: Typer =>
               val forwarderName = checkNoConflict(alias.toTypeName, isPrivate = false, span)
               var target = pathType.select(sym)
               if target.typeParams.nonEmpty then
-                target = target.EtaExpand(target.typeParams)
+                target = target.etaExpand(target.typeParams)
               newSymbol(
                 cls, forwarderName,
                 Exported | Final,
@@ -1518,7 +1518,7 @@ class Namer { typer: Typer =>
 
         def typedParentType(tree: untpd.Tree): tpd.Tree =
           val parentTpt = typer.typedType(parent, AnyTypeConstructorProto)
-          val ptpe = parentTpt.tpe
+          val ptpe = parentTpt.tpe.dealias.etaCollapse
           if ptpe.typeParams.nonEmpty
               && ptpe.underlyingClassRef(refinementOK = false).exists
           then

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -372,7 +372,7 @@ object RefChecks {
      */
     def checkOverride(checkSubType: (Type, Type) => Context ?=> Boolean, member: Symbol, other: Symbol): Unit =
       def memberTp(self: Type) =
-        if (member.isClass) TypeAlias(member.typeRef.EtaExpand(member.typeParams))
+        if (member.isClass) TypeAlias(member.typeRef.etaExpand(member.typeParams))
         else self.memberInfo(member)
       def otherTp(self: Type) =
         self.memberInfo(other)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4306,7 +4306,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               AppliedType(tree.tpe, tp.typeParams.map(Function.const(TypeBounds.empty)))
             else
               // Eta-expand higher-kinded type
-              tree.tpe.EtaExpand(tp.typeParamSymbols)
+              tree.tpe.etaExpand(tp.typeParamSymbols)
           tree.withType(tp1)
         }
       if (ctx.mode.is(Mode.Pattern) || ctx.mode.isQuotedPattern || tree1.tpe <:< pt) tree1

--- a/tests/neg/i4557.scala
+++ b/tests/neg/i4557.scala
@@ -9,11 +9,11 @@ object O {
   type S0[X, Y] = C1[X, Y]
   type S1 = C1[Int] // error
 
-  class D0 extends T0 // error
+  class D0 extends T0 // was error, now ok
   class D1 extends T0[Int]
   class D2 extends T0[String, Int] // error
 
-  class E0 extends S0 // error
+  class E0 extends S0 // was error, now ok
   class E1 extends S0[Int] // error
   class E2 extends S0[String, Int]
 }

--- a/tests/pos/i18623.scala
+++ b/tests/pos/i18623.scala
@@ -1,0 +1,15 @@
+final abstract class ForcedRecompilationToken[T]
+object ForcedRecompilationToken {
+  implicit def default: ForcedRecompilationToken["abc"] = null
+}
+
+class GoodNoParens[T](implicit ev: ForcedRecompilationToken[T])
+type BadNoParens[T] = GoodNoParens[T]
+
+// error
+object A extends BadNoParens
+
+// ok
+object B extends BadNoParens()
+object C extends GoodNoParens
+

--- a/tests/pos/i18623a.scala
+++ b/tests/pos/i18623a.scala
@@ -1,0 +1,20 @@
+final abstract class ForcedRecompilationToken[T]
+object ForcedRecompilationToken {
+  implicit def default: ForcedRecompilationToken["abc"] = null
+}
+
+object x {
+class GoodNoParens[T](implicit ev: ForcedRecompilationToken[T])
+}
+export x.GoodNoParens as BadNoParens
+
+// error
+object A extends BadNoParens
+
+// ok
+object B extends BadNoParens()
+object C extends x.GoodNoParens
+
+object App extends App {
+  println("compiled")
+}


### PR DESCRIPTION
When typing parent types as constructors with implicitly added `()` arguments, also admit alias types that become classes after eta-collapsing.

Fixes #18623