### PR TITLE
Deprecation warnings for old syntax: `xs: _*` varargs

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -25,7 +25,7 @@ def exec(projectDir: Path, binary: String, arguments: Seq[String], environment: 
   import scala.jdk.CollectionConverters._
   val command = binary +: arguments
   log(command.mkString(" "))
-  val builder = new ProcessBuilder(command: _*).directory(projectDir.toFile).inheritIO()
+  val builder = new ProcessBuilder(command*).directory(projectDir.toFile).inheritIO()
   builder.environment.putAll(environment.asJava)
   val process = builder.start()
   val exitCode = process.waitFor()

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2344,11 +2344,12 @@ object Parsers {
           val isVarargSplice = location.inArgs && followingIsVararg()
           in.nextToken()
           if isVarargSplice then
-            report.errorOrMigrationWarning(
-              em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead${rewriteNotice(`future-migration`)}",
+            report.gradualErrorOrMigrationWarning(
+              em"The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead${rewriteNotice(`3.4-migration`)}",
               in.sourcePos(uscoreStart),
-              future)
-            if sourceVersion == `future-migration` then
+              warnFrom = `3.4`,
+              errorFrom = future)
+            if sourceVersion.isMigrating && sourceVersion.isAtLeast(`3.4-migration`) then
               patch(source, Span(t.span.end, in.lastOffset), "*")
           else if opStack.nonEmpty then
             report.errorOrMigrationWarning(

--- a/sbt-bridge/test/xsbt/ScalaCompilerForUnitTesting.scala
+++ b/sbt-bridge/test/xsbt/ScalaCompilerForUnitTesting.scala
@@ -25,7 +25,7 @@ object ScalaCompilerForUnitTesting:
 class ScalaCompilerForUnitTesting {
 
   def extractEnteredPhases(srcs: String*): Seq[List[String]] = {
-    val (tempSrcFiles, Callbacks(_, testProgress)) = compileSrcs(srcs: _*)
+    val (tempSrcFiles, Callbacks(_, testProgress)) = compileSrcs(srcs*)
     val run = testProgress.runs.head
     tempSrcFiles.map(src => run.unitPhases(src.id))
   }
@@ -37,7 +37,7 @@ class ScalaCompilerForUnitTesting {
   }
 
   def extractProgressPhases(srcs: String*): List[String] = {
-    val (_, Callbacks(_, testProgress)) = compileSrcs(srcs: _*)
+    val (_, Callbacks(_, testProgress)) = compileSrcs(srcs*)
     testProgress.runs.head.phases
   }
 
@@ -91,7 +91,7 @@ class ScalaCompilerForUnitTesting {
    * Only the names used in the last src file are returned.
    */
   def extractUsedNamesFromSrc(sources: String*): Map[String, Set[String]] = {
-    val (srcFiles, Callbacks(analysisCallback, _)) = compileSrcs(sources: _*)
+    val (srcFiles, Callbacks(analysisCallback, _)) = compileSrcs(sources*)
     srcFiles
       .map { srcFile =>
         val classesInSrc = analysisCallback.classNames(srcFile).map(_._1)

--- a/tests/neg/i18862-3.4.check
+++ b/tests/neg/i18862-3.4.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg/i18862-3.4.scala:6:38 ------------------------------------------------------------------------------
+6 |def test(xs: List[Int]): Unit = f(xs: _*) // error: migration warning
+  |                                      ^
+  |                               The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
+  |                               This construct can be rewritten automatically under -rewrite -source 3.4-migration.

--- a/tests/neg/i18862-3.4.scala
+++ b/tests/neg/i18862-3.4.scala
@@ -1,0 +1,6 @@
+//> using options -Werror
+
+import scala.language.`3.4`
+
+def f(x: Int*): Unit = ()
+def test(xs: List[Int]): Unit = f(xs: _*) // error: migration warning

--- a/tests/neg/i18862-future-migration.scala
+++ b/tests/neg/i18862-future-migration.scala
@@ -1,0 +1,6 @@
+//> using options -Werror
+
+import scala.language.`future-migration`
+
+def f(x: Int*): Unit = ()
+def test(xs: List[Int]): Unit = f(xs: _*) // error: migration warning

--- a/tests/neg/i18862-future.scala
+++ b/tests/neg/i18862-future.scala
@@ -1,0 +1,4 @@
+import scala.language.future
+
+def f(x: Int*): Unit = ()
+def test(xs: List[Int]): Unit = f(xs: _*) // error: migration error

--- a/tests/patmat/exhaustive_heuristics.scala
+++ b/tests/patmat/exhaustive_heuristics.scala
@@ -18,8 +18,8 @@ object Test {
   // well, in truth, we do rewrite List() to Nil, but otherwise we do nothing
   // the full rewrite List(a, b) to a :: b :: Nil, for example is planned (but not sure it's a good idea)
   List(true, false) match {
-    case List(_, _, _:_*) =>
-    case List(node, _:_*)  =>
+    case List(_, _, _*) =>
+    case List(node, _*)  =>
     case Nil =>
   }
 

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3153,6 +3153,7 @@ Text => empty
 Language => Scala
 Symbols => 68 entries
 Occurrences => 115 entries
+Diagnostics => 1 entries
 Synthetics => 3 entries
 
 Symbols:
@@ -3341,6 +3342,10 @@ Occurrences:
 [32:47..32:48): s -> example/PickOneRefinement_1#run().(s)
 [32:49..32:56): pickOne -> example/SpecialRefinement#pickOne().
 [32:57..32:59): as -> example/PickOneRefinement_1#run().(as)
+
+Diagnostics:
+[32:60..32:60): [warning] The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
+This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 
 Synthetics:
 [15:23..15:34):elems.toMap => *[String, Any]


### PR DESCRIPTION
This is the first part of #18862