### PR TITLE
Avoid pure expression warning with Scala 2 library TASTy

### DIFF
--- a/tests/neg/i16601.check
+++ b/tests/neg/i16601.check
@@ -1,6 +1,6 @@
--- [E042] Type Error: tests/neg/i16601.scala:1:27 ----------------------------------------------------------------------
-1 |@main def Test: Unit = new concurrent.ExecutionContext  // error
-  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |                           ExecutionContext is a trait; it cannot be instantiated
+-- [E042] Type Error: tests/neg/i16601.scala:1:26 ----------------------------------------------------------------------
+1 |@main def Test: Any = new concurrent.ExecutionContext  // error
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                          ExecutionContext is a trait; it cannot be instantiated
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i16601.scala
+++ b/tests/neg/i16601.scala
@@ -1,1 +1,1 @@
-@main def Test: Unit = new concurrent.ExecutionContext  // error
+@main def Test: Any = new concurrent.ExecutionContext  // error

--- a/tests/neg/i16601a.check
+++ b/tests/neg/i16601a.check
@@ -1,7 +1,7 @@
--- [E042] Type Error: tests/neg/i16601a.scala:3:27 ---------------------------------------------------------------------
-3 |@main def Test: Unit = new concurrent.ExecutionContext  // error
-  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |                           ExecutionContext is a trait; it cannot be instantiated
+-- [E042] Type Error: tests/neg/i16601a.scala:3:26 ---------------------------------------------------------------------
+3 |@main def Test: Any = new concurrent.ExecutionContext  // error
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                          ExecutionContext is a trait; it cannot be instantiated
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/neg/i16601a.scala
+++ b/tests/neg/i16601a.scala
@@ -1,3 +1,3 @@
 //> using options -explain
 
-@main def Test: Unit = new concurrent.ExecutionContext  // error
+@main def Test: Any = new concurrent.ExecutionContext  // error


### PR DESCRIPTION
The extra information on trait initialization causes an extra warning. The warning/errors in the check files should be the same. The test now do not desugar the erroneous code into a statement anymore to avoid this warning.