### PR TITLE
Desugar `lazy val` pattern bindings into `lazy val`s

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1311,16 +1311,11 @@ object desugar {
           val restDefs =
             for (((named, tpt), n) <- vars.zipWithIndex if named.name != nme.WILDCARD)
             yield
-              if mods.is(Lazy) then
-                DefDef(named.name.asTermName, Nil, tpt, selector(n))
-                  .withMods(mods &~ Lazy)
+              valDef(
+                ValDef(named.name.asTermName, tpt, selector(n))
+                  .withMods(mods)
                   .withSpan(named.span)
-              else
-                valDef(
-                  ValDef(named.name.asTermName, tpt, selector(n))
-                    .withMods(mods)
-                    .withSpan(named.span)
-                )
+              )
           flatTree(firstDef :: restDefs)
       }
   }

--- a/tests/pos/i18878.scala
+++ b/tests/pos/i18878.scala
@@ -1,0 +1,6 @@
+object Foo:
+  lazy val (a, (b, c), d) = (1, (2, 3), 4)
+  def a2: a.type = a
+  def b2: b.type = b
+  def c2: c.type = c
+  def d2: d.type = d


### PR DESCRIPTION
Fixes #18878.

Reverts change in 54f6399b6625cb8f841c1e5965841d46a3e9230c.

Example:
```scala
lazy val (a, b) = ...
```
desugars into
```scala
private lazy val t$1 = ...
lazy val a = t$1._1 // before: def a = t$1._1
lazy val b = t$1._2 // before: def b = t$1._2
```
Where `a` and `b` should be stable identifiers.