### PR TITLE
Fix #18769: Allow HK type args in Java signatures.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -258,7 +258,7 @@ object GenericSignatures {
           if (sym == defn.PairClass && tupleArity(tp) > Definitions.MaxTupleArity)
             jsig(defn.TupleXXLClass.typeRef)
           else if (isTypeParameterInSig(sym, sym0)) {
-            assert(!sym.isAliasType, "Unexpected alias type: " + sym)
+            assert(!sym.isAliasType || sym.info.isLambdaSub, "Unexpected alias type: " + sym)
             typeParamSig(sym.name.lastPart)
           }
           else if (defn.specialErasure.contains(sym))
@@ -407,7 +407,6 @@ object GenericSignatures {
 
 
   // only refer to type params that will actually make it into the sig, this excludes:
-  // * higher-order type parameters
   // * type parameters appearing in method parameters
   // * type members not visible in an enclosing template
   private def isTypeParameterInSig(sym: Symbol, initialSymbol: Symbol)(using Context) =

--- a/tests/pos/i18769.scala
+++ b/tests/pos/i18769.scala
@@ -1,0 +1,9 @@
+trait Arb[Fx[_]] {
+  def pure[A](x: A): Fx[A]
+}
+
+class PfOps(private val self: Int) extends AnyVal {
+  def pf[Fy[_]](m: Arb[Fy]): PartialFunction[Int, Fy[Int]] = {
+    case x => m.pure(x)
+  }
+}


### PR DESCRIPTION
Contrary to what an earlier comment said, we do emit HK type parameters in Java signatures. They are always unbounded and never the type of values.

However, they can appear as type arguments to other higher-kinded types. Previously, an assertion error would trigger in that situation. We relax the assertion to allow this situation and emit a correct Java signature.

I manually verified that the generated Java signatures are consistent with what Scala 2 emits for the same code snippet.

fixes #18769 