### PR TITLE
Completion assert diffs will now show completion source

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -181,9 +181,8 @@ class CompletionProvider(
       item.setAdditionalTextEdits((completion.additionalEdits ++ additionalEdits).asJava)
       completion.insertMode.foreach(item.setInsertTextMode)
 
-      completion
-        .completionData(buildTargetIdentifier)
-        .foreach(data => item.setData(data.toJson))
+      val data = completion.completionData(buildTargetIdentifier)
+      item.setData(data.toJson)
 
       item.setTags(completion.lspTags.asJava)
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -17,6 +17,24 @@ import org.eclipse.lsp4j.InsertTextMode
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextEdit
 
+enum CompletionSource:
+  case Empty
+  case OverrideKind
+  case ImplementAllKind
+  case CompilerKind
+  case KeywordKind
+  case ScopeKind
+  case WorkspaceKind
+  case ExtensionKind
+  case NamedArgKind
+  case AutoFillKind
+  case FileSystemMemberKind
+  case IvyImportKind
+  case InterpolatorKind
+  case MatchCompletionKind
+  case CaseKeywordKind
+  case DocumentKind
+
 sealed trait CompletionValue:
   def label: String
   def insertText: Option[String] = None
@@ -25,11 +43,12 @@ sealed trait CompletionValue:
   def range: Option[Range] = None
   def filterText: Option[String] = None
   def completionItemKind(using Context): CompletionItemKind
+  def completionItemDataKind: Integer = CompletionItemData.None
   def description(printer: ShortenedTypePrinter)(using Context): String = ""
   def insertMode: Option[InsertTextMode] = None
   def completionData(buildTargetIdentifier: String)(
     using Context
-  ): Option[CompletionItemData] = None
+  ): CompletionItemData = CompletionItemData("<no-symbol>", buildTargetIdentifier, kind = completionItemDataKind)
   def command: Option[String] = None
 
   /**
@@ -45,17 +64,15 @@ object CompletionValue:
   sealed trait Symbolic extends CompletionValue:
     def symbol: Symbol
     def isFromWorkspace: Boolean = false
-    def completionItemDataKind = CompletionItemData.None
+    override def completionItemDataKind = CompletionItemData.None
 
     override def completionData(
         buildTargetIdentifier: String
-    )(using Context): Option[CompletionItemData] =
-      Some(
-        CompletionItemData(
-          SemanticdbSymbols.symbolName(symbol),
-          buildTargetIdentifier,
-          kind = completionItemDataKind
-        )
+    )(using Context): CompletionItemData =
+      CompletionItemData(
+        SemanticdbSymbols.symbolName(symbol),
+        buildTargetIdentifier,
+        kind = completionItemDataKind
       )
     def importSymbol: Symbol = symbol
 
@@ -105,12 +122,16 @@ object CompletionValue:
       label: String,
       symbol: Symbol,
       override val snippetSuffix: CompletionSuffix
-  ) extends Symbolic
+  ) extends Symbolic {
+    override def completionItemDataKind: Integer = CompletionSource.CompilerKind.ordinal
+  }
   case class Scope(
       label: String,
       symbol: Symbol,
       override val snippetSuffix: CompletionSuffix,
-  ) extends Symbolic
+  ) extends Symbolic {
+    override def completionItemDataKind: Integer = CompletionSource.ScopeKind.ordinal
+  }
   case class Workspace(
       label: String,
       symbol: Symbol,
@@ -118,6 +139,7 @@ object CompletionValue:
       override val importSymbol: Symbol
   ) extends Symbolic:
     override def isFromWorkspace: Boolean = true
+    override def completionItemDataKind: Integer = CompletionSource.WorkspaceKind.ordinal
 
   /**
    * CompletionValue for extension methods via SymbolSearch
@@ -129,6 +151,7 @@ object CompletionValue:
   ) extends Symbolic:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Method
+    override def completionItemDataKind: Integer = CompletionSource.ExtensionKind.ordinal
     override def description(printer: ShortenedTypePrinter)(using Context): String =
       s"${printer.completionSymbol(symbol)} (extension)"
 
@@ -149,8 +172,7 @@ object CompletionValue:
       override val range: Option[Range]
   ) extends Symbolic:
     override def insertText: Option[String] = Some(value)
-    override def completionItemDataKind: Integer =
-      CompletionItemData.OverrideKind
+    override def completionItemDataKind: Integer = CompletionSource.OverrideKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Method
     override def labelWithDescription(printer: ShortenedTypePrinter)(using Context): String =
@@ -163,6 +185,7 @@ object CompletionValue:
       symbol: Symbol
   ) extends Symbolic:
     override def insertText: Option[String] = Some(label.replace("$", "$$").nn)
+    override def completionItemDataKind: Integer = CompletionSource.OverrideKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Field
     override def description(printer: ShortenedTypePrinter)(using Context): String =
@@ -177,11 +200,13 @@ object CompletionValue:
   ) extends CompletionValue:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Enum
+    override def completionItemDataKind: Integer = CompletionSource.OverrideKind.ordinal
     override def insertText: Option[String] = Some(value)
     override def label: String = "Autofill with default values"
 
   case class Keyword(label: String, override val insertText: Option[String])
       extends CompletionValue:
+    override def completionItemDataKind: Integer = CompletionSource.KeywordKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Keyword
 
@@ -192,6 +217,7 @@ object CompletionValue:
   ) extends CompletionValue:
     override def label: String = filename
     override def insertText: Option[String] = Some(filename.stripSuffix(".sc"))
+    override def completionItemDataKind: Integer = CompletionSource.FileSystemMemberKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.File
 
@@ -201,6 +227,7 @@ object CompletionValue:
       override val range: Option[Range]
   ) extends CompletionValue:
     override val filterText: Option[String] = insertText
+    override def completionItemDataKind: Integer = CompletionSource.IvyImportKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Folder
 
@@ -215,6 +242,7 @@ object CompletionValue:
       isWorkspace: Boolean = false,
       isExtension: Boolean = false
   ) extends Symbolic:
+    override def completionItemDataKind: Integer = CompletionSource.InterpolatorKind.ordinal
     override def description(
         printer: ShortenedTypePrinter
     )(using Context): String =
@@ -228,6 +256,7 @@ object CompletionValue:
       override val additionalEdits: List[TextEdit],
       desc: String
   ) extends CompletionValue:
+    override def completionItemDataKind: Integer = CompletionSource.MatchCompletionKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Enum
     override def description(printer: ShortenedTypePrinter)(using Context): String =
@@ -241,6 +270,7 @@ object CompletionValue:
       override val range: Option[Range] = None,
       override val command: Option[String] = None
   ) extends Symbolic:
+    override def completionItemDataKind: Integer = CompletionSource.CaseKeywordKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Method
 
@@ -253,6 +283,7 @@ object CompletionValue:
     override def filterText: Option[String] = Some(description)
 
     override def insertText: Option[String] = Some(doc)
+    override def completionItemDataKind: Integer = CompletionSource.DocumentKind.ordinal
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Snippet
 

--- a/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
@@ -14,6 +14,7 @@ import scala.meta.pc.{PresentationCompiler, PresentationCompilerConfig}
 import scala.language.unsafeNulls
 
 import dotty.tools.pc.*
+import dotty.tools.pc.completions.CompletionSource
 import dotty.tools.pc.ScalaPresentationCompiler
 import dotty.tools.pc.tests.buildinfo.BuildInfo
 import dotty.tools.pc.utils._
@@ -113,10 +114,13 @@ abstract class BasePCSuite extends PcAssertions:
       " " + e.getRight.getValue
   }.trim
 
-  def sortLines(stableOrder: Boolean, string: String): String =
+  def sortLines(stableOrder: Boolean, string: String, completionSources: List[CompletionSource] = Nil): (String, List[CompletionSource]) =
     val strippedString = string.linesIterator.toList.filter(_.nonEmpty)
-    if (stableOrder) strippedString.mkString("\n")
-    else strippedString.sorted.mkString("\n")
+    if (stableOrder) strippedString.mkString("\n") -> completionSources
+    else
+      val paddedSources = completionSources.padTo(strippedString.size, CompletionSource.Empty)
+      val (sortedCompletions, sortedSources) = (strippedString zip paddedSources).sortBy(_._1).unzip
+      sortedCompletions.mkString("\n") -> sortedSources
 
   extension (s: String)
     def triplequoted: String = s.replace("'''", "\"\"\"")

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseSignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseSignatureHelpSuite.scala
@@ -84,6 +84,6 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite:
       }
     }
 
-    val obtainedSorted = sortLines(stableOrder, out.toString())
-    val expectedSorted = sortLines(stableOrder, expected)
-    assertCompletions(expectedSorted, obtainedSorted, Some(original))
+    val (obtainedSorted, _) = sortLines(stableOrder, out.toString())
+    val (expectedSorted, _) = sortLines(stableOrder, expected)
+    assertWithDiff(expectedSorted, obtainedSorted, includeSources = false, Some(original))

--- a/presentation-compiler/test/dotty/tools/pc/utils/TestingWorkspaceSearch.scala
+++ b/presentation-compiler/test/dotty/tools/pc/utils/TestingWorkspaceSearch.scala
@@ -45,11 +45,7 @@ class TestingWorkspaceSearch(classpath: Seq[String]):
 
           val nioPath = Paths.get(path)
           val uri = nioPath.toUri()
-          val symbols =
-            DefSymbolCollector(
-              driver,
-              CompilerVirtualFileParams(uri, text)
-            ).namedDefSymbols
+          val symbols = DefSymbolCollector(driver, CompilerVirtualFileParams(uri, text)).namedDefSymbols
 
           // We have to map symbol from this Context, to one in PresentationCompiler
           // To do it we are searching it with semanticdb symbol


### PR DESCRIPTION
Previously failed assertions showed a side by side diff of expected vs obtained completions:

<img width="275" alt="Screenshot 2023-11-09 at 18 28 46" src="https://github.com/lampepfl/dotty/assets/48657087/c80fbc71-7e58-4cba-b302-b4dfeff9bcec">

And now:
<img width="311" alt="Screenshot 2023-11-09 at 18 29 31" src="https://github.com/lampepfl/dotty/assets/48657087/829933c7-31c6-4c26-a20c-4d426eb5c11b">

This is extremely useful when debugging the completions, as we have multiple sources and finding what specific completion comes from is just a waste of time.

There is also a chance that we'd want to not include this info in data, but this is minimal trade-off for a significant boost when working on PC. 