### PR TITLE
Also add privateWithin when creating constructor proxies

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -111,8 +111,11 @@ object NamerOps:
   def addConstructorApplies(scope: MutableScope, cls: ClassSymbol, modcls: ClassSymbol)(using Context): scope.type =
     def proxy(constr: Symbol): Symbol =
       newSymbol(
-        modcls, nme.apply, ApplyProxyFlags | (constr.flagsUNSAFE & AccessFlags),
-        ApplyProxyCompleter(constr), coord = constr.coord)
+        modcls, nme.apply,
+        ApplyProxyFlags | (constr.flagsUNSAFE & AccessFlags),
+        ApplyProxyCompleter(constr),
+        cls.privateWithin,
+        constr.coord)
     for dcl <- cls.info.decls do
       if dcl.isConstructor then scope.enter(proxy(dcl))
     scope

--- a/tests/neg/i18545.check
+++ b/tests/neg/i18545.check
@@ -1,0 +1,16 @@
+-- [E173] Reference Error: tests/neg/i18545.scala:13:20 ----------------------------------------------------------------
+13 |  def test: IOLocal.IOLocalImpl[Int] = // error
+   |            ^^^^^^^^^^^^^^^^^^^
+   |class IOLocalImpl cannot be accessed as a member of iolib.IOLocal.type from the top-level definitions in package tests.
+   |  private[IOLocal] class IOLocalImpl can only be accessed from object IOLocal in package iolib.
+-- [E173] Reference Error: tests/neg/i18545.scala:14:24 ----------------------------------------------------------------
+14 |    IOLocal.IOLocalImpl.apply(42) // error
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |method apply cannot be accessed as a member of iolib.IOLocal.IOLocalImpl.type from the top-level definitions in package tests.
+   |  private[IOLocal] method apply can only be accessed from object IOLocal in package iolib.
+-- [E050] Type Error: tests/neg/i18545.scala:15:22 ---------------------------------------------------------------------
+15 |  def test2 = IOLocal.IOLocalImpl(42) // error
+   |              ^^^^^^^^^^^^^^^^^^^
+   |              object IOLocalImpl in object IOLocal does not take parameters
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i18545.scala
+++ b/tests/neg/i18545.scala
@@ -1,0 +1,15 @@
+package iolib:
+  case class IO[A](value: A)
+
+  sealed trait IOLocal[A]
+
+  object IOLocal:
+    def apply[A](default: A): IO[IOLocal[A]] = IO(new IOLocalImpl(default))
+
+    private[IOLocal] final class IOLocalImpl[A](default: A) extends IOLocal[A]
+
+package tests:
+  import iolib.IOLocal
+  def test: IOLocal.IOLocalImpl[Int] = // error
+    IOLocal.IOLocalImpl.apply(42) // error
+  def test2 = IOLocal.IOLocalImpl(42) // error


### PR DESCRIPTION
When creating a constructor proxy symbol we forgot to copy the privateWithin of the target class.

Fixes #18545