### PR TITLE
Reset `comparersInUse` to zero in `ContextState.reset`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -1063,6 +1063,7 @@ object Contexts {
       sources.clear()
       files.clear()
       comparers.clear()  // forces re-evaluation of top and bottom classes in TypeComparer
+      comparersInUse = 0
 
     // Test that access is single threaded
 

--- a/tests/pos-macros/i18855/invoc.scala
+++ b/tests/pos-macros/i18855/invoc.scala
@@ -1,0 +1,3 @@
+import scala.language.experimental.captureChecking
+val x = run()
+

--- a/tests/pos-macros/i18855/macro.scala
+++ b/tests/pos-macros/i18855/macro.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+import scala.language.experimental.captureChecking
+
+def impl()(using Quotes): Expr[Unit] = '{()}
+inline def run(): Unit = ${impl()}
+
+


### PR DESCRIPTION
Fixes #18855

The code in #18855 used to crash the compiler with an out-of-bound access exception. It was because, previously, `ContextState.reset` clears the `comparers`, the cached pool of `TypeComparer`s, while keeping the variable `comparersInUse` intact. However, the `comparer` method of a context assumes `comparers` has a size greater than or equal to `comparersInUse`. So the invariant is clearly violated here and thus triggers the crash.

This PR proposes a straightforward fix. Yet, the reason why only under both macros and cc this code path will be triggered remains to be investigated.