### PR TITLE
Fix condition in prefixIsElidable to prevent compiler crash

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -414,7 +414,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       case pre: ThisType =>
         tp.isType ||
         pre.cls.isStaticOwner ||
-        tp.symbol.isParamOrAccessor && !tp.symbol.owner.is(Trait) && ctx.owner.enclosingClass == pre.cls
+        tp.symbol.isParamOrAccessor && !pre.cls.is(Trait) && !tp.symbol.owner.is(Trait) && ctx.owner.enclosingClass == pre.cls
           // was ctx.owner.enclosingClass.derivesFrom(pre.cls) which was not tight enough
           // and was spuriously triggered in case inner class would inherit from outer one
           // eg anonymous TypeMap inside TypeMap.andThen

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -414,7 +414,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       case pre: ThisType =>
         tp.isType ||
         pre.cls.isStaticOwner ||
-        tp.symbol.isParamOrAccessor && !pre.cls.is(Trait) && ctx.owner.enclosingClass == pre.cls
+        tp.symbol.isParamOrAccessor && !tp.symbol.owner.is(Trait) && ctx.owner.enclosingClass == pre.cls
           // was ctx.owner.enclosingClass.derivesFrom(pre.cls) which was not tight enough
           // and was spuriously triggered in case inner class would inherit from outer one
           // eg anonymous TypeMap inside TypeMap.andThen

--- a/tests/pos/i18091.scala
+++ b/tests/pos/i18091.scala
@@ -1,0 +1,5 @@
+trait B(val y: Int)
+
+class C extends B(20)  {
+  def foo(): Unit = println(y)
+}


### PR DESCRIPTION
Fix #18901 

The check in `prefixIsElidable` was defined as follows:
```scala
tp.symbol.isParamOrAccessor && !pre.cls.is(Trait) && ctx.owner.enclosingClass == pre.cls
```

I assume that `!pre.cls.is(Trait)` condition was introduced to accommodate for `Mixin` phase getting rid of `ParamAccessor` defined in traits. However, the prefix does not indicate where the symbol is really defined - it only represents the prefix from the perspective of the current template, so it could be inherited. When it's inherited from a trait, the prefix would be the current class, but the member still is defined in the trait, and `Mixin` would get rid of the `ParamAccessor` flag. Therefore, I changed this condition to the following:

```scala
tp.symbol.isParamOrAccesso && !pre.cls.is(Trait) && !tp.symbol.owner.is(Trait) && ctx.owner.enclosingClass == pre.cls
```
