### PR TITLE
Make sure that trace is shown correctly in the presence of invalid line numbers

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -380,7 +380,7 @@ object Objects:
       case Some(theValue) =>
         theValue
       case _ =>
-        report.warning("[Internal error] Value not found " + x.show + "\nenv = " + data.show + ". Calling trace:\n" + Trace.show, Trace.position)
+        report.warning("[Internal error] Value not found " + x.show + "\nenv = " + data.show + ". " + Trace.show, Trace.position)
         Bottom
 
     def getVal(x: Symbol)(using data: Data, ctx: Context): Option[Value] = data.getVal(x)
@@ -619,7 +619,7 @@ object Objects:
   def call(value: Value, meth: Symbol, args: List[ArgInfo], receiver: Type, superType: Type, needResolve: Boolean = true): Contextual[Value] = log("call " + meth.show + ", this = " + value.show + ", args = " + args.map(_.value.show), printer, (_: Value).show) {
     value match
     case Cold =>
-      report.warning("Using cold alias. Calling trace:\n" + Trace.show, Trace.position)
+      report.warning("Using cold alias. " + Trace.show, Trace.position)
       Bottom
 
     case Bottom =>
@@ -781,7 +781,7 @@ object Objects:
               errorReadOtherStaticObject(State.currentObject, addr.owner)
               Bottom
           else if ref.isObjectRef && ref.klass.hasSource then
-            report.warning("Access uninitialized field " + field.show + ". Call trace: " + Trace.show, Trace.position)
+            report.warning("Access uninitialized field " + field.show + ". " + Trace.show, Trace.position)
             Bottom
           else
             // initialization error, reported by the initialization checker
@@ -789,7 +789,7 @@ object Objects:
         else if ref.hasVal(target) then
           ref.valValue(target)
         else if ref.isObjectRef && ref.klass.hasSource then
-          report.warning("Access uninitialized field " + field.show + ". Call trace: " + Trace.show, Trace.position)
+          report.warning("Access uninitialized field " + field.show + ". " + Trace.show, Trace.position)
           Bottom
         else
           // initialization error, reported by the initialization checker
@@ -836,7 +836,7 @@ object Objects:
       report.warning("[Internal error] unexpected tree in assignment, array = " + arr.show + Trace.show, Trace.position)
 
     case Cold =>
-      report.warning("Assigning to cold aliases is forbidden. Calling trace:\n" + Trace.show, Trace.position)
+      report.warning("Assigning to cold aliases is forbidden. " + Trace.show, Trace.position)
 
     case Bottom =>
 
@@ -851,7 +851,7 @@ object Objects:
         else
           Heap.writeJoin(addr, rhs)
       else
-        report.warning("Mutating a field before its initialization: " + field.show + ". Calling trace:\n" + Trace.show, Trace.position)
+        report.warning("Mutating a field before its initialization: " + field.show + ". " + Trace.show, Trace.position)
     end match
 
     Bottom
@@ -936,7 +936,7 @@ object Objects:
             Bottom
           end if
         case _ =>
-          report.warning("[Internal error] Variable not found " + sym.show + "\nenv = " + env.show + ". Calling trace:\n" + Trace.show, Trace.position)
+          report.warning("[Internal error] Variable not found " + sym.show + "\nenv = " + env.show + ". " + Trace.show, Trace.position)
           Bottom
       else
         given Env.Data = env
@@ -948,17 +948,17 @@ object Objects:
             given Env.Data = fun.env
             eval(fun.code, fun.thisV, fun.klass)
           case Cold =>
-            report.warning("Calling cold by-name alias. Call trace: \n" + Trace.show, Trace.position)
+            report.warning("Calling cold by-name alias. " + Trace.show, Trace.position)
             Bottom
           case _: ValueSet | _: Ref | _: OfArray =>
-            report.warning("[Internal error] Unexpected by-name value " + value.show  + ". Calling trace:\n" + Trace.show, Trace.position)
+            report.warning("[Internal error] Unexpected by-name value " + value.show  + ". " + Trace.show, Trace.position)
             Bottom
         else
           value
 
     case _ =>
       if isByNameParam(sym) then
-        report.warning("Calling cold by-name alias. Call trace: \n" + Trace.show, Trace.position)
+        report.warning("Calling cold by-name alias. " + Trace.show, Trace.position)
         Bottom
       else
         Cold
@@ -983,10 +983,10 @@ object Objects:
         else
           Heap.writeJoin(addr, value)
       case _ =>
-        report.warning("[Internal error] Variable not found " + sym.show + "\nenv = " + env.show + ". Calling trace:\n" + Trace.show, Trace.position)
+        report.warning("[Internal error] Variable not found " + sym.show + "\nenv = " + env.show + ". " + Trace.show, Trace.position)
 
     case _ =>
-      report.warning("Assigning to variables in outer scope. Calling trace:\n" + Trace.show, Trace.position)
+      report.warning("Assigning to variables in outer scope. " + Trace.show, Trace.position)
 
     Bottom
   }
@@ -1715,15 +1715,13 @@ object Objects:
   def errorMutateOtherStaticObject(currentObj: ClassSymbol, otherObj: ClassSymbol)(using Trace, Context) =
     val msg =
       s"Mutating ${otherObj.show} during initialization of ${currentObj.show}.\n" +
-      "Mutating other static objects during the initialization of one static object is forbidden. " +
-      "Calling trace:\n" + Trace.show
+      "Mutating other static objects during the initialization of one static object is forbidden. " + Trace.show
 
     report.warning(msg, Trace.position)
 
   def errorReadOtherStaticObject(currentObj: ClassSymbol, otherObj: ClassSymbol)(using Trace, Context) =
     val msg =
       "Reading mutable state of " + otherObj.show + " during initialization of " + currentObj.show + ".\n" +
-      "Reading mutable state of other static objects is forbidden as it breaks initialization-time irrelevance. " +
-      "Calling trace: " + Trace.show
+      "Reading mutable state of other static objects is forbidden as it breaks initialization-time irrelevance. " + Trace.show
 
     report.warning(msg, Trace.position)

--- a/tests/init-global/neg/global-cycle1.check
+++ b/tests/init-global/neg/global-cycle1.check
@@ -2,19 +2,19 @@
 1 |object A {             // error
   |       ^
   |       Cyclic initialization: object A -> object B -> object A. Calling trace:
-  |       -> object A {             // error	[ global-cycle1.scala:1 ]
-  |          ^
-  |       -> val a: Int = B.b	[ global-cycle1.scala:2 ]
-  |                       ^
-  |       -> object B {	[ global-cycle1.scala:5 ]
-  |          ^
-  |       -> val b: Int = A.a     // error	[ global-cycle1.scala:6 ]
-  |                       ^
+  |       ├── object A {             // error	[ global-cycle1.scala:1 ]
+  |       │   ^
+  |       ├── val a: Int = B.b	[ global-cycle1.scala:2 ]
+  |       │                ^
+  |       ├── object B {	[ global-cycle1.scala:5 ]
+  |       │   ^
+  |       └── val b: Int = A.a     // error	[ global-cycle1.scala:6 ]
+  |                        ^
 -- Error: tests/init-global/neg/global-cycle1.scala:6:17 ---------------------------------------------------------------
 6 |  val b: Int = A.a     // error
   |               ^^^
-  |               Access uninitialized field value a. Call trace: 
-  |               -> object B {	[ global-cycle1.scala:5 ]
-  |                  ^
-  |               -> val b: Int = A.a     // error	[ global-cycle1.scala:6 ]
-  |                               ^^^
+  |               Access uninitialized field value a. Calling trace:
+  |               ├── object B {	[ global-cycle1.scala:5 ]
+  |               │   ^
+  |               └── val b: Int = A.a     // error	[ global-cycle1.scala:6 ]
+  |                                ^^^

--- a/tests/init-global/neg/line-spacing.check
+++ b/tests/init-global/neg/line-spacing.check
@@ -2,12 +2,12 @@
 3 |    B
 4 |      .s.length // error
   |    ^
-  |    Access uninitialized field value s. Call trace: 
-  |    -> object B {	[ line-spacing.scala:7 ]
-  |       ^
-  |    -> val s: String = s"${A.a}a"	[ line-spacing.scala:8 ]
-  |                           ^^^
-  |    -> def a: Int =	[ line-spacing.scala:2 ]
-  |       ^
-  |    -> .s.length // error	[ line-spacing.scala:4 ]
-  |       ^
+  |    Access uninitialized field value s. Calling trace:
+  |    ├── object B {	[ line-spacing.scala:7 ]
+  |    │   ^
+  |    ├── val s: String = s"${A.a}a"	[ line-spacing.scala:8 ]
+  |    │                       ^^^
+  |    ├── def a: Int =	[ line-spacing.scala:2 ]
+  |    │   ^
+  |    └── .s.length // error	[ line-spacing.scala:4 ]
+  |        ^

--- a/tests/init-global/neg/patmat-unapplySeq.check
+++ b/tests/init-global/neg/patmat-unapplySeq.check
@@ -2,10 +2,10 @@
 8 |  def apply(i: Int): Box = array(i)             // error
   |                           ^^^^^^^^
   |Reading mutable state of object A during initialization of object B.
-  |Reading mutable state of other static objects is forbidden as it breaks initialization-time irrelevance. Calling trace: 
-  |-> object B:	[ patmat-unapplySeq.scala:15 ]
-  |   ^
-  |-> case A(b) =>	[ patmat-unapplySeq.scala:17 ]
-  |        ^^^^
-  |-> def apply(i: Int): Box = array(i)             // error	[ patmat-unapplySeq.scala:8 ]
-  |                            ^^^^^^^^
+  |Reading mutable state of other static objects is forbidden as it breaks initialization-time irrelevance. Calling trace:
+  |├── object B:	[ patmat-unapplySeq.scala:15 ]
+  |│   ^
+  |├── case A(b) =>	[ patmat-unapplySeq.scala:17 ]
+  |│        ^^^^
+  |└── def apply(i: Int): Box = array(i)             // error	[ patmat-unapplySeq.scala:8 ]
+  |                             ^^^^^^^^

--- a/tests/init/neg/closureLeak.check
+++ b/tests/init/neg/closureLeak.check
@@ -2,13 +2,13 @@
 11 |    l.foreach(a => a.addX(this)) // error
    |              ^^^^^^^^^^^^^^^^^
    |Could not verify that the method argument is transitively initialized (Hot). It was found to be a function where "this" is (the original object of type (class Outer) where initialization checking started). Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
-   |-> class Outer {	[ closureLeak.scala:1 ]
-   |   ^
-   |-> l.foreach(a => a.addX(this)) // error	[ closureLeak.scala:11 ]
-   |             ^^^^^^^^^^^^^^^^^
+   |├── class Outer {	[ closureLeak.scala:1 ]
+   |│   ^
+   |└── l.foreach(a => a.addX(this)) // error	[ closureLeak.scala:11 ]
+   |              ^^^^^^^^^^^^^^^^^
    |
    |Promoting the value to transitively initialized (Hot) failed due to the following problem:
    |Could not verify that the method argument is transitively initialized (Hot). It was found to be the original object of type (class Outer) where initialization checking started. Only transitively initialized arguments may be passed to methods (except constructors).
    |Non initialized field(s): value p. Promotion trace:
-   |-> l.foreach(a => a.addX(this)) // error	[ closureLeak.scala:11 ]
-   |                         ^^^^
+   |└── l.foreach(a => a.addX(this)) // error	[ closureLeak.scala:11 ]
+   |                          ^^^^

--- a/tests/init/neg/cycle-structure.check
+++ b/tests/init/neg/cycle-structure.check
@@ -2,29 +2,29 @@
 3 |    val x = B(this)   // error
   |            ^^^^^^^
   |            Problematic object instantiation: arg 1 is not transitively initialized (Hot). Calling trace:
-  |            -> case class A(b: B) {	[ cycle-structure.scala:1 ]
-  |               ^
-  |            -> val x = B(this)   // error	[ cycle-structure.scala:3 ]
-  |                       ^^^^^^^
+  |            ├── case class A(b: B) {	[ cycle-structure.scala:1 ]
+  |            │   ^
+  |            └── val x = B(this)   // error	[ cycle-structure.scala:3 ]
+  |                        ^^^^^^^
   |
   |            It leads to the following error during object initialization:
   |            Access field value x on an uninitialized (Cold) object. Calling trace:
-  |            -> case class B(a: A) {	[ cycle-structure.scala:7 ]
-  |               ^
-  |            -> val x1 = a.x	[ cycle-structure.scala:8 ]
-  |                        ^^^
+  |            ├── case class B(a: A) {	[ cycle-structure.scala:7 ]
+  |            │   ^
+  |            └── val x1 = a.x	[ cycle-structure.scala:8 ]
+  |                         ^^^
 -- Error: tests/init/neg/cycle-structure.scala:9:13 --------------------------------------------------------------------
 9 |    val x = A(this)   // error
   |            ^^^^^^^
   |            Problematic object instantiation: arg 1 is not transitively initialized (Hot). Calling trace:
-  |            -> case class B(a: A) {	[ cycle-structure.scala:7 ]
-  |               ^
-  |            -> val x = A(this)   // error	[ cycle-structure.scala:9 ]
-  |                       ^^^^^^^
+  |            ├── case class B(a: A) {	[ cycle-structure.scala:7 ]
+  |            │   ^
+  |            └── val x = A(this)   // error	[ cycle-structure.scala:9 ]
+  |                        ^^^^^^^
   |
   |            It leads to the following error during object initialization:
   |            Access field value x on an uninitialized (Cold) object. Calling trace:
-  |            -> case class A(b: B) {	[ cycle-structure.scala:1 ]
-  |               ^
-  |            -> val x1 = b.x	[ cycle-structure.scala:2 ]
-  |                        ^^^
+  |            ├── case class A(b: B) {	[ cycle-structure.scala:1 ]
+  |            │   ^
+  |            └── val x1 = b.x	[ cycle-structure.scala:2 ]
+  |                         ^^^

--- a/tests/init/neg/default-this.check
+++ b/tests/init/neg/default-this.check
@@ -3,11 +3,11 @@
   |        ^^^^^^^
   |Could not verify that the method argument is transitively initialized (Hot). It was found to be the original object of type (class B) where initialization checking started. Only transitively initialized arguments may be passed to methods (except constructors).
   |Non initialized field(s): value result. Calling trace:
-  |-> class B extends A {	[ default-this.scala:6 ]
-  |   ^
-  |-> val result = updateThenCompare(5)	[ default-this.scala:11 ]
-  |                ^^^^^^^^^^^^^^^^^^^^
-  |-> def updateThenCompare(c: Int): Boolean = {	[ default-this.scala:7 ]
-  |   ^
-  |-> compare() // error	[ default-this.scala:9 ]
-  |   ^^^^^^^
+  |├── class B extends A {	[ default-this.scala:6 ]
+  |│   ^
+  |├── val result = updateThenCompare(5)	[ default-this.scala:11 ]
+  |│                ^^^^^^^^^^^^^^^^^^^^
+  |├── def updateThenCompare(c: Int): Boolean = {	[ default-this.scala:7 ]
+  |│   ^
+  |└── compare() // error	[ default-this.scala:9 ]
+  |    ^^^^^^^

--- a/tests/init/neg/i15363.check
+++ b/tests/init/neg/i15363.check
@@ -2,14 +2,14 @@
 3 |  val b = new B(this) // error
   |          ^^^^^^^^^^^
   |          Problematic object instantiation: arg 1 is not transitively initialized (Hot). Calling trace:
-  |          -> class A:	[ i15363.scala:1 ]
-  |             ^
-  |          -> val b = new B(this) // error	[ i15363.scala:3 ]
-  |                     ^^^^^^^^^^^
+  |          ├── class A:	[ i15363.scala:1 ]
+  |          │   ^
+  |          └── val b = new B(this) // error	[ i15363.scala:3 ]
+  |                      ^^^^^^^^^^^
   |
   |          It leads to the following error during object initialization:
   |          Access field value m on an uninitialized (Cold) object. Calling trace:
-  |          -> class B(a: A):	[ i15363.scala:7 ]
-  |             ^
-  |          -> val x = a.m	[ i15363.scala:8 ]
-  |                     ^^^
+  |          ├── class B(a: A):	[ i15363.scala:7 ]
+  |          │   ^
+  |          └── val x = a.m	[ i15363.scala:8 ]
+  |                      ^^^

--- a/tests/init/neg/i15459.check
+++ b/tests/init/neg/i15459.check
@@ -3,9 +3,9 @@
   |          ^^^^
   |Could not verify that the method argument is transitively initialized (Hot). It was found to be the original object of type (class Sub) where initialization checking started. Only transitively initialized arguments may be passed to methods (except constructors).
   |Non initialized field(s): value b. Calling trace:
-  |-> class Sub extends Sup:	[ i15459.scala:5 ]
-  |   ^
-  |-> class Sup:	[ i15459.scala:1 ]
-  |   ^
-  |-> println(this)  // error	[ i15459.scala:3 ]
-  |           ^^^^
+  |├── class Sub extends Sup:	[ i15459.scala:5 ]
+  |│   ^
+  |├── class Sup:	[ i15459.scala:1 ]
+  |│   ^
+  |└── println(this)  // error	[ i15459.scala:3 ]
+  |            ^^^^

--- a/tests/init/neg/inherit-non-hot.check
+++ b/tests/init/neg/inherit-non-hot.check
@@ -2,16 +2,16 @@
 6 |            if b == null then b = new B(this) // error
   |                              ^^^^^^^^^^^^^^^
   |The RHS of reassignment must be transitively initialized (Hot). It was found to be a non-transitively initialized (Warm) object of type (class B) { outer = a transitively initialized (Hot) object, args = (an uninitialized (Cold) object) }.  Calling trace:
-  |-> class C extends A {	[ inherit-non-hot.scala:15 ]
-  |   ^
-  |-> val bAgain = toB.getBAgain	[ inherit-non-hot.scala:16 ]
-  |                ^^^
-  |-> def toB: B =	[ inherit-non-hot.scala:5 ]
-  |   ^
-  |-> if b == null then b = new B(this) // error	[ inherit-non-hot.scala:6 ]
-  |                     ^^^^^^^^^^^^^^^
+  |├── class C extends A {	[ inherit-non-hot.scala:15 ]
+  |│   ^
+  |├── val bAgain = toB.getBAgain	[ inherit-non-hot.scala:16 ]
+  |│                ^^^
+  |├── def toB: B =	[ inherit-non-hot.scala:5 ]
+  |│   ^
+  |└── if b == null then b = new B(this) // error	[ inherit-non-hot.scala:6 ]
+  |                      ^^^^^^^^^^^^^^^
   |
   |Promoting the value to transitively initialized (Hot) failed due to the following problem:
   |Could not verify that the field value a is transitively initialized (Hot). It was found to be an uninitialized (Cold) object. Promotion trace:
-  |-> class B(a: A) {	[ inherit-non-hot.scala:10 ]
-  |           ^^^^
+  |└── class B(a: A) {	[ inherit-non-hot.scala:10 ]
+  |            ^^^^

--- a/tests/init/neg/inlined-method.check
+++ b/tests/init/neg/inlined-method.check
@@ -3,9 +3,9 @@
   |                                             ^^^^^^^
   |Could not verify that the method argument is transitively initialized (Hot). It was found to be the original object of type (class InlineError) where initialization checking started. Only transitively initialized arguments may be passed to methods (except constructors).
   |Non initialized field(s): value v. Calling trace:
-  |-> class InlineError {	[ inlined-method.scala:1 ]
-  |   ^
-  |-> Assertion.failAssert(this)	[ inlined-method.scala:2 ]
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |-> scala.runtime.Scala3RunTime.assertFailed(message) // error	[ inlined-method.scala:8 ]
-  |                                            ^^^^^^^
+  |├── class InlineError {	[ inlined-method.scala:1 ]
+  |│   ^
+  |├── Assertion.failAssert(this)	[ inlined-method.scala:2 ]
+  |│   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |└── scala.runtime.Scala3RunTime.assertFailed(message) // error	[ inlined-method.scala:8 ]
+  |                                             ^^^^^^^

--- a/tests/init/neg/inner-first.check
+++ b/tests/init/neg/inner-first.check
@@ -3,7 +3,7 @@
   |            ^^^^
   |Could not verify that the method argument is transitively initialized (Hot). It was found to be the original object of type (class B) where initialization checking started. Only transitively initialized arguments may be passed to methods (except constructors).
   |Non initialized field(s): value n. Calling trace:
-  |-> class B:	[ inner-first.scala:2 ]
-  |   ^
-  |-> println(this)           // error	[ inner-first.scala:3 ]
-  |           ^^^^
+  |├── class B:	[ inner-first.scala:2 ]
+  |│   ^
+  |└── println(this)           // error	[ inner-first.scala:3 ]
+  |            ^^^^

--- a/tests/init/neg/leak-warm.check
+++ b/tests/init/neg/leak-warm.check
@@ -2,7 +2,7 @@
 19 |    val l2 = l.map(_.m()) // error
    |             ^^^^^^^^^^^^
    |             Call method method map on an uninitialized (Cold) object. Calling trace:
-   |             -> object leakWarm {	[ leak-warm.scala:1 ]
-   |                ^
-   |             -> val l2 = l.map(_.m()) // error	[ leak-warm.scala:19 ]
-   |                         ^^^^^^^^^^^^
+   |             ├── object leakWarm {	[ leak-warm.scala:1 ]
+   |             │   ^
+   |             └── val l2 = l.map(_.m()) // error	[ leak-warm.scala:19 ]
+   |                          ^^^^^^^^^^^^

--- a/tests/init/neg/promotion-loop.check
+++ b/tests/init/neg/promotion-loop.check
@@ -2,13 +2,13 @@
 16 |  println(b)      // error
    |          ^
    |Could not verify that the method argument is transitively initialized (Hot). It was found to be a non-transitively initialized (Warm) object of type (class B) { outer = the original object of type (class Test) where initialization checking started }. Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
-   |-> class Test { test =>	[ promotion-loop.scala:1 ]
-   |   ^
-   |-> println(b)      // error	[ promotion-loop.scala:16 ]
-   |           ^
+   |├── class Test { test =>	[ promotion-loop.scala:1 ]
+   |│   ^
+   |└── println(b)      // error	[ promotion-loop.scala:16 ]
+   |            ^
    |
    |Promoting the value to transitively initialized (Hot) failed due to the following problem:
    |Could not verify that the field value outer is transitively initialized (Hot). It was found to be the original object of type (class Test) where initialization checking started.
    |Non initialized field(s): value n. Promotion trace:
-   |-> val outer = test	[ promotion-loop.scala:12 ]
-   |   ^^^^^^^^^^^^^^^^
+   |└── val outer = test	[ promotion-loop.scala:12 ]
+   |    ^^^^^^^^^^^^^^^^

--- a/tests/init/neg/promotion-segment3.check
+++ b/tests/init/neg/promotion-segment3.check
@@ -2,10 +2,10 @@
 9 |  bar(new B)  // error
   |      ^^^^^
   |Could not verify that the method argument is transitively initialized (Hot). It was found to be a non-transitively initialized (Warm) object of type (class B) { outer = the original object of type (class A) where initialization checking started }. Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
-  |-> class A:	[ promotion-segment3.scala:2 ]
-  |   ^
-  |-> bar(new B)  // error	[ promotion-segment3.scala:9 ]
-  |       ^^^^^
+  |├── class A:	[ promotion-segment3.scala:2 ]
+  |│   ^
+  |└── bar(new B)  // error	[ promotion-segment3.scala:9 ]
+  |        ^^^^^
   |
   |Promoting the value to transitively initialized (Hot) failed due to the following problem:
   |Promotion cancelled as the value contains inner class C.

--- a/tests/init/neg/secondary-ctor4.check
+++ b/tests/init/neg/secondary-ctor4.check
@@ -2,43 +2,43 @@
 54 |      val c = new C(b, 5)   // error
    |              ^^^^^^^^^^^
    |              Problematic object instantiation: arg 1 is not transitively initialized (Hot). Calling trace:
-   |              -> class D {	[ secondary-ctor4.scala:52 ]
-   |                 ^
-   |              -> val c = new C(b, 5)   // error	[ secondary-ctor4.scala:54 ]
-   |                         ^^^^^^^^^^^
+   |              ├── class D {	[ secondary-ctor4.scala:52 ]
+   |              │   ^
+   |              └── val c = new C(b, 5)   // error	[ secondary-ctor4.scala:54 ]
+   |                          ^^^^^^^^^^^
    |
    |              It leads to the following error during object initialization:
    |              Access field value n on an uninitialized (Cold) object. Calling trace:
-   |              -> def this(b: B, x: Int) = this(b)	[ secondary-ctor4.scala:49 ]
-   |                                          ^^^^^^^
-   |              -> class C(b: B) extends A(b) with T {	[ secondary-ctor4.scala:48 ]
-   |                 ^
-   |              -> def this(b: B) = {	[ secondary-ctor4.scala:17 ]
-   |                 ^
-   |              -> Inner().foo()	[ secondary-ctor4.scala:26 ]
-   |                 ^^^^^^^
-   |              -> class Inner() {	[ secondary-ctor4.scala:21 ]
-   |                 ^
-   |              -> println(b.n)	[ secondary-ctor4.scala:23 ]
-   |                         ^^^
+   |              ├── def this(b: B, x: Int) = this(b)	[ secondary-ctor4.scala:49 ]
+   |              │                            ^^^^^^^
+   |              ├── class C(b: B) extends A(b) with T {	[ secondary-ctor4.scala:48 ]
+   |              │   ^
+   |              ├── def this(b: B) = {	[ secondary-ctor4.scala:17 ]
+   |              │   ^
+   |              ├── Inner().foo()	[ secondary-ctor4.scala:26 ]
+   |              │   ^^^^^^^
+   |              ├── class Inner() {	[ secondary-ctor4.scala:21 ]
+   |              │   ^
+   |              └── println(b.n)	[ secondary-ctor4.scala:23 ]
+   |                          ^^^
 -- Error: tests/init/neg/secondary-ctor4.scala:42:4 --------------------------------------------------------------------
 42 |    new A(new B(new D))  // error
    |    ^^^^^^^^^^^^^^^^^^^
    |Problematic object instantiation: the outer M.this and arg 1 are not transitively initialized (Hot). Calling trace:
-   |-> class N(d: D) extends M(d) {	[ secondary-ctor4.scala:59 ]
-   |   ^
-   |-> def this(d: D) = {	[ secondary-ctor4.scala:7 ]
-   |   ^
-   |-> new A(new B(new D))  // error	[ secondary-ctor4.scala:42 ]
-   |   ^^^^^^^^^^^^^^^^^^^
+   |├── class N(d: D) extends M(d) {	[ secondary-ctor4.scala:59 ]
+   |│   ^
+   |├── def this(d: D) = {	[ secondary-ctor4.scala:7 ]
+   |│   ^
+   |└── new A(new B(new D))  // error	[ secondary-ctor4.scala:42 ]
+   |    ^^^^^^^^^^^^^^^^^^^
    |
    |It leads to the following error during object initialization:
    |Access field value n on an uninitialized (Cold) object. Calling trace:
-   |-> def this(b: B) = {	[ secondary-ctor4.scala:17 ]
-   |   ^
-   |-> Inner().foo()	[ secondary-ctor4.scala:26 ]
-   |   ^^^^^^^
-   |-> class Inner() {	[ secondary-ctor4.scala:21 ]
-   |   ^
-   |-> println(b.n)	[ secondary-ctor4.scala:23 ]
-   |           ^^^
+   |├── def this(b: B) = {	[ secondary-ctor4.scala:17 ]
+   |│   ^
+   |├── Inner().foo()	[ secondary-ctor4.scala:26 ]
+   |│   ^^^^^^^
+   |├── class Inner() {	[ secondary-ctor4.scala:21 ]
+   |│   ^
+   |└── println(b.n)	[ secondary-ctor4.scala:23 ]
+   |            ^^^

--- a/tests/init/neg/super-resolution.check
+++ b/tests/init/neg/super-resolution.check
@@ -2,35 +2,35 @@
 21 |  val m = 30 // error
    |      ^
    |      Access non-initialized value m. Calling trace:
-   |      -> class C extends A with M with N:	[ super-resolution.scala:17 ]
-   |         ^
-   |      -> foo()	[ super-resolution.scala:18 ]
-   |         ^^^^^
-   |      -> override def foo(): Int = b * super.foo()	[ super-resolution.scala:15 ]
-   |                                       ^^^^^^^^^^^
-   |      -> override def foo(): Int = a + super.foo()	[ super-resolution.scala:11 ]
-   |                                       ^^^^^^^^^^^
-   |      -> def foo(): Int = m	[ super-resolution.scala:7 ]
-   |                          ^
+   |      ├── class C extends A with M with N:	[ super-resolution.scala:17 ]
+   |      │   ^
+   |      ├── foo()	[ super-resolution.scala:18 ]
+   |      │   ^^^^^
+   |      ├── override def foo(): Int = b * super.foo()	[ super-resolution.scala:15 ]
+   |      │                                 ^^^^^^^^^^^
+   |      ├── override def foo(): Int = a + super.foo()	[ super-resolution.scala:11 ]
+   |      │                                 ^^^^^^^^^^^
+   |      └── def foo(): Int = m	[ super-resolution.scala:7 ]
+   |                           ^
 -- Error: tests/init/neg/super-resolution.scala:19:6 -------------------------------------------------------------------
 19 |  val a = 10 // error
    |      ^
    |      Access non-initialized value a. Calling trace:
-   |      -> class C extends A with M with N:	[ super-resolution.scala:17 ]
-   |         ^
-   |      -> foo()	[ super-resolution.scala:18 ]
-   |         ^^^^^
-   |      -> override def foo(): Int = b * super.foo()	[ super-resolution.scala:15 ]
-   |                                       ^^^^^^^^^^^
-   |      -> override def foo(): Int = a + super.foo()	[ super-resolution.scala:11 ]
-   |                                   ^
+   |      ├── class C extends A with M with N:	[ super-resolution.scala:17 ]
+   |      │   ^
+   |      ├── foo()	[ super-resolution.scala:18 ]
+   |      │   ^^^^^
+   |      ├── override def foo(): Int = b * super.foo()	[ super-resolution.scala:15 ]
+   |      │                                 ^^^^^^^^^^^
+   |      └── override def foo(): Int = a + super.foo()	[ super-resolution.scala:11 ]
+   |                                    ^
 -- Error: tests/init/neg/super-resolution.scala:20:6 -------------------------------------------------------------------
 20 |  val b = 20 // error
    |      ^
    |      Access non-initialized value b. Calling trace:
-   |      -> class C extends A with M with N:	[ super-resolution.scala:17 ]
-   |         ^
-   |      -> foo()	[ super-resolution.scala:18 ]
-   |         ^^^^^
-   |      -> override def foo(): Int = b * super.foo()	[ super-resolution.scala:15 ]
-   |                                   ^
+   |      ├── class C extends A with M with N:	[ super-resolution.scala:17 ]
+   |      │   ^
+   |      ├── foo()	[ super-resolution.scala:18 ]
+   |      │   ^^^^^
+   |      └── override def foo(): Int = b * super.foo()	[ super-resolution.scala:15 ]
+   |                                    ^

--- a/tests/init/neg/super-resolution2.check
+++ b/tests/init/neg/super-resolution2.check
@@ -2,27 +2,27 @@
 19 |  val n = 40 // error
    |      ^
    |      Access non-initialized value n. Calling trace:
-   |      -> class N extends A with B:	[ super-resolution2.scala:9 ]
-   |         ^
-   |      -> new Inner	[ super-resolution2.scala:16 ]
-   |         ^^^^^^^^^
-   |      -> class Inner:	[ super-resolution2.scala:12 ]
-   |         ^
-   |      -> N.super[A].foo()	[ super-resolution2.scala:13 ]
-   |         ^^^^^^^^^^^^^^^^
-   |      -> def foo(): Int = n	[ super-resolution2.scala:3 ]
-   |                          ^
+   |      ├── class N extends A with B:	[ super-resolution2.scala:9 ]
+   |      │   ^
+   |      ├── new Inner	[ super-resolution2.scala:16 ]
+   |      │   ^^^^^^^^^
+   |      ├── class Inner:	[ super-resolution2.scala:12 ]
+   |      │   ^
+   |      ├── N.super[A].foo()	[ super-resolution2.scala:13 ]
+   |      │   ^^^^^^^^^^^^^^^^
+   |      └── def foo(): Int = n	[ super-resolution2.scala:3 ]
+   |                           ^
 -- Error: tests/init/neg/super-resolution2.scala:18:6 ------------------------------------------------------------------
 18 |  val m = 30 // error
    |      ^
    |      Access non-initialized value m. Calling trace:
-   |      -> class N extends A with B:	[ super-resolution2.scala:9 ]
-   |         ^
-   |      -> new Inner	[ super-resolution2.scala:16 ]
-   |         ^^^^^^^^^
-   |      -> class Inner:	[ super-resolution2.scala:12 ]
-   |         ^
-   |      -> N.super.foo()	[ super-resolution2.scala:14 ]
-   |         ^^^^^^^^^^^^^
-   |      -> def foo(): Int = m	[ super-resolution2.scala:7 ]
-   |                          ^
+   |      ├── class N extends A with B:	[ super-resolution2.scala:9 ]
+   |      │   ^
+   |      ├── new Inner	[ super-resolution2.scala:16 ]
+   |      │   ^^^^^^^^^
+   |      ├── class Inner:	[ super-resolution2.scala:12 ]
+   |      │   ^
+   |      ├── N.super.foo()	[ super-resolution2.scala:14 ]
+   |      │   ^^^^^^^^^^^^^
+   |      └── def foo(): Int = m	[ super-resolution2.scala:7 ]
+   |                           ^

--- a/tests/init/neg/super-resolution3.check
+++ b/tests/init/neg/super-resolution3.check
@@ -2,57 +2,57 @@
 27 |  val n = 40 // error
    |      ^
    |      Access non-initialized value n. Calling trace:
-   |      -> class C extends A with M with N:	[ super-resolution3.scala:22 ]
-   |         ^
-   |      -> new Inner()	[ super-resolution3.scala:23 ]
-   |         ^^^^^^^^^^^
-   |      -> class Inner:	[ super-resolution3.scala:17 ]
-   |         ^
-   |      -> N.super[A].foo()	[ super-resolution3.scala:18 ]
-   |         ^^^^^^^^^^^^^^^^
-   |      -> def foo(): Int = n	[ super-resolution3.scala:3 ]
-   |                          ^
+   |      ├── class C extends A with M with N:	[ super-resolution3.scala:22 ]
+   |      │   ^
+   |      ├── new Inner()	[ super-resolution3.scala:23 ]
+   |      │   ^^^^^^^^^^^
+   |      ├── class Inner:	[ super-resolution3.scala:17 ]
+   |      │   ^
+   |      ├── N.super[A].foo()	[ super-resolution3.scala:18 ]
+   |      │   ^^^^^^^^^^^^^^^^
+   |      └── def foo(): Int = n	[ super-resolution3.scala:3 ]
+   |                           ^
 -- Error: tests/init/neg/super-resolution3.scala:26:6 ------------------------------------------------------------------
 26 |  val m = 30 // error
    |      ^
    |      Access non-initialized value m. Calling trace:
-   |      -> class C extends A with M with N:	[ super-resolution3.scala:22 ]
-   |         ^
-   |      -> new Inner()	[ super-resolution3.scala:23 ]
-   |         ^^^^^^^^^^^
-   |      -> class Inner:	[ super-resolution3.scala:17 ]
-   |         ^
-   |      -> N.super.foo()	[ super-resolution3.scala:19 ]
-   |         ^^^^^^^^^^^^^
-   |      -> override def foo(): Int = a + super.foo()	[ super-resolution3.scala:11 ]
-   |                                       ^^^^^^^^^^^
-   |      -> def foo(): Int = m	[ super-resolution3.scala:7 ]
-   |                          ^
+   |      ├── class C extends A with M with N:	[ super-resolution3.scala:22 ]
+   |      │   ^
+   |      ├── new Inner()	[ super-resolution3.scala:23 ]
+   |      │   ^^^^^^^^^^^
+   |      ├── class Inner:	[ super-resolution3.scala:17 ]
+   |      │   ^
+   |      ├── N.super.foo()	[ super-resolution3.scala:19 ]
+   |      │   ^^^^^^^^^^^^^
+   |      ├── override def foo(): Int = a + super.foo()	[ super-resolution3.scala:11 ]
+   |      │                                 ^^^^^^^^^^^
+   |      └── def foo(): Int = m	[ super-resolution3.scala:7 ]
+   |                           ^
 -- Error: tests/init/neg/super-resolution3.scala:24:6 ------------------------------------------------------------------
 24 |  val a = 10 // error
    |      ^
    |      Access non-initialized value a. Calling trace:
-   |      -> class C extends A with M with N:	[ super-resolution3.scala:22 ]
-   |         ^
-   |      -> new Inner()	[ super-resolution3.scala:23 ]
-   |         ^^^^^^^^^^^
-   |      -> class Inner:	[ super-resolution3.scala:17 ]
-   |         ^
-   |      -> N.super.foo()	[ super-resolution3.scala:19 ]
-   |         ^^^^^^^^^^^^^
-   |      -> override def foo(): Int = a + super.foo()	[ super-resolution3.scala:11 ]
-   |                                   ^
+   |      ├── class C extends A with M with N:	[ super-resolution3.scala:22 ]
+   |      │   ^
+   |      ├── new Inner()	[ super-resolution3.scala:23 ]
+   |      │   ^^^^^^^^^^^
+   |      ├── class Inner:	[ super-resolution3.scala:17 ]
+   |      │   ^
+   |      ├── N.super.foo()	[ super-resolution3.scala:19 ]
+   |      │   ^^^^^^^^^^^^^
+   |      └── override def foo(): Int = a + super.foo()	[ super-resolution3.scala:11 ]
+   |                                    ^
 -- Error: tests/init/neg/super-resolution3.scala:25:6 ------------------------------------------------------------------
 25 |  val b = 20 // error
    |      ^
    |      Access non-initialized value b. Calling trace:
-   |      -> class C extends A with M with N:	[ super-resolution3.scala:22 ]
-   |         ^
-   |      -> new Inner()	[ super-resolution3.scala:23 ]
-   |         ^^^^^^^^^^^
-   |      -> class Inner:	[ super-resolution3.scala:17 ]
-   |         ^
-   |      -> foo()	[ super-resolution3.scala:20 ]
-   |         ^^^^^
-   |      -> override def foo(): Int = b * super.foo()	[ super-resolution3.scala:15 ]
-   |                                   ^
+   |      ├── class C extends A with M with N:	[ super-resolution3.scala:22 ]
+   |      │   ^
+   |      ├── new Inner()	[ super-resolution3.scala:23 ]
+   |      │   ^^^^^^^^^^^
+   |      ├── class Inner:	[ super-resolution3.scala:17 ]
+   |      │   ^
+   |      ├── foo()	[ super-resolution3.scala:20 ]
+   |      │   ^^^^^
+   |      └── override def foo(): Int = b * super.foo()	[ super-resolution3.scala:15 ]
+   |                                    ^

--- a/tests/init/neg/t3273.check
+++ b/tests/init/neg/t3273.check
@@ -2,25 +2,25 @@
 4 |  val num1: LazyList[Int] = 1 #:: num1.map(_ + 1)                        // error
   |                                  ^^^^^^^^^^^^^^^
   |Could not verify that the method argument is transitively initialized (Hot). It was found to be a function where "this" is (the original object of type (object Test) where initialization checking started). Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
-  |-> object Test {	[ t3273.scala:3 ]
-  |   ^
-  |-> val num1: LazyList[Int] = 1 #:: num1.map(_ + 1)                        // error	[ t3273.scala:4 ]
-  |                                   ^^^^^^^^^^^^^^^
+  |├── object Test {	[ t3273.scala:3 ]
+  |│   ^
+  |└── val num1: LazyList[Int] = 1 #:: num1.map(_ + 1)                        // error	[ t3273.scala:4 ]
+  |                                    ^^^^^^^^^^^^^^^
   |
   |Promoting the value to transitively initialized (Hot) failed due to the following problem:
   |Access non-initialized value num1. Promotion trace:
-  |-> val num1: LazyList[Int] = 1 #:: num1.map(_ + 1)                        // error	[ t3273.scala:4 ]
-  |                                   ^^^^
+  |└── val num1: LazyList[Int] = 1 #:: num1.map(_ + 1)                        // error	[ t3273.scala:4 ]
+  |                                    ^^^^
 -- Error: tests/init/neg/t3273.scala:5:61 ------------------------------------------------------------------------------
 5 |  val num2: LazyList[Int] = 1 #:: num2.iterator.map(_ + 1).to(LazyList)  // error
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |Could not verify that the method argument is transitively initialized (Hot). It was found to be a function where "this" is (the original object of type (object Test) where initialization checking started). Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
-  |-> object Test {	[ t3273.scala:3 ]
-  |   ^
-  |-> val num2: LazyList[Int] = 1 #:: num2.iterator.map(_ + 1).to(LazyList)  // error	[ t3273.scala:5 ]
-  |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |├── object Test {	[ t3273.scala:3 ]
+  |│   ^
+  |└── val num2: LazyList[Int] = 1 #:: num2.iterator.map(_ + 1).to(LazyList)  // error	[ t3273.scala:5 ]
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   |Promoting the value to transitively initialized (Hot) failed due to the following problem:
   |Access non-initialized value num2. Promotion trace:
-  |-> val num2: LazyList[Int] = 1 #:: num2.iterator.map(_ + 1).to(LazyList)  // error	[ t3273.scala:5 ]
-  |                                   ^^^^
+  |└── val num2: LazyList[Int] = 1 #:: num2.iterator.map(_ + 1).to(LazyList)  // error	[ t3273.scala:5 ]
+  |                                    ^^^^

--- a/tests/init/neg/unsound1.check
+++ b/tests/init/neg/unsound1.check
@@ -2,7 +2,7 @@
 2 |  if (m > 0) println(foo(m - 1).a2.n) // error
   |                     ^^^^^^^^^^^^^^^
   |                     Access field variable n on an uninitialized (Cold) object. Calling trace:
-  |                     -> class A(m: Int) {	[ unsound1.scala:1 ]
-  |                        ^
-  |                     -> if (m > 0) println(foo(m - 1).a2.n) // error	[ unsound1.scala:2 ]
-  |                                           ^^^^^^^^^^^^^^^
+  |                     ├── class A(m: Int) {	[ unsound1.scala:1 ]
+  |                     │   ^
+  |                     └── if (m > 0) println(foo(m - 1).a2.n) // error	[ unsound1.scala:2 ]
+  |                                            ^^^^^^^^^^^^^^^

--- a/tests/init/neg/unsound2.check
+++ b/tests/init/neg/unsound2.check
@@ -1,12 +1,12 @@
 -- Error: tests/init/neg/unsound2.scala:5:26 ---------------------------------------------------------------------------
 5 |        def getN: Int = a.n // error
   |                        ^^^
-  |   Access field value n on an uninitialized (Cold) object. Calling trace:
-  |   -> case class A(x: Int) {	[ unsound2.scala:1 ]
-  |      ^
-  |   -> println(foo(x).getB)	[ unsound2.scala:8 ]
-  |              ^^^^^^
-  |   -> def foo(y: Int): B = if (y > 10) then B(bar(y - 1), foo(y - 1).getN) else B(bar(y), 10)	[ unsound2.scala:2 ]
-  |                                                          ^^^^^^^^^^^^^^^
-  |   -> def getN: Int = a.n // error	[ unsound2.scala:5 ]
+  |  Access field value n on an uninitialized (Cold) object. Calling trace:
+  |  ├── case class A(x: Int) {	[ unsound2.scala:1 ]
+  |  │   ^
+  |  ├── println(foo(x).getB)	[ unsound2.scala:8 ]
+  |  │           ^^^^^^
+  |  ├── def foo(y: Int): B = if (y > 10) then B(bar(y - 1), foo(y - 1).getN) else B(bar(y), 10)	[ unsound2.scala:2 ]
+  |  │                                                       ^^^^^^^^^^^^^^^
+  |  └── def getN: Int = a.n // error	[ unsound2.scala:5 ]
   |                      ^^^

--- a/tests/init/neg/unsound3.check
+++ b/tests/init/neg/unsound3.check
@@ -2,11 +2,11 @@
 10 |        if (x < 12) then foo().getC().b else newB // error
    |                         ^^^^^^^^^^^^^^
    |                         Access field value b on an uninitialized (Cold) object. Calling trace:
-   |                         -> class C {	[ unsound3.scala:5 ]
-   |                            ^
-   |                         -> val b = foo()	[ unsound3.scala:12 ]
-   |                                    ^^^^^
-   |                         -> def foo(): B = {	[ unsound3.scala:7 ]
-   |                            ^
-   |                         -> if (x < 12) then foo().getC().b else newB // error	[ unsound3.scala:10 ]
-   |                                             ^^^^^^^^^^^^^^
+   |                         ├── class C {	[ unsound3.scala:5 ]
+   |                         │   ^
+   |                         ├── val b = foo()	[ unsound3.scala:12 ]
+   |                         │           ^^^^^
+   |                         ├── def foo(): B = {	[ unsound3.scala:7 ]
+   |                         │   ^
+   |                         └── if (x < 12) then foo().getC().b else newB // error	[ unsound3.scala:10 ]
+   |                                              ^^^^^^^^^^^^^^

--- a/tests/init/neg/unsound4.check
+++ b/tests/init/neg/unsound4.check
@@ -2,9 +2,9 @@
 3 |    val aAgain = foo(5) // error
   |        ^
   |        Access non-initialized value aAgain. Calling trace:
-  |        -> class A {	[ unsound4.scala:1 ]
-  |           ^
-  |        -> val aAgain = foo(5) // error	[ unsound4.scala:3 ]
-  |                        ^^^^^^
-  |        -> def foo(x: Int): A = if (x < 5) then this else foo(x - 1).aAgain	[ unsound4.scala:2 ]
-  |                                                          ^^^^^^^^^^^^^^^^^
+  |        ├── class A {	[ unsound4.scala:1 ]
+  |        │   ^
+  |        ├── val aAgain = foo(5) // error	[ unsound4.scala:3 ]
+  |        │                ^^^^^^
+  |        └── def foo(x: Int): A = if (x < 5) then this else foo(x - 1).aAgain	[ unsound4.scala:2 ]
+  |                                                           ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Make sure that trace is shown correctly in the presence of invalid line numbers (-1) in TASTy.

Before:

```Scala
Reading mutable state of object Array during initialization of object Parent.
Reading mutable state of other static objects is forbidden as it breaks initialization-time irrelevance. Calling trace: 
-> object Parent {                    // error  [ t9312.scala:11 ]
   ^
-> final val children = Set(Child1, Child2)     [ t9312.scala:21 ]
                        ^^^^^^^^^^^^^^^^^^^
-> BitmapIndexedSetNode.this.originalHashes.apply(index)
```

After:

```Scala
Reading mutable state of object Array during initialization of object Parent.
Reading mutable state of other static objects is forbidden as it breaks initialization-time irrelevance. Calling trace:
├── object Parent {                    // error	[ t9312.scala:11 ]
│      ^
├── final val children = Set(Child1, Child2)	[ t9312.scala:21 ]
│                        ^^^^^^^^^^^^^^^^^^^
├── scala.collection.IterableFactory.apply
├── IterableFactory.this.from[A](elems)
├── scala.collection.immutable.Set.from
├── scala.collection.immutable.Set.newBuilder[E].addAll(it)
├── scala.collection.immutable.SetBuilderImpl.addAll
├── super.addAll(xs)
├── scala.collection.mutable.Growable.addAll
├── Growable.this.addOne(it.next())
├── scala.collection.immutable.SetBuilderImpl.addOne
├── SetBuilderImpl.this.hashSetBuilder.addOne(elem)
├── scala.collection.immutable.HashSetBuilder.addOne
├── HashSetBuilder.this.update(HashSetBuilder.this.rootNode, elem, h, im, 0)
├── scala.collection.immutable.HashSetBuilder.update
├── bm.getHash(index)
├── scala.collection.immutable.BitmapIndexedSetNode.getHash
└── BitmapIndexedSetNode.this.originalHashes.apply(index)
```

 Ref: https://github.com/lampepfl/dotty/issues/18882