### PR TITLE
fix: scoverage statement's line number should be 1-base

### DIFF
--- a/compiler/src/dotty/tools/dotc/coverage/Coverage.scala
+++ b/compiler/src/dotty/tools/dotc/coverage/Coverage.scala
@@ -11,7 +11,12 @@ class Coverage:
 
   def addStatement(stmt: Statement): Unit = statementsById(stmt.id) = stmt
 
-/** A statement that can be invoked, and thus counted as "covered" by code coverage tools. */
+
+/**
+  * A statement that can be invoked, and thus counted as "covered" by code coverage tools.
+  *
+  * @param line 1-indexed line number
+  */
 case class Statement(
     location: Location,
     id: Int,

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -97,7 +97,9 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
         id = id,
         start = pos.start,
         end = pos.end,
-        line = pos.line,
+        // +1 to account for the line number starting at 1
+        // the internal line number is 0-base https://github.com/lampepfl/dotty/blob/18ada516a85532524a39a962b2ddecb243c65376/compiler/src/dotty/tools/dotc/util/SourceFile.scala#L173-L176
+        line = pos.line + 1,
         desc = sourceFile.content.slice(pos.start, pos.end).mkString,
         symbolName = tree.symbol.name.toSimpleName.toString,
         treeName = tree.getClass.getSimpleName.nn,

--- a/tests/coverage/pos/Constructor.scoverage.check
+++ b/tests/coverage/pos/Constructor.scoverage.check
@@ -27,7 +27,7 @@ covtest.C
 <init>
 28
 36
-3
+4
 <init>
 DefDef
 false
@@ -44,7 +44,7 @@ covtest.C
 <init>
 69
 72
-5
+6
 g
 Apply
 false
@@ -61,7 +61,7 @@ covtest.C
 <init>
 80
 88
-8
+9
 <init>
 DefDef
 false
@@ -78,7 +78,7 @@ covtest.C
 <init>
 108
 128
-9
+10
 +
 Apply
 false
@@ -95,7 +95,7 @@ covtest.C
 f
 133
 138
-11
+12
 f
 DefDef
 false
@@ -112,7 +112,7 @@ covtest.C
 x
 153
 158
-12
+13
 x
 DefDef
 false
@@ -129,7 +129,7 @@ covtest.C
 <init>
 165
 169
-13
+14
 f
 Apply
 false
@@ -146,7 +146,7 @@ covtest.C
 <init>
 167
 168
-13
+14
 x
 Select
 false
@@ -163,7 +163,7 @@ covtest.C
 g
 173
 178
-15
+16
 g
 DefDef
 false
@@ -180,7 +180,7 @@ covtest.O$
 g
 203
 208
-18
+19
 g
 DefDef
 false
@@ -197,7 +197,7 @@ covtest.O$
 y
 223
 228
-19
+20
 y
 DefDef
 false
@@ -214,7 +214,7 @@ covtest.O$
 <init>
 235
 239
-20
+21
 g
 Apply
 false
@@ -231,7 +231,7 @@ covtest.O$
 <init>
 237
 238
-20
+21
 y
 Ident
 false

--- a/tests/coverage/pos/ContextFunctions.scoverage.check
+++ b/tests/coverage/pos/ContextFunctions.scoverage.check
@@ -27,7 +27,7 @@ covtest.OnError
 onError
 56
 67
-3
+4
 onError
 DefDef
 false
@@ -44,7 +44,7 @@ covtest.Imperative
 readName2
 121
 134
-7
+8
 readName2
 DefDef
 false
@@ -61,7 +61,7 @@ covtest.Imperative
 readPerson
 252
 309
-13
+14
 onError
 Apply
 false
@@ -78,7 +78,7 @@ covtest.Imperative
 readPerson
 252
 295
-13
+14
 <init>
 Apply
 false
@@ -95,7 +95,7 @@ covtest.Imperative
 $anonfun
 267
 294
-13
+14
 apply
 Apply
 false
@@ -112,7 +112,7 @@ covtest.Imperative
 readPerson
 192
 206
-11
+12
 readPerson
 DefDef
 false

--- a/tests/coverage/pos/Enum.scoverage.check
+++ b/tests/coverage/pos/Enum.scoverage.check
@@ -27,7 +27,7 @@ covtest.Planet
 surfaceGravity
 338
 356
-14
+15
 surfaceGravity
 DefDef
 false
@@ -44,7 +44,7 @@ covtest.Planet
 surfaceWeight
 444
 458
-15
+16
 surfaceGravity
 Select
 false
@@ -61,7 +61,7 @@ covtest.Planet
 surfaceWeight
 392
 409
-15
+16
 surfaceWeight
 DefDef
 false
@@ -78,7 +78,7 @@ covtest.EnumTypes$
 test
 1043
 1077
-30
+31
 println
 Apply
 false
@@ -95,7 +95,7 @@ covtest.EnumTypes$
 test
 1051
 1076
-30
+31
 +
 Apply
 false
@@ -112,7 +112,7 @@ covtest.EnumTypes$
 test
 1082
 1103
-31
+32
 println
 Apply
 false
@@ -129,7 +129,7 @@ covtest.EnumTypes$
 test
 1090
 1102
-31
+32
 s
 Apply
 false
@@ -146,7 +146,7 @@ covtest.EnumTypes$
 calculateEarthWeightOnPlanets
 1195
 1222
-34
+35
 surfaceGravity
 Select
 false
@@ -163,7 +163,7 @@ covtest.EnumTypes$
 calculateEarthWeightOnPlanets
 1229
 1320
-35
+36
 foreach
 Apply
 false
@@ -180,7 +180,7 @@ covtest.EnumTypes$
 calculateEarthWeightOnPlanets
 1238
 1251
-35
+36
 refArrayOps
 Apply
 false
@@ -197,7 +197,7 @@ covtest.EnumTypes$
 $anonfun
 1263
 1320
-36
+37
 println
 Apply
 false
@@ -214,7 +214,7 @@ covtest.EnumTypes$
 $anonfun
 1271
 1319
-36
+37
 s
 Apply
 false
@@ -231,7 +231,7 @@ covtest.EnumTypes$
 $anonfun
 1296
 1317
-36
+37
 surfaceWeight
 Apply
 false
@@ -248,7 +248,7 @@ covtest.EnumTypes$
 calculateEarthWeightOnPlanets
 1109
 1142
-33
+34
 calculateEarthWeightOnPlanets
 DefDef
 false
@@ -265,7 +265,7 @@ covtest.EnumTypes$
 test
 1326
 1347
-38
+39
 println
 Apply
 false
@@ -282,7 +282,7 @@ covtest.EnumTypes$
 test
 1352
 1385
-39
+40
 calculateEarthWeightOnPlanets
 Apply
 false
@@ -299,7 +299,7 @@ covtest.EnumTypes$
 test
 901
 909
-27
+28
 test
 DefDef
 false

--- a/tests/coverage/pos/Escaping.scoverage.check
+++ b/tests/coverage/pos/Escaping.scoverage.check
@@ -27,7 +27,7 @@ covtest.\n.\r\n\f
 \r\n\f
 69
 80
-3
+4
 length
 Apply
 false
@@ -44,7 +44,7 @@ covtest.\n.\r\n\f
 \r\n\f
 40
 48
-3
+4
 \r\n\f
 DefDef
 false

--- a/tests/coverage/pos/For.scoverage.check
+++ b/tests/coverage/pos/For.scoverage.check
@@ -27,7 +27,7 @@ covtest.For$package$
 testForLoop
 43
 77
-3
+4
 foreach
 Apply
 false
@@ -44,7 +44,7 @@ covtest.For$package$
 testForLoop
 52
 59
-3
+4
 to
 Apply
 false
@@ -61,7 +61,7 @@ covtest.For$package$
 testForLoop
 52
 53
-3
+4
 intWrapper
 Apply
 false
@@ -78,7 +78,7 @@ covtest.For$package$
 $anonfun
 67
 77
-4
+5
 println
 Apply
 false
@@ -95,7 +95,7 @@ covtest.For$package$
 testForLoop
 17
 32
-2
+3
 testForLoop
 DefDef
 false
@@ -112,7 +112,7 @@ covtest.For$package$
 f
 109
 114
-7
+8
 f
 DefDef
 false
@@ -129,7 +129,7 @@ covtest.For$package$
 testForAdvanced
 141
 183
-8
+9
 foreach
 Apply
 false
@@ -146,7 +146,7 @@ covtest.For$package$
 testForAdvanced
 145
 165
-8
+9
 withFilter
 Apply
 false
@@ -163,7 +163,7 @@ covtest.For$package$
 testForAdvanced
 150
 157
-8
+9
 to
 Apply
 false
@@ -180,7 +180,7 @@ covtest.For$package$
 testForAdvanced
 150
 151
-8
+9
 intWrapper
 Apply
 false
@@ -197,7 +197,7 @@ covtest.For$package$
 $anonfun
 161
 165
-8
+9
 f
 Apply
 false
@@ -214,7 +214,7 @@ covtest.For$package$
 $anonfun
 173
 183
-9
+10
 println
 Apply
 false
@@ -231,7 +231,7 @@ covtest.For$package$
 testForAdvanced
 79
 98
-6
+7
 testForAdvanced
 DefDef
 false
@@ -248,7 +248,7 @@ covtest.For$package$
 testForeach
 301
 344
-13
+14
 foreach
 Apply
 false
@@ -265,7 +265,7 @@ covtest.For$package$
 $anonfun
 318
 343
-13
+14
 println
 Apply
 false
@@ -282,7 +282,7 @@ covtest.For$package$
 testForeach
 185
 200
-11
+12
 testForeach
 DefDef
 false

--- a/tests/coverage/pos/Givens.scoverage.check
+++ b/tests/coverage/pos/Givens.scoverage.check
@@ -27,7 +27,7 @@ covtest.Givens
 test
 174
 191
-10
+11
 println
 Apply
 false
@@ -44,7 +44,7 @@ covtest.Givens
 test
 196
 213
-11
+12
 println
 Apply
 false
@@ -61,7 +61,7 @@ covtest.Givens
 test
 100
 108
-8
+9
 test
 DefDef
 false
@@ -78,7 +78,7 @@ covtest.Givens
 printContext
 279
 291
-14
+15
 println
 Apply
 false
@@ -95,7 +95,7 @@ covtest.Givens
 printContext
 296
 311
-15
+16
 println
 Apply
 false
@@ -112,7 +112,7 @@ covtest.Givens
 printContext
 217
 233
-13
+14
 printContext
 DefDef
 false
@@ -129,7 +129,7 @@ covtest.Givens
 getMessage
 315
 329
-17
+18
 getMessage
 DefDef
 false
@@ -146,7 +146,7 @@ covtest.Givens
 test2
 399
 409
-20
+21
 <init>
 Apply
 false
@@ -163,7 +163,7 @@ covtest.Givens
 test2
 414
 443
-21
+22
 printContext
 Apply
 false
@@ -180,7 +180,7 @@ covtest.Givens
 test2
 448
 477
-22
+23
 printContext
 Apply
 false
@@ -197,7 +197,7 @@ covtest.Givens
 test2
 461
 476
-22
+23
 getMessage
 Apply
 false
@@ -214,7 +214,7 @@ covtest.Givens
 test2
 362
 371
-19
+20
 test2
 DefDef
 false

--- a/tests/coverage/pos/Inlined.scoverage.check
+++ b/tests/coverage/pos/Inlined.scoverage.check
@@ -27,7 +27,7 @@ covtest.Inlined$package$
 testInlined
 288
 330
-10
+11
 assertFailed
 Apply
 false
@@ -44,7 +44,7 @@ covtest.Inlined$package$
 testInlined
 288
 330
-10
+11
 assertFailed
 Apply
 true
@@ -61,7 +61,7 @@ covtest.Inlined$package$
 testInlined
 330
 330
-10
+11
 <none>
 Literal
 true
@@ -78,7 +78,7 @@ covtest.Inlined$package$
 testInlined
 155
 162
-6
+7
 apply
 Apply
 false
@@ -95,7 +95,7 @@ covtest.Inlined$package$
 testInlined
 155
 169
-6
+7
 length
 Select
 false
@@ -112,7 +112,7 @@ covtest.Inlined$package$
 testInlined
 288
 330
-10
+11
 assertFailed
 Apply
 false
@@ -129,7 +129,7 @@ covtest.Inlined$package$
 testInlined
 288
 330
-10
+11
 assertFailed
 Apply
 true
@@ -146,7 +146,7 @@ covtest.Inlined$package$
 testInlined
 330
 330
-10
+11
 <none>
 Literal
 true
@@ -163,7 +163,7 @@ covtest.Inlined$package$
 testInlined
 180
 187
-7
+8
 apply
 Apply
 false
@@ -180,7 +180,7 @@ covtest.Inlined$package$
 testInlined
 180
 194
-7
+8
 length
 Select
 false
@@ -197,7 +197,7 @@ covtest.Inlined$package$
 testInlined
 288
 330
-10
+11
 assertFailed
 Apply
 false
@@ -214,7 +214,7 @@ covtest.Inlined$package$
 testInlined
 288
 330
-10
+11
 assertFailed
 Apply
 true
@@ -231,7 +231,7 @@ covtest.Inlined$package$
 testInlined
 330
 330
-10
+11
 <none>
 Literal
 true
@@ -248,7 +248,7 @@ covtest.Inlined$package$
 testInlined
 86
 101
-3
+4
 testInlined
 DefDef
 false

--- a/tests/coverage/pos/InlinedFromLib.scoverage.check
+++ b/tests/coverage/pos/InlinedFromLib.scoverage.check
@@ -27,7 +27,7 @@ covtest.InlinedFromLib$package$
 testInlined
 169
 183
-6
+7
 assertFailed
 Apply
 false
@@ -44,7 +44,7 @@ covtest.InlinedFromLib$package$
 testInlined
 169
 183
-6
+7
 assertFailed
 Apply
 true
@@ -61,7 +61,7 @@ covtest.InlinedFromLib$package$
 testInlined
 169
 183
-6
+7
 <none>
 Literal
 true
@@ -78,7 +78,7 @@ covtest.InlinedFromLib$package$
 testInlined
 198
 205
-7
+8
 apply
 Apply
 false
@@ -95,7 +95,7 @@ covtest.InlinedFromLib$package$
 testInlined
 198
 212
-7
+8
 length
 Select
 false
@@ -112,7 +112,7 @@ covtest.InlinedFromLib$package$
 testInlined
 186
 213
-7
+8
 assertFailed
 Apply
 false
@@ -129,7 +129,7 @@ covtest.InlinedFromLib$package$
 testInlined
 186
 213
-7
+8
 assertFailed
 Apply
 true
@@ -146,7 +146,7 @@ covtest.InlinedFromLib$package$
 testInlined
 186
 213
-7
+8
 <none>
 Literal
 true
@@ -163,7 +163,7 @@ covtest.InlinedFromLib$package$
 testInlined
 223
 230
-8
+9
 apply
 Apply
 false
@@ -180,7 +180,7 @@ covtest.InlinedFromLib$package$
 testInlined
 223
 237
-8
+9
 length
 Select
 false
@@ -197,7 +197,7 @@ covtest.InlinedFromLib$package$
 testInlined
 216
 243
-8
+9
 assertFailed
 Apply
 false
@@ -214,7 +214,7 @@ covtest.InlinedFromLib$package$
 testInlined
 216
 243
-8
+9
 assertFailed
 Apply
 true
@@ -231,7 +231,7 @@ covtest.InlinedFromLib$package$
 testInlined
 216
 243
-8
+9
 <none>
 Literal
 true
@@ -248,7 +248,7 @@ covtest.InlinedFromLib$package$
 testInlined
 129
 144
-4
+5
 testInlined
 DefDef
 false

--- a/tests/coverage/pos/Lift.scoverage.check
+++ b/tests/coverage/pos/Lift.scoverage.check
@@ -27,7 +27,7 @@ covtest.SomeFunctions
 f
 40
 45
-3
+4
 f
 DefDef
 false
@@ -44,7 +44,7 @@ covtest.SomeFunctions
 g
 61
 66
-4
+5
 g
 DefDef
 false
@@ -61,7 +61,7 @@ covtest.SomeFunctions
 c
 83
 98
-5
+6
 <init>
 Apply
 false
@@ -78,7 +78,7 @@ covtest.SomeFunctions
 c
 75
 80
-5
+6
 c
 DefDef
 false
@@ -95,7 +95,7 @@ covtest.SomeFunctions
 test
 113
 121
-7
+8
 f
 Apply
 false
@@ -112,7 +112,7 @@ covtest.SomeFunctions
 test
 113
 114
-7
+8
 c
 Select
 false
@@ -129,7 +129,7 @@ covtest.SomeFunctions
 test
 117
 120
-7
+8
 g
 Apply
 false
@@ -146,7 +146,7 @@ covtest.SomeFunctions
 test
 102
 110
-7
+8
 test
 DefDef
 false

--- a/tests/coverage/pos/Literals.scoverage.check
+++ b/tests/coverage/pos/Literals.scoverage.check
@@ -27,7 +27,7 @@ covtest.Literals$package$
 block
 31
 50
-3
+4
 println
 Apply
 false
@@ -44,7 +44,7 @@ covtest.Literals$package$
 block
 17
 26
-2
+3
 block
 DefDef
 false
@@ -61,7 +61,7 @@ covtest.Literals$package$
 f
 177
 180
-8
+9
 ???
 Ident
 false
@@ -78,7 +78,7 @@ covtest.Literals$package$
 f
 137
 142
-8
+9
 f
 DefDef
 false
@@ -95,7 +95,7 @@ covtest.Literals$package$
 main
 201
 212
-11
+12
 f
 Apply
 false
@@ -112,7 +112,7 @@ covtest.Literals$package$
 main
 182
 190
-10
+11
 main
 DefDef
 false

--- a/tests/coverage/pos/MatchCaseClasses.scoverage.check
+++ b/tests/coverage/pos/MatchCaseClasses.scoverage.check
@@ -27,7 +27,7 @@ covtest.MatchCaseClasses$
 f
 151
 163
-7
+8
 println
 Apply
 false
@@ -44,7 +44,7 @@ covtest.MatchCaseClasses$
 f
 148
 163
-7
+8
 <none>
 Block
 true
@@ -61,7 +61,7 @@ covtest.MatchCaseClasses$
 f
 184
 196
-8
+9
 println
 Apply
 false
@@ -78,7 +78,7 @@ covtest.MatchCaseClasses$
 f
 181
 196
-8
+9
 <none>
 Block
 true
@@ -95,7 +95,7 @@ covtest.MatchCaseClasses$
 f
 225
 237
-9
+10
 println
 Apply
 false
@@ -112,7 +112,7 @@ covtest.MatchCaseClasses$
 f
 222
 237
-9
+10
 <none>
 Block
 true
@@ -129,7 +129,7 @@ covtest.MatchCaseClasses$
 f
 275
 285
-11
+12
 println
 Apply
 false
@@ -146,7 +146,7 @@ covtest.MatchCaseClasses$
 f
 292
 304
-12
+13
 println
 Apply
 false
@@ -163,7 +163,7 @@ covtest.MatchCaseClasses$
 f
 275
 304
-11
+12
 <none>
 Block
 true
@@ -180,7 +180,7 @@ covtest.MatchCaseClasses$
 f
 325
 337
-13
+14
 println
 Apply
 false
@@ -197,7 +197,7 @@ covtest.MatchCaseClasses$
 f
 322
 337
-13
+14
 <none>
 Block
 true
@@ -214,7 +214,7 @@ covtest.MatchCaseClasses$
 f
 352
 368
-14
+15
 println
 Apply
 false
@@ -231,7 +231,7 @@ covtest.MatchCaseClasses$
 f
 349
 368
-14
+15
 <none>
 Block
 true
@@ -248,7 +248,7 @@ covtest.MatchCaseClasses$
 f
 101
 106
-6
+7
 f
 DefDef
 false

--- a/tests/coverage/pos/MatchNumbers.scoverage.check
+++ b/tests/coverage/pos/MatchNumbers.scoverage.check
@@ -27,7 +27,7 @@ covtest.MatchNumbers$
 f
 127
 132
-6
+7
 <none>
 Block
 true
@@ -44,7 +44,7 @@ covtest.MatchNumbers$
 f
 149
 153
-7
+8
 <none>
 Block
 true
@@ -61,7 +61,7 @@ covtest.MatchNumbers$
 f
 171
 181
-8
+9
 <none>
 Block
 true
@@ -78,7 +78,7 @@ covtest.MatchNumbers$
 f
 69
 74
-5
+6
 f
 DefDef
 false
@@ -95,7 +95,7 @@ covtest.MatchNumbers$
 <init>
 185
 189
-10
+11
 f
 Apply
 false
@@ -112,7 +112,7 @@ covtest.MatchNumbers$
 <init>
 192
 197
-11
+12
 f
 Apply
 false

--- a/tests/coverage/pos/PolymorphicExtensions.scoverage.check
+++ b/tests/coverage/pos/PolymorphicExtensions.scoverage.check
@@ -27,7 +27,7 @@ covtest.PolyExt$
 foo
 61
 68
-4
+5
 foo
 DefDef
 false
@@ -44,7 +44,7 @@ covtest.PolyExt$
 get
 114
 121
-7
+8
 get
 DefDef
 false
@@ -61,7 +61,7 @@ covtest.PolyExt$
 tap
 170
 173
-8
+9
 ???
 Ident
 false
@@ -78,7 +78,7 @@ covtest.PolyExt$
 tap
 139
 146
-8
+9
 tap
 DefDef
 false
@@ -95,7 +95,7 @@ covtest.PolyExt$
 <init>
 177
 189
-10
+11
 foo
 Apply
 false
@@ -112,7 +112,7 @@ covtest.PolyExt$
 <init>
 177
 186
-10
+11
 foo
 Apply
 false
@@ -129,7 +129,7 @@ covtest.PolyExt$
 <init>
 277
 287
-11
+12
 get
 Apply
 false
@@ -146,7 +146,7 @@ covtest.PolyExt$
 foo
 370
 377
-13
+14
 foo
 DefDef
 false
@@ -163,7 +163,7 @@ covtest.PolyExt$
 bar
 405
 421
-14
+15
 tap
 Apply
 false
@@ -180,7 +180,7 @@ covtest.PolyExt$
 bar
 405
 412
-14
+15
 tap
 Apply
 false
@@ -197,7 +197,7 @@ covtest.PolyExt$
 bar
 405
 408
-14
+15
 foo
 Ident
 false
@@ -214,7 +214,7 @@ covtest.PolyExt$
 $anonfun
 413
 420
-14
+15
 println
 Apply
 false
@@ -231,7 +231,7 @@ covtest.PolyExt$
 bar
 390
 397
-14
+15
 bar
 DefDef
 false

--- a/tests/coverage/pos/PolymorphicMethods.scoverage.check
+++ b/tests/coverage/pos/PolymorphicMethods.scoverage.check
@@ -27,7 +27,7 @@ covtest.PolyMeth$
 f
 36
 41
-3
+4
 f
 DefDef
 false
@@ -44,7 +44,7 @@ covtest.PolyMeth$
 <init>
 60
 69
-4
+5
 f
 Apply
 false
@@ -61,7 +61,7 @@ covtest.PolyMeth$
 <init>
 147
 170
-6
+7
 f
 Apply
 false
@@ -78,7 +78,7 @@ covtest.PolyMeth$
 <init>
 147
 158
-6
+7
 <init>
 Apply
 false
@@ -95,7 +95,7 @@ covtest.C
 f
 187
 192
-9
+10
 f
 DefDef
 false

--- a/tests/coverage/pos/Select.scoverage.check
+++ b/tests/coverage/pos/Select.scoverage.check
@@ -27,7 +27,7 @@ covtest.A
 print
 82
 94
-6
+7
 println
 Apply
 false
@@ -44,7 +44,7 @@ covtest.A
 print
 68
 77
-6
+7
 print
 DefDef
 false
@@ -61,7 +61,7 @@ covtest.A
 instance
 97
 109
-7
+8
 instance
 DefDef
 false
@@ -78,7 +78,7 @@ covtest.B
 print
 166
 179
-11
+12
 print
 Apply
 false
@@ -95,7 +95,7 @@ covtest.B
 print
 184
 206
-12
+13
 println
 Apply
 false
@@ -112,7 +112,7 @@ covtest.B
 print
 192
 205
-12
+13
 instance
 Select
 false
@@ -129,7 +129,7 @@ covtest.B
 print
 139
 157
-10
+11
 print
 DefDef
 false
@@ -146,7 +146,7 @@ covtest.Select$package$
 test
 237
 240
-15
+16
 <init>
 Apply
 false
@@ -163,7 +163,7 @@ covtest.Select$package$
 test
 254
 259
-16
+17
 <init>
 Apply
 false
@@ -180,7 +180,7 @@ covtest.Select$package$
 test
 263
 281
-18
+19
 print
 Apply
 false
@@ -197,7 +197,7 @@ covtest.Select$package$
 test
 263
 273
-18
+19
 instance
 Select
 false
@@ -214,7 +214,7 @@ covtest.Select$package$
 test
 345
 354
-19
+20
 print
 Apply
 false
@@ -231,7 +231,7 @@ covtest.Select$package$
 test
 208
 216
-14
+15
 test
 DefDef
 false

--- a/tests/coverage/pos/SimpleMethods.scoverage.check
+++ b/tests/coverage/pos/SimpleMethods.scoverage.check
@@ -27,7 +27,7 @@ covtest.C
 a
 28
 33
-3
+4
 a
 DefDef
 false
@@ -44,7 +44,7 @@ covtest.C
 b
 46
 51
-4
+5
 b
 DefDef
 false
@@ -61,7 +61,7 @@ covtest.C
 c
 69
 74
-5
+6
 c
 DefDef
 false
@@ -78,7 +78,7 @@ covtest.C
 d
 88
 93
-6
+7
 d
 DefDef
 false
@@ -95,7 +95,7 @@ covtest.C
 e
 106
 111
-7
+8
 e
 DefDef
 false
@@ -112,7 +112,7 @@ covtest.C
 block
 128
 137
-9
+10
 block
 DefDef
 false
@@ -129,7 +129,7 @@ covtest.C
 cond
 206
 210
-14
+15
 <none>
 Literal
 true
@@ -146,7 +146,7 @@ covtest.C
 cond
 220
 225
-15
+16
 <none>
 Literal
 true
@@ -163,7 +163,7 @@ covtest.C
 cond
 168
 176
-13
+14
 cond
 DefDef
 false
@@ -180,7 +180,7 @@ covtest.C
 partialCond
 271
 273
-18
+19
 <none>
 Literal
 true
@@ -197,7 +197,7 @@ covtest.C
 partialCond
 273
 273
-18
+19
 <none>
 Literal
 true
@@ -214,7 +214,7 @@ covtest.C
 partialCond
 229
 244
-17
+18
 partialCond
 DefDef
 false
@@ -231,7 +231,7 @@ covtest.C
 new1
 277
 285
-20
+21
 new1
 DefDef
 false
@@ -248,7 +248,7 @@ covtest.C
 tryCatch
 330
 332
-23
+24
 <none>
 Literal
 true
@@ -265,7 +265,7 @@ covtest.C
 tryCatch
 367
 371
-25
+26
 <none>
 Block
 true
@@ -282,7 +282,7 @@ covtest.C
 tryCatch
 301
 313
-22
+23
 tryCatch
 DefDef
 false

--- a/tests/coverage/pos/StructuralTypes.scoverage.check
+++ b/tests/coverage/pos/StructuralTypes.scoverage.check
@@ -27,7 +27,7 @@ covtest.Record
 selectDynamic
 148
 172
-5
+6
 find
 Apply
 false
@@ -44,7 +44,7 @@ covtest.Record
 selectDynamic
 148
 176
-5
+6
 get
 Select
 false
@@ -61,7 +61,7 @@ covtest.Record
 selectDynamic
 109
 126
-5
+6
 selectDynamic
 DefDef
 false
@@ -78,7 +78,7 @@ covtest.StructuralTypes$
 test
 277
 293
-12
+13
 ->
 Apply
 false
@@ -95,7 +95,7 @@ covtest.StructuralTypes$
 test
 295
 306
-12
+13
 ->
 Apply
 false
@@ -112,7 +112,7 @@ covtest.StructuralTypes$
 test
 333
 344
-13
+14
 selectDynamic
 Apply
 false
@@ -129,7 +129,7 @@ covtest.StructuralTypes$
 test
 234
 242
-11
+12
 test
 DefDef
 false

--- a/tests/coverage/pos/TypeLambdas.scoverage.check
+++ b/tests/coverage/pos/TypeLambdas.scoverage.check
@@ -27,7 +27,7 @@ covtest.TypeLambdas$
 test
 306
 319
-13
+14
 apply
 Apply
 false
@@ -44,7 +44,7 @@ covtest.TypeLambdas$
 test
 310
 318
-13
+14
 ->
 Apply
 false
@@ -61,7 +61,7 @@ covtest.TypeLambdas$
 test
 324
 334
-14
+15
 println
 Apply
 false
@@ -78,7 +78,7 @@ covtest.TypeLambdas$
 test
 382
 396
-17
+18
 println
 Apply
 false
@@ -95,7 +95,7 @@ covtest.TypeLambdas$
 test
 259
 267
-12
+13
 test
 DefDef
 false

--- a/tests/coverage/pos/i16502.scoverage.check
+++ b/tests/coverage/pos/i16502.scoverage.check
@@ -27,7 +27,7 @@ Object
 $anonfun
 76
 85
-2
+3
 apply
 Apply
 false
@@ -44,7 +44,7 @@ Object
 asyncSum
 27
 39
-2
+3
 asyncSum
 DefDef
 false
@@ -61,7 +61,7 @@ Object
 Test
 174
 182
-7
+8
 apply
 Apply
 false
@@ -78,7 +78,7 @@ Object
 Test
 87
 101
-5
+6
 Test
 DefDef
 false

--- a/tests/coverage/pos/scoverage-samples-case.scoverage.check
+++ b/tests/coverage/pos/scoverage-samples-case.scoverage.check
@@ -27,7 +27,7 @@ org.scoverage.samples.PriceEngine
 $anonfun
 362
 368
-17
+18
 stop
 Apply
 false
@@ -44,7 +44,7 @@ org.scoverage.samples.PriceEngine
 $anonfun
 353
 368
-16
+17
 <none>
 Block
 true
@@ -61,7 +61,7 @@ org.scoverage.samples.PriceEngine
 $anonfun
 400
 406
-20
+21
 stop
 Apply
 false
@@ -78,7 +78,7 @@ org.scoverage.samples.PriceEngine
 $anonfun
 391
 406
-19
+20
 <none>
 Block
 true
@@ -95,7 +95,7 @@ org.scoverage.samples.PriceEngine
 receive
 302
 313
-15
+16
 receive
 DefDef
 false
@@ -112,7 +112,7 @@ org.scoverage.samples.PriceEngine
 stop
 470
 485
-25
+26
 println
 Apply
 false
@@ -129,7 +129,7 @@ org.scoverage.samples.PriceEngine
 stop
 470
 485
-25
+26
 println
 Apply
 true
@@ -146,7 +146,7 @@ org.scoverage.samples.PriceEngine
 stop
 485
 485
-25
+26
 <none>
 Literal
 true
@@ -163,7 +163,7 @@ org.scoverage.samples.PriceEngine
 stop
 414
 422
-23
+24
 stop
 DefDef
 false

--- a/tests/coverage/pos/scoverage-samples-implicit-class.scoverage.check
+++ b/tests/coverage/pos/scoverage-samples-implicit-class.scoverage.check
@@ -27,7 +27,7 @@ org.scoverage.samples.CreditEngine
 $anonfun
 263
 276
-10
+11
 !
 Apply
 false
@@ -44,7 +44,7 @@ org.scoverage.samples.CreditEngine
 $anonfun
 263
 269
-10
+11
 StringOpssssss
 Apply
 false
@@ -61,7 +61,7 @@ org.scoverage.samples.CreditEngine
 $anonfun
 263
 276
-10
+11
 !
 Apply
 true
@@ -78,7 +78,7 @@ org.scoverage.samples.CreditEngine
 $anonfun
 286
 303
-11
+12
 println
 Apply
 false
@@ -95,7 +95,7 @@ org.scoverage.samples.CreditEngine
 $anonfun
 286
 303
-11
+12
 println
 Apply
 true
@@ -112,7 +112,7 @@ org.scoverage.samples.CreditEngine
 receive
 201
 212
-8
+9
 receive
 DefDef
 false
@@ -129,7 +129,7 @@ org.scoverage.samples.StringOpssssss
 !
 152
 174
-4
+5
 println
 Apply
 false
@@ -146,7 +146,7 @@ org.scoverage.samples.StringOpssssss
 !
 160
 173
-4
+5
 +
 Apply
 false
@@ -163,7 +163,7 @@ org.scoverage.samples.StringOpssssss
 !
 160
 167
-4
+5
 +
 Apply
 false
@@ -180,7 +180,7 @@ org.scoverage.samples.StringOpssssss
 !
 124
 129
-4
+5
 !
 DefDef
 false
@@ -197,7 +197,7 @@ org.scoverage.samples.scoverage-samples-implicit-class$package$
 StringOpssssss
 79
 108
-3
+4
 StringOpssssss
 DefDef
 false

--- a/tests/coverage/run/currying/test.scoverage.check
+++ b/tests/coverage/run/currying/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 f1
 15
 21
-1
+2
 f1
 DefDef
 false
@@ -44,7 +44,7 @@ Object
 f2
 56
 62
-2
+3
 f2
 DefDef
 false
@@ -61,7 +61,7 @@ Object
 g1
 114
 120
-5
+6
 g1
 DefDef
 false
@@ -78,7 +78,7 @@ Object
 g2
 175
 181
-8
+9
 g2
 DefDef
 false
@@ -95,7 +95,7 @@ Object
 main
 277
 297
-11
+12
 println
 Apply
 false
@@ -112,7 +112,7 @@ Object
 main
 285
 296
-11
+12
 f1
 Apply
 false
@@ -129,7 +129,7 @@ Object
 main
 302
 322
-12
+13
 println
 Apply
 false
@@ -146,7 +146,7 @@ Object
 main
 310
 321
-12
+13
 apply
 Apply
 false
@@ -163,7 +163,7 @@ Object
 main
 310
 318
-12
+13
 apply
 Apply
 false
@@ -180,7 +180,7 @@ Object
 main
 310
 315
-12
+13
 apply
 Apply
 false
@@ -197,7 +197,7 @@ Object
 main
 310
 312
-12
+13
 f2
 Ident
 false
@@ -214,7 +214,7 @@ Object
 main
 327
 365
-13
+14
 println
 Apply
 false
@@ -231,7 +231,7 @@ Object
 main
 335
 364
-13
+14
 apply
 Apply
 false
@@ -248,7 +248,7 @@ Object
 main
 370
 408
-14
+15
 println
 Apply
 false
@@ -265,7 +265,7 @@ Object
 main
 378
 407
-14
+15
 g2
 Apply
 false
@@ -282,7 +282,7 @@ Object
 main
 235
 243
-10
+11
 main
 DefDef
 false

--- a/tests/coverage/run/erased/test.scoverage.check
+++ b/tests/coverage/run/erased/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 foo
 181
 203
-6
+7
 println
 Apply
 false
@@ -44,7 +44,7 @@ Object
 foo
 189
 202
-6
+7
 s
 Apply
 false
@@ -61,7 +61,7 @@ Object
 foo
 132
 139
-5
+6
 foo
 DefDef
 false
@@ -78,7 +78,7 @@ Object
 identity
 245
 269
-10
+11
 println
 Apply
 false
@@ -95,7 +95,7 @@ Object
 identity
 253
 268
-10
+11
 s
 Apply
 false
@@ -112,7 +112,7 @@ Object
 identity
 209
 221
-9
+10
 identity
 DefDef
 false
@@ -129,7 +129,7 @@ Object
 Test
 300
 323
-15
+16
 foo
 Apply
 false
@@ -146,7 +146,7 @@ Object
 Test
 326
 342
-16
+17
 foo
 Apply
 false
@@ -163,7 +163,7 @@ Object
 Test
 345
 374
-17
+18
 foo
 Apply
 false
@@ -180,7 +180,7 @@ Object
 Test
 357
 373
-17
+18
 identity
 Apply
 false
@@ -197,7 +197,7 @@ Object
 Test
 275
 289
-14
+15
 Test
 DefDef
 false

--- a/tests/coverage/run/extend-case-class/test.scoverage.check
+++ b/tests/coverage/run/extend-case-class/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 Test
 282
 303
-8
+9
 println
 Apply
 false
@@ -44,7 +44,7 @@ Object
 Test
 306
 337
-9
+10
 println
 Apply
 false
@@ -61,7 +61,7 @@ Object
 Test
 206
 220
-6
+7
 Test
 DefDef
 false

--- a/tests/coverage/run/i16940/i16940.scoverage.check
+++ b/tests/coverage/run/i16940/i16940.scoverage.check
@@ -27,7 +27,7 @@ Object
 <init>
 353
 552
-18
+19
 result
 Apply
 false
@@ -44,7 +44,7 @@ Object
 <init>
 371
 533
-19
+20
 map
 Apply
 false
@@ -61,7 +61,7 @@ Object
 <init>
 371
 454
-19
+20
 sequence
 Apply
 false
@@ -78,7 +78,7 @@ Object
 <init>
 387
 453
-19
+20
 apply
 Apply
 false
@@ -95,7 +95,7 @@ Object
 <init>
 391
 421
-19
+20
 brokenSynchronizedBlock
 Apply
 false
@@ -112,7 +112,7 @@ Object
 <init>
 423
 452
-19
+20
 brokenSynchronizedBlock
 Apply
 false
@@ -129,7 +129,7 @@ Object
 $anonfun
 486
 499
-21
+22
 println
 Apply
 false
@@ -146,7 +146,7 @@ Object
 $anonfun
 508
 525
-22
+23
 assertFailed
 Apply
 false
@@ -163,7 +163,7 @@ Object
 $anonfun
 508
 525
-22
+23
 assertFailed
 Apply
 true
@@ -180,7 +180,7 @@ Object
 $anonfun
 508
 525
-22
+23
 <none>
 Literal
 true
@@ -197,7 +197,7 @@ Object
 <init>
 539
 548
-24
+25
 seconds
 Select
 false
@@ -214,7 +214,7 @@ Object
 brokenSynchronizedBlock
 189
 323
-6
+7
 apply
 Apply
 false
@@ -231,7 +231,7 @@ Object
 brokenSynchronizedBlock
 218
 235
-8
+9
 sleep
 Apply
 false
@@ -248,7 +248,7 @@ Object
 brokenSynchronizedBlock
 212
 239
-7
+8
 <none>
 Block
 true
@@ -265,7 +265,7 @@ Object
 brokenSynchronizedBlock
 239
 239
-9
+10
 <none>
 Literal
 true
@@ -282,7 +282,7 @@ Object
 brokenSynchronizedBlock
 242
 321
-10
+11
 synchronized
 Apply
 false
@@ -299,7 +299,7 @@ Object
 brokenSynchronizedBlock
 280
 298
-12
+13
 sleep
 Apply
 false
@@ -316,7 +316,7 @@ Object
 brokenSynchronizedBlock
 128
 155
-6
+7
 brokenSynchronizedBlock
 DefDef
 false

--- a/tests/coverage/run/i18233-min/i18233-min.scoverage.check
+++ b/tests/coverage/run/i18233-min/i18233-min.scoverage.check
@@ -27,7 +27,7 @@ Object
 <init>
 131
 145
-10
+11
 println
 Apply
 false
@@ -44,7 +44,7 @@ Object
 <init>
 139
 144
-10
+11
 aList
 Ident
 false
@@ -61,7 +61,7 @@ Object
 <init>
 148
 168
-11
+12
 println
 Apply
 false
@@ -78,7 +78,7 @@ Object
 <init>
 156
 167
-11
+12
 anotherList
 Ident
 false
@@ -95,7 +95,7 @@ Object
 aList
 14
 36
-1
+2
 apply
 Apply
 false
@@ -112,7 +112,7 @@ Object
 aList
 19
 34
-1
+2
 apply
 Apply
 false
@@ -129,7 +129,7 @@ Object
 aList
 0
 9
-0
+1
 aList
 DefDef
 false
@@ -146,7 +146,7 @@ Object
 arr
 50
 69
-4
+5
 apply
 Apply
 false
@@ -163,7 +163,7 @@ Object
 arr
 38
 45
-3
+4
 arr
 DefDef
 false
@@ -180,7 +180,7 @@ Object
 anotherList
 91
 101
-7
+8
 apply
 Apply
 false
@@ -197,7 +197,7 @@ Object
 anotherList
 96
 99
-7
+8
 arr
 Ident
 false
@@ -214,7 +214,7 @@ Object
 anotherList
 71
 86
-6
+7
 anotherList
 DefDef
 false

--- a/tests/coverage/run/i18233/i18233.scoverage.check
+++ b/tests/coverage/run/i18233/i18233.scoverage.check
@@ -27,7 +27,7 @@ Object
 render
 54
 72
-4
+5
 apply
 Apply
 false
@@ -44,7 +44,7 @@ Object
 render
 59
 65
-4
+5
 refArrayOps
 Apply
 false
@@ -61,7 +61,7 @@ Object
 render
 59
 70
-4
+5
 tail
 Select
 false
@@ -78,7 +78,7 @@ Object
 render
 54
 81
-4
+5
 mkString
 Select
 false
@@ -95,7 +95,7 @@ Object
 render
 41
 51
-4
+5
 render
 DefDef
 false
@@ -112,7 +112,7 @@ Object
 <init>
 111
 130
-7
+8
 println
 Apply
 false
@@ -129,7 +129,7 @@ Object
 <init>
 119
 129
-7
+8
 render
 Select
 false

--- a/tests/coverage/run/inheritance/test.scoverage.check
+++ b/tests/coverage/run/inheritance/test.scoverage.check
@@ -27,7 +27,7 @@ Class
 <init>
 84
 100
-2
+3
 println
 Apply
 false
@@ -44,7 +44,7 @@ Class
 <init>
 125
 131
-3
+4
 <init>
 Apply
 false
@@ -61,7 +61,7 @@ Object
 Test
 161
 176
-7
+8
 println
 Apply
 false
@@ -78,7 +78,7 @@ Object
 Test
 169
 173
-7
+8
 <init>
 Apply
 false
@@ -95,7 +95,7 @@ Object
 Test
 211
 226
-9
+10
 println
 Apply
 false
@@ -112,7 +112,7 @@ Object
 Test
 219
 223
-9
+10
 <init>
 Apply
 false
@@ -129,7 +129,7 @@ Object
 Test
 136
 150
-6
+7
 Test
 DefDef
 false

--- a/tests/coverage/run/inline-def/test.scoverage.check
+++ b/tests/coverage/run/inline-def/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 Test
 225
 228
-12
+13
 <init>
 Apply
 false
@@ -44,7 +44,7 @@ Object
 Test
 231
 243
-13
+14
 println
 Apply
 false
@@ -61,7 +61,7 @@ Object
 Test
 246
 260
-14
+15
 println
 Apply
 false
@@ -78,7 +78,7 @@ Object
 Test
 134
 148
-7
+8
 toString
 Apply
 false
@@ -95,7 +95,7 @@ Object
 Test
 263
 277
-15
+16
 println
 Apply
 false
@@ -112,7 +112,7 @@ Object
 Test
 176
 190
-8
+9
 toString
 Apply
 false
@@ -129,7 +129,7 @@ Object
 Test
 295
 309
-17
+18
 println
 Apply
 false
@@ -146,7 +146,7 @@ Object
 Test
 303
 308
-17
+18
 foo
 Select
 false
@@ -163,7 +163,7 @@ Object
 Test
 192
 206
-11
+12
 Test
 DefDef
 false

--- a/tests/coverage/run/interpolation/test.scoverage.check
+++ b/tests/coverage/run/interpolation/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 simple
 60
 78
-3
+4
 s
 Apply
 false
@@ -44,7 +44,7 @@ Object
 simple
 68
 76
-3
+4
 length
 Apply
 false
@@ -61,7 +61,7 @@ Object
 simple
 16
 26
-2
+3
 simple
 DefDef
 false
@@ -78,7 +78,7 @@ Object
 hexa
 113
 126
-6
+7
 f
 Apply
 false
@@ -95,7 +95,7 @@ Object
 hexa
 82
 90
-5
+6
 hexa
 DefDef
 false
@@ -112,7 +112,7 @@ Object
 main
 195
 224
-9
+10
 apply
 Apply
 false
@@ -129,7 +129,7 @@ Object
 main
 229
 278
-10
+11
 map
 Apply
 false
@@ -146,7 +146,7 @@ Object
 main
 229
 244
-10
+11
 zipWithIndex
 Select
 false
@@ -163,7 +163,7 @@ Object
 $anonfun
 259
 277
-10
+11
 println
 Apply
 false
@@ -180,7 +180,7 @@ Object
 $anonfun
 267
 276
-10
+11
 s
 Apply
 false
@@ -197,7 +197,7 @@ Object
 main
 284
 309
-12
+13
 println
 Apply
 false
@@ -214,7 +214,7 @@ Object
 main
 292
 308
-12
+13
 simple
 Apply
 false
@@ -231,7 +231,7 @@ Object
 main
 314
 332
-13
+14
 println
 Apply
 false
@@ -248,7 +248,7 @@ Object
 main
 322
 331
-13
+14
 hexa
 Apply
 false
@@ -265,7 +265,7 @@ Object
 main
 337
 355
-14
+15
 println
 Apply
 false
@@ -282,7 +282,7 @@ Object
 main
 345
 354
-14
+15
 raw
 Apply
 false
@@ -299,7 +299,7 @@ Object
 main
 130
 138
-8
+9
 main
 DefDef
 false

--- a/tests/coverage/run/java-methods/test.scoverage.check
+++ b/tests/coverage/run/java-methods/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 Test
 61
 83
-4
+5
 simple
 Apply
 false
@@ -44,7 +44,7 @@ Object
 Test
 86
 127
-5
+6
 withTypeParam
 Apply
 false
@@ -61,7 +61,7 @@ Object
 Test
 140
 152
-6
+7
 <init>
 Apply
 false
@@ -78,7 +78,7 @@ Object
 Test
 155
 162
-7
+8
 f
 Apply
 false
@@ -95,7 +95,7 @@ Object
 Test
 165
 194
-8
+9
 println
 Apply
 false
@@ -112,7 +112,7 @@ Object
 Test
 173
 193
-8
+9
 identity
 Apply
 false
@@ -129,7 +129,7 @@ Object
 Test
 197
 211
-9
+10
 println
 Apply
 false
@@ -146,7 +146,7 @@ Object
 Test
 36
 50
-3
+4
 Test
 DefDef
 false

--- a/tests/coverage/run/lifting-bool/test.scoverage.check
+++ b/tests/coverage/run/lifting-bool/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 notCalled
 19
 22
-1
+2
 ???
 Ident
 false
@@ -44,7 +44,7 @@ Object
 notCalled
 1
 14
-1
+2
 notCalled
 DefDef
 false
@@ -61,7 +61,7 @@ Object
 f
 24
 29
-3
+4
 f
 DefDef
 false
@@ -78,7 +78,7 @@ Object
 Test
 109
 120
-7
+8
 notCalled
 Apply
 false
@@ -95,7 +95,7 @@ Object
 Test
 159
 170
-8
+9
 notCalled
 Apply
 false
@@ -112,7 +112,7 @@ Object
 Test
 219
 230
-9
+10
 notCalled
 Apply
 false
@@ -129,7 +129,7 @@ Object
 Test
 267
 278
-10
+11
 notCalled
 Apply
 false
@@ -146,7 +146,7 @@ Object
 Test
 318
 329
-11
+12
 notCalled
 Apply
 false
@@ -163,7 +163,7 @@ Object
 Test
 341
 367
-12
+13
 println
 Apply
 false
@@ -180,7 +180,7 @@ Object
 Test
 349
 366
-12
+13
 s
 Apply
 false
@@ -197,7 +197,7 @@ Object
 Test
 379
 393
-14
+15
 f
 Apply
 false
@@ -214,7 +214,7 @@ Object
 Test
 396
 406
-15
+16
 println
 Apply
 false
@@ -231,7 +231,7 @@ Object
 Test
 422
 466
-17
+18
 f
 Apply
 false
@@ -248,7 +248,7 @@ Object
 Test
 432
 443
-17
+18
 notCalled
 Apply
 false
@@ -265,7 +265,7 @@ Object
 Test
 454
 465
-17
+18
 notCalled
 Apply
 false
@@ -282,7 +282,7 @@ Object
 Test
 469
 479
-18
+19
 println
 Apply
 false
@@ -299,7 +299,7 @@ Object
 Test
 68
 82
-6
+7
 Test
 DefDef
 false

--- a/tests/coverage/run/lifting/test.scoverage.check
+++ b/tests/coverage/run/lifting/test.scoverage.check
@@ -27,7 +27,7 @@ Class
 <init>
 22
 29
-1
+2
 apply
 Apply
 false
@@ -44,7 +44,7 @@ Class
 <init>
 41
 57
-2
+3
 ::
 Apply
 false
@@ -61,7 +61,7 @@ Class
 <init>
 46
 57
-2
+3
 apply
 Apply
 false
@@ -78,7 +78,7 @@ Class
 msg
 104
 136
-5
+6
 +
 Apply
 false
@@ -95,7 +95,7 @@ Class
 msg
 104
 132
-5
+6
 +
 Apply
 false
@@ -112,7 +112,7 @@ Class
 msg
 104
 126
-5
+6
 +
 Apply
 false
@@ -129,7 +129,7 @@ Class
 msg
 104
 122
-5
+6
 +
 Apply
 false
@@ -146,7 +146,7 @@ Class
 msg
 104
 116
-5
+6
 +
 Apply
 false
@@ -163,7 +163,7 @@ Class
 msg
 70
 77
-5
+6
 msg
 DefDef
 false
@@ -180,7 +180,7 @@ Class
 integer
 139
 150
-6
+7
 integer
 DefDef
 false
@@ -197,7 +197,7 @@ Class
 ex
 162
 168
-7
+8
 ex
 DefDef
 false
@@ -214,7 +214,7 @@ Object
 Test
 221
 224
-11
+12
 <init>
 Apply
 false
@@ -231,7 +231,7 @@ Object
 f
 241
 246
-13
+14
 f
 DefDef
 false
@@ -248,7 +248,7 @@ Object
 Test
 264
 286
-14
+15
 msg
 Apply
 false
@@ -265,7 +265,7 @@ Object
 Test
 276
 285
-14
+15
 integer
 Select
 false
@@ -282,7 +282,7 @@ Object
 Test
 289
 299
-15
+16
 println
 Apply
 false
@@ -299,7 +299,7 @@ Object
 Test
 306
 334
-16
+17
 msg
 Apply
 false
@@ -316,7 +316,7 @@ Object
 Test
 306
 310
-16
+17
 ex
 Select
 false
@@ -333,7 +333,7 @@ Object
 Test
 321
 325
-16
+17
 ex
 Select
 false
@@ -350,7 +350,7 @@ Object
 Test
 321
 333
-16
+17
 integer
 Select
 false
@@ -367,7 +367,7 @@ Object
 Test
 337
 347
-17
+18
 println
 Apply
 false
@@ -384,7 +384,7 @@ Object
 Test
 354
 370
-18
+19
 msg
 Apply
 false
@@ -401,7 +401,7 @@ Object
 Test
 360
 363
-18
+19
 f
 Apply
 false
@@ -418,7 +418,7 @@ Object
 Test
 373
 383
-19
+20
 println
 Apply
 false
@@ -435,7 +435,7 @@ Object
 Test
 188
 202
-10
+11
 Test
 DefDef
 false

--- a/tests/coverage/run/parameterless/test.scoverage.check
+++ b/tests/coverage/run/parameterless/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 f
 32
 46
-2
+3
 println
 Apply
 false
@@ -44,7 +44,7 @@ Object
 f
 12
 17
-1
+2
 f
 DefDef
 false
@@ -61,7 +61,7 @@ Object
 g
 87
 101
-6
+7
 println
 Apply
 false
@@ -78,7 +78,7 @@ Object
 g
 64
 69
-5
+6
 g
 DefDef
 false
@@ -95,7 +95,7 @@ Object
 f
 162
 174
-12
+13
 println
 Apply
 false
@@ -112,7 +112,7 @@ Object
 f
 142
 147
-11
+12
 f
 DefDef
 false
@@ -129,7 +129,7 @@ Object
 g
 213
 225
-16
+17
 println
 Apply
 false
@@ -146,7 +146,7 @@ Object
 g
 190
 195
-15
+16
 g
 DefDef
 false
@@ -163,7 +163,7 @@ Object
 Test
 249
 250
-19
+20
 f
 Ident
 false
@@ -180,7 +180,7 @@ Object
 Test
 261
 262
-20
+21
 g
 Ident
 false
@@ -197,7 +197,7 @@ Object
 Test
 265
 275
-21
+22
 println
 Apply
 false
@@ -214,7 +214,7 @@ Object
 Test
 273
 274
-21
+22
 f
 Ident
 false
@@ -231,7 +231,7 @@ Object
 Test
 278
 288
-22
+23
 println
 Apply
 false
@@ -248,7 +248,7 @@ Object
 Test
 286
 287
-22
+23
 g
 Ident
 false
@@ -265,7 +265,7 @@ Object
 Test
 291
 303
-23
+24
 println
 Apply
 false
@@ -282,7 +282,7 @@ Object
 Test
 299
 302
-23
+24
 f
 Select
 false
@@ -299,7 +299,7 @@ Object
 Test
 306
 318
-24
+25
 println
 Apply
 false
@@ -316,7 +316,7 @@ Object
 Test
 314
 317
-24
+25
 g
 Select
 false
@@ -333,7 +333,7 @@ Object
 Test
 117
 131
-10
+11
 Test
 DefDef
 false

--- a/tests/coverage/run/trait/test.scoverage.check
+++ b/tests/coverage/run/trait/test.scoverage.check
@@ -27,7 +27,7 @@ Trait
 x
 12
 17
-1
+2
 x
 DefDef
 false
@@ -44,7 +44,7 @@ Class
 <init>
 133
 140
-7
+8
 <init>
 Apply
 false
@@ -61,7 +61,7 @@ Object
 Test
 170
 188
-11
+12
 println
 Apply
 false
@@ -78,7 +78,7 @@ Object
 Test
 178
 185
-11
+12
 <init>
 Apply
 false
@@ -95,7 +95,7 @@ Object
 Test
 178
 187
-11
+12
 x
 Select
 false
@@ -112,7 +112,7 @@ Object
 Test
 196
 214
-12
+13
 println
 Apply
 false
@@ -129,7 +129,7 @@ Object
 Test
 204
 211
-12
+13
 <init>
 Apply
 false
@@ -146,7 +146,7 @@ Object
 Test
 225
 243
-13
+14
 println
 Apply
 false
@@ -163,7 +163,7 @@ Object
 Test
 233
 240
-13
+14
 <init>
 Apply
 false
@@ -180,7 +180,7 @@ Object
 Test
 145
 159
-10
+11
 Test
 DefDef
 false

--- a/tests/coverage/run/type-apply/test.scoverage.check
+++ b/tests/coverage/run/type-apply/test.scoverage.check
@@ -27,7 +27,7 @@ Object
 Test
 163
 201
-4
+5
 println
 Apply
 false
@@ -44,7 +44,7 @@ Object
 Test
 171
 200
-4
+5
 map
 Apply
 false
@@ -61,7 +61,7 @@ Object
 Test
 171
 182
-4
+5
 apply
 Apply
 false
@@ -78,7 +78,7 @@ Object
 $anonfun
 192
 199
-4
+5
 apply
 Apply
 false
@@ -95,7 +95,7 @@ Object
 Test
 0
 14
-1
+2
 Test
 DefDef
 false

--- a/tests/coverage/run/varargs/test_1.scoverage.check
+++ b/tests/coverage/run/varargs/test_1.scoverage.check
@@ -27,7 +27,7 @@ Object
 repeated
 48
 60
-3
+4
 repeated
 DefDef
 false
@@ -44,7 +44,7 @@ Object
 f
 79
 84
-5
+6
 f
 DefDef
 false
@@ -61,7 +61,7 @@ Object
 Test
 120
 130
-9
+10
 repeated
 Apply
 false
@@ -78,7 +78,7 @@ Object
 Test
 133
 153
-10
+11
 repeated
 Apply
 false
@@ -95,7 +95,7 @@ Object
 Test
 142
 147
-10
+11
 f
 Apply
 false
@@ -112,7 +112,7 @@ Object
 Test
 156
 178
-11
+12
 method
 Apply
 false
@@ -129,7 +129,7 @@ Object
 Test
 181
 205
-12
+13
 method
 Apply
 false
@@ -146,7 +146,7 @@ Object
 Test
 217
 248
-14
+15
 multiple
 Apply
 false
@@ -163,7 +163,7 @@ Object
 Test
 251
 261
-15
+16
 println
 Apply
 false
@@ -180,7 +180,7 @@ Object
 Test
 268
 302
-16
+17
 multiple
 Apply
 false
@@ -197,7 +197,7 @@ Object
 Test
 291
 301
-16
+17
 f
 Apply
 false
@@ -214,7 +214,7 @@ Object
 Test
 305
 315
-17
+18
 println
 Apply
 false
@@ -231,7 +231,7 @@ Object
 Test
 322
 371
-18
+19
 multiple
 Apply
 false
@@ -248,7 +248,7 @@ Object
 Test
 345
 355
-18
+19
 f
 Apply
 false
@@ -265,7 +265,7 @@ Object
 Test
 374
 384
-19
+20
 println
 Apply
 false
@@ -282,7 +282,7 @@ Object
 Test
 101
 115
-8
+9
 Test
 DefDef
 false


### PR DESCRIPTION
fix https://github.com/lampepfl/dotty/issues/18916

This PR makes scoverage statements' line number 1-base, instead of 0-base. FYI @tarao

It would be ideal if we could find specifications of many of coverage report fomats (such as Jacoco XML, cobertura.xml, lcov.txt...) and confirm most of them expect the line numbers 1-base.

However, it seems there's no formal specification for them AFAIK. Since we've been using 1-base so far in Scala2 and it hasn't been a problem, so I guess it's OK to change to 1-base (and most of coverage report format and visualizer expect 1-base probably).

I believe we should make coverage report 1-base by default, and it should be reporter / aggregator's responsibility to adjust the line numbers if some coverage format expects 0-base.

---

I tested on https://github.com/scoverage/sbt-scoverage-samples with HTML reporter

## 3.3.1

![Screenshot 2023-11-15 at 16 55 06](https://github.com/lampepfl/dotty/assets/9353584/909b7eeb-22ca-41ca-bdfb-dc1e3ceb8ebb)

![Screenshot 2023-11-15 at 16 55 11](https://github.com/lampepfl/dotty/assets/9353584/97f086e2-f597-40e8-bee0-7a5d2dac9294)

In the latter picture, they are "3" even though the actual line number is 4, because

- scoverage deserializer parses `scoverage.coverage`'s line number as it is
  - https://github.com/scoverage/scalac-scoverage-plugin/blob/dd519767c916293f6d200639641a7f029970e261/serializer/src/main/scala/scoverage/serialize/Serializer.scala#L147
- and StatementWriter uses the `line` number without adjustment (to 1-base)
  - https://github.com/scoverage/scalac-scoverage-plugin/blob/dd519767c916293f6d200639641a7f029970e261/reporter/src/main/scala/scoverage/reporter/StatementWriter.scala#L34-L36

## 3.4.0-RC1-bin-SNAPSHOT
![Screenshot 2023-11-15 at 17 41 06](https://github.com/lampepfl/dotty/assets/9353584/6cbcaebd-3fae-4fcb-ae22-fc4bd844563a)

seems ok :+1:

![Screenshot 2023-11-15 at 17 41 01](https://github.com/lampepfl/dotty/assets/9353584/ca16653f-267c-4e43-962c-abdbf277f30f)

