### PR TITLE
Add checks for the consistency of the parents in TreeChecker

### DIFF
--- a/tests/neg-macros/i18677-a.check
+++ b/tests/neg-macros/i18677-a.check
@@ -1,0 +1,22 @@
+
+-- Error: tests/neg-macros/i18677-a/Test_2.scala:4:6 -------------------------------------------------------------------
+3 |@extendFoo
+4 |class AFoo // error
+  |^
+  |Malformed tree was found while expanding macro with -Xcheck-macros.
+  |The tree does not conform to the compiler's tree invariants.
+  |
+  |Macro was:
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-a/Test_2.scala") @extendFoo class AFoo()
+  |
+  |The macro returned:
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-a/Test_2.scala") @extendFoo class AFoo() extends Foo
+  |
+  |Error:
+  |assertion failed: Parents of class symbol differs from the parents in the tree for class AFoo
+  |
+  |Parents in symbol: [class Object]
+  |Parents in tree: [trait Foo]
+  |
+  |
+  |stacktrace available when compiling with `-Ydebug`

--- a/tests/neg-macros/i18677-a/Macro_1.scala
+++ b/tests/neg-macros/i18677-a/Macro_1.scala
@@ -1,0 +1,18 @@
+//> using -expermiental
+
+import annotation.MacroAnnotation
+import quoted.*
+
+trait Foo
+
+class extendFoo extends MacroAnnotation :
+    override def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+        import quotes.reflect.*
+        tree match
+            case ClassDef(name, ctr, p, self, body) =>
+                val parents = List(TypeTree.of[Foo])
+                val newTree = ClassDef.copy(tree)(name, ctr,  parents, self, body)
+                newTree :: Nil
+            case _ =>
+                report.error("@extendFoo can only annotate class definitions")
+                tree :: Nil

--- a/tests/neg-macros/i18677-a/Test_2.scala
+++ b/tests/neg-macros/i18677-a/Test_2.scala
@@ -1,0 +1,4 @@
+//> using -expermiental
+
+@extendFoo
+class AFoo // error

--- a/tests/neg-macros/i18677-b.check
+++ b/tests/neg-macros/i18677-b.check
@@ -1,0 +1,22 @@
+
+-- Error: tests/neg-macros/i18677-b/Test_2.scala:4:6 -------------------------------------------------------------------
+3 |@extendFoo
+4 |class AFoo // error
+  |^
+  |Malformed tree was found while expanding macro with -Xcheck-macros.
+  |The tree does not conform to the compiler's tree invariants.
+  |
+  |Macro was:
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-b/Test_2.scala") @extendFoo class AFoo()
+  |
+  |The macro returned:
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-b/Test_2.scala") @extendFoo class AFoo() extends Foo
+  |
+  |Error:
+  |assertion failed: Parents of class symbol differs from the parents in the tree for class AFoo
+  |
+  |Parents in symbol: [class Object]
+  |Parents in tree: [class Foo]
+  |
+  |
+  |stacktrace available when compiling with `-Ydebug`

--- a/tests/neg-macros/i18677-b/Macro_1.scala
+++ b/tests/neg-macros/i18677-b/Macro_1.scala
@@ -1,0 +1,18 @@
+//> using -expermiental
+
+import annotation.MacroAnnotation
+import quoted.*
+
+class Foo
+
+class extendFoo extends MacroAnnotation :
+    override def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+        import quotes.reflect.*
+        tree match
+            case ClassDef(name, ctr, p, self, body) =>
+                val parents = List(TypeTree.of[Foo])
+                val newTree = ClassDef.copy(tree)(name, ctr,  parents, self, body)
+                newTree :: Nil
+            case _ =>
+                report.error("@extendFoo can only annotate class definitions")
+                tree :: Nil

--- a/tests/neg-macros/i18677-b/Test_2.scala
+++ b/tests/neg-macros/i18677-b/Test_2.scala
@@ -1,0 +1,4 @@
+//> using -expermiental
+
+@extendFoo
+class AFoo // error

--- a/tests/neg-macros/wrong-owner.check
+++ b/tests/neg-macros/wrong-owner.check
@@ -5,19 +5,18 @@
 5 |class Foo // error
   |^
   |Malformed tree was found while expanding macro with -Xcheck-macros.
-  |               |The tree does not conform to the compiler's tree invariants.
-  |               |
-  |               |Macro was:
-  |               |@scala.annotation.internal.SourceFile("tests/neg-macros/wrong-owner/Test_2.scala") @wrongOwner @scala.annotation.experimental class Foo()
-  |               |
-  |               |The macro returned:
-  |               |@scala.annotation.internal.SourceFile("tests/neg-macros/wrong-owner/Test_2.scala") @wrongOwner @scala.annotation.experimental class Foo() {
+  |The tree does not conform to the compiler's tree invariants.
+  |
+  |Macro was:
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/wrong-owner/Test_2.scala") @wrongOwner @scala.annotation.experimental class Foo()
+  |
+  |The macro returned:
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/wrong-owner/Test_2.scala") @wrongOwner @scala.annotation.experimental class Foo() {
   |  override def toString(): java.lang.String = "Hello from macro"
   |}
-  |               |
-  |               |Error:
-  |               |assertion failed: bad owner; method toString has owner class String, expected was class Foo
+  |
+  |Error:
+  |assertion failed: bad owner; method toString has owner class String, expected was class Foo
   |owner chain = method toString, class String, package java.lang, package java, package <root>, ctxOwners = class Foo, class Foo, package <empty>, package <empty>, package <empty>, package <root>, package <root>, package <root>, package <root>, package <root>, package <root>, <none>, <none>, <none>, <none>, <none>
-  |               |
+  |
   |stacktrace available when compiling with `-Ydebug`
-  |               |


### PR DESCRIPTION
This PR adds a check for the parents in the TreeChecker. 

In the context of macro annotations, this PR doesn't allow the modification of the parents. This restriction will probably be partially lifted as we come up with the final specification.

This PR is related to #18677 put does not close it.