### PR TITLE
Do not show warnings when compiling the Scala 2 library

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1013,6 +1013,7 @@ object Build {
       Compile / doc / scalacOptions += "-Ydocument-synthetic-types",
       scalacOptions += "-Ycompile-scala2-library",
       scalacOptions -= "-Xfatal-warnings",
+      Compile / compile / logLevel := Level.Error,
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       libraryDependencies +=


### PR DESCRIPTION
We currently have 2305 warnings. Most of them are syntax migration warnings.