### PR TITLE
Refine `withReachCaptures`

### DIFF
--- a/tests/neg-custom-args/captures/reach-captures.scala
+++ b/tests/neg-custom-args/captures/reach-captures.scala
@@ -1,0 +1,14 @@
+import language.experimental.captureChecking
+trait IO
+def test1(): Unit =
+  val id: IO^ -> IO^ = x => x
+  val id1: IO^ -> IO^{id*} = id  // error
+
+def test2(): Unit =
+  val f: (IO^ => Unit) => Unit = ???
+  val f1: (IO^{f*} => Unit) ->{f*} Unit = f  // ok
+
+def test3(): Unit =
+  val f: IO^ -> (IO^ => Unit) => Unit = ???
+  val f1: IO^ -> (IO^{f*} => Unit) => Unit = f  // error
+  val f2: IO^ -> (IO^ => Unit) ->{f*} Unit = f  // error

--- a/tests/pos-custom-args/captures/i15749a.scala
+++ b/tests/pos-custom-args/captures/i15749a.scala
@@ -19,4 +19,4 @@ def test =
   def forceWrapper[A](mx: Wrapper[Unit ->{cap} A]): Wrapper[A] =
     // Γ ⊢ mx: Wrapper[□ {cap} Unit => A]
     // `force` should be typed as ∀(□ {cap} Unit -> A) A, but it can not
-    strictMap[Unit ->{mx*} A, A](mx)(t => force[A](t)) // error // should work
+    strictMap[Unit ->{mx*} A, A](mx)(t => force[A](t))

--- a/tests/pos-custom-args/captures/pair-reach.scala
+++ b/tests/pos-custom-args/captures/pair-reach.scala
@@ -1,0 +1,12 @@
+import language.experimental.captureChecking
+
+trait IO
+
+type Pair[+T, +U] = [R] -> (op: (T, U) => R) -> R
+def cons[T, U](a: T, b: U): Pair[T, U] = [R] => op => op(a, b)
+def car[T, U](p: Pair[T, U]): T = p((a, b) => a)
+def cdr[T, U](p: Pair[T, U]): U = p((a, b) => b)
+
+def foo(p: Pair[IO^, IO^]): Unit =
+  var x: IO^{p*} = null
+  x = car[IO^{p*}, IO^{p*}](p)


### PR DESCRIPTION
Follow-up of [this comment](https://github.com/lampepfl/dotty/pull/18899#issuecomment-1813647220).

Previously, we avoid refining co-variant `cap`s to reach capabilities as long as there exist contra-variant `cap`s. This limits expressivity. One counter-example is church-encodings: types like `[R] -> (op: (IO^, IO^) => R) -> R` cannot be refined, since the parameter `op` has a covariant `cap`.

This PR refines the treatment: only when a contra-variant `cap` is possibly reached by a co-variant `cap` do we refuse the refinement. Examples:
- The co-variant `cap` in `(c: IO^{cap}) -> IO^{cap}` cannot be refined, as it could refer to the impure contra-variant parameter `c`.
- `p : [R] -> (op: (IO^{cap}, IO^{cap}) => R) -> R` can be safely refined to `[R] -> (op: (IO^{p*}, IO^{p*}) => R) -> R`, as `op` is not possibly reached from the two co-variant `cap`s.