### PR TITLE
Backport "Don't generate a super accessor for an inline method call" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -153,7 +153,9 @@ class SuperAccessors(thisPhase: DenotTransformer) {
         }
     }
 
-    val needAccessor = name.isTermName && (
+    val needAccessor =
+      name.isTermName                // Types don't need super accessors
+      && !sym.isInlineMethod && (    // Inline methods can't be overridden, don't need superaccessors
       clazz != currentClass || !validCurrentClass || mix.name.isEmpty && clazz.is(Trait))
 
     if (needAccessor) atPhase(thisPhase.next)(superAccessorCall(sel, mix.name))

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -155,8 +155,9 @@ class SuperAccessors(thisPhase: DenotTransformer) {
 
     val needAccessor =
       name.isTermName                // Types don't need super accessors
-      && !sym.isInlineMethod && (    // Inline methods can't be overridden, don't need superaccessors
-      clazz != currentClass || !validCurrentClass || mix.name.isEmpty && clazz.is(Trait))
+      && !sym.isEffectivelyErased    // Erased and concrete inline methods are not called at runtime
+      && !sym.isInlineMethod         //   so they don't need superaccessors.
+      && (clazz != currentClass || !validCurrentClass || mix.name.isEmpty && clazz.is(Trait))
 
     if (needAccessor) atPhase(thisPhase.next)(superAccessorCall(sel, mix.name))
     else sel

--- a/tests/pos/i17584a.scala
+++ b/tests/pos/i17584a.scala
@@ -1,0 +1,7 @@
+
+import language.experimental.erasedDefinitions
+trait A:
+  erased def g = 1
+trait B extends A:
+  erased def f = super.g
+class C extends B

--- a/tests/run/i17584.scala
+++ b/tests/run/i17584.scala
@@ -1,0 +1,9 @@
+trait A:
+  inline def g = 1
+trait B extends A:
+  def f = super.g
+class C extends B
+
+@main def Test =
+  val c = C()
+  assert(c.f == 1)

--- a/tests/run/i17584a.scala
+++ b/tests/run/i17584a.scala
@@ -1,5 +1,7 @@
-trait A:
-  inline def g = 1
+trait T:
+  def g = 2
+trait A extends T:
+  inline override def g = 1
 trait B extends A:
   def f = super.g
 class C extends B
@@ -7,4 +9,3 @@ class C extends B
 @main def Test =
   val c = C()
   assert(c.f == 1)
-


### PR DESCRIPTION
Backports #17598 to the LTS branch.

PR submitted by the release tooling.
[skip ci]