### PR TITLE
Backport "chore: remove unused semanticdb directory" to LTS

### DIFF
--- a/semanticdb/project/build.properties
+++ b/semanticdb/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.8.2


### PR DESCRIPTION
Backports #17934 to the LTS branch.

PR submitted by the release tooling.
[skip ci]