### PR TITLE
Backport "chore(community-build): update scala stdLib213 in community build" to LTS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/dotty-staging/fastparse
 [submodule "community-build/community-projects/stdLib213"]
 	path = community-build/community-projects/stdLib213
-	url = https://github.com/dotty-staging/scala
+	url = https://github.com/dotty-staging/scala213
 [submodule "community-build/community-projects/sourcecode"]
 	path = community-build/community-projects/sourcecode
 	url = https://github.com/dotty-staging/sourcecode


### PR DESCRIPTION
Backports #17913 to the LTS branch.

PR submitted by the release tooling.
[skip ci]