### PR TITLE
Do not run CI on merges to relese

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ on:
       - '*'
     branches-ignore:
       - 'gh-readonly-queue/**'
+      - 'release-**'
   pull_request:
   merge_group:
   schedule:


### PR DESCRIPTION
PRs are merged to the release branches using our own implementation of the merge queue. The history for them is linearised, and we are running all the CI after every backported batch. Those builds are redundant and can clog our runners.

[skip ci]