### PR TITLE
Do not run CI on merges to relese

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ on:
       - '*'
     branches-ignore:
       - 'gh-readonly-queue/**'
+      - 'release-**'
   pull_request:
   merge_group:
   schedule:


### PR DESCRIPTION
https://github.com/lampepfl/dotty/pull/19004 for the release branch.