### PR TITLE
Skip CLA check for GitHub dependabot

### DIFF
--- a/project/scripts/check-cla.sh
+++ b/project/scripts/check-cla.sh
@@ -2,7 +2,7 @@
 set -eux
 
 echo "Pull request submitted by $AUTHOR";
-if [ "$AUTHOR" = "github-actions[bot]" ] ; then
+if [[ "$AUTHOR" == "github-actions[bot]" || "$AUTHOR" == "dependabot[bot]" ]] ; then
   echo "CLA check for $AUTHOR successful";
 else
   signed=$(curl -s "https://www.lightbend.com/contribute/cla/scala/check/$AUTHOR" | jq -r ".signed");


### PR DESCRIPTION
Skip the CLA check for dependabot. This should fix CI of https://github.com/lampepfl/dotty/pull/19003