### PR TITLE
Add compilation unit info to `ClassSymbol`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
@@ -9,12 +9,12 @@ import dotty.tools.tasty.TastyVersion
   *                       the class containing this symbol was generated,
   *                       null if not applicable.
   * @param tastyVersion   The TASTy version (major, minor, experimental)
-  * @param tastyExplicitNulls  Was this compilation unit compiled with explicit nulls?
+  * @param explicitNulls  This compilation unit has explicit nulls enabled?
   */
 class CompilationUnitInfo(
   val associatedFile: AbstractFile,
   val tastyVersion: Option[TastyVersion],
-  val tastyExplicitNulls: Boolean
+  val explicitNulls: Boolean
 ) {
 
   override def toString(): String =
@@ -22,10 +22,10 @@ class CompilationUnitInfo(
 }
 
 object CompilationUnitInfo:
-  def apply(assocFile: AbstractFile | Null): CompilationUnitInfo | Null =
+  def apply(assocFile: AbstractFile | Null, explicitNulls: Boolean = false): CompilationUnitInfo | Null =
     if assocFile == null then null
     else new CompilationUnitInfo(
       assocFile,
       tastyVersion = None,
-      tastyExplicitNulls = false // TODO track explicit nulls for current compilation units (not only TASTy)
+      explicitNulls = explicitNulls,
     )

--- a/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
@@ -9,10 +9,12 @@ import dotty.tools.tasty.TastyVersion
   *                       the class containing this symbol was generated,
   *                       null if not applicable.
   * @param tastyVersion   The TASTy version (major, minor, experimental)
+  * @param tastyExplicitNulls  Was this compilation unit compiled with explicit nulls?
   */
 class CompilationUnitInfo(
   val associatedFile: AbstractFile,
   val tastyVersion: Option[TastyVersion],
+  val tastyExplicitNulls: Boolean
 ) {
 
   override def toString(): String =
@@ -22,4 +24,8 @@ class CompilationUnitInfo(
 object CompilationUnitInfo:
   def apply(assocFile: AbstractFile | Null): CompilationUnitInfo | Null =
     if assocFile == null then null
-    else new CompilationUnitInfo(assocFile, tastyVersion = None) // TODO use current TASTy version
+    else new CompilationUnitInfo(
+      assocFile,
+      tastyVersion = None,
+      tastyExplicitNulls = false // TODO track explicit nulls for current compilation units (not only TASTy)
+    )

--- a/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
@@ -1,0 +1,21 @@
+package dotty.tools.dotc.core
+
+import dotty.tools.io.AbstractFile
+
+/** Information about the compilation unit of a class symbol.
+  *
+  * @param associatedFile The source or class file from which this class or
+  *                       the class containing this symbol was generated,
+  *                       null if not applicable.
+  */
+class CompilationUnitInfo(
+  val associatedFile: AbstractFile,
+) {
+  override def toString(): String =
+    s"CompilationUnitInfo($associatedFile)"
+}
+
+object CompilationUnitInfo:
+  def apply(assocFile: AbstractFile | Null): CompilationUnitInfo | Null =
+    if assocFile == null then null
+    else new CompilationUnitInfo(assocFile)

--- a/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
@@ -12,16 +12,8 @@ import dotty.tools.tasty.TastyVersion
   */
 class CompilationUnitInfo(
   val associatedFile: AbstractFile,
-  private var tastyVersionOpt: Option[TastyVersion],
+  val tastyVersion: Option[TastyVersion],
 ) {
-
-  def tastyVersion: Option[TastyVersion] = tastyVersionOpt
-
-  /** Sets the TASTy version. Used to initialize the TASTy version when
-   *  Loading a TASTy file in TastyLoader.
-   */
-  def initTastyVersion(version: TastyVersion): Unit =
-    tastyVersionOpt = Some(version)
 
   override def toString(): String =
     s"CompilationUnitInfo($associatedFile, $tastyVersion)"
@@ -30,4 +22,4 @@ class CompilationUnitInfo(
 object CompilationUnitInfo:
   def apply(assocFile: AbstractFile | Null): CompilationUnitInfo | Null =
     if assocFile == null then null
-    else new CompilationUnitInfo(assocFile, tastyVersionOpt = None) // TODO use current TASTy version
+    else new CompilationUnitInfo(assocFile, tastyVersion = None) // TODO use current TASTy version

--- a/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
@@ -1,21 +1,33 @@
 package dotty.tools.dotc.core
 
 import dotty.tools.io.AbstractFile
+import dotty.tools.tasty.TastyVersion
 
 /** Information about the compilation unit of a class symbol.
   *
   * @param associatedFile The source or class file from which this class or
   *                       the class containing this symbol was generated,
   *                       null if not applicable.
+  * @param tastyVersion   The TASTy version (major, minor, experimental)
   */
 class CompilationUnitInfo(
   val associatedFile: AbstractFile,
+  private var tastyVersionOpt: Option[TastyVersion],
 ) {
+
+  def tastyVersion: Option[TastyVersion] = tastyVersionOpt
+
+  /** Sets the TASTy version. Used to initialize the TASTy version when
+   *  Loading a TASTy file in TastyLoader.
+   */
+  def initTastyVersion(version: TastyVersion): Unit =
+    tastyVersionOpt = Some(version)
+
   override def toString(): String =
-    s"CompilationUnitInfo($associatedFile)"
+    s"CompilationUnitInfo($associatedFile, $tastyVersion)"
 }
 
 object CompilationUnitInfo:
   def apply(assocFile: AbstractFile | Null): CompilationUnitInfo | Null =
     if assocFile == null then null
-    else new CompilationUnitInfo(assocFile)
+    else new CompilationUnitInfo(assocFile, tastyVersionOpt = None) // TODO use current TASTy version

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1409,7 +1409,7 @@ class Definitions {
           ),
           privateWithin = patch.privateWithin,
           coord = denot.symbol.coord,
-          assocFile = denot.symbol.associatedFile
+          compUnitInfo = denot.symbol.compilationUnitInfo
         )
 
       def makeNonClassSymbol(patch: Symbol) =

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -298,14 +298,13 @@ object Denotations {
                        name: Name,
                        site: Denotation = NoDenotation,
                        args: List[Type] = Nil,
-                       source: AbstractFile | Null = null,
                        generateStubs: Boolean = true)
                       (p: Symbol => Boolean)
                       (using Context): Symbol =
       disambiguate(p) match {
         case m @ MissingRef(ownerd, name) if generateStubs =>
           if ctx.settings.YdebugMissingRefs.value then m.ex.printStackTrace()
-          newStubSymbol(ownerd.symbol, name, source)
+          newStubSymbol(ownerd.symbol, name)
         case NoDenotation | _: NoQualifyingRef | _: MissingRef =>
           def argStr = if (args.isEmpty) "" else i" matching ($args%, %)"
           val msg =

--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -141,7 +141,7 @@ object NamerOps:
         ConstructorCompanionFlags, ConstructorCompanionFlags,
         constructorCompanionCompleter(cls),
         coord = cls.coord,
-        assocFile = cls.assocFile)
+        compUnitInfo = cls.compUnitInfo)
     companion.moduleClass.registerCompanion(cls)
     cls.registerCompanion(companion.moduleClass)
     companion
@@ -150,7 +150,7 @@ object NamerOps:
     newSymbol(tsym.owner, tsym.name.toTermName,
         ConstructorCompanionFlags | StableRealizable | Method, ExprType(prefix.select(proxy)), coord = tsym.coord)
 
-  /** Add all necesssary constructor proxy symbols for members of class `cls`. This means:
+  /** Add all necessary constructor proxy symbols for members of class `cls`. This means:
    *
    *   - if a member is a class, or type alias, that needs a constructor companion, add one,
    *     provided no member with the same name exists.

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2588,7 +2588,7 @@ object SymDenotations {
       for (sym <- scope.toList.iterator)
         // We need to be careful to not force the denotation of `sym` here,
         // otherwise it will be brought forward to the current run.
-        if (sym.defRunId != ctx.runId && sym.isClass && sym.asClass.assocFile == file)
+        if (sym.defRunId != ctx.runId && sym.isClass && sym.asClass.compUnitInfo != null && sym.asClass.compUnitInfo.nn.associatedFile == file)
           scope.unlink(sym, sym.lastKnownDenotation.name)
     }
   }

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -424,16 +424,17 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
 
   def compilationUnitInfo: CompilationUnitInfo | Null =
     val tastyHeader = unpickler.unpickler.header
+    val tastyVersion = TastyVersion(
+      tastyHeader.majorVersion,
+      tastyHeader.minorVersion,
+      tastyHeader.experimentalVersion,
+    )
+    val attributes = unpickler.tastyAttributes
     new CompilationUnitInfo(
       tastyFile,
-      tastyVersion = Some(
-        TastyVersion(
-          tastyHeader.majorVersion,
-          tastyHeader.minorVersion,
-          tastyHeader.experimentalVersion,
-        )
-      )
-  )
+      tastyVersion = Some(tastyVersion),
+      tastyExplicitNulls = attributes.explicitNulls,
+    )
 
   def description(using Context): String = "TASTy file " + tastyFile.toString
 

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -418,7 +418,12 @@ class ClassfileLoader(val classfile: AbstractFile) extends SymbolLoader {
 
 class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
 
-  def compilationUnitInfo: CompilationUnitInfo | Null = CompilationUnitInfo(tastyFile)
+  private val compUnitInfo = new CompilationUnitInfo(
+    tastyFile,
+    tastyVersionOpt = None // set on doComplete
+  )
+
+  def compilationUnitInfo: CompilationUnitInfo | Null = compUnitInfo
 
   def description(using Context): String = "TASTy file " + tastyFile.toString
 
@@ -427,6 +432,7 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
       val (classRoot, moduleRoot) = rootDenots(root.asClass)
       val tastyBytes = tastyFile.toByteArray
       val unpickler = new tasty.DottyUnpickler(tastyBytes)
+      compUnitInfo.initTastyVersion(unpickler.tastyVersion)
       unpickler.enter(roots = Set(classRoot, moduleRoot, moduleRoot.sourceModule))(using ctx.withSource(util.NoSource))
       if mayLoadTreesFromTasty then
         classRoot.classSymbol.rootTreeOrProvider = unpickler

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -433,7 +433,7 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
     new CompilationUnitInfo(
       tastyFile,
       tastyVersion = Some(tastyVersion),
-      tastyExplicitNulls = attributes.explicitNulls,
+      explicitNulls = attributes.explicitNulls,
     )
 
   def description(using Context): String = "TASTy file " + tastyFile.toString

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -422,7 +422,7 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
       val tastyBytes = tastyFile.toByteArray
       new tasty.DottyUnpickler(tastyBytes) // reads header and name table
 
-  def compilationUnitInfo: CompilationUnitInfo | Null =
+  val compilationUnitInfo: CompilationUnitInfo | Null =
     val tastyHeader = unpickler.unpickler.header
     val tastyVersion = TastyVersion(
       tastyHeader.majorVersion,
@@ -453,10 +453,10 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
       val message = e match
         case e: UnpickleException =>
           s"""TASTy file ${tastyFile.canonicalPath} could not be read, failing with:
-            |  ${Option(e.getMessage).getOrElse("")}"""
+            |  ${Option(e.getMessage).getOrElse("")}""".stripMargin
         case _ =>
           s"""TASTy file ${tastyFile.canonicalPath} is broken, reading aborted with ${e.getClass}
-            |  ${Option(e.getMessage).getOrElse("")}"""
+            |  ${Option(e.getMessage).getOrElse("")}""".stripMargin
       throw IOException(message, e)
 
 

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -288,6 +288,11 @@ object Symbols {
       if compUnitInfo == null then None
       else compUnitInfo.tastyVersion
 
+    /** If this class has explicit nulls enabled */
+    def explicitNulls(using Context): Boolean =
+      val compUnitInfo = compilationUnitInfo
+      compUnitInfo != null && compUnitInfo.explicitNulls
+
     /** The class file from which this class was generated, null if not applicable. */
     final def binaryFile(using Context): AbstractFile | Null = {
       val file = associatedFile

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -34,6 +34,7 @@ import config.Printers.typr
 import dotty.tools.dotc.classpath.FileUtils.isScalaBinary
 
 import scala.compiletime.uninitialized
+import dotty.tools.tasty.TastyVersion
 
 object Symbols {
 
@@ -280,6 +281,12 @@ object Symbols {
      */
     def compilationUnitInfo(using Context): CompilationUnitInfo | Null =
       lastDenot.topLevelClass.compilationUnitInfo
+
+    /** The version of TASTy from which the symbol was loaded, None if not applicable. */
+    def tastyVersion(using Context): Option[TastyVersion] =
+      val compUnitInfo = compilationUnitInfo
+      if compUnitInfo == null then None
+      else compUnitInfo.tastyVersion
 
     /** The class file from which this class was generated, null if not applicable. */
     final def binaryFile(using Context): AbstractFile | Null = {

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -265,12 +265,21 @@ object Symbols {
 
     /** The source or class file from which this class or
      *  the class containing this symbol was generated, null if not applicable.
-     *  Note that this the returned classfile might be the top-level class
+     *  Note that the returned classfile might be from the top-level class
+     *  containing this symbol instead of the directly enclosing class.
+     */
+    def associatedFile(using Context): AbstractFile | Null =
+      val compUnitInfo = compilationUnitInfo
+      if compUnitInfo == null then (null: AbstractFile | Null)
+      else compUnitInfo.associatedFile
+
+    /** The compilation unit info (associated file, tasty versions, ...).
+     *  Note that the returned CompilationUnitInfo might be from the top-level class
      *  containing this symbol instead of the directly enclosing class.
      *  Overridden in ClassSymbol
      */
-    def associatedFile(using Context): AbstractFile | Null =
-      lastDenot.topLevelClass.associatedFile
+    def compilationUnitInfo(using Context): CompilationUnitInfo | Null =
+      lastDenot.topLevelClass.compilationUnitInfo
 
     /** The class file from which this class was generated, null if not applicable. */
     final def binaryFile(using Context): AbstractFile | Null = {
@@ -353,7 +362,7 @@ object Symbols {
     def paramRef(using Context): TypeRef = denot.typeRef
 
     /** Copy a symbol, overriding selective fields.
-     *  Note that `coord` and `associatedFile` will be set from the fields in `owner`, not
+     *  Note that `coord` and `compilationUnitInfo` will be set from the fields in `owner`, not
      *  the fields in `sym`. */
     def copy(using Context)(
         owner: Symbol = this.owner,
@@ -362,13 +371,14 @@ object Symbols {
         info: Type = this.info,
         privateWithin: Symbol = this.privateWithin,
         coord: Coord = NoCoord, // Can be `= owner.coord` once we bootstrap
-        associatedFile: AbstractFile | Null = null // Can be `= owner.associatedFile` once we bootstrap
+        compUnitInfo: CompilationUnitInfo | Null = null // Can be `= owner.associatedFile` once we bootstrap
     ): Symbol = {
       val coord1 = if (coord == NoCoord) owner.coord else coord
-      val associatedFile1 = if (associatedFile == null) owner.associatedFile else associatedFile
+      val compilationUnitInfo1 = if (compilationUnitInfo == null) owner.compilationUnitInfo else compilationUnitInfo
+
 
       if isClass then
-        newClassSymbol(owner, name.asTypeName, flags, _ => info, privateWithin, coord1, associatedFile1)
+        newClassSymbol(owner, name.asTypeName, flags, _ => info, privateWithin, coord1, compilationUnitInfo1)
       else
         newSymbol(owner, name, flags, info, privateWithin, coord1)
     }
@@ -396,7 +406,7 @@ object Symbols {
   type TermSymbol = Symbol { type ThisName = TermName }
   type TypeSymbol = Symbol { type ThisName = TypeName }
 
-  class ClassSymbol private[Symbols] (coord: Coord, val assocFile: AbstractFile | Null, id: Int, nestingLevel: Int)
+  class ClassSymbol private[Symbols] (coord: Coord, val compUnitInfo: CompilationUnitInfo | Null, id: Int, nestingLevel: Int)
     extends Symbol(coord, id, nestingLevel) {
 
     type ThisName = TypeName
@@ -456,9 +466,9 @@ object Symbols {
     }
 
     /** The source or class file from which this class was generated, null if not applicable. */
-    override def associatedFile(using Context): AbstractFile | Null =
-      if assocFile != null || this.is(Package) || this.owner.is(Package) then assocFile
-      else super.associatedFile
+    override def compilationUnitInfo(using Context): CompilationUnitInfo | Null =
+      if compUnitInfo != null || this.is(Package) || this.owner.is(Package) then compUnitInfo
+      else super.compilationUnitInfo
 
     private var mySource: SourceFile = NoSource
 
@@ -488,7 +498,7 @@ object Symbols {
   }
 
   @sharable object NoSymbol extends Symbol(NoCoord, 0, 0) {
-    override def associatedFile(using Context): AbstractFile | Null = NoSource.file
+    override def compilationUnitInfo(using Context): CompilationUnitInfo | Null = CompilationUnitInfo(NoSource.file)
     override def recomputeDenot(lastd: SymDenotation)(using Context): SymDenotation = NoDenotation
   }
 
@@ -537,9 +547,9 @@ object Symbols {
       infoFn: ClassSymbol => Type,
       privateWithin: Symbol = NoSymbol,
       coord: Coord = NoCoord,
-      assocFile: AbstractFile | Null = null)(using Context): ClassSymbol
+      compUnitInfo: CompilationUnitInfo | Null = null)(using Context): ClassSymbol
   = {
-    val cls = new ClassSymbol(coord, assocFile, ctx.base.nextSymId, ctx.nestingLevel)
+    val cls = new ClassSymbol(coord, compUnitInfo, ctx.base.nextSymId, ctx.nestingLevel)
     val denot = SymDenotation(cls, owner, name, flags, infoFn(cls), privateWithin)
     cls.denot = denot
     cls
@@ -555,11 +565,11 @@ object Symbols {
       selfInfo: Type = NoType,
       privateWithin: Symbol = NoSymbol,
       coord: Coord = NoCoord,
-      assocFile: AbstractFile | Null = null)(using Context): ClassSymbol =
+      compUnitInfo: CompilationUnitInfo | Null = null)(using Context): ClassSymbol =
     newClassSymbol(
         owner, name, flags,
         ClassInfo(owner.thisType, _, parents, decls, selfInfo),
-        privateWithin, coord, assocFile)
+        privateWithin, coord, compUnitInfo)
 
   /** Same as `newCompleteClassSymbol` except that `parents` can be a list of arbitrary
    *  types which get normalized into type refs and parameter bindings.
@@ -572,7 +582,7 @@ object Symbols {
       selfInfo: Type = NoType,
       privateWithin: Symbol = NoSymbol,
       coord: Coord = NoCoord,
-      assocFile: AbstractFile | Null = null)(using Context): ClassSymbol = {
+      compUnitInfo: CompilationUnitInfo | Null = null)(using Context): ClassSymbol = {
     def completer = new LazyType {
       def complete(denot: SymDenotation)(using Context): Unit = {
         val cls = denot.asClass.classSymbol
@@ -580,7 +590,7 @@ object Symbols {
         denot.info = ClassInfo(owner.thisType, cls, parentTypes.map(_.dealias), decls, selfInfo)
       }
     }
-    newClassSymbol(owner, name, flags, completer, privateWithin, coord, assocFile)
+    newClassSymbol(owner, name, flags, completer, privateWithin, coord, compUnitInfo)
   }
 
   def newRefinedClassSymbol(coord: Coord = NoCoord)(using Context): ClassSymbol =
@@ -598,7 +608,7 @@ object Symbols {
       infoFn: (TermSymbol, ClassSymbol) => Type, // typically a ModuleClassCompleterWithDecls
       privateWithin: Symbol = NoSymbol,
       coord: Coord = NoCoord,
-      assocFile: AbstractFile | Null = null)(using Context): TermSymbol
+      compUnitInfo: CompilationUnitInfo | Null = null)(using Context): TermSymbol
   = {
     val base = owner.thisType
     val modclsFlags = clsFlags | ModuleClassCreationFlags
@@ -606,7 +616,7 @@ object Symbols {
     val module = newSymbol(
       owner, name, modFlags | ModuleValCreationFlags, NoCompleter, privateWithin, coord)
     val modcls = newClassSymbol(
-      owner, modclsName, modclsFlags, infoFn(module, _), privateWithin, coord, assocFile)
+      owner, modclsName, modclsFlags, infoFn(module, _), privateWithin, coord, compUnitInfo)
     module.info =
       if (modcls.isCompleted) TypeRef(owner.thisType, modcls)
       else new ModuleCompleter(modcls)
@@ -627,12 +637,12 @@ object Symbols {
       decls: Scope,
       privateWithin: Symbol = NoSymbol,
       coord: Coord = NoCoord,
-      assocFile: AbstractFile | Null = null)(using Context): TermSymbol =
+      compUnitInfo: CompilationUnitInfo | Null = null)(using Context): TermSymbol =
     newModuleSymbol(
         owner, name, modFlags, clsFlags,
         (module, modcls) => ClassInfo(
           owner.thisType, modcls, parents, decls, TermRef(owner.thisType, module)),
-        privateWithin, coord, assocFile)
+        privateWithin, coord, compUnitInfo)
 
   /** Same as `newCompleteModuleSymbol` except that `parents` can be a list of arbitrary
    *  types which get normalized into type refs and parameter bindings.
@@ -646,7 +656,7 @@ object Symbols {
       decls: Scope,
       privateWithin: Symbol = NoSymbol,
       coord: Coord = NoCoord,
-      assocFile: AbstractFile | Null = null)(using Context): TermSymbol = {
+      compUnitInfo: CompilationUnitInfo | Null = null)(using Context): TermSymbol = {
     def completer(module: Symbol) = new LazyType {
       def complete(denot: SymDenotation)(using Context): Unit = {
         val cls = denot.asClass.classSymbol
@@ -657,7 +667,7 @@ object Symbols {
     newModuleSymbol(
         owner, name, modFlags, clsFlags,
         (module, modcls) => completer(module),
-        privateWithin, coord, assocFile)
+        privateWithin, coord, compUnitInfo)
   }
 
   /** Create a package symbol with associated package class
@@ -697,17 +707,17 @@ object Symbols {
   /** Create a stub symbol that will issue a missing reference error
    *  when attempted to be completed.
    */
-  def newStubSymbol(owner: Symbol, name: Name, file: AbstractFile | Null = null)(using Context): Symbol = {
+  def newStubSymbol(owner: Symbol, name: Name, compUnitInfo: CompilationUnitInfo | Null = null)(using Context): Symbol = {
     def stubCompleter = new StubInfo()
     val normalizedOwner = if (owner.is(ModuleVal)) owner.moduleClass else owner
-    typr.println(s"creating stub for ${name.show}, owner = ${normalizedOwner.denot.debugString}, file = $file")
+    typr.println(s"creating stub for ${name.show}, owner = ${normalizedOwner.denot.debugString}, compilation unit = $compUnitInfo")
     typr.println(s"decls = ${normalizedOwner.unforcedDecls.toList.map(_.debugString).mkString("\n  ")}") // !!! DEBUG
     //if (base.settings.debug.value) throw new Error()
     val stub = name match {
       case name: TermName =>
-        newModuleSymbol(normalizedOwner, name, EmptyFlags, EmptyFlags, stubCompleter, assocFile = file)
+        newModuleSymbol(normalizedOwner, name, EmptyFlags, EmptyFlags, stubCompleter, compUnitInfo = compUnitInfo)
       case name: TypeName =>
-        newClassSymbol(normalizedOwner, name, EmptyFlags, stubCompleter, assocFile = file)
+        newClassSymbol(normalizedOwner, name, EmptyFlags, stubCompleter, compUnitInfo = compUnitInfo)
     }
     stub
   }

--- a/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
@@ -56,6 +56,9 @@ class DottyUnpickler(bytes: Array[Byte], mode: UnpickleMode = UnpickleMode.TopLe
   private val attributeUnpicklerOpt = unpickler.unpickle(new AttributesSectionUnpickler)
   private val treeUnpickler = unpickler.unpickle(treeSectionUnpickler(posUnpicklerOpt, commentUnpicklerOpt, attributeUnpicklerOpt)).get
 
+  def tastyAttributes: Attributes =
+    attributeUnpicklerOpt.map(_.attributes).getOrElse(Attributes(false, false))
+
   /** Enter all toplevel classes and objects into their scopes
    *  @param roots          a set of SymDenotations that should be overwritten by unpickling
    */

--- a/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
@@ -56,13 +56,6 @@ class DottyUnpickler(bytes: Array[Byte], mode: UnpickleMode = UnpickleMode.TopLe
   private val attributeUnpicklerOpt = unpickler.unpickle(new AttributesSectionUnpickler)
   private val treeUnpickler = unpickler.unpickle(treeSectionUnpickler(posUnpicklerOpt, commentUnpicklerOpt, attributeUnpicklerOpt)).get
 
-  def tastyVersion: TastyVersion =
-    TastyVersion(
-      unpickler.header.majorVersion,
-      unpickler.header.minorVersion,
-      unpickler.header.experimentalVersion,
-    )
-
   /** Enter all toplevel classes and objects into their scopes
    *  @param roots          a set of SymDenotations that should be overwritten by unpickling
    */

--- a/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
@@ -14,6 +14,7 @@ import TreeUnpickler.UnpickleMode
 
 import dotty.tools.tasty.TastyReader
 import dotty.tools.tasty.TastyFormat.{ASTsSection, PositionsSection, CommentsSection, AttributesSection}
+import dotty.tools.tasty.TastyVersion
 
 object DottyUnpickler {
 
@@ -54,6 +55,13 @@ class DottyUnpickler(bytes: Array[Byte], mode: UnpickleMode = UnpickleMode.TopLe
   private val commentUnpicklerOpt = unpickler.unpickle(new CommentsSectionUnpickler)
   private val attributeUnpicklerOpt = unpickler.unpickle(new AttributesSectionUnpickler)
   private val treeUnpickler = unpickler.unpickle(treeSectionUnpickler(posUnpicklerOpt, commentUnpicklerOpt, attributeUnpicklerOpt)).get
+
+  def tastyVersion: TastyVersion =
+    TastyVersion(
+      unpickler.header.majorVersion,
+      unpickler.header.minorVersion,
+      unpickler.header.experimentalVersion,
+    )
 
   /** Enter all toplevel classes and objects into their scopes
    *  @param roots          a set of SymDenotations that should be overwritten by unpickling

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -4,8 +4,7 @@ package tasty
 
 import scala.language.unsafeNulls
 
-import dotty.tools.tasty.{TastyFormat, TastyBuffer, TastyReader, TastyHeaderUnpickler, UnpicklerConfig}
-import TastyHeaderUnpickler.TastyVersion
+import dotty.tools.tasty.{TastyFormat, TastyVersion, TastyBuffer, TastyReader, TastyHeaderUnpickler, UnpicklerConfig}
 import TastyFormat.NameTags.*, TastyFormat.nameTagToString
 import TastyBuffer.NameRef
 
@@ -122,7 +121,7 @@ class TastyUnpickler(reader: TastyReader) {
     result
   }
 
-  new TastyHeaderUnpickler(scala3CompilerConfig, reader).readHeader()
+  val header = new TastyHeaderUnpickler(scala3CompilerConfig, reader).readFullHeader()
 
   locally {
     until(readEnd()) { nameAtRef.add(readNameContents()) }

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -426,7 +426,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
               if (slowSearch(name).exists)
                 System.err.println(i"**** slow search found: ${slowSearch(name)}")
               if (ctx.settings.YdebugMissingRefs.value) Thread.dumpStack()
-              newStubSymbol(owner, name, source)
+              newStubSymbol(owner, name, CompilationUnitInfo(source))
             }
           }
         }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3922,7 +3922,9 @@ object Parsers {
     }
 
     private def checkAccessOnly(mods: Modifiers, where: String): Modifiers =
-      val mods1 = mods & (AccessFlags | Enum)
+      // We allow `infix to mark the `enum`s type as infix.
+      // Syntax rules disallow the soft infix modifier on `case`s.
+      val mods1 = mods & (AccessFlags | Enum | Infix)
       if mods1 ne mods then
         syntaxError(em"Only access modifiers are allowed on enum $where")
       mods1

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JUnitBootstrappers.scala
@@ -156,7 +156,7 @@ class JUnitBootstrappers extends MiniPhase {
     val moduleSym = newCompleteModuleSymbol(owner, bootstrapperName,
       Synthetic, Synthetic,
       List(defn.ObjectType, junitdefn.BootstrapperType), newScope,
-      coord = testClass.span, assocFile = testClass.assocFile).entered
+      coord = testClass.span, compUnitInfo = testClass.compUnitInfo).entered
     val classSym = moduleSym.moduleClass.asClass
 
     val constr = genConstructor(classSym)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1073,7 +1073,7 @@ trait Checking {
       case id @ Ident(name: Name) =>
         def methCompiledBeforeDeprecation =
           meth.tastyVersion match
-            case Some(version) => version.minor < 4 // compiled before 3.4
+            case Some(version) => version.major == 28 && version.minor < 4 // compiled before 3.4
             case _ => false // compiled with the current compiler
         name.toTermName match {
           case name: SimpleName

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -250,7 +250,7 @@ class Namer { typer: Typer =>
         val cls =
           createOrRefine[ClassSymbol](tree, name, flags, ctx.owner,
             cls => adjustIfModule(new ClassCompleter(cls, tree)(ctx), tree),
-            newClassSymbol(ctx.owner, name, _, _, _, tree.nameSpan, CompilationUnitInfo(ctx.source.file)))
+            newClassSymbol(ctx.owner, name, _, _, _, tree.nameSpan, CompilationUnitInfo(ctx.source.file, explicitNulls = ctx.explicitNulls)))
         cls.completer.asInstanceOf[ClassCompleter].init()
         cls
       case tree: MemberDef =>

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -250,7 +250,7 @@ class Namer { typer: Typer =>
         val cls =
           createOrRefine[ClassSymbol](tree, name, flags, ctx.owner,
             cls => adjustIfModule(new ClassCompleter(cls, tree)(ctx), tree),
-            newClassSymbol(ctx.owner, name, _, _, _, tree.nameSpan, ctx.source.file))
+            newClassSymbol(ctx.owner, name, _, _, _, tree.nameSpan, CompilationUnitInfo(ctx.source.file)))
         cls.completer.asInstanceOf[ClassCompleter].init()
         cls
       case tree: MemberDef =>

--- a/compiler/test-resources/repl/i1374
+++ b/compiler/test-resources/repl/i1374
@@ -1,4 +1,4 @@
-scala> implicit class Padder(val sb: StringBuilder) extends AnyVal { def pad2(width: Int) = { 1 to width - sb.length foreach { sb append '*' }; sb } }
+scala> implicit class Padder(val sb: StringBuilder) extends AnyVal { infix def pad2(width: Int) = { 1 to width - sb.length foreach { sb append '*' }; sb } }
 // defined class Padder
 def Padder(sb: StringBuilder): Padder
 scala> val greeting = new StringBuilder("Hello, kitteh!")

--- a/compiler/test-resources/type-printer/infix
+++ b/compiler/test-resources/type-printer/infix
@@ -29,7 +29,7 @@ def foo: (Int &: String) & Boolean
 scala> def foo: Int &: (Boolean & String) = ???
 def foo: Int &: (Boolean & String)
 scala> import scala.annotation.showAsInfix
-scala> @scala.annotation.showAsInfix class Mappy[T,U]
+scala> @scala.annotation.showAsInfix infix class Mappy[T,U]
 // defined class Mappy
 scala> def foo: (Int Mappy Boolean) && String = ???
 def foo: (Int Mappy Boolean) && String

--- a/compiler/test/dotty/tools/dotc/core/tasty/TastyHeaderUnpicklerTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/TastyHeaderUnpicklerTest.scala
@@ -9,7 +9,7 @@ import dotty.tools.tasty.TastyBuffer
 import dotty.tools.tasty.TastyReader
 import dotty.tools.tasty.UnpickleException
 import dotty.tools.tasty.TastyHeaderUnpickler
-import dotty.tools.tasty.TastyHeaderUnpickler.TastyVersion
+import dotty.tools.tasty.TastyVersion
 import dotty.tools.tasty.UnpicklerConfig
 
 class TastyHeaderUnpicklerTest {

--- a/language-server/test/dotty/tools/languageserver/util/embedded/CodeMarker.scala
+++ b/language-server/test/dotty/tools/languageserver/util/embedded/CodeMarker.scala
@@ -13,7 +13,7 @@ import PositionContext.PosCtx
 class CodeMarker(val name: String) extends Embedded {
 
   /** A range of positions between this marker and `other`. */
-  def to(other: CodeMarker): CodeRange = CodeRange(this, other)
+  infix def to(other: CodeMarker): CodeRange = CodeRange(this, other)
 
   /** The file containing this marker. */
   def file: PosCtx[TestFile] = posCtx.positionOf(this)._1

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2094,7 +2094,16 @@ object Build {
         }
       )
 
-    def asTastyCoreScala2: Project = project.settings(commonScala2Settings)
+    def asTastyCoreScala2: Project = project
+      .settings(commonScala2Settings)
+      // need to add @annotation.internal.sharable to the classpath for compiling
+      // we don't actually publish this library anywhere, so it's fine.
+      // if someone depends on the sources of tasty-core in a scala 2 project,
+      // they should strip the sharable annotation, or add -Ytasty-reader
+      .dependsOn(dottyLibrary(NonBootstrapped) % Provided)
+      .settings(
+        scalacOptions += "-Ytasty-reader" // to read scala3 library
+      )
 
     def asDottyBench(implicit mode: Mode): Project = project.withCommonSettings.
       dependsOn(dottyCompiler).

--- a/scaladoc-testcases/src/tests/infixTypes.scala
+++ b/scaladoc-testcases/src/tests/infixTypes.scala
@@ -4,9 +4,9 @@ package infixTypes
 import annotation.showAsInfix
 
 @showAsInfix
-trait SomeTrait[A, B]
+infix trait SomeTrait[A, B]
 
-trait SomeTrait2[A, B]
+infix trait SomeTrait2[A, B]
 
 def someTrait1[C, D]: C SomeTrait D
   = ???

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
@@ -236,9 +236,9 @@ object MemberLookup extends MemberLookup {
       // Scaladoc overloading support allows terminal * (and they're meaningless)
       val cleanStr = str.stripSuffix("*")
 
-      if cleanStr endsWith "$" then
+      if cleanStr.endsWith("$") then
         Selector(cleanStr.init, SelectorKind.ForceTerm)
-      else if cleanStr endsWith "!" then
+      else if cleanStr.endsWith("!") then
         Selector(cleanStr.init, SelectorKind.ForceType)
       else
         Selector(cleanStr, SelectorKind.NoForce)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/wiki/Parser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/wiki/Parser.scala
@@ -675,7 +675,7 @@ sealed class CharReader(buffer: String) { reader =>
 
   var offset: Int = 0
   def char: Char =
-    if (offset >= buffer.length) endOfText else buffer charAt offset
+    if (offset >= buffer.length) endOfText else buffer.charAt(offset)
 
   final def nextChar() =
     offset += 1
@@ -712,7 +712,7 @@ sealed class CharReader(buffer: String) { reader =>
     jumpWhitespace()
     val (ok0, chars0) =
       if (chars.charAt(0) == ' ')
-        (offset > poff, chars substring 1)
+        (offset > poff, chars.substring(1))
       else
         (true, chars)
     val ok = ok0 && jump(chars0)

--- a/scaladoc/test/dotty/tools/scaladoc/testUtils.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/testUtils.scala
@@ -71,7 +71,7 @@ def tastyFiles(name: String, allowEmpty: Boolean = false, rootPck: String = "tes
   }
   def collectFiles(dir: File): List[File] = listFilesSafe(dir).toList.flatMap {
       case f if f.isDirectory => collectFiles(f)
-      case f if f.getName endsWith ".tasty" => f :: Nil
+      case f if f.getName.endsWith(".tasty") => f :: Nil
       case _ => Nil
     }
   val outputDir = BuildInfo.test_testcasesOutputDir

--- a/staging/src/scala/quoted/staging/QuoteCompiler.scala
+++ b/staging/src/scala/quoted/staging/QuoteCompiler.scala
@@ -5,6 +5,7 @@ import dotty.tools.unsupported
 import dotty.tools.dotc._
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.CompilationUnitInfo
 import dotty.tools.dotc.core.Decorators._
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.Mode
@@ -69,12 +70,12 @@ private class QuoteCompiler extends Compiler:
           implicit val unitCtx: Context = SpliceScope.setSpliceScope(new RunScope)(using ctx1)
 
           val pos = Span(0)
-          val assocFile = new VirtualFile("<quote>")
+          val compUnitInfo = CompilationUnitInfo(new VirtualFile("<quote>"))
 
           // Places the contents of expr in a compilable tree for a class with the following format.
           // `package __root__ { class ' { def apply: Any = <expr> } }`
           val cls = newCompleteClassSymbol(defn.RootClass, outputClassName, EmptyFlags,
-            defn.ObjectType :: Nil, newScope, coord = pos, assocFile = assocFile).entered.asClass
+            defn.ObjectType :: Nil, newScope, coord = pos, compUnitInfo = compUnitInfo).entered.asClass
           cls.enter(newDefaultConstructor(cls), EmptyScope)
           val meth = newSymbol(cls, nme.apply, Method, ExprType(defn.AnyType), coord = pos).entered
 

--- a/tasty/src/dotty/tools/tasty/TastyHeaderUnpickler.scala
+++ b/tasty/src/dotty/tools/tasty/TastyHeaderUnpickler.scala
@@ -3,7 +3,6 @@ package dotty.tools.tasty
 import java.util.UUID
 
 import TastyFormat.{MajorVersion, MinorVersion, ExperimentalVersion, header}
-import TastyHeaderUnpickler.TastyVersion
 
 /**
  * The Tasty Header consists of four fields:
@@ -213,28 +212,5 @@ object TastyHeaderUnpickler {
         // e.g. 3.4.0 reading 3.4.0-RC1-NIGHTLY, or 3.3.0 reading 3.0.2-RC1-NIGHTLY
         BackwardIncompatibleExperimental
       else ForwardIncompatible
-  }
-
-  case class TastyVersion(major: Int, minor: Int, experimental: Int) {
-    def isExperimental: Boolean = experimental > 0
-
-    def nextStable: TastyVersion = copy(experimental = 0)
-
-    def minStable: TastyVersion = copy(minor = 0, experimental = 0)
-
-    def show: String = {
-      val suffix = if (isExperimental) s"-experimental-$experimental" else ""
-      s"$major.$minor$suffix"
-    }
-
-    def kind: String =
-      if (isExperimental) "experimental TASTy" else "TASTy"
-
-    def validRange: String = {
-      val min = TastyVersion(major, 0, 0)
-      val max = if (experimental == 0) this else TastyVersion(major, minor - 1, 0)
-      val extra = Option.when(experimental > 0)(this)
-      s"stable TASTy from ${min.show} to ${max.show}${extra.fold("")(e => s", or exactly ${e.show}")}"
-    }
   }
 }

--- a/tasty/src/dotty/tools/tasty/TastyVersion.scala
+++ b/tasty/src/dotty/tools/tasty/TastyVersion.scala
@@ -1,0 +1,24 @@
+package dotty.tools.tasty
+
+case class TastyVersion(major: Int, minor: Int, experimental: Int) {
+  def isExperimental: Boolean = experimental > 0
+
+  def nextStable: TastyVersion = copy(experimental = 0)
+
+  def minStable: TastyVersion = copy(minor = 0, experimental = 0)
+
+  def show: String = {
+    val suffix = if (isExperimental) s"-experimental-$experimental" else ""
+    s"$major.$minor$suffix"
+  }
+
+  def kind: String =
+    if (isExperimental) "experimental TASTy" else "TASTy"
+
+  def validRange: String = {
+    val min = TastyVersion(major, 0, 0)
+    val max = if (experimental == 0) this else TastyVersion(major, minor - 1, 0)
+    val extra = Option.when(experimental > 0)(this)
+    s"stable TASTy from ${min.show} to ${max.show}${extra.fold("")(e => s", or exactly ${e.show}")}"
+  }
+}

--- a/tests/init-global/pos/i18628-lazy.scala
+++ b/tests/init-global/pos/i18628-lazy.scala
@@ -55,10 +55,10 @@ trait Parsers {
     }
 
     def flatMap[U](f: T => Parser[U]): Parser[U]
-      = Parser{ in => this(in) flatMapWithNext(f)}
+      = Parser{ in => this(in).flatMapWithNext(f)}
 
     def map[U](f: T => U): Parser[U] //= flatMap{x => success(f(x))}
-      = Parser{ in => this(in) map(f)}
+      = Parser{ in => this(in).map(f)}
 
     def ^^ [U](f: T => U): Parser[U] = map(f)
   }

--- a/tests/init-global/pos/i18628.scala
+++ b/tests/init-global/pos/i18628.scala
@@ -55,10 +55,10 @@ trait Parsers {
     }
 
     def flatMap[U](f: T => Parser[U]): Parser[U]
-      = Parser{ in => this(in) flatMapWithNext(f)}
+      = Parser{ in => this(in).flatMapWithNext(f)}
 
     def map[U](f: T => U): Parser[U] //= flatMap{x => success(f(x))}
-      = Parser{ in => this(in) map(f)}
+      = Parser{ in => this(in).map(f)}
 
     def ^^ [U](f: T => U): Parser[U] = map(f)
   }

--- a/tests/init/pos/Properties.scala
+++ b/tests/init/pos/Properties.scala
@@ -23,9 +23,9 @@ private[scala] trait PropertiesTrait {
   /** The loaded properties */
   protected lazy val scalaProps: java.util.Properties = {
     val props = new java.util.Properties
-    val stream = pickJarBasedOn getResourceAsStream propFilename
+    val stream = pickJarBasedOn.getResourceAsStream(propFilename)
     if (stream ne null)
-      quietlyDispose(props load stream, stream.close)
+      quietlyDispose(props.load(stream), stream.close)
 
     props
   }
@@ -47,8 +47,8 @@ private[scala] trait PropertiesTrait {
   final def setProp(name: String, value: String)      = System.setProperty(name, value)
   final def clearProp(name: String)                   = System.clearProperty(name)
 
-  final def envOrElse(name: String, alt: String)      = Option(System getenv name) getOrElse alt
-  final def envOrNone(name: String)                   = Option(System getenv name)
+  final def envOrElse(name: String, alt: String)      = Option(System.getenv(name)) getOrElse alt
+  final def envOrNone(name: String)                   = Option(System.getenv(name))
 
   final def envOrSome(name: String, alt: Option[String])       = envOrNone(name) orElse alt
 
@@ -68,7 +68,7 @@ private[scala] trait PropertiesTrait {
   val releaseVersion =
     for {
       v <- scalaPropOrNone("maven.version.number")
-      if !(v endsWith "-SNAPSHOT")
+      if !(v.endsWith("-SNAPSHOT"))
     } yield v
 
   /** The development Scala version, if this is not a final release.
@@ -82,7 +82,7 @@ private[scala] trait PropertiesTrait {
   val developmentVersion =
     for {
       v <- scalaPropOrNone("maven.version.number")
-      if v endsWith "-SNAPSHOT"
+      if v.endsWith("-SNAPSHOT")
       ov <- scalaPropOrNone("version.number")
     } yield ov
 

--- a/tests/init/pos/i15465.scala
+++ b/tests/init/pos/i15465.scala
@@ -2,7 +2,7 @@ class TestSuite:
   protected val it = new ItWord
 
   protected final class ItWord:
-    def should(string: String) = new ItVerbString("should", string)
+    infix def should(string: String) = new ItVerbString("should", string)
 
   private def registerTestToRun(fun: => Any): Unit = ()
 

--- a/tests/neg/alphanumeric-infix-operator-3.4.scala
+++ b/tests/neg/alphanumeric-infix-operator-3.4.scala
@@ -1,0 +1,11 @@
+//> using options -Werror
+
+import language.`3.4`
+
+class Foo:
+  def x(i: Int) = i
+  infix def y(i: Int) = i
+
+def test(foo: Foo): Unit =
+  foo x 1 // error (because it was compiled with 3.4+)
+  foo y 2 // ok: is marked as infix

--- a/tests/neg/alphanumeric-infix-operator.check
+++ b/tests/neg/alphanumeric-infix-operator.check
@@ -1,0 +1,6 @@
+-- Error: tests/neg/alphanumeric-infix-operator.scala:8:6 --------------------------------------------------------------
+8 |  foo x 1 // error (because it was compiled with 3.4+)
+  |      ^
+  |      Alphanumeric method x is not declared infix; it should not be used as infix operator.
+  |      Instead, use method syntax .x(...) or backticked identifier `x`.
+  |      The latter can be rewritten automatically under -rewrite -source 3.4-migration.

--- a/tests/neg/alphanumeric-infix-operator.scala
+++ b/tests/neg/alphanumeric-infix-operator.scala
@@ -1,0 +1,9 @@
+//> using options -Werror
+
+class Foo:
+  def x(i: Int) = i
+  infix def y(i: Int) = i
+
+def test(foo: Foo): Unit =
+  foo x 1 // error (because it was compiled with 3.4+)
+  foo y 2 // ok: is marked as infix

--- a/tests/neg/i10901.scala
+++ b/tests/neg/i10901.scala
@@ -13,23 +13,23 @@ object BugExp4Point2D {
 
       // N - N
       @targetName("point2DConstant")
-      def º(y: T2): Point2D[T1,T2] = ???
+      infix def º(y: T2): Point2D[T1,T2] = ???
 
 
       // N - C
       @targetName("point2DConstantData")
-      def º(y: ColumnType[T2]): Point2D[T1,T2] = ???
+      infix def º(y: ColumnType[T2]): Point2D[T1,T2] = ???
 
 
 
     extension [T1:Numeric, T2:Numeric](x: ColumnType[T1])
       // C - C
       @targetName("point2DData")
-      def º(y: ColumnType[T2]): Point2D[T1,T2] = ???
+      infix def º(y: ColumnType[T2]): Point2D[T1,T2] = ???
 
       // C - N
       @targetName("point2DDataConstant")
-      def º(y: T2): Point2D[T1,T2] = ???
+      infix def º(y: T2): Point2D[T1,T2] = ???
 
 
   }

--- a/tests/neg/i18933.check
+++ b/tests/neg/i18933.check
@@ -1,0 +1,10 @@
+-- Error: tests/neg/i18933.scala:3:8 -----------------------------------------------------------------------------------
+3 |  infix case B(b: B) // error // error
+  |        ^^^^
+  |        end of statement expected but 'case' found
+-- [E006] Not Found Error: tests/neg/i18933.scala:3:2 ------------------------------------------------------------------
+3 |  infix case B(b: B) // error // error
+  |  ^^^^^
+  |  Not found: infix
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i18933.scala
+++ b/tests/neg/i18933.scala
@@ -1,0 +1,3 @@
+enum Extends[A, B]:
+  case A(a: A)
+  infix case B(b: B) // error // error

--- a/tests/neg/i2033.check
+++ b/tests/neg/i2033.check
@@ -13,3 +13,9 @@
 6 |    val out = new ObjectOutputStream(println)
   |                                     ^^^^^^^
   |method println is eta-expanded even though java.io.OutputStream does not have the @FunctionalInterface annotation.
+-- Warning: tests/neg/i2033.scala:7:18 ---------------------------------------------------------------------------------
+7 |    val arr = bos toByteArray ()  // error
+  |                  ^^^^^^^^^^^
+  |                  Alphanumeric method toByteArray is not declared infix; it should not be used as infix operator.
+  |                  Instead, use method syntax .toByteArray(...) or backticked identifier `toByteArray`.
+  |                  The latter can be rewritten automatically under -rewrite -source 3.4-migration.

--- a/tests/neg/rewrite-messages.check
+++ b/tests/neg/rewrite-messages.check
@@ -8,4 +8,4 @@
   |    ^^^
   |    Alphanumeric method foo is not declared infix; it should not be used as infix operator.
   |    Instead, use method syntax .foo(...) or backticked identifier `foo`.
-  |    The latter can be rewritten automatically under -rewrite -source future-migration.
+  |    The latter can be rewritten automatically under -rewrite -source 3.4-migration.

--- a/tests/neg/syntax-error-recovery.check
+++ b/tests/neg/syntax-error-recovery.check
@@ -136,3 +136,9 @@
    |       Discarded non-Unit value of type Null. You may want to use `()`.
    |
    | longer explanation available when compiling with `-explain`
+-- Warning: tests/neg/syntax-error-recovery.scala:61:2 -----------------------------------------------------------------
+61 |  println(bam)
+   |  ^^^^^^^
+   |  Alphanumeric method println is not declared infix; it should not be used as infix operator.
+   |  Instead, use method syntax .println(...) or backticked identifier `println`.
+   |  The latter can be rewritten automatically under -rewrite -source 3.4-migration.

--- a/tests/pos/alphanumeric-infix-operator-compat/A_1_c3.0.0.scala
+++ b/tests/pos/alphanumeric-infix-operator-compat/A_1_c3.0.0.scala
@@ -1,0 +1,3 @@
+class A:
+  def x(i: Int) = i
+  infix def y(i: Int) = i

--- a/tests/pos/alphanumeric-infix-operator-compat/B_1_c3.1.0.scala
+++ b/tests/pos/alphanumeric-infix-operator-compat/B_1_c3.1.0.scala
@@ -1,0 +1,3 @@
+class B:
+  def x(i: Int) = i
+  infix def y(i: Int) = i

--- a/tests/pos/alphanumeric-infix-operator-compat/C_1_c3.2.0.scala
+++ b/tests/pos/alphanumeric-infix-operator-compat/C_1_c3.2.0.scala
@@ -1,0 +1,3 @@
+class C:
+  def x(i: Int) = i
+  infix def y(i: Int) = i

--- a/tests/pos/alphanumeric-infix-operator-compat/D_1_c3.3.0.scala
+++ b/tests/pos/alphanumeric-infix-operator-compat/D_1_c3.3.0.scala
@@ -1,0 +1,3 @@
+class D:
+  def x(i: Int) = i
+  infix def y(i: Int) = i

--- a/tests/pos/alphanumeric-infix-operator-compat/Test3.4_2.scala
+++ b/tests/pos/alphanumeric-infix-operator-compat/Test3.4_2.scala
@@ -1,0 +1,15 @@
+//> using options -Werror
+
+import language.`3.4`
+
+def test1(a: A, b: B, c: C, d: D): Unit =
+  a x 1 // ok: was compiled with 3.0
+  b x 1 // ok: was compiled with 3.1
+  c x 1 // ok: was compiled with 3.2
+  d x 1 // ok: was compiled with 3.3
+
+  // ok: is marked as infix
+  a y 2
+  b y 2
+  c y 2
+  d y 2

--- a/tests/pos/alphanumeric-infix-operator-compat/TestFuture_2.scala
+++ b/tests/pos/alphanumeric-infix-operator-compat/TestFuture_2.scala
@@ -1,0 +1,13 @@
+import language.future
+
+def test2(a: A, b: B, c: C, d: D): Unit =
+  a x 1 // ok: was compiled with 3.0
+  b x 1 // ok: was compiled with 3.1
+  c x 1 // ok: was compiled with 3.2
+  d x 1 // ok: was compiled with 3.3
+
+  // ok: is marked as infix
+  a y 2
+  b y 2
+  c y 2
+  d y 2

--- a/tests/pos/i18933.scala
+++ b/tests/pos/i18933.scala
@@ -1,0 +1,4 @@
+//> using options -Werror
+
+infix enum Extends[A, B]:
+  case Ev[B, A <: B]() extends (A Extends B)

--- a/tests/pos/i7424c.scala
+++ b/tests/pos/i7424c.scala
@@ -1,6 +1,6 @@
 //> using options -Werror
 object Main extends App:
-   enum Extends[A, B]:
+   infix enum Extends[A, B]:
      case Ev[B, A <: B]() extends (A Extends B)
 
      def cast(a: A): B = this match {

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3460,6 +3460,7 @@ Text => empty
 Language => Scala
 Symbols => 12 entries
 Occurrences => 33 entries
+Diagnostics => 1 entries
 Synthetics => 4 entries
 
 Symbols:
@@ -3510,6 +3511,11 @@ Occurrences:
 [20:2..20:3): V -> example/StructuralTypes.V.
 [20:4..20:13): scalameta -> scala/reflect/Selectable#selectDynamic().
 [21:4..21:19): StructuralTypes -> example/StructuralTypes.
+
+Diagnostics:
+[14:20..14:23): [warning] Alphanumeric method foo is not declared infix; it should not be used as infix operator.
+Instead, use method syntax .foo(...) or backticked identifier `foo`.
+The latter can be rewritten automatically under -rewrite -source 3.4-migration.
 
 Synthetics:
 [12:2..12:6):user => reflectiveSelectable(*)


### PR DESCRIPTION
- [x] Add `compilationUnitInfo` to class symbols
- [x] Move `assocFile` into `CompilationUnitInfo`
- [x] Add tasty version to `CompilationUnitInfo`
- [x] Include #18925 to have test for `CompilationUnitInfo`
- [x] Add explicit nulls to `CompilationUnitInfo`

Fixes  #18933
