### PR TITLE
Stress test for add-class-deps (#18958)

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -902,7 +902,9 @@ object desugar {
       }
       if mods.isAllOf(Given | Inline | Transparent) then
         report.error("inline given instances cannot be trasparent", cdef)
-      val classMods = if mods.is(Given) then mods &~ (Inline | Transparent) | Synthetic else mods
+      var classMods = if mods.is(Given) then mods &~ (Inline | Transparent) | Synthetic else mods
+      if vparamAccessors.exists(_.mods.is(Tracked)) then
+        classMods |= Dependent
       cpy.TypeDef(cdef: TypeDef)(
         name = className,
         rhs = cpy.Template(impl)(constr, parents1, clsDerived, self1,

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -231,6 +231,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
     case class Infix()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Infix)
 
+    case class Tracked()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Tracked)
+
     /** Used under pureFunctions to mark impure function types `A => B` in `FunctionWithMods` */
     case class Impure()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Impure)
   }

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -242,7 +242,7 @@ object Flags {
   val (AccessorOrSealed @ _, Accessor @ _, Sealed @ _) = newFlags(11, "<accessor>", "sealed")
 
   /** A mutable var, an open class */
-  val (MutableOrOpen @ __, Mutable @ _, Open @ _) = newFlags(12, "mutable", "open")
+  val (MutableOrOpen @ _, Mutable @ _, Open @ _) = newFlags(12, "mutable", "open")
 
   /** Symbol is local to current class (i.e. private[this] or protected[this]
    *  pre: Private or Protected are also set
@@ -377,6 +377,8 @@ object Flags {
   /** Symbol cannot be found as a member during typer */
   val (Invisible @ _, _, _) = newFlags(45, "<invisible>")
 
+  val (Tracked @ _, _, _) = newFlags(46, "tracked")
+
   // ------------ Flags following this one are not pickled ----------------------------------
 
   /** Symbol is not a member of its owner */
@@ -452,7 +454,7 @@ object Flags {
     CommonSourceModifierFlags.toTypeFlags | Abstract | Sealed | Opaque | Open
 
   val TermSourceModifierFlags: FlagSet =
-    CommonSourceModifierFlags.toTermFlags | Inline | AbsOverride | Lazy
+    CommonSourceModifierFlags.toTermFlags | Inline | AbsOverride | Lazy | Tracked
 
   /** Flags representing modifiers that can appear in trees */
   val ModifierFlags: FlagSet =

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -470,7 +470,7 @@ object Flags {
     Scala2SpecialFlags, MutableOrOpen, Opaque, Touched, JavaStatic,
     OuterOrCovariant, LabelOrContravariant, CaseAccessor,
     Extension, NonMember, Implicit, Given, Permanent, Synthetic, Exported,
-    SuperParamAliasOrScala2x, Inline, Macro, ConstructorProxy, Invisible, Tracked)
+    SuperParamAliasOrScala2x, Inline, Macro, ConstructorProxy, Invisible)
 
   /** Flags that are not (re)set when completing the denotation, or, if symbol is
    *  a top-level class or object, when completing the denotation once the class
@@ -479,7 +479,7 @@ object Flags {
    */
   val AfterLoadFlags: FlagSet = commonFlags(
     FromStartFlags, AccessFlags, Final, AccessorOrSealed,
-    Abstract, LazyOrTrait, SelfName, JavaDefined, JavaAnnotation, Transparent)
+    Abstract, LazyOrTrait, SelfName, JavaDefined, JavaAnnotation, Transparent, Tracked)
 
   /** A value that's unstable unless complemented with a Stable flag */
   val UnstableValueFlags: FlagSet = Mutable | Method

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -377,7 +377,7 @@ object Flags {
   /** Symbol cannot be found as a member during typer */
   val (Invisible @ _, _, _) = newFlags(45, "<invisible>")
 
-  val (Tracked @ _, _, _) = newFlags(46, "tracked")
+  val (Tracked @ _, _, Dependent @ _) = newFlags(46, "tracked", "dependent")
 
   // ------------ Flags following this one are not pickled ----------------------------------
 
@@ -470,7 +470,7 @@ object Flags {
     Scala2SpecialFlags, MutableOrOpen, Opaque, Touched, JavaStatic,
     OuterOrCovariant, LabelOrContravariant, CaseAccessor,
     Extension, NonMember, Implicit, Given, Permanent, Synthetic, Exported,
-    SuperParamAliasOrScala2x, Inline, Macro, ConstructorProxy, Invisible)
+    SuperParamAliasOrScala2x, Inline, Macro, ConstructorProxy, Invisible, Tracked)
 
   /** Flags that are not (re)set when completing the denotation, or, if symbol is
    *  a top-level class or object, when completing the denotation once the class

--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -14,14 +14,15 @@ object NamerOps:
    *  @param ctor the constructor
    */
   def effectiveResultType(ctor: Symbol, paramss: List[List[Symbol]])(using Context): Type =
-    paramss match
+    var resType = paramss match
       case TypeSymbols(tparams) :: _ =>
-        var resType = ctor.owner.typeRef.appliedTo(tparams.map(_.typeRef))
-        for params <- paramss; param <- params do
-          if param.is(Tracked) then
-            resType = RefinedType(resType, param.name, param.termRef)
-        resType
-      case _ => ctor.owner.typeRef
+        ctor.owner.typeRef.appliedTo(tparams.map(_.typeRef))
+      case _ =>
+        ctor.owner.typeRef
+    for params <- paramss; param <- params do
+      if param.is(Tracked) then
+        resType = RefinedType(resType, param.name, param.termRef)
+    resType
 
   /** If isConstructor, make sure it has at least one non-implicit parameter list
    *  This is done by adding a () in front of a leading old style implicit parameter,

--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -15,7 +15,12 @@ object NamerOps:
    */
   def effectiveResultType(ctor: Symbol, paramss: List[List[Symbol]])(using Context): Type =
     paramss match
-      case TypeSymbols(tparams) :: _ => ctor.owner.typeRef.appliedTo(tparams.map(_.typeRef))
+      case TypeSymbols(tparams) :: _ =>
+        var resType = ctor.owner.typeRef.appliedTo(tparams.map(_.typeRef))
+        for params <- paramss; param <- params do
+          if param.is(Tracked) then
+            resType = RefinedType(resType, param.name, param.termRef)
+        resType
       case _ => ctor.owner.typeRef
 
   /** If isConstructor, make sure it has at least one non-implicit parameter list

--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -10,6 +10,7 @@ import Contexts.ctx
 import dotty.tools.dotc.reporting.trace
 import config.Feature.migrateTo3
 import config.Printers.*
+import transform.TypeUtils.stripRefinement
 
 trait PatternTypeConstrainer { self: TypeComparer =>
 
@@ -86,11 +87,6 @@ trait PatternTypeConstrainer { self: TypeComparer =>
           patCls.derivesFrom(scrCls) || scrCls.derivesFrom(patCls)
         else true
       }
-    }
-
-    def stripRefinement(tp: Type): Type = tp match {
-      case tp: RefinedOrRecType => stripRefinement(tp.parent)
-      case tp => tp
     }
 
     def tryConstrainSimplePatternType(pat: Type, scrut: Type) = {

--- a/compiler/src/dotty/tools/dotc/core/Scopes.scala
+++ b/compiler/src/dotty/tools/dotc/core/Scopes.scala
@@ -17,6 +17,7 @@ import Denotations.*
 import printing.Texts.*
 import printing.Printer
 import SymDenotations.NoDenotation
+import util.common.alwaysFalse
 
 import collection.mutable
 import scala.compiletime.uninitialized
@@ -94,15 +95,13 @@ object Scopes {
     def foreach[U](f: Symbol => U)(using Context): Unit = toList.foreach(f)
 
     /** Selects all Symbols of this Scope which satisfy a predicate. */
-    def filter(p: Symbol => Boolean)(using Context): List[Symbol] = {
+    def filter(p: Symbol => Boolean, stopAt: Symbol => Boolean = alwaysFalse)(using Context): List[Symbol] = {
       ensureComplete()
       var syms: List[Symbol] = Nil
       var e = lastEntry
-      while ((e != null) && e.owner == this) {
-        val sym = e.sym
-        if (p(sym)) syms = sym :: syms
+      while e != null && e.owner == this && !stopAt(e.sym) do
+        if p(e.sym) then syms = e.sym :: syms
         e = e.prev
-      }
       syms
     }
 

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -623,6 +623,7 @@ object StdNames {
     val toString_ : N           = "toString"
     val toTypeConstructor: N    = "toTypeConstructor"
     val tpe : N                 = "tpe"
+    val tracked: N              = "tracked"
     val transparent : N         = "transparent"
     val tree : N                = "tree"
     val true_ : N               = "true"

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2380,7 +2380,7 @@ object SymDenotations {
      *  Both getters and setters are returned in this list.
      */
     def paramAccessors(using Context): List[Symbol] =
-      unforcedDecls.filter(_.is(ParamAccessor))
+      unforcedDecls.filter(_.is(ParamAccessor))//, stopAt = sym => sym.is(Method, butNot = ParamAccessor))
 
     /** The term parameter getters of this class. */
     def paramGetters(using Context): List[Symbol] =

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -776,6 +776,7 @@ class TreePickler(pickler: TastyPickler) {
     if (flags.is(Exported)) writeModTag(EXPORTED)
     if (flags.is(Given)) writeModTag(GIVEN)
     if (flags.is(Implicit)) writeModTag(IMPLICIT)
+    if (flags.is(Tracked)) writeModTag(TRACKED)
     if (isTerm) {
       if (flags.is(Lazy, butNot = Module)) writeModTag(LAZY)
       if (flags.is(AbsOverride)) { writeModTag(ABSTRACT); writeModTag(OVERRIDE) }
@@ -787,7 +788,6 @@ class TreePickler(pickler: TastyPickler) {
       if (flags.is(Extension)) writeModTag(EXTENSION)
       if (flags.is(ParamAccessor)) writeModTag(PARAMsetter)
       if (flags.is(SuperParamAlias)) writeModTag(PARAMalias)
-      if (flags.is(Tracked)) writeModTag(TRACKED)
       assert(!(flags.is(Label)))
     }
     else {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -787,6 +787,7 @@ class TreePickler(pickler: TastyPickler) {
       if (flags.is(Extension)) writeModTag(EXTENSION)
       if (flags.is(ParamAccessor)) writeModTag(PARAMsetter)
       if (flags.is(SuperParamAlias)) writeModTag(PARAMalias)
+      if (flags.is(Tracked)) writeModTag(TRACKED)
       assert(!(flags.is(Label)))
     }
     else {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -733,6 +733,7 @@ class TreeUnpickler(reader: TastyReader,
           case INVISIBLE => addFlag(Invisible)
           case TRANSPARENT => addFlag(Transparent)
           case INFIX => addFlag(Infix)
+          case TRACKED => addFlag(Tracked)
           case PRIVATEqualified =>
             readByte()
             privateWithin = readWithin

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -61,7 +61,7 @@ object Parsers {
     case ExtensionFollow // extension clause, following extension parameter
 
     def isClass = // owner is a class
-      this == Class || this == CaseClass
+      this == Class || this == CaseClass || this == Given
     def takesOnlyUsingClauses = // only using clauses allowed for this owner
       this == Given || this == ExtensionFollow
     def acceptsVariance =
@@ -3283,7 +3283,7 @@ object Parsers {
         val isAbstractOwner = paramOwner == ParamOwner.Type || paramOwner == ParamOwner.TypeParam
         val start = in.offset
         var mods = annotsAsMods() | Param
-        if paramOwner == ParamOwner.Class || paramOwner == ParamOwner.CaseClass then
+        if paramOwner.isClass then
           mods |= PrivateLocal
         if isIdent(nme.raw.PLUS) && checkVarianceOK() then
           mods |= Covariant
@@ -4001,6 +4001,13 @@ object Parsers {
       val nameStart = in.offset
       val name = if isIdent && followingIsGivenSig() then ident() else EmptyTermName
 
+      def adjustDefParams(paramss: List[ParamClause]): List[ParamClause] =
+        paramss.nestedMap: param =>
+          if !param.mods.isAllOf(PrivateLocal) then
+            syntaxError(em"method parameter ${param.name} may not be `a val`", param.span)
+          param.withMods(param.mods &~ (AccessFlags | ParamAccessor | Mutable) | Param)
+        .asInstanceOf[List[ParamClause]]
+
       val gdef =
         val tparams = typeParamClauseOpt(ParamOwner.Given)
         newLineOpt()
@@ -4022,16 +4029,17 @@ object Parsers {
             mods1 |= Lazy
             ValDef(name, parents.head, subExpr())
           else
-            DefDef(name, joinParams(tparams, vparamss), parents.head, subExpr())
+            DefDef(name, adjustDefParams(joinParams(tparams, vparamss)), parents.head, subExpr())
         else if (isStatSep || isStatSeqEnd) && parentsIsType then
           if name.isEmpty then
             syntaxError(em"anonymous given cannot be abstract")
-          DefDef(name, joinParams(tparams, vparamss), parents.head, EmptyTree)
+          DefDef(name, adjustDefParams(joinParams(tparams, vparamss)), parents.head, EmptyTree)
         else
-          val tparams1 = tparams.map(tparam => tparam.withMods(tparam.mods | PrivateLocal))
-          val vparamss1 = vparamss.map(_.map(vparam =>
-            vparam.withMods(vparam.mods &~ Param | ParamAccessor | Protected)))
-          val constr = makeConstructor(tparams1, vparamss1)
+          val vparamss1 = vparamss.nestedMap: vparam =>
+            if vparam.mods.is(Private)
+            then vparam.withMods(vparam.mods &~ PrivateLocal | Protected)
+            else vparam
+          val constr = makeConstructor(tparams, vparamss1)
           val templ =
             if isStatSep || isStatSeqEnd then Template(constr, parents, Nil, EmptyValDef, Nil)
             else withTemplate(constr, parents)

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -294,7 +294,7 @@ object Tokens extends TokensCommon {
 
   final val closingParens = BitSet(RPAREN, RBRACKET, RBRACE)
 
-  final val softModifierNames = Set(nme.inline, nme.into, nme.opaque, nme.open, nme.transparent, nme.infix)
+  final val softModifierNames = Set(nme.inline, nme.into, nme.opaque, nme.open, nme.transparent, nme.infix, nme.tracked)
 
   def showTokenDetailed(token: Int): String = debugString(token)
 

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -111,7 +111,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def refinementNameString(tp: RefinedType): String = nameString(tp.refinedName)
 
   /** String representation of a refinement */
-  protected def toTextRefinement(rt: RefinedType): Text =
+  def toTextRefinement(rt: RefinedType): Text =
     val keyword = rt.refinedInfo match {
       case _: ExprType | _: MethodOrPoly => "def "
       case _: TypeBounds => "type "

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -4,7 +4,7 @@ package printing
 
 import core.*
 import Texts.*, ast.Trees.*
-import Types.{Type, SingletonType, LambdaParam, NamedType},
+import Types.{Type, SingletonType, LambdaParam, NamedType, RefinedType},
        Symbols.Symbol, Scopes.Scope, Constants.Constant,
        Names.Name, Denotations._, Annotations.Annotation, Contexts.Context
 import typer.Implicits.*
@@ -103,6 +103,9 @@ abstract class Printer {
 
   /** Textual representation of a prefix of some reference, ending in `.` or `#` */
   def toTextPrefixOf(tp: NamedType): Text
+
+  /** textual representation of a refinement, with no enclosing {...} */
+  def toTextRefinement(rt: RefinedType): Text
 
   /** Textual representation of a reference in a capture set */
   def toTextCaptureRef(tp: Type): Text

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -332,11 +332,11 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
             case Select(nu: New, nme.CONSTRUCTOR) if isCheckable(nu) =>
               // need to check instantiability here, because the type of the New itself
               // might be a type constructor.
-              ctx.typer.checkClassType(tree.tpe, tree.srcPos, traitReq = false, stablePrefixReq = true)
+              ctx.typer.checkClassType(tree.tpe, tree.srcPos, traitReq = false, stablePrefixReq = true, refinementOK = true)
               if !nu.tpe.isLambdaSub then
                 // Check the constructor type as well; it could be an illegal singleton type
                 // which would not be reflected as `tree.tpe`
-                ctx.typer.checkClassType(nu.tpe, tree.srcPos, traitReq = false, stablePrefixReq = false)
+                ctx.typer.checkClassType(nu.tpe, tree.srcPos, traitReq = false, stablePrefixReq = false, refinementOK = true)
               Checking.checkInstantiable(tree.tpe, nu.tpe, nu.srcPos)
               withNoCheckNews(nu :: Nil)(app1)
             case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -7,11 +7,11 @@ import TypeErasure.ErasedValueType
 import Types.*, Contexts.*, Symbols.*, Flags.*, Decorators.*
 import Names.Name
 
-object TypeUtils {
+object TypeUtils:
   /** A decorator that provides methods on types
    *  that are needed in the transformer pipeline.
    */
-  extension (self: Type) {
+  extension (self: Type)
 
     def isErasedValueType(using Context): Boolean =
       self.isInstanceOf[ErasedValueType]
@@ -104,5 +104,11 @@ object TypeUtils {
       case _ =>
         val cls = self.underlyingClassRef(refinementOK = false).typeSymbol
         cls.isTransparentClass && (!traitOnly || cls.is(Trait))
-  }
-}
+
+    /** Strip all outer refinements off this type */
+    def stripRefinement: Type = self match
+      case self: RefinedOrRecType => self.parent.stripRefinement
+      case seld => self
+
+end TypeUtils
+

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -198,7 +198,7 @@ object Checking {
    *  and that the instance conforms to the self type of the created class.
    */
   def checkInstantiable(tp: Type, srcTp: Type, pos: SrcPos)(using Context): Unit =
-    tp.underlyingClassRef(refinementOK = false) match
+    tp.underlyingClassRef(refinementOK = true) match
       case tref: TypeRef =>
         val cls = tref.symbol
         if (cls.isOneOf(AbstractOrTrait)) {

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1021,8 +1021,8 @@ trait Checking {
   *   check that class prefix is stable.
    *  @return  `tp` itself if it is a class or trait ref, ObjectType if not.
    */
-  def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean)(using Context): Type =
-    tp.underlyingClassRef(refinementOK = false) match {
+  def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean, refinementOK: Boolean = false)(using Context): Type =
+    tp.underlyingClassRef(refinementOK) match
       case tref: TypeRef =>
         if (traitReq && !tref.symbol.is(Trait)) report.error(TraitIsExpected(tref.symbol), pos)
         if (stablePrefixReq && ctx.phase <= refchecksPhase) checkStable(tref.prefix, pos, "class prefix")
@@ -1030,7 +1030,6 @@ trait Checking {
       case _ =>
         report.error(NotClassType(tp), pos)
         defn.ObjectType
-    }
 
   /** If `sym` is an old-style implicit conversion, check that implicit conversions are enabled.
    *  @pre  sym.is(GivenOrImplicit)
@@ -1601,7 +1600,7 @@ trait NoChecking extends ReChecking {
   override def checkNonCyclic(sym: Symbol, info: TypeBounds, reportErrors: Boolean)(using Context): Type = info
   override def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, pos: SrcPos)(using Context): Unit = ()
   override def checkStable(tp: Type, pos: SrcPos, kind: String)(using Context): Unit = ()
-  override def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean)(using Context): Type = tp
+  override def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean, refinementOK: Boolean)(using Context): Type = tp
   override def checkImplicitConversionDefOK(sym: Symbol)(using Context): Unit = ()
   override def checkImplicitConversionUseOK(tree: Tree, expected: Type)(using Context): Unit = ()
   override def checkFeasibleParent(tp: Type, pos: SrcPos, where: => String = "")(using Context): Type = tp

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1201,7 +1201,7 @@ trait Checking {
   def checkOnlyDependentRefinements(cls: ClassSymbol, parent: Tree)(using Context): Unit =
     def recur(ptype: Type): Unit = ptype.dealias match
       case rt @ RefinedType(ptype1, rname, rinfo) =>
-        val ok = rname.isTermName && cls.info.member(rname).hasAltWith(_.symbol.is(Tracked))
+        val ok = rname.isTermName && ptype1.nonPrivateMember(rname).hasAltWith(_.symbol.is(Tracked))
         if !ok then
           report.error(
               em"""Illegal refinement { ${ctx.printer.toTextRefinement(rt).show} } in parent type of $cls;

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2704,6 +2704,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           ensureAccessible(constr.termRef, superAccess = true, tree.srcPos)
       else
         checkParentCall(result, cls)
+      if !cls.isRefinementClass then
+        checkOnlyDependentRefinements(cls, parent)
       if cls is Case then
         checkCaseInheritance(psym, cls, tree.srcPos)
       result

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4360,7 +4360,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           cpy.Ident(qual)(qual.symbol.name.sourceModuleName.toTypeName)
         case _ =>
           errorTree(tree, em"cannot convert from $tree to an instance creation expression")
-      val tycon = tree.tpe.widen.finalResultType.underlyingClassRef(refinementOK = false)
+      val tycon = tree.tpe.widen.finalResultType.underlyingClassRef(refinementOK = true)
       typed(
         untpd.Select(
           untpd.New(untpd.TypedSplice(tpt.withType(tycon))),

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -111,3 +111,6 @@ java-inherited-type1
 
 # recursion limit exceeded
 i7445b.scala
+
+# alias types at different levels of dereferencing
+parsercombinators-givens.scala

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -219,6 +219,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   EXPORTED                                                         -- An export forwarder
                   OPEN                                                             -- an open class
                   INVISIBLE                                                        -- invisible during typechecking
+                  TRACKED                                                          -- a tracked class parameter / a dependent class
                   Annotation
 
   Variance      = STABLE                                                           -- invariant

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -485,6 +485,7 @@ object TastyFormat {
   final val INVISIBLE = 44
   final val EMPTYCLAUSE = 45
   final val SPLITCLAUSE = 46
+  final val TRACKED = 47
 
   // Cat. 2:    tag Nat
 
@@ -662,7 +663,8 @@ object TastyFormat {
        | INVISIBLE
        | ANNOTATION
        | PRIVATEqualified
-       | PROTECTEDqualified => true
+       | PROTECTEDqualified
+       | TRACKED => true
     case _ => false
   }
 

--- a/tests/neg/i0248-inherit-refined.check
+++ b/tests/neg/i0248-inherit-refined.check
@@ -1,0 +1,18 @@
+-- Error: tests/neg/i0248-inherit-refined.scala:4:18 -------------------------------------------------------------------
+4 |  class B extends X                                   // error
+  |                  ^
+  |                  Illegal refinement { type T = Int } in parent type of class B;
+  |                  only val refinements of tracked parameters are allowed.
+-- [E170] Type Error: tests/neg/i0248-inherit-refined.scala:6:18 -------------------------------------------------------
+6 |  class C extends Y                                   // error
+  |                  ^
+  |                  test.A & test.B is not a class type
+-- [E170] Type Error: tests/neg/i0248-inherit-refined.scala:8:18 -------------------------------------------------------
+8 |  class D extends Z                                   // error
+  |                  ^
+  |                  test.A | test.B is not a class type
+-- Error: tests/neg/i0248-inherit-refined.scala:9:28 -------------------------------------------------------------------
+9 |  abstract class E extends ({ val x: Int })           // error
+  |                            ^^^^^^^^^^^^^^
+  |                            Illegal refinement { val x: Int } in parent type of class E;
+  |                            only val refinements of tracked parameters are allowed.

--- a/tests/neg/i3964.scala
+++ b/tests/neg/i3964.scala
@@ -10,3 +10,7 @@ object Test1:
   trait Foo { val x: Animal }
   val foo: Foo { val x: Cat } = new Foo { val x = new Cat }  // error, but should work
 
+object Test3:
+  trait Vec(tracked val size: Int)
+  class Vec8 extends Vec(8):
+    val s: 8 = size    // error, but should work

--- a/tests/neg/i3964.scala
+++ b/tests/neg/i3964.scala
@@ -10,23 +10,3 @@ object Test1:
   trait Foo { val x: Animal }
   val foo: Foo { val x: Cat } = new Foo { val x = new Cat }  // error, but should work
 
-object Test2:
-  abstract class Bar(tracked val x: Animal)
-  val b = new Bar(new Cat)
-  val bar: Bar { val x: Cat } = new Bar(new Cat)  // ok
-
-  trait Foo(tracked val x: Animal)
-  val foo: Foo { val x: Cat } = new Foo(new Cat)  // ok
-
-object Test3:
-  trait Vec(tracked val size: Int)
-  class Vec8 extends Vec(8)
-
-  abstract class Lst(tracked val size: Int)
-  class Lst8 extends Lst(8)
-
-  val v8a: Vec { val size: 8 } = new Vec8        // error, but should work
-  val v8b: Vec { val size: 8 } = new Vec(8)      // ok
-
-  val l8a: Lst { val size: 8 } = new Lst8        // error, but should work
-  val l8b: Lst { val size: 8 } = new Lst(8)      // ok

--- a/tests/neg/i3964.scala
+++ b/tests/neg/i3964.scala
@@ -1,0 +1,32 @@
+trait Animal
+class Dog extends Animal
+class Cat extends Animal
+
+object Test1:
+
+  abstract class Bar { val x: Animal }
+  val bar: Bar { val x: Cat } = new Bar { val x = new Cat }  // error, but should work
+
+  trait Foo { val x: Animal }
+  val foo: Foo { val x: Cat } = new Foo { val x = new Cat }  // error, but should work
+
+object Test2:
+  abstract class Bar(tracked val x: Animal)
+  val b = new Bar(new Cat)
+  val bar: Bar { val x: Cat } = new Bar(new Cat)  // ok
+
+  trait Foo(tracked val x: Animal)
+  val foo: Foo { val x: Cat } = new Foo(new Cat)  // ok
+
+object Test3:
+  trait Vec(tracked val size: Int)
+  class Vec8 extends Vec(8)
+
+  abstract class Lst(tracked val size: Int)
+  class Lst8 extends Lst(8)
+
+  val v8a: Vec { val size: 8 } = new Vec8        // error, but should work
+  val v8b: Vec { val size: 8 } = new Vec(8)      // ok
+
+  val l8a: Lst { val size: 8 } = new Lst8        // error, but should work
+  val l8b: Lst { val size: 8 } = new Lst(8)      // ok

--- a/tests/pos/depclass-1.scala
+++ b/tests/pos/depclass-1.scala
@@ -1,0 +1,8 @@
+class A(tracked val source: String)
+
+class B(source: String) extends A(source)
+
+class C(source: String) extends B(source)
+
+val x = C("hello")
+val _: A{ val source: "hello" } = x

--- a/tests/pos/i3920.scala
+++ b/tests/pos/i3920.scala
@@ -1,0 +1,32 @@
+
+trait Ordering {
+  type T
+  def compare(t1:T, t2: T): Int
+}
+
+class SetFunctor(tracked val ord: Ordering) {
+  type Set = List[ord.T]
+  def empty: Set = Nil
+
+  implicit class helper(s: Set) {
+    def add(x: ord.T): Set = x :: remove(x)
+    def remove(x: ord.T): Set = s.filter(e => ord.compare(x, e) != 0)
+    def member(x: ord.T): Boolean = s.exists(e => ord.compare(x, e) == 0)
+  }
+}
+
+object Test {
+  val orderInt = new Ordering {
+    type T = Int
+    def compare(t1: T, t2: T): Int = t1 - t2
+  }
+
+  val IntSet = new SetFunctor(orderInt)
+  import IntSet._
+
+  def main(args: Array[String]) = {
+    val set = IntSet.empty.add(6).add(8).add(23)
+    assert(!set.member(7))
+    assert(set.member(8))
+  }
+}

--- a/tests/pos/i3964.scala
+++ b/tests/pos/i3964.scala
@@ -1,0 +1,31 @@
+trait Animal
+class Dog extends Animal
+class Cat extends Animal
+
+object Test2:
+  class Bar(tracked val x: Animal)
+  val b = new Bar(new Cat)
+  val bar: Bar { val x: Cat } = new Bar(new Cat)  // ok
+
+  trait Foo(tracked val x: Animal)
+  val foo: Foo { val x: Cat } = new Foo(new Cat) {} // ok
+
+object Test3:
+  trait Vec(tracked val size: Int)
+  class Vec8 extends Vec(8)
+
+  abstract class Lst(tracked val size: Int)
+  class Lst8 extends Lst(8)
+
+  val v8a: Vec { val size: 8 } = new Vec8
+  val v8b: Vec { val size: 8 } = new Vec(8) {}
+
+  val l8a: Lst { val size: 8 } = new Lst8
+  val l8b: Lst { val size: 8 } = new Lst(8) {}
+
+  class VecN(tracked val n: Int) extends Vec(n)
+  class Vec9 extends VecN(9)
+  val v9a = VecN(9)
+  val _: Vec { val size: 9 } = v9a
+  val v9b = Vec9()
+  val _: Vec { val size: 9 } = v9b

--- a/tests/pos/i3964a/Defs_1.scala
+++ b/tests/pos/i3964a/Defs_1.scala
@@ -1,0 +1,16 @@
+trait Animal
+class Dog extends Animal
+class Cat extends Animal
+
+object Test2:
+  class Bar(tracked val x: Animal)
+  val b = new Bar(new Cat)
+  val bar: Bar { val x: Cat } = new Bar(new Cat)  // ok
+
+  trait Foo(tracked val x: Animal)
+  val foo: Foo { val x: Cat } = new Foo(new Cat) {} // ok
+
+trait Vec(tracked val size: Int)
+class Vec8 extends Vec(8)
+
+abstract class Lst(tracked val size: Int)

--- a/tests/pos/i3964a/Uses_2.scala
+++ b/tests/pos/i3964a/Uses_2.scala
@@ -1,0 +1,14 @@
+class Lst8 extends Lst(8)
+
+val v8a: Vec { val size: 8 } = new Vec8
+val v8b: Vec { val size: 8 } = new Vec(8) {}
+
+val l8a: Lst { val size: 8 } = new Lst8
+val l8b: Lst { val size: 8 } = new Lst(8) {}
+
+class VecN(tracked val n: Int) extends Vec(n)
+class Vec9 extends VecN(9)
+val v9a = VecN(9)
+val _: Vec { val size: 9 } = v9a
+val v9b = Vec9()
+val _: Vec { val size: 9 } = v9b

--- a/tests/pos/parsercombinators-expanded.scala
+++ b/tests/pos/parsercombinators-expanded.scala
@@ -1,0 +1,67 @@
+import collection.mutable
+
+/// A parser combinator.
+trait Combinator[T]:
+
+  /// The context from which elements are being parsed, typically a stream of tokens.
+  type Context
+  /// The element being parsed.
+  type Element
+
+  extension (self: T)
+    /// Parses and returns an element from `context`.
+    def parse(context: Context): Option[Element]
+end Combinator
+
+final case class Apply[C, E](action: C => Option[E])
+final case class Combine[A, B](first: A, second: B)
+
+object test:
+
+  class apply[C, E] extends Combinator[Apply[C, E]]:
+    type Context = C
+    type Element = E
+    extension(self: Apply[C, E])
+      def parse(context: C): Option[E] = self.action(context)
+
+  def apply[C, E]: apply[C, E] = new apply[C, E]
+
+  class combine[A, B](
+      val f: Combinator[A],
+      val s: Combinator[B] { type Context = f.Context}
+  ) extends Combinator[Combine[A, B]]:
+    type Context = f.Context
+    type Element = (f.Element, s.Element)
+    extension(self: Combine[A, B])
+      def parse(context: Context): Option[Element] = ???
+
+  def combine[A, B](
+      _f: Combinator[A],
+      _s: Combinator[B] { type Context = _f.Context}
+    ): combine[A, B] {
+      type Context = _f.Context
+      type Element = (_f.Element, _s.Element)
+    } = new combine[A, B](_f, _s).asInstanceOf
+    // cast is needed since the type of new combine[A, B](_f, _s)
+    // drops the required refinement.
+
+  extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
+    if buf.isEmpty then None
+    else try Some(buf.head) finally buf.remove(0)
+
+  @main def hello: Unit = {
+    val source = (0 to 10).toList
+    val stream = source.to(mutable.ListBuffer)
+
+    val n = Apply[mutable.ListBuffer[Int], Int](s => s.popFirst())
+    val m = Combine(n, n)
+
+    val c = combine[
+        Apply[mutable.ListBuffer[Int], Int],
+        Apply[mutable.ListBuffer[Int], Int]
+      ](
+        apply[mutable.ListBuffer[Int], Int],
+        apply[mutable.ListBuffer[Int], Int]
+      )
+    val r = c.parse(m)(stream) // type mismatch, found `mutable.ListBuffer[Int]`, required `?1.Context`
+  }

--- a/tests/pos/parsercombinators-expanded.scala
+++ b/tests/pos/parsercombinators-expanded.scala
@@ -27,8 +27,8 @@ object test:
   def apply[C, E]: apply[C, E] = new apply[C, E]
 
   class combine[A, B](
-      val f: Combinator[A],
-      val s: Combinator[B] { type Context = f.Context}
+      tracked val f: Combinator[A],
+      tracked val s: Combinator[B] { type Context = f.Context}
   ) extends Combinator[Combine[A, B]]:
     type Context = f.Context
     type Element = (f.Element, s.Element)
@@ -38,10 +38,7 @@ object test:
   def combine[A, B](
       _f: Combinator[A],
       _s: Combinator[B] { type Context = _f.Context}
-    ): combine[A, B] {
-      type Context = _f.Context
-      type Element = (_f.Element, _s.Element)
-    } = new combine[A, B](_f, _s).asInstanceOf
+    ) = new combine[A, B](_f, _s)
     // cast is needed since the type of new combine[A, B](_f, _s)
     // drops the required refinement.
 
@@ -56,12 +53,10 @@ object test:
     val n = Apply[mutable.ListBuffer[Int], Int](s => s.popFirst())
     val m = Combine(n, n)
 
-    val c = combine[
-        Apply[mutable.ListBuffer[Int], Int],
-        Apply[mutable.ListBuffer[Int], Int]
-      ](
+    val c = combine(
         apply[mutable.ListBuffer[Int], Int],
         apply[mutable.ListBuffer[Int], Int]
       )
-    val r = c.parse(m)(stream) // type mismatch, found `mutable.ListBuffer[Int]`, required `?1.Context`
+    val r = c.parse(m)(stream) // was type mismatch, now OK
+    val rc: Option[(Int, Int)] = r
   }

--- a/tests/pos/parsercombinators-givens-2.scala
+++ b/tests/pos/parsercombinators-givens-2.scala
@@ -1,0 +1,50 @@
+import collection.mutable
+
+/// A parser combinator.
+trait Combinator[T]:
+
+  /// The context from which elements are being parsed, typically a stream of tokens.
+  type Context
+  /// The element being parsed.
+  type Element
+
+  extension (self: T)
+    /// Parses and returns an element from `context`.
+    def parse(context: Context): Option[Element]
+end Combinator
+
+final case class Apply[C, E](action: C => Option[E])
+final case class Combine[A, B](first: A, second: B)
+
+given apply[C, E]: Combinator[Apply[C, E]] with {
+  type Context = C
+  type Element = E
+  extension(self: Apply[C, E]) {
+    def parse(context: C): Option[E] = self.action(context)
+  }
+}
+
+given combine[A, B, C](using
+    f: Combinator[A] { type Context = C },
+    s: Combinator[B] { type Context = C }
+): Combinator[Combine[A, B]] with {
+  type Context = f.Context
+  type Element = (f.Element, s.Element)
+  extension(self: Combine[A, B]) {
+    def parse(context: Context): Option[Element] = ???
+  }
+}
+
+extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
+  if buf.isEmpty then None
+  else try Some(buf.head) finally buf.remove(0)
+
+@main def hello: Unit = {
+  val source = (0 to 10).toList
+  val stream = source.to(mutable.ListBuffer)
+
+  val n = Apply[mutable.ListBuffer[Int], Int](s => s.popFirst())
+  val m = Combine(n, n)
+
+  val r = m.parse(stream) // works, but Element type is not resolved correctly
+}

--- a/tests/pos/parsercombinators-givens.scala
+++ b/tests/pos/parsercombinators-givens.scala
@@ -1,0 +1,51 @@
+import collection.mutable
+
+/// A parser combinator.
+trait Combinator[T]:
+
+  /// The context from which elements are being parsed, typically a stream of tokens.
+  type Context
+  /// The element being parsed.
+  type Element
+
+  extension (self: T)
+    /// Parses and returns an element from `context`.
+    def parse(context: Context): Option[Element]
+end Combinator
+
+final case class Apply[C, E](action: C => Option[E])
+final case class Combine[A, B](first: A, second: B)
+
+given apply[C, E]: Combinator[Apply[C, E]] with {
+  type Context = C
+  type Element = E
+  extension(self: Apply[C, E]) {
+    def parse(context: C): Option[E] = self.action(context)
+  }
+}
+
+given combine[A, B, C](using
+    f: Combinator[A] { type Context = C },
+    s: Combinator[B] { type Context = C }
+): Combinator[Combine[A, B]] with {
+  type Context = f.Context
+  type Element = (f.Element, s.Element)
+  extension(self: Combine[A, B]) {
+    def parse(context: Context): Option[Element] = ???
+  }
+}
+
+extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
+  if buf.isEmpty then None
+  else try Some(buf.head) finally buf.remove(0)
+
+@main def hello: Unit = {
+  val source = (0 to 10).toList
+  val stream = source.to(mutable.ListBuffer)
+
+  val n = Apply[mutable.ListBuffer[Int], Int](s => s.popFirst())
+  val m = Combine(n, n)
+
+  // val r = m.parse(stream) // error: type mismatch, found `mutable.ListBuffer[Int]`, required `?1.Context`
+  // it would be great if this worked
+}

--- a/tests/pos/parsercombinators-givens.scala
+++ b/tests/pos/parsercombinators-givens.scala
@@ -24,9 +24,9 @@ given apply[C, E]: Combinator[Apply[C, E]] with {
   }
 }
 
-given combine[A, B, C](using
-    f: Combinator[A] { type Context = C },
-    s: Combinator[B] { type Context = C }
+given combine[A, B](using
+    tracked val f: Combinator[A],
+    tracked val s: Combinator[B] { type Context = f.Context }
 ): Combinator[Combine[A, B]] with {
   type Context = f.Context
   type Element = (f.Element, s.Element)
@@ -46,6 +46,7 @@ extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
   val n = Apply[mutable.ListBuffer[Int], Int](s => s.popFirst())
   val m = Combine(n, n)
 
-  // val r = m.parse(stream) // error: type mismatch, found `mutable.ListBuffer[Int]`, required `?1.Context`
+  val r = m.parse(stream) // error: type mismatch, found `mutable.ListBuffer[Int]`, required `?1.Context`
+  val rc: Option[(Int, Int)] = r
   // it would be great if this worked
 }


### PR DESCRIPTION
Based on #18958 with one additional commit.

This commit marks all explicitly declared vals tracked. It causes many test failures, which
makes it unlikely that we will be able to do this in the end. But it's an excellent basis
for stress testing the implementation of dependent classes. 

The idea is to

 - look at the test failures in this test
 - convert each failing test into a test with explicit `tracked` modifiers and compile with #18958.
 - if the test still fails (it probably will), try to fix the root cause 
   or determine that the pattern should not be supported.
