### PR TITLE
Refactor some tuple methods

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -19,7 +19,6 @@ import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.core.StdNames.{nme, str}
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.transform.Erasure
-import dotty.tools.dotc.transform.SymUtils.*
 import dotty.tools.dotc.util.Spans.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Phases.*

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -20,7 +20,7 @@ import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.util.Spans.*
 import dotty.tools.dotc.report
-import dotty.tools.dotc.transform.SymUtils.*
+
 
 /*
  *

--- a/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
@@ -12,7 +12,7 @@ import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Phases.*
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Phases.Phase
-import dotty.tools.dotc.transform.SymUtils.*
+
 import dotty.tools.dotc.core.StdNames
 import dotty.tools.dotc.core.Phases
 

--- a/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
@@ -9,7 +9,7 @@ import dotty.tools.dotc.core.Phases.Phase
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import dotty.tools.dotc.transform.SymUtils.*
+
 import dotty.tools.dotc.interfaces
 import dotty.tools.dotc.report
 

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -4,7 +4,7 @@ import scala.language.unsafeNulls
 
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Flags.*
-import dotty.tools.dotc.transform.SymUtils.*
+
 import java.io.{File => _}
 
 import scala.reflect.ClassTag

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -21,7 +21,7 @@ import StdNames.*
 import TypeErasure.ErasedValueType
 
 import dotty.tools.dotc.transform.{Erasure, ValueClasses}
-import dotty.tools.dotc.transform.SymUtils.*
+
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.report
 

--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -12,7 +12,6 @@ import ast.{tpd, untpd}
 import tpd.{Tree, TreeTraverser}
 import ast.Trees.{Import, Ident}
 import typer.Nullables
-import transform.SymUtils.*
 import core.Decorators.*
 import config.{SourceVersion, Feature}
 import StdNames.nme

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -5,7 +5,7 @@ package ast
 import core.*
 import util.Spans.*, Types.*, Contexts.*, Constants.*, Names.*, NameOps.*, Flags.*
 import Symbols.*, StdNames.*, Trees.*, ContextOps.*
-import Decorators.*, transform.SymUtils.*
+import Decorators.*
 import Annotations.Annotation
 import NameKinds.{UniqueName, ContextBoundParamName, ContextFunctionParamName, DefaultGetterName, WildcardParamName}
 import typer.{Namer, Checking}

--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -7,7 +7,7 @@ import Flags.*, Trees.*, Types.*, Contexts.*
 import Names.*, StdNames.*, NameOps.*, Symbols.*
 import typer.ConstFold
 import reporting.trace
-import dotty.tools.dotc.transform.SymUtils.*
+
 import Decorators.*
 import Constants.Constant
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -6,7 +6,7 @@ import core.*
 import Types.*, Contexts.*, Flags.*
 import Symbols.*, Annotations.*, Trees.*, Symbols.*, Constants.Constant
 import Decorators.*
-import dotty.tools.dotc.transform.SymUtils.*
+
 
 /** A map that applies three functions and a substitution together to a tree and
  *  makes sure they are coordinated so that the result is well-typed. The functions are

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -4,7 +4,6 @@ package ast
 
 import dotty.tools.dotc.transform.{ExplicitOuter, Erasure}
 import typer.ProtoTypes
-import transform.SymUtils.*
 import core.*
 import Scopes.newScope
 import util.Spans.*, Types.*, Contexts.*, Constants.*, Names.*, Flags.*, NameOps.*

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -5,7 +5,6 @@ package ast
 import dotty.tools.dotc.transform.{ExplicitOuter, Erasure}
 import typer.ProtoTypes
 import transform.SymUtils.*
-import transform.TypeUtils.*
 import core.*
 import Scopes.newScope
 import util.Spans.*, Types.*, Contexts.*, Constants.*, Names.*, Flags.*, NameOps.*

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -15,7 +15,6 @@ import typer.Checking.{checkBounds, checkAppliedTypesIn}
 import typer.ErrorReporting.{Addenda, err}
 import typer.ProtoTypes.{AnySelectionProto, LhsProto}
 import util.{SimpleIdentitySet, EqHashMap, EqHashSet, SrcPos, Property}
-import transform.SymUtils.*
 import transform.{Recheck, PreRecheck, CapturedVars}
 import Recheck.*
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -7,7 +7,7 @@ import classpath.AggregateClassPath
 import core.*
 import Symbols.*, Types.*, Contexts.*, StdNames.*
 import Flags.*
-import transform.ExplicitOuter, transform.SymUtils.*
+import transform.ExplicitOuter
 
 class JavaPlatform extends Platform {
 

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -10,7 +10,6 @@ import Flags.*
 import config.Config
 import config.Printers.typr
 import typer.ProtoTypes.{newTypeVar, representedParamRef}
-import transform.TypeUtils.isTransparent
 import UnificationDirection.*
 import NameKinds.AvoidNameKind
 import util.SimpleIdentitySet

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1749,26 +1749,6 @@ class Definitions {
     else TypeOps.nestedPairs(elems)
   }
 
-  def tupleTypes(tp: Type, bound: Int = Int.MaxValue)(using Context): Option[List[Type]] = {
-    @tailrec def rec(tp: Type, acc: List[Type], bound: Int): Option[List[Type]] = tp.normalized.dealias match {
-      case _ if bound < 0 => Some(acc.reverse)
-      case tp: AppliedType if PairClass == tp.classSymbol => rec(tp.args(1), tp.args.head :: acc, bound - 1)
-      case tp: AppliedType if isTupleNType(tp) => Some(acc.reverse ::: tp.args)
-      case tp: TermRef if tp.symbol == defn.EmptyTupleModule => Some(acc.reverse)
-      case _ => None
-    }
-    rec(tp.stripTypeVar, Nil, bound)
-  }
-
-  def isSmallGenericTuple(tp: Type)(using Context): Boolean =
-    if tp.derivesFrom(defn.PairClass) && !defn.isTupleNType(tp.widenDealias) then
-      // If this is a generic tuple we need to cast it to make the TupleN/ members accessible.
-      // This works only for generic tuples of known size up to 22.
-      defn.tupleTypes(tp.widenTermRefExpr) match
-        case Some(elems) if elems.length <= Definitions.MaxTupleArity => true
-        case _ => false
-    else false
-
   def isProductSubType(tp: Type)(using Context): Boolean = tp.derivesFrom(ProductClass)
 
   /** Is `tp` (an alias) of either a scala.FunctionN or a scala.ContextFunctionN

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -23,7 +23,6 @@ import scala.util.control.NonFatal
 import config.Config
 import reporting.*
 import collection.mutable
-import transform.TypeUtils.*
 import cc.{CapturingType, derivedCapturingType}
 
 import scala.annotation.internal.sharable

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -18,7 +18,6 @@ import util.Spans.*
 import DenotTransformers.*
 import StdNames.*
 import NameOps.*
-import transform.SymUtils.*
 import NameKinds.LazyImplicitName
 import ast.tpd
 import tpd.{Tree, TreeProvider, TreeOps}
@@ -35,7 +34,7 @@ import dotty.tools.dotc.classpath.FileUtils.isScalaBinary
 
 import scala.compiletime.uninitialized
 
-object Symbols {
+object Symbols extends SymUtils {
 
   implicit def eqSymbol: CanEqual[Symbol, Symbol] = CanEqual.derived
 

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -12,7 +12,6 @@ import Names.*
 import StdNames.nme
 import Flags.{Module, Provisional}
 import dotty.tools.dotc.config.Config
-import dotty.tools.dotc.transform.TypeUtils.isErasedValueType
 
 object TypeApplications {
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -16,7 +16,6 @@ import TypeErasure.{erasedLub, erasedGlb}
 import TypeApplications.*
 import Variances.{Variance, variancesConform}
 import Constants.Constant
-import transform.SymUtils.*
 import scala.util.control.NonFatal
 import typer.ProtoTypes.constrained
 import typer.Applications.productSelectorTypes

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -16,7 +16,6 @@ import TypeErasure.{erasedLub, erasedGlb}
 import TypeApplications.*
 import Variances.{Variance, variancesConform}
 import Constants.Constant
-import transform.TypeUtils.*
 import transform.SymUtils.*
 import scala.util.control.NonFatal
 import typer.ProtoTypes.constrained

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -9,7 +9,6 @@ import TypeOps.makePackageObjPrefixExplicit
 import backend.sjs.JSDefinitions
 import transform.ExplicitOuter.*
 import transform.ValueClasses.*
-import transform.TypeUtils.*
 import transform.ContextFunctionResults.*
 import unpickleScala2.Scala2Erasure
 import Decorators.*
@@ -404,7 +403,6 @@ object TypeErasure {
       tp1 // After erasure, T | Nothing is just T and C | Null is just C, if C is a reference type.
     else tp1 match {
       case JavaArrayType(elem1) =>
-        import dotty.tools.dotc.transform.TypeUtils.*
         tp2 match {
           case JavaArrayType(elem2) =>
             if (elem1.isPrimitiveValueType || elem2.isPrimitiveValueType)

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -71,7 +71,7 @@ end SourceLanguage
 object TypeErasure {
 
   private def erasureDependsOnArgs(sym: Symbol)(using Context) =
-    sym == defn.ArrayClass || sym == defn.PairClass || isDerivedValueClass(sym)
+    sym == defn.ArrayClass || sym == defn.PairClass || sym.isDerivedValueClass
 
   /** The arity of this tuple type, which can be made up of EmptyTuple, TupleX and `*:` pairs.
    *
@@ -125,7 +125,7 @@ object TypeErasure {
     case tp: TypeRef =>
       val sym = tp.symbol
       sym.isClass &&
-      (!erasureDependsOnArgs(sym) || isDerivedValueClass(sym)) &&
+      (!erasureDependsOnArgs(sym) || sym.isDerivedValueClass) &&
       !defn.specialErasure.contains(sym) &&
       !defn.isSyntheticFunctionClass(sym)
     case _: TermRef =>
@@ -630,7 +630,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
       case tp: TypeRef =>
         val sym = tp.symbol
         if !sym.isClass then this(checkedSuperType(tp))
-        else if semiEraseVCs && isDerivedValueClass(sym) then eraseDerivedValueClass(tp)
+        else if semiEraseVCs && sym.isDerivedValueClass then eraseDerivedValueClass(tp)
         else if defn.isSyntheticFunctionClass(sym) then defn.functionTypeErasure(sym)
         else eraseNormalClassRef(tp)
       case tp: AppliedType =>
@@ -638,7 +638,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
         if (tycon.isRef(defn.ArrayClass)) eraseArray(tp)
         else if (tycon.isRef(defn.PairClass)) erasePair(tp)
         else if (tp.isRepeatedParam) apply(tp.translateFromRepeated(toArray = sourceLanguage.isJava))
-        else if (semiEraseVCs && isDerivedValueClass(tycon.classSymbol)) eraseDerivedValueClass(tp)
+        else if (semiEraseVCs && tycon.classSymbol.isDerivedValueClass) eraseDerivedValueClass(tp)
         else this(checkedSuperType(tp))
       case tp: TermRef =>
         this(underlyingOfTermRef(tp))
@@ -898,7 +898,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
           if (!info.exists) assert(false, i"undefined: $tp with symbol $sym")
           return sigName(info)
         }
-        if (semiEraseVCs && isDerivedValueClass(sym)) {
+        if (semiEraseVCs && sym.isDerivedValueClass) {
           val erasedVCRef = eraseDerivedValueClass(tp)
           if (erasedVCRef.exists) return sigName(erasedVCRef)
         }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -13,7 +13,6 @@ import ast.tpd.*
 import reporting.trace
 import config.Printers.typr
 import config.Feature
-import transform.SymUtils.*
 import typer.ProtoTypes.*
 import typer.ForceDegree
 import typer.Inferencing.*

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -1,13 +1,12 @@
 package dotty.tools
 package dotc
-package transform
+package core
 
-import core.*
 import TypeErasure.ErasedValueType
 import Types.*, Contexts.*, Symbols.*, Flags.*, Decorators.*
 import Names.Name
 
-object TypeUtils {
+class TypeUtils {
   /** A decorator that provides methods on types
    *  that are needed in the transformer pipeline.
    */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -43,9 +43,8 @@ import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
 
 import dotty.tools.dotc.transform.SymUtils.*
-import dotty.tools.dotc.transform.TypeUtils.isErasedClass
 
-object Types {
+object Types extends TypeUtils {
 
   @sharable private var nextId = 0
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -42,7 +42,7 @@ import CaptureSet.{CompareResult, IdempotentCaptRefMap, IdentityCaptRefMap}
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
 
-import dotty.tools.dotc.transform.SymUtils.*
+
 
 object Types extends TypeUtils {
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -14,7 +14,6 @@ import Contexts.*, Symbols.*, Types.*, Names.*, Constants.*, Decorators.*, Annot
 import Comments.{Comment, CommentsContext}
 import NameKinds.*
 import StdNames.nme
-import transform.SymUtils.*
 import config.Config
 import collection.mutable
 import reporting.{Profile, NoProfile}

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -31,7 +31,6 @@ import util.{SourceFile, Property}
 import ast.{Trees, tpd, untpd}
 import Trees.*
 import Decorators.*
-import transform.SymUtils.*
 import dotty.tools.dotc.quoted.QuotePatterns
 
 import dotty.tools.tasty.{TastyBuffer, TastyReader}

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -23,7 +23,6 @@ import util.common.*
 import util.NoSourcePosition
 import typer.Checking.checkNonCyclic
 import typer.Nullables.*
-import transform.SymUtils.*
 import PickleBuffer.*
 import PickleFormat.*
 import Decorators.*

--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -5,7 +5,6 @@ package inlines
 import ast.*, core.*
 import Flags.*, Symbols.*, Types.*, Decorators.*, Contexts.*
 import StdNames.nme
-import transform.SymUtils.*
 import typer.*
 import Names.TermName
 import NameKinds.{InlineAccessorName, InlineBinderName, InlineScrutineeName}

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -4,7 +4,6 @@ package inlines
 
 import ast.*, core.*
 import Flags.*, Symbols.*, Types.*, Decorators.*, Constants.*, Contexts.*
-import transform.SymUtils.*
 import StdNames.nme
 import typer.*
 import Names.Name

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -5,7 +5,6 @@ package inlines
 import ast.*, core.*
 import Flags.*, Symbols.*, Types.*, Decorators.*, Constants.*, Contexts.*
 import StdNames.{tpnme, nme}
-import transform.SymUtils.*
 import typer.*
 import NameKinds.BodyRetainerName
 import SymDenotations.SymDenotation

--- a/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
@@ -19,7 +19,6 @@ import NameOps.*
 import Annotations.*
 import transform.{AccessProxies, Splicer}
 import staging.CrossStageSafety
-import transform.SymUtils.*
 import config.Printers.inlining
 import util.Property
 import staging.StagingLevel

--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -10,7 +10,6 @@ import ast.{NavigateAST, Trees, tpd, untpd}
 import core.*
 import Decorators.*, ContextOps.*
 import Contexts.*, Flags.*, Names.*, NameOps.*, Symbols.*, Trees.*, Types.*
-import transform.SymUtils.*
 import util.Spans.*, util.SourceFile, util.SourcePosition
 
 /** High-level API to get information out of typed trees, designed to be used by IDEs.

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -235,7 +235,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
 
     def appliedText(tp: Type): Text = tp match
       case tp @ AppliedType(tycon, args) =>
-        tp.tupleElementTypes match
+        tp.tupleElementTypesUpTo(200, normalize = false) match
           case Some(types) if types.size >= 2 && !printDebug => toTextTuple(types)
           case _ =>
             val tsym = tycon.typeSymbol

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -23,7 +23,6 @@ import Trees.*
 import TypeApplications.*
 import NameKinds.{WildcardParamName, DefaultGetterName}
 import util.Chars.isOperatorPart
-import transform.TypeUtils.*
 import transform.SymUtils.*
 import config.{Config, Feature}
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -23,7 +23,6 @@ import Trees.*
 import TypeApplications.*
 import NameKinds.{WildcardParamName, DefaultGetterName}
 import util.Chars.isOperatorPart
-import transform.SymUtils.*
 import config.{Config, Feature}
 
 import dotty.tools.dotc.util.SourcePosition

--- a/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
@@ -18,7 +18,7 @@ import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.TypeOps.*
 import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.reporting.IllegalVariableInPatternAlternative
-import dotty.tools.dotc.transform.SymUtils.*
+
 
 import scala.collection.mutable
 

--- a/compiler/src/dotty/tools/dotc/reporting/DidYouMean.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/DidYouMean.scala
@@ -6,7 +6,6 @@ import core.*
 import Contexts.*
 import Decorators.*, Symbols.*, Names.*, Types.*, Flags.*
 import typer.ProtoTypes.{FunProto, SelectionProto}
-import transform.SymUtils.isNoValue
 
 /** A utility object to support "did you mean" hinting */
 object DidYouMean:

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -25,7 +25,6 @@ import printing.Formatting.hl
 import ast.Trees.*
 import ast.untpd
 import ast.tpd
-import transform.SymUtils.*
 import scala.util.matching.Regex
 import java.util.regex.Matcher.quoteReplacement
 import cc.CaptureSet.IdentityCaptRefMap

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -18,7 +18,6 @@ import Names.*
 import NameOps.*
 import inlines.Inlines
 import transform.ValueClasses
-import transform.SymUtils.*
 import dotty.tools.io.File
 import java.io.PrintWriter
 
@@ -274,7 +273,7 @@ private class ExtractAPICollector(using Context) extends ThunkHolder {
             report.error(ex, csym.sourcePos)
             defn.ObjectType :: Nil
         }
-      if (ValueClasses.isDerivedValueClass(csym)) {
+      if (csym.isDerivedValueClass) {
         val underlying = ValueClasses.valueClassUnbox(csym).info.finalResultType
         // The underlying type of a value class should be part of the name hash
         // of the value class (see the test `value-class-underlying`), this is accomplished

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -18,7 +18,7 @@ import dotty.tools.dotc.core.Phases.*
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Denotations.StaleSymbol
 import dotty.tools.dotc.core.Types.*
-import dotty.tools.dotc.transform.SymUtils.*
+
 import dotty.tools.dotc.util.{SrcPos, NoSourcePosition}
 import dotty.tools.io
 import dotty.tools.io.{AbstractFile, PlainFile, ZipArchive, NoAbstractFile}

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -17,7 +17,6 @@ import NameOps.*
 import Denotations.StaleSymbol
 import util.Spans.Span
 import util.SourceFile
-import transform.SymUtils.*
 
 import scala.collection.mutable
 import scala.annotation.{ threadUnsafe => tu, tailrec }

--- a/compiler/src/dotty/tools/dotc/staging/HealType.scala
+++ b/compiler/src/dotty/tools/dotc/staging/HealType.scala
@@ -9,7 +9,7 @@ import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.staging.StagingLevel.*
 import dotty.tools.dotc.staging.QuoteTypeTags.*
-import dotty.tools.dotc.transform.SymUtils.*
+
 import dotty.tools.dotc.typer.Implicits.SearchFailureType
 import dotty.tools.dotc.util.SrcPos
 

--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -9,7 +9,6 @@ import Flags.*
 import Names.*
 import NameOps.*
 import Decorators.*
-import TypeUtils.*
 import Types.*
 import util.Spans.Span
 import config.Printers.transforms

--- a/compiler/src/dotty/tools/dotc/transform/ArrayConstructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayConstructors.scala
@@ -38,10 +38,10 @@ class ArrayConstructors extends MiniPhase {
       val cs = tp.tpe.classSymbol
       tree.fun match {
         case Apply(TypeApply(t: Ident, targ), dims)
-          if !TypeErasure.isGeneric(targ.head.tpe) && !ValueClasses.isDerivedValueClass(cs) =>
+          if !TypeErasure.isGeneric(targ.head.tpe) && !cs.isDerivedValueClass =>
           expand(targ.head.tpe, dims)
         case Apply(TypeApply(t: Select, targ), dims)
-          if !TypeErasure.isGeneric(targ.head.tpe) && !ValueClasses.isDerivedValueClass(cs) =>
+          if !TypeErasure.isGeneric(targ.head.tpe) && !cs.isDerivedValueClass =>
           Block(t.qualifier :: Nil, expand(targ.head.tpe, dims))
         case _ => tree
       }

--- a/compiler/src/dotty/tools/dotc/transform/BeanProperties.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BeanProperties.scala
@@ -6,7 +6,7 @@ import ast.tpd.*
 import Annotations.*
 import Contexts.*
 import Symbols.*
-import SymUtils.*
+
 import Decorators.*
 import Flags.*
 import Names.*

--- a/compiler/src/dotty/tools/dotc/transform/CheckShadowing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckShadowing.scala
@@ -19,8 +19,7 @@ import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.core.Types
 import dotty.tools.dotc.semanticdb.TypeOps
 import dotty.tools.dotc.cc.boxedCaptureSet
-import dotty.tools.dotc.core.Symbols.NoSymbol
-import dotty.tools.dotc.transform.SymUtils.isParamOrAccessor
+import dotty.tools.dotc.core.Symbols.{NoSymbol, isParamOrAccessor}
 import scala.collection.mutable
 import dotty.tools.dotc.core.Scopes.Scope
 import scala.collection.immutable.HashMap

--- a/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckStatic.scala
@@ -9,7 +9,7 @@ import Symbols.*
 import dotty.tools.dotc.ast.tpd
 import reporting.*
 
-import dotty.tools.dotc.transform.SymUtils.*
+
 
 /** A transformer that check that requirements of Static fields\methods are implemented:
   *  1. Only objects can have members annotated with `@static`

--- a/compiler/src/dotty/tools/dotc/transform/CollectNullableFields.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CollectNullableFields.scala
@@ -5,7 +5,7 @@ import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.transform.MegaPhase.MiniPhase
-import dotty.tools.dotc.transform.SymUtils.*
+
 
 import scala.collection.mutable
 

--- a/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CompleteJavaEnums.scala
@@ -13,7 +13,7 @@ import Symbols.*
 import Constants.*
 import Decorators.*
 import DenotTransformers.*
-import SymUtils.*
+
 
 
 object CompleteJavaEnums {

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -10,7 +10,7 @@ import Flags.*
 import Names.Name
 import NameOps.*
 import NameKinds.{FieldName, ExplicitFieldName}
-import SymUtils.*
+
 import Symbols.*
 import Decorators.*
 import DenotTransformers.*

--- a/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
@@ -3,7 +3,7 @@ package transform
 
 import core.*
 import Symbols.*, Contexts.*, Types.*, Flags.*, Decorators.*
-import SymUtils.*
+
 import collection.mutable.{LinkedHashMap, LinkedHashSet}
 import annotation.constructorOnly
 import scala.compiletime.uninitialized

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -29,7 +29,6 @@ import dotty.tools.dotc.ast.{tpd, untpd}
 import ast.TreeTypeMap
 import dotty.tools.dotc.core.{Constants, Flags}
 import ValueClasses.*
-import TypeUtils.*
 import ContextFunctionResults.*
 import ExplicitOuter.*
 import core.Mode

--- a/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
@@ -6,7 +6,7 @@ import MegaPhase.MiniPhase
 import core.*
 import Symbols.*, Contexts.*, Types.*, Decorators.*
 import StdNames.nme
-import SymUtils.*
+
 import NameKinds.AdaptedClosureName
 
 /** Rewrite `(x1, ... xN) => f(x1, ... xN)` for N >= 0 to `f`,

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -7,7 +7,7 @@ import Scopes.newScope
 import Contexts.*, Symbols.*, Types.*, Flags.*, Decorators.*, StdNames.*, Constants.*
 import MegaPhase.*
 import Names.TypeName
-import SymUtils.*
+
 import NullOpsDecorator.*
 import ast.untpd
 

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -14,7 +14,7 @@ import core.StdNames.nme
 import core.Names.*
 import core.NameOps.*
 import core.NameKinds.SuperArgName
-import SymUtils.*
+
 import dotty.tools.dotc.ast.tpd
 
 import collection.mutable

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitSelf.scala
@@ -3,7 +3,7 @@ package transform
 
 import core.*
 import Contexts.*, Types.*, MegaPhase.*, ast.Trees.*, Symbols.*, Decorators.*, Flags.*
-import SymUtils.*
+
 
 /** Transform references of the form
  *

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -15,7 +15,6 @@ import SymDenotations.*, Symbols.*, StdNames.*, Denotations.*
 import TypeErasure.{ valueErasure, ErasedValueType }
 import NameKinds.{ExtMethName, BodyRetainerName}
 import Decorators.*
-import TypeUtils.*
 
 /**
  * Perform Step 1 in the inline classes SIP: Creates extension methods for all

--- a/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FirstTransform.scala
@@ -16,7 +16,6 @@ import DenotTransformers.*
 import NameOps.*
 import NameKinds.OuterSelectName
 import StdNames.*
-import TypeUtils.isErasedValueType
 import config.Feature
 import inlines.Inlines.inInlineMethod
 

--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -6,7 +6,6 @@ import Types.*
 import Contexts.*
 import Symbols.*
 import Decorators.*
-import TypeUtils.*
 import StdNames.nme
 import ast.*
 

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -14,7 +14,7 @@ import core.TypeApplications.{EtaExpansion, TypeParamInfo}
 import core.TypeErasure.{erasedGlb, erasure, fullErasure, isGenericArrayElement, tupleArity}
 import core.Types.*
 import core.classfile.ClassfileConstants
-import SymUtils.*
+
 import config.Printers.transforms
 import reporting.trace
 import java.lang.StringBuilder
@@ -272,7 +272,7 @@ object GenericSignatures {
             if (!primitiveOK) jsig(defn.ObjectType)
             else if (sym == defn.UnitClass) jsig(defn.BoxedUnitClass.typeRef)
             else builder.append(defn.typeTag(sym.info))
-          else if (ValueClasses.isDerivedValueClass(sym)) {
+          else if (sym.isDerivedValueClass) {
             val erasedUnderlying = fullErasure(tp)
             if (erasedUnderlying.isPrimitiveValueType && !primitiveOK)
               classSig(sym, pre, args)

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -15,7 +15,6 @@ import core.TypeErasure.{erasedGlb, erasure, fullErasure, isGenericArrayElement,
 import core.Types.*
 import core.classfile.ClassfileConstants
 import SymUtils.*
-import TypeUtils.*
 import config.Printers.transforms
 import reporting.trace
 import java.lang.StringBuilder

--- a/compiler/src/dotty/tools/dotc/transform/Getters.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Getters.scala
@@ -9,8 +9,7 @@ import Types.*
 import Symbols.*
 import MegaPhase.*
 import Flags.*
-import ValueClasses.*
-import SymUtils.*
+
 import NameOps.*
 
 
@@ -66,7 +65,7 @@ class Getters extends MiniPhase with SymTransformer { thisPhase =>
   override def transformSym(d: SymDenotation)(using Context): SymDenotation = {
     def noGetterNeeded =
       d.isOneOf(NoGetterNeededFlags) ||
-      d.isAllOf(PrivateLocal) && !d.owner.is(Trait) && !isDerivedValueClass(d.owner) && !d.is(Lazy) ||
+      d.isAllOf(PrivateLocal) && !d.owner.is(Trait) && !d.owner.isDerivedValueClass && !d.is(Lazy) ||
       d.is(Module) && d.isStatic ||
       d.hasAnnotation(defn.ScalaStaticAnnot) ||
       d.isSelfSym

--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -12,7 +12,7 @@ import core.Decorators.*
 import collection.mutable
 import ast.Trees.*
 import core.NameKinds.SuperArgName
-import SymUtils.*
+
 import core.Decorators.*
 
 object HoistSuperArgs {

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -5,7 +5,7 @@ import core.*
 import Flags.*
 import Contexts.*
 import Symbols.*
-import SymUtils.*
+
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.Trees.*
 import dotty.tools.dotc.quoted.*

--- a/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LambdaLift.scala
@@ -13,7 +13,7 @@ import core.StdNames.nme
 import core.Names.*
 import core.NameOps.*
 import core.NameKinds.ExpandPrefixName
-import SymUtils.*
+
 import ExplicitOuter.outer
 import util.Store
 import collection.mutable.{HashMap, LinkedHashMap, ListBuffer}

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -16,7 +16,6 @@ import core.Types.*
 import core.{Names, StdNames}
 import dotty.tools.dotc.config.Feature
 import transform.MegaPhase.MiniPhase
-import transform.SymUtils.*
 
 import scala.collection.mutable
 import scala.compiletime.uninitialized

--- a/compiler/src/dotty/tools/dotc/transform/Memoize.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Memoize.scala
@@ -8,7 +8,7 @@ import Phases.*
 import SymDenotations.SymDenotation
 import Denotations.*
 import Symbols.*
-import SymUtils.*
+
 import Constants.*
 import MegaPhase.*
 import NameOps.*

--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -6,7 +6,7 @@ import core.*
 import MegaPhase.*
 import Contexts.*
 import Flags.*
-import SymUtils.*
+
 import Symbols.*
 import SymDenotations.*
 import Types.*

--- a/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
@@ -4,7 +4,7 @@ package transform
 import core.*
 import Symbols.*, Types.*, Contexts.*, DenotTransformers.*, Flags.*
 import util.Spans.*
-import SymUtils.*
+
 import StdNames.*, NameOps.*
 import typer.Nullables
 

--- a/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MoveStatics.scala
@@ -15,7 +15,7 @@ import NameOps.*
 
 import ast.*
 
-import SymUtils.*
+
 import MegaPhase.*
 
 /** Move static methods from companion to the class itself */

--- a/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ParamForwarding.scala
@@ -3,7 +3,7 @@ package dotc
 package transform
 
 import core.*
-import Contexts.*, Types.*, Symbols.*, Flags.*, TypeUtils.*, DenotTransformers.*, StdNames.*
+import Contexts.*, Types.*, Symbols.*, Flags.*, DenotTransformers.*, StdNames.*
 import Decorators.*
 import MegaPhase.*
 import NameKinds.ParamAccessorName

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -9,7 +9,6 @@ import patmat.SpaceEngine
 import util.Spans.*
 import typer.Applications.*
 import SymUtils.*
-import TypeUtils.*
 import Annotations.*
 import Flags.*, Constants.*
 import Decorators.*

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -8,7 +8,7 @@ import Symbols.*, Contexts.*, Types.*, StdNames.*, NameOps.*
 import patmat.SpaceEngine
 import util.Spans.*
 import typer.Applications.*
-import SymUtils.*
+
 import Annotations.*
 import Flags.*, Constants.*
 import Decorators.*
@@ -1022,7 +1022,7 @@ object PatternMatcher {
           case Block((_: ValDef) :: Block(_, Match(_, cases)) :: Nil, _) => cases
           case _ => Nil
         val caseThreshold =
-          if ValueClasses.isDerivedValueClass(tpt.tpe.typeSymbol) then 1
+          if tpt.tpe.typeSymbol.isDerivedValueClass then 1
           else MinSwitchCases
         def typesInPattern(pat: Tree): List[Type] = pat match
           case Alternative(pats) => pats.flatMap(typesInPattern)

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -11,7 +11,7 @@ import Constants.*
 import ast.Trees.*
 import ast.untpd
 import ast.TreeTypeMap
-import SymUtils.*
+
 import NameKinds.*
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.untpd

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -12,7 +12,7 @@ import typer.ErrorReporting.errorTree
 import Types.*, Contexts.*, Names.*, Flags.*, DenotTransformers.*, Phases.*
 import SymDenotations.*, StdNames.*, Annotations.*, Trees.*, Scopes.*
 import Decorators.*
-import Symbols.*, SymUtils.*, NameOps.*
+import Symbols.*, NameOps.*
 import ContextFunctionResults.annotateContextResults
 import config.Printers.typr
 import config.Feature

--- a/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
@@ -10,7 +10,7 @@ import Symbols.*
 import typer.RefChecks
 import MegaPhase.MiniPhase
 import ast.tpd
-import SymUtils.*
+
 import config.Feature
 import Decorators.*
 import dotty.tools.dotc.core.Types.MethodType

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -4,7 +4,7 @@ package transform
 
 import core.*
 import Symbols.*, Contexts.*, Types.*, ContextOps.*, Decorators.*, SymDenotations.*
-import Flags.*, SymUtils.*, NameKinds.*, Denotations.{Denotation, SingleDenotation}
+import Flags.*, NameKinds.*, Denotations.{Denotation, SingleDenotation}
 import ast.*
 import Names.Name
 import Phases.Phase

--- a/compiler/src/dotty/tools/dotc/transform/ReifiedReflect.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ReifiedReflect.scala
@@ -7,7 +7,7 @@ import Flags.*
 import Types.*
 import Contexts.*
 import Symbols.*
-import SymUtils.*
+
 import NameKinds.*
 import dotty.tools.dotc.ast.tpd
 import tpd.*

--- a/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
@@ -5,7 +5,7 @@ import core.*
 import MegaPhase.*
 import Contexts.*
 import Flags.*
-import SymUtils.*
+
 import Symbols.*
 import Decorators.*
 import DenotTransformers.*

--- a/compiler/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -8,7 +8,7 @@ import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.*
 import dotty.tools.dotc.transform.MegaPhase.*
-import dotty.tools.dotc.transform.SymUtils.*
+
 
 /** Removes `Select`s that would be compiled into `GetStatic`.
  *

--- a/compiler/src/dotty/tools/dotc/transform/Splicing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicing.scala
@@ -11,7 +11,7 @@ import Constants.*
 import ast.Trees.*
 import ast.{TreeTypeMap, untpd}
 import util.Spans.*
-import SymUtils.*
+
 import NameKinds.*
 import dotty.tools.dotc.ast.tpd
 

--- a/compiler/src/dotty/tools/dotc/transform/Staging.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Staging.scala
@@ -10,7 +10,7 @@ import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.inlines.Inlines
 import dotty.tools.dotc.util.SrcPos
-import dotty.tools.dotc.transform.SymUtils.*
+
 import dotty.tools.dotc.staging.StagingLevel.*
 import dotty.tools.dotc.staging.CrossStageSafety
 import dotty.tools.dotc.staging.HealType

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 import ValueClasses.isMethodWithExtension
 import core.*
 import Contexts.*, Flags.*, Symbols.*, Names.*, StdNames.*, NameOps.*, Trees.*
-import TypeUtils.*, SymUtils.*
+import SymUtils.*
 import DenotTransformers.DenotTransformer
 import Symbols.*
 import util.Spans.*

--- a/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SuperAccessors.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 import ValueClasses.isMethodWithExtension
 import core.*
 import Contexts.*, Flags.*, Symbols.*, Names.*, StdNames.*, NameOps.*, Trees.*
-import SymUtils.*
+
 import DenotTransformers.DenotTransformer
 import Symbols.*
 import util.Spans.*

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc
 package transform
 
 import core.*
-import Symbols.*, Types.*, Contexts.*, Names.*, StdNames.*, Constants.*, SymUtils.*
+import Symbols.*, Types.*, Contexts.*, Names.*, StdNames.*, Constants.*
 import Flags.*
 import DenotTransformers.*
 import Decorators.*
@@ -10,8 +10,7 @@ import NameOps.*
 import Annotations.Annotation
 import typer.ProtoTypes.constrained
 import ast.untpd
-import ValueClasses.isDerivedValueClass
-import SymUtils.*
+
 import util.Property
 import util.Spans.Span
 import config.Printers.derive
@@ -90,7 +89,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
   def caseAndValueMethods(clazz: ClassSymbol)(using Context): List[Tree] = {
     val clazzType = clazz.appliedRef
     lazy val accessors =
-      if (isDerivedValueClass(clazz)) clazz.paramAccessors.take(1) // Tail parameters can only be `erased`
+      if clazz.isDerivedValueClass then clazz.paramAccessors.take(1) // Tail parameters can only be `erased`
       else clazz.caseAccessors
     val isEnumValue = clazz.isAnonymousClass && clazz.info.parents.head.classSymbol.is(Enum)
     val isSimpleEnumValue = isEnumValue && !clazz.owner.isAllOf(EnumCase)
@@ -98,12 +97,12 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     val isNonJavaEnumValue = isEnumValue && !isJavaEnumValue
 
     val symbolsToSynthesize: List[Symbol] =
-      if (clazz.is(Case))
-        if (clazz.is(Module)) caseModuleSymbols
+      if clazz.is(Case) then
+        if clazz.is(Module) then caseModuleSymbols
         else caseSymbols
-      else if (isNonJavaEnumValue) nonJavaEnumValueSymbols
-      else if (isEnumValue) enumValueSymbols
-      else if (isDerivedValueClass(clazz)) valueSymbols
+      else if isNonJavaEnumValue then nonJavaEnumValueSymbols
+      else if isEnumValue then enumValueSymbols
+      else if clazz.isDerivedValueClass then valueSymbols
       else Nil
 
     def syntheticDefIfMissing(sym: Symbol): List[Tree] =

--- a/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
@@ -10,7 +10,6 @@ import StdNames.*
 import Symbols.*
 import MegaPhase.*
 import Types.*
-import transform.TypeUtils.*
 import dotty.tools.dotc.ast.tpd
 
 /** Optimize generic operations on tuples */

--- a/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TupleOptimizations.scala
@@ -10,8 +10,8 @@ import StdNames.*
 import Symbols.*
 import MegaPhase.*
 import Types.*
+import transform.TypeUtils.*
 import dotty.tools.dotc.ast.tpd
-
 
 /** Optimize generic operations on tuples */
 class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
@@ -33,7 +33,7 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
 
   private def transformTupleCons(tree: tpd.Apply)(using Context): Tree = {
     val head :: tail :: Nil = tree.args: @unchecked
-    defn.tupleTypes(tree.tpe.widenTermRefExpr.dealias) match {
+    tree.tpe.widenTermRefExpr.tupleElementTypes match {
       case Some(tpes) =>
         // Generate a the tuple directly with TupleN+1.apply
         val size = tpes.size
@@ -61,7 +61,7 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
 
   private def transformTupleTail(tree: tpd.Apply)(using Context): Tree = {
     val Apply(_, tup :: Nil) = tree: @unchecked
-    defn.tupleTypes(tup.tpe.widenTermRefExpr.dealias, MaxTupleArity + 1) match {
+    tup.tpe.widenTermRefExpr.tupleElementTypesUpTo(MaxTupleArity + 1) match {
       case Some(tpes) =>
         // Generate a the tuple directly with TupleN-1.apply
         val size = tpes.size
@@ -104,7 +104,7 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
 
   private def transformTupleConcat(tree: tpd.Apply)(using Context): Tree = {
     val Apply(_, self :: that :: Nil) = tree: @unchecked
-    (defn.tupleTypes(self.tpe.widenTermRefExpr.dealias), defn.tupleTypes(that.tpe.widenTermRefExpr.dealias)) match {
+    (self.tpe.widenTermRefExpr.tupleElementTypes, that.tpe.widenTermRefExpr.tupleElementTypes) match {
       case (Some(tpes1), Some(tpes2)) =>
         // Generate a the tuple directly with TupleN+M.apply
         val n = tpes1.size
@@ -139,7 +139,7 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
 
   private def transformTupleApply(tree: tpd.Apply)(using Context): Tree = {
     val Apply(_, tup :: nTree :: Nil) = tree: @unchecked
-    (defn.tupleTypes(tup.tpe.widenTermRefExpr.dealias), nTree.tpe) match {
+    (tup.tpe.widenTermRefExpr.tupleElementTypes, nTree.tpe) match {
       case (Some(tpes), nTpe: ConstantType) =>
         // Get the element directly with TupleM._n+1 or TupleXXL.productElement(n)
         val size = tpes.size
@@ -166,7 +166,7 @@ class TupleOptimizations extends MiniPhase with IdentityDenotTransformer {
 
   private def transformTupleToArray(tree: tpd.Apply)(using Context): Tree = {
     val Apply(_, tup :: Nil) = tree: @unchecked
-    defn.tupleTypes(tup.tpe.widen, MaxTupleArity) match {
+    tup.tpe.widen.tupleElementTypesUpTo(MaxTupleArity) match {
       case Some(tpes) =>
         val size = tpes.size
         if (size == 0)

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -9,8 +9,7 @@ import Contexts.*, Symbols.*, Types.*, Constants.*, StdNames.*, Decorators.*
 import ast.untpd
 import Erasure.Boxing.*
 import TypeErasure.*
-import ValueClasses.*
-import SymUtils.*
+
 import core.Flags.*
 import util.Spans.*
 import reporting.*
@@ -218,7 +217,7 @@ object TypeTestsCasts {
             !(!testCls.isPrimitiveValueClass && foundCls.isPrimitiveValueClass) &&
                // foundCls can be `Boolean`, while testCls is `Integer`
                // it can happen in `(3: Boolean | Int).isInstanceOf[Int]`
-            !isDerivedValueClass(foundCls) && !isDerivedValueClass(testCls)
+            !foundCls.isDerivedValueClass && !testCls.isDerivedValueClass
                // we don't have the logic to handle derived value classes
 
           /** Check whether a runtime test that a value of `foundCls` can be a `testCls`

--- a/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeUtils.scala
@@ -45,22 +45,45 @@ object TypeUtils {
       case ps => ps.reduceLeft(AndType(_, _))
     }
 
-    /** The element types of this tuple type, which can be made up of EmptyTuple, TupleX and `*:` pairs */
-    def tupleElementTypes(using Context): Option[List[Type]] = self.dealias match {
-      case AppliedType(tycon, hd :: tl :: Nil) if tycon.isRef(defn.PairClass) =>
-        tl.tupleElementTypes.map(hd :: _)
-      case self: SingletonType =>
-        if self.termSymbol == defn.EmptyTupleModule then Some(Nil) else None
-      case AndType(tp1, tp2) =>
-        // We assume that we have the following property:
-        // (T1, T2, ..., Tn) & (U1, U2, ..., Un) = (T1 & U1, T2 & U2, ..., Tn & Un)
-        tp1.tupleElementTypes.zip(tp2.tupleElementTypes).map { case (t1, t2) => t1.intersect(t2) }
-      case OrType(tp1, tp2) =>
-        None // We can't combine the type of two tuples
-      case _ =>
-        if defn.isTupleClass(self.typeSymbol) then Some(self.dealias.argInfos)
-        else None
-    }
+    /** The element types of this tuple type, which can be made up of EmptyTuple, TupleX and `*:` pairs
+     */
+    def tupleElementTypes(using Context): Option[List[Type]] =
+      tupleElementTypesUpTo(Int.MaxValue)
+
+    /** The element types of this tuple type, which can be made up of EmptyTuple, TupleX and `*:` pairs
+     *  @param bound     The maximum number of elements that needs generating minus 1
+     *                   The generation will stop once more than bound elems have been generated
+     *  @param normalize If true, normalize and dealias at each step.
+     *                   If false, never normalize and dealias only to find *:
+     *                   and EmptyTuple types. This is useful for printing.
+     */
+    def tupleElementTypesUpTo(bound: Int, normalize: Boolean = true)(using Context): Option[List[Type]] =
+      def recur(tp: Type, bound: Int): Option[List[Type]] =
+        if bound < 0 then Some(Nil)
+        else (if normalize then tp.normalized else tp).dealias match
+          case AppliedType(tycon, hd :: tl :: Nil) if tycon.isRef(defn.PairClass) =>
+            recur(tl, bound - 1).map(hd :: _)
+          case tp: AppliedType if defn.isTupleNType(tp) && normalize =>
+            Some(tp.args)  // if normalize is set, use the dealiased tuple
+                           // otherwise rely on the default case below to print unaliased tuples.
+          case tp: SingletonType =>
+            if tp.termSymbol == defn.EmptyTupleModule then Some(Nil) else None
+          case _ =>
+            if defn.isTupleClass(tp.typeSymbol) && !normalize then Some(tp.dealias.argInfos)
+            else None
+      recur(self.stripTypeVar, bound)
+
+    /** Is this a generic tuple that would fit into the range 1..22,
+     *  but is not already an instance of one of Tuple1..22?
+     *  In this case we need to cast it to make the TupleN/ members accessible.
+     *  This works only for generic tuples of known size up to 22.
+     */
+    def isSmallGenericTuple(using Context): Boolean =
+      self.derivesFrom(defn.PairClass)
+      && !defn.isTupleNType(self.widenDealias)
+      && self.widenTermRefExpr.tupleElementTypesUpTo(Definitions.MaxTupleArity).match
+          case Some(elems) if elems.length <= Definitions.MaxTupleArity => true
+          case _ => false
 
     /** The `*:` equivalent of an instance of a Tuple class */
     def toNestedPairs(using Context): Type =

--- a/compiler/src/dotty/tools/dotc/transform/ValueClasses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ValueClasses.scala
@@ -8,18 +8,9 @@ import Contexts.*
 import Phases.*
 import Flags.*
 import StdNames.*
-import SymUtils.*
 
 /** Methods that apply to user-defined value classes */
 object ValueClasses {
-
-  def isDerivedValueClass(sym: Symbol)(using Context): Boolean = sym.isClass && {
-    val d = sym.denot
-    !d.isRefinementClass &&
-    d.isValueClass &&
-    (d.initial.symbol ne defn.AnyValClass) && // Compare the initial symbol because AnyVal does not exist after erasure
-    !d.isPrimitiveValueClass
-  }
 
   def isMethodWithExtension(sym: Symbol)(using Context): Boolean =
     val d = sym.denot.initial

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -5,7 +5,6 @@ package patmat
 
 import core.*
 import Types.*
-import TypeUtils.*
 import Contexts.*
 import Flags.*
 import ast.*

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -17,7 +17,6 @@ import typer.*
 import Applications.*
 import Inferencing.*
 import ProtoTypes.*
-import transform.SymUtils.*
 import reporting.*
 import config.Printers.{exhaustivity => debug}
 import util.{SrcPos, NoSourcePosition}

--- a/compiler/src/dotty/tools/dotc/transform/sjs/ExplicitJSClasses.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/ExplicitJSClasses.scala
@@ -19,7 +19,7 @@ import core.StdNames.nme
 import core.SymDenotations.SymDenotation
 import core.Names.*
 import core.NameKinds.*
-import SymUtils.*
+
 
 import util.Store
 

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
@@ -11,7 +11,7 @@ import Names.*
 import Phases.*
 import StdNames.*
 import Symbols.*
-import SymUtils.*
+
 import ast.Trees.*
 import Types.*
 

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSExports.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSExports.scala
@@ -11,7 +11,7 @@ import Flags.*
 import NameKinds.DefaultGetterName
 import StdNames.*
 import Symbols.*
-import SymUtils.*
+
 import Types.*
 
 import util.Spans.Span

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
@@ -18,7 +18,7 @@ import NameKinds.{DefaultGetterName, ModuleClassName}
 import NameOps.*
 import StdNames.*
 import Symbols.*
-import SymUtils.*
+
 import Types.*
 
 import JSSymUtils.*

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -21,7 +21,6 @@ import NameKinds.DefaultGetterName
 import ProtoTypes.*
 import Inferencing.*
 import reporting.*
-import transform.TypeUtils.*
 import transform.SymUtils.*
 import Nullables.*, NullOpsDecorator.*
 import config.Feature

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -21,7 +21,6 @@ import NameKinds.DefaultGetterName
 import ProtoTypes.*
 import Inferencing.*
 import reporting.*
-import transform.SymUtils.*
 import Nullables.*, NullOpsDecorator.*
 import config.Feature
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -23,8 +23,6 @@ import util.SrcPos
 import util.Spans.Span
 import rewrites.Rewrites.patch
 import inlines.Inlines
-import transform.SymUtils.*
-import transform.ValueClasses.*
 import Decorators.*
 import ErrorReporting.{err, errorType}
 import config.Printers.{typr, patmatch}
@@ -34,6 +32,7 @@ import SymDenotations.{NoCompleter, NoDenotation}
 import Applications.unapplyArgs
 import Inferencing.isFullyDefined
 import transform.patmat.SpaceEngine.{isIrrefutable, isIrrefutableQuotePattern}
+import transform.ValueClasses.underlyingOfValueClass
 import config.Feature
 import config.Feature.sourceVersion
 import config.SourceVersion.*
@@ -709,7 +708,7 @@ object Checking {
       case _ =>
         report.error(ValueClassesMayNotContainInitalization(clazz), stat.srcPos)
     }
-    if (isDerivedValueClass(clazz)) {
+    if (clazz.isDerivedValueClass) {
       if (clazz.is(Trait))
         report.error(CannotExtendAnyVal(clazz), clazz.srcPos)
       if clazz.is(Module) then

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -38,7 +38,6 @@ import config.Feature
 import config.Feature.sourceVersion
 import config.SourceVersion.*
 import printing.Formatting.hlAsKeyword
-import transform.TypeUtils.*
 import cc.isCaptureChecking
 
 import collection.mutable

--- a/compiler/src/dotty/tools/dotc/typer/ConstFold.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ConstFold.scala
@@ -11,7 +11,6 @@ import Constants.*
 import Names.*
 import StdNames.*
 import Contexts.*
-import transform.TypeUtils.*
 
 object ConstFold:
 

--- a/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/CrossVersionChecks.scala
@@ -3,7 +3,7 @@ package dotc
 package transform
 
 import core.*
-import Symbols.*, Types.*, Contexts.*, Flags.*, SymUtils.*, Decorators.*, reporting.*
+import Symbols.*, Types.*, Contexts.*, Flags.*, Decorators.*, reporting.*
 import util.SrcPos
 import config.{ScalaVersion, NoScalaVersion, Feature, ScalaRelease}
 import MegaPhase.MiniPhase

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -16,8 +16,8 @@ import dotty.tools.dotc.core.Decorators.*
 import dotty.tools.dotc.core.TypeErasure
 import util.Spans.*
 import core.Symbols.*
+import transform.ValueClasses
 import ErrorReporting.*
-import dotty.tools.dotc.transform.ValueClasses
 import reporting.*
 import inlines.Inlines
 
@@ -239,7 +239,7 @@ trait Dynamic {
        */
       def maybeBoxingCast(tpe: Type) =
         val maybeBoxed =
-          if ValueClasses.isDerivedValueClass(tpe.classSymbol) && qual.tpe <:< defn.ReflectSelectableTypeRef then
+          if tpe.classSymbol.isDerivedValueClass && qual.tpe <:< defn.ReflectSelectableTypeRef then
             val genericUnderlying = ValueClasses.valueClassUnbox(tpe.classSymbol.asClass)
             val underlying = tpe.select(genericUnderlying).widen.resultType
             New(tpe.widen, tree.cast(underlying) :: Nil)

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -18,7 +18,6 @@ import util.Spans.*
 import core.Symbols.*
 import ErrorReporting.*
 import dotty.tools.dotc.transform.ValueClasses
-import dotty.tools.dotc.transform.TypeUtils.isPrimitiveValueType
 import reporting.*
 import inlines.Inlines
 

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -24,7 +24,6 @@ import ErrorReporting.*
 import Inferencing.{fullyDefinedType, isFullyDefined}
 import Scopes.newScope
 import Typer.BindingPrec, BindingPrec.*
-import transform.TypeUtils.*
 import Hashable.*
 import util.{EqHashMap, Stats}
 import config.{Config, Feature}

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -9,7 +9,6 @@ import ProtoTypes.*
 import NameKinds.UniqueName
 import util.Spans.*
 import util.{Stats, SimpleIdentityMap, SimpleIdentitySet, SrcPos}
-import transform.TypeUtils.isTransparent
 import Decorators._
 import config.Printers.{gadts, typr}
 import annotation.tailrec

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -23,7 +23,6 @@ import parsing.Parsers.Parser
 import Annotations.*
 import Inferencing.*
 import transform.ValueClasses.*
-import transform.TypeUtils.*
 import transform.SymUtils.*
 import TypeErasure.erasure
 import reporting.*

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -23,7 +23,6 @@ import parsing.Parsers.Parser
 import Annotations.*
 import Inferencing.*
 import transform.ValueClasses.*
-import transform.SymUtils.*
 import TypeErasure.erasure
 import reporting.*
 import config.Feature.sourceVersion

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -17,7 +17,7 @@ import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.inlines.PrepareInlineable
 import dotty.tools.dotc.quoted.QuotePatterns
 import dotty.tools.dotc.staging.StagingLevel.*
-import dotty.tools.dotc.transform.SymUtils.*
+
 import dotty.tools.dotc.typer.ErrorReporting.errorTree
 import dotty.tools.dotc.typer.Implicits.*
 import dotty.tools.dotc.typer.Inferencing.*

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -5,7 +5,7 @@ package typer
 import transform.*
 import core.*
 import Symbols.*, Types.*, Contexts.*, Flags.*, Names.*, NameOps.*, NameKinds.*
-import StdNames.*, Denotations.*, SymUtils.*, Phases.*, SymDenotations.*
+import StdNames.*, Denotations.*, Phases.*, SymDenotations.*
 import NameKinds.DefaultGetterName
 import util.Spans.*
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -12,7 +12,6 @@ import ProtoTypes.*
 import Inferencing.{fullyDefinedType, isFullyDefined}
 import ast.untpd
 import transform.SymUtils.*
-import transform.TypeUtils.*
 import transform.SyntheticMembers.*
 import util.Property
 import ast.Trees.genericEmptyTree

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -119,7 +119,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
             // TupledFunction[?, (...) => R]
             tupled.functionArgInfos match
               case tupledArgs :: funRet :: Nil =>
-                defn.tupleTypes(tupledArgs.dealias) match
+                tupledArgs.tupleElementTypes match
                   case Some(funArgs) if functionTypeEqual(tupled, funArgs, funRet, fun) =>
                     // TupledFunction[?, ((...funArgs...)) => funRet]
                     funArgs.size

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -11,7 +11,6 @@ import Decorators.*
 import ProtoTypes.*
 import Inferencing.{fullyDefinedType, isFullyDefined}
 import ast.untpd
-import transform.SymUtils.*
 import transform.SyntheticMembers.*
 import util.Property
 import ast.Trees.genericEmptyTree

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -45,7 +45,6 @@ import config.Feature.{sourceVersion, migrateTo3}
 import config.SourceVersion.*
 import rewrites.Rewrites.patch
 import staging.StagingLevel
-import transform.SymUtils.*
 import reporting.*
 import Nullables.*
 import NullOpsDecorator.*

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -707,8 +707,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
        // There's a second trial where we try to instantiate all type variables in `qual.tpe.widen`,
        // but that is done only after we search for extension methods or conversions.
       typedSelect(tree, pt, qual)
-    else if defn.isSmallGenericTuple(qual.tpe) then
-      val elems = defn.tupleTypes(qual.tpe.widenTermRefExpr).getOrElse(Nil)
+    else if qual.tpe.isSmallGenericTuple then
+      val elems = qual.tpe.widenTermRefExpr.tupleElementTypes.getOrElse(Nil)
       typedSelect(tree, pt, qual.cast(defn.tupleType(elems)))
     else
       val tree1 = tryExtensionOrConversion(
@@ -729,7 +729,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             if checkedType1.exists then
               gadts.println(i"Member selection healed by GADT approximation")
               finish(tree1, qual1, checkedType1)
-            else if defn.isSmallGenericTuple(qual1.tpe) then
+            else if qual1.tpe.isSmallGenericTuple then
               gadts.println(i"Tuple member selection healed by GADT approximation")
               typedSelect(tree, pt, qual1)
             else

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -46,7 +46,6 @@ import config.SourceVersion.*
 import rewrites.Rewrites.patch
 import staging.StagingLevel
 import transform.SymUtils.*
-import transform.TypeUtils.*
 import reporting.*
 import Nullables.*
 import NullOpsDecorator.*

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -11,9 +11,8 @@ import core.NameOps.isUnapplyName
 import core.Names.*
 import core.NameKinds
 import core.Types.*
-import core.Symbols.NoSymbol
+import core.Symbols.{NoSymbol, isLocalToBlock}
 import interactive.Interactive
-import transform.SymUtils.isLocalToBlock
 import util.Spans.Span
 import reporting.*
 

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -7,7 +7,6 @@ import dotc.*, core.*
 import Contexts.*, Denotations.*, Flags.*, NameOps.*, StdNames.*, Symbols.*
 import printing.ReplPrinter
 import reporting.Diagnostic
-import transform.ValueClasses
 import util.StackTraceOps.*
 
 import scala.compiletime.uninitialized
@@ -127,7 +126,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
    * @param value underlying value
    */
   private def rewrapValueClass(sym: Symbol, value: Object)(using Context): Option[Object] =
-    if ValueClasses.isDerivedValueClass(sym) then
+    if sym.isDerivedValueClass then
       val valueClass = Class.forName(sym.binaryClassName, true, classLoader())
       valueClass.getConstructors.headOption.map(_.newInstance(value))
     else

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -7,7 +7,6 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Types.Type
-import dotty.tools.dotc.transform.SymUtils.*
 import dotty.tools.pc.printer.ShortenedTypePrinter
 import dotty.tools.pc.utils.MtagsEnrichments.decoded
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -26,7 +26,6 @@ import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.interactive.Completion
 import dotty.tools.dotc.interactive.Completion.Mode
-import dotty.tools.dotc.transform.SymUtils.*
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans
 import dotty.tools.dotc.util.Spans.Span

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/KeywordsCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/KeywordsCompletions.scala
@@ -11,7 +11,6 @@ import dotty.tools.dotc.ast.untpd.UntypedTreeTraverser
 import dotty.tools.dotc.core.Comments
 import dotty.tools.dotc.core.Comments.Comment
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans.Span
 


### PR DESCRIPTION
 - Move from Definitions to TypeUtils
 - Unify TypeUtils.tupleElementTypes and Definitions.tupleTypes. They do the same thing.

I'd like to move more things out of Definitions and into TypeUtils and SymUtils. Then I'd like to move these files to the core package, and make their operations accessible automatically by having the companion objects of Types and Symbols inherit from them. This is a first step into that direction.