### PR TITLE
Backport "Spec: Rewrite the type system fundamentals." to LTS

### DIFF
--- a/docs/_docs/internals/syntax.md
+++ b/docs/_docs/internals/syntax.md
@@ -201,7 +201,6 @@ SimpleType1       ::=  id                                                       
 Singleton         ::=  SimpleRef
                     |  SimpleLiteral
                     |  Singleton ‘.’ id
-Singletons        ::=  Singleton { ‘,’ Singleton }
 FunArgType        ::=  [`erased`] Type
                     |  [`erased`] ‘=>’ Type                                     PrefixOp(=>, t)
 FunArgTypes       ::=  FunArgType { ‘,’ FunArgType }
@@ -357,8 +356,8 @@ ClsParam          ::=  {Annotation}                                             
                        [{Modifier} (‘val’ | ‘var’) | ‘inline’] Param
 
 DefParamClauses   ::=  DefParamClause { DefParamClause } -- and two DefTypeParamClause cannot be adjacent
-DefParamClause    ::=  DefTypeParamClause 
-                    |  DefTermParamClause 
+DefParamClause    ::=  DefTypeParamClause
+                    |  DefTermParamClause
                     |  UsingParamClause
 TypelessClauses   ::=  TypelessClause {TypelessClause}
 TypelessClause    ::=  DefTermParamClause

--- a/docs/_docs/reference/new-types/intersection-types-spec.md
+++ b/docs/_docs/reference/new-types/intersection-types-spec.md
@@ -46,11 +46,10 @@ A & B <: B       A & B <: A
 In another word, `A & B` is the same type as `B & A`, in the sense that the two types
 have the same values and are subtypes of each other.
 
-If `C` is a type constructor, then `C[A] & C[B]` can be simplified using the following three rules:
+If `C` is a co- or contravariant type constructor, then `C[A] & C[B]` can be simplified using the following rules:
 
 - If `C` is covariant, `C[A] & C[B] ~> C[A & B]`
 - If `C` is contravariant, `C[A] & C[B] ~> C[A | B]`
-- If `C` is non-variant, emit a compile error
 
 When `C` is covariant, `C[A & B] <: C[A] & C[B]` can be derived:
 

--- a/docs/_spec/02-identifiers-names-and-scopes.md
+++ b/docs/_spec/02-identifiers-names-and-scopes.md
@@ -53,7 +53,7 @@ In that case, the type of ´x´ is the type of the referenced entity.
 
 A reference to a qualified (type- or term-) identifier ´e.x´ refers to the member of the type ´T´ of ´e´ which has the name ´x´ in the same namespace as the identifier.
 It is an error if ´T´ is not a [value type](03-types.html#value-types).
-The type of ´e.x´ is the member type of the referenced entity in ´T´.
+The type of ´e.x´ is specified as a [type designator](03-types.html#type-designators).
 
 Binding precedence implies that the way source is bundled in files affects name resolution.
 In particular, imported names have higher precedence than names, defined in other files, that might otherwise be visible because they are defined in either the current package or an enclosing package.

--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -370,6 +370,8 @@ A _type lambda_ of the form `[´\pm a_1 >: L_1 <: H_1´, ..., ´\pm a_n >: L_n <
 When applied to ´n´ type arguments that conform to the specified bounds, it produces another type ´U´.
 Type lambdas are always concrete types.
 
+The scope of a type parameter extends over the result type ´U´ as well as the bounds of the type parameters themselves.
+
 All type constructors conform to some type lambda.
 
 The type bounds of the parameters of a type lambda are in contravariant position, while its result type is in covariant position.

--- a/docs/_spec/12-the-scala-standard-library.md
+++ b/docs/_spec/12-the-scala-standard-library.md
@@ -349,6 +349,39 @@ All case classes automatically extend the `Product` trait (and generate syntheti
 <!-- TODO: Move somewhere else ? -->
 All enum definitions automatically extend the `reflect.Enum` trait (and generate synthetic methods to conform to it).
 
+### Tuple Classes
+
+Tuple classes are case classes whose fields can be accessed using selectors `_1`, ..., `_n`.
+Their functionality is abstracted in the corresponding `scala.Product_´n´` trait.
+The _n_-ary tuple class and product trait are defined at least as follows in the standard Scala library (they might also add other methods and implement other traits).
+
+```scala
+case class Tuple´_n´[+´T_1´, ..., +´T_n´](_1: ´T_1´, ..., _n: ´T_n´)
+extends Product´_n´[´T_1´, ..., ´T_n´]
+
+trait Product´_n´[+´T_1´, ..., +´T_n´] extends Product:
+  override def productArity = ´n´
+  def _1: ´T_1´
+  ...
+  def _n: ´T_n´
+```
+
+#### Short-hand syntax
+
+Tuple classes have dedicated syntax.
+
+```ebnf
+SimpleType    ::=   ‘(’ Types ‘)’
+```
+
+A _tuple type_ ´(T_1, ..., T_n)´ where ´n \geq 2´ is an alias for the type `´T_1´ *: ... *: ´T_n´ *: scala.EmptyTuple`.
+
+Notes:
+- `(´T´)` is just the type ´T´, and not `´T´ *: scala.EmptyTuple`.
+- `()` is not a valid type, and not `scala.EmptyTuple`.
+
+If ´n \leq 22´, the type `´T_1´ *: ... *: ´T_n´ *: scala.EmptyTuple` is both a subtype and a supertype of tuple class `scala.Tuple´_n´[´T_1´, ..., ´T_n´]`.
+
 ### Class `Array`
 
 All operations on arrays desugar to the corresponding operations of the underlying platform.

--- a/docs/_spec/index.md
+++ b/docs/_spec/index.md
@@ -7,7 +7,7 @@ layout: toc
 
 #### Authors and Contributors
 
-Martin Odersky, Philippe Altherr, Vincent Cremet, Gilles Dubochet, Burak Emir, Philipp Haller, Stéphane Micheloud, Nikolay Mihaylov, Adriaan Moors, Lukas Rytz, Michel Schinz, Erik Stenman, Matthias Zenger
+Martin Odersky, Philippe Altherr, Vincent Cremet, Sébastien Doeraene, Gilles Dubochet, Burak Emir, Philipp Haller, Stéphane Micheloud, Nikolay Mihaylov, Adriaan Moors, Lukas Rytz, Michel Schinz, Erik Stenman, Matthias Zenger
 
 Markdown Conversion by Iain McGinniss.
 
@@ -32,12 +32,11 @@ Scala classes can call Java methods, create Java objects, inherit from Java
 classes and implement Java interfaces. None of this requires interface
 definitions or glue code.
 
-Scala has been developed from 2001 in the programming methods
-laboratory at EPFL. Version 1.0 was released in November 2003. This
-document describes the second version of the language, which was
-released in March 2006. It acts as a reference for the language
-definition and some core library modules. It is not intended to teach
-Scala or its concepts; for this there are [other documents](14-references.html).
+Scala has been developed from 2001 in the programming methods laboratory at EPFL.
+Version 1.0 was released in November 2003.
+This document describes the third version of the language, which was released in May 2021.
+It acts as a reference for the language definition and some core library modules.
+It is not intended to teach Scala or its concepts; for this there are [other documents](https://docs.scala-lang.org/).
 
 Scala has been a collective effort of many people. The design and the
 implementation of version 1.0 was completed by Philippe Altherr,


### PR DESCRIPTION
Backports #17447 to the LTS branch.

This PR was initially erroneously skipped.
It also includes changes form #17940.

[skip ci]