### PR TITLE
Add TASTyInfo abstraction

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
@@ -8,24 +8,15 @@ import dotty.tools.tasty.TastyVersion
   * @param associatedFile The source or class file from which this class or
   *                       the class containing this symbol was generated,
   *                       null if not applicable.
-  * @param tastyVersion   The TASTy version (major, minor, experimental)
-  * @param explicitNulls  This compilation unit has explicit nulls enabled?
+  * @param tastyInfo      Information about the TASTy from which this class was loaded.
+  *                       None if not loaded from TASTy,
   */
-class CompilationUnitInfo(
-  val associatedFile: AbstractFile,
-  val tastyVersion: Option[TastyVersion],
-  val explicitNulls: Boolean
-) {
-
-  override def toString(): String =
-    s"CompilationUnitInfo($associatedFile, $tastyVersion)"
-}
+case class CompilationUnitInfo(
+  associatedFile: AbstractFile,
+  tastyInfo: Option[TastyInfo],
+)
 
 object CompilationUnitInfo:
-  def apply(assocFile: AbstractFile | Null, explicitNulls: Boolean = false): CompilationUnitInfo | Null =
+  def apply(assocFile: AbstractFile | Null): CompilationUnitInfo | Null =
     if assocFile == null then null
-    else new CompilationUnitInfo(
-      assocFile,
-      tastyVersion = None,
-      explicitNulls = explicitNulls,
-    )
+    else new CompilationUnitInfo(assocFile, tastyInfo = None)

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -432,8 +432,7 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
     val attributes = unpickler.tastyAttributes
     new CompilationUnitInfo(
       tastyFile,
-      tastyVersion = Some(tastyVersion),
-      explicitNulls = attributes.explicitNulls,
+      tastyInfo = Some(TastyInfo(tastyVersion, attributes)),
     )
 
   def description(using Context): String = "TASTy file " + tastyFile.toString

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -281,16 +281,11 @@ object Symbols extends SymUtils {
     def compilationUnitInfo(using Context): CompilationUnitInfo | Null =
       lastDenot.topLevelClass.compilationUnitInfo
 
-    /** The version of TASTy from which the symbol was loaded, None if not applicable. */
-    def tastyVersion(using Context): Option[TastyVersion] =
+    /** The info of the TASTy from which this symbol was loaded, None if not applicable. */
+    def tastyInfo(using Context): Option[TastyInfo] =
       val compUnitInfo = compilationUnitInfo
       if compUnitInfo == null then None
-      else compUnitInfo.tastyVersion
-
-    /** If this class has explicit nulls enabled */
-    def explicitNulls(using Context): Boolean =
-      val compUnitInfo = compilationUnitInfo
-      compUnitInfo != null && compUnitInfo.explicitNulls
+      else compUnitInfo.tastyInfo
 
     /** The class file from which this class was generated, null if not applicable. */
     final def binaryFile(using Context): AbstractFile | Null = {

--- a/compiler/src/dotty/tools/dotc/core/TastyInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/TastyInfo.scala
@@ -1,0 +1,11 @@
+package dotty.tools.dotc.core
+
+import dotty.tools.io.AbstractFile
+import dotty.tools.tasty.TastyVersion
+
+/** Information about the TASTy of a class symbol.
+ *
+ *  @param version     The TASTy version (major, minor, experimental)
+ *  @param attributes  Attributes of in the TASTy attributes section
+ */
+case class TastyInfo(version: TastyVersion, attributes: tasty.Attributes)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1078,8 +1078,8 @@ trait Checking {
     tree.op match {
       case id @ Ident(name: Name) =>
         def methCompiledBeforeDeprecation =
-          meth.tastyVersion match
-            case Some(version) => version.major == 28 && version.minor < 4 // compiled before 3.4
+          meth.tastyInfo match
+            case Some(info) => info.version.major == 28 && info.version.minor < 4 // compiled before 3.4
             case _ => false // compiled with the current compiler
         name.toTermName match {
           case name: SimpleName

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -248,7 +248,7 @@ class Namer { typer: Typer =>
         val cls =
           createOrRefine[ClassSymbol](tree, name, flags, ctx.owner,
             cls => adjustIfModule(new ClassCompleter(cls, tree)(ctx), tree),
-            newClassSymbol(ctx.owner, name, _, _, _, tree.nameSpan, CompilationUnitInfo(ctx.source.file, explicitNulls = ctx.explicitNulls)))
+            newClassSymbol(ctx.owner, name, _, _, _, tree.nameSpan, CompilationUnitInfo(ctx.source.file)))
         cls.completer.asInstanceOf[ClassCompleter].init()
         cls
       case tree: MemberDef =>


### PR DESCRIPTION
This abstraction makes it clearer which fields of the `CompilationUnitInfo` are set when the symbol is loaded from TASTy. It also makes it trivial to add new attributes without the need to change the `CompilationUnitInfo` and possibly the `ClassSymbol` helper methods.