### PR TITLE
Refactor TASTy Attributes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/AttributePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/AttributePickler.scala
@@ -5,8 +5,6 @@ import dotty.tools.dotc.ast.{tpd, untpd}
 import dotty.tools.tasty.TastyBuffer
 import dotty.tools.tasty.TastyFormat, TastyFormat.AttributesSection
 
-import java.nio.charset.StandardCharsets
-
 object AttributePickler:
 
   def pickleAttributes(
@@ -14,12 +12,11 @@ object AttributePickler:
     pickler: TastyPickler,
     buf: TastyBuffer
   ): Unit =
-    if attributes.scala2StandardLibrary || attributes.explicitNulls then // or any other attribute is set
+    if attributes.booleanTags.nonEmpty then
       pickler.newSection(AttributesSection, buf)
-      // Pickle attributes
-      if attributes.scala2StandardLibrary then buf.writeNat(TastyFormat.SCALA2STANDARDLIBRARYattr)
-      if attributes.explicitNulls then buf.writeNat(TastyFormat.EXPLICITNULLSattr)
-    end if
+
+    for tag <- attributes.booleanTags do
+      buf.writeByte(tag)
 
   end pickleAttributes
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/AttributeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/AttributeUnpickler.scala
@@ -5,29 +5,16 @@ import scala.language.unsafeNulls
 
 import dotty.tools.tasty.{TastyFormat, TastyReader, TastyBuffer}
 
-import java.nio.charset.StandardCharsets
-
 class AttributeUnpickler(reader: TastyReader):
   import reader._
 
-  lazy val attributeTags: List[Int] =
-    val listBuilder = List.newBuilder[Int]
-    while !isAtEnd do listBuilder += readNat()
-    listBuilder.result()
-
   lazy val attributes: Attributes = {
-    var scala2StandardLibrary = false
-    var explicitNulls = false
-    for attributeTag <- attributeTags do
-      attributeTag match
-        case TastyFormat.SCALA2STANDARDLIBRARYattr => scala2StandardLibrary = true
-        case TastyFormat.EXPLICITNULLSattr => explicitNulls = true
-        case attribute =>
-          assert(false, "Unexpected attribute value: " + attribute)
-    Attributes(
-      scala2StandardLibrary,
-      explicitNulls,
-    )
+    val booleanTags = List.newBuilder[Int]
+
+    while !isAtEnd do
+      booleanTags += readByte()
+
+    new Attributes(booleanTags.result())
   }
 
 end AttributeUnpickler

--- a/compiler/src/dotty/tools/dotc/core/tasty/Attributes.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/Attributes.scala
@@ -1,6 +1,23 @@
 package dotty.tools.dotc.core.tasty
 
+import dotty.tools.tasty.TastyFormat
+
 class Attributes(
-  val scala2StandardLibrary: Boolean,
-  val explicitNulls: Boolean,
-)
+  val booleanTags: List[Int],
+) {
+  def scala2StandardLibrary: Boolean =
+    booleanTags.contains(TastyFormat.SCALA2STANDARDLIBRARYattr)
+  def explicitNulls: Boolean =
+    booleanTags.contains(TastyFormat.EXPLICITNULLSattr)
+}
+
+object Attributes:
+  def apply(
+    scala2StandardLibrary: Boolean,
+    explicitNulls: Boolean,
+  ): Attributes =
+    val booleanTags = List.newBuilder[Int]
+    if scala2StandardLibrary then booleanTags += TastyFormat.SCALA2STANDARDLIBRARYattr
+    if explicitNulls then booleanTags += TastyFormat.EXPLICITNULLSattr
+    new Attributes(booleanTags.result())
+  end apply

--- a/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
@@ -57,7 +57,7 @@ class DottyUnpickler(bytes: Array[Byte], mode: UnpickleMode = UnpickleMode.TopLe
   private val treeUnpickler = unpickler.unpickle(treeSectionUnpickler(posUnpicklerOpt, commentUnpicklerOpt, attributeUnpicklerOpt)).get
 
   def tastyAttributes: Attributes =
-    attributeUnpicklerOpt.map(_.attributes).getOrElse(Attributes(false, false))
+    attributeUnpicklerOpt.map(_.attributes).getOrElse(new Attributes(booleanTags = Nil))
 
   /** Enter all toplevel classes and objects into their scopes
    *  @param roots          a set of SymDenotations that should be overwritten by unpickling

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -225,15 +225,19 @@ class TastyPrinter(bytes: Array[Byte]) {
   }
 
   class AttributesSectionUnpickler extends SectionUnpickler[String](AttributesSection) {
-  import dotty.tools.tasty.TastyFormat.attributeTagToString
+    import dotty.tools.tasty.TastyFormat.*
+
     private val sb: StringBuilder = new StringBuilder
 
     def unpickle(reader: TastyReader, tastyName: NameTable): String = {
+      import reader.*
       sb.append(s" ${reader.endAddr.index - reader.currentAddr.index}")
-      val attributeTags = new AttributeUnpickler(reader).attributeTags
+      val attributes = new AttributeUnpickler(reader).attributes
       sb.append(s"  attributes bytes:\n")
-      for attributeTag <- attributeTags do
-        sb.append("    ").append(attributeTagToString(attributeTag)).append("\n")
+
+      for tag <- attributes.booleanTags do
+        sb.append("   ").append(attributeTagToString(tag)).append("\n")
+
       sb.result
     }
   }


### PR DESCRIPTION
We generalize the internal encoding of `Attributes` to be a list of tags. Then we add add helper methods to have simpler ways to interact with this abstraction using booleans. This implies that the pickling/unpickling can be agnostic of the semantics of each tag. Therefore reducing the number of places that need to be updated when we add a new tag.

Useful for #19074, #19033, and #18948.