### PR TITLE
Refactor migration warnings

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
@@ -1,0 +1,42 @@
+package dotty.tools
+package dotc
+package config
+
+import SourceVersion.*
+import Feature.*
+import core.Contexts.Context
+
+class MigrationVersion(val warnFrom: SourceVersion, val errorFrom: SourceVersion):
+  assert(warnFrom.ordinal <= errorFrom.ordinal)
+  def needsPatch(using Context): Boolean =
+    sourceVersion.isMigrating && sourceVersion.isAtLeast(errorFrom)
+
+object MigrationVersion:
+
+  val Scala2to3 = MigrationVersion(`3.0`, `3.0`)
+
+  val OverrideValParameter = MigrationVersion(`3.0`, future)
+
+  // we tighten for-comprehension without `case` to error in 3.4,
+  // but we keep pat-defs as warnings for now ("@unchecked"),
+  // until we propose an alternative way to assert exhaustivity to the typechecker.
+  val ForComprehensionPatternWithoutCase = MigrationVersion(`3.2`,  `3.4`)
+  val ForComprehensionUncheckedPathDefs = MigrationVersion(`3.2`,  future)
+
+  val NonLocalReturns = MigrationVersion(`3.2`, future)
+
+  val AscriptionAfterPattern = MigrationVersion(`3.3`, future)
+
+  val AlphanumericInfix = MigrationVersion(`3.4`, future)
+  val RemoveThisQualifier = MigrationVersion(`3.4`, future)
+  val UninitializedVars = MigrationVersion(`3.4`, future)
+  val VarargSpliceAscription = MigrationVersion(`3.4`, future)
+  val WildcardType = MigrationVersion(`3.4`, future)
+  val WithOperator = MigrationVersion(`3.4`, future)
+  val FunctionUnderscore = MigrationVersion(`3.4`, future)
+
+  val ImportWildcard = MigrationVersion(future, future)
+  val ImportRename = MigrationVersion(future, future)
+  val ParameterEnclosedByParenthesis = MigrationVersion(future, future)
+
+end MigrationVersion

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -19,6 +19,7 @@ import rewrites.Rewrites.patch
 import config.Feature
 import config.Feature.{migrateTo3, fewerBracesEnabled}
 import config.SourceVersion.{`3.0`, `3.0-migration`}
+import config.MigrationVersion
 import reporting.{NoProfile, Profile, Message}
 
 import java.util.Objects
@@ -257,8 +258,8 @@ object Scanners {
           report.errorOrMigrationWarning(
             em"$what is now a keyword, write `$what` instead of $what to keep it as an identifier${rewriteNotice("This", `3.0-migration`)}",
             sourcePos(),
-            from = `3.0`)
-          if sourceVersion.isMigrating then
+            MigrationVersion.Scala2to3)
+          if MigrationVersion.Scala2to3.needsPatch then
             patch(source, Span(offset), "`")
             patch(source, Span(offset + identifier.length), "`")
           IDENTIFIER
@@ -470,7 +471,7 @@ object Scanners {
             em"""$what starts with an operator;
                 |it is now treated as a continuation of the $previous,
                 |not as a separate statement.""",
-            sourcePos(), from = `3.0`)
+            sourcePos(), MigrationVersion.Scala2to3)
         true
       }
 

--- a/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/NonLocalReturns.scala
@@ -7,6 +7,7 @@ import MegaPhase.*
 import NameKinds.NonLocalReturnKeyName
 import config.SourceVersion.*
 import Decorators.em
+import dotty.tools.dotc.config.MigrationVersion
 
 object NonLocalReturns {
   import ast.tpd.*
@@ -96,11 +97,10 @@ class NonLocalReturns extends MiniPhase {
 
   override def transformReturn(tree: Return)(using Context): Tree =
     if isNonLocalReturn(tree) then
-      report.gradualErrorOrMigrationWarning(
+      report.errorOrMigrationWarning(
           em"Non local returns are no longer supported; use `boundary` and `boundary.break` in `scala.util` instead",
           tree.srcPos,
-          warnFrom = `3.2`,
-          errorFrom = future)
+          MigrationVersion.NonLocalReturns)
       nonLocalReturnThrow(tree.expr, tree.from.symbol).withSpan(tree.span)
     else tree
 }

--- a/tests/neg/i11567.scala
+++ b/tests/neg/i11567.scala
@@ -1,4 +1,4 @@
-import language.`future-migration`
+import language.future
 class Test
 object Test {
   def foo[A <% Test](x: A) = x  // error


### PR DESCRIPTION
Now we have a single way to define migration warning versions and a single place to see all the deprecations we still need to address.