### PR TITLE
Fix TASTy source position printer

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -218,12 +218,12 @@ class TastyPrinter(bytes: Array[Byte]) {
         sb.append(s": ${offsetToInt(pos.start)} .. ${pos.end}\n")
       }
 
-      val sources = posUnpickler.sourcePaths
+      val sources = posUnpickler.sourceNameRefs
       sb.append(s"\n  source paths:\n")
       val sortedPath = sources.toSeq.sortBy(_._1.index)
-      for ((addr, path) <- sortedPath) {
+      for ((addr, nameRef) <- sortedPath) {
         sb.append(treeStr("%6d: ".format(addr.index)))
-        sb.append(path)
+        sb.append(nameStr(s"${nameRef.index} [${tastyName(nameRef)}]"))
         sb.append("\n")
       }
 

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -27,7 +27,7 @@ echo "testing sbt scalac -print-tasty"
 clear_out "$OUT"
 "$SBT" ";scalac $SOURCE -d $OUT ;scalac -print-tasty -color:never $TASTY" > "$tmp"
 grep -qe "0: ASTs" "$tmp"
-grep -qe "0: tests/pos/HelloWorld.scala" "$tmp"
+grep -qe "0: 41 \[tests/pos/HelloWorld.scala\]" "$tmp"
 
 echo "testing that paths SourceFile annotations are relativized"
 clear_out "$OUT"


### PR DESCRIPTION
Based on #19106

Now it properly shows that the sources form the position section are references in the name table. This includes the coloring of the indices and referenced names.

```diff
 source paths:
-         0: t/Test.scala
+         0: 21 [t/Test.scala]
```

<img width="272" alt="Screenshot 2023-11-30 at 10 32 35" src="https://github.com/lampepfl/dotty/assets/3648029/36c87ff4-0a21-4af9-907d-1b36d3f70496">

Can be reproduced with
```scala
// Test.scala
class Test
```
```
scalac -Yprint-tasty Test.scala
```
