### PR TITLE
Homogenize TASTy printer formatting

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -258,10 +258,10 @@ class TastyPrinter(bytes: Array[Byte]) {
       import reader.*
       sb.append(s" ${reader.endAddr.index - reader.currentAddr.index}")
       val attributes = new AttributeUnpickler(reader).attributes
-      sb.append(s"  attributes bytes:\n")
+      sb.append(s"Attributes (${reader.endAddr.index - reader.startAddr.index} bytes, starting from $base):\n")
 
       for tag <- attributes.booleanTags do
-        sb.append("   ").append(attributeTagToString(tag)).append("\n")
+        sb.append("  ").append(attributeTagToString(tag)).append("\n")
 
       sb.result
     }


### PR DESCRIPTION
* Homogenize the formatting of section names and sizes
* Homogenize indentation across sections
* Add TASTy header section
* Add Names section size

## New
```scala
/** aa */
class Test
```
<img width="699" alt="Screenshot 2023-11-30 at 12 03 21" src="https://github.com/lampepfl/dotty/assets/3648029/a9ac9230-ca36-433c-89ce-096fc05d7f61">

## Old
<img width="697" alt="Screenshot 2023-11-30 at 12 04 10" src="https://github.com/lampepfl/dotty/assets/3648029/25efbae4-84a6-4c74-aa02-2601d3de63e0">
