### PR TITLE
Avoid diagnostic message forcing crashing the compiler

### DIFF
--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -155,6 +155,7 @@ object report:
        |  An unhandled exception was thrown in the compiler.
        |  Please file a crash report here:
        |  https://github.com/lampepfl/dotty/issues/new/choose
+       |  For non-enriched exceptions, compile with -Yno-enrich-error-messages.
        |
        |$info1
        |""".stripMargin

--- a/compiler/src/dotty/tools/dotc/reporting/HideNonSensicalMessages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/HideNonSensicalMessages.scala
@@ -13,19 +13,8 @@ trait HideNonSensicalMessages extends Reporter {
    */
   override def isHidden(dia: Diagnostic)(using Context): Boolean =
     super.isHidden(dia) || {
-        (if !errorsReported && dia.isInstanceOf[Diagnostic.Error] then
-          // Bump up errorCount so hasErrors is true while forcing the message.
-          // We use errorsReported as a predicate for broken code.
-          // So now any forcing won't cause, for instance,
-          // assertion errors and thus compiler crashes.
-          // Some messages, once forced, run more code
-          // to generate useful hints for the user.
-          try
-            _errorCount += 1
-            dia.msg.isNonSensical
-          finally _errorCount -= 1 // decrease rather than reset the value so we only ever decrease by 1
-        else dia.msg.isNonSensical) &&
-        hasErrors && // if there are no errors yet, report even if diagnostic is non-sensical
-        !ctx.settings.YshowSuppressedErrors.value
+        hasErrors  // if there are no errors yet, report even if diagnostic is non-sensical
+        && dia.msg.isNonSensical // defer forcing the message by calling hasErrors first
+        && !ctx.settings.YshowSuppressedErrors.value
     }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/HideNonSensicalMessages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/HideNonSensicalMessages.scala
@@ -13,7 +13,18 @@ trait HideNonSensicalMessages extends Reporter {
    */
   override def isHidden(dia: Diagnostic)(using Context): Boolean =
     super.isHidden(dia) || {
-        dia.msg.isNonSensical &&
+        (if !errorsReported && dia.isInstanceOf[Diagnostic.Error] then
+          // Bump up errorCount so hasErrors is true while forcing the message.
+          // We use errorsReported as a predicate for broken code.
+          // So now any forcing won't cause, for instance,
+          // assertion errors and thus compiler crashes.
+          // Some messages, once forced, run more code
+          // to generate useful hints for the user.
+          try
+            _errorCount += 1
+            dia.msg.isNonSensical
+          finally _errorCount -= 1 // decrease rather than reset the value so we only ever decrease by 1
+        else dia.msg.isNonSensical) &&
         hasErrors && // if there are no errors yet, report even if diagnostic is non-sensical
         !ctx.settings.YshowSuppressedErrors.value
     }

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -92,8 +92,8 @@ abstract class Reporter extends interfaces.ReporterResult {
 
   private def isIncompleteChecking = incompleteHandler ne defaultIncompleteHandler
 
-  protected var _errorCount = 0
-  protected var _warningCount = 0
+  private var _errorCount = 0
+  private var _warningCount = 0
 
   /** The number of errors reported by this reporter (ignoring outer reporters) */
   def errorCount: Int = _errorCount
@@ -155,8 +155,6 @@ abstract class Reporter extends interfaces.ReporterResult {
       addUnreported(key, 1)
     case _                                                  =>
       if !isHidden(dia) then // avoid isHidden test for summarized warnings so that message is not forced
-        markReported(dia)
-        withMode(Mode.Printing)(doReport(dia))
         dia match {
           case w: Warning =>
             warnings = w :: warnings
@@ -169,6 +167,8 @@ abstract class Reporter extends interfaces.ReporterResult {
           case _: Info    => // nothing to do here
           // match error if d is something else
         }
+        markReported(dia)
+        withMode(Mode.Printing)(doReport(dia))
   end issueUnconfigured
 
   def issueIfNotSuppressed(dia: Diagnostic)(using Context): Unit =

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -92,8 +92,8 @@ abstract class Reporter extends interfaces.ReporterResult {
 
   private def isIncompleteChecking = incompleteHandler ne defaultIncompleteHandler
 
-  private var _errorCount = 0
-  private var _warningCount = 0
+  protected var _errorCount = 0
+  protected var _warningCount = 0
 
   /** The number of errors reported by this reporter (ignoring outer reporters) */
   def errorCount: Int = _errorCount
@@ -154,20 +154,7 @@ abstract class Reporter extends interfaces.ReporterResult {
       val key = w.enablingOption.name
       addUnreported(key, 1)
     case _                                                  =>
-      val hide = if !errorsReported && dia.isInstanceOf[Error] then
-        // We bump up errorCount so errorsReported is true while executing isHidden.
-        // We use errorsReported as a predicate for broken code.
-        // So now any code `isHidden` runs won't cause, for instance,
-        // assertion errors and thus compiler crashes.
-        // This normally amounts to forcing the message, which might run more code
-        // to generate useful hints for the user.
-        try
-          _errorCount += 1
-          isHidden(dia)
-        finally
-          _errorCount -= 1 // decrease rather than set back to `oldErrorCount` so we only ever decrease by 1
-      else isHidden(dia)
-      if !hide then // avoid isHidden test for summarized warnings so that message is not forced
+      if !isHidden(dia) then // avoid isHidden test for summarized warnings so that message is not forced
         markReported(dia)
         withMode(Mode.Printing)(doReport(dia))
         dia match {


### PR DESCRIPTION
Using issue #18650 as the reference (but issue #18999 is another option) building on the fix in PR #18719 (refined in PR #18727) as well as the fix in PR #18760, I'm trying to make a more root change here by making sure that message forcing only occurs with `hasErrors`/`errorsReported` is true, so as to avoid assertion errors crashing the compiler.