### PR TITLE
Make sure that the stacktrace is shown with `-Ydebug-unpickling`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -145,12 +145,7 @@ class TreeUnpickler(reader: TastyReader,
         def where =
           val f = denot.symbol.associatedFile
           if f == null then "" else s" in $f"
-        if ctx.settings.YdebugUnpickling.value then throw ex
-        else throw TypeError(
-          em"""Could not read definition of $denot$where
-              |An exception was encountered:
-              |  $ex
-              |Run with -Ydebug-unpickling to see full stack trace.""")
+        throw UnpicklingError(denot, where, ex)
       treeAtAddr(currentAddr) =
         try
           atPhaseBeforeTransforms {


### PR DESCRIPTION

#### New behaviour, tested on #18967

```scala
// Test.scala
def test: Option[Int] = ???
```

```
sbt> set ThisBuild/Build.scala2Library := Build.Scala2LibraryCCTasty
sbt> scala3-bootstrapped/scalac Test.scala
-- Error: Test.scala:1:10 ----------------------------------------------------
1 |def test: Option[Int] = ???
  |          ^
  |Could not read definition class Option in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/Option.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.UnpicklingError: Could not read definition type IterableOnce in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/package.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.UnpicklingError: Could not read definition trait IterableOnce in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/IterableOnce.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.UnpicklingError: Could not read definition trait Iterable in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/immutable/Iterable.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.UnpicklingError: Could not read definition trait Iterable out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/Iterable.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.CyclicReference: Cyclic reference involving trait Seq
  |
  |Run with -Ydebug-unpickling to see full stack trace.

sbt> scala3-bootstrapped/scalac -Ydebug-unpickling Test.scala
-- Error: Test.scala:1:10 ----------------------------------------------------
1 |def test: Option[Int] = ???
  |          ^
  |Could not read definition class Option in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/Option.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.UnpicklingError: Could not read definition type IterableOnce in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/package.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.UnpicklingError: Could not read definition trait IterableOnce in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/IterableOnce.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.UnpicklingError: Could not read definition trait Iterable in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/immutable/Iterable.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.UnpicklingError: Could not read definition trait Iterable in out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/Iterable.tasty). Caused by the following exception:
  |dotty.tools.dotc.core.CyclicReference: Cyclic reference involving trait Seq
  |    dotty.tools.dotc.core.CyclicReference$.apply(TypeErrors.scala:186)
  |    dotty.tools.dotc.core.SymDenotations$BaseDataImpl.apply(SymDenotations.scala:2973)
  |    dotty.tools.dotc.core.SymDenotations$ClassDenotation.baseData(SymDenotations.scala:1954)
  |    dotty.tools.dotc.core.SymDenotations$ClassDenotation.baseClassSet(SymDenotations.scala:1970)
  |    dotty.tools.dotc.core.SymDenotations$ClassDenotation.isValueClass(SymDenotations.scala:2032)
  |    dotty.tools.dotc.core.SymUtils.isDerivedValueClass(SymUtils.scala:85)
  |    dotty.tools.dotc.core.TypeErasure$.dotty$tools$dotc$core$TypeErasure$$$erasureDependsOnArgs(TypeErasure.scala:74)
  |    ...
```

#### Old behaviour
```
sbt> set ThisBuild/Build.scala2Library := Build.Scala2LibraryCCTasty
sbt> scala3-bootstrapped/scalac Test.scala 
-- Error: Test.scala:1:10 ----------------------------------------------------
1 |def test: Option[Int] = ???
  |          ^
  |Could not read definition of class Option in /Users/nicolasstucki/Github/dotty/scala2-library-cc-tasty/../out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/Option.tasty)
  |An exception was encountered:
  |  dotty.tools.dotc.core.TypeError$$anon$1: Could not read definition of type IterableOnce in /Users/nicolasstucki/Github/dotty/scala2-library-cc-tasty/../out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/package.tasty)
  |An exception was encountered:
  |  dotty.tools.dotc.core.TypeError$$anon$1: Could not read definition of trait IterableOnce in /Users/nicolasstucki/Github/dotty/scala2-library-cc-tasty/../out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/IterableOnce.tasty)
  |An exception was encountered:
  |  dotty.tools.dotc.core.TypeError$$anon$1: Could not read definition of trait Iterable in /Users/nicolasstucki/Github/dotty/scala2-library-cc-tasty/../out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/immutable/Iterable.tasty)
  |An exception was encountered:
  |  dotty.tools.dotc.core.TypeError$$anon$1: Could not read definition of trait Iterable in /Users/nicolasstucki/Github/dotty/scala2-library-cc-tasty/../out/bootstrap/scala2-library-cc-tasty/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala2-library-cc-tasty_3-3.4.0-RC1-bin-SNAPSHOT.jar(scala/collection/Iterable.tasty)
  |An exception was encountered:
  |  dotty.tools.dotc.core.CyclicReference: Cyclic reference involving trait Seq
  |Run with -Ydebug-unpickling to see full stack trace.
  |Run with -Ydebug-unpickling to see full stack trace.
  |Run with -Ydebug-unpickling to see full stack trace.
  |Run with -Ydebug-unpickling to see full stack trace.
  |Run with -Ydebug-unpickling to see full stack trace.
1 error found

sbt> scala3-bootstrapped/scalac t/Test.scala -Ydebug-unpickling
-- Error: t/Test.scala:1:10 ----------------------------------------------------
1 |def test: Option[Int] = ???
  |          ^
  |          Cyclic reference involving trait Seq
  |
  | longer explanation available when compiling with `-explain`
1 error found
```