### PR TITLE
Backport "Replace `is{Poly|Erased}FunctionType` with `{PolyOrErased,Poly,Erased}FunctionOf`" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -947,6 +947,8 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   def isStructuralTermSelectOrApply(tree: Tree)(using Context): Boolean = {
     def isStructuralTermSelect(tree: Select) =
       def hasRefinement(qualtpe: Type): Boolean = qualtpe.dealias match
+        case defn.PolyOrErasedFunctionOf(_) =>
+          false
         case RefinedType(parent, rname, rinfo) =>
           rname == tree.name || hasRefinement(parent)
         case tp: TypeProxy =>
@@ -959,10 +961,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
           false
       !tree.symbol.exists
       && tree.isTerm
-      && {
-        val qualType = tree.qualifier.tpe
-        hasRefinement(qualType) && !defn.isPolyOrErasedFunctionType(qualType)
-      }
+      && hasRefinement(tree.qualifier.tpe)
     def loop(tree: Tree): Boolean = tree match
       case TypeApply(fun, _) =>
         loop(fun)

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -509,7 +509,7 @@ class TypeApplications(val self: Type) extends AnyVal {
    *  Handles `ErasedFunction`s and poly functions gracefully.
    */
   final def functionArgInfos(using Context): List[Type] = self.dealias match
-    case RefinedType(parent, nme.apply, mt: MethodType) if defn.isPolyOrErasedFunctionType(parent) => (mt.paramInfos :+ mt.resultType)
+    case defn.ErasedFunctionOf(mt) => (mt.paramInfos :+ mt.resultType)
     case _ => self.dropDependentRefinement.dealias.argInfos
 
   /** Argument types where existential types in arguments are disallowed */

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -659,7 +659,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                 isSubType(info1, info2)
 
             if defn.isFunctionType(tp2) then
-              if defn.isPolyFunctionType(tp2) then
+              if tp2.derivesFrom(defn.PolyFunctionClass) then
                 // TODO should we handle ErasedFunction is this same way?
                 tp1.member(nme.apply).info match
                   case info1: PolyType =>

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -654,8 +654,8 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
         else SuperType(eThis, eSuper)
       case ExprType(rt) =>
         defn.FunctionType(0)
-      case RefinedType(parent, nme.apply, refinedInfo) if defn.isPolyOrErasedFunctionType(parent) =>
-        eraseRefinedFunctionApply(refinedInfo)
+      case defn.PolyOrErasedFunctionOf(mt) =>
+        eraseRefinedFunctionApply(mt)
       case tp: TypeVar if !tp.isInstantiated =>
         assert(inSigName, i"Cannot erase uninstantiated type variable $tp")
         WildcardType
@@ -936,7 +936,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
         sigName(defn.FunctionOf(Nil, rt))
       case tp: TypeVar if !tp.isInstantiated =>
         tpnme.Uninstantiated
-      case tp @ RefinedType(parent, nme.apply, _) if defn.isPolyOrErasedFunctionType(parent) =>
+      case tp @ defn.PolyOrErasedFunctionOf(_) =>
         // we need this case rather than falling through to the default
         // because RefinedTypes <: TypeProxy and it would be caught by
         // the case immediately below

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1737,9 +1737,7 @@ object Types {
         if !tf1.exists then tf2
         else if !tf2.exists then tf1
         else NoType
-      case t if defn.isNonRefinedFunction(t) =>
-        t
-      case t @ defn.PolyOrErasedFunctionOf(_) =>
+      case t if defn.isFunctionType(t) =>
         t
       case t @ SAMType(_, _) =>
         t

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1739,7 +1739,7 @@ object Types {
         else NoType
       case t if defn.isNonRefinedFunction(t) =>
         t
-      case t if defn.isErasedFunctionType(t) =>
+      case t @ defn.PolyOrErasedFunctionOf(_: MethodType) =>
         t
       case t @ SAMType(_, _) =>
         t

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1739,7 +1739,7 @@ object Types {
         else NoType
       case t if defn.isNonRefinedFunction(t) =>
         t
-      case t @ defn.PolyOrErasedFunctionOf(_: MethodType) =>
+      case t @ defn.PolyOrErasedFunctionOf(_) =>
         t
       case t @ SAMType(_, _) =>
         t

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -677,7 +677,7 @@ object Erasure {
           // Instead, we manually lookup the type of `apply` in the qualifier.
           inContext(preErasureCtx) {
             val qualTp = tree.qualifier.typeOpt.widen
-            if defn.isPolyOrErasedFunctionType(qualTp) then
+            if qualTp.derivesFrom(defn.PolyFunctionClass) || qualTp.derivesFrom(defn.ErasedFunctionClass) then
               eraseRefinedFunctionApply(qualTp.select(nme.apply).widen).classSymbol
             else
               NoSymbol

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -446,7 +446,11 @@ object TreeChecker {
       val tpe = tree.typeOpt
 
       // PolyFunction and ErasedFunction apply methods stay structural until Erasure
-      val isRefinedFunctionApply = (tree.name eq nme.apply) && defn.isPolyOrErasedFunctionType(tree.qualifier.typeOpt)
+      val isRefinedFunctionApply = (tree.name eq nme.apply) && {
+        val qualTpe = tree.qualifier.typeOpt
+        qualTpe.derivesFrom(defn.PolyFunctionClass) || qualTpe.derivesFrom(defn.ErasedFunctionClass)
+      }
+
       // Outer selects are pickled specially so don't require a symbol
       val isOuterSelect = tree.name.is(OuterSelectName)
       val isPrimitiveArrayOp = ctx.erasedTypes && nme.isPrimitiveName(tree.name)

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -105,7 +105,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
           expected =:= defn.FunctionOf(actualArgs, actualRet,
             defn.isContextFunctionType(baseFun))
         val arity: Int =
-          if defn.isErasedFunctionType(fun) then -1 // TODO support?
+          if fun.derivesFrom(defn.ErasedFunctionClass) then -1 // TODO support?
           else if defn.isFunctionNType(fun) then
             // TupledFunction[(...) => R, ?]
             fun.functionArgInfos match

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1779,7 +1779,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def isContextFunctionType: Boolean =
           dotc.core.Symbols.defn.isContextFunctionType(self)
         def isErasedFunctionType: Boolean =
-          dotc.core.Symbols.defn.isErasedFunctionType(self)
+          self.derivesFrom(dotc.core.Symbols.defn.ErasedFunctionClass)
         def isDependentFunctionType: Boolean =
           val tpNoRefinement = self.dropDependentRefinement
           tpNoRefinement != self


### PR DESCRIPTION
Backports #18207 to the LTS branch.

PR submitted by the release tooling.
[skip ci]