### PR TITLE
Backport "XcheckMacro types of Block expression and Apply/TypeApply function" to LTS

### DIFF
--- a/tests/neg-macros/i18113.check
+++ b/tests/neg-macros/i18113.check
@@ -1,0 +1,15 @@
+
+-- Error: tests/neg-macros/i18113/Test_2.scala:7:8 ---------------------------------------------------------------------
+ 7 |  X.test(ref) // error
+   |  ^^^^^^^^^^^
+   |Exception occurred while executing macro expansion.
+   |java.lang.AssertionError: Reference to a method must be eta-expanded before it is used as an expression: x.Main.ref.plus
+   |	at x.X$.testImpl(Macro_1.scala:16)
+   |
+   |--------------------------------------------------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from Macro_1.scala:11
+11 |   inline def test(ref:IntRef):Int = ${ testImpl('ref) }
+   |                                     ^^^^^^^^^^^^^^^^^^^
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i18113/Macro_1.scala
+++ b/tests/neg-macros/i18113/Macro_1.scala
@@ -1,0 +1,21 @@
+package x
+
+import scala.quoted.*
+
+class IntRef(var x: Int) {
+   def plus(y:Int): Int = ???
+}
+
+object X {
+
+   inline def test(ref:IntRef):Int = ${ testImpl('ref) }
+
+   def testImpl(ref:Expr[IntRef])(using Quotes):Expr[Int] = {
+     import quotes.reflect.*
+     val fun0 = Select.unique(ref.asTerm,"plus")
+     val fun1 = Block(List(Assign(Select.unique(ref.asTerm,"x"),Literal(IntConstant(1)))),fun0)
+     val r = Apply(fun1,List(Literal(IntConstant(2))))
+     r.asExprOf[Int]
+   }
+
+}

--- a/tests/neg-macros/i18113/Test_2.scala
+++ b/tests/neg-macros/i18113/Test_2.scala
@@ -1,0 +1,9 @@
+package x
+
+object Main {
+
+  val ref = IntRef(0)
+
+  X.test(ref) // error
+
+}

--- a/tests/neg-macros/i18113b.check
+++ b/tests/neg-macros/i18113b.check
@@ -1,0 +1,15 @@
+
+-- Error: tests/neg-macros/i18113b/Test_2.scala:7:8 --------------------------------------------------------------------
+ 7 |  X.test(ref) // error
+   |  ^^^^^^^^^^^
+   |  Exception occurred while executing macro expansion.
+   |  java.lang.AssertionError: Expected `fun.tpe` to widen into a `MethodType`
+   |  	at x.X$.testImpl(Macro_1.scala:27)
+   |
+   |--------------------------------------------------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from Macro_1.scala:12
+12 |   inline def test(ref:IntRef):Int = ${ testImpl('ref) }
+   |                                     ^^^^^^^^^^^^^^^^^^^
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i18113b/Macro_1.scala
+++ b/tests/neg-macros/i18113b/Macro_1.scala
@@ -1,0 +1,31 @@
+package x
+
+import scala.quoted.*
+
+class IntRef(var x: Int) {
+   def plus(y:Int): Int = ???
+}
+
+
+object X {
+
+   inline def test(ref:IntRef):Int = ${ testImpl('ref) }
+
+   def testImpl(ref:Expr[IntRef])(using Quotes):Expr[Int] = {
+     import quotes.reflect.*
+     val fun0 = Select.unique(ref.asTerm,"plus")
+     val mt = MethodType(List("p"))(
+                _ => List(TypeRepr.of[Int]),
+                _ => TypeRepr.of[Int]
+              )
+     val etaExpanded = Lambda(Symbol.spliceOwner, mt, (owner, params) => {
+             Block(
+               List(Assign(Select.unique(ref.asTerm,"x"),Literal(IntConstant(1)))),
+               Apply(fun0,params.map(_.asInstanceOf[Term]))
+             )
+     })
+     val r = Apply(etaExpanded,List(Literal(IntConstant(2))))
+     r.asExprOf[Int]
+   }
+
+}

--- a/tests/neg-macros/i18113b/Test_2.scala
+++ b/tests/neg-macros/i18113b/Test_2.scala
@@ -1,0 +1,9 @@
+package x
+
+object Main {
+
+  val ref = IntRef(0)
+
+  X.test(ref) // error
+
+}


### PR DESCRIPTION
Backports #18242 to the LTS branch.

PR submitted by the release tooling.
[skip ci]