### PR TITLE
Backport "enable ability to only record Stats.trackTime" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -240,7 +240,7 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
 
       for (phase <- ctx.base.allPhases)
         if (phase.isRunnable)
-          Stats.trackTime(s"$phase ms ") {
+          Stats.trackTime(s"phase time ms/$phase") {
             val start = System.currentTimeMillis
             val profileBefore = profiler.beforePhase(phase)
             units = phase.runOn(units)

--- a/compiler/src/dotty/tools/dotc/util/Stats.scala
+++ b/compiler/src/dotty/tools/dotc/util/Stats.scala
@@ -9,7 +9,11 @@ import collection.mutable
 
 @sharable object Stats {
 
+  // when false, Stats.record and Stats.trackTime are elided.
   inline val enabled = false
+
+  // set to true if only `trackTime` should be recorded by default
+  inline val timerOnly = false
 
   var monitored: Boolean = false
 
@@ -19,8 +23,8 @@ import collection.mutable
     override def default(key: String): Int = 0
   }
 
-  inline def record(inline fn: String, inline n: Int = 1): Unit =
-    if (enabled) doRecord(fn, n)
+  inline def record(inline fn: String, inline n: Int = 1, inline skip: Boolean = timerOnly): Unit =
+    if (enabled && !skip) doRecord(fn, n)
 
   def doRecord(fn: String, n: Int) =
     if (monitored) {
@@ -38,7 +42,7 @@ import collection.mutable
   def doTrackTime[T](fn: String)(op: => T): T = {
     if (monitored) {
       val start = System.nanoTime
-      try op finally record(fn, ((System.nanoTime - start) / 1000).toInt)
+      try op finally record(fn, ((System.nanoTime - start) / 1000).toInt, skip = false)
     }
     else op
   }


### PR DESCRIPTION
Backports #18337 to the LTS branch.

PR submitted by the release tooling.
[skip ci]