### PR TITLE
Backport "Handle macro dependencies through class of `this`" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1067,6 +1067,8 @@ class Inliner(val call: tpd.Tree)(using Context):
         tree match {
           case tree: RefTree if tree.isTerm && level == -1 && tree.symbol.isDefinedInCurrentRun && !tree.symbol.isLocal =>
             foldOver(tree.symbol :: syms, tree)
+          case _: This if level == -1 && tree.symbol.isDefinedInCurrentRun =>
+            tree.symbol :: syms
           case _: TypTree => syms
           case _ => foldOver(syms, tree)
         }

--- a/tests/pos-macros/i18393/Inline_2.scala
+++ b/tests/pos-macros/i18393/Inline_2.scala
@@ -1,0 +1,8 @@
+package user
+
+import defn.Macro
+
+object Inline extends Macro {
+  inline def callMacro(): Int =
+    ${ this.impl() }
+}

--- a/tests/pos-macros/i18393/Macro_1.scala
+++ b/tests/pos-macros/i18393/Macro_1.scala
@@ -1,0 +1,7 @@
+package defn
+
+import scala.quoted.*
+
+abstract class Macro {
+  def impl()(using Quotes): Expr[Int] = '{1}
+}

--- a/tests/pos-macros/i18393/Test_2.scala
+++ b/tests/pos-macros/i18393/Test_2.scala
@@ -1,0 +1,5 @@
+package user
+
+object Test {
+  Inline.callMacro()
+}


### PR DESCRIPTION
Backports #18396 to the LTS branch.

PR submitted by the release tooling.
[skip ci]