### PR TITLE
Make reach refinement shallow

### DIFF
--- a/tests/neg-custom-args/captures/refine-reach-shallow.scala
+++ b/tests/neg-custom-args/captures/refine-reach-shallow.scala
@@ -1,0 +1,18 @@
+import language.experimental.captureChecking
+trait IO
+def test1(): Unit =
+  val f: IO^ => IO^ = x => x
+  val g: IO^ => IO^{f*} = f  // error
+def test2(): Unit =
+  val f: [R] -> (IO^ => R) -> R = ???
+  val g: [R] -> (IO^{f*} => R) -> R = f  // error
+def test3(): Unit =
+  val f: [R] -> (IO^ -> R) -> R = ???
+  val g: [R] -> (IO^{f*} -> R) -> R = f  // error
+def test4(): Unit =
+  val xs: List[IO^] = ???
+  val ys: List[IO^{xs*}] = xs  // ok
+def test5(): Unit =
+  val f: [R] -> (IO^ -> R) -> IO^ = ???
+  val g: [R] -> (IO^ -> R) -> IO^{f*} = f  // ok
+  val h: [R] -> (IO^{f*} -> R) -> IO^ = f  // error

--- a/tests/neg-custom-args/captures/refine-withFile.scala
+++ b/tests/neg-custom-args/captures/refine-withFile.scala
@@ -1,0 +1,8 @@
+import language.experimental.captureChecking
+
+trait File
+val useFile: [R] -> (path: String) -> (op: File^ -> R) -> R = ???
+def main(): Unit =
+  val f: [R] -> (path: String) -> (op: File^ -> R) -> R = useFile
+  val g: [R] -> (path: String) -> (op: File^{f*} -> R) -> R = f  // error
+  val leaked = g[File^{f*}]("test")(f => f)  // boom


### PR DESCRIPTION
This is to address the following soundness issue:

```scala
trait File
val useFile: [R] -> (path: String) -> (op: File^ -> R) -> R = ???
def main(): Unit =
  val f: [R] -> (path: String) -> (op: File^ -> R) -> R = useFile
  val g: [R] -> (path: String) -> (op: File^{f*} -> R) -> R = f  // should be an error
  val leaked = g[File^{f*}]("test")(f => f)  // boom
```