### PR TITLE
Treat new Array(0) as immutable

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -875,7 +875,7 @@ object Objects:
    * @param ctor        The symbol of the target constructor.
    * @param args        The arguments passsed to the constructor.
    */
-  def instantiate(outer: Value, klass: ClassSymbol, ctor: Symbol, args: List[ArgInfo], inKlass: ClassSymbol): Contextual[Value] = log("instantiating " + klass.show + ", outer = " + outer + ", args = " + args.map(_.value.show), printer, (_: Value).show) {
+  def instantiate(outer: Value, klass: ClassSymbol, ctor: Symbol, args: List[ArgInfo]): Contextual[Value] = log("instantiating " + klass.show + ", outer = " + outer + ", args = " + args.map(_.value.show), printer, (_: Value).show) {
     outer match
 
     case _ : Fun | _: OfArray  =>
@@ -914,7 +914,7 @@ object Objects:
         instance
 
     case ValueSet(values) =>
-      values.map(ref => instantiate(ref, klass, ctor, args, inKlass)).join
+      values.map(ref => instantiate(ref, klass, ctor, args)).join
   }
 
   /** Handle local variable definition, `val x = e` or `var x = e`.
@@ -1088,7 +1088,7 @@ object Objects:
         val cls = tref.classSymbol.asClass
         withTrace(trace2) {
           val outer = outerValue(tref, thisV, klass)
-          instantiate(outer, cls, ctor, args, klass)
+          instantiate(outer, cls, ctor, args)
         }
 
       case Apply(ref, arg :: Nil) if ref.symbol == defn.InitRegionMethod =>

--- a/tests/init-global/pos/array-size-zero.scala
+++ b/tests/init-global/pos/array-size-zero.scala
@@ -1,0 +1,10 @@
+object A:
+  val emptyArray = new Array(0)
+
+object B:
+  def build(data: Int*) =
+    if data.size == 0 then A.emptyArray else Array(data)
+
+  val arr = build(5, 6)
+  val first = arr(0)
+


### PR DESCRIPTION
An array of size 0 is immutable, thus we can safely abstract them with the bottom value.

For the rules to be simple and understandable, we usually want to avoid such fine-tuning. However, given that we expect such code patterns to be rare and we want to avoid changes in the standard library, we fine-tune the analysis as a compromise.

Partly fixes #18882. The warnings in compiling `tests/init-global/neg/t9312.scala` goes down to 28 from 87.