### PR TITLE
Normalise mirrorType for mirror Synthesis

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -339,7 +339,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
      *  or a TermRef to a singleton value. These are
      *  the base elements required to generate a mirror.
      */
-    def reduce(mirroredType: Type)(using Context): Either[String, MirrorSource] = mirroredType match
+    def reduce(mirroredType: Type)(using Context): Either[String, MirrorSource] = mirroredType.normalized match
       case tp: TypeRef =>
         val sym = tp.symbol
         if sym.isClass then // direct ref to a class, not an alias

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -339,7 +339,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
      *  or a TermRef to a singleton value. These are
      *  the base elements required to generate a mirror.
      */
-    def reduce(mirroredType: Type)(using Context): Either[String, MirrorSource] = mirroredType.normalized match
+    def reduce(mirroredType: Type)(using Context): Either[String, MirrorSource] = mirroredType match
       case tp: TypeRef =>
         val sym = tp.symbol
         if sym.isClass then // direct ref to a class, not an alias
@@ -379,6 +379,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
                 // avoid type aliases for tuples
                 Right(MirrorSource.GenericTuple(types))
               case _ => reduce(tp.underlying)
+          case tp: MatchType => reduce(tp.normalized)
           case _ => reduce(tp.superType)
       case tp @ AndType(l, r) =>
         for

--- a/tests/pos/i19198.scala
+++ b/tests/pos/i19198.scala
@@ -1,0 +1,13 @@
+import deriving.Mirror
+import compiletime.summonInline
+
+inline def check1[Tps <: NonEmptyTuple]: Unit =
+  summonInline[Mirror.Of[Tuple.Head[Tps]]]
+
+inline def check2[Tps <: NonEmptyTuple]: Unit =
+  type FromType = Tuple.Head[Tps]
+  summonInline[Mirror.Of[FromType]]
+
+@main def Test: Unit =
+  check1[Option[Int] *: EmptyTuple] // Ok
+  check2[Option[Int] *: EmptyTuple] // Error: FromType is widened to Any in Syntheziser


### PR DESCRIPTION
If `MirrorSource.reduce` is given a proxy to an unreduced match type, it will simply get its supertype `Any`. We need to normalise the `mirroredType` before attempting to reduce it to a kind of mirror source. 

Fix #19198 