### PR TITLE
Get generic signature of fields entered after erasure from their accessor 

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -397,6 +397,9 @@ trait BCodeHelpers extends BCodeIdiomatic {
       atPhase(erasurePhase) {
         val memberTpe =
           if (sym.is(Method)) sym.denot.info
+          else if sym.denot.validFor.phaseId > erasurePhase.id && sym.isField && sym.getter.exists then
+            // Memoization field of getter entered after erasure, see run/i17069 for an example
+            sym.getter.denot.info.resultType
           else owner.denot.thisType.memberInfo(sym)
         getGenericSignatureHelper(sym, owner, memberTpe).orNull
       }

--- a/tests/generic-java-signatures/17069.scala
+++ b/tests/generic-java-signatures/17069.scala
@@ -1,0 +1,10 @@
+
+class Foo:
+  val generic: List[String] = ???
+
+@main def Test =
+  val tpe = classOf[Foo].getDeclaredField("generic").getGenericType()
+  assert(tpe.getTypeName == "scala.collection.immutable.List<java.lang.String>")
+
+  val tpe2 = classOf[Foo].getDeclaredMethod("generic").getGenericReturnType()
+  assert(tpe2.getTypeName == "scala.collection.immutable.List<java.lang.String>")


### PR DESCRIPTION
Fix #17069 

@mbovel 