### PR TITLE
Handle TupleXXL in match analysis

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -836,6 +836,7 @@ object SpaceEngine {
       val tpw = tp.widen.dealias
       val classSym = tpw.classSymbol
       classSym.is(Sealed) && !tpw.isLargeGenericTuple || // exclude large generic tuples from exhaustivity
+                                                         // requires an unknown number of changes to make work
       tpw.isInstanceOf[OrType] ||
       (tpw.isInstanceOf[AndType] && {
         val and = tpw.asInstanceOf[AndType]

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -287,11 +287,9 @@ object SpaceEngine {
     || (unapp.symbol.is(Synthetic) && unapp.symbol.owner.linkedClass.is(Case))  // scala2 compatibility
     || unapplySeqTypeElemTp(unappResult).exists // only for unapplySeq
     || isProductMatch(unappResult, argLen)
-    || {
-      val isEmptyTp = extractorMemberType(unappResult, nme.isEmpty, NoSourcePosition)
-      isEmptyTp <:< ConstantType(Constant(false))
-    }
+    || extractorMemberType(unappResult, nme.isEmpty, NoSourcePosition) <:< ConstantType(Constant(false))
     || unappResult.derivesFrom(defn.NonEmptyTupleClass)
+    || unapp.symbol == defn.TupleXXL_unapplySeq // Fixes TupleXXL.unapplySeq which returns Some but declares Option
   }
 
   /** Is the unapply or unapplySeq irrefutable?
@@ -505,6 +503,7 @@ object SpaceEngine {
   def isSubType(tp1: Type, tp2: Type)(using Context): Boolean = trace(i"$tp1 <:< $tp2", debug, show = true) {
     if tp1 == ConstantType(Constant(null)) && !ctx.mode.is(Mode.SafeNulls)
     then tp2 == ConstantType(Constant(null))
+    else if tp1.isTupleXXLExtract(tp2) then true // See isTupleXXLExtract, fixes TupleXXL parameter type
     else tp1 <:< tp2
   }
 
@@ -836,7 +835,7 @@ object SpaceEngine {
     def isCheckable(tp: Type): Boolean =
       val tpw = tp.widen.dealias
       val classSym = tpw.classSymbol
-      classSym.is(Sealed) ||
+      classSym.is(Sealed) && !tpw.isLargeGenericTuple || // exclude large generic tuples from exhaustivity
       tpw.isInstanceOf[OrType] ||
       (tpw.isInstanceOf[AndType] && {
         val and = tpw.asInstanceOf[AndType]

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -936,7 +936,10 @@ trait Checking {
       false
     }
 
-    def check(pat: Tree, pt: Type): Boolean = (pt <:< pat.tpe) || fail(pat, pt, Reason.NonConforming)
+    def check(pat: Tree, pt: Type): Boolean =
+      pt.isTupleXXLExtract(pat.tpe) // See isTupleXXLExtract, fixes TupleXXL parameter type
+      || pt <:< pat.tpe
+      || fail(pat, pt, Reason.NonConforming)
 
     def recur(pat: Tree, pt: Type): Boolean =
       !sourceVersion.isAtLeast(`3.2`)

--- a/tests/pos/i14588.scala
+++ b/tests/pos/i14588.scala
@@ -1,0 +1,20 @@
+//> using options -Werror
+
+class Test:
+  def t1: Unit =
+    (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23) match
+      case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23) =>
+  def t2: Unit =
+    (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23) match
+      case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23, x24) =>
+  def t3: Unit =
+    (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24) match
+      case (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23) =>
+
+object Main:
+  def main(args: Array[String]): Unit = {
+    val t = new Test
+    t.t1
+    try { t.t2; ??? } catch case _: MatchError => ()
+    try { t.t3; ??? } catch case _: MatchError => ()
+  }

--- a/tests/pos/i16186.scala
+++ b/tests/pos/i16186.scala
@@ -1,0 +1,9 @@
+//> using options -Werror
+
+class Test:
+  val x = 42
+  val tup23 = (x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+
+  tup23 match {
+    case (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => "Tuple Pattern"
+  }

--- a/tests/pos/i16657.scala
+++ b/tests/pos/i16657.scala
@@ -1,0 +1,13 @@
+//> using options -Werror
+
+class Test:
+  val (_, (
+    _, _, _, _, _, _, _, _, _, _, // 10
+    _, _, _, _, _, _, _, _, _, _, // 20
+    _, c22, _                     // 23
+  )) = // nested pattern has 23 elems
+    (0, (
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 20,
+      1, 2, 3
+    )) // ok, exhaustive, reachable, conforming and irrefutable

--- a/tests/pos/i19084.scala
+++ b/tests/pos/i19084.scala
@@ -1,0 +1,14 @@
+//> using options -Werror
+
+class Test:
+  def t1(y: (
+    Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+    "Bob", Int, 33, Int,
+    Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)
+        ): Unit = y match
+    case b @ (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9,
+          "Bob", y1, 33, y2,
+          z0, z1, z2, z3, z4, z5, z6, z7, z8, z9)
+     => // was: !!! spurious unreachable case warning
+      ()
+    case _ => ()

--- a/tests/warn/i19084.scala
+++ b/tests/warn/i19084.scala
@@ -1,0 +1,17 @@
+
+
+class Test:
+  def t1(y: (
+    Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+    "Bob", Int, 33, Int,
+    Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)
+        ): Unit = y match
+    case b @ (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9,
+          "Bob", y1, 33, y2,
+          z0, z1, z2, z3, z4, z5, z6, z7, z8, z9)
+     => ()
+    case b @ (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, // warn: unreachable
+          "Bob", y1, 33, y2,
+          z0, z1, z2, z3, z4, z5, z6, z7, z8, z9)
+     => ()
+    case _ => ()


### PR DESCRIPTION
There's a number of problems with the match analysis of TupleXXL.
Of course, they manifest as (in)exhaustivity and (un)reachability
warnings.

Reachability suffered by the problem that a large generic tuple
scrutinee type wasn't considered extractable by the TupleXXL extractor
that Typer associates the extractor pattern with.  That was solved by
special handling in SpaceEngine's isSubType.

Exhaustivity suffered by a variety of problems, again stemming from the
disconnect between the TupleXXL pattern type and the large generic tuple
scrutinee (or component) type.  That was solved by special handling in
exhaustivityCheckable to ignore large generic tuple scrutinees.

That then highlighted an irrefutable failure (checkIrrefutable), which
also needed to be taught that extra large generic tuples do conform to
TupleXXL extractors type, after which SpaceEngine isIrrefutable needed
special handling to consider TupleXXL irrefutable.
