### PR TITLE
Update docs: package objects are not deprecated yet.

### DIFF
--- a/docs/_docs/reference/dropped-features/package-objects.md
+++ b/docs/_docs/reference/dropped-features/package-objects.md
@@ -11,7 +11,7 @@ package object p {
   def b = ...
 }
 ```
-will be dropped. They are still available in Scala 3.0 and 3.1, but will be deprecated and removed afterwards.
+will be dropped. They are still available, but will be deprecated and removed at some point in the future.
 
 Package objects are no longer needed since all kinds of definitions can now be written at the top-level. Example:
 ```scala


### PR DESCRIPTION
Package objects are not deprecated in Scala 3.3.1 yet.