### PR TITLE
Update `.gitignore` paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,8 @@ testlogs/
 local/
 compiler/test/debug/Gen.jar
 
-compiler/before-pickling.txt
-compiler/after-pickling.txt
+before-pickling.txt
+after-pickling.txt
 bench/compile.txt
 
 community-build/scala3-bootstrapped.version


### PR DESCRIPTION
These files are generated in the project root when we use `testCompilation` and have a pickling failure.

[skip ci]