### PR TITLE
Add default output directory scalac in dotty project

### DIFF
--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -25,7 +25,7 @@ grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
 echo "testing sbt scalac -print-tasty"
 clear_out "$OUT"
-"$SBT" ";scalac $SOURCE -d $OUT ;scalac -print-tasty -color:never $TASTY" > "$tmp"
+"$SBT" ";scalac $SOURCE -d $OUT ;scalac -print-tasty -color:never $OUT/$TASTY" > "$tmp"
 grep -qe "0: ASTs" "$tmp"
 grep -qe "0: 41 \[tests/pos/HelloWorld.scala\]" "$tmp"
 


### PR DESCRIPTION
The previous default output directory when executing `scalac`, `run`, `scala3-bootstrapped/scalac` and `scala3-bootstrapped/run` was the root directory of the project. This could easily pollute the project with `.class`/`.tasty` files. In some situations, these could be mistakenly loaded by some of the projects or scripts.

Now when we execute `scalac` with no `-d` option set, we output  `./out/default-last-scalac-out.jar`. We also make `scala` and `run` use that JAR by default in the classpath if no `-classpath` option is set.