### PR TITLE
Backport "Coverage: Do not lift applications of context functions" to LTS

### DIFF
--- a/tests/coverage/pos/i16502.scala
+++ b/tests/coverage/pos/i16502.scala
@@ -1,0 +1,8 @@
+import scala.concurrent.*
+
+def asyncSum: ExecutionContext ?=> Future[Int] = Future(1)
+
+@main
+def Test(): Unit =
+  import scala.concurrent.ExecutionContext.Implicits.global
+  asyncSum

--- a/tests/coverage/pos/i16502.scoverage.check
+++ b/tests/coverage/pos/i16502.scoverage.check
@@ -1,0 +1,88 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+i16502.scala
+<empty>
+i16502$package$
+Object
+<empty>.i16502$package$
+$anonfun
+76
+85
+2
+apply
+Apply
+false
+0
+false
+Future(1)
+
+1
+i16502.scala
+<empty>
+i16502$package$
+Object
+<empty>.i16502$package$
+asyncSum
+27
+39
+2
+asyncSum
+DefDef
+false
+0
+false
+def asyncSum
+
+2
+i16502.scala
+<empty>
+i16502$package$
+Object
+<empty>.i16502$package$
+Test
+174
+182
+7
+apply
+Apply
+false
+0
+false
+asyncSum
+
+3
+i16502.scala
+<empty>
+i16502$package$
+Object
+<empty>.i16502$package$
+Test
+87
+101
+5
+Test
+DefDef
+false
+0
+false
+@main\ndef Test
+


### PR DESCRIPTION
Backports #18498 to the LTS branch.

PR submitted by the release tooling.
[skip ci]