### PR TITLE
Do not add inlineable passing accessor on packages

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
@@ -140,7 +140,7 @@ object PrepareInlineable {
 
       def preTransform(tree: Tree)(using Context): Tree = tree match {
         case _: Apply | _: TypeApply | _: RefTree
-        if needsAccessor(tree.symbol) && tree.isTerm && !tree.symbol.isConstructor =>
+        if needsAccessor(tree.symbol) && tree.isTerm && !tree.symbol.isConstructor && !tree.symbol.owner.is(Package) =>
           val refPart = funPart(tree)
           val argss = allArgss(tree)
           val qual = qualifier(refPart)

--- a/tests/run/i19237.check
+++ b/tests/run/i19237.check
@@ -1,0 +1,9 @@
+public boolean java.lang.Object.equals(java.lang.Object)
+public final native java.lang.Class java.lang.Object.getClass()
+public native int java.lang.Object.hashCode()
+public final native void java.lang.Object.notify()
+public final native void java.lang.Object.notifyAll()
+public java.lang.String java.lang.Object.toString()
+public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException
+public final void java.lang.Object.wait() throws java.lang.InterruptedException
+public final native void java.lang.Object.wait(long) throws java.lang.InterruptedException

--- a/tests/run/i19237.scala
+++ b/tests/run/i19237.scala
@@ -1,0 +1,21 @@
+package mono {
+  trait C
+  object Focus:
+    import internals.FocusImpl
+    class MkFocus[From]: // This class only has methods of object at runtime
+      transparent inline def apply[To](inline f: C ?=> From => To): Any =
+        ${ FocusImpl('f) } // no accessor should be generated
+
+  package internals {
+    import scala.quoted.*
+
+    private[mono] object FocusImpl:
+      def apply[From: Type, To: Type](f: Expr[C ?=> From => To])(using Quotes): Expr[Any] =
+        ???
+  }
+}
+
+@main def Test =
+  new mono.Focus.MkFocus[Any].getClass().getMethods().toList
+    .sortBy(_.getName)
+    .foreach(println)


### PR DESCRIPTION
Fix #19237


This is a binary-breaking change. We need #18402 to be able to warn about this change using `-WunstableInlineAccessors`.
