### PR TITLE
Fix assert stack trace

### DIFF
--- a/library/src/scala/runtime/Scala3RunTime.scala
+++ b/library/src/scala/runtime/Scala3RunTime.scala
@@ -5,10 +5,14 @@ object Scala3RunTime:
   // Called by inline def assert's. Extracted to minimize the bytecode size at call site.
 
   def assertFailed(message: Any): Nothing =
-    throw new java.lang.AssertionError("assertion failed: " + message)
+    val assertionError = new java.lang.AssertionError("assertion failed: " + message)
+    assertionError.setStackTrace(assertionError.getStackTrace().nn.tail)
+    throw assertionError
 
   def assertFailed(): Nothing =
-    throw new java.lang.AssertionError("assertion failed")
+    val assertionError = new java.lang.AssertionError("assertion failed")
+    assertionError.setStackTrace(assertionError.getStackTrace().nn.tail)
+    throw assertionError
 
   /** Called by the inline extension def `nn`.
    *

--- a/tests/run/assert-stack.check
+++ b/tests/run/assert-stack.check
@@ -1,6 +1,10 @@
-scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
 Test$.main(assert-stack.scala:7)
 
-scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:11)
 Test$.main(assert-stack.scala:12)
+
+Test$.foo(assert-stack.scala:21)
+Test$.main(assert-stack.scala:16)
+
+Test$.foo(assert-stack.scala:26)
+Test$.main(assert-stack.scala:16)
 

--- a/tests/run/assert-stack.scala
+++ b/tests/run/assert-stack.scala
@@ -12,7 +12,20 @@ object Test {
       assert(false)
     catch
       case ae: AssertionError => printStack(ae)
+
+    foo()
   }
+
+  def foo() =
+    try
+      assert(false, "my message")
+    catch
+      case ae: AssertionError => printStack(ae)
+
+    try
+      assert(false)
+    catch
+      case ae: AssertionError => printStack(ae)
 
   def printStack(ae: AssertionError): Unit =
     for elem <- ae.getStackTrace().iterator.takeWhile(x => !(x.getMethodName == "main" && x.getLineNumber == -1)) do


### PR DESCRIPTION
We added the `Scala3RunTime.assertFailed` as an optimization to reduce the size of the bytecode at the assertion site. However, this adds an extra stack frame to the stack trace, which is not desirable. To fix it we drop that frame from the stack trace.