### PR TITLE
Add regression test for #17429

### DIFF
--- a/tests/warn/i17429.check
+++ b/tests/warn/i17429.check
@@ -1,0 +1,6 @@
+-- Warning: tests/warn/i17429.scala:3:17 -------------------------------------------------------------------------------
+3 |    println(A(1) plus A(2)) // warn
+  |                 ^^^^
+  |                 Alphanumeric method plus is not declared infix; it should not be used as infix operator.
+  |                 Instead, use method syntax .plus(...) or backticked identifier `plus`.
+  |                 The latter can be rewritten automatically under -rewrite -source 3.4-migration.

--- a/tests/warn/i17429.scala
+++ b/tests/warn/i17429.scala
@@ -1,0 +1,3 @@
+case class A(a:Int):
+  def plus(a:A) = A(this.a+a.a)
+    println(A(1) plus A(2)) // warn


### PR DESCRIPTION
Alphanumeric infix operator syntax will warn from `3.4`.

Fixes #17429