### PR TITLE
Update experimental comments on Tuple reverse

### DIFF
--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -92,10 +92,10 @@ val experimentalDefinitionInLibrary = Set(
   "scala.quoted.Quotes.reflectModule.TermParamClauseMethods.hasErasedArgs",
 
   // New feature: reverse method on Tuple
-  "scala.Tuple.reverse", // can be stabilized in 3.4
-  "scala.Tuple$.Reverse", // can be stabilized in 3.4
-  "scala.Tuple$.ReverseOnto", // can be stabilized in 3.4
-  "scala.runtime.Tuples$.reverse", // can be stabilized in 3.4
+  "scala.Tuple.reverse", // can be stabilized in 3.5
+  "scala.Tuple$.Reverse", // can be stabilized in 3.5
+  "scala.Tuple$.ReverseOnto", // can be stabilized in 3.5
+  "scala.runtime.Tuples$.reverse", // can be stabilized in 3.5
 )
 
 


### PR DESCRIPTION
These definition was updated in #19183. This does not leave much time to test before the release of 3.4. As a precaution we must delay it to 3.5.