### PR TITLE
Drop some unnecessary given wrappers around extension methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Comments.scala
+++ b/compiler/src/dotty/tools/dotc/core/Comments.scala
@@ -17,8 +17,7 @@ object Comments {
   val ContextDoc: Key[ContextDocstrings] = new Key[ContextDocstrings]
 
   /** Decorator for getting docbase out of context */
-  given CommentsContext: AnyRef with
-    extension (c: Context) def docCtx: Option[ContextDocstrings] = c.property(ContextDoc)
+  extension (c: Context) def docCtx: Option[ContextDocstrings] = c.property(ContextDoc)
 
   /** Context for Docstrings, contains basic functionality for getting
     * docstrings via `Symbol` and expanding templates

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -752,20 +752,18 @@ object Contexts {
       c
   end FreshContext
 
-  given ops: AnyRef with
-    extension (c: Context)
-      def addNotNullInfo(info: NotNullInfo) =
-        c.withNotNullInfos(c.notNullInfos.extendWith(info))
+  extension (c: Context)
+    def addNotNullInfo(info: NotNullInfo) =
+      c.withNotNullInfos(c.notNullInfos.extendWith(info))
 
-      def addNotNullRefs(refs: Set[TermRef]) =
-        c.addNotNullInfo(NotNullInfo(refs, Set()))
+    def addNotNullRefs(refs: Set[TermRef]) =
+      c.addNotNullInfo(NotNullInfo(refs, Set()))
 
-      def withNotNullInfos(infos: List[NotNullInfo]): Context =
-        if c.notNullInfos eq infos then c else c.fresh.setNotNullInfos(infos)
+    def withNotNullInfos(infos: List[NotNullInfo]): Context =
+      if c.notNullInfos eq infos then c else c.fresh.setNotNullInfos(infos)
 
-      def relaxedOverrideContext: Context =
-        c.withModeBits(c.mode &~ Mode.SafeNulls | Mode.RelaxedOverriding)
-  end ops
+    def relaxedOverrideContext: Context =
+      c.withModeBits(c.mode &~ Mode.SafeNulls | Mode.RelaxedOverriding)
 
   // TODO: Fix issue when converting ModeChanges and FreshModeChanges to extension givens
   extension (c: Context) {

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -11,8 +11,7 @@ import collection.mutable
 import Denotations.{SingleDenotation, staticRef}
 import util.{SimpleIdentityMap, SourceFile, NoSource}
 import typer.ImportInfo.RootRef
-import Comments.CommentsContext
-import Comments.Comment
+import Comments.{Comment, docCtx}
 import util.Spans.NoSpan
 import config.Feature
 import Symbols.requiredModuleRef

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -11,7 +11,7 @@ import dotty.tools.tasty.TastyBuffer.*
 import ast.Trees.*
 import ast.{untpd, tpd}
 import Contexts.*, Symbols.*, Types.*, Names.*, Constants.*, Decorators.*, Annotations.*, Flags.*
-import Comments.{Comment, CommentsContext}
+import Comments.{Comment, docCtx}
 import NameKinds.*
 import StdNames.nme
 import config.Config

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -5,7 +5,7 @@ package tasty
 
 import scala.language.unsafeNulls
 
-import Comments.CommentsContext
+import Comments.docCtx
 import Contexts.*
 import Symbols.*
 import Types.*

--- a/compiler/src/dotty/tools/dotc/util/ParsedComment.scala
+++ b/compiler/src/dotty/tools/dotc/util/ParsedComment.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc.util
 
 import scala.language.unsafeNulls
 
-import dotty.tools.dotc.core.Comments.{Comment, CommentsContext}
+import dotty.tools.dotc.core.Comments.{Comment, docCtx}
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Names.TermName
 import dotty.tools.dotc.core.Symbols.*

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2628,7 +2628,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           if self.exists then Some(self.sourcePos) else None
 
         def docstring: Option[String] =
-          import dotc.core.Comments.CommentsContext
+          import dotc.core.Comments.docCtx
           val docCtx = ctx.docCtx.getOrElse {
             throw new RuntimeException(
               "DocCtx could not be found and documentations are unavailable. This is a compiler-internal error."

--- a/compiler/test/dotty/tools/dotc/core/tasty/CommentPicklingTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/CommentPicklingTest.scala
@@ -5,7 +5,7 @@ import scala.language.unsafeNulls
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.tpd.TreeOps
 import dotty.tools.dotc.{Driver, Main}
-import dotty.tools.dotc.core.Comments.CommentsContext
+import dotty.tools.dotc.core.Comments.docCtx
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Decorators.{toTermName, toTypeName}
 import dotty.tools.dotc.core.Mode

--- a/compiler/test/dotty/tools/dotc/core/tasty/PathPicklingTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/PathPicklingTest.scala
@@ -14,7 +14,6 @@ import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.tpd.TreeOps
 import dotty.tools.dotc.{Driver, Main}
 import dotty.tools.dotc.decompiler
-import dotty.tools.dotc.core.Comments.CommentsContext
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Decorators.{toTermName, toTypeName}
 import dotty.tools.dotc.core.Mode

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilerDataCollector.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilerDataCollector.scala
@@ -26,7 +26,7 @@ class SnippetCompilerDataCollector[Q <: Quotes](val qctx: Q):
     p.fold(SnippetCompilerData.Position(0, 0))(p => SnippetCompilerData.Position(p.startLine - 1, p.startColumn))
 
   private def hackGetPositionOfDocstring(using Quotes)(s: qctx.reflect.Symbol): Option[qctx.reflect.Position] =
-    import dotty.tools.dotc.core.Comments.CommentsContext
+    import dotty.tools.dotc.core.Comments.docCtx
     import dotty.tools.dotc
     given ctx: Contexts.Context = qctx.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
     val docCtx = ctx.docCtx.getOrElse {

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ScalaDocSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ScalaDocSupport.scala
@@ -45,7 +45,7 @@ object ScaladocSupport:
     val commentString: String =
       if tree.symbol.isClassDef || tree.symbol.owner.isClassDef then
         import dotty.tools.dotc
-        import dotty.tools.dotc.core.Comments.CommentsContext
+        import dotty.tools.dotc.core.Comments.docCtx
         given ctx: dotc.core.Contexts.Context = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
 
         val docCtx = ctx.docCtx.get


### PR DESCRIPTION
The compiler codebase contains several extension methods in 
```scala
given AnyRef with
```
where this is not really necessary. We can just import the extension methods directly, in particular if there is only one extension method after `with`. That makes it clearer.

It's good to eliminate these things aggressively, since otherwise newcomers will tend to imitate the idiom without understanding what it serves for. 