### PR TITLE
Revert "Fix callTrace if inlined methods"

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -661,8 +661,7 @@ object Trees {
    *
    *  @param  call      Info about the original call that was inlined
    *                    Until PostTyper, this is the full call, afterwards only
-   *                    a reference to the method or the top-level class from
-   *                    which the call was inlined.
+   *                    a reference to the toplevel class from which the call was inlined.
    *  @param  bindings  Bindings for proxies to be used in the inlined code
    *  @param  expansion The inlined tree, minus bindings.
    *

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -299,6 +299,20 @@ object Inlines:
     (new Reposition).transform(tree)
   end reposition
 
+  /** Leave only a call trace consisting of
+   *  - a reference to the top-level class from which the call was inlined,
+   *  - the call's position
+   *  in the call field of an Inlined node.
+   *  The trace has enough info to completely reconstruct positions.
+   *  Note: For macros it returns a Select and for other inline methods it returns an Ident (this distinction is only temporary to be able to run YCheckPositions)
+   */
+  def inlineCallTrace(callSym: Symbol, pos: SourcePosition)(using Context): Tree = {
+    assert(ctx.source == pos.source)
+    val topLevelCls = callSym.topLevelClass
+    if (callSym.is(Macro)) ref(topLevelCls.owner).select(topLevelCls.name)(using ctx.withOwner(topLevelCls.owner)).withSpan(pos.span)
+    else Ident(topLevelCls.typeRef).withSpan(pos.span)
+  }
+
   private object Intrinsics:
     import dotty.tools.dotc.reporting.Diagnostic.Error
     private enum ErrorKind:

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -304,7 +304,7 @@ object PickleQuotes {
     def pickleAsTasty() = {
       val body1 =
         if body.isType then body
-        else Inlined(ref(ctx.owner.topLevelClass.typeRef).withSpan(quote.span), Nil, body)
+        else Inlined(Inlines.inlineCallTrace(ctx.owner, quote.sourcePos), Nil, body)
       val pickleQuote = PickledQuotes.pickleQuote(body1)
       val pickledQuoteStrings = pickleQuote match
         case x :: Nil => Literal(Constant(x))

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -367,7 +367,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           val pos = call.sourcePos
           CrossVersionChecks.checkExperimentalRef(call.symbol, pos)
           withMode(Mode.NoInline)(transform(call))
-          val callTrace = ref(call.symbol)(using ctx.withSource(pos.source)).withSpan(pos.span)
+          val callTrace = Inlines.inlineCallTrace(call.symbol, pos)(using ctx.withSource(pos.source))
           cpy.Inlined(tree)(callTrace, transformSub(bindings), transform(expansion)(using inlineContext(tree)))
         case templ: Template =>
           Checking.checkPolyFunctionExtension(templ)


### PR DESCRIPTION
This reverts commit ec75826f6ff78d0a04d3f93e6ca92bad9308f75d.

The previous encoding of INLINE nodes in TASTy assumed that the callTrace was a type. We cannot make it a term, or we would not be able to unpickle this tree properly. We need another solution to be able to pickle this correctly. For now we revert the change to avoid generating invalid TASTy.