### PR TITLE
Upgrade ruby version in spec.yml

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -26,10 +26,11 @@ jobs:
       # Keep in sync with ./docs/_spec/Dockerfile
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
       - name: Install required gems
         run: |
-          gem update --system
+          gem update --system 3.2.3
+          gem install rexml
           gem install sass-embedded -v 1.58.0
           gem install bundler:1.17.2 jekyll
           bundle install


### PR DESCRIPTION
[skip ci]


Solves
```
Run gem update --system
ERROR:  Error installing rubygems-update:
	There are no versions of rubygems-update (= 3.5.1) compatible with your Ruby & RubyGems
	rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
Updating rubygems-update
```