### PR TITLE
Fix #19286: Freeze rubygems-update at < 3.5.0.

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -29,7 +29,8 @@ jobs:
           ruby-version: '2.7'
       - name: Install required gems
         run: |
-          gem update --system
+          gem install "rubygems-update:<3.5" --no-document
+          update_rubygems
           gem install sass-embedded -v 1.58.0
           gem install bundler:1.17.2 jekyll
           bundle install


### PR DESCRIPTION
[skip ci]

v3.5.0 dropped support for Ruby 2.7.