### PR TITLE
Temporarily disable parallel backend tests due to frequent timeouts

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -4,7 +4,7 @@ package dotc
 
 import scala.language.unsafeNulls
 
-import org.junit.{ Test, BeforeClass, AfterClass }
+import org.junit.{ Test, BeforeClass, AfterClass, Ignore }
 import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.experimental.categories.Category
@@ -250,6 +250,7 @@ class CompilationTests {
   }
 
   // parallel backend tests
+  @Ignore("Temporarily disabled due to frequent timeouts")
   @Test def parallelBackend: Unit = {
     given TestGroup = TestGroup("parallelBackend")
     val parallelism = Runtime.getRuntime().availableProcessors().min(16)


### PR DESCRIPTION
Compilation tests run with `-Ybackend-parallelism:N` flag seem to be stuck when compiling probably due to deadlock or infinite loop. See
https://github.com/lampepfl/dotty/actions/runs/7243042276/job/19729290631#step:9:2254 which failed to compile `tests/pos/reference/auto-param-tupling.scala`

To be restored when underlying issue would be fixed