### PR TITLE
`@publicInBinary` override spec change

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1033,10 +1033,7 @@ object SymDenotations {
 
     /** Is this a member that will become public in the generated binary */
     def hasPublicInBinary(using Context): Boolean =
-      isTerm && (
-        hasAnnotation(defn.PublicInBinaryAnnot) ||
-        allOverriddenSymbols.exists(sym => sym.hasAnnotation(defn.PublicInBinaryAnnot))
-      )
+      isTerm && hasAnnotation(defn.PublicInBinaryAnnot)
 
     /** ()T and => T types should be treated as equivalent for this symbol.
      *  Note: For the moment, we treat Scala-2 compiled symbols as loose matching,

--- a/library/src/scala/annotation/publicInBinary.scala
+++ b/library/src/scala/annotation/publicInBinary.scala
@@ -1,6 +1,6 @@
 package scala.annotation
 
-/** A binary API is a definition that is annotated with `@publicInBinary` or overrides a definition annotated with `@publicInBinary`.
+/** A binary API is a definition that is annotated with `@publicInBinary`.
  *  This annotation can be placed on `def`, `val`, `lazy val`, `var`, class constructors, `object`, and `given` definitions.
  *  A binary API will be publicly available in the bytecode. Tools like TASTy MiMa will take this into account to check
  *  compatibility.

--- a/tests/neg/publicInBinaryOverride.check
+++ b/tests/neg/publicInBinaryOverride.check
@@ -1,0 +1,5 @@
+-- [E164] Declaration Error: tests/neg/publicInBinaryOverride.scala:8:15 -----------------------------------------------
+8 |  override def f(): Unit = () // error
+  |               ^
+  |               error overriding method f in class A of type (): Unit;
+  |                 method f of type (): Unit also needs to be declared with @publicInBinary

--- a/tests/neg/publicInBinaryOverride.scala
+++ b/tests/neg/publicInBinaryOverride.scala
@@ -1,0 +1,9 @@
+import scala.annotation.publicInBinary
+
+class A:
+  @publicInBinary def f(): Unit = ()
+  @publicInBinary def g(): Unit = ()
+
+class B extends A:
+  override def f(): Unit = () // error
+  @publicInBinary override def g(): Unit = ()

--- a/tests/run/publicInBinary/Lib_1.scala
+++ b/tests/run/publicInBinary/Lib_1.scala
@@ -21,14 +21,15 @@ class Foo(@publicInBinary private[Foo] val paramVal: Int, @publicInBinary privat
     paramVal + paramVar + protectedVal + packagePrivateVal + protectedVar + packagePrivateVar
 
 class Bar() extends Foo(3, 3):
+  @publicInBinary
   override protected val protectedVal: Int = 2
-
+  @publicInBinary
   override private[foo] val packagePrivateVal: Int = 2
 
   inline def bar: Int = protectedVal + packagePrivateVal
 
 class Baz() extends Foo(4, 4):
-  @publicInBinary // TODO warn? Not needed because Foo.protectedVal is already @publicInBinary
+  @publicInBinary
   override protected val protectedVal: Int = 2
 
   @publicInBinary


### PR DESCRIPTION
Followup of #18402 (see https://github.com/lampepfl/dotty/pull/18402#discussion_r1424551306).

This was split from the main PR due to the blocker described in https://github.com/lampepfl/dotty/pull/18402#issuecomment-1859838924. During the Dotty meeting, we decided to merge #18402 without the second commit ([Require @publicInBinary on overrides](https://github.com/lampepfl/dotty/commit/34f3dee06e5150471a645f2b17ddce4db4ed779f)). If we manage to fix this issue before 3.4.0-RC1 we will include it there, otherwise it will be part of 3.4.0-RC2.