### PR TITLE
Fix deadlock in lazy intialization of CoreBTypes

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -4,7 +4,7 @@ package dotc
 
 import scala.language.unsafeNulls
 
-import org.junit.{ Test, BeforeClass, AfterClass, Ignore }
+import org.junit.{ Test, BeforeClass, AfterClass }
 import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.experimental.categories.Category
@@ -250,7 +250,6 @@ class CompilationTests {
   }
 
   // parallel backend tests
-  @Ignore("Temporarily disabled due to frequent timeouts")
   @Test def parallelBackend: Unit = {
     given TestGroup = TestGroup("parallelBackend")
     val parallelism = Runtime.getRuntime().availableProcessors().min(16)


### PR DESCRIPTION
Fixes #19293 caused by double synchronisation of lazy val initialisation. When `PostProcessor` thread tried to access `CoreBTypesFromSymbols.jliLambdaMetaFactoryAltMetafactoryHandle` in `BackendUtils.collectSerializableLambdas` it could have one the data race for initialisation of lazy val with the main GenBCode thread, but it could have failed the synchronisation race with `frontendSynch` leading to deadlock. 
To fix this issue we use `@threadUnsafe lazy val` so the synchronisation is only based on the `frontendSynch` lock.  

Usage of `@threadUnsafe lazy val`s makes semantics of `CoreBTypes` initialisation more aligned with Scala 2 backend (threadUnsafe lazy vals is almost identical with  Scala2 lazy val)

Alternative solution to this issue is to create a PostProcessor/BackendUtils local `jliLambdaMetaFactoryAltMetafactoryHandle` instance using mangled Strings with descriptor which would not use any `Symbol`s or `Context`, but it seems be more error-prone in the long term maintenance.