### PR TITLE
Show `git diff` command on checkfile failure

### DIFF
--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -12,10 +12,13 @@ import java.nio.charset.StandardCharsets
 
 
 object FileDiff {
+  def diffCommand(expectFile: String, actualFile: String): String =
+    s"git diff --no-index -- $expectFile $actualFile"
+
   def diffMessage(expectFile: String, actualFile: String): String =
       s"""Test output dumped in: $actualFile
-          |  See diff of the checkfile (`brew install icdiff` for colored diff)
-          |    > diff $expectFile $actualFile
+          |  See diff of the checkfile (`--color=always` for colored diff)
+          |    > ${FileDiff.diffCommand(expectFile, actualFile)}
           |  Replace checkfile with current output
           |    > mv $actualFile $expectFile
       """.stripMargin


### PR DESCRIPTION
This diff is more familiar and consistent across systems. We can assume that all developers of Dotty have git installed.

When a checkfile fails we now show
```diff
Test output dumped in: tests/run/xyz.check.out
- See diff of the checkfile (`brew install icdiff` for colored diff)
-   > diff tests/run/xyz.check tests/run/xyz.check.out
+ See diff of the checkfile (`--color=always` for colored diff)
+   > git diff --no-index -- tests/run/xyz.check tests/run/xyz.check.out
  Replace checkfile with current output
    > mv tests/run/xyz.check.out tests/run/xyz.check
```