### PR TITLE
Properly identify empty bounds in error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -147,7 +147,7 @@ object Message:
       }
 
       def addendum(cat: String, info: Type): String = info match {
-        case bounds @ TypeBounds(lo, hi) if bounds ne TypeBounds.empty =>
+        case bounds @ TypeBounds(lo, hi) if !(bounds =:= TypeBounds.empty) =>
           if (lo eq hi) i" which is an alias of $lo"
           else i" with $cat ${boundsStr(bounds)}"
         case _ =>

--- a/tests/neg/i13780-1.check
+++ b/tests/neg/i13780-1.check
@@ -5,7 +5,7 @@
    |                      Required: h
    |
    |                      where:    VS is a type in method foo with bounds <: Tuple
-   |                                h  is a type in method foo with bounds 
+   |                                h  is a type in method foo
    |                                t  is a type in method foo with bounds <: Tuple
    |
    |


### PR DESCRIPTION
This caused a trailing space which can easily misbehave in checkfiles.