### PR TITLE
improvement: Support completions for implicit classes

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/CompilerSearchVisitor.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/CompilerSearchVisitor.scala
@@ -9,6 +9,7 @@ import scala.meta.pc.*
 import scala.util.control.NonFatal
 
 import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.Symbols.*
 
@@ -19,8 +20,14 @@ class CompilerSearchVisitor(
 
   val logger: Logger = Logger.getLogger(classOf[CompilerSearchVisitor].getName().nn).nn
 
+  private def isAccessibleImplicitClass(sym: Symbol) =
+    val owner = sym.maybeOwner
+    owner != NoSymbol && owner.isClass &&
+    owner.is(Flags.Implicit) &&
+    owner.isStatic && owner.isPublic
+
   private def isAccessible(sym: Symbol): Boolean = try
-    sym != NoSymbol && sym.isPublic && sym.isStatic
+    sym != NoSymbol && sym.isPublic && sym.isStatic || isAccessibleImplicitClass(sym)
   catch
     case err: AssertionError =>
       logger.log(Level.WARNING, err.getMessage())

--- a/presentation-compiler/src/main/dotty/tools/pc/SemanticdbSymbols.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SemanticdbSymbols.scala
@@ -49,7 +49,16 @@ object SemanticdbSymbols:
                   //   however in scalac this method is defined only in `module Files`
                   if typeSym.is(JavaDefined) then
                     typeSym :: owner.info.decl(termName(value)).symbol :: Nil
+                  /**
+                   * Looks like decl doesn't work for:
+                   *  package a:
+                   *   implicit class <<A>> (i: Int):
+                   *      def inc = i + 1
+                   */
+                  else if typeSym == NoSymbol then
+                    owner.info.member(typeName(value)).symbol :: Nil
                   else typeSym :: Nil
+                  end if
                 case Descriptor.Term(value) =>
                   val outSymbol = owner.info.decl(termName(value)).symbol
                   if outSymbol.exists
@@ -92,6 +101,8 @@ object SemanticdbSymbols:
                     .map(_.symbol)
                     .filter(sym => symbolName(sym) == s)
                     .toList
+          end match
+        end tryMember
 
         parentSymbol.flatMap(tryMember)
     try

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -215,7 +215,7 @@ class CompletionProvider(
 
     def mkItemWithImports(
         v: CompletionValue.Workspace | CompletionValue.Extension |
-          CompletionValue.Interpolator
+          CompletionValue.Interpolator | CompletionValue.ImplicitClass
     ) =
       val sym = v.symbol
       path match
@@ -260,7 +260,7 @@ class CompletionProvider(
     end mkItemWithImports
 
     completion match
-      case v: (CompletionValue.Workspace | CompletionValue.Extension) =>
+      case v: (CompletionValue.Workspace | CompletionValue.Extension | CompletionValue.ImplicitClass) =>
         mkItemWithImports(v)
       case v: CompletionValue.Interpolator if v.isWorkspace || v.isExtension =>
         mkItemWithImports(v)

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -144,6 +144,20 @@ object CompletionValue:
     override def completionItemDataKind: Integer = CompletionSource.WorkspaceKind.ordinal
 
   /**
+   * CompletionValue for old implicit classes methods via SymbolSearch
+   */
+  case class ImplicitClass(
+      label: String,
+      symbol: Symbol,
+      override val snippetSuffix: CompletionSuffix,
+      override val importSymbol: Symbol,
+  ) extends Symbolic:
+    override def completionItemKind(using Context): CompletionItemKind =
+      CompletionItemKind.Method
+    override def description(printer: ShortenedTypePrinter)(using Context): String =
+      s"${printer.completionSymbol(symbol)} (implicit)"
+
+  /**
    * CompletionValue for extension methods via SymbolSearch
    */
   case class Extension(

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
@@ -20,6 +20,20 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
+  @Test def `simple-old-syntax` =
+    check(
+      """|package example
+        |
+        |object Test:
+        |  implicit class TestOps(a: Int):
+        |    def testOps(b: Int): String = ???
+        |
+        |def main = 100.test@@
+        |""".stripMargin,
+      """|testOps(b: Int): String (implicit)
+        |""".stripMargin
+    )
+
   @Test def `simple2` =
     check(
       """|package example
@@ -33,6 +47,21 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
       """|incr: Int (extension)
          |""".stripMargin,
       filter = _.contains("(extension)")
+    )
+
+  @Test def `simple2-old-syntax` =
+    check(
+      """|package example
+         |
+         |object enrichments:
+         |  implicit class TestOps(a: Int):
+         |    def testOps(b: Int): String = ???
+         |
+         |def main = 100.t@@
+         |""".stripMargin,
+      """|testOps(b: Int): String (implicit)
+         |""".stripMargin,
+      filter = _.contains("(implicit)")
     )
 
   @Test def `filter-by-type` =
@@ -50,6 +79,22 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
       """|identity: String (extension)
          |""".stripMargin, // incr won't be available
       filter = _.contains("(extension)")
+    )
+
+  @Test def `filter-by-type-old` =
+    check(
+      """|package example
+        |
+        |object enrichments:
+        |  implicit class A(num: Int):
+        |    def identity2: Int = num + 1
+        |  implicit class B(str: String):
+        |    def identity: String = str
+        |
+        |def main = "foo".iden@@
+        |""".stripMargin,
+      """|identity: String (implicit)
+        |""".stripMargin // identity2 won't be available
     )
 
   @Test def `filter-by-type-subtype` =
@@ -70,6 +115,24 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
       filter = _.contains("(extension)")
     )
 
+  @Test def `filter-by-type-subtype-old` =
+    check(
+      """|package example
+         |
+         |class A
+         |class B extends A
+         |
+         |object enrichments:
+         |  implicit class Test(a: A):
+         |    def doSomething: A = a
+         |
+         |def main = (new B).do@@
+         |""".stripMargin,
+      """|doSomething: A (implicit)
+         |""".stripMargin,
+      filter = _.contains("(implicit)")
+    )
+
   @Test def `simple-edit` =
     checkEdit(
       """|package example
@@ -86,6 +149,28 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
          |
          |object enrichments:
          |  extension (num: Int)
+         |    def incr: Int = num + 1
+         |
+         |def main = 100.incr
+         |""".stripMargin
+    )
+
+  @Test def `simple-edit-old` =
+    checkEdit(
+      """|package example
+         |
+         |object enrichments:
+         |  implicit class A (num: Int):
+         |    def incr: Int = num + 1
+         |
+         |def main = 100.inc@@
+         |""".stripMargin,
+      """|package example
+         |
+         |import example.enrichments.A
+         |
+         |object enrichments:
+         |  implicit class A (num: Int):
          |    def incr: Int = num + 1
          |
          |def main = 100.incr
@@ -114,6 +199,28 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
+  @Test def `simple-edit-suffix-old` =
+    checkEdit(
+     """|package example
+        |
+        |object enrichments:
+        |  implicit class A (val num: Int):
+        |    def plus(other: Int): Int = num + other
+        |
+        |def main = 100.pl@@
+        |""".stripMargin,
+     """|package example
+        |
+        |import example.enrichments.A
+        |
+        |object enrichments:
+        |  implicit class A (val num: Int):
+        |    def plus(other: Int): Int = num + other
+        |
+        |def main = 100.plus($0)
+        |""".stripMargin
+    )
+
   @Test def `simple-empty` =
     check(
       """|package example
@@ -127,6 +234,21 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
       """|incr: Int (extension)
          |""".stripMargin,
       filter = _.contains("(extension)")
+    )
+
+  @Test def `simple-empty-old` =
+    check(
+      """|package example
+         |
+         |object enrichments:
+         |  implicit class TestOps(a: Int):
+         |    def testOps(b: Int): String = ???
+         |
+         |def main = 100.@@
+         |""".stripMargin,
+      """|testOps(b: Int): String (implicit)
+         |""".stripMargin,
+      filter = _.contains("(implicit)")
     )
 
   @Test def `directly-in-pkg1` =
@@ -143,6 +265,20 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
+  @Test def `directly-in-pkg1-old` =
+  check(
+      """|
+         |package examples:
+         |  implicit class A(num: Int):
+         |    def incr: Int = num + 1
+         |
+         |package examples2:
+         |  def main = 100.inc@@
+         |""".stripMargin,
+      """|incr: Int (implicit)
+         |""".stripMargin
+    )
+
   @Test def `directly-in-pkg2` =
     check(
       """|package example:
@@ -154,6 +290,20 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
          |  def main = 100.inc@@
          |""".stripMargin,
       """|incr: Int (extension)
+         |""".stripMargin
+    )
+
+  @Test def `directly-in-pkg2-old` =
+    check(
+      """|package examples:
+         |  object X:
+         |    def fooBar(num: Int) = num + 1
+         |  implicit class A (num: Int) { def incr: Int = num + 1 }
+         |
+         |package examples2:
+         |  def main = 100.inc@@
+         |""".stripMargin,
+      """|incr: Int (implicit)
          |""".stripMargin
     )
 
@@ -175,7 +325,25 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
-  @Test def `name-conflict` = 
+  @Test def `nested-pkg-old` =
+    check(
+      """|package aa:  // some comment
+         |  package cc:
+         |    implicit class A (num: Int):
+         |        def increment2 = num + 2
+         |  implicit class A (num: Int):
+         |    def increment = num + 1
+         |
+         |
+         |package bb:
+         |  def main: Unit = 123.incre@@
+         |""".stripMargin,
+      """|increment: Int (implicit)
+         |increment2: Int (implicit)
+         |""".stripMargin
+    )
+
+  @Test def `name-conflict` =
     checkEdit(
       """
         |package example


### PR DESCRIPTION
Previously, we would only support extension methods and not the old style implicit classes. Now, those are supported also.

Introduced in https://github.com/scalameta/metals/pull/5904/