### PR TITLE
Add tests to verify that crash is fixed elsewhere. Fixes #19328

### DIFF
--- a/tests/neg/i19328.check
+++ b/tests/neg/i19328.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/i19328.scala:14:5 ----------------------------------------------------------------------
+14 |  bar // error: missing implicit (should not crash)
+   |     ^
+   |     No given instance of type Boolean was found for parameter bool of method bar in object i19328

--- a/tests/neg/i19328.scala
+++ b/tests/neg/i19328.scala
@@ -1,0 +1,14 @@
+import scala.language.implicitConversions
+
+object i19328:
+
+  trait Foo[B]
+  given foo[C]: Foo[C] = new Foo[C] {}
+
+  type Id[A] = A
+
+  implicit def wrapId[A](a: A): Id[A] = a
+
+  def bar(using bool: Boolean): Unit = ()
+
+  bar // error: missing implicit (should not crash)

--- a/tests/neg/i19328conversion.check
+++ b/tests/neg/i19328conversion.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/i19328conversion.scala:13:5 ------------------------------------------------------------
+13 |  bar // error: missing implicit (should not crash)
+   |     ^
+   |     No given instance of type Boolean was found for parameter bool of method bar in object i19328conversion

--- a/tests/neg/i19328conversion.scala
+++ b/tests/neg/i19328conversion.scala
@@ -1,0 +1,13 @@
+object i19328conversion:
+
+  trait Foo[B]
+  given foo[C]: Foo[C] = new Foo[C] {}
+
+  type Id[A] = A
+
+  given wrapId[A]: Conversion[A, Id[A]] with
+    def apply(x: A): Id[A] = x
+
+  def bar(using bool: Boolean): Unit = ()
+
+  bar // error: missing implicit (should not crash)


### PR DESCRIPTION
Adding tests for crash reproduction #19328 that I reported, that was already fixed in nightly.

I added the `pos` ones just in case, as protection against potential regressions. So far I managed to reproduce the crash only when the implicit was missing, as in `neg` tests. I can remove the `pos` tests if you think these are excessive.

I ran only my own tests locally, they passed.

Fixes #19328

cc @soronpo