### PR TITLE
Scaladoc - add option for dynamic side menu

### DIFF
--- a/project/ScaladocGeneration.scala
+++ b/project/ScaladocGeneration.scala
@@ -137,6 +137,10 @@ object ScaladocGeneration {
     def key: String = "-quick-links"
   }
 
+  case class DynamicSideMenu(value: Boolean) extends Arg[Boolean] {
+    def key: String = "-dynamic-side-menu"
+  }
+
   import _root_.scala.reflect._
 
   trait GenerationConfig {

--- a/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
@@ -45,7 +45,8 @@ object Scaladoc:
     apiSubdirectory : Boolean = false,
     scastieConfiguration: String = "",
     defaultTemplate: Option[String] = None,
-    quickLinks: List[QuickLink] = List.empty
+    quickLinks: List[QuickLink] = List.empty,
+    dynamicSideMenu: Boolean = false,
   )
 
   def run(args: Array[String], rootContext: CompilerContext): Reporter =
@@ -228,7 +229,8 @@ object Scaladoc:
         apiSubdirectory.get,
         scastieConfiguration.get,
         defaultTemplate.nonDefault,
-        quickLinksParsed
+        quickLinksParsed,
+        dynamicSideMenu.get,
       )
       (Some(docArgs), newContext)
     }

--- a/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
@@ -133,5 +133,8 @@ class ScaladocSettings extends SettingGroup with AllScalaSettings:
       "List of quick links that is displayed in the header of documentation."
     )
 
+  val dynamicSideMenu: Setting[Boolean] =
+    BooleanSetting("-dynamic-side-menu", "Generate side menu via JS instead of embedding it in every html file", false)
+
   def scaladocSpecificSettings: Set[Setting[?]] =
-    Set(sourceLinks, legacySourceLink, syntax, revision, externalDocumentationMappings, socialLinks, skipById, skipByRegex, deprecatedSkipPackages, docRootContent, snippetCompiler, generateInkuire, defaultTemplate, scastieConfiguration, quickLinks)
+    Set(sourceLinks, legacySourceLink, syntax, revision, externalDocumentationMappings, socialLinks, skipById, skipByRegex, deprecatedSkipPackages, docRootContent, snippetCompiler, generateInkuire, defaultTemplate, scastieConfiguration, quickLinks, dynamicSideMenu)


### PR DESCRIPTION
Closes #18543 

This PR adds `-dynamic-side-menu` option to Scaladoc.
With this option Scaladoc doesn't generate side menu (packages etc. tree) in html files. Instead it is serialized into .json file and rendered on the client using Javascript.

- [ ] Add documentation for this option in docs.scala-lang (Update: related PR - https://github.com/scala/docs.scala-lang/pull/2942)