### PR TITLE
Fix #19369 - duplicate macro execution in unapply methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1446,7 +1446,7 @@ trait Applications extends Compatibility {
             unapplyArgType
 
         val dummyArg = dummyTreeOfType(ownType)
-        val unapplyApp = typedExpr(untpd.TypedSplice(Apply(unapplyFn, dummyArg :: Nil)))
+        val unapplyApp = typedExpr(untpd.TypedSplice(Apply(unapplyFn, dummyArg :: Nil)))(using ctx.addMode(Mode.NoInline))
         def unapplyImplicits(unapp: Tree): List[Tree] = {
           val res = List.newBuilder[Tree]
           def loop(unapp: Tree): Unit = unapp match {

--- a/tests/pos-macros/i19369/Macro_1.scala
+++ b/tests/pos-macros/i19369/Macro_1.scala
@@ -1,0 +1,11 @@
+import scala.quoted._
+
+object Unapplier:
+  transparent inline def unapply(arg: Any): Option[Int] = ${unapplyImpl('arg)}
+
+  def unapplyImpl(using Quotes)(argExpr: Expr[Any]): Expr[Option[Int]] =
+    import quotes.reflect._
+    // The code below will recurse, throwing cyclic reference, if it is being inlined too early,
+    // which is caused by the same problem as the duplicate macro execution here
+    println(Symbol.spliceOwner.owner.tree)
+    '{Some(1)}

--- a/tests/pos-macros/i19369/Main_2.scala
+++ b/tests/pos-macros/i19369/Main_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val Unapplier(result) = Some(5)
+  }
+}


### PR DESCRIPTION
It looks like the macro really was called twice - first an unapply application is typed in `typedUnapply` (and thus the transparent inline macro expansion is run), and then a custom method `inlinedUnapply` is run (which inlines the unapply and also also wraps the unapply with a anon class). I've disabled inlining for the first call, so now only the second should be run.

I've had some trouble preparing the tests, as it is impossible in our test suite to inspect stdout in a clean way and warnings/report would only be reported once. I remembered, however, that this issue caused me another problem when inspecting trees of splice owner and macro expansion would get triggered recursively, which is also fixed by this, as the first, now disabled call, was run in a bit of a non-standard context. Hopefully this test is enough.

Fixes #19369 