### PR TITLE
Fix #19388: disable `fromBelow` during implicit conversion

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1157,9 +1157,10 @@ trait Implicits:
                       locked)),
                   nme.apply)
               else untpdGenerated
-            typed(
+            val fromConv = ref.symbol.is(Inline) && ref.symbol.isOldStyleImplicitConversion()
+            typed_fromConv(
               untpd.Apply(untpdConv, untpd.TypedSplice(argument) :: Nil),
-              pt, locked)
+              pt, locked, fromConv)
           }
           pt match
             case selProto @ SelectionProto(selName: TermName, mbrType, _, _, nameSpan) =>

--- a/tests/pos/i19388.scala
+++ b/tests/pos/i19388.scala
@@ -1,0 +1,8 @@
+import language.implicitConversions
+class Foo[+T]
+
+implicit inline def conv[T, R](from: R): Foo[T] =
+  compiletime.summonInline[T =:= Int]
+  new Foo[T]
+
+val f: Foo[Int] = "o"


### PR DESCRIPTION
This is probably the wrong way to do this.
Just trying it out for now for testing.