### PR TITLE
Remove `ascriptionVarargsUnpacking` as we never used it

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -26,7 +26,6 @@ object Feature:
   val dependent = experimental("dependent")
   val erasedDefinitions = experimental("erasedDefinitions")
   val symbolLiterals = deprecated("symbolLiterals")
-  val ascriptionVarargsUnpacking = deprecated("ascriptionVarargsUnpacking")
   val fewerBraces = experimental("fewerBraces")
   val saferExceptions = experimental("saferExceptions")
   val clauseInterleaving = experimental("clauseInterleaving")

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -115,9 +115,6 @@ object language:
     @compileTimeOnly("`symbolLiterals` can only be used at compile time in import statements")
     object symbolLiterals
 
-    /** TODO */
-    @compileTimeOnly("`ascriptionVarargsUnpacking` can only be used at compile time in import statements")
-    object ascriptionVarargsUnpacking
   end deprecated
 
   /** Where imported, auto-tupling is disabled.


### PR DESCRIPTION
This was added by mistake.

This should be removed before _3.4.0_. We will need a _3.4.0-RC2_.

Ping @Kordyjan