### PR TITLE
Package Scala 2 library TASTy for `scalac` and `scala` commands

### DIFF
--- a/dist/bin/common
+++ b/dist/bin/common
@@ -150,6 +150,7 @@ find_lib () {
 DOTTY_COMP=$(find_lib "*scala3-compiler*")
 DOTTY_INTF=$(find_lib "*scala3-interfaces*")
 DOTTY_LIB=$(find_lib "*scala3-library*")
+SCALA2_LIB_TASTY=$(find_lib "*scala2-library-tasty*")
 DOTTY_STAGING=$(find_lib "*scala3-staging*")
 DOTTY_TASTY_INSPECTOR=$(find_lib "*scala3-tasty-inspector*")
 TASTY_CORE=$(find_lib "*tasty-core*")
@@ -167,12 +168,17 @@ compilerJavaClasspathArgs () {
   # echo "dotty-compiler: $DOTTY_COMP"
   # echo "dotty-interface: $DOTTY_INTF"
   # echo "dotty-library: $DOTTY_LIB"
+  # echo "scala2-library-tasty: $SCALA2_LIB_TASTY"
   # echo "tasty-core: $TASTY_CORE"
   # echo "scala-asm: $SCALA_ASM"
   # echo "scala-lib: $SCALA_LIB"
   # echo "sbt-intface: $SBT_INTF"
 
   toolchain=""
+  if [ "$1" = true ] ; then
+    toolchain+="$SCALA2_LIB_TASTY$PSEP" # needs to be added before the SCALA_LIB
+    echo "Warning: Scala 2 library TASTy is still unstable."
+  fi
   toolchain+="$SCALA_LIB$PSEP"
   toolchain+="$DOTTY_LIB$PSEP"
   toolchain+="$SCALA_ASM$PSEP"

--- a/dist/bin/scala
+++ b/dist/bin/scala
@@ -28,6 +28,7 @@ fi
 
 source "$PROG_HOME/bin/common"
 
+USE_SCALA2_LIBRARY_TASTY=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -D*)
@@ -55,6 +56,10 @@ while [[ $# -gt 0 ]]; do
         shift
       fi
       ;;
+    -Yuse-scala2-library-tasty)
+      USE_SCALA2_LIBRARY_TASTY=true
+      shift
+      ;;
     *)
       addScala "$1"
       shift
@@ -63,7 +68,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # exec here would prevent onExit from being called, leaving terminal in unusable state
-compilerJavaClasspathArgs
+compilerJavaClasspathArgs "$USE_SCALA2_LIBRARY_TASTY"
 [ -z "${ConEmuPID-}" -o -n "${cygwin-}" ] && export MSYSTEM= PWD= # workaround for #12405
 eval "\"$JAVACMD\"" "${java_args[@]}" "-Dscala.home=\"$PROG_HOME\"" "-classpath \"$jvm_cp_args\"" "dotty.tools.MainGenericRunner" "-classpath \"$jvm_cp_args\"" "${scala_args[@]}"
 scala_exit_status=$?

--- a/dist/bin/scalac
+++ b/dist/bin/scalac
@@ -30,6 +30,8 @@ source "$PROG_HOME/bin/common"
 
 [ -z "$PROG_NAME" ] && PROG_NAME=$CompilerMain
 
+USE_SCALA2_LIBRARY_TASTY=false
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --)
@@ -69,6 +71,10 @@ while [[ $# -gt 0 ]]; do
         shift
       fi
       ;;
+    -Yuse-scala2-library-tasty)
+      USE_SCALA2_LIBRARY_TASTY=true
+      shift
+      ;;
     *)
       addScala "$1"
       shift
@@ -76,7 +82,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-compilerJavaClasspathArgs
+compilerJavaClasspathArgs "$USE_SCALA2_LIBRARY_TASTY"
 
 [ -n "$script_trace" ] && set -x
 [ -z "${ConEmuPID-}" -o -n "${cygwin-}" ] && export MSYSTEM= PWD= # workaround for #12405

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2112,7 +2112,7 @@ object Build {
     // FIXME: we do not aggregate `bin` because its tests delete jars, thus breaking other tests
     def asDottyRoot(implicit mode: Mode): Project = project.withCommonSettings.
       aggregate(`scala3-interfaces`, dottyLibrary, dottyCompiler, tastyCore, `scala3-sbt-bridge`, scala3PresentationCompiler).
-      bootstrappedAggregate(`scala3-language-server`, `scala3-staging`,
+      bootstrappedAggregate(`scala2-library-tasty`, `scala3-language-server`, `scala3-staging`,
         `scala3-tasty-inspector`, `scala3-library-bootstrappedJS`, scaladoc).
       dependsOn(tastyCore).
       dependsOn(dottyCompiler).

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2204,7 +2204,7 @@ object Build {
     def asDist(implicit mode: Mode): Project = project.
       enablePlugins(PackPlugin).
       withCommonSettings.
-      dependsOn(`scala3-interfaces`, dottyCompiler, dottyLibrary, tastyCore, `scala3-staging`, `scala3-tasty-inspector`, scaladoc).
+      dependsOn(`scala3-interfaces`, dottyCompiler, dottyLibrary, `scala2-library-tasty`, tastyCore, `scala3-staging`, `scala3-tasty-inspector`, scaladoc).
       settings(commonDistSettings).
       bootstrappedSettings(
         target := baseDirectory.value / "target" // override setting in commonBootstrappedSettings

--- a/project/scripts/bootstrappedOnlyCmdTests
+++ b/project/scripts/bootstrappedOnlyCmdTests
@@ -135,3 +135,11 @@ sbt_test_command="++${scala_version}!;clean;prepareSources;compile;copyChanges;c
 rm -rf "$sbt_test_dir/target"
 rm -rf "$sbt_test_dir/project/target"
 rm -f "$sbt_test_dir/src/main/scala/a/zz.scala"
+
+# check that `scalac -use-scala2-library-tasty` compiles and `scala -use-scala2-library-tasty` runs it
+echo "testing './bin/scalac -Yuse-scala2-library-tasty' and './bin/scala -Yuse-scala2-library-tasty'"
+clear_out "$OUT"
+./bin/scalac "$SOURCE" -Yuse-scala2-library-tasty -d "$OUT"
+./bin/scala -Yuse-scala2-library-tasty -classpath "$OUT" "$MAIN" > "$tmp"
+grep -qe "Warning: Scala 2 library TASTy is still unstable" "$tmp"
+grep -qe "hello world" "$tmp"


### PR DESCRIPTION
Publish Scala 2 library TASTy

- [x] Package `scala2-library-tasty`
- [x] update `scalac` and `scala` scripts
- [ ] make sure that `scala2-library-tasty` is not used by SBT projects by default
- [ ] find a way to enable `scala2-library-tasty` in SBT 

Using the Scala 2 library TASTy is still unstable. It can be enabled by using the `-Yuse-scala2-library-tasty` on the `scalac` and `scala` commands. Not available on `scalac.bat` and `scala.bat`.