### PR TITLE
Better error diagnostics for cyclic references

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -343,6 +343,8 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
     runCtx.setProfiler(Profiler())
     unfusedPhases.foreach(_.initContext(runCtx))
     val fusedPhases = runCtx.base.allPhases
+    if ctx.settings.explainCyclic.value then
+      runCtx.setProperty(CyclicReference.Trace, new CyclicReference.Trace())
     runCtx.withProgressCallback: cb =>
       _progress = Progress(cb, this, fusedPhases.map(_.traversals).sum)
     runPhases(allPhases = fusedPhases)(using runCtx)

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -120,6 +120,7 @@ trait CommonScalaSettings:
   // -explain-types setting is necessary for cross compilation, since it is mentioned in sbt-tpolecat, for instance
   // it is otherwise subsumed by -explain, and should be dropped as soon as we can.
   val explainTypes: Setting[Boolean] = BooleanSetting("-explain-types", "Explain type errors in more detail (deprecated, use -explain instead).", aliases = List("--explain-types", "-explaintypes"))
+  val explainCyclic: Setting[Boolean] = BooleanSetting("-explain-cyclic", "Explain cyclic reference errors in more detail.", aliases = List("--explain-cyclic"))
   val unchecked: Setting[Boolean] = BooleanSetting("-unchecked", "Enable additional warnings where generated code depends on assumptions.", initialValue = true, aliases = List("--unchecked"))
   val language: Setting[List[String]] = MultiStringSetting("-language", "feature", "Enable one or more language features.", aliases = List("--language"))
   val experimental: Setting[Boolean] = BooleanSetting("-experimental", "Annotate all top-level definitions with @experimental. This enables the use of experimental features anywhere in the project.")
@@ -351,6 +352,7 @@ private sealed trait YSettings:
   val YdebugTypeError: Setting[Boolean] = BooleanSetting("-Ydebug-type-error", "Print the stack trace when a TypeError is caught", false)
   val YdebugError: Setting[Boolean] = BooleanSetting("-Ydebug-error", "Print the stack trace when any error is caught.", false)
   val YdebugUnpickling: Setting[Boolean] = BooleanSetting("-Ydebug-unpickling", "Print the stack trace when an error occurs when reading Tasty.", false)
+  val YdebugCyclic: Setting[Boolean] = BooleanSetting("-Ydebug-cyclic", "Print the stack trace when a cyclic reference error occurs.", false)
   val YtermConflict: Setting[String] = ChoiceSetting("-Yresolve-term-conflict", "strategy", "Resolve term conflicts", List("package", "object", "error"), "error")
   val Ylog: Setting[List[String]] = PhasesSetting("-Ylog", "Log operations during")
   val YlogClasspath: Setting[Boolean] = BooleanSetting("-Ylog-classpath", "Output information about what classpath is being applied.")

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -171,7 +171,7 @@ object SymDenotations {
           val traceCycles = CyclicReference.isTraced
           try
             if traceCycles then
-              CyclicReference.pushTrace("complete the info of ", symbol, "")
+              CyclicReference.pushTrace("compute the signature of ", symbol, "")
             if myFlags.is(Touched) then
               throw CyclicReference(this)(using ctx.withOwner(symbol))
             myFlags |= Touched

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -141,20 +141,25 @@ class TreeUnpickler(reader: TastyReader,
     val mode = ctx.mode
     val source = ctx.source
     def complete(denot: SymDenotation)(using Context): Unit =
-      def fail(ex: Throwable) =
-        def where =
-          val f = denot.symbol.associatedFile
-          if f == null then "" else s" in $f"
-        throw UnpicklingError(denot, where, ex)
+      def where =
+        val f = denot.symbol.associatedFile
+        if f == null then "" else s" in $f"
+      def fail(ex: Throwable) = throw UnpicklingError(denot, where, ex)
       treeAtAddr(currentAddr) =
+        val traceCycles = CyclicReference.isTraced
         try
+          if traceCycles then
+            CyclicReference.pushTrace("read the definition of ", denot.symbol, where)
           atPhaseBeforeTransforms {
             new TreeReader(reader).readIndexedDef()(
               using ctx.withOwner(owner).withModeBits(mode).withSource(source))
           }
         catch
+          case ex: CyclicReference => throw ex
           case ex: AssertionError => fail(ex)
           case ex: Exception => fail(ex)
+        finally
+          if traceCycles then CyclicReference.popTrace()
   }
 
   class TreeReader(val reader: TastyReader) {

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -391,7 +391,7 @@ object Checking {
     catch {
       case ex: CyclicReference =>
         if (reportErrors)
-          errorType(IllegalCyclicTypeReference(sym, checker.where, checker.lastChecked), sym.srcPos)
+          errorType(IllegalCyclicTypeReference(ex, sym, checker.where, checker.lastChecked), sym.srcPos)
         else info
     }
   }

--- a/tests/neg-macros/i14772.check
+++ b/tests/neg-macros/i14772.check
@@ -3,8 +3,8 @@
   |       ^
   |       Overloaded or recursive method impl needs return type
   |
-  |       The error occurred while trying to complete the info of method $anonfun
-  |         which required to complete the info of method impl
+  |       The error occurred while trying to compute the signature of method $anonfun
+  |         which required to compute the signature of method impl
   |
   |        Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
   |

--- a/tests/neg-macros/i14772.check
+++ b/tests/neg-macros/i14772.check
@@ -1,6 +1,11 @@
--- [E044] Cyclic Error: tests/neg-macros/i14772.scala:7:7 --------------------------------------------------------------
-7 |    foo(a)    // error
+-- [E044] Cyclic Error: tests/neg-macros/i14772.scala:8:7 --------------------------------------------------------------
+8 |    foo(a)    // error
   |       ^
   |       Overloaded or recursive method impl needs return type
+  |
+  |       The error occurred while trying to complete the info of method $anonfun
+  |         which required to complete the info of method impl
+  |
+  |        Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-macros/i14772.scala
+++ b/tests/neg-macros/i14772.scala
@@ -1,3 +1,4 @@
+//> using options -explain-cyclic
 import scala.quoted.*
 
 object A {

--- a/tests/neg-macros/i16582.check
+++ b/tests/neg-macros/i16582.check
@@ -5,9 +5,9 @@
   |           Exception occurred while executing macro expansion.
   |           dotty.tools.dotc.core.CyclicReference: Recursive value o2 needs type
   |
-  |           The error occurred while trying to complete the info of method test
-  |             which required to complete the info of value o2
-  |             which required to complete the info of value o2
+  |           The error occurred while trying to compute the signature of method test
+  |             which required to compute the signature of value o2
+  |             which required to compute the signature of value o2
   |
   |            Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
   |

--- a/tests/neg-macros/i16582.check
+++ b/tests/neg-macros/i16582.check
@@ -1,9 +1,15 @@
 
--- Error: tests/neg-macros/i16582/Test_2.scala:5:27 --------------------------------------------------------------------
-5 |  val o2 = ownerDoesNotWork(2) // error
+-- Error: tests/neg-macros/i16582/Test_2.scala:6:27 --------------------------------------------------------------------
+6 |  val o2 = ownerDoesNotWork(2) // error
   |           ^^^^^^^^^^^^^^^^^^^
   |           Exception occurred while executing macro expansion.
   |           dotty.tools.dotc.core.CyclicReference: Recursive value o2 needs type
+  |
+  |           The error occurred while trying to complete the info of method test
+  |             which required to complete the info of value o2
+  |             which required to complete the info of value o2
+  |
+  |            Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
   |
   |           See full stack trace using -Ydebug
   |---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i16582/Test_2.scala
+++ b/tests/neg-macros/i16582/Test_2.scala
@@ -1,3 +1,4 @@
+//> using options -explain-cyclic
 def test=
   val o1 = ownerWorks(1)
   println(o1)

--- a/tests/neg/cyclic.check
+++ b/tests/neg/cyclic.check
@@ -1,0 +1,14 @@
+-- [E044] Cyclic Error: tests/neg/cyclic.scala:6:12 --------------------------------------------------------------------
+6 |  def i() = f()  // error
+  |            ^
+  |            Overloaded or recursive method f needs return type
+  |
+  |            The error occurred while trying to complete the info of method f
+  |              which required to complete the info of method g
+  |              which required to complete the info of method h
+  |              which required to complete the info of method i
+  |              which required to complete the info of method f
+  |
+  |             Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/cyclic.check
+++ b/tests/neg/cyclic.check
@@ -3,11 +3,11 @@
   |            ^
   |            Overloaded or recursive method f needs return type
   |
-  |            The error occurred while trying to complete the info of method f
-  |              which required to complete the info of method g
-  |              which required to complete the info of method h
-  |              which required to complete the info of method i
-  |              which required to complete the info of method f
+  |            The error occurred while trying to compute the signature of method f
+  |              which required to compute the signature of method g
+  |              which required to compute the signature of method h
+  |              which required to compute the signature of method i
+  |              which required to compute the signature of method f
   |
   |             Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
   |

--- a/tests/neg/cyclic.scala
+++ b/tests/neg/cyclic.scala
@@ -1,0 +1,6 @@
+//> using options -explain-cyclic
+object O:
+  def f() = g()
+  def g() = h()
+  def h() = i()
+  def i() = f()  // error

--- a/tests/neg/i10870.check
+++ b/tests/neg/i10870.check
@@ -5,3 +5,5 @@
    |            Extension methods were tried, but the search failed with:
    |
    |                Overloaded or recursive method x needs return type
+   |                
+   |                 Run with -explain-cyclic for more details.

--- a/tests/neg/i11994.check
+++ b/tests/neg/i11994.check
@@ -1,14 +1,26 @@
--- [E008] Not Found Error: tests/neg/i11994.scala:1:28 -----------------------------------------------------------------
-1 |implicit def foo[T <: Tuple.meow]: Unit = ??? // error
+-- [E008] Not Found Error: tests/neg/i11994.scala:2:28 -----------------------------------------------------------------
+2 |implicit def foo[T <: Tuple.meow]: Unit = ??? // error
   |                      ^^^^^^^^^^
   |                      type meow is not a member of object Tuple.
   |                      Extension methods were tried, but the search failed with:
   |
   |                          Cyclic reference involving method foo
--- [E008] Not Found Error: tests/neg/i11994.scala:2:18 -----------------------------------------------------------------
-2 |given [T <: Tuple.meow]: Unit = ??? // error
+  |                          
+  |                          The error occurred while trying to complete the info of method foo
+  |                            which required to complete the info of type T
+  |                            which required to complete the info of method foo
+  |                          
+  |                           Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
+-- [E008] Not Found Error: tests/neg/i11994.scala:3:18 -----------------------------------------------------------------
+3 |given [T <: Tuple.meow]: Unit = ??? // error
   |            ^^^^^^^^^^
   |            type meow is not a member of object Tuple.
   |            Extension methods were tried, but the search failed with:
   |
   |                Cyclic reference involving method given_Unit
+  |                
+  |                The error occurred while trying to complete the info of given instance given_Unit
+  |                  which required to complete the info of type T
+  |                  which required to complete the info of given instance given_Unit
+  |                
+  |                 Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.

--- a/tests/neg/i11994.check
+++ b/tests/neg/i11994.check
@@ -6,9 +6,9 @@
   |
   |                          Cyclic reference involving method foo
   |                          
-  |                          The error occurred while trying to complete the info of method foo
-  |                            which required to complete the info of type T
-  |                            which required to complete the info of method foo
+  |                          The error occurred while trying to compute the signature of method foo
+  |                            which required to compute the signature of type T
+  |                            which required to compute the signature of method foo
   |                          
   |                           Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
 -- [E008] Not Found Error: tests/neg/i11994.scala:3:18 -----------------------------------------------------------------
@@ -19,8 +19,8 @@
   |
   |                Cyclic reference involving method given_Unit
   |                
-  |                The error occurred while trying to complete the info of given instance given_Unit
-  |                  which required to complete the info of type T
-  |                  which required to complete the info of given instance given_Unit
+  |                The error occurred while trying to compute the signature of given instance given_Unit
+  |                  which required to compute the signature of type T
+  |                  which required to compute the signature of given instance given_Unit
   |                
   |                 Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.

--- a/tests/neg/i11994.scala
+++ b/tests/neg/i11994.scala
@@ -1,2 +1,3 @@
+//> using options -explain-cyclic
 implicit def foo[T <: Tuple.meow]: Unit = ??? // error
 given [T <: Tuple.meow]: Unit = ??? // error


### PR DESCRIPTION
We now suggest to compile with -explain-cyclic, in which case we give a trace of the forcings that led to the cycle.

The reason for the separate option is that maintaining a trace is not free so we should not be doing it by default.