### PR TITLE
Fix main: remove an incompatible java api method with java 8 from a test

### DIFF
--- a/tests/pos/i19354.orig.scala
+++ b/tests/pos/i19354.orig.scala
@@ -10,7 +10,6 @@ class P extends AbstractProcessor {
       .flatMap(annotation => roundEnv.getElementsAnnotatedWith(annotation).stream())
       .filter(element => element.getKind == ElementKind.PACKAGE)
       .map(element => element.asInstanceOf[PackageElement])
-      .toList()
     true
   }
 }


### PR DESCRIPTION
Looks like the issue with main and the nightly release was caused by the test in #19354. I checked and that `toList` method does not seem to affect what is being tested there (the previous error would still appear without it), so I removed it here.

Closes #19423, #19418

[test_java8]
[test_windows_full]