### PR TITLE
CC: Infer more self types automatically

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -236,19 +236,19 @@ extension (tp: Type)
    *  (2) all covariant occurrences of cap replaced by `x*`, provided there
    *  are no occurrences in `T` at other variances. (1) is standard, whereas
    *  (2) is new.
-   * 
+   *
    *  For (2), multiple-flipped covariant occurrences of cap won't be replaced.
    *  In other words,
    *
    *    - For xs: List[File^]  ==>  List[File^{xs*}], the cap is replaced;
    *    - while f: [R] -> (op: File^ => R) -> R remains unchanged.
-   * 
+   *
    *  Without this restriction, the signature of functions like withFile:
-   * 
+   *
    *    (path: String) -> [R] -> (op: File^ => R) -> R
    *
    *  could be refined to
-   * 
+   *
    *    (path: String) -> [R] -> (op: File^{withFile*} => R) -> R
    *
    *  which is clearly unsound.
@@ -314,6 +314,15 @@ extension (cls: ClassSymbol)
                                  // unless a self type is explicitly given, we can't tell
                                  // and err on the side of impure.
               && selfType.exists && selfType.captureSet.isAlwaysEmpty
+
+  def baseClassHasExplicitSelfType(using Context): Boolean =
+    cls.baseClasses.exists: bc =>
+      bc.is(CaptureChecked) && bc.givenSelfType.exists
+
+  def matchesExplicitRefsInBaseClass(refs: CaptureSet)(using Context): Boolean =
+    cls.baseClasses.tail.exists: bc =>
+      val selfType = bc.givenSelfType
+      bc.is(CaptureChecked) && selfType.exists && selfType.captureSet.elems == refs.elems
 
 extension (sym: Symbol)
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -672,17 +672,13 @@ class CheckCaptures extends Recheck, SymTransformer:
     def checkInferredResult(tp: Type, tree: ValOrDefDef)(using Context): Type =
       val sym = tree.symbol
 
-      def isLocal =
-        sym.owner.ownersIterator.exists(_.isTerm)
-        || sym.accessBoundary(defn.RootClass).isContainedIn(sym.topLevelClass)
-
       def canUseInferred =    // If canUseInferred is false, all capturing types in the type of `sym` need to be given explicitly
         sym.is(Private)                   // private symbols can always have inferred types
         || sym.name.is(DefaultGetterName) // default getters are exempted since otherwise it would be
                                           // too annoying. This is a hole since a defualt getter's result type
                                           // might leak into a type variable.
         ||                                // non-local symbols cannot have inferred types since external capture types are not inferred
-          isLocal                         // local symbols still need explicit types if
+          sym.isLocalToCompilationUnit    // local symbols still need explicit types if
           && !sym.owner.is(Trait)         // they are defined in a trait, since we do OverridingPairs checking before capture inference
 
       def addenda(expected: Type) = new Addenda:
@@ -1178,7 +1174,7 @@ class CheckCaptures extends Recheck, SymTransformer:
     /** Check that self types of subclasses conform to self types of super classes.
      *  (See comment below how this is achieved). The check assumes that classes
      *  without an explicit self type have the universal capture set `{cap}` on the
-     *  self type. If a class without explicit self type is not `effectivelyFinal`
+     *  self type. If a class without explicit self type is not `effectivelySealed`
      *  it is checked that the inferred self type is universal, in order to assure
      *  that joint and separate compilation give the same result.
      */
@@ -1208,23 +1204,20 @@ class CheckCaptures extends Recheck, SymTransformer:
             checkSelfAgainstParents(root, root.baseClasses)
             val selfType = root.asClass.classInfo.selfType
             interpolator(startingVariance = -1).traverse(selfType)
-            if !root.isEffectivelySealed  then
-              def matchesExplicitRefsInBaseClass(refs: CaptureSet, cls: ClassSymbol): Boolean =
-                cls.baseClasses.tail.exists { psym =>
-                  val selfType = psym.asClass.givenSelfType
-                  selfType.exists && selfType.captureSet.elems == refs.elems
-                }
-              selfType match
-                case CapturingType(_, refs: CaptureSet.Var)
-                if !refs.elems.exists(_.isRootCapability) && !matchesExplicitRefsInBaseClass(refs, root) =>
-                  // Forbid inferred self types unless they are already implied by an explicit
-                  // self type in a parent.
-                  report.error(
-                    em"""$root needs an explicitly declared self type since its
-                        |inferred self type $selfType
-                        |is not visible in other compilation units that define subclasses.""",
-                    root.srcPos)
-                case _ =>
+            selfType match
+              case CapturingType(_, refs: CaptureSet.Var)
+              if !root.isEffectivelySealed
+                  && !refs.elems.exists(_.isRootCapability)
+                  && !root.matchesExplicitRefsInBaseClass(refs)
+              =>
+                // Forbid inferred self types unless they are already implied by an explicit
+                // self type in a parent.
+                report.error(
+                  em"""$root needs an explicitly declared self type since its
+                      |inferred self type $selfType
+                      |is not visible in other compilation units that define subclasses.""",
+                  root.srcPos)
+              case _ =>
             parentTrees -= root
             capt.println(i"checked $root with $selfType")
     end checkSelfTypes

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1197,7 +1197,14 @@ object SymDenotations {
      *  is defined in Scala 3 and is neither abstract nor open.
      */
     final def isEffectivelySealed(using Context): Boolean =
-      isOneOf(FinalOrSealed) || isClass && !isOneOf(EffectivelyOpenFlags)
+      isOneOf(FinalOrSealed)
+      || isClass && (!isOneOf(EffectivelyOpenFlags)
+      || isLocalToCompilationUnit)
+
+    final def isLocalToCompilationUnit(using Context): Boolean =
+      is(Private)
+      || owner.ownersIterator.exists(_.isTerm)
+      || accessBoundary(defn.RootClass).isContainedIn(symbol.topLevelClass)
 
     final def isTransparentClass(using Context): Boolean =
       is(TransparentType)

--- a/scala2-library-cc/src/scala/collection/IndexedSeqView.scala
+++ b/scala2-library-cc/src/scala/collection/IndexedSeqView.scala
@@ -55,7 +55,6 @@ object IndexedSeqView {
 
   @SerialVersionUID(3L)
   private[collection] class IndexedSeqViewIterator[A](self: IndexedSeqView[A]^) extends AbstractIterator[A] with Serializable {
-    this: IndexedSeqViewIterator[A]^ =>
     private[this] var current = 0
     private[this] var remainder = self.length
     override def knownSize: Int = remainder
@@ -90,7 +89,6 @@ object IndexedSeqView {
   }
   @SerialVersionUID(3L)
   private[collection] class IndexedSeqViewReverseIterator[A](self: IndexedSeqView[A]^) extends AbstractIterator[A] with Serializable {
-    this: IndexedSeqViewReverseIterator[A]^ =>
     private[this] var remainder = self.length
     private[this] var pos = remainder - 1
     @inline private[this] def _hasNext: Boolean = remainder > 0

--- a/scala2-library-cc/src/scala/collection/Iterable.scala
+++ b/scala2-library-cc/src/scala/collection/Iterable.scala
@@ -9,7 +9,6 @@
  * See the NOTICE file distributed with this work for
  * additional information regarding copyright ownership.
  */
-
 package scala
 package collection
 
@@ -29,7 +28,6 @@ import language.experimental.captureChecking
 trait Iterable[+A] extends IterableOnce[A]
   with IterableOps[A, Iterable, Iterable[A]]
   with IterableFactoryDefaults[A, Iterable] {
-  this: Iterable[A]^ =>
 
   // The collection itself
   @deprecated("toIterable is internal and will be made protected; its name is similar to `toList` or `toSeq`, but it doesn't copy non-immutable collections", "2.13.7")
@@ -134,7 +132,6 @@ trait Iterable[+A] extends IterableOnce[A]
   *  and may be nondeterministic.
   */
 trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with IterableOnceOps[A, CC, C] {
-  this: IterableOps[A, CC, C]^ =>
 
   /**
     * @return This collection as an `Iterable[A]`. No new collection will be built if `this` is already an `Iterable[A]`.

--- a/scala2-library-cc/src/scala/collection/IterableOnce.scala
+++ b/scala2-library-cc/src/scala/collection/IterableOnce.scala
@@ -43,7 +43,6 @@ import language.experimental.captureChecking
   * @define coll collection
   */
 trait IterableOnce[+A] extends Any {
-  this: IterableOnce[A]^ =>
 
   /** Iterator can be used only once */
   def iterator: Iterator[A]^{this}

--- a/scala2-library-cc/src/scala/collection/Iterator.scala
+++ b/scala2-library-cc/src/scala/collection/Iterator.scala
@@ -1302,5 +1302,4 @@ object Iterator extends IterableFactory[Iterator] {
 }
 
 /** Explicit instantiation of the `Iterator` trait to reduce class file size in subclasses. */
-abstract class AbstractIterator[+A] extends Iterator[A]:
-  this: Iterator[A]^ =>
+abstract class AbstractIterator[+A] extends Iterator[A]

--- a/scala2-library-cc/src/scala/collection/Map.scala
+++ b/scala2-library-cc/src/scala/collection/Map.scala
@@ -104,7 +104,6 @@ trait Map[K, +V]
 trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   extends IterableOps[(K, V), Iterable, C]
     with PartialFunction[K, V] {
-  this: MapOps[K, V, CC, C]^ =>
 
   override def view: MapView[K, V]^{this} = new MapView.Id(this)
 

--- a/scala2-library-cc/src/scala/collection/MapView.scala
+++ b/scala2-library-cc/src/scala/collection/MapView.scala
@@ -21,7 +21,6 @@ import caps.unsafe.unsafeAssumePure
 trait MapView[K, +V]
   extends MapOps[K, V, ({ type l[X, Y] = View[(X, Y)] })#l, View[(K, V)]]
     with View[(K, V)] {
-  this: MapView[K, V]^ =>
 
   override def view: MapView[K, V]^{this} = this
 
@@ -191,6 +190,5 @@ trait MapViewFactory extends collection.MapFactory[({ type l[X, Y] = View[(X, Y)
 
 /** Explicit instantiation of the `MapView` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)
-abstract class AbstractMapView[K, +V] extends AbstractView[(K, V)] with MapView[K, V]:
-  this: AbstractMapView[K, V]^ =>
+abstract class AbstractMapView[K, +V] extends AbstractView[(K, V)] with MapView[K, V]
 

--- a/scala2-library-cc/src/scala/collection/Stepper.scala
+++ b/scala2-library-cc/src/scala/collection/Stepper.scala
@@ -39,7 +39,6 @@ import scala.collection.Stepper.EfficientSplit
   * @tparam A the element type of the Stepper
   */
 trait Stepper[@specialized(Double, Int, Long) +A] {
-  this: Stepper[A]^ =>
 
   /** Check if there's an element available. */
   def hasStep: Boolean
@@ -186,7 +185,6 @@ object Stepper {
 
 /** A Stepper for arbitrary element types. See [[Stepper]]. */
 trait AnyStepper[+A] extends Stepper[A] {
-  this: AnyStepper[A]^ =>
 
   def trySplit(): AnyStepper[A]
 
@@ -258,7 +256,6 @@ object AnyStepper {
 
 /** A Stepper for Ints. See [[Stepper]]. */
 trait IntStepper extends Stepper[Int] {
-  this: IntStepper^ =>
 
   def trySplit(): IntStepper
 
@@ -298,7 +295,6 @@ object IntStepper {
 
 /** A Stepper for Doubles. See [[Stepper]]. */
 trait DoubleStepper extends Stepper[Double] {
-  this: DoubleStepper^ =>
   def trySplit(): DoubleStepper
 
   def spliterator[B >: Double]: Spliterator.OfDouble^{this} = new DoubleStepper.DoubleStepperSpliterator(this)
@@ -338,7 +334,6 @@ object DoubleStepper {
 
 /** A Stepper for Longs. See [[Stepper]]. */
 trait LongStepper extends Stepper[Long] {
-  this: LongStepper^ =>
 
   def trySplit(): LongStepper^{this}
 

--- a/scala2-library-cc/src/scala/collection/View.scala
+++ b/scala2-library-cc/src/scala/collection/View.scala
@@ -24,7 +24,6 @@ import language.experimental.captureChecking
   * @define Coll `View`
   */
 trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] with IterableFactoryDefaults[A, View] with Serializable {
-  this: View[A]^ =>
 
   override def view: View[A]^{this} = this
 

--- a/scala2-library-cc/src/scala/collection/WithFilter.scala
+++ b/scala2-library-cc/src/scala/collection/WithFilter.scala
@@ -23,7 +23,6 @@ import language.experimental.captureChecking
   */
 @SerialVersionUID(3L)
 abstract class WithFilter[+A, +CC[_]] extends Serializable {
-  this: WithFilter[A, CC]^ =>
 
   /** Builds a new collection by applying a function to all elements of the
     * `filtered` outer $coll.

--- a/scala2-library-cc/src/scala/collection/immutable/Iterable.scala
+++ b/scala2-library-cc/src/scala/collection/immutable/Iterable.scala
@@ -25,8 +25,6 @@ import language.experimental.captureChecking
 trait Iterable[+A] extends collection.Iterable[A]
                       with collection.IterableOps[A, Iterable, Iterable[A]]
                       with IterableFactoryDefaults[A, Iterable] {
-  this: Iterable[A]^ =>
-
   override def iterableFactory: IterableFactory[Iterable] = Iterable
 }
 

--- a/scala2-library-cc/src/scala/collection/immutable/LazyListIterable.scala
+++ b/scala2-library-cc/src/scala/collection/immutable/LazyListIterable.scala
@@ -251,7 +251,6 @@ final class LazyListIterable[+A] private(private[this] var lazyState: () => Lazy
     with IterableOps[A, LazyListIterable, LazyListIterable[A]]
     with IterableFactoryDefaults[A, LazyListIterable]
     with Serializable {
-  this: LazyListIterable[A]^ =>
   import LazyListIterable._
 
   @volatile private[this] var stateEvaluated: Boolean = false
@@ -964,7 +963,6 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   private[this] val _empty = newLL(State.Empty).force
 
   private sealed trait State[+A] extends Serializable {
-    this: State[A]^ =>
     def head: A
     def tail: LazyListIterable[A]^
   }
@@ -1252,7 +1250,6 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   private class SlidingIterator[A](private[this] var lazyList: LazyListIterable[A]^, size: Int, step: Int)
     extends AbstractIterator[LazyListIterable[A]] {
-    this: SlidingIterator[A]^ =>
     private val minLen = size - step max 0
     private var first = true
 
@@ -1273,7 +1270,6 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   private final class WithFilter[A] private[LazyListIterable](lazyList: LazyListIterable[A]^, p: A => Boolean)
     extends collection.WithFilter[A, LazyListIterable] {
-    this: WithFilter[A]^ =>
     private[this] val filtered = lazyList.filter(p)
     def map[B](f: A => B): LazyListIterable[B]^{this, f} = filtered.map(f)
     def flatMap[B](f: A => IterableOnce[B]^): LazyListIterable[B]^{this, f} = filtered.flatMap(f)
@@ -1320,7 +1316,6 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   private object LazyBuilder {
     final class DeferredState[A] {
-      this: DeferredState[A]^ =>
       private[this] var _state: (() => State[A]^) @uncheckedCaptures = _
 
       def eval(): State[A]^ = {

--- a/scala2-library-cc/src/scala/collection/mutable/CheckedIndexedSeqView.scala
+++ b/scala2-library-cc/src/scala/collection/mutable/CheckedIndexedSeqView.scala
@@ -16,7 +16,6 @@ package mutable
 import language.experimental.captureChecking
 
 private[mutable] trait CheckedIndexedSeqView[+A] extends IndexedSeqView[A] {
-  this: CheckedIndexedSeqView[A]^ =>
 
   protected val mutationCount: () => Int
 

--- a/scala2-library-cc/src/scala/collection/mutable/Iterable.scala
+++ b/scala2-library-cc/src/scala/collection/mutable/Iterable.scala
@@ -19,7 +19,6 @@ trait Iterable[A]
   extends collection.Iterable[A]
     with collection.IterableOps[A, Iterable, Iterable[A]]
     with IterableFactoryDefaults[A, Iterable] {
-  this: Iterable[A]^ =>
 
   override def iterableFactory: IterableFactory[Iterable] = Iterable
 }
@@ -33,5 +32,4 @@ trait Iterable[A]
 object Iterable extends IterableFactory.Delegate[Iterable](ArrayBuffer)
 
 /** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses. */
-abstract class AbstractIterable[A] extends scala.collection.AbstractIterable[A] with Iterable[A]:
-  this: AbstractIterable[A]^ =>
+abstract class AbstractIterable[A] extends scala.collection.AbstractIterable[A] with Iterable[A]

--- a/tests/neg-custom-args/captures/cc-this4.check
+++ b/tests/neg-custom-args/captures/cc-this4.check
@@ -1,6 +1,7 @@
--- Error: tests/neg-custom-args/captures/cc-this4.scala:1:11 -----------------------------------------------------------
-1 |open class C: // error
-  |           ^
-  |           class C needs an explicitly declared self type since its
-  |           inferred self type C^{}
-  |           is not visible in other compilation units that define subclasses.
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-this4.scala:2:13 --------------------------------------
+2 |  val x: C = this  // error
+  |             ^^^^
+  |             Found:    (C.this : C^)
+  |             Required: C
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/cc-this4.scala
+++ b/tests/neg-custom-args/captures/cc-this4.scala
@@ -1,5 +1,5 @@
-open class C: // error
-  val x: C = this
+open class C:
+  val x: C = this  // error
 
 open class D:
   this: D =>

--- a/tests/pos-custom-args/captures/colltest.scala
+++ b/tests/pos-custom-args/captures/colltest.scala
@@ -3,22 +3,18 @@ object CollectionStrawMan5 {
 
   /** Base trait for generic collections */
   trait Iterable[+A] extends IterableLike[A] {
-    this: Iterable[A]^ =>
     def iterator: Iterator[A]^{this}
     def coll: Iterable[A]^{this} = this
   }
 
   trait IterableLike[+A]:
-    this: IterableLike[A]^ =>
     def coll: Iterable[A]^{this}
     def partition(p: A => Boolean): Unit =
       val pn = Partition(coll, p)
       ()
 
   /** Concrete collection type: View */
-  trait View[+A] extends Iterable[A] with IterableLike[A] {
-    this: View[A]^ =>
-  }
+  trait View[+A] extends Iterable[A] with IterableLike[A]
 
   case class Partition[A](val underlying: Iterable[A]^, p: A => Boolean) {
     self: Partition[A]^{underlying, p} =>

--- a/tests/pos-custom-args/captures/future-traverse.scala
+++ b/tests/pos-custom-args/captures/future-traverse.scala
@@ -5,7 +5,7 @@ trait BuildFrom[-From, -A, +C] {
   def newBuilder(from: From): Builder[A, C]
 }
 
-trait Future[+T] { this: Future[T]^ =>
+trait Future[+T] {
   import Future.*
   def foldLeft[R](r: R): R = r
   def traverse[A, B, M[X] <: IterableOnce[X]](in: M[A]^, bf: BuildFrom[M[A]^, B, M[B]^]): Unit =

--- a/tests/pos-custom-args/captures/hk-param.scala
+++ b/tests/pos-custom-args/captures/hk-param.scala
@@ -12,6 +12,5 @@ trait Itable[+A] extends ItableOnce[A] with ILike[A, Itable^]
 
 /** Iterator can be used only once */
 trait ItableOnce[+A] {
-  this: ItableOnce[A]^ =>
   def iterator: Iterator[A]^{this}
 }

--- a/tests/pos-custom-args/captures/iterators.scala
+++ b/tests/pos-custom-args/captures/iterators.scala
@@ -1,7 +1,6 @@
 package cctest
 
 trait IterableOnce[A]:
-  this: IterableOnce[A]^ =>
   def iterator: Iterator[A]^{this}
 
 abstract class Iterator[T]:

--- a/tests/pos-custom-args/captures/lazylists.scala
+++ b/tests/pos-custom-args/captures/lazylists.scala
@@ -2,8 +2,6 @@ class CC
 type Cap = CC^
 
 trait LazyList[+A]:
-  this: LazyList[A]^ =>
-
   def isEmpty: Boolean
   def head: A
   def tail: LazyList[A]^{this}

--- a/tests/pos-custom-args/captures/selftypes.scala
+++ b/tests/pos-custom-args/captures/selftypes.scala
@@ -20,5 +20,11 @@ class IM:
   def coll: IM^{this} = ???
   foo(coll)
 
+// Demonstrates root mapping for self types, implicitly
+class IM2:
+  def coll: IM2^{this} = ???
+  foo2(coll)
+
 def foo(im: IM^): Unit = ???
 
+def foo2(im: IM2^): Unit = ???

--- a/tests/pos-custom-args/captures/steppers.scala
+++ b/tests/pos-custom-args/captures/steppers.scala
@@ -1,6 +1,5 @@
 
-trait Stepper[+A]:
-  this: Stepper[A]^ =>
+trait Stepper[+A]
 
 object Stepper:
   trait EfficientSplit
@@ -8,7 +7,6 @@ object Stepper:
 sealed trait StepperShape[-T, S <: Stepper[_]^] extends Pure
 
 trait IterableOnce[+A] extends Any:
-  this: IterableOnce[A]^ =>
   def stepper[S <: Stepper[_]^{this}](implicit shape: StepperShape[A, S]): S = ???
 
 sealed abstract class ArraySeq[T] extends IterableOnce[T], Pure:


### PR DESCRIPTION
Fixes #19398 

Clean up the logic how we infer self types, and add a new clause:

> If we have an externally extensible class that itself does not have a
declared self type itself and also not in any of its base classes,
assume {cap} as the self type. Previously we would install a capture
set but then check after the fact that that capture set is indeed {cap}.
So it's less verbose to just assume that from the start.
