### PR TITLE
Reuse `-Yscala2Unpickler` to check Scala 2 library compilation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -151,7 +151,6 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
   assert(moduleRoot.isTerm)
 
   checkVersion(using ictx)
-  checkScala2Stdlib(using ictx)
 
   private val loadingMirror = defn(using ictx) // was: mirrorThatLoaded(classRoot)
 
@@ -237,9 +236,6 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         "\n found: " + major + "." + minor +
         " in " + source)
   }
-
-  private def checkScala2Stdlib(using Context): Unit =
-    assert(!ctx.settings.YcompileScala2Library.value, "No Scala 2 libraries should be unpickled under -Ycompile-scala2-library")
 
   /** The `decls` scope associated with given symbol */
   protected def symScope(sym: Symbol): Scope = symScopes.getOrElseUpdate(sym, newScope(0))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1063,6 +1063,7 @@ object Build {
       },
       Compile / doc / scalacOptions += "-Ydocument-synthetic-types",
       scalacOptions += "-Ycompile-scala2-library",
+      scalacOptions += "-Yscala2Unpickler:never",
       scalacOptions -= "-Xfatal-warnings",
       Compile / compile / logLevel := Level.Error,
       ivyConfigurations += SourceDeps.hide,


### PR DESCRIPTION
We want to make sure that the Scala 2 library JAR compiled with Scala 2 is not loaded when we compile the Scala 2 library TASTy. The `-Yscala2Unpickler:never` can be used to ensure this.