### PR TITLE
Clean `scala2-library` on `scala3-bootstrapped/clean`

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2117,6 +2117,9 @@ object Build {
       dependsOn(tastyCore).
       dependsOn(dottyCompiler).
       dependsOn(dottyLibrary).
+      bootstrappedSettings(
+        addCommandAlias("clean", ";scala3-bootstrapped/clean;scala2-library-bootstrapped/clean;scala2-library-cc/clean"),
+      ).
       nonBootstrappedSettings(
         addCommandAlias("run", "scala3-compiler/run"),
         // Clean everything by default


### PR DESCRIPTION
Follow-up of #19447