### PR TITLE
Scala 2.13.12 (was 2.13.10)

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -852,8 +852,8 @@ class CompletionSuite extends BaseCompletionSuite:
       """|dynamics scala.languageFeature
          |existentials scala.languageFeature
          |experimental scala.languageFeature
-         |higherKinds scala.languageFeature
          |implicitConversions scala.languageFeature
+         |postfixOps scala.languageFeature
          |""".stripMargin,
       topLines = Some(5)
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -121,8 +121,8 @@ object Build {
    *  scala-library.
    */
   def stdlibVersion(implicit mode: Mode): String = mode match {
-    case NonBootstrapped => "2.13.10"
-    case Bootstrapped => "2.13.10"
+    case NonBootstrapped => "2.13.12"
+    case Bootstrapped => "2.13.12"
   }
 
   val dottyOrganization = "org.scala-lang"

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -14,6 +14,10 @@ object MiMaFilters {
     ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.relaxedExtensionImports"),
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$relaxedExtensionImports$"),
     // end of New experimental features in 3.3.X
+
+    // New in 2.13.12 -- can be removed once scala/scala#10549 lands in 2.13.13
+    // and we take the upgrade here
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.MapNodeRemoveAllSetNodeIterator.next"),
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
   )

--- a/project/scripts/cmdScaladocTests
+++ b/project/scripts/cmdScaladocTests
@@ -37,7 +37,7 @@ dist/target/pack/bin/scaladoc \
   "-snippet-compiler:scaladoc-testcases/docs=compile" \
   "-comment-syntax:scaladoc-testcases/src/example/comment-md=markdown,scaladoc-testcases/src/example/comment-wiki=wiki" \
   -siteroot scaladoc-testcases/docs \
-  -project-footer "Copyright (c) 2002-2023, LAMP/EPFL" \
+  -project-footer "Copyright (c) 2002-2024, LAMP/EPFL" \
   -default-template static-site-main \
   -author -groups -revision main -project-version "${DOTTY_BOOTSTRAPPED_VERSION}" \
   "-quick-links:Learn::https://docs.scala-lang.org/,Install::https://www.scala-lang.org/download/,Playground::https://scastie.scala-lang.org,Find A Library::https://index.scala-lang.org,Community::https://www.scala-lang.org/community/,Blog::https://www.scala-lang.org/blog/," \


### PR DESCRIPTION
backports https://github.com/lampepfl/dotty/pull/18525 , which was on the "Scala 3.3 LTS backports" project board but seems to have been overlooked

@Kordyjan is it too late for this to make 3.3.2...?

fyi @lrytz 

yes, I think we should ship this even though 2.13.13 is coming soon