### PR TITLE
Warn when @volatile is used on vals

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -206,6 +206,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case PureUnitExpressionID // errorNumber: 190
   case MatchTypeLegacyPatternID // errorNumber: 191
   case UnstableInlineAccessorID // errorNumber: 192
+  case VolatileOnValID // errorNumber: 193
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3146,3 +3146,8 @@ class UnstableInlineAccessor(accessed: Symbol, accessorTree: tpd.Tree)(using Con
     if accessor.owner.name.isPackageObjectName then accessor.owner.owner.name.stripModuleClassSuffix
     else accessor.owner.name.stripModuleClassSuffix
 }
+
+class VolatileOnVal()(using Context)
+extends SyntaxMsg(VolatileOnValID):
+  protected def msg(using Context): String = "values cannot be volatile"
+  protected def explain(using Context): String = ""

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1001,6 +1001,10 @@ object RefChecks {
           report.error(em"private $sym cannot override ${other.showLocated}", sym.srcPos)
   end checkNoPrivateOverrides
 
+  def checkVolatile(sym: Symbol)(using Context): Unit =
+    if sym.isVolatile && !sym.is(Mutable) then 
+      report.warning(VolatileOnVal(), sym.srcPos)
+  
   /** Check that unary method definition do not receive parameters.
    *  They can only receive inferred parameters such as type parameters and implicit parameters.
    */
@@ -1183,6 +1187,7 @@ class RefChecks extends MiniPhase { thisPhase =>
     if tree.symbol.exists then
       checkNoPrivateOverrides(tree)
       val sym = tree.symbol
+      checkVolatile(sym)
       if (sym.exists && sym.owner.isTerm) {
         tree.rhs match {
           case Ident(nme.WILDCARD) => report.error(UnboundPlaceholderParameter(), sym.srcPos)

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -160,7 +160,7 @@ final class FileZipArchive(jpath: JPath, release: Option[String]) extends ZipArc
     override def sizeOption: Option[Int] = Some(zipEntry.getSize.toInt)
   }
 
-  @volatile lazy val (root, allDirs): (DirEntry, collection.Map[String, DirEntry]) = {
+  lazy val (root, allDirs): (DirEntry, collection.Map[String, DirEntry]) = {
     val root = new DirEntry("/", null)
     val dirs = mutable.HashMap[String, DirEntry]("/" -> root)
     val zipFile = openZipFile()

--- a/sbt-test/sbt-dotty/scaladoc/src/main/scala/AutoParamTupling.scala
+++ b/sbt-test/sbt-dotty/scaladoc/src/main/scala/AutoParamTupling.scala
@@ -11,7 +11,7 @@ object AutoParamTupling {
       * In order to get thread safety, you need to put @volatile before lazy vals.
       * https://dotty.epfl.ch/docs/reference/changed-features/lazy-vals.html
       */
-    @volatile lazy val xs: List[String] = List("d", "o", "t", "t", "y")
+    lazy val xs: List[String] = List("d", "o", "t", "t", "y")
 
     /**
       * Current behaviour in Scala 2.12.2 :

--- a/tests/warn/i19416.check
+++ b/tests/warn/i19416.check
@@ -1,0 +1,4 @@
+-- [E193] Syntax Warning: tests/warn/i19416.scala:2:18 -----------------------------------------------------------------
+2 |    @volatile val x: Int = ??? // warn
+  |                  ^
+  |                  values cannot be volatile

--- a/tests/warn/i19416.scala
+++ b/tests/warn/i19416.scala
@@ -1,0 +1,2 @@
+class Foo:
+    @volatile val x: Int = ??? // warn


### PR DESCRIPTION
Fixes #19416

Done on the scala spree of 16.01.2024 with @mbovel 