### PR TITLE
Backport "Fix expandParam's use of argForParam/isArgPrefixOf."

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6276,7 +6276,7 @@ object Types extends TypeUtils {
      */
     def expandParam(tp: NamedType, pre: Type): Type =
       tp.argForParam(pre) match {
-        case arg @ TypeRef(pre, _) if pre.isArgPrefixOf(arg.symbol) =>
+        case arg @ TypeRef(`pre`, _) if pre.isArgPrefixOf(arg.symbol) =>
           arg.info match {
             case argInfo: TypeBounds => expandBounds(argInfo)
             case argInfo => useAlternate(arg)

--- a/tests/pos/i19354.orig.scala
+++ b/tests/pos/i19354.orig.scala
@@ -10,7 +10,6 @@ class P extends AbstractProcessor {
       .flatMap(annotation => roundEnv.getElementsAnnotatedWith(annotation).stream())
       .filter(element => element.getKind == ElementKind.PACKAGE)
       .map(element => element.asInstanceOf[PackageElement])
-      .toList()
     true
   }
 }

--- a/tests/pos/i19354.orig.scala
+++ b/tests/pos/i19354.orig.scala
@@ -1,0 +1,16 @@
+import javax.annotation.processing.{ AbstractProcessor, RoundEnvironment }
+import javax.lang.model.element.{ ElementKind, PackageElement, TypeElement }
+
+import java.util as ju
+
+class P extends AbstractProcessor {
+  override def process(annotations: ju.Set[? <: TypeElement], roundEnv: RoundEnvironment): Boolean = {
+    annotations
+      .stream()
+      .flatMap(annotation => roundEnv.getElementsAnnotatedWith(annotation).stream())
+      .filter(element => element.getKind == ElementKind.PACKAGE)
+      .map(element => element.asInstanceOf[PackageElement])
+      .toList()
+    true
+  }
+}

--- a/tests/pos/i19354.scala
+++ b/tests/pos/i19354.scala
@@ -1,0 +1,7 @@
+class Foo; class Bar
+class Test:
+  def t1(xs: java.util.stream.Stream[? <: Foo]) =
+    xs.map(x => take(x))
+
+  def take(x: Foo) = ""
+  def take(x: Bar) = ""


### PR DESCRIPTION
Backports #19412 for 3.4.0