### PR TITLE
Update base version to 3.4.1-RC1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -85,7 +85,7 @@ object Build {
 
   val referenceVersion = "3.3.1"
 
-  val baseVersion = "3.4.0-RC1"
+  val baseVersion = "3.4.1-RC1"
 
   // Versions used by the vscode extension to create a new project
   // This should be the latest published releases.
@@ -101,7 +101,7 @@ object Build {
    *  set to 3.1.3. If it is going to be 3.1.0, it must be set to the latest
    *  3.0.x release.
    */
-  val previousDottyVersion = "3.3.1"
+  val previousDottyVersion = "3.4.0-RC1"
 
   object CompatMode {
     final val BinaryCompatible = 0

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2163,7 +2163,8 @@ object Build {
             (Compile/doc/target).value
           },
           commonMiMaSettings,
-          mimaBinaryIssueFilters ++= MiMaFilters.Library
+          mimaBackwardIssueFilters := MiMaFilters.LibraryBackwards,
+          mimaForwardIssueFilters := MiMaFilters.LibraryForward,
         )
       } else base
     }

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -3,18 +3,17 @@ import com.typesafe.tools.mima.core._
 
 object MiMaFilters {
   val Library: Seq[ProblemFilter] = Seq(
-    // New API in 3.4.X
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#FlagsModule.AbsOverride"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule.ValOrDefDefTypeTest"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule.ValOrDefDefMethods"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#defnModule.FunctionClass"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#defnModule.PolyFunctionClass"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TypeReprMethods.dealiasKeepOpaques"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.paramVariance"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TypeLambdaMethods.paramVariances"),
+    // This language feature was in 3.4.0-RC1 but will be removed in 3.4.0-RC2
+    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#deprecated.ascriptionVarargsUnpacking"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$deprecated$ascriptionVarargsUnpacking$"),
+
+    // This language feature is not in 3.4.0-RC1 but will be added in 3.4.0-RC2
+    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.5-migration"),
+    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.5"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E5$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E5$minusmigration$"),
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
-    ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyFormat.EXPLICITtpt"),
   )
   val Interfaces: Seq[ProblemFilter] = Seq(
   )

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -2,16 +2,24 @@
 import com.typesafe.tools.mima.core._
 
 object MiMaFilters {
-  val Library: Seq[ProblemFilter] = Seq(
-    // This language feature was in 3.4.0-RC1 but will be removed in 3.4.0-RC2
-    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#deprecated.ascriptionVarargsUnpacking"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$deprecated$ascriptionVarargsUnpacking$"),
-
-    // This language feature is not in 3.4.0-RC1 but will be added in 3.4.0-RC2
-    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.5-migration"),
-    ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.5"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E5$"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E5$minusmigration$"),
+  val LibraryBackwards: Map[String, Seq[ProblemFilter]] = Map(
+    // In general we should never have backwards incompatible changes in the library.
+    // Only exceptional cases should be added here.
+    Build.previousDottyVersion -> Seq(
+      // This language feature was in 3.4.0-RC1 but will be removed in 3.4.0-RC2
+      ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#deprecated.ascriptionVarargsUnpacking"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$deprecated$ascriptionVarargsUnpacking$"),
+    )
+  )
+  val LibraryForward: Map[String, Seq[ProblemFilter]] = Map(
+    // Additions that require a new minor version of the library
+    Build.previousDottyVersion -> Seq(
+      // This language feature is not in 3.4.0-RC1 but will be added in 3.4.0-RC2
+      ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.5-migration"),
+      ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.5"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E5$"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E5$minusmigration$"),
+    )
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
   )


### PR DESCRIPTION
Part of #19321

We are currently releasing nightlies with the wrong version. We should update this now. We do not need to wait until we can update the reference version.

Now we can check MiMa against 3.4.0-RC1 to ensure that the API has not changed.
However, that version has a couple of mistakes that will be fixed in 3.4.0-RC2.
