### PR TITLE
Disable i19170b on Windows

### DIFF
--- a/staging/src/scala/quoted/staging/QuoteDriver.scala
+++ b/staging/src/scala/quoted/staging/QuoteDriver.scala
@@ -56,7 +56,7 @@ private class QuoteDriver(appClassloader: ClassLoader) extends Driver:
         try method.invoke(inst).asInstanceOf[T]
         catch case ex: java.lang.reflect.InvocationTargetException =>
           ex.getCause match
-            case ex: java.lang.NoClassDefFoundError =>
+            case _: java.lang.NoClassDefFoundError =>
               throw new Exception(
                 s"""`scala.quoted.staging.run` failed to load a class.
                    |The classloader used for the `staging.Compiler` instance might not be the correct one.

--- a/tests/run-staging/i19170b.scala
+++ b/tests/run-staging/i19170b.scala
@@ -8,9 +8,10 @@ class A(i: Int)
 def f(i: Expr[Int])(using Quotes): Expr[A] = { '{ new A($i) } }
 
 @main def Test = {
-  try
-    val g: Int => A = staging.run { '{ (i: Int) => ${ f('{i}) } } }
-    println(g(3))
-  catch case ex: Exception =>
-    assert(ex.getMessage().startsWith("`scala.quoted.staging.run` failed to load a class."))
+  if !System.getProperty("os.name").contains("Windows") then
+    try
+      val g: Int => A = staging.run { '{ (i: Int) => ${ f('{i}) } } }
+      println(g(3))
+    catch case ex: Exception =>
+      assert(ex.getMessage().startsWith("`scala.quoted.staging.run` failed to load a class."), ex.getMessage())
 }


### PR DESCRIPTION
This is currently broken on the `main` branch.

This fails due to a different exception in Windows. In that case it is not obvious how the heuristic can identify a probable classpath issue.

[test_windows_full]
