### PR TITLE
Update TASTy minor version for nightlies of 3.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -83,7 +83,7 @@ object DottyJSPlugin extends AutoPlugin {
 object Build {
   import ScaladocConfigs._
 
-  val referenceVersion = "3.4.0-RC1"
+  val referenceVersion = "3.3.1"
 
   val baseVersion = "3.4.1-RC1"
 

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -316,9 +316,9 @@ object TastyFormat {
   /** Natural number. Each increment of the `MinorVersion`, within
    *  a series declared by the `MajorVersion`, breaks forward
    *  compatibility, but remains backwards compatible, with all
-   *  preceeding `MinorVersion`.
+   *  preceding `MinorVersion`.
    */
-  final val MinorVersion: Int = 4
+  final val MinorVersion: Int = 5
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing


### PR DESCRIPTION
These have a minor version one greater that the Scala minor version. Only released version and RCs have the same minor version as Scala.

Use the latest stable version of Scala due to some conflicts with the TASTy version in 3.4.0-RC1.