### PR TITLE
Disable i19170b on JDK8

### DIFF
--- a/tests/run-staging/i19170b.scala
+++ b/tests/run-staging/i19170b.scala
@@ -8,7 +8,8 @@ class A(i: Int)
 def f(i: Expr[Int])(using Quotes): Expr[A] = { '{ new A($i) } }
 
 @main def Test = {
-  if !System.getProperty("os.name").contains("Windows") then
+  // The heuristic to give the extra information does not work on JDK 8
+  if System.getProperty("java.specification.version") != "1.8" then
     try
       val g: Int => A = staging.run { '{ (i: Int) => ${ f('{i}) } } }
       println(g(3))


### PR DESCRIPTION
Fixes #19481
Fixes #19495
Fixes #19502
Followup of  #19471

[test_java8]
[test_windows_full]