### PR TITLE
Make PC more resiliant to crashes

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/ConvertToNamedArgumentsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ConvertToNamedArgumentsProvider.scala
@@ -35,7 +35,7 @@ final class ConvertToNamedArgumentsProvider(
     val tree = Interactive.pathTo(trees, pos)(using newctx).headOption
 
     def paramss(fun: tpd.Tree)(using Context): List[String] =
-      fun.tpe match
+      fun.typeOpt match
         case m: MethodType => m.paramNamess.flatten.map(_.toString)
         case _ =>
           fun.symbol.rawParamss.flatten

--- a/presentation-compiler/src/main/dotty/tools/pc/ExtractMethodProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ExtractMethodProvider.scala
@@ -128,7 +128,7 @@ final class ExtractMethodProvider(
       yield
         val defnPos = stat.sourcePos
         val extractedPos = head.sourcePos.withEnd(expr.sourcePos.end)
-        val exprType = prettyPrint(expr.tpe.widen)
+        val exprType = prettyPrint(expr.typeOpt.widen)
         val name =
           genName(indexedCtx.scopeSymbols.map(_.decodedName).toSet, "newMethod")
         val (methodParams, typeParams) =

--- a/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
@@ -48,7 +48,7 @@ object HoverProvider:
     val indexedContext = IndexedContext(ctx)
 
     def typeFromPath(path: List[Tree]) =
-      if path.isEmpty then NoType else path.head.tpe
+      if path.isEmpty then NoType else path.head.typeOpt
 
     val tp = typeFromPath(path)
     val tpw = tp.widenTermRefExpr
@@ -185,7 +185,7 @@ object HoverProvider:
             findRefinement(parent)
           case _ => None
 
-      val refTpe = sel.tpe.widen.metalsDealias match
+      val refTpe = sel.typeOpt.widen.metalsDealias match
         case r: RefinedType => Some(r)
         case t: (TermRef | TypeProxy) => Some(t.termSymbol.info.metalsDealias)
         case _ => None

--- a/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
@@ -138,7 +138,7 @@ final class InferredTypeProvider(
           adjustOpt.foreach(adjust => endPos.setEnd(adjust.adjustedEndPos))
           new TextEdit(
             endPos,
-            ": " + printType(optDealias(tpt.tpe)) + {
+            ": " + printType(optDealias(tpt.typeOpt)) + {
               if withParens then ")" else ""
             }
           )
@@ -211,7 +211,7 @@ final class InferredTypeProvider(
           adjustOpt.foreach(adjust => end.setEnd(adjust.adjustedEndPos))
           new TextEdit(
             end,
-            ": " + printType(optDealias(tpt.tpe))
+            ": " + printType(optDealias(tpt.typeOpt))
           )
         end typeNameEdit
 
@@ -241,7 +241,7 @@ final class InferredTypeProvider(
         def baseEdit(withParens: Boolean) =
           new TextEdit(
             bind.endPos.toLsp,
-            ": " + printType(optDealias(body.tpe)) + {
+            ": " + printType(optDealias(body.typeOpt)) + {
               if withParens then ")" else ""
             }
           )
@@ -274,7 +274,7 @@ final class InferredTypeProvider(
       case Some(i @ Ident(name)) =>
         val typeNameEdit = new TextEdit(
           i.endPos.toLsp,
-          ": " + printType(optDealias(i.tpe.widen))
+          ": " + printType(optDealias(i.typeOpt.widen))
         )
         typeNameEdit :: imports
 

--- a/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
@@ -190,7 +190,7 @@ object MetalsInteractive:
        */
       case (tpt: TypeTree) :: parent :: _
           if tpt.span != parent.span && !tpt.symbol.is(Synthetic) =>
-        List((tpt.symbol, tpt.tpe))
+        List((tpt.symbol, tpt.typeOpt))
 
       /* TypeTest class https://dotty.epfl.ch/docs/reference/other-new-features/type-test.html
        * compiler automatically adds unapply if possible, we need to find the type symbol

--- a/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
@@ -108,7 +108,7 @@ class PcDefinitionProvider(
       case Nil =>
         path.headOption match
           case Some(value: Literal) =>
-            definitionsForSymbol(List(value.tpe.widen.typeSymbol), pos)
+            definitionsForSymbol(List(value.typeOpt.widen.typeSymbol), pos)
           case _ => DefinitionResultImpl.empty
       case _ =>
         definitionsForSymbol(typeSymbols, pos)

--- a/presentation-compiler/src/main/dotty/tools/pc/PcSyntheticDecorationProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcSyntheticDecorationProvider.scala
@@ -114,7 +114,7 @@ final class PcSyntheticDecorationsProvider(
   ): String =
     val tpdPath =
       Interactive.pathTo(unit.tpdTree, pos.span)
-    
+
     val indexedCtx = IndexedContext(Interactive.contextOfPath(tpdPath))
     val printer = ShortenedTypePrinter(
       symbolSearch
@@ -210,7 +210,7 @@ object TypeParameters:
           case sel: Select if sel.isInfix =>
             sel.sourcePos.withEnd(sel.nameSpan.end)
           case _ => fun.sourcePos
-        val tpes = args.map(_.tpe.stripTypeVar.widen.finalResultType)
+        val tpes = args.map(_.typeOpt.stripTypeVar.widen.finalResultType)
         Some((tpes, pos.endPos, fun))
       case _ => None
   private def inferredTypeArgs(args: List[Tree]): Boolean =
@@ -232,7 +232,7 @@ object InferredType:
             !vd.symbol.is(Flags.Enum) &&
             !isValDefBind(text, vd) =>
         if vd.symbol == vd.symbol.sourceSymbol then
-          Some(tpe.tpe, tpe.sourcePos.withSpan(vd.nameSpan), vd)
+          Some(tpe.typeOpt, tpe.sourcePos.withSpan(vd.nameSpan), vd)
         else None
       case vd @ DefDef(_, _, tpe, _)
           if isValidSpan(tpe.span, vd.nameSpan) &&
@@ -240,7 +240,7 @@ object InferredType:
             !vd.symbol.isConstructor &&
             !vd.symbol.is(Flags.Mutable) =>
         if vd.symbol == vd.symbol.sourceSymbol then
-          Some(tpe.tpe, tpe.sourcePos, vd)
+          Some(tpe.typeOpt, tpe.sourcePos, vd)
         else None
       case bd @ Bind(
             name,

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -122,7 +122,7 @@ class Completions(
           // should not show completions for toplevel
           case Nil | (_: PackageDef) :: _ if pos.source.file.extension != "sc" =>
             (allAdvanced, SymbolSearch.Result.COMPLETE)
-          case Select(qual, _) :: _ if qual.tpe.isErroneous =>
+          case Select(qual, _) :: _ if qual.typeOpt.isErroneous =>
             (allAdvanced, SymbolSearch.Result.COMPLETE)
           case Select(qual, _) :: _ =>
             val (_, compilerCompletions) = Completion.completions(pos)
@@ -752,7 +752,7 @@ class Completions(
         items
 
     def forSelect(sel: Select): CompletionApplication =
-      val tpe = sel.qualifier.tpe
+      val tpe = sel.qualifier.typeOpt
       val members = tpe.allMembers.map(_.symbol).toSet
 
       new CompletionApplication:

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
@@ -74,8 +74,8 @@ object CaseKeywordCompletion:
     val parents: Parents = selector match
       case EmptyTree =>
         val seenFromType = parent match
-          case TreeApply(fun, _) if !fun.tpe.isErroneous => fun.tpe
-          case _ => parent.tpe
+          case TreeApply(fun, _) if !fun.typeOpt.isErroneous => fun.typeOpt
+          case _ => parent.typeOpt
         seenFromType.paramInfoss match
           case (head :: Nil) :: _
               if definitions.isFunctionType(head) || head.isRef(
@@ -84,7 +84,7 @@ object CaseKeywordCompletion:
             val argTypes = head.argTypes.init
             new Parents(argTypes, definitions)
           case _ => new Parents(NoType, definitions)
-      case sel => new Parents(sel.tpe, definitions)
+      case sel => new Parents(sel.typeOpt, definitions)
 
     val selectorSym = parents.selector.widen.metalsDealias.typeSymbol
 
@@ -240,7 +240,7 @@ object CaseKeywordCompletion:
       completionPos,
       clientSupportsSnippets
     )
-    val tpe = selector.tpe.widen.metalsDealias.bounds.hi match
+    val tpe = selector.typeOpt.widen.metalsDealias.bounds.hi match
       case tr @ TypeRef(_, _) => tr.underlying
       case t => t
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
@@ -95,7 +95,7 @@ object OverrideCompletions:
     // not using `td.tpe.abstractTermMembers` because those members includes
     // the abstract members in `td.tpe`. For example, when we type `def foo@@`,
     // `td.tpe.abstractTermMembers` contains `method foo: <error>` and it overrides the parent `foo` method.
-    val overridables = td.tpe.parents
+    val overridables = td.typeOpt.parents
       .flatMap { parent =>
         parent.membersBasedOnFlags(
           flags,
@@ -279,7 +279,7 @@ object OverrideCompletions:
         else ""
       (indent, indent, lastIndent)
     end calcIndent
-    val abstractMembers = defn.tpe.abstractTermMembers.map(_.symbol)
+    val abstractMembers = defn.typeOpt.abstractTermMembers.map(_.symbol)
 
     val caseClassOwners = Set("Product", "Equals")
     val overridables =
@@ -307,7 +307,7 @@ object OverrideCompletions:
     if edits.isEmpty then Nil
     else
       // A list of declarations in the class/object to implement
-      val decls = defn.tpe.decls.toList
+      val decls = defn.typeOpt.decls.toList
         .filter(sym =>
           !sym.isPrimaryConstructor &&
             !sym.isTypeParam &&
@@ -418,7 +418,7 @@ object OverrideCompletions:
       // `iterator` method in `new Iterable[Int] { def iterato@@ }`
       // should be completed as `def iterator: Iterator[Int]` instead of `Iterator[A]`.
       val seenFrom =
-        val memInfo = defn.tpe.memberInfo(sym.symbol)
+        val memInfo = defn.typeOpt.memberInfo(sym.symbol)
         if memInfo.isErroneous || memInfo.finalResultType.isAny then
           sym.info.widenTermRefExpr
         else memInfo

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/MtagsEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/MtagsEnrichments.scala
@@ -298,10 +298,10 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
     def seenFrom(sym: Symbol)(using Context): (Type, Symbol) =
       try
         val pre = tree.qual
-        val denot = sym.denot.asSeenFrom(pre.tpe.widenTermRefExpr)
+        val denot = sym.denot.asSeenFrom(pre.typeOpt.widenTermRefExpr)
         (denot.info, sym.withUpdatedTpe(denot.info))
       catch case NonFatal(e) => (sym.info, sym)
-    
+
     def isInfix(using ctx: Context) =
       tree match
         case Select(New(_), _) => false
@@ -355,7 +355,7 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
               case t: GenericApply
                   if t.fun.srcPos.span.contains(
                     pos.span
-                  ) && !t.tpe.isErroneous =>
+                  ) && !t.typeOpt.isErroneous =>
                 tryTail(tail).orElse(Some(enclosing))
               case in: Inlined =>
                 tryTail(tail).orElse(Some(enclosing))

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1679,3 +1679,11 @@ class CompletionSuite extends BaseCompletionSuite:
         |""".stripMargin,
       ""
     )
+
+  @Test def `dont-crash-implicit-search` =
+    check(
+      """object M:
+        |  Array[Int].fi@@
+        |""".stripMargin,
+      ""
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTypeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTypeSuite.scala
@@ -368,3 +368,29 @@ class HoverTypeSuite extends BaseHoverSuite:
       """|extension (i: MyIntOut) def uneven: Boolean
          |""".stripMargin.hover,
     )
+
+  @Test def `recursive-enum-without-type` =
+    check(
+      """class Wrapper(n: Int):
+        |  extension (x: Int)
+        |    def + (y: Int) = new Wrap@@per(x) + y
+        |""".stripMargin,
+      """```scala
+        |def this(n: Int): Wrapper
+        |```
+        |""".stripMargin
+    )
+
+  @Test def `recursive-enum-without-type-1` =
+    check(
+      """class Wrapper(n: Int):
+        |  def add(x: Int): Wrapper = ???
+        |  extension (x: Int)
+        |    def + (y: Int) = Wrap@@per(x).add(5)
+        |""".stripMargin,
+      """```scala
+        |def this(n: Int): Wrapper
+        |```
+        |""".stripMargin
+    )
+


### PR DESCRIPTION
When working with code that is recovered from errors, we should use `typeOpt` instead of `tpe` as it can sometimes be null. The added test cases were the exact snippet that previously failed. I took this opportunity to change all calls to `tpe` to `typeOpt`.