### PR TITLE
tweak: snippet compiler settings

### DIFF
--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -1637,10 +1637,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      *    val q: Quotes = summon[Quotes]
      *    import q.reflect._
      *  //}
-     *    val intArgs = List(Literal(Constant(1)), Literal(Constant(2)))
+     *    val intArgs = List(Literal(IntConstant(1)), Literal(IntConstant(2)))
      *    Typed(
-     *     Repeated(intArgs, TypeTree.of[Int]),
-     *     Inferred(defn.RepeatedParamClass.typeRef.appliedTo(TypeRepr.of[Int]))
+     *      Repeated(intArgs, TypeTree.of[Int]),
+     *      Inferred(defn.RepeatedParamClass.typeRef.appliedTo(TypeRepr.of[Int]))
+     *    )
      *  //{
      *  }
      *  //}

--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -15,14 +15,16 @@ import scala.annotation.implicitNotFound
  *      be rewritten to jumps.
  *
  * Example usage:
+ * 
+ * ```scala
+ * import scala.util.boundary, boundary.break
  *
- *      import scala.util.boundary, boundary.break
- *
- *      def firstIndex[T](xs: List[T], elem: T): Int =
- *        boundary:
- *          for (x, i) <- xs.zipWithIndex do
- *            if x == elem then break(i)
- *          -1
+ * def firstIndex[T](xs: List[T], elem: T): Int =
+ *   boundary:
+ *     for (x, i) <- xs.zipWithIndex do
+ *       if x == elem then break(i)
+ *     -1
+ * ```
  */
 object boundary:
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2359,7 +2359,10 @@ object ScaladocConfigs {
       .add(VersionsDictionaryUrl("https://scala-lang.org/api/versions.json"))
       .add(DocumentSyntheticTypes(true))
       .add(SnippetCompiler(List(
-        s"${dottyLibRoot}/scala=compile",
+        s"$dottyLibRoot/src/scala=compile",
+        s"$dottyLibRoot/src/scala/compiletime=compile",
+        s"$dottyLibRoot/src/scala/util=compile",
+        s"$dottyLibRoot/src/scala/util/control=compile"
       )))
       .add(SiteRoot("docs"))
       .add(ApiSubdirectory(true))
@@ -2375,7 +2378,9 @@ object ScaladocConfigs {
       .add(SnippetCompiler(
         List(
           s"$dottyLibrarySrc/scala/quoted=compile",
-          s"$dottyLibrarySrc/scala/compiletime=compile"
+          s"$dottyLibrarySrc/scala/compiletime=compile",
+          s"$dottyLibrarySrc/scala/util=compile",
+          s"$dottyLibrarySrc/scala/util/control=compile"
         )
       ))
       .add(CommentSyntax(List(


### PR DESCRIPTION
- Fix build settings to make the snippet compiler to work properly
   - Before this change, snippet compiler read from `library/scala` instead of `library/src/scala` 
- Tweak some doc snippets so that they pass snippet compiker check

Related to: https://github.com/lampepfl/dotty/issues/12967