### PR TITLE
fix(#15784): ident rule for pat match  was too strict

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -944,7 +944,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
      *                   (x: T) to (x @ (w: T)). This is either `_` or `_*`.
      */
     def cases(ifPat: => Tree, ifExpr: => Tree, wildName: TermName) = tree.expr match {
-      case id: untpd.Ident if (ctx.mode is Mode.Pattern) && untpd.isVarPattern(id) =>
+      case id: untpd.Ident if (ctx.mode is Mode.Pattern) =>
         if (id.name == nme.WILDCARD || id.name == nme.WILDCARD_STAR) ifPat
         else {
           import untpd.*

--- a/tests/neg/i15784.check
+++ b/tests/neg/i15784.check
@@ -1,12 +1,12 @@
--- [E006] Not Found Error: tests/neg/i15784.scala:2:26 -----------------------------------------------------------------
-2 |      case List(_, Rest @ `a`) => Rest // error
-  |                          ^^^
-  |                          Not found: a
+-- [E006] Not Found Error: tests/neg/i15784.scala:2:22 -----------------------------------------------------------------
+2 |  case List(_, Rest @ `a`) => Rest // error
+  |                      ^^^
+  |                      Not found: a
   |
   | longer explanation available when compiling with `-explain`
--- [E006] Not Found Error: tests/neg/i15784.scala:3:26 -----------------------------------------------------------------
-3 |      case List(_, Rest @ A) => Rest // error 
-  |                          ^
-  |                          Not found: A
+-- [E006] Not Found Error: tests/neg/i15784.scala:3:22 -----------------------------------------------------------------
+3 |  case List(_, Rest @ A) => Rest // error 
+  |                      ^
+  |                      Not found: A
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i15784.check
+++ b/tests/neg/i15784.check
@@ -1,0 +1,12 @@
+-- [E006] Not Found Error: tests/neg/i15784.scala:2:26 -----------------------------------------------------------------
+2 |      case List(_, Rest @ `a`) => Rest // error
+  |                          ^^^
+  |                          Not found: a
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i15784.scala:3:26 -----------------------------------------------------------------
+3 |      case List(_, Rest @ A) => Rest // error 
+  |                          ^
+  |                          Not found: A
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i15784.scala
+++ b/tests/neg/i15784.scala
@@ -1,4 +1,4 @@
 def i15784 = List(42) match
-      case List(_, Rest @ `a`) => Rest // error
-      case List(_, Rest @ A) => Rest // error 
-      case _ => ???
+  case List(_, Rest @ `a`) => Rest // error
+  case List(_, Rest @ A) => Rest // error 
+  case _ => ???

--- a/tests/neg/i15784.scala
+++ b/tests/neg/i15784.scala
@@ -1,0 +1,4 @@
+def i15784 = List(42) match
+      case List(_, Rest @ `a`) => Rest // error
+      case List(_, Rest @ A) => Rest // error 
+      case _ => ???

--- a/tests/pos/i15784.scala
+++ b/tests/pos/i15784.scala
@@ -1,0 +1,8 @@
+def i15784 = List(42) match
+      case List(_, rest @ _*) => rest
+      case List(_, Rest @ _*) => Rest
+      case List(_, `Rest` @ _*) => Rest
+      case _ => ???
+
+def i15784_auxiliary = 42 match
+      case `type` : Int => `type`

--- a/tests/pos/i15784.scala
+++ b/tests/pos/i15784.scala
@@ -1,8 +1,8 @@
 def i15784 = List(42) match
-      case List(_, rest @ _*) => rest
-      case List(_, Rest @ _*) => Rest
-      case List(_, `Rest` @ _*) => Rest
-      case _ => ???
+  case List(_, rest @ _*) => rest
+  case List(_, Rest @ _*) => Rest
+  case List(_, `Rest` @ _*) => Rest
+  case _ => ???
 
 def i15784_auxiliary = 42 match
-      case `type` : Int => `type`
+  case `type` : Int => `type`


### PR DESCRIPTION
close https://github.com/lampepfl/dotty/issues/15784

Scala 2 allows backticked identifier and capital identifier in pattern match, but Scala 3 mistakenly prohibited them.

For example, the following code is valid in Scala 2,

```scala
List(42) match {
  case List(_, Rest @ _*) => Rest
  case List(_, `Rest` @ _*) => `Rest`
  _ => ???
}
```
whereas it resulted in `Not Found Rest` error in Scala 3.

This is because the condition to detect wildcard pattern was so strict that it chose the wrong match arm; `case _ => ifExpr`.