### PR TITLE
Add MiMa checks against LTS version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -103,6 +103,9 @@ object Build {
    */
   val previousDottyVersion = "3.4.0-RC1"
 
+  /** Version against which we check binary compatibility. */
+  val ltsDottyVersion = "3.3.0"
+
   object CompatMode {
     final val BinaryCompatible = 0
     final val SourceAndBinaryCompatible = 1
@@ -2163,6 +2166,14 @@ object Build {
             (Compile/doc/target).value
           },
           commonMiMaSettings,
+          mimaPreviousArtifacts += {
+            val thisProjectID = projectID.value
+            val crossedName = thisProjectID.crossVersion match {
+              case cv: Disabled => thisProjectID.name
+              case cv: Binary => s"${thisProjectID.name}_${cv.prefix}3${cv.suffix}"
+            }
+            (thisProjectID.organization % crossedName % ltsDottyVersion)
+          },
           mimaBackwardIssueFilters := MiMaFilters.LibraryBackwards,
           mimaForwardIssueFilters := MiMaFilters.LibraryForward,
         )

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -5,11 +5,29 @@ object MiMaFilters {
   val LibraryBackwards: Map[String, Seq[ProblemFilter]] = Map(
     // In general we should never have backwards incompatible changes in the library.
     // Only exceptional cases should be added here.
+
+    // Breaking changes since last reference version
     Build.previousDottyVersion -> Seq(
       // This language feature was in 3.4.0-RC1 but will be removed in 3.4.0-RC2
       ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#deprecated.ascriptionVarargsUnpacking"),
       ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$deprecated$ascriptionVarargsUnpacking$"),
-    )
+    ),
+
+    // Breaking changes since last LTS
+    Build.ltsDottyVersion -> Seq(
+      // Quotes is assumed to only be implemented by the compiler and on the same version of the library.
+      // It is exceptionally OK to break this compatibility. In these cases, there add new abstract methods that would
+      // potentially not be implemented by others. If some other library decides to implement these,
+      // they need to recompile and republish on each minor release.
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule.ValOrDefDefMethods"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule.ValOrDefDefTypeTest"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#defnModule.FunctionClass"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#defnModule.PolyFunctionClass"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#FlagsModule.AbsOverride"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.paramVariance"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TypeLambdaMethods.paramVariances"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TypeReprMethods.dealiasKeepOpaques"),
+    ),
   )
   val LibraryForward: Map[String, Seq[ProblemFilter]] = Map(
     // Additions that require a new minor version of the library
@@ -19,7 +37,34 @@ object MiMaFilters {
       ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.5"),
       ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E5$"),
       ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E5$minusmigration$"),
-    )
+    ),
+
+    // Additions since last LTS
+    Build.ltsDottyVersion -> Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule.ValOrDefDefMethods"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule.ValOrDefDefTypeTest"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#defnModule.FunctionClass"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#defnModule.PolyFunctionClass"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#FlagsModule.AbsOverride"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolMethods.paramVariance"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TypeLambdaMethods.paramVariances"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TypeReprMethods.dealiasKeepOpaques"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Tuples.reverse"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.annotation.internal.AssignedNonLocally"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.annotation.internal.CaptureChecked"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.annotation.internal.reachCapability"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.annotation.unchecked.uncheckedCaptures"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.quoted.Quotes$reflectModule$ValOrDefDefMethods"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E4$"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$3$u002E4$minusmigration$"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$clauseInterleaving$"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$relaxedExtensionImports$"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.scalajs.runtime.AnonFunctionXXL"),
+      ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.4-migration"),
+      ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language.3.4"),
+      ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.clauseInterleaving"),
+      ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.relaxedExtensionImports"),
+    ),
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
   )


### PR DESCRIPTION
This addition is mostly for documentation. It is important to keep track of the exceptional forward-breaking changes that we have done so far. Having a full list of backward-breaking changes might also be useful for debugging. It might also be useful long term for the day we move to the next LTS.