### PR TITLE
Handle default implicits to context parameters under -3.4-migration

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -309,7 +309,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         toText(tp.argType) ~ " ?=>? " ~ toText(tp.resultType)
       case tp @ FunProto(args, resultType) =>
         "[applied to ("
-        ~ keywordText("using ").provided(tp.isContextualMethod)
+        ~ keywordText("using ").provided(tp.applyKind == ApplyKind.Using)
         ~ argsTreeText(args)
         ~ ") returning "
         ~ toText(resultType)

--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -106,12 +106,14 @@ trait Migrations:
       && isContextBoundParams
       && pt.applyKind != ApplyKind.Using
     then
-      def rewriteMsg = Message.rewriteNotice("This code", mversion.patchFrom)
+      def rewriteMsg =
+        if pt.args.isEmpty then ""
+        else Message.rewriteNotice("This code", mversion.patchFrom)
       report.errorOrMigrationWarning(
         em"""Context bounds will map to context parameters.
             |A `using` clause is needed to pass explicit arguments to them.$rewriteMsg""",
         tree.srcPos, mversion)
-      if mversion.needsPatch then
+      if mversion.needsPatch && pt.args.nonEmpty then
         patch(Span(pt.args.head.span.start), "using ")
   end contextBoundParams
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3906,7 +3906,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               if (arg.tpe.isError) Nil else untpd.NamedArg(pname, untpd.TypedSplice(arg)) :: Nil
             }
             val app = cpy.Apply(tree)(untpd.TypedSplice(tree), namedArgs)
-            if (wtp.isContextualMethod) app.setApplyKind(ApplyKind.Using)
+            val needsUsing = wtp.isContextualMethod || wtp.match
+              case MethodType(ContextBoundParamName(_) :: _) => sourceVersion.isAtLeast(`3.4`)
+              case _ => false
+            if needsUsing then app.setApplyKind(ApplyKind.Using)
             typr.println(i"try with default implicit args $app")
             typed(app, pt, locked)
           else issueErrors()

--- a/tests/neg/i19506.scala
+++ b/tests/neg/i19506.scala
@@ -1,0 +1,8 @@
+//> using options "-source:3.4-migration",
+
+trait Reader[T]
+def read[T: Reader](s: String, trace: Boolean = false): T = ???
+
+def Test =
+  read[Object]("") // error
+  read[Object]("")() // error


### PR DESCRIPTION
Synthesized calls for default implicits need a using clause when the method is an implicit method with a context bound parameter, but only in in 3.4-migration. Before this PR we still generated a normal empty parameter list.

Also, we can't rewrite adding a `using` clause if the argument list is empty, since we are lacking precise position info.

Fixes #19506