### PR TITLE
Heal occurrences of => T between ElimByName and Erasure

### DIFF
--- a/tests/pos/i19548.scala
+++ b/tests/pos/i19548.scala
@@ -1,0 +1,2 @@
+def byName[T](p: => T): T = p
+val test = (if ??? then byName else (??? : ((=> Int) => Int))) (42)


### PR DESCRIPTION
There's a window of vulnerability between ElimByName and Erasure where some ExprTypes `=> T` that appear as parameters of function types are not yet converted to by-name functions `() ?=> T`. These would cause an assertion violation when used as operands of & or |. We fix this on the fly when forming these types in TypeComparer. As explained in ElimByName, we can't fix it beforehand by mapping all occurrences of `=> T` to `() ?=> T` since that could lead to cycles.

Fixes #19548