### PR TITLE
Only cache base types when gadt state is empty

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2192,7 +2192,7 @@ object SymDenotations {
           Stats.record("basetype cache entries")
           if (!baseTp.exists) Stats.record("basetype cache NoTypes")
         }
-        if (!tp.isProvisional && !CapturingType.isUncachable(tp))
+        if !(tp.isProvisional || CapturingType.isUncachable(tp) || ctx.gadt.isNarrowing) then
           btrCache(tp) = baseTp
         else
           btrCache.remove(tp) // Remove any potential sentinel value

--- a/tests/pos/i19521.scala
+++ b/tests/pos/i19521.scala
@@ -1,0 +1,13 @@
+
+final abstract class PLet
+
+sealed trait Expr[+P]
+case class ELet[+A](name: String, expr: Expr[A]) extends Expr[A | PLet]
+
+def go[P](e: Expr[P]): P = e match
+  case ELet(_, _) =>
+    val x: Expr[P] | ELet[P] = ???
+    val y: Expr[P] = x // conforms iff using gadt constraints
+    // error before changes: cast from gadt reasoning was not inserted because
+    // `Expr[P]` was erronously cached as a baseType of `Expr[P] | ELet[P]` (only true with gadt constraints)
+    ???


### PR DESCRIPTION
The `Typer` inserts casts for trees which only conform using gadt constraints, so that -Ycheck succeeds in later phases.
We recheck in an empty GadtState, whether the type is found to already be a subtype, in which case we do not add the cast. The issue is that `isSubtype` relies on the baseType cache, which might have been populated in a ctx with the narrowing gadt constraints.

https://github.com/lampepfl/dotty/blob/1716bcd9dbefbef88def848c09768a698b6b9ed9/compiler/src/dotty/tools/dotc/typer/Typer.scala#L4075-L4084

Fixes #19521