### PR TITLE
Don't search for implicit conversions to NoType

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1074,7 +1074,7 @@ trait Implicits:
         if (argument.isEmpty) i"missing implicit parameter of type $pt after typer at phase ${ctx.phase.phaseName}"
         else i"type error: ${argument.tpe} does not conform to $pt${err.whyNoMatchStr(argument.tpe, pt)}")
 
-      val usableForInference = !pt.unusableForInference
+      val usableForInference = pt.exists && !pt.unusableForInference
         && (argument.isEmpty || !argument.tpe.unusableForInference)
 
       val result0 = if usableForInference then

--- a/tests/neg/i19320.scala
+++ b/tests/neg/i19320.scala
@@ -1,0 +1,15 @@
+//> using scala "3.3.1"
+//> using dep org.http4s::http4s-ember-client:1.0.0-M40
+//> using dep org.http4s::http4s-ember-server:1.0.0-M40
+//> using dep org.http4s::http4s-dsl:1.0.0-M40
+
+//import cats.effect.*
+//import cats.implicits.*
+
+class Concurrent[F[_]]
+
+class Test[F[_]: Concurren]: // error
+    def hello = ???
+
+object Test:
+    def apply[F[_]: Concurrent] = new Test[F]


### PR DESCRIPTION
There's a good chance this will fix #19320. My problem is that without a lot of added boilerplate I cannot test it, since it's hard to have at the same time external dependencies and ad-hoc instrumentation in the compiler. But what I could observe from the minimized example, it searches for a conversion of `Concurrent[F[_]]` to `NoType` and that must have caused the blowup. 

In any case, the change makes obvious sense, so let's add that and see whether it improves things.
