### PR TITLE
jsoup: 1.14.3 → 1.17.2

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1770,7 +1770,7 @@ object Build {
       ),
       libraryDependencies ++= Dependencies.flexmarkDeps ++ Seq(
         "nl.big-o" % "liqp" % "0.8.2",
-        "org.jsoup" % "jsoup" % "1.14.3", // Needed to process .html files for static site
+        "org.jsoup" % "jsoup" % "1.17.2", // Needed to process .html files for static site
         Dependencies.`jackson-dataformat-yaml`,
 
         "com.github.sbt" % "junit-interface" % "0.13.3" % Test,


### PR DESCRIPTION
From MVNRepository:

Direct vulnerabilities:
- CVE-2022-36033

Vulnerabilities from dependencies:
- CVE-2023-26049
- CVE-2023-26048
- CVE-2022-25647

https://mvnrepository.com/artifact/org.jsoup/jsoup/1.14.3

Only reviewed release notes in search of breaking changes and found none: https://github.com/jhy/jsoup/releases

Repeat of #14304