### PR TITLE
Normalize MatchAlias in unrollTupleTypes

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -443,6 +443,9 @@ object Inlines:
             unrollTupleTypes(tail).map(head :: _)
           case tpe: TermRef if tpe.symbol == defn.EmptyTupleModule =>
             Some(Nil)
+          case tpRef: TypeRef => tpRef.info match
+            case MatchAlias(alias) => unrollTupleTypes(alias.tryNormalize)
+            case _ => None
           case _ =>
             None
 

--- a/tests/pos/i19385.scala
+++ b/tests/pos/i19385.scala
@@ -1,0 +1,8 @@
+import scala.compiletime.summonAll
+
+inline def f[M <: Tuple]: Unit =
+  type Alias = Tuple.Map[M, [X] =>> Numeric[X]]
+  summonAll[Tuple.Map[M, [X] =>> Numeric[X]]] // compiles
+  summonAll[Alias] // error: Tuple element types must be known at compile time
+
+val y1 = f[(Int, Int)]


### PR DESCRIPTION
I'm not sure whether the normalisation of `MatchAlias` should be done in `dealias`. 
I suppose it is safer to only add the change in `unrollTupleTypes` where it is necessary.

Fixes #19385