### PR TITLE
Check and enter missing symbols in MacroAnnotations only for definitions

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -141,7 +141,7 @@ class MacroAnnotations(phase: IdentityDenotTransformer):
     def traverse(tree: tpd.Tree)(using Context): Unit = tree match
       case tdef @ TypeDef(_, template: Template) =>
         val isSymbolInDecls = tdef.symbol.asClass.info.decls.toList.toSet
-        for tree <- template.body do
+        for tree <- template.body if tree.isDef do
           if tree.symbol.owner != tdef.symbol then
             report.error(em"Macro added a definition with the wrong owner - ${tree.symbol.owner} - ${tdef.symbol} in ${tree.source}", tree.srcPos)
           else if !isSymbolInDecls(tree.symbol) then

--- a/tests/pos-macros/i19537/Macro_1.scala
+++ b/tests/pos-macros/i19537/Macro_1.scala
@@ -1,0 +1,6 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted.*
+
+@experimental
+class annotation extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition) = List(tree)

--- a/tests/pos-macros/i19537/Test_2.scala
+++ b/tests/pos-macros/i19537/Test_2.scala
@@ -1,0 +1,4 @@
+@scala.annotation.experimental
+@annotation
+class Test:
+  { }

--- a/tests/pos-macros/i19539/Macro_1.scala
+++ b/tests/pos-macros/i19539/Macro_1.scala
@@ -1,0 +1,6 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted.*
+
+@experimental
+class annotation extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition) = List(tree)

--- a/tests/pos-macros/i19539/Test_2.scala
+++ b/tests/pos-macros/i19539/Test_2.scala
@@ -1,0 +1,4 @@
+@scala.annotation.experimental
+@annotation
+class Test:
+  println()


### PR DESCRIPTION
Fixes #19537
Fixes #19539
