### PR TITLE
sbt 1.9.7 (was 1.9.3)

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -140,7 +140,7 @@ final case class SbtCommunityProject(
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
     extraSbtArgs ++ sbtProps ++ List(
-      "-sbt-version", "1.9.3",
+      "-sbt-version", "1.9.7",
       "-Dsbt.supershell=false",
       s"-Ddotty.communitybuild.dir=$communitybuildDir",
       s"--addPluginSbtFile=$sbtPluginFilePath"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,5 +28,5 @@ object Dependencies {
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % flexmarkVersion,
   )
 
-  val compilerInterface = "org.scala-sbt" % "compiler-interface" % "1.9.3"
+  val compilerInterface = "org.scala-sbt" % "compiler-interface" % "1.9.6"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.7

--- a/tests/cmdTest-sbt-tests/sourcepath-with-inline-api-hash/project/build.properties
+++ b/tests/cmdTest-sbt-tests/sourcepath-with-inline-api-hash/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.7

--- a/tests/cmdTest-sbt-tests/sourcepath-with-inline/project/build.properties
+++ b/tests/cmdTest-sbt-tests/sourcepath-with-inline/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.7


### PR DESCRIPTION
modeled on #18322

I found that we cannot go to 1.9.8 right now, because the self-hosted part of our GitHub Actions setup runs afoul of https://github.com/sbt/sbt/issues/7463, which will supposedly be fixed in sbt 1.10.0

compiler-interface going just to 1.9.6 is intentional — that's the most recent published version, as per https://github.com/sbt/zinc/releases/

~(gonna let CI tell me if anything else is needed besides the simple version number bumping)~