### PR TITLE
Backport "jsoup: 1.14.3 → 1.17.2" to release-3.4.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1711,7 +1711,7 @@ object Build {
       ),
       libraryDependencies ++= Dependencies.flexmarkDeps ++ Seq(
         "nl.big-o" % "liqp" % "0.8.2",
-        "org.jsoup" % "jsoup" % "1.14.3", // Needed to process .html files for static site
+        "org.jsoup" % "jsoup" % "1.17.2", // Needed to process .html files for static site
         Dependencies.`jackson-dataformat-yaml`,
 
         "com.github.sbt" % "junit-interface" % "0.13.3" % Test,


### PR DESCRIPTION
Backport of #19564 to 3.4.z

From MVNRepository:

Direct vulnerabilities:
- CVE-2022-36033

Vulnerabilities from dependencies:
- CVE-2023-26049
- CVE-2023-26048
- CVE-2022-25647

https://mvnrepository.com/artifact/org.jsoup/jsoup/1.14.3

(cherry picked from commit 27fbeaf85965a9f0345459730a744b2f9ee51698)