### PR TITLE
Avoid cycles when loading standard library under cc

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
@@ -58,8 +58,7 @@ object CapturingType:
     case AnnotatedType(parent, ann: CaptureAnnotation)
     if isCaptureCheckingOrSetup =>
       Some((parent, ann.refs))
-    case AnnotatedType(parent, ann)
-    if ann.symbol == defn.RetainsAnnot && isCaptureChecking =>
+    case AnnotatedType(parent, ann) if ann.symbol.isRetains && isCaptureChecking =>
       // There are some circumstances where we cannot map annotated types
       // with retains annotations to capturing types, so this second recognizer
       // path still has to exist. One example is when checking capture sets

--- a/compiler/src/dotty/tools/dotc/cc/RetainingType.scala
+++ b/compiler/src/dotty/tools/dotc/cc/RetainingType.scala
@@ -23,7 +23,7 @@ object RetainingType:
 
   def unapply(tp: AnnotatedType)(using Context): Option[(Type, List[Tree])] =
     val sym = tp.annot.symbol
-    if sym == defn.RetainsAnnot || sym == defn.RetainsByNameAnnot then
+    if sym.isRetainsLike then
       tp.annot match
         case _: CaptureAnnotation =>
           assert(ctx.mode.is(Mode.IgnoreCaptures), s"bad retains $tp at ${ctx.phase}")

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -120,7 +120,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
       case tp @ CapturingType(parent, refs) =>
         if tp.isBoxed then tp else tp.boxed
       case tp @ AnnotatedType(parent, ann) =>
-        if ann.symbol == defn.RetainsAnnot
+        if ann.symbol.isRetains
         then CapturingType(parent, ann.tree.toCaptureSet, boxed = true)
         else tp.derivedAnnotatedType(box(parent), ann)
       case tp1 @ AppliedType(tycon, args) if defn.isNonRefinedFunction(tp1) =>
@@ -192,7 +192,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
       def apply(tp: Type) =
         val tp1 = tp match
-          case AnnotatedType(parent, annot) if annot.symbol == defn.RetainsAnnot =>
+          case AnnotatedType(parent, annot) if annot.symbol.isRetains =>
             // Drop explicit retains annotations
             apply(parent)
           case tp @ AppliedType(tycon, args) =>
@@ -283,7 +283,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             t.derivedCapturingType(this(parent), refs)
           case t @ AnnotatedType(parent, ann) =>
             val parent1 = this(parent)
-            if ann.symbol == defn.RetainsAnnot then
+            if ann.symbol.isRetains then
               for tpt <- tptToCheck do
                 checkWellformedLater(parent1, ann.tree, tpt)
               CapturingType(parent1, ann.tree.toCaptureSet)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1057,6 +1057,7 @@ class Definitions {
   @tu lazy val ReachCapabilityAnnot = requiredClass("scala.annotation.internal.reachCapability")
   @tu lazy val RequiresCapabilityAnnot: ClassSymbol = requiredClass("scala.annotation.internal.requiresCapability")
   @tu lazy val RetainsAnnot: ClassSymbol = requiredClass("scala.annotation.retains")
+  @tu lazy val RetainsCapAnnot: ClassSymbol = requiredClass("scala.annotation.retainsCap")
   @tu lazy val RetainsByNameAnnot: ClassSymbol = requiredClass("scala.annotation.retainsByName")
   @tu lazy val PublicInBinaryAnnot: ClassSymbol = requiredClass("scala.annotation.publicInBinary")
 
@@ -2008,7 +2009,7 @@ class Definitions {
   @tu lazy val ccExperimental: Set[Symbol] = Set(
     CapsModule, CapsModule.moduleClass, PureClass,
     CapabilityAnnot, RequiresCapabilityAnnot,
-    RetainsAnnot, RetainsByNameAnnot)
+    RetainsAnnot, RetainsCapAnnot, RetainsByNameAnnot)
 
   // ----- primitive value class machinery ------------------------------------------
 

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -583,6 +583,7 @@ object StdNames {
     val releaseFence : N        = "releaseFence"
     val retains: N              = "retains"
     val retainsByName: N        = "retainsByName"
+    val retainsCap: N           = "retainsCap"
     val rootMirror : N          = "rootMirror"
     val run: N                  = "run"
     val runOrElse: N            = "runOrElse"

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1765,12 +1765,11 @@ object Parsers {
           RefinedTypeTree(rejectWildcardType(t), refinement(indentOK = true))
         })
       else if Feature.ccEnabled && in.isIdent(nme.UPARROW) && isCaptureUpArrow then
-        val upArrowStart = in.offset
-        in.nextToken()
-        def cs =
-          if in.token == LBRACE then captureSet()
-          else atSpan(upArrowStart)(captureRoot) :: Nil
-        makeRetaining(t, cs, tpnme.retains)
+        atSpan(t.span.start):
+          in.nextToken()
+          if in.token == LBRACE
+          then makeRetaining(t, captureSet(), tpnme.retains)
+          else makeRetaining(t, Nil, tpnme.retainsCap)
       else
         t
     }

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -27,7 +27,7 @@ import config.{Config, Feature}
 
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.ast.untpd.{MemberDef, Modifiers, PackageDef, RefTree, Template, TypeDef, ValOrDefDef}
-import cc.{CaptureSet, CapturingType, toCaptureSet, IllegalCaptureRef}
+import cc.{CaptureSet, CapturingType, toCaptureSet, IllegalCaptureRef, isRetains}
 import dotty.tools.dotc.parsing.JavaParsers
 
 class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
@@ -643,7 +643,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         def toTextRetainsAnnot =
           try changePrec(GlobalPrec)(toText(arg) ~ "^" ~ toTextCaptureSet(captureSet))
           catch case ex: IllegalCaptureRef => toTextAnnot
-        if annot.symbol.maybeOwner == defn.RetainsAnnot
+        if annot.symbol.maybeOwner.isRetains
             && Feature.ccEnabled && !printDebug
             && Phases.checkCapturesPhase.exists // might be missing on -Ytest-pickler
         then toTextRetainsAnnot

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -38,7 +38,7 @@ import config.Feature.sourceVersion
 import config.SourceVersion.*
 import config.MigrationVersion
 import printing.Formatting.hlAsKeyword
-import cc.isCaptureChecking
+import cc.{isCaptureChecking, isRetainsLike}
 
 import collection.mutable
 import reporting.*
@@ -705,8 +705,7 @@ object Checking {
             declaredParents =
               tp.declaredParents.map(p => transformedParent(apply(p)))
             )
-        case tp @ AnnotatedType(underlying, annot)
-        if annot.symbol == defn.RetainsAnnot || annot.symbol == defn.RetainsByNameAnnot =>
+        case tp @ AnnotatedType(underlying, annot) if annot.symbol.isRetainsLike =>
           val underlying1 = this(underlying)
           val saved = inCaptureSet
           inCaptureSet = true

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -48,7 +48,7 @@ import staging.StagingLevel
 import reporting.*
 import Nullables.*
 import NullOpsDecorator.*
-import cc.CheckCaptures
+import cc.{CheckCaptures, isRetainsLike}
 import config.Config
 import config.MigrationVersion
 
@@ -2940,9 +2940,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     val arg1 = typed(tree.arg, pt)
     if (ctx.mode is Mode.Type) {
       val cls = annot1.symbol.maybeOwner
-      if Feature.ccEnabled
-          && (cls == defn.RetainsAnnot || cls == defn.RetainsByNameAnnot)
-      then
+      if Feature.ccEnabled && cls.isRetainsLike then
         CheckCaptures.checkWellformed(arg1, annot1)
       if arg1.isType then
         assignType(cpy.Annotated(tree)(arg1, annot1), arg1, annot1)

--- a/library/src/scala/annotation/retains.scala
+++ b/library/src/scala/annotation/retains.scala
@@ -13,3 +13,11 @@ package scala.annotation
  */
 @experimental
 class retains(xs: Any*) extends annotation.StaticAnnotation
+
+/** Equivalent in meaning to `@retains(cap)`, but consumes less bytecode. 
+ */
+@experimental
+class retainsCap() extends annotation.StaticAnnotation
+  // This special case is needed to be able to load standard library modules without
+  // cyclic reference errors. Specifically, load sequences involving IterableOnce.
+

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -51,6 +51,7 @@ val experimentalDefinitionInLibrary = Set(
   "scala.annotation.capability",
   "scala.annotation.retains",
   "scala.annotation.retainsByName",
+  "scala.annotation.retainsCap",
   "scala.Pure",
   "scala.caps",
   "scala.caps$",

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -399,7 +399,7 @@ Diagnostics => 3 entries
 Synthetics => 2 entries
 
 Symbols:
-example/Anonymous# => class Anonymous extends Object { self: Anonymous & Anonymous => +9 decls }
+example/Anonymous# => class Anonymous extends Object { self: Anonymous => +9 decls }
 example/Anonymous#Bar# => trait Bar extends Object { self: Bar => +2 decls }
 example/Anonymous#Bar#`<init>`(). => primary ctor <init> (): Bar
 example/Anonymous#Bar#bar(). => abstract method bar => String
@@ -3414,7 +3414,7 @@ local1 => selfparam self: B
 local2 => selfparam self: B & C1
 selfs/B# => class B extends Object { self: B => +1 decls }
 selfs/B#`<init>`(). => primary ctor <init> (): B
-selfs/C1# => class C1 extends B { self: C1 & C1 => +1 decls }
+selfs/C1# => class C1 extends B { self: C1 => +1 decls }
 selfs/C1#`<init>`(). => primary ctor <init> (): C1
 selfs/C2# => class C2 extends B { self: B & C2 => +1 decls }
 selfs/C2#`<init>`(). => primary ctor <init> (): C2


### PR DESCRIPTION
Two measures:

 - Introduce a new annotation @retainsCap that's equivalent to `@retains(cap)` but that does not need to load Seq to analyze a vararg argument.
 - Don't use `&` when computing self types of classes with explicitly declared capturing self types.

Partial fix of #19586 