### PR TITLE
Refine handling of StaleSymbol type errors

### DIFF
--- a/tests/pos/i19604/ZSet.scala
+++ b/tests/pos/i19604/ZSet.scala
@@ -1,0 +1,11 @@
+// ZSet.scala
+// moving it to core.scala would lead to Recursion limit exceeded: find-member prelude.ZSetSyntax
+package prelude
+
+import prelude.newtypes._
+
+class ZSet[+A, +B]
+object ZSet
+trait ZSetSyntax {
+  implicit final class ZSetMapOps[+A](self: Map[A, Natural])
+}

--- a/tests/pos/i19604/core.scala
+++ b/tests/pos/i19604/core.scala
@@ -1,0 +1,37 @@
+// core.scala
+package prelude
+
+sealed trait Assertion[-A]
+object Assertion:
+  def greaterThanOrEqualTo[A](value: A): Assertion[A] = ???
+
+sealed trait AssertionError
+
+abstract class NewtypeCustom[A] {
+  type Type
+  protected inline def validateInline(inline value: A): Unit
+
+  inline def apply(inline a1: A): Type = {
+    validateInline(a1)
+    a1.asInstanceOf[Type]
+  }
+}
+abstract class Newtype[A] extends NewtypeCustom[A] {
+  def assertion: Assertion[A] = ???
+  protected inline def validateInline(inline value: A): Unit = ${
+    Macros.validateInlineImpl[A]('assertion, 'value)
+  }
+}
+
+abstract class Subtype[A] extends Newtype[A] {
+  type Type <: A
+}
+
+
+package object newtypes {
+  type Natural = Natural.Type
+  object Natural extends Subtype[Int] {
+    override inline def assertion = Assertion.greaterThanOrEqualTo(0)
+    val one: Natural =  Natural(1) // triggers macro
+  }
+}

--- a/tests/pos/i19604/macro.scala
+++ b/tests/pos/i19604/macro.scala
@@ -1,0 +1,8 @@
+// macro.scala
+package prelude
+import scala.quoted.*
+
+object Macros {
+  def validateInlineImpl[A: Type](assertionExpr: Expr[Assertion[A]], a: Expr[A])(using Quotes): Expr[Unit] =
+    '{ () }
+}

--- a/tests/pos/i19604/prelude.scala
+++ b/tests/pos/i19604/prelude.scala
@@ -1,0 +1,8 @@
+// prelude.scala
+
+import prelude.newtypes.Natural
+
+package object prelude extends ZSetSyntax {
+  type MultiSet[+A] = ZSet[A, Natural]
+  val MultiSet: ZSet.type = ZSet
+}


### PR DESCRIPTION
Regular StaleSymbol can be caught and masked in some situations. Stale symbol type errors need to allow the same.

Fixes #19604