### PR TITLE
Fix untupling of functions in for comprehensions

### DIFF
--- a/tests/pos/i19576.scala
+++ b/tests/pos/i19576.scala
@@ -1,0 +1,6 @@
+
+object Test:
+  val z = Seq(0 -> 1, 2 -> 3).lazyZip(Seq("A", "B"))
+  for case ((beg, end), c) <- z yield c // Ok: a withFilter is inserted before map
+  for (range, c) <- z yield c           // Ok: exact shape
+  for ((beg, end), c) <- z yield c      // Error before changes: Wrong number of parameters, expected 2


### PR DESCRIPTION
Fixes #19576

```scala 3
val z = Seq(0 -> 1, 2 -> 3).lazyZip(Seq("A", "B"))
for case ((beg, end), c) <- z yield c // Ok: a withFilter is inserted before map
for (range, c) <- z yield c           // Ok: exact shape
for ((beg, end), c) <- z yield c      // Error before changes: Wrong number of parameters, expected 2
```

The issue did not arise a 3.3.1, as a `withFilter` was always inserted before `map`, this is no longer the case as the pattern is irrefutable. 
Note that the `map` method of `LazyZip2` expects `(El1, El2) => B` and not `((El1, El2)) => B`. This kind of situation was previously already accounted for in the specific case where the pattern is exactly the shape of the function arguments. 
Otherwise we can fallback to a less optimised version, using the untupled version of the lambda and keeping the match with the more refined pattern.