### PR TITLE
Disallow covariant `cap`s in the lower bound of type members

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -151,9 +151,9 @@ object CheckCaptures:
 
               // Check the lower bound of path dependent types.
               // See issue #19330.
-              val isMember = t.prefix eq NoPrefix
+              val isMember = t.prefix ne NoPrefix
               t.info match
-                case TypeBounds(lo, _) if !isMember => traverse(lo)
+                case TypeBounds(lo, _) if isMember => traverse(lo)
                 case _ =>
           case AnnotatedType(_, ann) if ann.symbol == defn.UncheckedCapturesAnnot =>
             ()

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -168,6 +168,13 @@ object CheckCaptures:
             if !seen.contains(t) then
               seen += t
               traverseChildren(t)
+
+              // Check the lower bound of path dependent types.
+              // See issue #19330.
+              val isTypeParam = t.prefix eq NoPrefix
+              t.info match
+                case TypeBounds(lo, hi) if !isTypeParam => traverse(lo)
+                case _ =>
           case AnnotatedType(_, ann) if ann.symbol == defn.UncheckedCapturesAnnot =>
             ()
           case t =>

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -142,26 +142,6 @@ object CheckCaptures:
 
       private val seen = new EqHashSet[TypeRef]
 
-      /** Check that there is at least one method containing carrier and defined
-       *  in the scope of tparam. E.g. this is OK:
-       *    def f[T] = { ... var x: T ... }
-       *  So is this:
-       *    class C[T] { def f() = { class D { var x: T }}}
-       *  But this is not OK:
-       *    class C[T] { object o { var x: T }}
-       */
-      extension (tparam: Symbol) def isParametricIn(carrier: Symbol): Boolean =
-        carrier.exists && {
-          val encl = carrier.owner.enclosingMethodOrClass
-          if encl.isClass then tparam.isParametricIn(encl)
-          else
-            def recur(encl: Symbol): Boolean =
-              if tparam.owner == encl then true
-              else if encl.isStatic || !encl.exists then false
-              else recur(encl.owner.enclosingMethodOrClass)
-            recur(encl)
-        }
-
       def traverse(t: Type) =
         t.dealiasKeepAnnots match
           case t: TypeRef =>

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -171,9 +171,9 @@ object CheckCaptures:
 
               // Check the lower bound of path dependent types.
               // See issue #19330.
-              val isTypeParam = t.prefix eq NoPrefix
+              val isMember = t.prefix eq NoPrefix
               t.info match
-                case TypeBounds(lo, hi) if !isTypeParam => traverse(lo)
+                case TypeBounds(lo, _) if !isMember => traverse(lo)
                 case _ =>
           case AnnotatedType(_, ann) if ann.symbol == defn.UncheckedCapturesAnnot =>
             ()

--- a/tests/neg-custom-args/captures/i19330-alt.scala
+++ b/tests/neg-custom-args/captures/i19330-alt.scala
@@ -1,0 +1,14 @@
+import language.experimental.captureChecking
+
+trait Logger
+def usingLogger[T](op: Logger^ => T): T = ???
+
+def foo[T >: () => Logger^](): T =
+  val leaked = usingLogger[T]: l =>  // ok
+    val t: () => Logger^ = () => l
+    t: T
+  leaked
+
+def test(): Unit =
+  val bad: () => Logger^ = foo[() => Logger^]  // error
+  val leaked: Logger^ = bad()  // leaked scoped capability!

--- a/tests/neg-custom-args/captures/i19330-alt2.scala
+++ b/tests/neg-custom-args/captures/i19330-alt2.scala
@@ -1,0 +1,13 @@
+import language.experimental.captureChecking
+
+trait Logger
+def usingLogger[T](op: Logger^ => T): T = ???
+
+trait Foo:
+  type T >: () => Logger^
+
+  def foo: this.T =
+    val leaked = usingLogger[T]: l =>  // error
+      val t: () => Logger^ = () => l
+      t: T
+    leaked

--- a/tests/neg-custom-args/captures/i19330.scala
+++ b/tests/neg-custom-args/captures/i19330.scala
@@ -1,0 +1,21 @@
+import language.experimental.captureChecking
+
+trait Logger
+def usingLogger[T](op: Logger^ => T): T = ???
+
+trait Foo:
+  type T >: () => Logger^
+
+class Bar extends Foo:
+  type T = () => Logger^
+
+def foo(x: Foo): x.T =
+  val leaked = usingLogger[x.T]: l =>  // error
+    val t: () => Logger^ = () => l
+    t: x.T
+  leaked
+
+def test(): Unit =
+  val bar = new Bar
+  val bad: bar.T = foo(bar)
+  val leaked: Logger^ = bad()  // leaked scoped capability!


### PR DESCRIPTION
Fixes #19330.

Since when instantiating a type member we do not disallow covariant `cap`s in the instance, a check is added at the application site to check for covariant `cap`s in the lower bound of type members to maintain soundness. This check is elided for type parameters since their instances are always checked at the instantiation site.