### PR TITLE
Fix #19607: Allow to instantiate *wildcard* type captures to TypeBounds.

### DIFF
--- a/tests/pos/i19607.scala
+++ b/tests/pos/i19607.scala
@@ -1,0 +1,12 @@
+trait Foo
+trait Bar[T]
+
+type MatchType[T] = T match
+  case Bar[?] => Nothing
+  case _ => T
+
+object Test:
+  def foo(b: Bar[? >: Foo]): Unit =
+    summon[MatchType[b.type] =:= Nothing]
+    summon[MatchType[Bar[? >: Foo]] =:= Nothing]
+end Test


### PR DESCRIPTION
When matching in a match type, if we encounter a `TypeBounds` scrutinee and we have a wildcard capture on the right, we used to pick the `hi` bound "because anything between between `lo` and `hi` would work".

It turns out that *nothing* between `lo` and `hi` works when the type constructor is invariant. Instead, we must be keep the type bounds, and instantiate the wildcard capture to a wildcard type argument.

This is fine because a wildcard capture can never be referred to in the body of the case. However, previously this could never happen in successful cases, and we therefore used the presence of a `TypeBounds` in the `instances` as the canonical signal for "fail as not specific". We now use a separate `noInstances` list to be that signal.

This change departs from the letter of the spec but not from its spirit. As evidenced by the wording, the spec always *intended* for "the pick" to one that would always succeed. We wrongly assumed `hi` was always working.