### PR TITLE
Attempt to inline by name matcher methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -812,6 +812,9 @@ object StdNames {
       case _  => termName("x$" + i)
     }
 
+    def isProductAccessorName(name: Name): Boolean =
+      name.startsWith("_") && name.toString.drop(1).toIntOption.isDefined
+
     def productAccessorName(j: Int): TermName = (j: @switch) match {
       case 1  => nme._1
       case 2  => nme._2

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -5,6 +5,7 @@ import core.*
 import Flags.*
 import Contexts.*
 import Symbols.*
+import StdNames.*
 
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.Trees.*
@@ -44,8 +45,12 @@ class Inlining extends MacroTransform, IdentityDenotTransformer {
     tree match {
       case PackageDef(pid, _) if tree.symbol.owner == defn.RootClass =>
         new TreeTraverser {
+
           def traverse(tree: Tree)(using Context): Unit =
             tree match
+              case tree: Select if PatternMatcher.isPatmatGenerated(tree) =>
+               // Purposefully skip any nodes introduced by the pattern matcher. We
+               // will inline them at a later stage.
               case tree: RefTree if !Inlines.inInlineMethod && StagingLevel.level == 0 =>
                 assert(!tree.symbol.isInlineMethod, tree.show)
               case _ =>

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -80,6 +80,7 @@ object PatternMatcher {
 
   def isPatmatGenerated(select: Select)(using Context): Boolean = select match {
     case Select(sel, nme.isEmpty | nme.get) if isPatmatGenerated(sel.symbol) => true
+    case Select(sel, name) if isPatmatGenerated(sel.symbol) && nme.isProductAccessorName(name) => true
     case _ => false
   }
 

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -78,6 +78,11 @@ object PatternMatcher {
   def isPatmatGenerated(sym: Symbol)(using Context): Boolean =
     sym.is(Synthetic) && sym.name.is(PatMatStdBinderName)
 
+  def isPatmatGenerated(select: Select)(using Context): Boolean = select match {
+    case Select(sel, nme.isEmpty | nme.get) if isPatmatGenerated(sel.symbol) => true
+    case _ => false
+  }
+
   /** The pattern matching translator.
    *  Its general structure is a pipeline:
    *

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -453,8 +453,7 @@ object Signatures {
    * Filter returning only members starting with underscore followed with number
    */
   private object underscoreMembersFilter extends NameFilter {
-    def apply(pre: Type, name: Name)(using Context): Boolean =
-      name.startsWith("_") && name.toString.drop(1).toIntOption.isDefined
+    def apply(pre: Type, name: Name)(using Context): Boolean = nme.isProductAccessorName(name)
     def isStable = true
   }
 

--- a/tests/pos/byname-inline.scala
+++ b/tests/pos/byname-inline.scala
@@ -1,11 +1,23 @@
 final class ByName1(val x: Int) extends AnyVal:
-  inline def isEmpty: Boolean = false
+  inline def isEmpty: Boolean = x == 1
   inline def get: String = x.toString
 
 object ByName1:
   inline def unapply(x: Int): ByName1 = new ByName1(x)
 
-def useByNamePatMatch: String =
+def useByName1PatMatch: String =
   val x = 1
   x match
     case ByName1(s) => s
+
+final class ByName2(val x: Int) extends AnyVal:
+  inline def isEmpty: false = false
+  inline def get: Int = x
+
+object ByName2:
+  inline def unapply(x: Int): ByName2 = new ByName2(x)
+
+def useByName2PatMatch: Int =
+  val x = 1
+  x match
+    case ByName2(s) => s

--- a/tests/pos/byname-inline.scala
+++ b/tests/pos/byname-inline.scala
@@ -1,0 +1,11 @@
+final class ByName1(val x: Int) extends AnyVal:
+  inline def isEmpty: Boolean = false
+  inline def get: String = x.toString
+
+object ByName1:
+  inline def unapply(x: Int): ByName1 = new ByName1(x)
+
+def useByNamePatMatch: String =
+  val x = 1
+  x match
+    case ByName1(s) => s

--- a/tests/pos/byname-inline.scala
+++ b/tests/pos/byname-inline.scala
@@ -21,3 +21,19 @@ def useByName2PatMatch: Int =
   val x = 1
   x match
     case ByName2(s) => s
+
+final class Accessor(val x: Int) extends AnyVal:
+  inline def _1: Int = x + 1
+  inline def _2: String = x.toString
+
+final class ByName3(val x: Int) extends AnyVal:
+  inline def isEmpty: Boolean = x == 1
+  inline def get: Accessor = new Accessor(x)
+
+object ByName3:
+  inline def unapply(x: Int): ByName3 = new ByName3(x)
+
+def useByName3PatMatch: (Int, String) =
+  val x = 1
+  x match
+    case ByName3(i, s) => (i, s)


### PR DESCRIPTION
This is part of the attempt to get #19577 working without an allocation and using a by name matcher.

It attempts to correctly inline the `isEmpty`, `get` and `_N` methods for by name matchers.

The current test `by-inline.scala` failed prior to the changes the following stacktrace:

<details>

```
error while checking tests/pos/byname-inline.scala after phase MegaPhase{protectedAccessors, extmethods, uncacheGivenAliases, checkStatic, elimByName, hoistSuperArgs, forwardDepChecks, specializeApplyMethods, tryCatchPatterns, patternMatcher} ***

  unhandled exception while running Ycheck on tests/pos/byname-inline.scala

  An unhandled exception was thrown in the compiler.
  Please file a crash report here:
  https://github.com/lampepfl/dotty/issues/new/choose
  For non-enriched exceptions, compile with -Yno-enrich-error-messages.

     while compiling: tests/pos/byname-inline.scala
        during phase: Ycheck
                mode: Mode(ImplicitsEnabled,ReadPositions)
     library version: version 2.13.12
    compiler version: version 3.4.1-RC1-bin-SNAPSHOT-nonbootstrapped-git-641ab7a
            settings: -Xsemanticdb true -Xunchecked-java-output-version 9 -Xverify-signatures true -Ycheck List(all) -Yforce-sbt-phases true -Yno-deep-subtypes true -Yno-double-bindings true -Ysafe-init true -classpath /home/yilin/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar:/home/yilin/devel/github/dotty/library/../out/bootstrap/scala3-library-bootstrapped/scala-3.4.1-RC1-bin-SNAPSHOT-nonbootstrapped/scala3-library_3-3.4.1-RC1-bin-SNAPSHOT.jar:out/compilePos/pos/byname-inline -color never -d out/compilePos/pos/byname-inline -indent true -pagewidth 120
[=======================================>] completed (1/1, 1 failed, 0s)
Fatal compiler crash when compiling: tests/pos/byname-inline.scala:
assertion failed: x4.isEmpty
	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:51)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.fold$1(Trees.scala:1660)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.apply(Trees.scala:1662)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1693)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1695)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1693)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.fold$1(Trees.scala:1660)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.apply(Trees.scala:1662)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1693)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1703)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1693)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1748)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.fold$1(Trees.scala:1660)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.apply(Trees.scala:1662)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1755)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1752)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.apply(Trees.scala:1796)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.fold$1(Trees.scala:1660)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.apply(Trees.scala:1662)
	at dotty.tools.dotc.ast.Trees$Instance$TreeAccumulator.foldOver(Trees.scala:1761)
	at dotty.tools.dotc.ast.Trees$Instance$TreeTraverser.traverseChildren(Trees.scala:1797)
	at dotty.tools.dotc.transform.Inlining$$anon$1.traverse(Inlining.scala:53)
	at dotty.tools.dotc.transform.Inlining.checkPostCondition(Inlining.scala:54)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted$$anonfun$1(TreeChecker.scala:415)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:415)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.transform.TreeChecker.check(TreeChecker.scala:129)
	at dotty.tools.dotc.transform.TreeChecker.run(TreeChecker.scala:109)
	at dotty.tools.dotc.core.Phases$Phase.runOn$$anonfun$1(Phases.scala:354)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at dotty.tools.dotc.core.Phases$Phase.runOn(Phases.scala:360)
	at dotty.tools.dotc.Run.runPhases$1$$anonfun$1(Run.scala:315)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
	at dotty.tools.dotc.Run.runPhases$1(Run.scala:337)
	at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:350)
	at dotty.tools.dotc.Run.compileUnits$$anonfun$adapted$1(Run.scala:360)
	at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:69)
	at dotty.tools.dotc.Run.compileUnits(Run.scala:360)
	at dotty.tools.dotc.Run.compileSources(Run.scala:261)
	at dotty.tools.dotc.Run.compile(Run.scala:246)
	at dotty.tools.dotc.Driver.doCompile(Driver.scala:37)
	at dotty.tools.dotc.Driver.process(Driver.scala:196)
	at dotty.tools.dotc.Driver.process(Driver.scala:164)
	at dotty.tools.vulpix.ParallelTesting$Test.compile(ParallelTesting.scala:549)
	at dotty.tools.vulpix.ParallelTesting$CompilationLogic.compileTestSource$$anonfun$1(ParallelTesting.scala:230)
	at scala.util.Try$.apply(Try.scala:210)
	at dotty.tools.vulpix.ParallelTesting$CompilationLogic.dotty$tools$vulpix$ParallelTesting$CompilationLogic$$compileTestSource(ParallelTesting.scala:239)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource$$anonfun$1(ParallelTesting.scala:285)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource$$anonfun$adapted$1(ParallelTesting.scala:288)
	at scala.Function0.apply$mcV$sp(Function0.scala:42)
	at dotty.tools.vulpix.ParallelTesting$Test.tryCompile(ParallelTesting.scala:472)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource(ParallelTesting.scala:288)
	at dotty.tools.vulpix.ParallelTesting$Test$LoggedRunnable.run(ParallelTesting.scala:368)
	at dotty.tools.vulpix.ParallelTesting$Test$LoggedRunnable.run$(ParallelTesting.scala:350)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.run(ParallelTesting.scala:283)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1403)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)

```

</details>

Looking through the code, it looks as though we delay inlining for unapply nodes. 

The actual logic of which methods to call is done in the `PatternMatcher` phase. However, the pattern matcher doesn't inline any calls when emitting the calls. We have a later phase `InlinePatterns` to inline the body of the `unapply` object we create temporarily.

My approach so far was to attempt to add the various methods in the `InlinePattern` phase but I get the error below:

I'm not entirely clear why the inliner doesn't "get" the owner from the inlined calls and wanted to understand whether this approach would work.

EDIT:

It seems to fail specifically when returning the literals.

<details>

```
Fatal compiler crash when compiling: tests/pos/byname-inline.scala:
assertion failed: no owner from <none>/<none> in (false:Boolean).unary_!
	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
	at dotty.tools.dotc.transform.Erasure$Typer.typedSelect(Erasure.scala:717)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:3088)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3196)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.typedIf(Typer.scala:1267)
	at dotty.tools.dotc.transform.Erasure$Typer.typedIf(Erasure.scala:888)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3122)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.typer.Typer.typedBlock(Typer.scala:1200)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3121)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:3327)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:3346)
	at dotty.tools.dotc.transform.Erasure$Typer.typedStats(Erasure.scala:1058)
	at dotty.tools.dotc.typer.Typer.typedBlockStats(Typer.scala:1193)
	at dotty.tools.dotc.typer.Typer.typedBlock(Typer.scala:1197)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3121)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.typedLabeled(Typer.scala:1992)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:3106)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3196)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.typer.Typer.typedBlock(Typer.scala:1200)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3121)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.typer.Typer.$anonfun$62(Typer.scala:2603)
	at dotty.tools.dotc.inlines.PrepareInlineable$.dropInlineIfError(PrepareInlineable.scala:256)
	at dotty.tools.dotc.typer.Typer.typedDefDef(Typer.scala:2603)
	at dotty.tools.dotc.transform.Erasure$Typer.typedDefDef(Erasure.scala:959)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:3095)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3196)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:3300)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:3346)
	at dotty.tools.dotc.transform.Erasure$Typer.typedStats(Erasure.scala:1058)
	at dotty.tools.dotc.typer.Typer.typedClassDef(Typer.scala:2790)
	at dotty.tools.dotc.transform.Erasure$Typer.typedClassDef(Erasure.scala:1047)
	at dotty.tools.dotc.typer.Typer.typedTypeOrClassDef$1(Typer.scala:3101)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:3105)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3196)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:3300)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:3346)
	at dotty.tools.dotc.transform.Erasure$Typer.typedStats(Erasure.scala:1058)
	at dotty.tools.dotc.typer.Typer.typedPackageDef(Typer.scala:2923)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3147)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.transform.Erasure.run(Erasure.scala:143)
	at dotty.tools.dotc.core.Phases$Phase.runOn$$anonfun$1(Phases.scala:354)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at dotty.tools.dotc.core.Phases$Phase.runOn(Phases.scala:360)
	at dotty.tools.dotc.Run.runPhases$1$$anonfun$1(Run.scala:315)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
	at dotty.tools.dotc.Run.runPhases$1(Run.scala:337)
	at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:350)
	at dotty.tools.dotc.Run.compileUnits$$anonfun$adapted$1(Run.scala:360)
	at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:69)
	at dotty.tools.dotc.Run.compileUnits(Run.scala:360)
	at dotty.tools.dotc.Run.compileSources(Run.scala:261)
	at dotty.tools.dotc.Run.compile(Run.scala:246)
	at dotty.tools.dotc.Driver.doCompile(Driver.scala:37)
	at dotty.tools.dotc.Driver.process(Driver.scala:196)
	at dotty.tools.dotc.Driver.process(Driver.scala:164)
	at dotty.tools.vulpix.ParallelTesting$Test.compile(ParallelTesting.scala:549)
	at dotty.tools.vulpix.ParallelTesting$CompilationLogic.compileTestSource$$anonfun$1(ParallelTesting.scala:230)
	at scala.util.Try$.apply(Try.scala:210)
	at dotty.tools.vulpix.ParallelTesting$CompilationLogic.dotty$tools$vulpix$ParallelTesting$CompilationLogic$$compileTestSource(ParallelTesting.scala:239)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource$$anonfun$1(ParallelTesting.scala:285)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource$$anonfun$adapted$1(ParallelTesting.scala:288)
	at scala.Function0.apply$mcV$sp(Function0.scala:42)
	at dotty.tools.vulpix.ParallelTesting$Test.tryCompile(ParallelTesting.scala:472)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource(ParallelTesting.scala:288)
	at dotty.tools.vulpix.ParallelTesting$Test$LoggedRunnable.run(ParallelTesting.scala:368)
	at dotty.tools.vulpix.ParallelTesting$Test$LoggedRunnable.run$(ParallelTesting.scala:350)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.run(ParallelTesting.scala:283)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1403)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```

</details>

Or if calling a method returning the literal:

<details>

```
  exception while retyping falsity:false.type of class Typed # -1

  An unhandled exception was thrown in the compiler.
  Please file a crash report here:
  https://github.com/lampepfl/dotty/issues/new/choose
  For non-enriched exceptions, compile with -Yno-enrich-error-messages.

     while compiling: tests/pos/byname-inline.scala
        during phase: Ycheck
                mode: Mode(ImplicitsEnabled,ReadPositions)
     library version: version 2.13.12
    compiler version: version 3.4.1-RC1-bin-SNAPSHOT-nonbootstrapped-git-4c36dc1
            settings: -Xsemanticdb true -Xunchecked-java-output-version 9 -Xverify-signatures true -Ycheck List(all) -Yforce-sbt-phases true -Yno-deep-subtypes true -Yno-double-bindings true -Ysafe-init true -classpath /home/yilin/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar:/home/yilin/devel/github/dotty/library/../out/bootstrap/scala3-library-bootstrapped/scala-3.4.1-RC1-bin-SNAPSHOT-nonbootstrapped/scala3-library_3-3.4.1-RC1-bin-SNAPSHOT.jar:out/compilePos/pos/byname-inline -color never -d out/compilePos/pos/byname-inline -indent true -pagewidth 120
*** error while checking tests/pos/byname-inline.scala after phase MegaPhase{pruneErasedDefs, uninitialized, inlinePatterns, vcInlineMethods, seqLiterals, intercepted, getters, specializeFunctions, specializeTuples, collectNullableFields, elimOuterSelect, resolveSuper, functionXXLForwarders, paramForwarding, genericTuples, letOverApply, arrayConstructors} ***
[=======================================>] completed (1/1, 1 failed, 1s)
Fatal compiler crash when compiling: tests/pos/byname-inline.scala:
assertion failed: illegal tree: false.type
	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
	at dotty.tools.dotc.transform.FirstTransform.checkPostCondition(FirstTransform.scala:65)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted$$anonfun$1(TreeChecker.scala:415)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:415)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.typedType(Typer.scala:3392)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedTyped(TreeChecker.scala:518)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3118)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.ReTyper.typedInlined(ReTyper.scala:100)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedInlined$$anonfun$1(TreeChecker.scala:639)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withDefinedSyms(TreeChecker.scala:248)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedInlined(TreeChecker.scala:639)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3136)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:3327)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:3346)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedStats(TreeChecker.scala:654)
	at dotty.tools.dotc.typer.Typer.typedBlockStats(Typer.scala:1193)
	at dotty.tools.dotc.typer.Typer.typedBlock(Typer.scala:1197)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock$$anonfun$1$$anonfun$1(TreeChecker.scala:636)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withDefinedSyms(TreeChecker.scala:248)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock$$anonfun$1(TreeChecker.scala:636)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withBlock(TreeChecker.scala:276)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock(TreeChecker.scala:636)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3121)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.typedIf(Typer.scala:1267)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3122)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.typer.Typer.typedBlock(Typer.scala:1200)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock$$anonfun$1$$anonfun$1(TreeChecker.scala:636)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withDefinedSyms(TreeChecker.scala:248)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock$$anonfun$1(TreeChecker.scala:636)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withBlock(TreeChecker.scala:276)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock(TreeChecker.scala:636)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3121)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:3327)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:3346)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedStats(TreeChecker.scala:654)
	at dotty.tools.dotc.typer.Typer.typedBlockStats(Typer.scala:1193)
	at dotty.tools.dotc.typer.Typer.typedBlock(Typer.scala:1197)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock$$anonfun$1$$anonfun$1(TreeChecker.scala:636)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withDefinedSyms(TreeChecker.scala:248)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock$$anonfun$1(TreeChecker.scala:636)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withBlock(TreeChecker.scala:276)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock(TreeChecker.scala:636)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3121)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.typedLabeled(Typer.scala:1992)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedLabeled$$anonfun$1(TreeChecker.scala:659)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withDefinedSyms(TreeChecker.scala:248)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedLabeled(TreeChecker.scala:659)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:3106)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3196)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.typer.Typer.typedBlock(Typer.scala:1200)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock$$anonfun$1$$anonfun$1(TreeChecker.scala:636)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withDefinedSyms(TreeChecker.scala:248)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock$$anonfun$1(TreeChecker.scala:636)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withBlock(TreeChecker.scala:276)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedBlock(TreeChecker.scala:636)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3121)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.typer.Typer.$anonfun$62(Typer.scala:2603)
	at dotty.tools.dotc.inlines.PrepareInlineable$.dropInlineIfError(PrepareInlineable.scala:256)
	at dotty.tools.dotc.typer.Typer.typedDefDef(Typer.scala:2603)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedDefDef$$anonfun$1(TreeChecker.scala:611)
	at dotty.tools.dotc.transform.TreeChecker$Checker.withDefinedSyms(TreeChecker.scala:248)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedDefDef(TreeChecker.scala:614)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:3095)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3196)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:3300)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:3346)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedStats(TreeChecker.scala:654)
	at dotty.tools.dotc.typer.Typer.typedClassDef(Typer.scala:2790)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedClassDef(TreeChecker.scala:581)
	at dotty.tools.dotc.typer.Typer.typedTypeOrClassDef$1(Typer.scala:3101)
	at dotty.tools.dotc.typer.Typer.typedNamed$1(Typer.scala:3105)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3196)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.traverse$1(Typer.scala:3300)
	at dotty.tools.dotc.typer.Typer.typedStats(Typer.scala:3346)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedStats(TreeChecker.scala:654)
	at dotty.tools.dotc.typer.Typer.typedPackageDef(Typer.scala:2923)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedPackageDef(TreeChecker.scala:680)
	at dotty.tools.dotc.typer.Typer.typedUnnamed$1(Typer.scala:3147)
	at dotty.tools.dotc.typer.Typer.typedUnadapted(Typer.scala:3197)
	at dotty.tools.dotc.typer.ReTyper.typedUnadapted(ReTyper.scala:174)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typedUnadapted(TreeChecker.scala:398)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3274)
	at dotty.tools.dotc.typer.Typer.typed(Typer.scala:3278)
	at dotty.tools.dotc.transform.TreeChecker$Checker.typed(TreeChecker.scala:381)
	at dotty.tools.dotc.typer.Typer.typedExpr(Typer.scala:3389)
	at dotty.tools.dotc.transform.TreeChecker.check(TreeChecker.scala:129)
	at dotty.tools.dotc.transform.TreeChecker.run(TreeChecker.scala:109)
	at dotty.tools.dotc.core.Phases$Phase.runOn$$anonfun$1(Phases.scala:354)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at dotty.tools.dotc.core.Phases$Phase.runOn(Phases.scala:360)
	at dotty.tools.dotc.Run.runPhases$1$$anonfun$1(Run.scala:315)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
	at dotty.tools.dotc.Run.runPhases$1(Run.scala:337)
	at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:350)
	at dotty.tools.dotc.Run.compileUnits$$anonfun$adapted$1(Run.scala:360)
	at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:69)
	at dotty.tools.dotc.Run.compileUnits(Run.scala:360)
	at dotty.tools.dotc.Run.compileSources(Run.scala:261)
	at dotty.tools.dotc.Run.compile(Run.scala:246)
	at dotty.tools.dotc.Driver.doCompile(Driver.scala:37)
	at dotty.tools.dotc.Driver.process(Driver.scala:196)
	at dotty.tools.dotc.Driver.process(Driver.scala:164)
	at dotty.tools.vulpix.ParallelTesting$Test.compile(ParallelTesting.scala:549)
	at dotty.tools.vulpix.ParallelTesting$CompilationLogic.compileTestSource$$anonfun$1(ParallelTesting.scala:230)
	at scala.util.Try$.apply(Try.scala:210)
	at dotty.tools.vulpix.ParallelTesting$CompilationLogic.dotty$tools$vulpix$ParallelTesting$CompilationLogic$$compileTestSource(ParallelTesting.scala:239)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource$$anonfun$1(ParallelTesting.scala:285)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource$$anonfun$adapted$1(ParallelTesting.scala:288)
	at scala.Function0.apply$mcV$sp(Function0.scala:42)
	at dotty.tools.vulpix.ParallelTesting$Test.tryCompile(ParallelTesting.scala:472)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.checkTestSource(ParallelTesting.scala:288)
	at dotty.tools.vulpix.ParallelTesting$Test$LoggedRunnable.run(ParallelTesting.scala:368)
	at dotty.tools.vulpix.ParallelTesting$Test$LoggedRunnable.run$(ParallelTesting.scala:350)
	at dotty.tools.vulpix.ParallelTesting$$anon$4.run(ParallelTesting.scala:283)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1403)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```

</details>