### PR TITLE
Parse search query param in Scaladoc

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1688,7 +1688,7 @@ object Build {
   lazy val `scaladoc-js-common` = project.in(file("scaladoc-js/common")).
     enablePlugins(DottyJSPlugin).
     dependsOn(`scala3-library-bootstrappedJS`).
-    settings(libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "1.1.0").cross(CrossVersion.for3Use2_13))
+    settings(libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "2.8.0"))
 
   lazy val `scaladoc-js-main` = project.in(file("scaladoc-js/main")).
     enablePlugins(DottyJSPlugin).
@@ -1704,7 +1704,7 @@ object Build {
     settings(
       Test / fork := false,
       scalaJSUseMainModuleInitializer := true,
-      libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "1.1.0").cross(CrossVersion.for3Use2_13)
+      libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "2.8.0")
     )
 
   def generateDocumentation(configTask: Def.Initialize[Task[GenerationConfig]]) =

--- a/scaladoc-js/contributors/src/content-contributors/ContentContributors.scala
+++ b/scaladoc-js/contributors/src/content-contributors/ContentContributors.scala
@@ -5,9 +5,10 @@ import org.scalajs.dom.ext._
 
 import scala.util.matching.Regex._
 import scala.util.matching._
-import org.scalajs.dom.ext.Ajax
-import scala.scalajs.js.JSON
+import org.scalajs.dom._
 import scala.scalajs.js
+import scala.scalajs.js.JSON
+import scala.scalajs.js.Thenable.Implicits.thenable2future
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -55,8 +56,8 @@ class ContentContributors:
   def linkForFilename(filename: String) = githubContributorsUrl() + s"/commits?path=$filename"
   def getAuthorsForFilename(filename: String): Future[List[FullAuthor]] = {
     val link = linkForFilename(filename)
-    Ajax.get(link).map(_.responseText).flatMap { json =>
-      val res = JSON.parse(json).asInstanceOf[Commits]
+    fetch(link).flatMap(_.json()).flatMap { json =>
+      val res = json.asInstanceOf[Commits]
       val authors = res.map { commit =>
         commit.author match
           case null =>
@@ -79,8 +80,8 @@ class ContentContributors:
     }
   }
   def findRename(link: String, filename: String): Future[Option[String]] = {
-    Ajax.get(link).map(_.responseText).map { json =>
-        val res = JSON.parse(json).asInstanceOf[CommitDescription]
+    fetch(link).flatMap(_.json()).map { json =>
+        val res = json.asInstanceOf[CommitDescription]
         val files = res.files
         files
           .find(_.filename == filename)

--- a/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
+++ b/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
@@ -17,6 +17,9 @@ import java.net.URI
 class SearchbarComponent(engine: PageSearchEngine, inkuireEngine: InkuireJSSearchEngine, parser: QueryParser):
   val initialChunkSize = 5
   val resultsChunkSize = 20
+
+  val querySearch = Option(URLSearchParams(window.location.search).get("search")).filter(_.nonEmpty)
+
   def pathToRoot() = window.document.documentElement.getAttribute("data-pathToRoot")
   extension (p: PageEntry)
     def toHTML(boldChars: Set[Int]) =
@@ -262,7 +265,8 @@ class SearchbarComponent(engine: PageSearchEngine, inkuireEngine: InkuireJSSearc
     document.body.addEventListener("keydown", (e: KeyboardEvent) => handleGlobalKeyDown(e))
 
   private val inputElem: html.Input =
-    input(cls := "scaladoc-searchbar-input", `type` := "search", `placeholder`:= "Find anything").tap { element =>
+    val initialValue = querySearch.getOrElse("")
+    input(cls := "scaladoc-searchbar-input", `type` := "search", `placeholder`:= "Find anything", value := initialValue).tap { element =>
       element.addEventListener("input", { e =>
         clearTimeout(timeoutHandle)
         val inputValue = e.target.asInstanceOf[html.Input].value
@@ -453,3 +457,7 @@ class SearchbarComponent(engine: PageSearchEngine, inkuireEngine: InkuireJSSearc
   }
 
   inputElem.dispatchEvent(new Event("input"))
+  if (querySearch.isDefined && !document.body.contains(rootDiv)) {
+    document.body.appendChild(rootDiv)
+    inputElem.focus()
+  }

--- a/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
+++ b/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
@@ -148,7 +148,7 @@ class SearchbarComponent(engine: PageSearchEngine, inkuireEngine: InkuireJSSearc
             val htmlEntries = results.map(result => result.pageEntry.toHTML(result.indices))
             val loadMoreElement = createLoadMoreElement
 
-            def loadMoreResults(entries: List[raw.HTMLElement]): Unit = {
+            def loadMoreResults(entries: List[HTMLElement]): Unit = {
               loadMoreElement.onclick = (event: Event) => {
                 entries.take(resultsChunkSize).foreach(_.classList.remove("hidden"))
                 val nextElems = entries.drop(resultsChunkSize)
@@ -192,7 +192,7 @@ class SearchbarComponent(engine: PageSearchEngine, inkuireEngine: InkuireJSSearc
     }
   }
 
-  def createLoadingAnimation: raw.HTMLElement =
+  def createLoadingAnimation: HTMLElement =
     div(cls := "loading-wrapper")(
       div(cls := "loading")
     )
@@ -346,7 +346,7 @@ class SearchbarComponent(engine: PageSearchEngine, inkuireEngine: InkuireJSSearc
     val selectedElement = resultsDiv.querySelector("[selected]")
     if selectedElement != null then {
       selectedElement.removeAttribute("selected")
-      def recur(elem: raw.Element): raw.Element = {
+      def recur(elem: Element): Element = {
         val prev = elem.previousElementSibling
         if prev == null then null
         else {
@@ -366,7 +366,7 @@ class SearchbarComponent(engine: PageSearchEngine, inkuireEngine: InkuireJSSearc
   }
   private def handleArrowDown() = {
     val selectedElement = resultsDiv.querySelector("[selected]")
-    def recur(elem: raw.Element): raw.Element = {
+    def recur(elem: Element): Element = {
       val next = elem.nextElementSibling
       if next == null then null
       else {

--- a/scaladoc-js/main/src/searchbar/engine/InkuireJSSearchEngine.scala
+++ b/scaladoc-js/main/src/searchbar/engine/InkuireJSSearchEngine.scala
@@ -2,7 +2,6 @@ package dotty.tools.scaladoc
 
 import scala.io.Source
 import dotty.tools.scaladoc.PageEntry
-import org.scalajs.dom.webworkers.Worker
 import org.scalajs.dom._
 import scala.scalajs.js.{ JSON, Dynamic }
 import scala.collection.mutable.ListBuffer

--- a/scaladoc-js/main/src/versions-dropdown/DropdownHandler.scala
+++ b/scaladoc-js/main/src/versions-dropdown/DropdownHandler.scala
@@ -7,9 +7,10 @@ import scala.util.{Success,Failure}
 import org.scalajs.dom._
 import org.scalajs.dom.ext._
 import scala.scalajs.js.annotation.JSExportTopLevel
-import org.scalajs.dom.ext.Ajax
+import org.scalajs.dom._
 import scala.scalajs.js
 import scala.scalajs.js.JSON
+import scala.scalajs.js.Thenable.Implicits.thenable2future
 
 import utils.HTML._
 
@@ -33,7 +34,7 @@ class DropdownHandler:
     btn.classList.add("disabled")
     btn.classList.add("hidden")
 
-  private def getURLContent(url: String): Future[String] = Ajax.get(url).map(_.responseText)
+  private def getURLContent(url: String): Future[String] = fetch(url).flatMap(_.text())
 
   window.sessionStorage.getItem(KEY) match
     case null => // If no key, returns null
@@ -68,7 +69,7 @@ end DropdownHandler
 def dropdownHandler(e: Event) =
   e.stopPropagation()
   if document.getElementById("version-dropdown").getElementsByTagName("a").size > 0 &&
-     window.getSelection.toString.length == 0 then
+     window.getSelection().toString.length == 0 then
     document.getElementById("version-dropdown").classList.toggle("expanded")
     document.getElementById("dropdown-trigger").classList.toggle("selected")
 


### PR DESCRIPTION
Scaladoc in Scala 2 supported a `search` query parameter that would immediately send an user to the search result page.

This was used by search engines to integrate with Scaladoc (e.g. searching `Future !scala` in Duck Duck Go would send a user straight to the results of searching `Future`).

This PR adds the same functionality to the new Scaladoc.

I also needed to update `scala-js-dom`, as otherwise `URLSearchParams` was not available.