### PR TITLE
Add patch for undefined behavior with `object $`

### DIFF
--- a/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
@@ -114,6 +114,10 @@ object FileUtils {
       if classOrModuleName.endsWith("$")
         && classOrModuleName != "Null$" // scala.runtime.Null$
         && classOrModuleName != "Nothing$" // scala.runtime.Nothing$
+        // Special case for `object $` in Amonite.
+        // This is an ad-hoc workaround for Amonite `object $`. See issue #19702
+        // This definition is not valid Scala.
+        && classOrModuleName != "$"
       then classOrModuleName.stripSuffix("$")
       else classOrModuleName
     className + SUFFIX_TASTY

--- a/tests/pos/i19702/Macro_1.scala
+++ b/tests/pos/i19702/Macro_1.scala
@@ -1,0 +1,9 @@
+package test
+
+// IMPORTANT: this object has undefined behavior due to its illegal use of a $ in an identifier
+//            This test is only to check that the ad-hoc workaround for Amonite `object $` is working.
+//            If at some point it becomes impossible to support this test, we can drop it.
+//            Ideally Amonite will have deprecated the `object $` by then.
+object $ {
+  def test(): Int = 1
+}

--- a/tests/pos/i19702/Test_2.scala
+++ b/tests/pos/i19702/Test_2.scala
@@ -1,0 +1,4 @@
+@main def hello =
+  test.$.test()
+
+  println("?")


### PR DESCRIPTION
Add an ad-hoc patch to make it possible to use the broken `object $` definitions in https://github.com/com-lihaoyi/Ammonite/blob/main/amm/interp/api/src/main/scala/ammonite/Stubs.scala.

This is a temporary patch while these definitions get deprecated. There is not guarantee that the semantics of these objects are correct. There is also no way to adapt the spec to allow there definition without breaking the language. For example consider `object $` and `object $$`, how would we know if the `$$.class` is the class of `$$` or the module class of `$`. We need to know this before we read the file.

Closes #19702