### PR TITLE
Update local `Dockerfile` used for spec changes to be in line with github workflows

### DIFF
--- a/docs/_spec/Dockerfile
+++ b/docs/_spec/Dockerfile
@@ -7,9 +7,11 @@ RUN apt-get install -y curl \
   && apt-get install -y nodejs \
   && curl -L https://www.npmjs.com/install.sh | sh
 
-RUN gem update --system
+RUN gem install "rubygems-update:<3.5" --no-document
+RUN update_rubygems
+
 RUN gem install sass-embedded -v 1.58.0
-RUN gem install bundler:1.17.2 jekyll
+RUN gem install bundler:2.3.5
 
 WORKDIR /srv/jekyll
 

--- a/docs/_spec/Gemfile
+++ b/docs/_spec/Gemfile
@@ -1,5 +1,6 @@
 # To build the spec on Travis CI
 source "https://rubygems.org"
+ruby "~> 2.7"
 
 gem "jekyll", "3.6.3"
 gem "webrick"


### PR DESCRIPTION
Currently the local server for the spec fails to build with the same issue as in https://github.com/lampepfl/dotty/pull/19288 on a fresh docker build.

This is the minimum amount of changes to actually get the spec building for users to make changes. I highly recommend updating all the versions when https://github.com/lampepfl/dotty/pull/19716 is finished.