### PR TITLE
Tweak parameter accessor scheme

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -116,7 +116,8 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
      *  This info is used in phase ParamForwarding
      */
     private def forwardParamAccessors(impl: Template)(using Context): Unit = impl.parents match
-      case superCall @ Apply(fn, superArgs) :: _ if superArgs.nonEmpty =>
+      case superCall @ Apply(fn, superArgs) :: _
+      if superArgs.nonEmpty && fn.symbol.isPrimaryConstructor =>
         fn.tpe.widen match
           case MethodType(superParamNames) =>
             for case stat: ValDef <- impl.body do

--- a/tests/run/i19711.scala
+++ b/tests/run/i19711.scala
@@ -1,0 +1,29 @@
+class Foo(val s: Any):
+  def this(s: String) =
+    this(0)
+class Bar(s: String) extends Foo(s):
+  def foo = s
+
+class Foo2(val s: Any)
+class Bar2(s: String) extends Foo2(s):
+  def foo = s
+
+case class Config(_config: String)
+
+abstract class Foo3(val config: Config) {
+  def this(config: String) = {
+    this(Config(config))
+  }
+}
+
+class Bar3(config: String) extends Foo3(config) {
+  def foo(): Unit = {
+    config.getClass()
+  }
+}
+
+
+@main def Test =
+  Bar("").foo
+  Bar2("").foo
+  Bar3("").foo()


### PR DESCRIPTION
To qualify as a super-parameter alias, a parameter of a subclass has to be passed to the primary constructor of the superclass.

Fixes #19711