### PR TITLE
Port coverage filter options for packages and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,3 @@ docs/_spec/.jekyll-metadata
 
 # scaladoc related
 scaladoc/output/
-
-#coverage
-coverage/
-

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -127,8 +127,8 @@ trait CommonScalaSettings:
 
   /* Coverage settings */
   val coverageOutputDir = PathSetting("-coverage-out", "Destination for coverage classfiles and instrumentation data.", "", aliases = List("--coverage-out"))
-  val coverageExcludePackages: Setting[List[String]] = MultiStringSetting("-coverage-exclude-packages", "packages", "Semicolon separated list of regexes for packages to exclude from coverage.", aliases = List("--coverage-exclude-packages"))
-  val coverageExcludeFiles: Setting[List[String]] = MultiStringSetting("-coverage-exclude-files", "files", "Semicolon separated list of regexes for files to exclude from coverage.", aliases = List("--coverage-exclude-files"))
+  val coverageExcludePackages: Setting[List[String]] = MultiStringSetting("-coverage-exclude-packages", "packages", "List of regexes for packages to exclude from coverage.", aliases = List("--coverage-exclude-packages"))
+  val coverageExcludeFiles: Setting[List[String]] = MultiStringSetting("-coverage-exclude-files", "files", "List of regexes for files to exclude from coverage.", aliases = List("--coverage-exclude-files"))
 
   /* Other settings */
   val encoding: Setting[String] = StringSetting("-encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding, aliases = List("--encoding"))

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -127,7 +127,7 @@ trait CommonScalaSettings:
 
   /* Coverage settings */
   val coverageOutputDir = PathSetting("-coverage-out", "Destination for coverage classfiles and instrumentation data.", "", aliases = List("--coverage-out"))
-  val coverageExcludeClasslikes: Setting[List[String]] = MultiStringSetting("-coverage-exclude-classlikes", "packages, clesses and modules", "List of regexes for packages, classes and modules to exclude from coverage.", aliases = List("--coverage-exclude-classlikes"))
+  val coverageExcludeClasslikes: Setting[List[String]] = MultiStringSetting("-coverage-exclude-classlikes", "packages, classes and modules", "List of regexes for packages, classes and modules to exclude from coverage.", aliases = List("--coverage-exclude-classlikes"))
   val coverageExcludeFiles: Setting[List[String]] = MultiStringSetting("-coverage-exclude-files", "files", "List of regexes for files to exclude from coverage.", aliases = List("--coverage-exclude-files"))
 
   /* Other settings */

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -127,6 +127,8 @@ trait CommonScalaSettings:
 
   /* Coverage settings */
   val coverageOutputDir = PathSetting("-coverage-out", "Destination for coverage classfiles and instrumentation data.", "", aliases = List("--coverage-out"))
+  val coverageExcludePackages: Setting[List[String]] = MultiStringSetting("-coverage-exclude-packages", "packages", "Semicolon separated list of regexes for packages to exclude from coverage.", aliases = List("--coverage-exclude-packages"))
+  val coverageExcludeFiles: Setting[List[String]] = MultiStringSetting("-coverage-exclude-files", "files", "Semicolon separated list of regexes for files to exclude from coverage.", aliases = List("--coverage-exclude-files"))
 
   /* Other settings */
   val encoding: Setting[String] = StringSetting("-encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding, aliases = List("--encoding"))

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -127,7 +127,7 @@ trait CommonScalaSettings:
 
   /* Coverage settings */
   val coverageOutputDir = PathSetting("-coverage-out", "Destination for coverage classfiles and instrumentation data.", "", aliases = List("--coverage-out"))
-  val coverageExcludePackages: Setting[List[String]] = MultiStringSetting("-coverage-exclude-packages", "packages", "List of regexes for packages to exclude from coverage.", aliases = List("--coverage-exclude-packages"))
+  val coverageExcludeClasslikes: Setting[List[String]] = MultiStringSetting("-coverage-exclude-classlikes", "packages, clesses and modules", "List of regexes for packages, classes and modules to exclude from coverage.", aliases = List("--coverage-exclude-classlikes"))
   val coverageExcludeFiles: Setting[List[String]] = MultiStringSetting("-coverage-exclude-files", "files", "List of regexes for files to exclude from coverage.", aliases = List("--coverage-exclude-files"))
 
   /* Other settings */

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -69,13 +69,15 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
     Serializer.serialize(coverage, outputPath, ctx.settings.sourceroot.value)
 
   private def isClassIncluded(sym: Symbol)(using Context): Boolean =
+    val fqn = sym.fullName.toText(ctx.printerFn(ctx)).show
     coverageExcludeClasslikePatterns.isEmpty || !coverageExcludeClasslikePatterns.exists(
-      _.matcher(sym.fullName.toText(ctx.printerFn(ctx)).show).nn.matches
+      _.matcher(fqn).nn.matches
     )
 
   private def isFileIncluded(file: SourceFile)(using Context): Boolean =
+    val normalizedPath = file.path.replace(".scala", "")
     coverageExcludeFilePatterns.isEmpty || !coverageExcludeFilePatterns.exists(
-      _.matcher(file.path.replace(".scala", "")).nn.matches
+      _.matcher(normalizedPath).nn.matches
     )
 
   override protected def newTransformer(using Context) =

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -61,7 +61,7 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
     Serializer.serialize(coverage, outputPath, ctx.settings.sourceroot.value)
 
   private def isClassIncluded(sym: Symbol)(using Context): Boolean =
-    val excludedClassNamePatterns = ctx.settings.coverageExcludePackages.value.map(_.r.pattern)
+    val excludedClassNamePatterns = ctx.settings.coverageExcludeClasslikes.value.map(_.r.pattern)
     excludedClassNamePatterns.isEmpty || !excludedClassNamePatterns.exists(
       _.matcher(sym.fullName.toText(ctx.printerFn(ctx)).show).nn.matches
     )

--- a/tests/coverage/pos/ExcludeClass.scala
+++ b/tests/coverage/pos/ExcludeClass.scala
@@ -1,0 +1,19 @@
+//> using options -coverage-exclude-packages:covtest.Klass
+
+package covtest
+
+class Klass {
+  def abs(i: Int) =
+    if i > 0 then
+      i
+    else
+      -i
+}
+
+class Klass2 {
+  def abs(i: Int) =
+    if i > 0 then
+      i
+    else
+      -i
+}

--- a/tests/coverage/pos/ExcludeClass.scala
+++ b/tests/coverage/pos/ExcludeClass.scala
@@ -1,4 +1,4 @@
-//> using options -coverage-exclude-packages:covtest.Klass
+//> using options -coverage-exclude-classlikes:covtest.Klass
 
 package covtest
 

--- a/tests/coverage/pos/ExcludeClass.scoverage.check
+++ b/tests/coverage/pos/ExcludeClass.scoverage.check
@@ -25,8 +25,8 @@ Klass2
 Class
 covtest.Klass2
 abs
-217
-218
+219
+220
 16
 i
 Ident
@@ -42,8 +42,8 @@ Klass2
 Class
 covtest.Klass2
 abs
-234
 236
+238
 18
 unary_-
 Select
@@ -59,8 +59,8 @@ Klass2
 Class
 covtest.Klass2
 abs
-175
-182
+177
+184
 14
 abs
 DefDef

--- a/tests/coverage/pos/ExcludeClass.scoverage.check
+++ b/tests/coverage/pos/ExcludeClass.scoverage.check
@@ -1,0 +1,71 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------
+0
+ExcludeClass.scala
+covtest
+Klass2
+Class
+covtest.Klass2
+abs
+217
+218
+16
+i
+Ident
+true
+0
+false
+i
+
+1
+ExcludeClass.scala
+covtest
+Klass2
+Class
+covtest.Klass2
+abs
+234
+236
+18
+unary_-
+Select
+true
+0
+false
+-i
+
+2
+ExcludeClass.scala
+covtest
+Klass2
+Class
+covtest.Klass2
+abs
+175
+182
+14
+abs
+DefDef
+false
+0
+false
+def abs
+

--- a/tests/coverage/pos/ExcludeDef.scala
+++ b/tests/coverage/pos/ExcludeDef.scala
@@ -1,0 +1,9 @@
+//> using options -coverage-exclude-packages:covtest\..*
+
+package covtest
+
+def abs(i: Int) =
+  if i > 0 then
+    i
+  else
+    -i

--- a/tests/coverage/pos/ExcludeDef.scala
+++ b/tests/coverage/pos/ExcludeDef.scala
@@ -1,4 +1,4 @@
-//> using options -coverage-exclude-packages:covtest\..*
+//> using options -coverage-exclude-classlikes:covtest\..*
 
 package covtest
 

--- a/tests/coverage/pos/ExcludeDef.scoverage.check
+++ b/tests/coverage/pos/ExcludeDef.scoverage.check
@@ -1,0 +1,20 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------

--- a/tests/coverage/pos/ExcludeFile.scala
+++ b/tests/coverage/pos/ExcludeFile.scala
@@ -1,0 +1,11 @@
+//> using options -coverage-exclude-files:.*ExcludeFile
+
+package covtest
+
+class Klass {
+  def abs(i: Int) =
+    if i > 0 then
+      i
+    else
+      -i
+}

--- a/tests/coverage/pos/ExcludeFile.scoverage.check
+++ b/tests/coverage/pos/ExcludeFile.scoverage.check
@@ -1,0 +1,20 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------

--- a/tests/coverage/pos/ExcludeOtherStuff.scala
+++ b/tests/coverage/pos/ExcludeOtherStuff.scala
@@ -1,0 +1,15 @@
+//> using options -coverage-exclude-packages:covtest.Oject,covtest.Tait
+
+package covtest
+
+object Oject {
+  def abs(i: Int) =
+    if i > 0 then
+      i
+    else
+      -i
+}
+
+trait Tait {
+  def abs(i: Int): Int
+}

--- a/tests/coverage/pos/ExcludeOtherStuff.scala
+++ b/tests/coverage/pos/ExcludeOtherStuff.scala
@@ -1,4 +1,4 @@
-//> using options -coverage-exclude-packages:covtest.Oject,covtest.Tait
+//> using options -coverage-exclude-classlikes:covtest.Oject,covtest.Tait
 
 package covtest
 

--- a/tests/coverage/pos/ExcludeOtherStuff.scoverage.check
+++ b/tests/coverage/pos/ExcludeOtherStuff.scoverage.check
@@ -1,0 +1,20 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------

--- a/tests/coverage/pos/ExcludePackage.scala
+++ b/tests/coverage/pos/ExcludePackage.scala
@@ -1,0 +1,11 @@
+//> using options -coverage-exclude-packages:covtest
+
+package covtest
+
+class Klass {
+  def abs(i: Int) =
+    if i > 0 then
+      i
+    else
+      -i
+}

--- a/tests/coverage/pos/ExcludePackage.scala
+++ b/tests/coverage/pos/ExcludePackage.scala
@@ -1,4 +1,4 @@
-//> using options -coverage-exclude-packages:covtest
+//> using options -coverage-exclude-classlikes:covtest
 
 package covtest
 

--- a/tests/coverage/pos/ExcludePackage.scoverage.check
+++ b/tests/coverage/pos/ExcludePackage.scoverage.check
@@ -1,0 +1,20 @@
+# Coverage data, format version: 3.0
+# Statement data:
+# - id
+# - source path
+# - package name
+# - class name
+# - class type (Class, Object or Trait)
+# - full class name
+# - method name
+# - start offset
+# - end offset
+# - line number
+# - symbol name
+# - tree name
+# - is branch
+# - invocations count
+# - is ignored
+# - description (can be multi-line)
+# '' sign
+# ------------------------------------------


### PR DESCRIPTION
- Add `-coverage-exclude-packages` option that excludes packages and classes
  from generating coverage
- Add `-coverage-exclude-files` option that excludes files from
  generating coverage