### PR TITLE
remove implementation from asInstanceOf

### DIFF
--- a/docs/_spec/12-the-scala-standard-library.md
+++ b/docs/_spec/12-the-scala-standard-library.md
@@ -68,11 +68,7 @@ abstract class Any {
   def isInstanceOf[a]: Boolean
 
   /** Type cast; needs to be inlined to work as given */ */
-  def asInstanceOf[A]: A = this match {
-    case x: A => x
-    case _ => if (this eq null) this
-              else throw new ClassCastException()
-  }
+  def asInstanceOf[A]: A
 }
 
 /** The root class of all value types */


### PR DESCRIPTION
it only adds to the confusion about asInstanceOf introducing type checks. 

See https://contributors.scala-lang.org/t/this-trick-enables-overloading-for-opaque-types/6560/17 and https://contributors.scala-lang.org/t/pre-sip-deprecate-asinstanceof-introduce-unsafeasinstanceof/6568