### PR TITLE
fix(#17255): cannot find Scala companion module from Java

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -41,7 +41,10 @@ object ContextOps:
             else pre.findMember(name, pre, required, excluded)
           }
           else // we are in the outermost context belonging to a class; self is invisible here. See inClassContext.
-            ctx.owner.findMember(name, ctx.owner.thisType, required, excluded)
+            if ctx.isJava then
+              javaFindMember(name, ctx.owner.thisType, lookInCompanion = true,required, excluded)
+            else
+              ctx.owner.findMember(name, ctx.owner.thisType, required, excluded)
         else
           ctx.scope.denotsNamed(name).filterWithFlags(required, excluded).toDenot(NoPrefix)
       }

--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -59,13 +59,16 @@ object ContextOps:
         val preSym = pre.typeSymbol
         // 1. Try to search in current type and parents.
         val directSearch =
-          if name.isTypeName && name.endsWith(StdNames.str.MODULE_SUFFIX) then
-            pre.findMember(name.stripModuleClassSuffix, pre, required, excluded) match
-              case NoDenotation => NoDenotation
-              case symDenot: SymDenotation =>
-                symDenot.companionModule.denot
-          else
-            pre.findMember(name, pre, required, excluded)
+          def asModule =
+            if name.isTypeName && name.endsWith(StdNames.str.MODULE_SUFFIX) then
+              pre.findMember(name.stripModuleClassSuffix, pre, required, excluded) match
+                case NoDenotation => NoDenotation
+                case symDenot: SymDenotation =>
+                  symDenot.companionModule.denot
+            else NoDenotation
+          pre.findMember(name, pre, required, excluded) match
+            case NoDenotation => asModule
+            case denot => denot
 
         // 2. Try to search in companion class if current is an object.
         def searchCompanionClass = if lookInCompanion && preSym.is(Flags.Module) then

--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -61,7 +61,7 @@ object ContextOps:
         val directSearch =
           def asModule =
             if name.isTypeName && name.endsWith(StdNames.str.MODULE_SUFFIX) then
-              pre.findMember(name.stripModuleClassSuffix, pre, required, excluded) match
+              pre.findMember(name.stripModuleClassSuffix.moduleClassName, pre, required, excluded) match
                 case NoDenotation => NoDenotation
                 case symDenot: SymDenotation =>
                   symDenot.companionModule.denot

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -29,6 +29,7 @@ i16649-irrefutable.scala
 strict-pattern-bindings-3.0-migration.scala
 i17186b.scala
 i11982a.scala
+i17255
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/compiler/test/dotc/run-test-pickling.blacklist
+++ b/compiler/test/dotc/run-test-pickling.blacklist
@@ -44,3 +44,5 @@ t6138
 t6138-2
 i12656.scala
 trait-static-forwarder
+i17255
+

--- a/tests/pos/i17255/Bar.java
+++ b/tests/pos/i17255/Bar.java
@@ -1,0 +1,6 @@
+package example;
+
+
+public class Bar {
+	private static final example.Foo$ MOD = example.Foo$.MODULE$;
+}

--- a/tests/pos/i17255/Baz.java
+++ b/tests/pos/i17255/Baz.java
@@ -1,0 +1,7 @@
+package example;
+
+import example.Foo$;
+
+public class Baz {
+	private static final Foo$ MOD = Foo$.MODULE$;
+}

--- a/tests/pos/i17255/Foo.scala
+++ b/tests/pos/i17255/Foo.scala
@@ -1,0 +1,5 @@
+package example
+
+case class Foo(i: Int)
+
+object Foo

--- a/tests/run/i17255/J.java
+++ b/tests/run/i17255/J.java
@@ -5,6 +5,9 @@ public class J {
 	public static p.J f() {
 		return p.J.j;
 	}
+	public static Module$ module2() {
+		return p.Module$.MODULE$;
+	}
 	public static p.Module$ module() {
 		return p.Module$.MODULE$;
 	}

--- a/tests/run/i17255/J.java
+++ b/tests/run/i17255/J.java
@@ -1,0 +1,13 @@
+package p;
+
+public class J {
+	public static J j = new J();
+	public static p.J f() {
+		return p.J.j;
+	}
+	public static p.Module$ module() {
+		return p.Module$.MODULE$;
+	}
+
+	public String toString() { return "J"; }
+}

--- a/tests/run/i17255/Module.scala
+++ b/tests/run/i17255/Module.scala
@@ -9,4 +9,5 @@ package p {
 object Test extends App {
   assert(p.J.f().toString == "J")
   assert(p.J.module().toString == "Module")
+  assert(p.J.module2().toString == "Module")
 }

--- a/tests/run/i17255/Module.scala
+++ b/tests/run/i17255/Module.scala
@@ -1,0 +1,10 @@
+package p {
+  object Module {
+    override def toString = "Module"
+  }
+}
+
+object Test extends App {
+  assert(p.J.f().toString == "J")
+  assert(p.J.module().toString == "Module")
+}

--- a/tests/run/i17255/Module.scala
+++ b/tests/run/i17255/Module.scala
@@ -1,3 +1,5 @@
+// scalajs: --skip
+
 package p {
   object Module {
     override def toString = "Module"


### PR DESCRIPTION
To find Scala companion mudule from Java, we should strip module suffix `$`.
This ~provides workaround~ fixes #17255 as well as forward-port https://github.com/scala/scala/pull/10644. ~, but it requires some refinment to fix it because not-fully-qualified type like the following example still fails to compile due to missing symbol.~

Related to https://github.com/scala/scala/pull/10644