### PR TITLE
Fix a REPL bad symbolic reference

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -112,16 +112,23 @@ object Symbols extends SymUtils {
     private def computeDenot(lastd: SymDenotation)(using Context): SymDenotation = {
       util.Stats.record("Symbol.computeDenot")
       val now = ctx.period
+      val prev = checkedPeriod
       checkedPeriod = now
-      if (lastd.validFor contains now) lastd else recomputeDenot(lastd)
+      if lastd.validFor.contains(now) then
+        lastd
+      else
+        val newd = recomputeDenot(lastd)
+        if newd.exists then
+          lastDenot = newd
+        else
+          checkedPeriod = prev
+        newd
     }
 
     /** Overridden in NoSymbol */
     protected def recomputeDenot(lastd: SymDenotation)(using Context): SymDenotation = {
       util.Stats.record("Symbol.recomputeDenot")
-      val newd = lastd.current.asInstanceOf[SymDenotation]
-      lastDenot = newd
-      newd
+      lastd.current.asSymDenotation
     }
 
     /** The original denotation of this symbol, without forcing anything */

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -423,6 +423,20 @@ class ReplCompilerTests extends ReplTest:
     s2
   }
 
+  @Test def i15562b: Unit = initially {
+    val s1 = run("List(1, 2).filter(_ % 2 == 0).foreach(println)")
+    assertEquals("2", storedOutput().trim)
+    s1
+  } andThen { s1 ?=>
+    val comp = tabComplete("val x = false + true; List(1, 2).filter(_ % 2 == 0).fore")
+    assertEquals(List("foreach"), comp.distinct)
+    s1
+  } andThen {
+    val s2 = run("List(1, 2).filter(_ % 2 == 0).foreach(println)")
+    assertEquals("2", storedOutput().trim)
+    s2
+  }
+
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -409,6 +409,20 @@ class ReplCompilerTests extends ReplTest:
   @Test def `i13097 expect template after colon` = contextually:
     assert(ParseResult.isIncomplete("class C:"))
 
+  @Test def i15562: Unit = initially {
+    val s1 = run("List(1, 2).filter(_ % 2 == 0).foreach(println)")
+    assertEquals("2", storedOutput().trim)
+    s1
+  } andThen { s1 ?=>
+    val comp = tabComplete("List(1, 2).filter(_ % 2 == 0).fore")
+    assertEquals(List("foreach"), comp.distinct)
+    s1
+  } andThen {
+    val s2 = run("List(1, 2).filter(_ % 2 == 0).foreach(println)")
+    assertEquals("2", storedOutput().trim)
+    s2
+  }
+
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -40,6 +40,10 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
 
   def contextually[A](op: Context ?=> A): A = op(using initialState.context)
 
+  /** Returns the `(<instance completions>, <companion completions>)`*/
+  def tabComplete(src: String)(implicit state: State): List[String] =
+    completions(src.length, src, state).map(_.value).sorted
+
   extension [A](state: State)
     infix def andThen(op: State ?=> A): A = op(using state)
 

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -8,10 +8,6 @@ import org.junit.Test
 /** These tests test input that has proved problematic */
 class TabcompleteTests extends ReplTest {
 
-  /** Returns the `(<instance completions>, <companion completions>)`*/
-  private def tabComplete(src: String)(implicit state: State): List[String] =
-    completions(src.length, src, state).map(_.value).sorted
-
   @Test def tabCompleteList = initially {
     val comp = tabComplete("List.r")
     assertEquals(List("range"), comp.distinct)


### PR DESCRIPTION
Fixes #15562

Copy of #19756, targetting main, where tests are more likely to pass.
