### PR TITLE
Allow range selection on function parameter to select a parameter list

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/SelectionRangeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/SelectionRangeSuite.scala
@@ -101,3 +101,49 @@ class SelectionRangeSuite extends BaseSelectionRangeSuite:
            |}<<region<<""".stripMargin
       )
     )
+
+  @Test def `function params` =
+    check(
+      """|object Main extends App {
+         |  def func(a@@: Int, b: Int) =
+         |    a + b
+         |}""".stripMargin,
+      List[String](
+        """|object Main extends App {
+           |  def func(>>region>>a: Int<<region<<, b: Int) =
+           |    a + b
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  def func(>>region>>a: Int, b: Int<<region<<) =
+           |    a + b
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  >>region>>def func(a: Int, b: Int) =
+           |    a + b<<region<<
+           |}""".stripMargin
+      )
+    )
+    check(
+      """|object Main extends App {
+         |  val func = (a@@: Int, b: Int) =>
+         |    a + b
+         |}""".stripMargin,
+      List[String](
+        """|object Main extends App {
+           |  val func = (>>region>>a: Int<<region<<, b: Int) =>
+           |    a + b
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  val func = (>>region>>a: Int, b: Int<<region<<) =>
+           |    a + b
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  val func = >>region>>(a: Int, b: Int) =>
+           |    a + b<<region<<
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  >>region>>val func = (a: Int, b: Int) =>
+           |    a + b<<region<<
+           |}""".stripMargin
+      )
+    )


### PR DESCRIPTION

<!--
  TODO first sign the CLA
  https://www.lightbend.com/contribute/cla/scala
-->

Fixes https://github.com/scalameta/metals/issues/5894.

<!-- TODO description of the change -->

- Add selection range for a parameter list in a function/method.
  Given a query as
  ```scala
  def func(a@@: Int, b: Int)(c: Int) =
      a + b + c
  ```
  range selection will now let you choose `a: Int, b: Int`.
  The previous options are `a: Int` and the whole definition of `func`.
- Add a new test for selection range on function parameters.

<!-- Ideally should have a called "Fix #XYZ: A SHORT FIX DESCRIPTION" -->
