### PR TITLE
Rename scala2-library-tasty  with experimental

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1229,6 +1229,7 @@ object Build {
   lazy val `scala2-library-tasty` = project.in(file("scala2-library-tasty")).
     withCommonSettings(Bootstrapped).
     settings(
+      moduleName := "scala2-library-tasty-experimental",
       exportJars := true,
       Compile / packageBin / mappings := {
         (`scala2-library-bootstrapped` / Compile / packageBin / mappings).value
@@ -1240,6 +1241,7 @@ object Build {
   lazy val `scala2-library-cc-tasty` = project.in(file("scala2-library-cc-tasty")).
     withCommonSettings(Bootstrapped).
     settings(
+      moduleName := "scala2-library-cc-tasty-experimental",
       exportJars := true,
       Compile / packageBin / mappings := {
         (`scala2-library-cc` / Compile / packageBin / mappings).value

--- a/sbt-test/sbt-dotty/scala2-library-tasty/build.sbt
+++ b/sbt-test/sbt-dotty/scala2-library-tasty/build.sbt
@@ -1,4 +1,4 @@
 scalaVersion := sys.props("plugin.scalaVersion")
 
-libraryDependencies += "org.scala-lang" %% "scala2-library-tasty" % scalaVersion.value
+libraryDependencies += "org.scala-lang" %% "scala2-library-tasty-experimental" % scalaVersion.value
 scalacOptions += "-Yscala2-unpickler:never" // check that we do not load symbol from the Scala 2 library classfiles (use TASTy)


### PR DESCRIPTION
This is to prepare the it for release. The name of the jar will be `scala2-library-tasty-experimental` to make it clear that it is not stable yet.