### PR TITLE
Add scala3-bootstrapped/testCompilation to 'test_windows_fast'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,7 +227,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test
-        run: sbt ";scala3-bootstrapped/compile"
+        run: sbt ";scala3-bootstrapped/compile; scala3-bootstrapped/testCompilation"
         shell: cmd
 
       - name: build binary


### PR DESCRIPTION
In light of the issue (post merge) of #19080 . We should add test compilation to windows_fast (not only windows_full).

Also see: #19802

cc @sjrd 