### PR TITLE
Tag experimental API tests

### DIFF
--- a/tests/neg-macros/i18677-a.check
+++ b/tests/neg-macros/i18677-a.check
@@ -7,10 +7,10 @@
   |The tree does not conform to the compiler's tree invariants.
   |
   |Macro was:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-a/Test_2.scala") @extendFoo class AFoo()
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-a/Test_2.scala") @scala.annotation.experimental @extendFoo class AFoo()
   |
   |The macro returned:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-a/Test_2.scala") @extendFoo class AFoo() extends Foo
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-a/Test_2.scala") @scala.annotation.experimental @extendFoo class AFoo() extends Foo
   |
   |Error:
   |assertion failed: Parents of class symbol differs from the parents in the tree for class AFoo

--- a/tests/neg-macros/i18677-a/Macro_1.scala
+++ b/tests/neg-macros/i18677-a/Macro_1.scala
@@ -1,4 +1,4 @@
-//> using -expermiental
+//> using options -experimental -Yno-experimental
 
 import annotation.MacroAnnotation
 import quoted.*

--- a/tests/neg-macros/i18677-a/Test_2.scala
+++ b/tests/neg-macros/i18677-a/Test_2.scala
@@ -1,4 +1,4 @@
-//> using -expermiental
+//> using options -experimental -Yno-experimental
 
 @extendFoo
 class AFoo // error

--- a/tests/neg-macros/i18677-b.check
+++ b/tests/neg-macros/i18677-b.check
@@ -7,10 +7,10 @@
   |The tree does not conform to the compiler's tree invariants.
   |
   |Macro was:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-b/Test_2.scala") @extendFoo class AFoo()
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-b/Test_2.scala") @scala.annotation.experimental @extendFoo class AFoo()
   |
   |The macro returned:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-b/Test_2.scala") @extendFoo class AFoo() extends Foo
+  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-b/Test_2.scala") @scala.annotation.experimental @extendFoo class AFoo() extends Foo
   |
   |Error:
   |assertion failed: Parents of class symbol differs from the parents in the tree for class AFoo

--- a/tests/neg-macros/i18677-b/Macro_1.scala
+++ b/tests/neg-macros/i18677-b/Macro_1.scala
@@ -1,4 +1,4 @@
-//> using -expermiental
+//> using options -experimental -Yno-experimental
 
 import annotation.MacroAnnotation
 import quoted.*

--- a/tests/neg-macros/i18677-b/Test_2.scala
+++ b/tests/neg-macros/i18677-b/Test_2.scala
@@ -1,4 +1,4 @@
-//> using -expermiental
+//> using options -experimental -Yno-experimental
 
 @extendFoo
 class AFoo // error

--- a/tests/neg-macros/newClassExtendsNoParents/Macro_1.scala
+++ b/tests/neg-macros/newClassExtendsNoParents/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.quoted.*
 
 inline def makeClass(inline name: String): Any = ${ makeClassExpr('name) }

--- a/tests/neg-macros/newClassExtendsNoParents/Test_2.scala
+++ b/tests/neg-macros/newClassExtendsNoParents/Test_2.scala
@@ -1,1 +1,3 @@
+//> using options -experimental -Yno-experimental
+
 def test: Any = makeClass("foo") // error

--- a/tests/neg-macros/newClassExtendsOnlyTrait/Macro_1.scala
+++ b/tests/neg-macros/newClassExtendsOnlyTrait/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.quoted.*
 
 inline def makeClass(inline name: String): Foo = ${ makeClassExpr('name) }

--- a/tests/neg-macros/newClassExtendsOnlyTrait/Test_2.scala
+++ b/tests/neg-macros/newClassExtendsOnlyTrait/Test_2.scala
@@ -1,1 +1,3 @@
+//> using options -experimental -Yno-experimental
+
 def test: Foo = makeClass("foo") // error

--- a/tests/pos-macros/annot-in-object/Macro_1.scala
+++ b/tests/pos-macros/annot-in-object/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/pos-macros/annot-in-object/Test_2.scala
+++ b/tests/pos-macros/annot-in-object/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @Foo.void
 @Foo.Bar.void
 def test = 0

--- a/tests/pos-macros/annot-suspend/Macro_1.scala
+++ b/tests/pos-macros/annot-suspend/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/pos-macros/annot-suspend/Test_2.scala
+++ b/tests/pos-macros/annot-suspend/Test_2.scala
@@ -1,2 +1,4 @@
+//> using options -experimental -Yno-experimental
+
 @void
 def test = 0

--- a/tests/pos-macros/annot-then-inline/Macro_1.scala
+++ b/tests/pos-macros/annot-then-inline/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/pos-macros/annot-then-inline/Test_2.scala
+++ b/tests/pos-macros/annot-then-inline/Test_2.scala
@@ -1,2 +1,4 @@
+//> using options -experimental -Yno-experimental
+
 @useInlinedIdentity
 def test = 0

--- a/tests/pos-macros/i15413/Macro_1.scala
+++ b/tests/pos-macros/i15413/Macro_1.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -WunstableInlineAccessors
+//> using options -experimental -Yno-experimental -Werror -WunstableInlineAccessors
 
 import scala.quoted.*
 import scala.annotation.publicInBinary

--- a/tests/pos-macros/i15413/Test_2.scala
+++ b/tests/pos-macros/i15413/Test_2.scala
@@ -1,2 +1,4 @@
+//> using options -experimental -Yno-experimental
+
 def test =
   new Macro().foo

--- a/tests/pos-macros/i15413b/Macro_1.scala
+++ b/tests/pos-macros/i15413b/Macro_1.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -WunstableInlineAccessors
+//> using options -experimental -Yno-experimental -Werror -WunstableInlineAccessors
 
 package bar
 

--- a/tests/pos-macros/i15413b/Test_2.scala
+++ b/tests/pos-macros/i15413b/Test_2.scala
@@ -1,1 +1,3 @@
+//> using options -experimental -Yno-experimental
+
 def test = bar.foo

--- a/tests/pos-macros/i19526b/Test.scala
+++ b/tests/pos-macros/i19526b/Test.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 package crash.test
 
 case class Stack private[crash] (

--- a/tests/run-macros/Xmacro-settings-compileTimeEnv/Test.scala
+++ b/tests/run-macros/Xmacro-settings-compileTimeEnv/Test.scala
@@ -1,4 +1,4 @@
-//> using options -Xmacro-settings:a,b=1,c.b.a=x.y.z=1,myLogger.level=INFO
+//> using options -experimental -Yno-experimental -Xmacro-settings:a,b=1,c.b.a=x.y.z=1,myLogger.level=INFO
 
 import scala.compiletime.*
 

--- a/tests/run-macros/Xmacro-settings-simple/M1.scala
+++ b/tests/run-macros/Xmacro-settings-simple/M1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 package x
 
 import scala.quoted.*

--- a/tests/run-macros/annot-add-global-class/Macro_1.scala
+++ b/tests/run-macros/annot-add-global-class/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 package mymacro
 
 import scala.annotation.{experimental, MacroAnnotation}

--- a/tests/run-macros/annot-add-global-class/Test_2.scala
+++ b/tests/run-macros/annot-add-global-class/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import mymacro.addClass
 
 @addClass def foo(): Unit =

--- a/tests/run-macros/annot-add-global-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-global-object/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-add-global-object/Test_2.scala
+++ b/tests/run-macros/annot-add-global-object/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @addClass def foo(): Unit =
   println("macro generated main")
   println("executed in: " + (new Throwable().getStackTrace().head.getClassName))

--- a/tests/run-macros/annot-add-local-class/Macro_1.scala
+++ b/tests/run-macros/annot-add-local-class/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-add-local-class/Test_2.scala
+++ b/tests/run-macros/annot-add-local-class/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @main def Test(): Unit =
   @addClass def foo(): Unit =
     println("macro generated main")

--- a/tests/run-macros/annot-add-local-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-local-object/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-add-local-object/Test_2.scala
+++ b/tests/run-macros/annot-add-local-object/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @main def Test(): Unit =
   @addClass def foo(): Unit =
     println("macro generated main")

--- a/tests/run-macros/annot-add-nested-class/Macro_1.scala
+++ b/tests/run-macros/annot-add-nested-class/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-add-nested-class/Test_2.scala
+++ b/tests/run-macros/annot-add-nested-class/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 class Foo():
   @addClass def foo(): Unit =
     println("macro generated main")

--- a/tests/run-macros/annot-add-nested-object/Macro_1.scala
+++ b/tests/run-macros/annot-add-nested-object/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-add-nested-object/Test_2.scala
+++ b/tests/run-macros/annot-add-nested-object/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 class Foo():
   @addClass def foo(): Unit =
     println("macro generated main")

--- a/tests/run-macros/annot-annot-order/Macro_1.scala
+++ b/tests/run-macros/annot-annot-order/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/run-macros/annot-annot-order/Test_2.scala
+++ b/tests/run-macros/annot-annot-order/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @print("foo")
 def foo(): Unit = ()
 

--- a/tests/run-macros/annot-bind/Macro_1.scala
+++ b/tests/run-macros/annot-bind/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/run-macros/annot-bind/Test_2.scala
+++ b/tests/run-macros/annot-bind/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @bind("a")
 val foo: String = "foo"
 

--- a/tests/run-macros/annot-changeVal/Macro_1.scala
+++ b/tests/run-macros/annot-changeVal/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.experimental
 import scala.quoted.*
 import scala.annotation.MacroAnnotation

--- a/tests/run-macros/annot-changeVal/Test_2.scala
+++ b/tests/run-macros/annot-changeVal/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import ChangeVal._
 
 class Bar:

--- a/tests/run-macros/annot-concrete-class/Macro_1.scala
+++ b/tests/run-macros/annot-concrete-class/Macro_1.scala
@@ -1,16 +1,18 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.MacroAnnotation
 import scala.quoted.*
 
 class implementAFoo extends MacroAnnotation:
 
-    def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] = 
+    def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
         import quotes.reflect.*
         tree match
-            case ClassDef(name, cstr, parents, self, body) => 
+            case ClassDef(name, cstr, parents, self, body) =>
                 val owner = tree.symbol
                 val sym = Symbol.newMethod(tree.symbol, "foo", ByNameType.apply(TypeRepr.of[String]))
                 val mtd = DefDef.apply(sym, _ => Some(Literal(StringConstant("Hello, I was added by a MacroAnnotation and without being defined in the class."))))
                 List(ClassDef.copy(tree)(name, cstr, parents, self, mtd :: body))
             case _ => report.errorAndAbort(s"@implementAFoo can only be applied to classes that extend AFoo")
-        
+
 end implementAFoo

--- a/tests/run-macros/annot-concrete-class/Test_2.scala
+++ b/tests/run-macros/annot-concrete-class/Test_2.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 
 trait AFoo:
     def foo: String
@@ -5,7 +6,6 @@ trait AFoo:
 @implementAFoo
 class Foo extends AFoo
 
-@main def Test = 
+@main def Test =
     val foo = new Foo
     println(foo.foo)
-    

--- a/tests/run-macros/annot-export/Macro_1.scala
+++ b/tests/run-macros/annot-export/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable.Map

--- a/tests/run-macros/annot-export/Test_2.scala
+++ b/tests/run-macros/annot-export/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 object Bar:
   @returnClassName
   def f(): String = ??? // def f(): String = "Bar"

--- a/tests/run-macros/annot-gen2/Macro_1.scala
+++ b/tests/run-macros/annot-gen2/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/run-macros/annot-gen2/Macro_2.scala
+++ b/tests/run-macros/annot-gen2/Macro_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/run-macros/annot-gen2/Test_3.scala
+++ b/tests/run-macros/annot-gen2/Test_3.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 class Bar:
   @foo def bar(s: String) = s
 

--- a/tests/run-macros/annot-generate/Macro_1.scala
+++ b/tests/run-macros/annot-generate/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/run-macros/annot-generate/Macro_2.scala
+++ b/tests/run-macros/annot-generate/Macro_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/run-macros/annot-generate/Test_3.scala
+++ b/tests/run-macros/annot-generate/Test_3.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 class Bar:
   @foo def bar(x: Int) = x + 1
 

--- a/tests/run-macros/annot-macro-main/Macro_1.scala
+++ b/tests/run-macros/annot-macro-main/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-macro-main/Test_2.scala
+++ b/tests/run-macros/annot-macro-main/Test_2.scala
@@ -1,1 +1,3 @@
+//> using options -experimental -Yno-experimental
+
 @mainMacro def Test(): Unit = println("macro generated main")

--- a/tests/run-macros/annot-memo/Macro_1.scala
+++ b/tests/run-macros/annot-memo/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-memo/Test_2.scala
+++ b/tests/run-macros/annot-memo/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 class Bar:
   @memoize
   def fib(n: Int): Int =

--- a/tests/run-macros/annot-mod-class-add-def/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-add-def/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-add-def/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-add-def/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @addIndirectToString("This is Foo")
 class Foo
   //> private def string$macro$1: String = "This is Foo"

--- a/tests/run-macros/annot-mod-class-add-inner-class/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-add-inner-class/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-add-inner-class/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-add-inner-class/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @addInnerClass
 class Foo
   //> class Show:

--- a/tests/run-macros/annot-mod-class-add-lazy-val/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-add-lazy-val/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-add-lazy-val/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-add-lazy-val/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @addMemoToString("This is Foo")
 class Foo
   //> private lazy val string$macro$1: String = "This is Foo"

--- a/tests/run-macros/annot-mod-class-add-local-class/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-add-local-class/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-add-local-class/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-add-local-class/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @addInnerClass
 class Foo
   //> def toString(): String =

--- a/tests/run-macros/annot-mod-class-add-val/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-add-val/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-add-val/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-add-val/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @addMemoToString("This is Foo")
 class Foo
   //> private val string$macro$1: String = "This is Foo"

--- a/tests/run-macros/annot-mod-class-add-var/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-add-var/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-add-var/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-add-var/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @addCountToString("This is Foo: ")
 class Foo:
   //> private var count$macro$1: Int = 0

--- a/tests/run-macros/annot-mod-class-data/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-data/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted.*
 

--- a/tests/run-macros/annot-mod-class-data/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-data/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @data class Foo(val a: String, val b: Int)
   //> override def toString(): String = Seq(this.a, this.b).mkString("Foo(", ", ", ")")
   //> override def equals(that: Any): Boolean =

--- a/tests/run-macros/annot-mod-class-equals/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-equals/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted.*
 

--- a/tests/run-macros/annot-mod-class-equals/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-equals/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @equals class Foo(val a: String, val b: Int)
   //> override def equals(that: Any): Boolean =
   //>   that match

--- a/tests/run-macros/annot-mod-class-mod-def/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-mod-def/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-mod-def/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-mod-def/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @modToString("This is Foo")
 class Foo:
   override def toString(): String = "?" //> override def toString(): String = "This is Foo"

--- a/tests/run-macros/annot-mod-class-mod-val/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-mod-val/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-mod-val/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-mod-val/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @setValue("valDef", "a")
 @setValue("varDef", "b")
 @setValue("lazyVarDef", "c")

--- a/tests/run-macros/annot-mod-class-override-def/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-override-def/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-override-def/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-override-def/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @genToString("This is Foo")
 class Foo
   //> override def toString(): String = "This is Foo"

--- a/tests/run-macros/annot-mod-class-override-val/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-override-val/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-override-val/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-override-val/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 class Foo:
   val val1: String = "?"
   def def1: String = "?"

--- a/tests/run-macros/annot-mod-class-unused-new-sym/Macro_1.scala
+++ b/tests/run-macros/annot-mod-class-unused-new-sym/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable

--- a/tests/run-macros/annot-mod-class-unused-new-sym/Test_2.scala
+++ b/tests/run-macros/annot-mod-class-unused-new-sym/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @newUnusedSymbol
 class Foo
 

--- a/tests/run-macros/annot-result-order/Macro_1.scala
+++ b/tests/run-macros/annot-result-order/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 

--- a/tests/run-macros/annot-result-order/Test_2.scala
+++ b/tests/run-macros/annot-result-order/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @print("foo")
 def foo(): Unit = ()
 

--- a/tests/run-macros/annot-simple-fib/Macro_1.scala
+++ b/tests/run-macros/annot-simple-fib/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted._
 import scala.collection.mutable.Map

--- a/tests/run-macros/annot-simple-fib/Test_2.scala
+++ b/tests/run-macros/annot-simple-fib/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 class Bar:
   @memoize
   def fib(n: Int): Int =

--- a/tests/run-macros/i11685/Macro_1.scala
+++ b/tests/run-macros/i11685/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 package test
 
 import scala.quoted.*

--- a/tests/run-macros/i11685/Test_2.scala
+++ b/tests/run-macros/i11685/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import test.MyMacro
 
 trait Command {

--- a/tests/run-macros/i16734b/Macro_1.scala
+++ b/tests/run-macros/i16734b/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.quoted.*
 
 inline def typeVariances[A <: AnyKind]: String =

--- a/tests/run-macros/i16734b/Test_2.scala
+++ b/tests/run-macros/i16734b/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 type F1Inv[A]
 type F1Cov[+A]
 type F1Con[-A]

--- a/tests/run-macros/newClass/Macro_1.scala
+++ b/tests/run-macros/newClass/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.quoted.*
 
 inline def makeClass(inline name: String): Any = ${ makeClassExpr('name) }

--- a/tests/run-macros/newClass/Test_2.scala
+++ b/tests/run-macros/newClass/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @main def Test: Unit = {
   val foo = makeClass("foo")
   println(foo.getClass)

--- a/tests/run-macros/newClassExtends/Macro_1.scala
+++ b/tests/run-macros/newClassExtends/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.quoted.*
 
 inline def makeClass(inline name: String): Foo = ${ makeClassExpr('name) }

--- a/tests/run-macros/newClassExtends/Test_2.scala
+++ b/tests/run-macros/newClassExtends/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @main def Test: Unit = {
   val foo: Foo = makeClass("foo")
   foo.foo()

--- a/tests/run-macros/newClassExtendsClassParams/Macro_1.scala
+++ b/tests/run-macros/newClassExtendsClassParams/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.quoted.*
 
 inline def makeClass(inline name: String): Foo = ${ makeClassExpr('name) }

--- a/tests/run-macros/newClassExtendsClassParams/Test_2.scala
+++ b/tests/run-macros/newClassExtendsClassParams/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @main def Test: Unit = {
   val foo: Foo = makeClass("foo")
   foo.foo()

--- a/tests/run-macros/newClassSelf/Macro_1.scala
+++ b/tests/run-macros/newClassSelf/Macro_1.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.quoted.*
 
 inline def makeClass(inline name: String): Bar = ${ makeClassExpr('name) }

--- a/tests/run-macros/newClassSelf/Test_2.scala
+++ b/tests/run-macros/newClassSelf/Test_2.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 @main def Test: Unit = {
   val a: Bar = makeClass("A")
   a.bar()

--- a/tests/run/main-annotation-birthday.scala
+++ b/tests/run/main-annotation-birthday.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-dash-dash.scala
+++ b/tests/run/main-annotation-dash-dash.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-default-value-1.scala
+++ b/tests/run/main-annotation-default-value-1.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-default-value-2.scala
+++ b/tests/run/main-annotation-default-value-2.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-example.scala
+++ b/tests/run/main-annotation-example.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.*

--- a/tests/run/main-annotation-flags.scala
+++ b/tests/run/main-annotation-flags.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-help-override.scala
+++ b/tests/run/main-annotation-help-override.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-help.scala
+++ b/tests/run/main-annotation-help.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-homemade-annot-1.scala
+++ b/tests/run/main-annotation-homemade-annot-1.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.concurrent._

--- a/tests/run/main-annotation-homemade-annot-2.scala
+++ b/tests/run/main-annotation-homemade-annot-2.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.collection.mutable

--- a/tests/run/main-annotation-homemade-annot-3.scala
+++ b/tests/run/main-annotation-homemade-annot-3.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.*

--- a/tests/run/main-annotation-homemade-annot-4.scala
+++ b/tests/run/main-annotation-homemade-annot-4.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.*

--- a/tests/run/main-annotation-homemade-annot-5.scala
+++ b/tests/run/main-annotation-homemade-annot-5.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.*

--- a/tests/run/main-annotation-homemade-annot-6.scala
+++ b/tests/run/main-annotation-homemade-annot-6.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.*

--- a/tests/run/main-annotation-homemade-parser-1.scala
+++ b/tests/run/main-annotation-homemade-parser-1.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-homemade-parser-2.scala
+++ b/tests/run/main-annotation-homemade-parser-2.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-homemade-parser-3.scala
+++ b/tests/run/main-annotation-homemade-parser-3.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-homemade-parser-4.scala
+++ b/tests/run/main-annotation-homemade-parser-4.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-homemade-parser-5.scala
+++ b/tests/run/main-annotation-homemade-parser-5.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-multiple.scala
+++ b/tests/run/main-annotation-multiple.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-named-params.scala
+++ b/tests/run/main-annotation-named-params.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-newMain.scala
+++ b/tests/run/main-annotation-newMain.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.*

--- a/tests/run/main-annotation-no-parameters-no-parens.scala
+++ b/tests/run/main-annotation-no-parameters-no-parens.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-no-parameters.scala
+++ b/tests/run/main-annotation-no-parameters.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-overload.scala
+++ b/tests/run/main-annotation-overload.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-param-annot-1.scala
+++ b/tests/run/main-annotation-param-annot-1.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-param-annot-2.scala
+++ b/tests/run/main-annotation-param-annot-2.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-param-annot-invalid-params.scala
+++ b/tests/run/main-annotation-param-annot-invalid-params.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-return-type-1.scala
+++ b/tests/run/main-annotation-return-type-1.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-return-type-2.scala
+++ b/tests/run/main-annotation-return-type-2.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-short-name.scala
+++ b/tests/run/main-annotation-short-name.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-simple.scala
+++ b/tests/run/main-annotation-simple.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-top-level.scala
+++ b/tests/run/main-annotation-top-level.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-types.scala
+++ b/tests/run/main-annotation-types.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-vararg-1.scala
+++ b/tests/run/main-annotation-vararg-1.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-vararg-2.scala
+++ b/tests/run/main-annotation-vararg-2.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-wrong-param-1.scala
+++ b/tests/run/main-annotation-wrong-param-1.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-wrong-param-names.scala
+++ b/tests/run/main-annotation-wrong-param-names.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-wrong-param-number.scala
+++ b/tests/run/main-annotation-wrong-param-number.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-annotation-wrong-param-type.scala
+++ b/tests/run/main-annotation-wrong-param-type.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 import scala.annotation.newMain

--- a/tests/run/main-calculator-example.scala
+++ b/tests/run/main-calculator-example.scala
@@ -1,3 +1,4 @@
+//> using options -experimental -Yno-experimental
 // scalajs: --skip
 
 sealed trait Expression:
@@ -23,7 +24,7 @@ import scala.annotation.{ MainAnnotation, experimental }
 import scala.annotation.MainAnnotation.{ Info, Parameter }
 import scala.util.CommandLineParser.FromString
 
-@experimental class showAndEval extends MainAnnotation[FromString, Expression]:
+class showAndEval extends MainAnnotation[FromString, Expression]:
   def command(info: Info, args: Seq[String]): Option[Seq[String]] =
     assert(info.parameters.forall(param => param.typeName == "Number"), "Only Number parameters allowed")
     println(s"executing ${info.name} with inputs: ${args.mkString(" ")}")

--- a/tests/run/tupled-function-andThen.scala
+++ b/tests/run/tupled-function-andThen.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.util.TupledFunction
 
 object Test {

--- a/tests/run/tupled-function-apply.scala
+++ b/tests/run/tupled-function-apply.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.util.TupledFunction
 
 object Test {

--- a/tests/run/tupled-function-compose.scala
+++ b/tests/run/tupled-function-compose.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.util.TupledFunction
 object Test {
   def main(args: Array[String]): Unit = {

--- a/tests/run/tupled-function-extension-method.scala
+++ b/tests/run/tupled-function-extension-method.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.util.TupledFunction
 object Test {
   def main(args: Array[String]): Unit = {

--- a/tests/run/tupled-function-tupled.scala
+++ b/tests/run/tupled-function-tupled.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.util.TupledFunction
 
 object Test {

--- a/tests/run/tupled-function-untupled.scala
+++ b/tests/run/tupled-function-untupled.scala
@@ -1,3 +1,5 @@
+//> using options -experimental -Yno-experimental
+
 import scala.util.TupledFunction
 object Test {
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
Add explicitly `-experimental -Yno-experimental` to tests that use definitions that are `@experimental` in the standard library. `-Yno-experimental` disables the experimental mode from nightly builds and `-experimental` adds `@experimental` to all top-level definitions.

This is in preparation of #19760 and the disabling of experimental mode by default in nightly builds. When nighly experimental mode will be disabled we will be able to drop the `-Yno-experimental`.

These tests are for 
* `scala.annotation.MacroAnnotation`
* `scala.annotation.MainAnnotation`
* `scala.annotation.newMain`
* `scala.util.TupledFunction`
* Expreminetal definitions in `scala.quoted.Quotes`



