### PR TITLE
Add nightly tests for `scala2-library-cc-tasty`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,9 +198,9 @@ jobs:
       - name: Test with Scala 2 library TASTy
         run: ./project/scripts/sbt ";set ThisBuild/Build.scala2Library := Build.Scala2LibraryTasty ;scala3-bootstrapped/test"
 
-      # TODO test all the test configurations in non-CC library (currently disabled due to bug while loading the library)
-      # - name: Test with Scala 2 library with CC TASTy
-      #   run: ./project/scripts/sbt ";set ThisBuild/Build.scala2Library := Build.Scala2LibraryCCTasty ;scala3-bootstrapped/test"
+      # TODO increase coverage to `scala3-bootstrapped/test`
+      - name: Test with Scala 2 library with CC TASTy
+        run: ./project/scripts/sbt ";set ThisBuild/Build.scala2Library := Build.Scala2LibraryCCTasty ;scala3-bootstrapped/testCompilation pos"
 
 
   test_windows_fast:


### PR DESCRIPTION
Only test a subset of tests that are known to currently work.

[test_scala2_library_tasty]

All `pos` tests work now. We will increase coverage to all tests once failures in https://github.com/lampepfl/dotty/issues/19652#issuecomment-1969370722 are fixed.