### PR TITLE
Fix Function tree copier

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1254,11 +1254,12 @@ object Trees {
         case _ => finalize(tree, untpd.Ident(name)(sourceFile(tree)))
       }
       def Select(tree: Tree)(qualifier: Tree, name: Name)(using Context): Select = tree match {
-        case tree: SelectWithSig =>
-          if ((qualifier eq tree.qualifier) && (name == tree.name)) tree
-          else finalize(tree, SelectWithSig(qualifier, name, tree.sig)(sourceFile(tree)))
         case tree: Select if (qualifier eq tree.qualifier) && (name == tree.name) => tree
-        case _ => finalize(tree, untpd.Select(qualifier, name)(sourceFile(tree)))
+        case _ =>
+          val tree1 = tree match
+            case tree: SelectWithSig => untpd.SelectWithSig(qualifier, name, tree.sig)(using sourceFile(tree))
+            case _ => untpd.Select(qualifier, name)(using sourceFile(tree))
+          finalize(tree, tree1)
       }
       /** Copy Ident or Select trees */
       def Ref(tree: RefTree)(name: Name)(using Context): RefTree = tree match {

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -609,7 +609,11 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
     }
     def Function(tree: Tree)(args: List[Tree], body: Tree)(using Context): Tree = tree match {
       case tree: Function if (args eq tree.args) && (body eq tree.body) => tree
-      case _ => finalize(tree, untpd.Function(args, body)(tree.source))
+      case _ =>
+        val tree1 = tree match
+          case tree: FunctionWithMods => untpd.FunctionWithMods(args, body, tree.mods, tree.erasedParams)(using tree.source)
+          case _ => untpd.Function(args, body)(using tree.source)
+        finalize(tree, tree1)
     }
     def PolyFunction(tree: Tree)(targs: List[Tree], body: Tree)(using Context): Tree = tree match {
       case tree: PolyFunction if (targs eq tree.targs) && (body eq tree.body) => tree

--- a/tests/pos-custom-args/captures/i19751.scala
+++ b/tests/pos-custom-args/captures/i19751.scala
@@ -1,0 +1,22 @@
+import language.experimental.captureChecking
+import annotation.capability
+import caps.cap
+
+trait Ptr[A]
+@capability trait Scope:
+  def allocate(size: Int): Ptr[Unit]^{this}
+
+
+object Scope:
+  def confined[A](fn: Scope ?->{cap} A): A =
+    val scope = new Scope:
+      def allocate(size: Int) = new Ptr[Unit] {}
+    fn(using scope)
+
+def Test: Unit =
+  val s = Scope.confined:
+    val s2 = summon[Scope]
+    Scope.confined:
+      s2.allocate(5)
+    5
+


### PR DESCRIPTION
It did not copy correctly instances of the FunctionWithMods subclass.

Fixes #19751