### PR TITLE
used derived types to type arguments of dependent function type

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1463,14 +1463,14 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           if isErasedClass then arg.withAddedFlags(Erased) else arg
         }
         return typedDependent(newParams)
-      val resTpt = TypeTree(mt.nonDependentResultApprox).withSpan(body.span)
-      val typeArgs = appDef.termParamss.head.map(_.tpt) :+ resTpt
       val core =
         if mt.hasErasedParams then TypeTree(defn.PolyFunctionClass.typeRef)
         else
+          val resTpt = TypeTree(mt.nonDependentResultApprox).withSpan(body.span)
+          val paramTpts = appDef.termParamss.head.map(p => TypeTree(p.tpt.tpe).withSpan(p.tpt.span))
           val funSym = defn.FunctionSymbol(numArgs, isContextual, isImpure)
           val tycon = TypeTree(funSym.typeRef)
-          AppliedTypeTree(tycon, typeArgs)
+          AppliedTypeTree(tycon, paramTpts :+ resTpt)
       RefinedTypeTree(core, List(appDef), ctx.owner.asClass)
     end typedDependent
 

--- a/tests/pos/i19629.scala
+++ b/tests/pos/i19629.scala
@@ -1,0 +1,10 @@
+trait CP[A,B]
+trait TypeEqK[F[_], G[_]]
+
+trait Knit[CP[_, _], F[_]] {
+  type Res
+
+  def visit[R](
+    caseInFst: [F1[_], Y] => (k: Knit[CP, F1]) => (ev: TypeEqK[F, [x] =>> CP[F1[x], Y]]) => R
+  ): R
+}

--- a/tests/run/i19629/Test_2.scala
+++ b/tests/run/i19629/Test_2.scala
@@ -1,0 +1,12 @@
+
+class Container[Y1, G[_]]:
+  lazy val outer: Knit[CP, G] = new:
+    type Res = Y1
+    def visit[R](caseInFst: [F1[_], Y] => (k: Knit[CP, F1]) => (ev: TypeEqK[G, [x] =>> CP[F1[x], Y]]) => R): R =
+      caseInFst[G, Res](outer)(new TypeEqK[G, [x] =>> CP[G[x], Res]] {})
+
+@main def Test =
+  val knit = new Container[Unit, Option].outer
+  val res = knit.visit:
+    [F1[_], Y] => (k: Knit[CP, F1]) => (ev: TypeEqK[Option, [x] =>> CP[F1[x], Y]]) => 42
+  assert(res == 42)

--- a/tests/run/i19629/lib_1.scala
+++ b/tests/run/i19629/lib_1.scala
@@ -1,0 +1,10 @@
+trait CP[A,B]
+trait TypeEqK[F[_], G[_]]
+
+trait Knit[CP[_, _], F[_]] {
+  type Res
+
+  def visit[R](
+    caseInFst: [F1[_], Y] => (k: Knit[CP, F1]) => (ev: TypeEqK[F, [x] =>> CP[F1[x], Y]]) => R
+  ): R
+}


### PR DESCRIPTION
We don't need to repeat the tree twice, instead derive a type tree from the original tree, and reuse its spans.

fixes #19629 