### PR TITLE
Drop FreeSeqFactory from stdlib-cc

### DIFF
--- a/scala2-library-cc/src/scala/collection/Factory.scala
+++ b/scala2-library-cc/src/scala/collection/Factory.scala
@@ -297,16 +297,20 @@ object IterableFactory {
 }
 
 // !!! Needed to add this separate trait
-trait FreeSeqFactory[+CC[A]] extends IterableFactory[CC]:
-  def from[A](source: IterableOnce[A]^): CC[A]
-  override def apply[A](elems: A*): CC[A] = from(elems)
+//trait FreeSeqFactory[+CC[A]] extends IterableFactory[CC]:
+//  def from[A](source: IterableOnce[A]^): CC[A]
+//  override def apply[A](elems: A*): CC[A]
+
+// type FreeSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] = SeqFactory[CC]
 
 /**
   * @tparam CC Collection type constructor (e.g. `List`)
   */
-trait SeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extends FreeSeqFactory[CC] {
+trait SeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extends IterableFactory[CC] {
   import SeqFactory.UnapplySeqWrapper
   final def unapplySeq[A](x: CC[A] @uncheckedVariance): UnapplySeqWrapper[A] = new UnapplySeqWrapper(x) // TODO is uncheckedVariance sound here?
+  def from[A](source: IterableOnce[A]^): CC[A]
+  override def apply[A](elems: A*): CC[A] = from(elems)
 }
 
 object SeqFactory {

--- a/scala2-library-cc/src/scala/collection/Factory.scala
+++ b/scala2-library-cc/src/scala/collection/Factory.scala
@@ -296,21 +296,12 @@ object IterableFactory {
   }
 }
 
-// !!! Needed to add this separate trait
-//trait FreeSeqFactory[+CC[A]] extends IterableFactory[CC]:
-//  def from[A](source: IterableOnce[A]^): CC[A]
-//  override def apply[A](elems: A*): CC[A]
-
-// type FreeSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] = SeqFactory[CC]
-
 /**
   * @tparam CC Collection type constructor (e.g. `List`)
   */
 trait SeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extends IterableFactory[CC] {
   import SeqFactory.UnapplySeqWrapper
   final def unapplySeq[A](x: CC[A] @uncheckedVariance): UnapplySeqWrapper[A] = new UnapplySeqWrapper(x) // TODO is uncheckedVariance sound here?
-  def from[A](source: IterableOnce[A]^): CC[A]
-  override def apply[A](elems: A*): CC[A] = from(elems)
 }
 
 object SeqFactory {

--- a/scala2-library-cc/src/scala/collection/generic/IsSeq.scala
+++ b/scala2-library-cc/src/scala/collection/generic/IsSeq.scala
@@ -84,7 +84,7 @@ object IsSeq {
           def toIterable: Iterable[Char] = new immutable.WrappedString(s)
           protected[this] def coll: String = s
           protected[this] def fromSpecific(coll: IterableOnce[Char]^): String = coll.iterator.mkString
-          def iterableFactory: FreeSeqFactory[immutable.ArraySeq] = immutable.ArraySeq.untagged
+          def iterableFactory: IterableFactory[immutable.ArraySeq] = immutable.ArraySeq.untagged
           override def empty: String = ""
           protected[this] def newSpecificBuilder: mutable.Builder[Char, String] = new StringBuilder
           def iterator: Iterator[Char] = s.iterator
@@ -102,7 +102,7 @@ object IsSeq {
           def toIterable: Iterable[A] = mutable.ArraySeq.make[A](a)
           protected def coll: Array[A] = a
           protected def fromSpecific(coll: IterableOnce[A]^): Array[A] = Array.from(coll)
-          def iterableFactory: FreeSeqFactory[mutable.ArraySeq] = mutable.ArraySeq.untagged
+          def iterableFactory: IterableFactory[mutable.ArraySeq] = mutable.ArraySeq.untagged
           override def empty: Array[A] = Array.empty[A]
           protected def newSpecificBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder
           def iterator: Iterator[A] = a.iterator


### PR DESCRIPTION
FreeSeqFactory was a construction to demonstrate type safety for certain iterableFactory.from calls where we rely in the fact that for all Seqs iterableFactory has an eager implementation of from.

While that shows that we _can_ make it typesafe, it does not work at runtime as a drop-in replacement for stdlib since of course stdlib does not have a FreeSeqFactory.

This commit drops FreeSeqFactory and adds three unsafeAssumePure calls instead, with explanations.

Fixes #19845