### PR TITLE
Hide capture sets when the current unit is not capture checked

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -242,7 +242,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         val refsText = if showAsCap then rootSetText else toTextCaptureSet(refs)
         toTextCapturing(parent, refsText, boxText)
       case tp @ RetainingType(parent, refs) =>
-        if ctx.compilationUnit.needsCaptureChecking then
+        if Feature.ccEnabledSomewhere then
           val refsText = refs match
             case ref :: Nil if ref.symbol == defn.captureRoot => rootSetText
             case _ => toTextRetainedElems(refs)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -242,10 +242,12 @@ class PlainPrinter(_ctx: Context) extends Printer {
         val refsText = if showAsCap then rootSetText else toTextCaptureSet(refs)
         toTextCapturing(parent, refsText, boxText)
       case tp @ RetainingType(parent, refs) =>
-        val refsText = refs match
-          case ref :: Nil if ref.symbol == defn.captureRoot => rootSetText
-          case _ => toTextRetainedElems(refs)
-        toTextCapturing(parent, refsText, "") ~ Str("R").provided(printDebug)
+        if ctx.compilationUnit.needsCaptureChecking then
+          val refsText = refs match
+            case ref :: Nil if ref.symbol == defn.captureRoot => rootSetText
+            case _ => toTextRetainedElems(refs)
+          toTextCapturing(parent, refsText, "") ~ Str("R").provided(printDebug)
+        else toText(parent)
       case tp: PreviousErrorType if ctx.settings.XprintTypes.value =>
         "<error>" // do not print previously reported error message because they may try to print this error type again recuresevely
       case tp: ErrorType =>


### PR DESCRIPTION
Fixes #19847