### PR TITLE
Increase BootstrappedOnlyCompilationTests timeout

### DIFF
--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -206,7 +206,7 @@ class BootstrappedOnlyCompilationTests {
 object BootstrappedOnlyCompilationTests extends ParallelTesting {
   // Test suite configuration --------------------------------------------------
 
-  def maxDuration = 60.seconds
+  def maxDuration = 100.seconds
   def numberOfSlaves = Runtime.getRuntime().availableProcessors()
   def safeMode = Properties.testsSafeMode
   def isInteractive = SummaryReport.isInteractive


### PR DESCRIPTION
Some of the tests in this file are a bit heavy and tend to timeout when the CI is overloaded.

Tests that take may take longer include tests with the tasty inspector and the staging tests.