### PR TITLE
Adjust owner in `Interactive.contextOfPath` causing crash in `ImplicitSearch`

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -297,14 +297,14 @@ object Interactive {
           else
             outer
         case tree @ Block(stats, expr) =>
-          val localCtx = outer.fresh.setNewScope
+          val localCtx = outer.localContext(tree, outer.owner).setNewScope
           stats.foreach {
             case stat: MemberDef => localCtx.enter(stat.symbol)
             case _ =>
           }
-          contextOfStat(stats, nested, ctx.owner, localCtx)
+          contextOfStat(stats, nested, localCtx.owner, localCtx)
         case tree @ CaseDef(pat, _, _) =>
-          val localCtx = outer.fresh.setNewScope
+          val localCtx = outer.localContext(tree, outer.owner).setNewScope
           pat.foreachSubTree {
             case bind: Bind => localCtx.enter(bind.symbol)
             case _ =>

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -35,6 +35,20 @@ class CompletionTest {
       .completion(("Conversion", Class, "Conversion"))
   }
 
+  @Test def implicitSearchCrash: Unit =
+    code"""
+          |object Test:
+          |  trait Foo:
+          |    def test(): String
+          |  given Int = ???
+          |  given (using ev: Int): Conversion[String, Foo] = ???
+          |
+          |  val test = {
+          |    "".tes$m1
+          |    1
+          |  }"""
+      .completion(("test", Method, "(): String"))
+
   @Test def completionFromScalaPackageObject: Unit = {
     code"class Foo { val foo: BigD${m1} }"
       .completion(


### PR DESCRIPTION
`Interactive` provided us with the method `contextOfPath` which should return enclosing ctx for given position. It was working fine until given loop detection was improved some time ago.

It started crashing as the context owner was set to original context owner, instead of the real owner. This PR changes this and sets context to its outer context owner.

Fixes https://github.com/scalameta/metals/issues/6193