### PR TITLE
chore: do not assume scala types as transparent, source should enforce it

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -279,12 +279,12 @@ class Definitions {
    * To achieve this, we synthesize all Any and Object methods; Object methods no longer get
    * loaded from a classfile.
    */
-  @tu lazy val AnyClass: ClassSymbol = completeClass(enterCompleteClassSymbol(ScalaPackageClass, tpnme.Any, Abstract, Nil), ensureCtor = false)
+  @tu lazy val AnyClass: ClassSymbol = completeClass(enterCompleteClassSymbol(ScalaPackageClass, tpnme.Any, Abstract | TransparentType, Nil), ensureCtor = false)
   def AnyType: TypeRef = AnyClass.typeRef
-  @tu lazy val MatchableClass: ClassSymbol = completeClass(enterCompleteClassSymbol(ScalaPackageClass, tpnme.Matchable, Trait, AnyType :: Nil), ensureCtor = false)
+  @tu lazy val MatchableClass: ClassSymbol = completeClass(enterCompleteClassSymbol(ScalaPackageClass, tpnme.Matchable, Trait | TransparentType, AnyType :: Nil), ensureCtor = false)
   def MatchableType: TypeRef = MatchableClass.typeRef
   @tu lazy val AnyValClass: ClassSymbol =
-    val res = completeClass(enterCompleteClassSymbol(ScalaPackageClass, tpnme.AnyVal, Abstract, List(AnyType, MatchableType)))
+    val res = completeClass(enterCompleteClassSymbol(ScalaPackageClass, tpnme.AnyVal, Abstract | TransparentType, List(AnyType, MatchableType)))
     // Mark companion as absent, so that class does not get re-completed
     val companion = ScalaPackageVal.info.decl(nme.AnyVal).symbol
     companion.moduleClass.markAbsent()
@@ -2062,42 +2062,12 @@ class Definitions {
     HasProblematicGetClass.contains(className)
 
   @tu lazy val assumedTransparentNames: Map[Name, Set[Symbol]] =
-    // add these for now, until we had a chance to retrofit 2.13 stdlib
     // we should do a more through sweep through it then.
     val strs = Map(
-      "Any" -> Set("scala"),
-      "AnyVal" -> Set("scala"),
-      "Matchable" -> Set("scala"),
-      "Product" -> Set("scala"),
       "Object" -> Set("java.lang"),
       "Comparable" -> Set("java.lang"),
       "Serializable" -> Set("java.io"),
-      "BitSetOps" -> Set("scala.collection"),
-      "IndexedSeqOps" -> Set("scala.collection", "scala.collection.mutable", "scala.collection.immutable"),
-      "IterableOnceOps" -> Set("scala.collection"),
-      "IterableOps" -> Set("scala.collection"),
-      "LinearSeqOps" -> Set("scala.collection", "scala.collection.immutable"),
-      "MapOps" -> Set("scala.collection", "scala.collection.mutable", "scala.collection.immutable"),
-      "SeqOps" -> Set("scala.collection", "scala.collection.mutable", "scala.collection.immutable"),
-      "SetOps" -> Set("scala.collection", "scala.collection.mutable", "scala.collection.immutable"),
-      "SortedMapOps" -> Set("scala.collection", "scala.collection.mutable", "scala.collection.immutable"),
-      "SortedOps" -> Set("scala.collection"),
-      "SortedSetOps" -> Set("scala.collection", "scala.collection.mutable", "scala.collection.immutable"),
-      "StrictOptimizedIterableOps" -> Set("scala.collection"),
-      "StrictOptimizedLinearSeqOps" -> Set("scala.collection"),
-      "StrictOptimizedMapOps" -> Set("scala.collection", "scala.collection.immutable"),
-      "StrictOptimizedSeqOps" -> Set("scala.collection", "scala.collection.immutable"),
-      "StrictOptimizedSetOps" -> Set("scala.collection", "scala.collection.immutable"),
-      "StrictOptimizedSortedMapOps" -> Set("scala.collection", "scala.collection.immutable"),
-      "StrictOptimizedSortedSetOps" -> Set("scala.collection", "scala.collection.immutable"),
-      "ArrayDequeOps" -> Set("scala.collection.mutable"),
-      "DefaultSerializable" -> Set("scala.collection.generic"),
-      "IsIterable" -> Set("scala.collection.generic"),
-      "IsIterableLowPriority" -> Set("scala.collection.generic"),
-      "IsIterableOnce" -> Set("scala.collection.generic"),
-      "IsIterableOnceLowPriority" -> Set("scala.collection.generic"),
-      "IsMap" -> Set("scala.collection.generic"),
-      "IsSeq" -> Set("scala.collection.generic"))
+    )
     strs.map { case (simple, pkgs) => (
         simple.toTypeName,
         pkgs.map(pkg => staticRef(pkg.toTermName, isPackage = true).symbol.moduleClass)


### PR DESCRIPTION
Follow-up of #23104

This is done in a separate PR as both PRs only share the parent commit of 2012. Working on these kinds of changes in the future would be easier when #23099 is merged.