### PR TITLE
[SUPERSEDED] Take the high bound in extension check

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1180,7 +1180,7 @@ object RefChecks {
       def targetOfHiddenExtension: Symbol =
         val target =
           val target0 = explicitInfo.firstParamTypes.head // required for extension method, the putative receiver
-          target0.dealiasKeepOpaques.typeSymbol.info
+          target0.dealiasKeepOpaques.typeSymbol.info.hiBound
         val member = target.nonPrivateMember(sym.name)
           .filterWithPredicate: member =>
             member.symbol.isPublic && memberHidesMethod(member)

--- a/tests/warn/i23293.scala
+++ b/tests/warn/i23293.scala
@@ -1,0 +1,4 @@
+
+trait SelectByName[Field <: String & Singleton, Rec <: Tuple]:
+  type Out
+  extension (r: Rec) def apply[F <: Field]: Out // warn not crash


### PR DESCRIPTION
Fixes #23293 

Don't look up member in type of a type parameter that is a type bound; always just take its `hiBound`.

Also, the mnemonic for "nilary" is that the parameter list is `Nil`, i.e., it exists and is empty.
