### PR TITLE
Add accessible check for import usage

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -305,8 +305,10 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
     def matchingSelector(info: ImportInfo): ImportSelector | Null =
       val qtpe = info.site
       def hasAltMember(nm: Name) = qtpe.member(nm).hasAltWith: alt =>
-           alt.symbol == sym
-        || nm.isTypeName && alt.symbol.isAliasType && alt.info.dealias.typeSymbol == sym
+        val sameSym =
+             alt.symbol == sym
+          || nm.isTypeName && alt.symbol.isAliasType && alt.info.dealias.typeSymbol == sym
+        sameSym && alt.symbol.isAccessibleFrom(qtpe)
       def loop(sels: List[ImportSelector]): ImportSelector | Null = sels match
         case sel :: sels =>
           val matches =

--- a/tests/warn/i23347.scala
+++ b/tests/warn/i23347.scala
@@ -1,0 +1,22 @@
+//> using options -Wunused:all
+
+object USED {
+  case class A(value: Int)
+}
+
+object UNUSED {
+  // In reality UNUSED would contain several other necessary members!
+  private type A = USED.A // warn private
+  class B
+}
+
+object Test {
+  import USED.*
+  import UNUSED.*
+
+  def foo(a: A): Int = a.value
+
+  def g(b: B) = ()
+
+}
+


### PR DESCRIPTION
Fixes #23347 

The code for deciding whether a selector is used to import a symbol was missing a check for accessibility (importability).

3.6.4 doesn't warn, so it would be nice to know why it excludes the member. The algorithm is different but the code for choosing import selectors is similar. 3.7.0 also doesn't warn, but no change stands out as a culprit. Possibly the selector was spuriously excluded (by result caching in 3.7.0).
