### PR TITLE
Drop invalid assumption from TastyUnpickler

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1190,7 +1190,6 @@ class TreeUnpickler(reader: TastyReader,
     inline def readImportOrExport(inline mkTree:
         (Tree, List[untpd.ImportSelector]) => Tree)()(using Context): Tree = {
       val start = currentAddr
-      assert(sourcePathAt(start).isEmpty)
       readByte()
       readEnd()
       val expr = readTree()

--- a/scaladoc-testcases/src/tests/22265/macro.scala
+++ b/scaladoc-testcases/src/tests/22265/macro.scala
@@ -1,0 +1,13 @@
+import scala.quoted._
+
+object TestBuilder:
+  // transparent is needed
+  transparent inline def apply(inline expr: Unit): Any =
+    ${ TestBuilder.processTests('expr) }
+
+  def processTests(using Quotes)(body: Expr[Unit]): Expr[Any] =
+    import quotes.reflect._
+    body.asTerm match {
+      case Inlined(_, _, bindings) =>
+        '{ ${bindings.asExpr}; () } // can also be List(${bindings})
+    }

--- a/scaladoc-testcases/src/tests/22265/test.scala
+++ b/scaladoc-testcases/src/tests/22265/test.scala
@@ -1,0 +1,4 @@
+object breaks {
+  TestBuilder:
+    import List.empty
+}


### PR DESCRIPTION
Fixes #22265

I'm actually not sure if the scaladox-testcases sub-project is the right place for the test. In `sbt scaladoc/test` fails the ` dotty.tools.scaladoc.tasty.comments.MemberLookupTests`.