### PR TITLE
minor refactor to avoid unsoundness caused by flexible types

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -44,10 +44,10 @@ trait PropertiesTrait {
 
   def propIsSet(name: String): Boolean                  = System.getProperty(name) != null
   def propIsSetTo(name: String, value: String): Boolean = propOrNull(name) == value
-  def propOrElse(name: String, alt: => String | Null): String  = Option(System.getProperty(name)).getOrElse(alt)
+  def propOrNone(name: String): Option[String]          = Option[String](System.getProperty(name))
+  def propOrElse(name: String, alt: => String): String  = propOrNone(name).getOrElse(alt)
   def propOrEmpty(name: String): String                 = propOrElse(name, "")
-  def propOrNull(name: String): String                  = propOrElse(name, null)
-  def propOrNone(name: String): Option[String]          = Option(propOrNull(name))
+  def propOrNull(name: String): String|Null             = propOrNone(name).orNull
   def propOrFalse(name: String): Boolean                = propOrNone(name) exists (x => List("yes", "on", "true") contains x.toLowerCase)
   def setProp(name: String, value: String): String      = System.setProperty(name, value)
   def clearProp(name: String): String                   = System.clearProperty(name)


### PR DESCRIPTION
`propOrElse` exploits unsoundness of flexible types to take a nullable `alt` and return it as a non-null `String`. This is due to a flexible type being inferred as the type argument of `Option.apply` and of `getOrElse()`. It's possible that a `null` `alt` could be passed to `propOrElse` and it would return it, violating its return type. This refactoring cleans up `propOrElse` and related methods; it specifies a type argument explicitly to ensure that a flexible type is not inferred.