### PR TITLE
Fix issue with macro results having unexpected source switches in TASTy

### DIFF
--- a/scaladoc-testcases/src/tests/i22265/macro.scala
+++ b/scaladoc-testcases/src/tests/i22265/macro.scala
@@ -1,0 +1,13 @@
+import scala.quoted._
+
+object TestBuilder:
+  // transparent is needed
+  transparent inline def apply(inline expr: Unit): Any =
+    ${ TestBuilder.processTests('expr) }
+
+  def processTests(using Quotes)(body: Expr[Unit]): Expr[Any] =
+    import quotes.reflect._
+    body.asTerm match {
+      case Inlined(_, _, bindings) =>
+        '{ ${bindings.asExpr}; () }
+    }

--- a/scaladoc-testcases/src/tests/i22265/main.scala
+++ b/scaladoc-testcases/src/tests/i22265/main.scala
@@ -1,0 +1,4 @@
+object breaks {
+  TestBuilder:
+    import List.empty
+}


### PR DESCRIPTION
Problem seems to have been derived from the fact that we would only remap the source of the outermost tree inserted in a Hole, instead of going through the whole tree inserted there. This meant that when inserting `Block` with `Imports` in the contents, the Block node would have a new source assigned (causing a source change encoded in the TASTy), and all contents would still have the previous source assigned (causing more source changes encoded).

Now we reassign sources to nodes recursively, meaning that only the outermost node has a source change assigned in TASTy.
Fixes #22265 