### PR TITLE
Implement boxing for singleton type arguments

### DIFF
--- a/tests/neg-custom-args/captures/i23207.check
+++ b/tests/neg-custom-args/captures/i23207.check
@@ -1,0 +1,14 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23207.scala:15:17 ---------------------------------------
+15 |  val a: A = box.x // error
+   |             ^^^^^
+   |             Found:    (box.x : (b : B^{io})^{b})
+   |             Required: A
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23207.scala:16:11 ---------------------------------------
+16 |  b.getBox.x // error
+   |  ^^^^^^^^^^
+   |  Found:    (Box[(b : B^{io})^{b}]#x : (b : B^{io})^{b})
+   |  Required: A^?
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i23207.scala
+++ b/tests/neg-custom-args/captures/i23207.scala
@@ -1,0 +1,16 @@
+import language.experimental.captureChecking
+import caps.*
+
+case class Box[T](x: T)
+
+class A:
+  def getBox: Box[this.type] = Box(this)
+
+def leak(io: AnyRef^): A =
+  class B extends A:
+    val hide: AnyRef^{io} = io
+
+  val b = new B
+  val box = b.getBox
+  val a: A = box.x // error
+  b.getBox.x // error

--- a/tests/pos-custom-args/captures/singleton-subtyping.scala
+++ b/tests/pos-custom-args/captures/singleton-subtyping.scala
@@ -1,0 +1,16 @@
+class Box[+T](x: T)
+
+def Test(c: Object^): Unit =
+  val x: Object^{c} = c
+
+  val x2: x.type^{x} = x
+  val x3: x.type = x2
+
+  val b: Box[x.type] = Box(x)
+  val b1: Box[x.type^{x}] = b
+  val b2: Box[x.type] = b1
+
+
+
+
+


### PR DESCRIPTION
A type `A[b.type]` with a singleton type argument is converted to `A[box b.type^{b}]` so that the box status is recorded. Since box status only comes with CapturingTypes we have to convert the singleton type to a capturing type.

Fixes #23207