### PR TITLE
chore: add `CODEOWNERS` file for stdlib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Any changes to the Scala 3 Standard Library must be approve
+# by one of the officers responsible of maintaining it
+/library/      @scala/stdlib-officers
+/library-aux/  @scala/stdlib-officers


### PR DESCRIPTION
Until `3.8.0`, and because we are pinning the files for the scala 3 lib, we add a `CODEOWNERS` so that GitHub can notify us in case a PR changes the stdlib. This way, we can make sure that the PR doesn't go against the spirit of pinning the files and that its intentions are actually fulfilled.

[skip ci]