### PR TITLE
Check for mismatched argument type length in PatternMatcher due to Named Tuple :* syntax

### DIFF
--- a/tests/neg/i23155a.scala
+++ b/tests/neg/i23155a.scala
@@ -1,0 +1,7 @@
+import scala.NamedTuple
+object Unpack_NT {
+  (1, 2) match {
+    case Unpack_NT(first, _) => first // error
+  }
+  def unapply(e: (Int, Int)): Some[NamedTuple.NamedTuple["x" *: "y" *: EmptyTuple, Int *: Int *: EmptyTuple]] = ???
+}

--- a/tests/neg/i23155b.scala
+++ b/tests/neg/i23155b.scala
@@ -1,0 +1,6 @@
+object Unpack_T {
+  (1, 2) match {
+    case Unpack_T(first, _) => first // error
+  }
+  def unapply(e: (Int, Int)): Some[Int *: Int *: EmptyTuple] = ???
+}


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/23155

After discussing at the compiler meeting, it was decided that the Named Tuple behavior should be the same as the Tuple behavior with respect to pattern matching with the `:*` syntax. To error in the exact same way, it should be caught here: https://github.com/scala/scala3/blob/00d19dfd0906d2b4a8c076ded8af15cc3a6f2dc9/compiler/src/dotty/tools/dotc/typer/Applications.scala#L291

For regular tuples, `argTypes` is an `AppliedType` of `:*` and is not yet reduced, so has length 1, so the arity check will fail. However, at this point Named Tuple types are fully reduced by `tupleElementTypes` here: https://github.com/scala/scala3/blob/00d19dfd0906d2b4a8c076ded8af15cc3a6f2dc9/compiler/src/dotty/tools/dotc/typer/Applications.scala#L249

So for Named Tuples, `argTypes` at the time of the check will be `(Int, Int)` so the arity check will pass, causing a later crash in PatternMatcher here: https://github.com/scala/scala3/blob/6146b90b8e32ac81d2703fccdebbc85e72cc5c5b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala#L270

We cannot un-reduce or fail to reduce for Named Tuple types because it will cause a host of other tests to fail that rely on the fully reduced Named Tuple-value types. For now I have added a check in PatternMatcher because it’s better to fix the compiler crash ASAP, but I think we could revisit if we want something like `Int :* Int :* EmptyTuple` to really behave differently from `(Int, Int)` here, since pattern matching currently works for both Tuples and Named Tuples using `(Int, Int)`  or `Tuple2[Int, Int]` , just not `:*`.