### PR TITLE
Add missing reference page: `Quoted Patterns with Polymorphic Functions`

### DIFF
--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -172,6 +172,7 @@ subsection:
           - page: reference/experimental/runtimeChecked.md
           - page: reference/experimental/unrolled-defs.md
           - page: reference/experimental/package-object-values.md
+          - page: reference/experimental/quoted-patterns-with-polymorphic-functions.md
       - page: reference/syntax.md
       - title: Language Versions
         index: reference/language-versions/language-versions.md


### PR DESCRIPTION
A little embarrassed about this, but I just noticed yesterday that we never properly published the page for `Quoted Patterns with Polymorphic Functions` experimental feature, because it was missing from the sidebar file (which I didn't notice during the review). So users might not have known about this feature before... 