### PR TITLE
Reenable better-fors under '-source:3.7 -preview' settings

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -43,7 +43,7 @@ enum SourceVersion:
   def enablesClauseInterleaving = isAtLeast(`3.6`)
   def enablesNewGivens = isAtLeast(`3.6`)
   def enablesNamedTuples = isAtLeast(`3.7`)
-  def enablesBetterFors = isAtLeast(`3.8`)
+  def enablesBetterFors(using Context) = isAtLeast(`3.8`) || (isAtLeast(`3.7`) && isPreviewEnabled)
 
   def requiresNewSyntax = isAtLeast(future)
 


### PR DESCRIPTION
Addendum to #23630 with missing adjustment for older source verisons