### PR TITLE
[build] Increment default thread stack size from to 2MB (was 1MB)

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,4 @@
--Xss1m
+-Xss2m
 -Xms1024m
 -Xmx8192m
 -XX:MaxInlineLevel=35


### PR DESCRIPTION
Tries to fix #23612 - the StackOverflow is triggered during sbt compilation of the project, we have not performed any sbt changes recently that could have caused that, however, our build definitions size has increased. 
I suspect the StackOverflow errors started to get triggered recently as our build got larger/more complicated - increae in the thread stack size should mitigate the issue, otherwise, we'll need to investigate it again.