### PR TITLE
More careful ClassTag instantiation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5116,17 +5116,11 @@ object Types extends TypeUtils {
      */
     private def currentEntry(using Context): Type = ctx.typerState.constraint.entry(origin)
 
-    /** For uninstantiated type variables: the lower bound */
-    def lowerBound(using Context): Type = currentEntry.loBound
-
-    /** For uninstantiated type variables: the upper bound */
-    def upperBound(using Context): Type = currentEntry.hiBound
-
     /** For uninstantiated type variables: Is the lower bound different from Nothing? */
-    def hasLowerBound(using Context): Boolean = !lowerBound.isExactlyNothing
+    def hasLowerBound(using Context): Boolean = !currentEntry.loBound.isExactlyNothing
 
     /** For uninstantiated type variables: Is the upper bound different from Any? */
-    def hasUpperBound(using Context): Boolean = !upperBound.isTopOfSomeKind
+    def hasUpperBound(using Context): Boolean = !currentEntry.hiBound.isTopOfSomeKind
 
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar

--- a/tests/pos/i23611a.scala
+++ b/tests/pos/i23611a.scala
@@ -1,0 +1,30 @@
+import java.io.{File, IOException}
+import java.net.URI
+import java.nio.file.{Path, Paths}
+import scala.reflect.ClassTag
+
+trait FileConnectors {
+  def listPath(path: => Path): ZStream[Any, IOException, Path]
+
+  final def listFile(file: => File): ZStream[Any, IOException, File] =
+    for {
+      path <- null.asInstanceOf[ZStream[Any, IOException, Path]]
+      r    <- listPath(path).mapZIO(a => ZIO.attempt(a.toFile).refineToOrDie)
+    } yield r
+}
+
+sealed abstract class CanFail[-E]
+object CanFail:
+  given [E]: CanFail[E] = ???
+
+sealed trait ZIO[-R, +E, +A]
+extension [R, E <: Throwable, A](self: ZIO[R, E, A])
+  def refineToOrDie[E1 <: E: ClassTag](using CanFail[E]): ZIO[R, E1, A] = ???
+
+object ZIO:
+  def attempt[A](code: => A): ZIO[Any, Throwable, A] = ???
+
+sealed trait ZStream[-R, +E, +A]:
+  def map[B](f: A => B): ZStream[R, E, B] = ???
+  def flatMap[R1 <: R, E1 >: E, B](f: A => ZStream[R1, E1, B]): ZStream[R1, E1, B]
+  def mapZIO[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1]): ZStream[R1, E1, A1]


### PR DESCRIPTION
We now use a blend of the new scheme and a backwards compatible special case if type variables as ClassTag arguments are constrained by further type variables.

Fixes #23611