### PR TITLE
chore: add `scala-library-cc` project

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -219,6 +219,24 @@ jobs:
       - name: Compile `scala3-tasty-inspector`
         run: ./project/scripts/sbt scala3-tasty-inspector-new/compile
 
+  scala-library-cc:
+    runs-on: ubuntu-latest
+    needs  : [scala3-compiler-nonbootstrapped, scala3-sbt-bridge-nonbootstrapped, scala-library-nonbootstrapped, scala3-library-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala-library-cc`
+        run: ./project/scripts/sbt scala-library-cc/compile
+  
   #################################################################################################
   ########################################### TEST JOBS ###########################################
   #################################################################################################

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ val `scala-library-bootstrapped` = Build.`scala-library-bootstrapped`
 val `scala3-library-bootstrapped-new` = Build.`scala3-library-bootstrapped-new`
 val `scala3-library` = Build.`scala3-library`
 val `scala3-library-bootstrapped` = Build.`scala3-library-bootstrapped`
+val `scala-library-cc` = Build.`scala-library-cc`
 val `scala3-library-bootstrappedJS` = Build.`scala3-library-bootstrappedJS`
 val `scala3-sbt-bridge` = Build.`scala3-sbt-bridge`
 val `scala3-sbt-bridge-bootstrapped` = Build.`scala3-sbt-bridge-bootstrapped`


### PR DESCRIPTION
Include the project to set up Scala-library with cc based on the new stdlib configuration.