### PR TITLE
Backport "Generalize "Don't approximate a type using Nothing as prefix"" to 3.7.3

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6507,7 +6507,7 @@ object Types extends TypeUtils {
     protected def range(lo: Type, hi: Type): Type =
       if variance > 0 then hi
       else if variance < 0 then
-        if (lo eq defn.NothingType) && hi.hasSimpleKind then
+        if (lo eq defn.NothingType) then
           // Approximate by Nothing & hi instead of just Nothing, in case the
           // approximated type is used as the prefix of another type (this would
           // lead to a type with a `NoDenotation` denot and a possible
@@ -6518,8 +6518,14 @@ object Types extends TypeUtils {
           // example if Nothing is the type of a parameter being depended on in
           // a MethodType)
           //
-          // Test case in tests/pos/i23530.scala
-          AndType(lo, hi)
+          // Test case in tests/pos/i23530.scala (and tests/pos/i23627.scala for
+          // the higher-kinded case which requires eta-expansion)
+          hi.etaExpand match
+            case expandedHi: HKTypeLambda =>
+              expandedHi.derivedLambdaType(resType = AndType(lo, expandedHi.resType))
+            case _ =>
+              // simple-kinded case
+              AndType(lo, hi)
         else
           lo
       else if lo `eq` hi then lo

--- a/tests/pos/i23627.scala
+++ b/tests/pos/i23627.scala
@@ -1,0 +1,18 @@
+trait TestContainer:
+  trait TestPath[T]:
+    type AbsMember
+
+  extension (path: TestPath[?])
+    infix def ext(color: path.AbsMember): Unit = ???
+    infix def ext(other: Int): Unit = ???
+
+object Repro:
+  val dc2: TestContainer = ???
+  import dc2.TestPath
+
+  def transition(path: TestPath[?])(using DummyImplicit): TestPath[?] = ???
+
+  def test: Unit =
+    val di: TestPath[?] = ???
+    // error
+    val z1 = transition(di).ext(1)


### PR DESCRIPTION
Backports #23628.