### PR TITLE
chore: add support for `sbt-test` in the new build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Cmd Tests
         run: |
           ./project/scripts/buildScalaBinary
-          ./project/scripts/sbt ";scala3-bootstrapped/compile ;sbt-test/scripted scala2-compat/* ;scala3-compiler-bootstrapped/scala3CompilerCoursierTest:test"
+          ./project/scripts/sbt ";scala3-bootstrapped/compile ;scala3-bootstrapped/publishLocal ;scala3-compiler-bootstrapped/scala3CompilerCoursierTest:test"
           ./project/scripts/cmdTests
           ./project/scripts/bootstrappedOnlyCmdTests
 
@@ -339,51 +339,6 @@ jobs:
         if: ${{ always() }}
         run: cat community-build/dotty-community-build-deps || true
 
-  test_sbt:
-    runs-on: [self-hosted, Linux]
-    container:
-      image: lampepfl/dotty:2024-10-18
-      options: --cpu-shares 4096
-      volumes:
-        - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
-        - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
-        - ${{ github.workspace }}/../../cache/general:/root/.cache
-    if: "github.event_name == 'schedule' && github.repository == 'scala/scala3'
-         || github.event_name == 'push'
-         || (
-           github.event_name == 'pull_request'
-           && !contains(github.event.pull_request.body, '[skip ci]')
-           && !contains(github.event.pull_request.body, '[skip test_sbt]')
-         )
-         || (
-           github.event_name == 'workflow_dispatch'
-           && github.repository == 'scala/scala3'
-         )"
-
-    steps:
-      - name: Set JDK 17 as default
-        run: echo "/usr/lib/jvm/java-17-openjdk-amd64/bin" >> $GITHUB_PATH
-
-      - name: Reset existing repo
-        run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-          git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
-
-      - name: Checkout cleanup script
-        uses: actions/checkout@v5
-
-      - name: Cleanup
-        run: .github/workflows/cleanup.sh
-
-      - name: Git Checkout
-        uses: actions/checkout@v5
-
-      - name: Add SBT proxy repositories
-        run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
-
-      - name: Test sbt
-        run: ./project/scripts/sbt "sbt-test/scripted"
-
   publish_release:
     permissions:
       contents: write  # for GH CLI to create a release
@@ -395,7 +350,7 @@ jobs:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
         - ${{ github.workspace }}/../../cache/ivy:/root/.ivy2/cache
         - ${{ github.workspace }}/../../cache/general:/root/.cache
-    needs: [test, community_build_a, community_build_b, community_build_c, test_sbt, build-sdk-package, build-msi-package]
+    needs: [test, community_build_a, community_build_b, community_build_c, build-sdk-package, build-msi-package]
     if: "github.event_name == 'push'
          && startsWith(github.event.ref, 'refs/tags/')"
 

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -62,9 +62,6 @@ jobs:
       - name: Generate Scala 3 documentation
         run: ./project/scripts/sbt scaladoc/generateScalaDocumentation
 
-      - name: Generate documentation for example project using dotty-sbt
-        run: ./project/scripts/sbt "sbt-test/scripted sbt-dotty/scaladoc"
-
   stdlib-sourcelinks-test:
     runs-on: ubuntu-latest
     # if false - disable flaky test

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -539,3 +539,20 @@ jobs:
       - name: Scala.js JUnit tests
         run: ./project/scripts/sbt ";sjsJUnitTests/test ;set sjsJUnitTests/scalaJSLinkerConfig ~= switchToESModules ;sjsJUnitTests/test"
   # TODO Scala.js on Windows
+
+  scripted-tests:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala3-staging, scala3-tasty-inspector, scala-library-sjs, scaladoc]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Run SBT scripted tests
+        run: ./project/scripts/sbt scala3-bootstrapped-new/scripted

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,5 @@ val sjsSandbox = Build.sjsSandbox
 val sjsJUnitTests = Build.sjsJUnitTests
 val sjsCompilerTests = Build.sjsCompilerTests
 
-val `sbt-test` = Build.`sbt-test`
-
 inThisBuild(Build.thisBuildSettings)
 inScope(Global)(Build.globalSettings)


### PR DESCRIPTION
This PR configures the scripted tests (`sbt-test`) to be run using the new stdlib.
~This PR should fail at the moment as we do not have the `scaladoc` artifacts yet in the build.~