### PR TITLE
chore: keep context bounds as implicits in Scala 2 mode

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -339,7 +339,7 @@ object desugar {
         case Some(param) if param.mods.isOneOf(GivenOrImplicit) =>
           param.mods.flags & GivenOrImplicit
         case _ =>
-          if Feature.sourceVersion.isAtLeast(`3.6`) then Given
+          if Feature.sourceVersion.isAtLeast(`3.6`) && !Feature.sourceVersion.isScala2 then Given
           else Implicit
       val flags = if isPrimaryConstructor then iflag | LocalParamAccessor else iflag | Param
       mapParamss(paramss) {


### PR DESCRIPTION
During the transition, we will keep desugaring context bounds in Scala 2 files as `implicit` clauses, not `using` clauses.

Related to #21257