### PR TITLE
chore: add develocity token to the new nightly artifacts workflow

### DIFF
--- a/.github/workflows/release-maven-artifacts.yml
+++ b/.github/workflows/release-maven-artifacts.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
 jobs:
   release-maven-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We add the develocity token to the nightly artifact release workflow to be able to consume the artifacts from caching and have build scans published for nightly releases.

/cc @Duhemm