### PR TITLE
chore: add the dependencies between projects

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -32,7 +32,7 @@ jobs:
 
   scala3-library-nonbootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [scala-library-nonbootstrapped] Add when we add support for caching here
+    needs: [scala-library-nonbootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -48,9 +48,61 @@ jobs:
       - name: Compile `scala3-library-nonbootstrapped`
         run: ./project/scripts/sbt scala3-library-nonbootstrapped/compile
 
+  tasty-core-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-library-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `tasty-core-nonbootstrapped`
+        run: ./project/scripts/sbt tasty-core-nonbootstrapped/compile
+
+  scala3-compiler-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [tasty-core-nonbootstrapped, scala3-library-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala3-compiler-nonbootstrapped`
+        run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/compile
+
+  scala3-sbt-bridge-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala3-sbt-bridge-nonbootstrapped`
+        run: ./project/scripts/sbt scala3-sbt-bridge-nonbootstrapped/compile
+
   scala-library-bootstrapped:
     runs-on: ubuntu-latest
-    needs  : [scala3-compiler-nonbootstrapped, scala3-sbt-bridge-nonbootstrapped, scala-library-nonbootstrapped, scala3-library-nonbootstrapped]
+    needs  : [scala-library-nonbootstrapped, scala3-library-nonbootstrapped, tasty-core-nonbootstrapped,
+              scala3-compiler-nonbootstrapped, scala3-sbt-bridge-nonbootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -68,7 +120,7 @@ jobs:
 
   scala3-library-bootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [scala-library-bootstrapped] Add when we add support for caching here
+    needs: [scala-library-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -84,60 +136,9 @@ jobs:
       - name: Compile `scala3-library-bootstrapped`
         run: ./project/scripts/sbt scala3-library-bootstrapped-new/compile
 
-  tasty-core-nonbootstrapped:
-    runs-on: ubuntu-latest
-    ##needs: [scala3-library-nonbootstrapped] Add when we add support for caching here
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `tasty-core-nonbootstrapped`
-        run: ./project/scripts/sbt tasty-core-nonbootstrapped/compile
-
-  scala3-compiler-nonbootstrapped:
-    runs-on: ubuntu-latest
-    ##needs: [tasty-core-nonbootstrapped, scala3-library-nonbootstrapped] Add when we add support for caching here
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-compiler-nonbootstrapped`
-        run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/compile
-
-  scala3-sbt-bridge-nonbootstrapped:
-    runs-on: ubuntu-latest
-    ##needs: [scala3-compiler-nonbootstrapped] Add when we add support for caching here
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-sbt-bridge-nonbootstrapped`
-        run: ./project/scripts/sbt scala3-sbt-bridge-nonbootstrapped/compile
-
   tasty-core-bootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [scala3-library-bootstrapped] Add when we add support for caching here
+    needs: [scala3-library-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -154,7 +155,7 @@ jobs:
 
   scala3-compiler-bootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [tasty-core-bootstrapped, scala3-library-bootstrapped] Add when we add support for caching here
+    needs: [tasty-core-bootstrapped, scala3-library-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -171,7 +172,7 @@ jobs:
 
   scala3-sbt-bridge-bootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [scala3-compiler-bootstrapped] Add when we add support for caching here
+    needs: [scala3-compiler-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -188,7 +189,7 @@ jobs:
 
   scala3-staging:
     runs-on: ubuntu-latest
-    ##needs: [scala3-compiler-bootstrapped] Add when we add support for caching here
+    needs: [scala3-compiler-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -205,7 +206,7 @@ jobs:
 
   scala3-tasty-inspector:
     runs-on: ubuntu-latest
-    ##needs: [scala3-compiler-bootstrapped] Add when we add support for caching here
+    needs: [scala3-compiler-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -224,11 +225,8 @@ jobs:
 
   scala-library-sjs:
     runs-on: ubuntu-latest
-    ## Add when we add support for caching here
-    ##needs: [scala3-library-nonbootstrapped,
-    ##        tasty-core-nonbootstrapped,
-    ##        scala3-compiler-nonbootstrapped,
-    ##        scala3-sbt-bridge-nonbootstrapped]
+    needs: [scala-library-nonbootstrapped, scala3-library-nonbootstrapped, tasty-core-nonbootstrapped,
+            scala3-compiler-nonbootstrapped, scala3-sbt-bridge-nonbootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -247,8 +245,7 @@ jobs:
 
   scala3-library-sjs:
     runs-on: ubuntu-latest
-    ## Add when we add support for caching here
-    ##needs: [scala-library-sjs]
+    needs: [scala-library-sjs]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -267,8 +264,7 @@ jobs:
 
   scaladoc:
     runs-on: ubuntu-latest
-    ## Add when we add support for caching here
-    ##needs: [scala3-compiler-bootstrapped, scala3-tasty-inspector]
+    needs: [scala3-compiler-bootstrapped, scala3-tasty-inspector]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -290,7 +286,7 @@ jobs:
 
   test-scala3-sbt-bridge-nonbootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [scala3-sbt-bridge-nonbootstrapped] Add when we add support for caching here
+    needs: [scala3-sbt-bridge-nonbootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -307,7 +303,7 @@ jobs:
 
   test-scala3-sbt-bridge-bootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [scala3-sbt-bridge-bootstrapped] Add when we add support for caching here
+    needs: [scala3-sbt-bridge-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -324,7 +320,7 @@ jobs:
 
   test-tasty-core-nonbootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [tasty-core-nonbootstrapped] Add when we add support for caching here
+    needs: [tasty-core-nonbootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5
@@ -341,7 +337,7 @@ jobs:
 
   test-tasty-core-bootstrapped:
     runs-on: ubuntu-latest
-    ##needs: [tasty-core-bootstrapped] Add when we add support for caching here
+    needs: [tasty-core-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Actually wire the dependencies in the workflow to leverage and improve the caching from develocity

[skip ci]

/cc @Duhemm 