### PR TITLE
chore: no more open issue on failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -743,27 +743,6 @@ jobs:
       - name: Publish Release
         run: ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonaUpload"
 
-
-  open_issue_on_failure:
-    runs-on: [self-hosted, Linux]
-    container:
-      image: lampepfl/dotty:2024-10-18
-    needs: [nightly_documentation, test_windows_full]
-    # The `failure()` expression is true iff at least one of the dependencies
-    # of this job (including transitive dependencies) has failed.
-    if: "failure() && github.event_name == 'schedule'"
-    steps:
-      - name: Checkout issue template
-        uses: actions/checkout@v5
-
-      - name: Open an issue
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: .github/workflows/issue_nightly_failed.md
-
   build-msi-package:
     uses: ./.github/workflows/build-msi.yml
     if  :


### PR DESCRIPTION
After #23797, there is no path to the `open_issue_on_failure` job.

[skip ci]