### PR TITLE
Fix NotNullInfo in multi-case match

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2216,7 +2216,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     var alreadyStripped = false
     val cases1 = tree.cases.zip(pt.cases)
       .map { case (cas, tpe) =>
-        val case1 = typedCase(cas, sel, wideSelType, tpe)(using caseCtx)
+        given Context = caseCtx
+        val case1 = typedCase(cas, sel, wideSelType, tpe)
         caseCtx = Nullables.afterPatternContext(sel, case1.pat)
         if !alreadyStripped && Nullables.matchesNull(case1) then
           wideSelType = wideSelType.stripNull()
@@ -2248,7 +2249,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     var wideSelType = wideSelType0
     var alreadyStripped = false
     cases.mapconserve { cas =>
-      val case1 = typedCase(cas, sel, wideSelType, pt)(using caseCtx)
+      given Context = caseCtx
+      val case1 = typedCase(cas, sel, wideSelType, pt)
       caseCtx = Nullables.afterPatternContext(sel, case1.pat)
       if !alreadyStripped && Nullables.matchesNull(case1) then
         wideSelType = wideSelType.stripNull()

--- a/tests/explicit-nulls/pos/flow-match.scala
+++ b/tests/explicit-nulls/pos/flow-match.scala
@@ -55,4 +55,20 @@ object MatchTest {
     case s2 => s2.nn
     case s3 => s3
   }
+
+  def f8(a: AnyRef | Null): String = a match {
+    case null => "null"
+    case s: String => s
+    case _ =>
+      val a2: AnyRef = a
+      a.toString
+  }
+
+  def f9(a: AnyRef | Null): String = a match {
+    case null => "null"
+    case s: String => s
+    case a1 =>
+      val a2: AnyRef = a1
+      a1.toString
+  }
 }


### PR DESCRIPTION
When we compute `afterPatternContext`, the wrong `ctx` is passed to the function.

```scala
def f(s: AnyRef | Null) = s match
  case null => 0
  case s: String => s.length
  case _ =>
    val a: AnyRef = s
    a.toString.length
```

Will be useful for #23566 