### PR TITLE
Derived members succeed other givens in cycle test

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1718,7 +1718,10 @@ trait Implicits:
           def candSucceedsGiven(sym: Symbol): Boolean =
             val owner = sym.owner
             if owner == candSym.owner then
-              sym.is(GivenVal) && sym.span.exists && sym.span.start <= candSym.span.start
+              sym.is(GivenVal)
+              && sym.span.exists && sym.span.start <= candSym.span.start
+              && (sym.span.isSourceDerived || !sym.name.startsWith("derived$", 0))
+                // logically a synthetic injected at the end of the body
             else if owner.isClass then false
             else candSucceedsGiven(owner)
 

--- a/tests/pos/i23897.scala
+++ b/tests/pos/i23897.scala
@@ -1,0 +1,14 @@
+
+import scala.deriving.Mirror
+
+class Test[A]
+object Test:
+  def derived[A](using m: Mirror.Of[A], t: Test[Int]): Test[A] = new Test[A]
+
+case class Foo(i: Int) derives Test
+object Foo:
+  given i: Test[Int] = new Test[Int]
+
+case class Bar(i: Int) derives Test
+object Bar:
+  given Test[Int]()

--- a/tests/run/i23897.scala
+++ b/tests/run/i23897.scala
@@ -1,0 +1,31 @@
+
+import scala.deriving.Mirror
+
+trait Semigroup[A] {
+  def combine(x: A, y: A): A
+}
+object Semigroup {
+  given semigroupInt: Semigroup[Int] = _ + _
+
+  given emptyTuple: Semigroup[EmptyTuple] = (x, _) => x
+
+  given tupleN[H, T <: Tuple](using h: Semigroup[H], t: Semigroup[T]): Semigroup[H *: T] =
+    (x, y) => h.combine(x.head, y.head) *: t.combine(x.tail, y.tail)
+
+  def derived[A <: Product](using m: Mirror.ProductOf[A], s: Semigroup[m.MirroredElemTypes]): Semigroup[A] =
+    (x, y) => m.fromTuple(s.combine(Tuple.fromProductTyped(x), Tuple.fromProductTyped(y)))
+}
+
+case class Foo(i: Int) derives Semigroup
+object Foo {
+  given overrideSemigroupInt: Semigroup[Int] = _ * _
+}
+
+@main def Test =
+  assert:
+    summon[Semigroup[Foo]].combine(Foo(2), Foo(3)) == Foo(6)
+
+// Scala 3.3 and 3.4
+//summon[Semigroup[Foo]].combine(Foo(2), Foo(3)) // => Foo(6)
+// Scala 3.5+
+//summon[Semigroup[Foo]].combine(Foo(2), Foo(3)) // => Foo(5)


### PR DESCRIPTION
Sibling givens are always eligible for derived members,
which are appended to the enclosing template.

Fixes #23897 

### Why was the ticket worth tackling?

The behavior change is a regression that makes `derived` less intuitive.
User-written code is logically antecedent to synthetic derived code.

### How I fixed it

I merely confirmed the diagnosis by @mrdziuban on the ticket.
Instead of fiddling with positions, the fix takes `derived` members as a special case,
where derived members always follow other members.
Perhaps all definitions with a synthetic, zero-extent span deserve the same consideration.

### Why is this PR worth reviewing?

It is one LOC that is easy to review if the premise is agreed upon in principle.

### What's the worst that could happen?

Existing code that relies on the changed behavior may break.