### PR TITLE
fix: do not transform `Ident` to `This` in PostTyper anymore

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -391,11 +391,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
             checkNotPackage(tree)
           else
             registerNeedsInlining(tree)
-            val tree1 = checkUsableAsValue(tree)
-            tree1.tpe match {
-              case tpe: ThisType => This(tpe.cls).withSpan(tree.span)
-              case _ => tree1
-            }
+            checkUsableAsValue(tree)
         case tree @ Select(qual, name) =>
           registerNeedsInlining(tree)
           if name.isTypeName then

--- a/tests/run/i23875.check
+++ b/tests/run/i23875.check
@@ -1,0 +1,3 @@
+true
+false
+false

--- a/tests/run/i23875.scala
+++ b/tests/run/i23875.scala
@@ -1,0 +1,11 @@
+object Foo {
+  override def equals(that : Any) = that match {
+    case _: this.type => true
+    case _            => false
+  }
+}
+
+@main def Test =
+  println(Foo.equals(Foo))
+  println(Foo.equals(new AnyRef {}))
+  println(Foo.equals(0))


### PR DESCRIPTION
Closes #23875

In PostTyper, we used to change the representation of an `Ident` with a `ThisType` to a `This(...)` node.
In patterns, this causes an issue where we ended up not matching any previously known pattern and end up generating code that triggers an infinite loop.