### PR TITLE
fix: avoid cyclic initialisation *warning* between `Predef`, `Manifest` and `ManifestFactory`

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -76,8 +76,12 @@ class Objects(using Context @constructorOnly):
   val HashMap_EmptyMap: Symbol = immutableHashMap.requiredValue("EmptyMap")
   val immutableLazyList: Symbol = requiredModule("scala.collection.immutable.LazyList")
   val LazyList_empty: Symbol = immutableLazyList.requiredValue("_empty")
+  val ManifestFactory_ObjectTYPE = defn.ManifestFactoryModule.requiredValue("ObjectTYPE")
+  val ManifestFactory_NothingTYPE = defn.ManifestFactoryModule.requiredValue("NothingTYPE")
+  val ManifestFactory_NullTYPE = defn.ManifestFactoryModule.requiredValue("NullTYPE")
 
-  val allowList: Set[Symbol] = Set(SetNode_EmptySetNode, HashSet_EmptySet, Vector_EmptyIterator, MapNode_EmptyMapNode, HashMap_EmptyMap, LazyList_empty)
+  val allowList: Set[Symbol] = Set(SetNode_EmptySetNode, HashSet_EmptySet, Vector_EmptyIterator, MapNode_EmptyMapNode, HashMap_EmptyMap, LazyList_empty,
+    ManifestFactory_ObjectTYPE, ManifestFactory_NothingTYPE, ManifestFactory_NullTYPE)
 
   // ----------------------------- abstract domain -----------------------------
 


### PR DESCRIPTION
With the new stdlib fully compiled with Scala 3, we get the following warning in the test suite before this change

```scala
 at 109: Cyclic initialization: object Predef -> object Manifest -> object ManifestFactory -> object Predef. Calling trace:
├── object Manifest {	[ Manifest.scala:76 ]
│   ^
├── val Byte: ManifestFactory.ByteManifest = ManifestFactory.Byte	[ Manifest.scala:86 ]
│                                            ^^^^^^^^^^^^^^^
├── object Predef extends LowPriorityImplicits {	[ Predef.scala:109 ]
│   ^
├── val Manifest          = scala.reflect.Manifest	[ Predef.scala:210 ]
│                           ^^^^^^^^^^^^^^^^^^^^^^
├── object ManifestFactory {	[ Manifest.scala:171 ]
│   ^
└── private[this] val ObjectTYPE = classOf[java.lang.Object]	[ Manifest.scala:323 ]
```

Since `Predef.classOf` is magic, we can safely ignore these fields in the init checker.