### PR TITLE
simplify `scala.runtime.Statics.releaseFence`

### DIFF
--- a/library/src/scala/runtime/Statics.java
+++ b/library/src/scala/runtime/Statics.java
@@ -12,11 +12,6 @@
 
 package scala.runtime;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.Field;
-
 /** Not for public consumption.  Usage by the runtime only.
  */
 
@@ -145,46 +140,7 @@ public final class Statics {
 
   // @ForceInline would be nice here.
   public static void releaseFence() throws Throwable {
-    VM.RELEASE_FENCE.invoke();
-  }
-
-  final static class VM {
-      static final MethodHandle RELEASE_FENCE;
-
-      static {
-          RELEASE_FENCE = mkHandle();
-      }
-
-      private static MethodHandle mkHandle() {
-          MethodHandles.Lookup lookup = MethodHandles.lookup();
-          try {
-              return lookup.findStatic(Class.forName("java.lang.invoke.VarHandle"), "releaseFence", MethodType.methodType(Void.TYPE));
-          } catch (NoSuchMethodException | ClassNotFoundException e) {
-              try {
-                  Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
-                  return lookup.findVirtual(unsafeClass, "storeFence", MethodType.methodType(void.class)).bindTo(findUnsafe(unsafeClass));
-              } catch (NoSuchMethodException | ClassNotFoundException | IllegalAccessException e1) {
-                  ExceptionInInitializerError error = new ExceptionInInitializerError(e1);
-                  error.addSuppressed(e);
-                  throw error;
-              }
-          } catch (IllegalAccessException e) {
-              throw new ExceptionInInitializerError(e);
-          }
-      }
-
-      private static Object findUnsafe(Class<?> unsafeClass) throws IllegalAccessException {
-          Object found = null;
-          for (Field field : unsafeClass.getDeclaredFields()) {
-              if (field.getType() == unsafeClass) {
-                  field.setAccessible(true);
-                  found = field.get(null);
-                  break;
-              }
-          }
-          if (found == null) throw new IllegalStateException("No instance of Unsafe found");
-          return found;
-      }
+    java.lang.invoke.VarHandle.releaseFence();
   }
 
   /**


### PR DESCRIPTION
https://www.scala-lang.org/news/next-scala-lts-jdk.html

JDK 17 will be the new minimum version.

- https://github.com/scala/scala/pull/6425

> The runtime support is a bit complicated becausse we need to be cross
> compatible with JDK 8 and 9+. We use method handle based reflection
> to achieve this. This has zero runtime overhead in the manner used.

I think it's time to delete JDK 8 compatible reflection code.