### PR TITLE
Call inhabited for AppliedType recursively

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -702,6 +702,7 @@ object SpaceEngine {
             case OrType(tp1, tp2) => inhabited(tp1) || inhabited(tp2)
             case tp: RefinedType => inhabited(tp.parent)
             case tp: TypeRef => !containsUninhabitedField(tp) && inhabited(tp.prefix)
+            case tp: AppliedType => !containsUninhabitedField(tp) && inhabited(tp.tycon)
             case _ => !containsUninhabitedField(tp)
 
           if inhabited(refined) then refined

--- a/tests/pos/i23734.scala
+++ b/tests/pos/i23734.scala
@@ -1,0 +1,18 @@
+trait Nodes1 {
+  sealed trait B
+  final case class R1() extends B
+}
+
+trait Nodes2 extends Nodes1 {
+  final case class R2[T]() extends B
+}
+
+
+object Impl1 extends Nodes1
+
+object test2 {
+  val a: Impl1.B = ???
+  a match {
+    case Impl1.R1() => ???
+  }
+}


### PR DESCRIPTION
closes https://github.com/scala/scala3/issues/23734

tycon of Applied type was avoided from checking inhabited.