### PR TITLE
Backport "chore: render `@consume` as the `consume` modifier" to 3.7.4

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/api.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/api.scala
@@ -45,6 +45,7 @@ enum Modifier(val name: String, val prefix: Boolean):
   case Infix extends Modifier("infix", true)
   case AbsOverride extends Modifier("abstract override", true)
   case Update extends Modifier("update", true)
+  case Consume extends Modifier("consume", true)
 
 case class ExtensionTarget(name: String, typeParams: Seq[TypeParameter], argsLists: Seq[TermParameterList], signature: Signature, dri: DRI, position: Long)
 case class ImplicitConversion(from: DRI, to: DRI)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/BasicSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/BasicSupport.scala
@@ -57,7 +57,7 @@ trait BasicSupport:
       )
       val fqNameAllowlist =
         if ccEnabled then
-          fqNameAllowlist0 + CaptureDefs.useAnnotFullName + CaptureDefs.consumeAnnotFullName
+          fqNameAllowlist0 + CaptureDefs.useAnnotFullName
         else fqNameAllowlist0
       val documentedSymbol = summon[Quotes].reflect.Symbol.requiredClass("java.lang.annotation.Documented")
       val annotations = sym.annotations.filter { a =>


### PR DESCRIPTION
Backports #23754 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]