### PR TITLE
Backport "Explain no expansion of ContextFunction0" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3745,12 +3745,18 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           val ifpt = defn.asContextFunctionType(pt)
           val result =
             if ifpt.exists
-              && defn.functionArity(ifpt) > 0 // ContextFunction0 is only used after ElimByName
+              && !ctx.isAfterTyper
+              && {
+                // ContextFunction0 is only used after ElimByName
+                val arity = defn.functionArity(ifpt)
+                if arity == 0 then
+                  report.error(em"context function types require at least one parameter", xtree.srcPos)
+                arity > 0
+              }
               && xtree.isTerm
               && !untpd.isContextualClosure(xtree)
               && !ctx.mode.is(Mode.Pattern)
               && !xtree.isInstanceOf[SplicePattern]
-              && !ctx.isAfterTyper
               && !ctx.isInlineContext
             then
               makeContextualFunction(xtree, ifpt)

--- a/tests/neg/context-function-syntax.scala
+++ b/tests/neg/context-function-syntax.scala
@@ -2,7 +2,7 @@ val test =
   (using x: Int) => x  // error // error // error
 
 val f = () ?=> 23 // error
-val g: ContextFunction0[Int] = ??? // ok
+val g: ContextFunction0[Int] = ??? // error at typer for RHS not expanded
 val h: () ?=> Int = ??? // error
 
 object Example3 extends App {

--- a/tests/neg/i21321.check
+++ b/tests/neg/i21321.check
@@ -1,0 +1,19 @@
+-- Error: tests/neg/i21321.scala:3:42 ----------------------------------------------------------------------------------
+3 |val v1b: scala.ContextFunction0[String] = () ?=> "x" // error
+  |                                          ^^
+  |                                          context function literals require at least one formal parameter
+-- Error: tests/neg/i21321.scala:4:8 -----------------------------------------------------------------------------------
+4 |val v2: () ?=> String = "y" // error // error in parser
+  |        ^^
+  |        context function types require at least one parameter
+-- Error: tests/neg/i21321.scala:2:41 ----------------------------------------------------------------------------------
+2 |val v1: scala.ContextFunction0[String] = "x" // error
+  |                                         ^^^
+  |                                         context function types require at least one parameter
+-- [E007] Type Mismatch Error: tests/neg/i21321.scala:4:24 -------------------------------------------------------------
+4 |val v2: () ?=> String = "y" // error // error in parser
+  |                        ^^^
+  |                        Found:    ("y" : String)
+  |                        Required: () => String
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i21321.scala
+++ b/tests/neg/i21321.scala
@@ -1,0 +1,4 @@
+
+val v1: scala.ContextFunction0[String] = "x" // error
+val v1b: scala.ContextFunction0[String] = () ?=> "x" // error
+val v2: () ?=> String = "y" // error // error in parser


### PR DESCRIPTION
Backports #23844 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]