### PR TITLE
Backport "Add missing reference page: `Quoted Patterns with Polymorphic Functions`" to 3.7.4

### DIFF
--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -172,6 +172,7 @@ subsection:
           - page: reference/experimental/runtimeChecked.md
           - page: reference/experimental/unrolled-defs.md
           - page: reference/experimental/package-object-values.md
+          - page: reference/experimental/quoted-patterns-with-polymorphic-functions.md
       - page: reference/syntax.md
       - title: Language Versions
         index: reference/language-versions/language-versions.md


### PR DESCRIPTION
Backports #23632 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]