### PR TITLE
Backport "scaladoc: indicate optional parameters with `= ...`" to 3.7.4

### DIFF
--- a/scaladoc-testcases/src/tests/extendsCall.scala
+++ b/scaladoc-testcases/src/tests/extendsCall.scala
@@ -3,4 +3,4 @@ package extendsCall
 
 class Impl() extends Base(Seq.empty, c = "-") //expected: class Impl() extends Base
 
-class Base(val a: Seq[String], val b: String = "", val c: String = "") //expected: class Base(val a: Seq[String], val b: String, val c: String)
+class Base(val a: Seq[String], val b: String = "", val c: String = "") //expected: class Base(val a: Seq[String], val b: String = ..., val c: String = ...)

--- a/scaladoc-testcases/src/tests/optionalParams.scala
+++ b/scaladoc-testcases/src/tests/optionalParams.scala
@@ -1,0 +1,23 @@
+package tests
+package optionalParams
+
+class C(val a: Seq[String], val b: String = "", var c: String = "") //expected: class C(val a: Seq[String], val b: String = ..., var c: String = ...)
+{
+  def m(x: Int, s: String = "a"): Nothing //expected: def m(x: Int, s: String = ...): Nothing
+    = ???
+}
+
+def f(x: Int, s: String = "a"): Nothing //expected: def f(x: Int, s: String = ...): Nothing
+  = ???
+
+extension (y: Int)
+  def ext(x: Int = 0): Int //expected: def ext(x: Int = ...): Int
+    = 0
+
+def byname(s: => String = "a"): Int //expected: def byname(s: => String = ...): Int
+  = 0
+
+enum E(val x: Int = 0) //expected: enum E(val x: Int = ...)
+{
+  case E1(y: Int = 10) extends E(y) //expected: final case class E1(y: Int = ...) extends E
+}

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -454,14 +454,15 @@ trait ClassLikeSupport:
     val inlinePrefix = if symbol.flags.is(Flags.Inline) then "inline " else ""
     val name = symbol.normalizedName
     val nameIfNotSynthetic = Option.when(!symbol.flags.is(Flags.Synthetic))(name)
+    val defaultValue = Option.when(symbol.flags.is(Flags.HasDefault))(Plain(" = ..."))
     api.TermParameter(
       symbol.getAnnotations(),
       inlinePrefix + prefix(symbol),
       nameIfNotSynthetic,
       symbol.dri,
-      argument.tpt.asSignature(classDef, symbol.owner),
-      isExtendedSymbol,
-      isGrouped
+      argument.tpt.asSignature(classDef, symbol.owner) :++ defaultValue,
+      isExtendedSymbol = isExtendedSymbol,
+      isGrouped = isGrouped
     )
 
   def mkTypeArgument(

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -130,3 +130,5 @@ class RightAssocExtension extends SignatureTest("rightAssocExtension", Signature
 class NamedTuples extends SignatureTest("namedTuples", SignatureTest.all)
 
 class InnerClasses extends SignatureTest("innerClasses", SignatureTest.all)
+
+class OptionalParams extends SignatureTest("optionalParams", SignatureTest.all)


### PR DESCRIPTION
Backports #23676 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]