### PR TITLE
Ignore warnings when compiletime.testing is imported

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -501,10 +501,12 @@ object CheckUnused:
         if inliners == 0
           && languageImport(imp.expr).isEmpty
           && !imp.isGeneratedByEnum
-          && !imp.isCompiletimeTesting
           && !ctx.owner.name.isReplWrapperName
         then
-          imps.put(imp, ())
+          if imp.isCompiletimeTesting then
+            isNullified = true
+          else
+            imps.put(imp, ())
       case tree: Bind =>
         if !tree.name.isInstanceOf[DerivedName] && !tree.name.is(WildcardParamName) then
           if tree.hasAttachment(NoWarn) then
@@ -534,6 +536,9 @@ object CheckUnused:
         asss.addOne(sym)
       else
         refs.addOne(sym)
+
+    // currently compiletime.testing is completely erased, so ignore the unit
+    var isNullified = false
   end RefInfos
 
   // Names are resolved by definitions and imports, which have four precedence levels:
@@ -548,7 +553,7 @@ object CheckUnused:
       inline def weakerThan(q: Precedence): Boolean = p > q
       inline def isNone: Boolean = p == NoPrecedence
 
-  def reportUnused()(using Context): Unit =
+  def reportUnused()(using Context): Unit = if !refInfos.isNullified then
     for (msg, pos, origin) <- warnings do
       if origin.isEmpty then report.warning(msg, pos)
       else report.warning(msg, pos, origin)

--- a/tests/warn/i21805.scala
+++ b/tests/warn/i21805.scala
@@ -1,4 +1,4 @@
-//> using options -Wunused:imports
+//> using options -Wunused:all
 
 def i23967: Boolean = {
   //import scala.compiletime.testing.typeCheckErrors
@@ -12,8 +12,8 @@ package c:
   class C(i: Int)
 
 package q:
-  import c.* // warn should be nowarn
-  import p.* // warn should be nowarn
+  import c.* // nowarn, unit is nullified
+  import p.* // nowarn
   import scala.compiletime.testing.*
   def test() = typeCheckErrors("""println(C("hello, world"))""")
   def ok() = typeChecks("println(code)")


### PR DESCRIPTION
Fixes #23967 

It needs more mechanism for compiletime ops that are inlined but not `Inlined`.