### PR TITLE
scaladoc: Fix rendering of function-type aliases

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -276,7 +276,12 @@ trait TypesSupport:
         ++ inParens(inner(rhs, skipThisTypePrefix), shouldWrapInParens(rhs, t, false))
 
       case t @ AppliedType(tpe, args) if t.isFunctionType =>
-        functionType(tpe, args, skipThisTypePrefix)
+        val dealiased = t.dealiasKeepOpaques
+        if t == dealiased then
+          functionType(tpe, args, skipThisTypePrefix)
+        else
+          val AppliedType(tpe, args) = dealiased.asInstanceOf[AppliedType]
+          functionType(tpe, args, skipThisTypePrefix)
 
       case t @ AppliedType(tpe, typeList) =>
         inner(tpe, skipThisTypePrefix) ++ plain("[").l ++ commas(typeList.map { t => t match


### PR DESCRIPTION
Fixes #23456

We now eagerly dealias (modulo opaque types) type aliases that are known to be concrete function types.