### PR TITLE
Backport "Prevent crash in SAM conversion with mismatched arity" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1683,11 +1683,15 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           val restpe = mt.resultType match
             case mt: MethodType => mt.toFunctionType(isJava = samParent.classSymbol.is(JavaDefined))
             case tp => tp
-          (formals,
-           if (mt.isResultDependent)
-             untpd.InLambdaTypeTree(isResult = true, (_, syms) => restpe.substParams(mt, syms.map(_.termRef)))
-           else
-             typeTree(restpe))
+          val tree =
+            if (mt.isResultDependent) {
+              if (formals.length != defaultArity)
+                typeTree(WildcardType)
+              else
+                untpd.InLambdaTypeTree(isResult = true, (_, syms) => restpe.substParams(mt, syms.map(_.termRef)))
+            } else
+              typeTree(restpe)
+          (formals, tree)
         case _ =>
           (List.tabulate(defaultArity)(alwaysWildcardType), untpd.TypeTree())
       }

--- a/tests/neg/i123577.check
+++ b/tests/neg/i123577.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/i123577.scala:11:4 ------------------------------------------------------------
+11 |    (msg: String) => ??? // error
+   |    ^^^^^^^^^^^^^^^^^^^^
+   |    Found:    String => Nothing
+   |    Required: MillRpcChannel
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i123577.scala
+++ b/tests/neg/i123577.scala
@@ -1,0 +1,13 @@
+trait MillRpcMessage {
+  type Response
+}
+
+trait MillRpcChannel {
+  def apply(requestId: Long, input: MillRpcMessage): input.Response
+}
+
+object MillRpcChannel {
+  def createChannel: MillRpcChannel = {
+    (msg: String) => ??? // error
+  }
+}


### PR DESCRIPTION
Backports #23877 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]