### PR TITLE
Backport "Improve symbol order in completions provided by the presentation compiler" to 3.7.4

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
@@ -437,3 +437,44 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
          |""".stripMargin,
       assertSingleItem = false
     )
+
+  @Test def `extension-for-case-class` =
+    check(
+      """|case class Bar():
+         |  def baz(): Unit = ???
+         |
+         |object Bar:
+         |  extension (f: Bar)
+         |    def qux: Unit = ???
+         |
+         |object Main:
+         |  val _ = Bar().@@
+         |""".stripMargin,
+      """|baz(): Unit
+         |copy(): Bar
+         |qux: Unit
+         |asInstanceOf[X0]: X0
+         |canEqual(that: Any): Boolean
+         |equals(x$0: Any): Boolean
+         |getClass[X0 >: Bar](): Class[? <: X0]
+         |hashCode(): Int
+         |isInstanceOf[X0]: Boolean
+         |productArity: Int
+         |productElement(n: Int): Any
+         |productElementName(n: Int): String
+         |productElementNames: Iterator[String]
+         |productIterator: Iterator[Any]
+         |productPrefix: String
+         |synchronized[X0](x$0: X0): X0
+         |toString(): String
+         |->[B](y: B): (Bar, B)
+         |ensuring(cond: Boolean): Bar
+         |ensuring(cond: Bar => Boolean): Bar
+         |ensuring(cond: Boolean, msg: => Any): Bar
+         |ensuring(cond: Bar => Boolean, msg: => Any): Bar
+         |nn: `?1`.type
+         |runtimeChecked: `?2`.type
+         |formatted(fmtstr: String): String
+         |→[B](y: B): (Bar, B)
+         | """.stripMargin
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -109,18 +109,9 @@ class CompletionSuite extends BaseCompletionSuite:
          |tabulate[A](n: Int)(f: Int => A): List[A]
          |unapplySeq[A](x: List[A] @uncheckedVariance): UnapplySeqWrapper[A]
          |unfold[A, S](init: S)(f: S => Option[(A, S)]): List[A]
-         |->[B](y: B): (List.type, B)
-         |ensuring(cond: Boolean): List.type
-         |ensuring(cond: List.type => Boolean): List.type
-         |ensuring(cond: Boolean, msg: => Any): List.type
-         |ensuring(cond: List.type => Boolean, msg: => Any): List.type
          |fromSpecific(from: Any)(it: IterableOnce[Nothing]): List[Nothing]
          |fromSpecific(it: IterableOnce[Nothing]): List[Nothing]
-         |nn: List.type
-         |runtimeChecked scala.collection.immutable
          |toFactory(from: Any): Factory[Nothing, List[Nothing]]
-         |formatted(fmtstr: String): String
-         |→[B](y: B): (List.type, B)
          |iterableFactory[A]: Factory[A, List[A]]
          |asInstanceOf[X0]: X0
          |equals(x$0: Any): Boolean
@@ -129,6 +120,15 @@ class CompletionSuite extends BaseCompletionSuite:
          |isInstanceOf[X0]: Boolean
          |synchronized[X0](x$0: X0): X0
          |toString(): String
+         |->[B](y: B): (List.type, B)
+         |ensuring(cond: Boolean): List.type
+         |ensuring(cond: List.type => Boolean): List.type
+         |ensuring(cond: Boolean, msg: => Any): List.type
+         |ensuring(cond: List.type => Boolean, msg: => Any): List.type
+         |nn: List.type
+         |runtimeChecked scala.collection.immutable
+         |formatted(fmtstr: String): String
+         |→[B](y: B): (List.type, B)
          |""".stripMargin
     )
 


### PR DESCRIPTION
Backports #23888 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]