### PR TITLE
Fix cyclicity error for self-referential enum case

### DIFF
--- a/tests/neg/i6601.scala
+++ b/tests/neg/i6601.scala
@@ -1,22 +1,22 @@
 object GADTs2 {
   enum Var[G, A] {
     case Z[A, G]() extends Expr[(A, G), A] // error
-    case X extends AnyRef                  // error
+    case X extends AnyRef                  // error // error
   }
   enum Expr[G, A] {
     case Lit[G](n: Int) extends Expr[G, Int]
         // case S[A, G](x:
   }
   enum Covariant[+T] {
-    case Bottom extends AnyRef // error
+    case Bottom extends AnyRef // error // error
   }
   enum Contravariant[-T] {
-    case Top extends AnyRef // error
+    case Top extends AnyRef // error // error
   }
   enum Color {
-    case Red extends AnyRef // error
+    case Red extends AnyRef // error // error
   }
   enum Parameterized[T](x: T) {
-    case Foo extends AnyRef // error
+    case Foo extends AnyRef // error // error
   }
 }

--- a/tests/pos/i11443.scala
+++ b/tests/pos/i11443.scala
@@ -1,0 +1,5 @@
+enum Opt[T] {
+  case Nn extends Opt[Nothing] with Comparable[Nn.type]
+
+  def compareTo(nn: Nn.type) = 0
+}

--- a/tests/pos/i21860.scala
+++ b/tests/pos/i21860.scala
@@ -8,7 +8,7 @@ enum Shape extends Figure:
   case Ellipsis extends Shape
 
 def hasCorners(s: Shape): Boolean = s match
-  case hasCorners: Corners => true //  <--- reported as `Unreachable case`
+  case hasCorners: Corners => true //  <--- previously reported as `Unreachable case` (i21860), ok now (i11443)
   case _                   => false
 
 class Test:


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/11443

When an enum case references itself in a parent type (e.g.,
`case Nn extends Opt[Nothing] with Comparable[Nn.type]`), the
compiler previously reported a cyclic reference error during type
inference.

The fix attempts to provide an explicit type annotation
(the intersection of all parents) for parameterless enum cases
early at desugaring time.
