### PR TITLE
Discard `scala.caps.Pure` in the erasure of union and intersection types

### DIFF
--- a/tests/run/i23882.check
+++ b/tests/run/i23882.check
@@ -1,0 +1,6 @@
+public void Foo.foo(java.lang.Object)
+public void Foo.foo(scala.Equals)
+public void Foo.bar(Bar)
+public void Foo.bar2(Bar)
+public void Foo.bar3(Bar)
+public void Foo.bar4(Bar)

--- a/tests/run/i23882.scala
+++ b/tests/run/i23882.scala
@@ -1,0 +1,18 @@
+// scalajs: --skip
+
+import scala.collection.*
+import scala.caps.Pure
+
+trait Bar
+
+class Foo:
+  def foo[T](x: Seq[T] | Set[T]): Unit = ??? // erases to a weird thing: scala.Equals
+  def foo[T](x: Array[T]): Unit = ???        // erases to Object
+  def bar(x: Bar & Pure): Unit = ???      // erases to Bar
+  def bar2(x: Pure & Bar): Unit = ???      // erases to Bar
+  def bar3[T <: Pure](x: Bar & T): Unit = ???      // erases to Bar
+  def bar4[T <: Pure](x: T & Bar): Unit = ???      // erases to Bar
+
+@main def Test =
+  for mtd <- classOf[Foo].getDeclaredMethods do
+    println(mtd)


### PR DESCRIPTION
Since CC should not be visible in the binary code in general, and as a workaround for #24113 and #24148, we treat specially the erasure of `A & Pure` and if `Pure` appears in the base classes when erasing `A | B`

Closes #23882