### PR TITLE
fix: make the order deterministic in i23882

### DIFF
--- a/tests/run/i23882.check
+++ b/tests/run/i23882.check
@@ -1,6 +1,6 @@
-public void Foo.foo(java.lang.Object)
-public void Foo.foo(scala.Equals)
-public void Foo.bar(Bar)
-public void Foo.bar2(Bar)
-public void Foo.bar3(Bar)
-public void Foo.bar4(Bar)
+foo(scala.Equals): void
+foo(java.lang.Object): void
+bar(Bar): void
+bar2(Bar): void
+bar3(Bar): void
+bar4(Bar): void

--- a/tests/run/i23882.scala
+++ b/tests/run/i23882.scala
@@ -13,6 +13,16 @@ class Foo:
   def bar3[T <: Pure](x: Bar & T): Unit = ???      // erases to Bar
   def bar4[T <: Pure](x: T & Bar): Unit = ???      // erases to Bar
 
+def printGenericSignature(m: java.lang.reflect.Method): Unit =
+  val tpe = m.getParameterTypes().map(_.getTypeName).mkString(", ")
+  val ret = m.getReturnType().getTypeName
+  println(s"${m.getName}($tpe): $ret")
+
 @main def Test =
-  for mtd <- classOf[Foo].getDeclaredMethods do
-    println(mtd)
+  val cls = classOf[Foo]
+  printGenericSignature(cls.getDeclaredMethod("foo", classOf[scala.Equals]))
+  printGenericSignature(cls.getDeclaredMethod("foo", classOf[Object]))
+  printGenericSignature(cls.getDeclaredMethod("bar", classOf[Bar]))
+  printGenericSignature(cls.getDeclaredMethod("bar2", classOf[Bar]))
+  printGenericSignature(cls.getDeclaredMethod("bar3", classOf[Bar]))
+  printGenericSignature(cls.getDeclaredMethod("bar4", classOf[Bar]))


### PR DESCRIPTION
The order in the test suite in i23332 is not deterministic, we know make it so that is doesn't break the CI.