### PR TITLE
fix bytecode attributes for patched files

### DIFF
--- a/project/ScalaLibraryPlugin.scala
+++ b/project/ScalaLibraryPlugin.scala
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import xsbti.VirtualFileRef
 import sbt.internal.inc.Stamper
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.scalaJSVersion
+import org.objectweb.asm.*
 
 object ScalaLibraryPlugin extends AutoPlugin {
 
@@ -55,8 +56,8 @@ object ScalaLibraryPlugin extends AutoPlugin {
         dest = target / (id.toString)
         ref <- dest.relativeTo((LocalRootProject / baseDirectory).value)
       } {
-        // Copy the files to the classDirectory
-        IO.copyFile(file, dest)
+        // Read -> Strip Scala 2 Pickles -> Write
+        IO.write(dest, unpickler(IO.readBytes(file)))
         // Update the timestamp in the analysis
         stamps = stamps.markProduct(
           VirtualFileRef.of(s"$${BASE}/$ref"),
@@ -76,7 +77,8 @@ object ScalaLibraryPlugin extends AutoPlugin {
         // Copy all the specialized classes in the stdlib
         // no need to update any stamps as these classes exist nowhere in the analysis
         for (orig <- diff; dest <- orig.relativeTo(reference)) {
-          IO.copyFile(orig, ((Compile / classDirectory).value / dest.toString()))
+          // Read -> Strip Scala 2 Pickles -> Write
+          IO.write((Compile / classDirectory).value / dest.toString, unpickler(IO.readBytes(orig)))
         }
       }
 
@@ -100,6 +102,25 @@ object ScalaLibraryPlugin extends AutoPlugin {
       IO.unzip(jar, target)
       (target ** "*.class").get.toSet ++ (target ** "*.sjsir").get.toSet
     } (Set(jar)), target)
+  }
+
+  /* Remove Scala 2 Pickles from Classfiles */
+  private def unpickler(bytes: Array[Byte]): Array[Byte] = {
+    val reader = new ClassReader(bytes)
+    val writer = new ClassWriter(0)
+    val visitor = new ClassVisitor(Opcodes.ASM9, writer) {
+      override def visitAttribute(attr: Attribute): Unit = attr.`type` match {
+        case "ScalaSig" | "ScalaInlineInfo" => ()
+        case _ => super.visitAttribute(attr)
+      }
+
+      override def visitAnnotation(desc: String, visible: Boolean): AnnotationVisitor =
+        if (desc == "Lscala/reflect/ScalaSignature;" || desc == "Lscala/reflect/ScalaLongSignature;") null
+        else super.visitAnnotation(desc, visible)
+
+    }
+    reader.accept(visitor, 0)
+    writer.toByteArray
   }
 
   private lazy val filesToCopy = Set(

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,5 @@
 // Used by VersionUtil to get gitHash and commitDate
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "4.11.0.201803080745-r"
+libraryDependencies += "org.ow2.asm" % "asm" % "9.9"
 
 libraryDependencies += Dependencies.`jackson-databind`


### PR DESCRIPTION
We should probably add a `TASTY` attribute in the bytecode too but as a first glance, it looks very annoying to compute in the plugin.

Closes #24161