### PR TITLE
Prohibit selection of tuples with members named `apply`.

### DIFF
--- a/tests/neg/named-tuple-apply.check
+++ b/tests/neg/named-tuple-apply.check
@@ -1,0 +1,28 @@
+-- Error: tests/neg/named-tuple-apply.scala:5:2 ------------------------------------------------------------------------
+5 |  (apply = () => 1)(())  // error // error
+  |  ^^^^^^^^^^^^^^^^^
+  |  Named tuples that define an `apply` field do not allow field selection.
+  |  The `apply` field should be renamed to something else.
+-- [E007] Type Mismatch Error: tests/neg/named-tuple-apply.scala:5:20 --------------------------------------------------
+5 |  (apply = () => 1)(())  // error // error
+  |                    ^^
+  |                    Found:    Unit
+  |                    Required: Int
+  |
+  | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/named-tuple-apply.scala:6:29 -----------------------------------------------------------------------
+6 |  (apply = () => 1, foo = 2).foo  // error
+  |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |  Named tuples that define an `apply` field do not allow field selection.
+  |  The `apply` field should be renamed to something else.
+-- Error: tests/neg/named-tuple-apply.scala:7:29 -----------------------------------------------------------------------
+7 |  (apply = () => 1, foo = 2).apply(1)  // error
+  |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |  Named tuples that define an `apply` field do not allow field selection.
+  |  The `apply` field should be renamed to something else.
+-- [E050] Type Error: tests/neg/named-tuple-apply.scala:10:2 -----------------------------------------------------------
+10 |  foo() // error (error message could be better)
+   |  ^^^
+   |  method apply in class Foo does not take parameters
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/named-tuple-apply.scala
+++ b/tests/neg/named-tuple-apply.scala
@@ -1,0 +1,10 @@
+class Foo:
+  def apply: () => Int = () => 2
+
+def test =
+  (apply = () => 1)(())  // error // error
+  (apply = () => 1, foo = 2).foo  // error
+  (apply = () => 1, foo = 2).apply(1)  // error
+
+  val foo = Foo()
+  foo() // error (error message could be better)


### PR DESCRIPTION
Similar to #24188, but we now disallow `apply` members at tuple selection instead of tuple formation. This also works for hand-rolled tuples built using `NamedTuple(...)`. And it constitutes the minimal fix to avoid the recursion.