### PR TITLE
[community-build] Fix failing mill builds

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -74,7 +74,7 @@ final case class MillCommunityProject(
   override val docCommand = null
     // uncomment once mill is released
     // if ignoreDocs then null else s"$baseCommand.docJar"
-  override val runCommandsArgs = List("-i", "-D", s"dottyVersion=$compilerVersion")
+  override val runCommandsArgs = List("-i", "-D", s"dottyVersion=$compilerVersion", "--no-server")
 
 final case class SbtCommunityProject(
     project: String,


### PR DESCRIPTION
* Stop setting explicit MILL_VERSION as explicit variable - version should be set at the project level 
* Don't start mill build server