### PR TITLE
Backport "Fix java record varargs field accessor" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -879,9 +879,14 @@ object JavaParsers {
         fieldsByName -= name
       end for
 
+      // accessor for record's vararg field  (T...) returns array type (T[])
+      def adaptVarargsType(tpt: Tree) = tpt match
+        case PostfixOp(tpt2, Ident(tpnme.raw.STAR)) => arrayOf(tpt2)
+        case _ => tpt
+
       val accessors =
         (for (name, (tpt, annots)) <- fieldsByName yield
-          DefDef(name, List(Nil), tpt, unimplementedExpr)
+          DefDef(name, List(Nil), adaptVarargsType(tpt), unimplementedExpr)
             .withMods(Modifiers(Flags.JavaDefined | Flags.Method | Flags.Synthetic))
         ).toList
 

--- a/tests/pos-java16+/java-records/FromScala.scala
+++ b/tests/pos-java16+/java-records/FromScala.scala
@@ -49,3 +49,7 @@ object C:
   def useR4: Unit =
     val r4 = R4(1)
     val i: Int = r4.t
+
+  def useR5: Unit =
+    val r5 = R5("hi", 1, 2, 3)
+    val xs: Array[Int] = r5.values

--- a/tests/pos-java16+/java-records/R5.java
+++ b/tests/pos-java16+/java-records/R5.java
@@ -1,0 +1,1 @@
+public record R5(String s, int... values) {}


### PR DESCRIPTION
Backports #24172 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]