### PR TITLE
Backport "Fix compiler crash with `-Ymagic-offset-header`" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -57,7 +57,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
     info match
       // This span is in user code
       case HasHeader(offset, originalFile)
-        if span != NoSpan && span.start >= offset =>
+        if span.exists && span.start >= offset =>
           originalFile.atSpan(span.shift(-offset))
       // Otherwise, return the source position in the wrapper code
       case _ => source.atSpan(span)


### PR DESCRIPTION
Backports #24124 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]