### PR TITLE
Check for synthetic case methods in unused lint

### DIFF
--- a/tests/warn/i15503c.scala
+++ b/tests/warn/i15503c.scala
@@ -70,3 +70,10 @@ object LazyVals:
 
   final class Waiting extends CountDownLatch(1), LazyValControlState:
     private def writeReplace(): Any = null
+
+package i24235:
+  object Test:
+    private case class Unused() // warn
+    private class Regular // nowarn
+    private object Regular: // warn
+      def r = Regular() // usage


### PR DESCRIPTION
Fixes #24235 

References to a case class from synthetic methods in its companion
are not usages for `-Wunused`.
