### PR TITLE
chore: officially deprecate `scala.App` in Scala 3

### DIFF
--- a/library-js/src/scala/App.scala
+++ b/library-js/src/scala/App.scala
@@ -41,6 +41,7 @@ import scala.collection.mutable.ListBuffer
  *  @author  Martin Odersky
  *  @since   2.1
  */
+@deprecated(message = "Support for trait App is deprecated in Scala 3. Please refer to https://docs.scala-lang.org/scala3/book/methods-main-methods.html.", since = "3.8.0")
 trait App extends DelayedInit {
 
   /** The time when the execution of this program started, in milliseconds since 1

--- a/library/src/scala/App.scala
+++ b/library/src/scala/App.scala
@@ -39,19 +39,19 @@ import scala.collection.mutable.ListBuffer
  *  before the main method has been executed.'''''
  *
  *  Future versions of this trait will no longer extend `DelayedInit`.
- * 
+ *
  *  In Scala 3, the `DelayedInit` feature was dropped. `App` exists only in a limited form
  *  that also does not support command line arguments and will be deprecated in the future.
- * 
+ *
  *  [[https://docs.scala-lang.org/scala3/book/methods-main-methods.html @main]] methods are the
  *  recommended scheme to generate programs that can be invoked from the command line in Scala 3.
- * 
+ *
  *  {{{
  *  @main def runMyProgram(args: String*): Unit = {
  *    // your program here
  *  }
  *  }}}
- * 
+ *
  *  If programs need to cross-build between Scala 2 and Scala 3, it is recommended to use an
  *  explicit `main` method:
  *  {{{
@@ -62,7 +62,7 @@ import scala.collection.mutable.ListBuffer
  *  }
  *  }}}
  */
-@nowarn("cat=deprecation")
+@deprecated(message = "Support for trait App is deprecated in Scala 3. Please refer to https://docs.scala-lang.org/scala3/book/methods-main-methods.html.", since = "3.8.0")
 trait App extends DelayedInit {
 
   /** The time when the execution of this program started, in milliseconds since 1

--- a/tests/neg/i21207.scala
+++ b/tests/neg/i21207.scala
@@ -15,7 +15,7 @@ class C extends P {
   def g4(): Int = 4
 }
 
-object Test extends App {
+object Test {
   val c = new C
   println(c.foo1) // error was omitted because of nullary fallback during ambiguous overload resolution
   println(c.foo2) // error, add parens

--- a/tests/patmat/i12241.scala
+++ b/tests/patmat/i12241.scala
@@ -23,7 +23,7 @@ object EndpointInput {
   case class Empty[T]() extends EndpointInput[T]
 }
 
-object Test extends App {
+object Test {
   import EndpointInput._
 
   def compare(left: EndpointInput[?], right: EndpointInput[?]): Boolean =

--- a/tests/patmat/t2425.scala
+++ b/tests/patmat/t2425.scala
@@ -1,6 +1,6 @@
 trait B
 class D extends B
-object Test extends App {
+object Test {
   def foo[T](bar: T) = {
     bar match {
       case _: Array[Array[?]] => println("array 2d")

--- a/tests/patmat/t7466.scala
+++ b/tests/patmat/t7466.scala
@@ -1,4 +1,4 @@
-object Test extends App {
+object Test {
   val Yes1 = true
   val Yes2 = true
   val No1 = false

--- a/tests/patmat/t9672.scala
+++ b/tests/patmat/t9672.scala
@@ -17,7 +17,7 @@ trait IntExpr {
 object SimpleExpr extends Hierarchy with If with Word with IntExpr
 //object OtherExpr extends Hierarchy with If with IntExpr
 
-object Demo extends App {
+object Demo {
   import SimpleExpr.*
   def func(expr: Expr) = expr match {
     case If(cond, yes, no) => cond

--- a/tests/patmat/virtpatmat_reach_sealed_unsealed.scala
+++ b/tests/patmat/virtpatmat_reach_sealed_unsealed.scala
@@ -2,7 +2,7 @@ sealed abstract class X
 sealed case class A(x: Int) extends X
 
 // test reachability on mixed sealed / non-sealed matches
-object Test extends App {
+object Test {
   val B: X = A(0)
   val C: X = A(1)
 

--- a/tests/pos/i5970.scala
+++ b/tests/pos/i5970.scala
@@ -1,6 +1,6 @@
 //> using options -Xfatal-warnings -deprecation -feature
 
-object Test extends App {
+object Test {
   case class Foo[T](t: T)
 
   def foo[T](ft: Unit|Foo[T]): T = {

--- a/tests/pos/t2425.scala
+++ b/tests/pos/t2425.scala
@@ -1,6 +1,6 @@
 trait B
 class D extends B
-object Test extends App {
+object Test {
   def foo[T](bar: T) = {
     bar match {
       case _: Array[Array[_]] => println("array 2d")

--- a/tests/warn/i19302.scala
+++ b/tests/warn/i19302.scala
@@ -3,7 +3,7 @@
 @deprecated("is deprecated", "n/a")
 class Thing(val value: Int)
 
-object Main extends App {
+object Main {
 
   def doo(): Option[Thing] = // warn
     Some(new Thing(1)) // warn

--- a/tests/warn/i21207/usage.scala
+++ b/tests/warn/i21207/usage.scala
@@ -9,7 +9,7 @@ class C extends P {
   def g(i: Int): Int = 42 + i
 }
 
-object Test extends App {
+object Test {
   val over = Over()
   println(over.f) // nowarn Java
   val c = C()

--- a/tests/warn/i7821.scala
+++ b/tests/warn/i7821.scala
@@ -20,7 +20,7 @@ object MyXObject {
   }
 }
 
-object Main extends App {
+object Main {
   println(XObject.anX + XObject.anX) // prints 10
   println(MyXObject.anX + MyXObject.anX) // infinite loop
 }

--- a/tests/warn/i9166.scala
+++ b/tests/warn/i9166.scala
@@ -1,5 +1,5 @@
 //> using options  -Wimplausible-patterns
-object UnitTest extends App {
+object UnitTest {
   def foo(m: Unit) = m match {
     case runtime.BoxedUnit.UNIT => println("ok") // warn
   }


### PR DESCRIPTION
`scala.App` has always existed in a limited form in Scala 3 but was never fully deprecated.