### PR TITLE
Fix #24207: Cleanup the type of `UnApply` trees in posttyper

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -523,7 +523,10 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
         case UnApply(fun, implicits, patterns) =>
           // Reverse transform order for the same reason as in `app1` above.
           val patterns1 = transform(patterns)
-          cpy.UnApply(tree)(transform(fun), transform(implicits), patterns1)
+          val tree1 = cpy.UnApply(tree)(transform(fun), transform(implicits), patterns1)
+          // The pickling of UnApply trees uses the tpe of the tree,
+          // so we need to clean retains from it here
+          tree1.withType(transformAnnotsIn(CleanupRetains()(tree1.tpe)))
         case tree: TypeApply =>
           if tree.symbol == defn.QuotedTypeModule_of then
             ctx.compilationUnit.needsStaging = true

--- a/tests/pos-custom-args/captures/i24207.scala
+++ b/tests/pos-custom-args/captures/i24207.scala
@@ -1,0 +1,14 @@
+import language.experimental.captureChecking
+
+class Generator:
+  private def generateTable(table: Table) =
+    val (ownRelations, _) = calculateOwnRelations(table)
+    ownRelations
+
+  private def calculateOwnRelations(table: Table) =
+    val ownRelations = table.relations.filter(_.association.isDefined)
+    (ownRelations, Nil)
+
+case class Table(relations: Seq[TableRelation])
+case class TableRelation(association: Option[Association])
+trait Association

--- a/tests/pos/i24207.scala
+++ b/tests/pos/i24207.scala
@@ -1,0 +1,12 @@
+class Generator:
+  private def generateTable(table: Table) =
+    val (ownRelations, _) = calculateOwnRelations(table)
+    ownRelations
+
+  private def calculateOwnRelations(table: Table) =
+    val ownRelations = table.relations.filter(_.association.isDefined)
+    (ownRelations, Nil)
+
+case class Table(relations: Seq[TableRelation])
+case class TableRelation(association: Option[Association])
+trait Association


### PR DESCRIPTION
Fix #24207

The pickling of `UnApply` trees uses the type of the tree, so we need to clean retains annotations from it as inferred type.