### PR TITLE
Refine .gitignore rule for local folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ testlogs/
 /.cache-tests
 
 # Put local stuff here
-local/
+/local/
 
 /bin/.cp
 


### PR DESCRIPTION
Previously, every subfolder named `local` would be excluded from git tracking.

This can be a footgun, e.g., I had some leftover junk files in `library/src/local` that went unnoticed for a long time and caused inexplicable behavior in sbt tasks.

Now, exclude only the top-level `local`.

[skip ci]