### PR TITLE
Relax flow typing checks on Flexible Types

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NullOpsDecorator.scala
+++ b/compiler/src/dotty/tools/dotc/core/NullOpsDecorator.scala
@@ -47,7 +47,7 @@ object NullOpsDecorator:
 
     /** Is self (after widening and dealiasing) a type of the form `T | Null`? */
     def isNullableUnion(using Context): Boolean = {
-      val stripped = self.stripNull()
+      val stripped = self.stripNull(stripFlexibleTypes = false)
       stripped ne self
     }
   end extension

--- a/tests/explicit-nulls/pos/flow-flexible.scala
+++ b/tests/explicit-nulls/pos/flow-flexible.scala
@@ -1,0 +1,9 @@
+// This test is based on sconfig/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
+// In cases where a nullable variable is assigned a flexible type, we want
+// later code to type the variable access as non-nullable
+// Added in https://github.com/scala/scala3/pull/24278
+
+def main() =
+  var result: String | Null = null
+  result = "".trim()
+  result.trim()


### PR DESCRIPTION
These changes allow flow-typing to view flexible types as non-nullable at relevant places. 
```scala
//> using options -Yexplicit-nulls

def main() =
  var result: String | Null = null
  result = "".trim()
  result.trim()
```

Without this PR, the access of trim on result will give an error. This pattern is used in community build projects like sconfig.  

After this change, calling .nn on a flexible type **directly** will still not give a warning, as intended.  
However, calling .nn on a variable that is previously flow typed to be a flexible type will now give a warning as a side effect of this change. We believe that the benefits of this change outweigh the drawback.