### PR TITLE
Register no elements for lint after inlining

### DIFF
--- a/tests/warn/i24265.scala
+++ b/tests/warn/i24265.scala
@@ -1,0 +1,10 @@
+//> using options -Wall -Werror
+
+object test {
+  inline def f(testFun: => Any) = testFun
+
+  f {
+    val i = 1
+    summon[i.type <:< Int]
+  }
+}


### PR DESCRIPTION
Fixes #24265 

The lint previously registered imports only after typer, but no new symbols after inlining should be subject to the unused lint.