### PR TITLE
Use enclosing enclosingInlineds for empty call

### DIFF
--- a/tests/warn/i24248/lib.scala
+++ b/tests/warn/i24248/lib.scala
@@ -1,0 +1,18 @@
+
+import scala.quoted.*
+
+trait Thing
+object Stuff:
+  given Thing()
+
+object lib:
+  inline def m: Thing = ${ mImpl[Thing] }
+
+  def mImpl[T](using Quotes, Type[T]): Expr[T] =
+    import quotes.reflect.*
+    val thing = Implicits.search(TypeRepr.of[T]) match
+      case iss: ImplicitSearchSuccess => iss.tree.asExprOf[T]
+    '{
+      val res = $thing
+      res
+    }

--- a/tests/warn/i24248/test.scala
+++ b/tests/warn/i24248/test.scala
@@ -1,0 +1,6 @@
+//> using options -Werror -Wunused:all
+
+import Stuff.given
+
+@main def test = println:
+  lib.m


### PR DESCRIPTION
Fixes #24248 

Adjust enclosing inlineds for inlined parameter, and do look-up in imports if tree position is enclosed by any enclosing inlined position (any intermediate position, not just outermost).