### PR TITLE
Backport "Exclude synthetic opaque proxy from lint" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -642,7 +642,7 @@ object CheckUnused:
 
     def checkLocal(sym: Symbol, pos: SrcPos) =
       if ctx.settings.WunusedHas.locals
-        && !sym.is(InlineProxy)
+        && !sym.isOneOf(InlineProxy | Synthetic)
         && !sym.isCanEqual
       then
         if sym.is(Mutable) && infos.asss(sym) then

--- a/tests/warn/i24263.scala
+++ b/tests/warn/i24263.scala
@@ -1,0 +1,6 @@
+//> using options -Werror -Wunused:all
+
+object test {
+  def f(t: Tuple): Nothing = ???
+  val _ = (inputTuple: NamedTuple.NamedTuple[Tuple, Tuple]) => f(inputTuple)
+}


### PR DESCRIPTION
Backports #24264 to the 3.7.4.

PR submitted by the release tooling.