### PR TITLE
improve the generic signatures for singleton types

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -246,6 +246,12 @@ object GenericSignatures {
             jsig(erasedUnderlying, toplevel = toplevel, unboxedVCs = unboxedVCs)
           else typeParamSig(ref.paramName.lastPart)
 
+        case ref: SingletonType =>
+          // Singleton types like `x.type` need to be widened to their underlying type
+          // For example, `def identity[A](x: A): x.type` should have signature 
+          // with return type `A` (not `java.lang.Object`)
+          jsig(ref.underlying, toplevel = toplevel, unboxedVCs = unboxedVCs)
+
         case defn.ArrayOf(elemtp) =>
           if (isGenericArrayElement(elemtp, isScala2 = false))
             jsig1(defn.ObjectType)

--- a/tests/run/i24272.check
+++ b/tests/run/i24272.check
@@ -1,0 +1,1 @@
+public <B> B Foo.bar(B)

--- a/tests/run/i24272.scala
+++ b/tests/run/i24272.scala
@@ -1,0 +1,8 @@
+// scalajs: --skip
+
+class Foo:
+  def bar[B](x: B): x.type = x
+
+@main def Test =
+  for mtd <- classOf[Foo].getDeclaredMethods.sortBy(_.getName) do
+    println(mtd.toGenericString)


### PR DESCRIPTION
When generating the generic signature of a singleton type, instead of relying on the erased type,  generate it from its underlying type.

Closes #24272