### PR TITLE
fix: less logs in the CI workflow

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -10,6 +10,7 @@ permissions:
   contents: read
 
 env:
+  DOTTY_CI_RUN: true
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:


### PR DESCRIPTION
Pretty much self explanatory. For the vulpix, we recover the old behavior of removing the progress bar.
For the warnings, a PR was already merged #24240 and more to come.