### PR TITLE
do not expose flexible types

### DIFF
--- a/library/src/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/library/src/scala/collection/convert/JavaCollectionWrappers.scala
@@ -279,7 +279,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
           new ju.Map.Entry[K, V] {
             def getKey = k
             def getValue = v
-            def setValue(v1 : V) = self.put(k, v1)
+            def setValue(v1 : V): V = self.put(k, v1)
 
             // It's important that this implementation conform to the contract
             // specified in the javadocs of java.util.Map.Entry.hashCode
@@ -421,7 +421,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     }
 
     def iterator: Iterator[(K, V)] = new AbstractIterator[(K, V)] {
-      val ui = underlying.entrySet.iterator
+      val ui: java.util.Iterator[java.util.Map.Entry[K, V]] = underlying.entrySet.iterator
       def hasNext = ui.hasNext
       def next() = { val e = ui.next(); (e.getKey, e.getValue) }
     }
@@ -610,7 +610,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     }
 
     def iterator: Iterator[(String, String)] = new AbstractIterator[(String, String)] {
-      val ui = underlying.entrySet.iterator
+      val ui: java.util.Iterator[java.util.Map.Entry[Object, Object]] = underlying.entrySet.iterator
       def hasNext = ui.hasNext
       def next() = {
         val e = ui.next()

--- a/library/src/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/library/src/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -123,17 +123,17 @@ private[concurrent] object ExecutionContextImpl {
         new ExecutionContextImpl(some, reporter) with ExecutionContextExecutorService {
             private final def asExecutorService: ExecutorService = executor.asInstanceOf[ExecutorService]
             final override def shutdown() = asExecutorService.shutdown()
-            final override def shutdownNow() = asExecutorService.shutdownNow()
+            final override def shutdownNow(): java.util.List[Runnable] = asExecutorService.shutdownNow()
             final override def isShutdown = asExecutorService.isShutdown
             final override def isTerminated = asExecutorService.isTerminated
             final override def awaitTermination(l: Long, timeUnit: TimeUnit) = asExecutorService.awaitTermination(l, timeUnit)
-            final override def submit[T](callable: Callable[T]) = asExecutorService.submit(callable)
-            final override def submit[T](runnable: Runnable, t: T) = asExecutorService.submit(runnable, t)
-            final override def submit(runnable: Runnable) = asExecutorService.submit(runnable)
-            final override def invokeAll[T](callables: Collection[? <: Callable[T]]) = asExecutorService.invokeAll(callables)
-            final override def invokeAll[T](callables: Collection[? <: Callable[T]], l: Long, timeUnit: TimeUnit) = asExecutorService.invokeAll(callables, l, timeUnit)
-            final override def invokeAny[T](callables: Collection[? <: Callable[T]]) = asExecutorService.invokeAny(callables)
-            final override def invokeAny[T](callables: Collection[? <: Callable[T]], l: Long, timeUnit: TimeUnit) = asExecutorService.invokeAny(callables, l, timeUnit)
+            final override def submit[T](callable: Callable[T]): java.util.concurrent.Future[T] = asExecutorService.submit(callable)
+            final override def submit[T](runnable: Runnable, t: T): java.util.concurrent.Future[T] = asExecutorService.submit(runnable, t)
+            final override def submit(runnable: Runnable): java.util.concurrent.Future[?] = asExecutorService.submit(runnable)
+            final override def invokeAll[T](callables: Collection[? <: Callable[T]]): java.util.List[java.util.concurrent.Future[T]] = asExecutorService.invokeAll(callables)
+            final override def invokeAll[T](callables: Collection[? <: Callable[T]], l: Long, timeUnit: TimeUnit): java.util.List[java.util.concurrent.Future[T]] = asExecutorService.invokeAll(callables, l, timeUnit)
+            final override def invokeAny[T](callables: Collection[? <: Callable[T]]): T = asExecutorService.invokeAny(callables)
+            final override def invokeAny[T](callables: Collection[? <: Callable[T]], l: Long, timeUnit: TimeUnit): T = asExecutorService.invokeAny(callables, l, timeUnit)
           }
         }
 }

--- a/library/src/scala/sys/process/ProcessImpl.scala
+++ b/library/src/scala/sys/process/ProcessImpl.scala
@@ -97,7 +97,7 @@ private[process] trait ProcessImpl {
     def exitValue() = futureValue() getOrElse scala.sys.error("No exit code: process destroyed.")
     def start()     = { futureThread ;() }
 
-    protected lazy val (processThread, (futureThread, futureValue), destroyer) = {
+    protected lazy val (processThread, (futureThread, futureValue: (() => Option[Int])), destroyer) = {
       val code = new LinkedBlockingQueue[Option[Int]](1)
       val thread = Spawn("CompoundProcess") {
         var value: Option[Int] = None


### PR DESCRIPTION
Do not infer public flexible type in the stdlib.
This is the only remaining exposed flexible type in the library:
```scala
[warn] -- Warning: /Users/hamzaremmal/Desktop/scala/scala3/library/src/scala/util/control/NoStackTrace.scala:27:42 
[warn] 27 |    if (NoStackTrace.noSuppression) super.fillInStackTrace()
[warn]    |                                          ^
[warn]    |method scala$util$control$NoStackTrace$$super$fillInStackTrace exposes a flexible type in its inferred result type (Throwable)?. Consider annotating the type explicitly
```