### PR TITLE
[chore] Set build for 3.8.1 developement

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2223,9 +2223,9 @@ object Build {
       },
       // Add configuration for MiMa
       commonMiMaSettings,
-      mimaForwardIssueFilters := MiMaFilters.Scala3Library.ForwardsBreakingChanges,
-      mimaBackwardIssueFilters := MiMaFilters.Scala3Library.BackwardsBreakingChanges,
-      customMimaReportBinaryIssues("MiMaFilters.Scala3Library"),
+      mimaForwardIssueFilters := MiMaFilters.ScalaLibrarySJS.ForwardsBreakingChanges,
+      mimaBackwardIssueFilters := MiMaFilters.ScalaLibrarySJS.BackwardsBreakingChanges,
+      customMimaReportBinaryIssues("MiMaFilters.ScalaLibrarySJS"),
       // Should we also patch .sjsir files
       keepSJSIR := true,
     )

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -590,6 +590,26 @@ object MiMaFilters {
     )
   }
 
+  object ScalaLibrarySJS {
+    val ForwardsBreakingChanges: Map[String, Seq[ProblemFilter]] = Map(
+      // Additions that require a new minor version of the library
+      Build.mimaPreviousDottyVersion -> Seq(
+        // No .class files generated in the artifacts, only `scala.scalajs.*` files might be present
+        ProblemFilters.exclude[MissingClassProblem]("scala.*"),
+      ),
+      Build.mimaPreviousLTSDottyVersion -> Seq(
+        // No .class files generated in the artifacts, only `scala.scalajs.*` files might be present
+        ProblemFilters.exclude[MissingClassProblem]("scala.*"),
+      ),
+    )
+
+    val BackwardsBreakingChanges: Map[String, Seq[ProblemFilter]] = Map(
+      // We should never break backwards compatibility
+      Build.mimaPreviousDottyVersion -> Seq.empty,
+      Build.mimaPreviousLTSDottyVersion -> Seq.empty,
+    )
+  }
+
   object TastyCore {
     val ForwardsBreakingChanges: Map[String, Seq[ProblemFilter]] = Map(
       // Additions that require a new minor version of tasty core


### PR DESCRIPTION
Scala 3.8.0 branch has been cutoff, we're now entering the 3.8.1 development cycle which also means start of the planned feature freeze until 3.10

* Set reference version to 3.8.0-RC1 - we're also using this version for MiMa checks (until 3.8.0 is released) 
* Set developed version to 3.8.1 
* Adjust MiMa filters, remove no longer needed comparison with fat-lib artifacts, ignore all missing classes in `scala-library-sjs` - it does not store classfiles, only few `scala.scalajs.*` classes remain


As a result:
* all non-experimental features  will be delayed until the end of the freeze, regardless of influence on binary compatibility, being approved by SIP or other factors
* features behind experimental flags should also be treated with care (in particular, no new ones can be introduced in 3.9.0)
* do remember to inform external contributors about this as you review their PRs (if they'd be affected)
* during the entirety of the feature freeze we will be working in maintenance mode, with the new LTS stability being the number one focus.
* any exceptions from the above (if at all) will have to go through Scala Core