### PR TITLE
Test behavior of path uses ending in pure types

### DIFF
--- a/tests/neg/i20481.check
+++ b/tests/neg/i20481.check
@@ -1,0 +1,40 @@
+-- [E007] Type Mismatch Error: tests/neg/i20481.scala:8:14 -------------------------------------------------------------
+8 |  val c1: A = a      // error
+  |              ^
+  |              Found:    (a : A^)
+  |              Required: A
+  |
+  |              Note that capability cap is not included in capture set {}.
+  |
+  |              where:    ^ and cap refer to a fresh root capability in the type of parameter a
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i20481.scala:10:16 ------------------------------------------------------------
+10 |  val c3: A = a.f    // error
+   |              ^^^
+   |              Found:    (a.f : A^)
+   |              Required: A
+   |
+   |              Note that capability cap is not included in capture set {}.
+   |
+   |              where:    ^ and cap refer to a fresh root capability in the type of value f
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i20481.scala:11:23 ------------------------------------------------------------
+11 |  val f1: () -> Unit = () => println(a) // error
+   |                       ^^^^^^^^^^^^^^^^
+   |                       Found:    () ->{a} Unit
+   |                       Required: () -> Unit
+   |
+   |                       Note that capability a is not included in capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i20481.scala:13:23 ------------------------------------------------------------
+13 |  val f3: () -> Unit = () => println(a.f) // error
+   |                       ^^^^^^^^^^^^^^^^^^
+   |                       Found:    () ->{a.f} Unit
+   |                       Required: () -> Unit
+   |
+   |                       Note that capability a.f is not included in capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i20481.scala
+++ b/tests/neg/i20481.scala
@@ -1,0 +1,13 @@
+import language.experimental.captureChecking
+
+class A:
+  val b: A = this
+  val f: A^ = this
+
+def test(a: A^) =
+  val c1: A = a      // error
+  val c2: A = a.b    // ok
+  val c3: A = a.f    // error
+  val f1: () -> Unit = () => println(a) // error
+  val f2: () -> Unit = () => println(a.b)  // ok!
+  val f3: () -> Unit = () => println(a.f) // error


### PR DESCRIPTION
This nails down the current behavior, which we argue is correct.

Closes #20481 
