### PR TITLE
Make `quotes.reflect.Position.ofMacroExpansion` consider `-Ymagic-offset-header`

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/MacroExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/MacroExpansion.scala
@@ -13,6 +13,6 @@ object MacroExpansion {
     ctx.property(MacroExpansionPosition)
 
   def context(inlinedFrom: tpd.Tree)(using Context): Context =
-    QuotesCache.init(ctx.fresh).setProperty(MacroExpansionPosition, SourcePosition(inlinedFrom.source, inlinedFrom.span)).setTypeAssigner(new Typer(ctx.nestingLevel + 1)).withSource(inlinedFrom.source)
+    QuotesCache.init(ctx.fresh).setProperty(MacroExpansionPosition, inlinedFrom.sourcePos).setTypeAssigner(new Typer(ctx.nestingLevel + 1)).withSource(inlinedFrom.source)
 }
 


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/24300

Tested manually with the reproduction in the original ticket, seems that `quotes.reflect.Position.ofMacroExpansion.startLine` and `.sourceFile`  now correctly considers the `///MAGIC:build.sbt` comment

```scala
lihaoyi scala3$ bin/scala -Ymagic-offset-header:MAGIC
The `--offline` option is experimental
Please bear in mind that non-ideal user experience should be expected.
If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
Welcome to Scala 3.8.0-RC1-bin-SNAPSHOT-git-840804f (17.0.14, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> import scala.quoted.*
     | def lineImpl(using Quotes): Expr[Int] = {
     |   val sourceFile = quotes.reflect.Position.ofMacroExpansion.sourceFile
     |   val line = quotes.reflect.Position.ofMacroExpansion.startLine + 1
     |   Expr(line)
     | }
     | inline implicit def line: Int = ${ lineImpl }
     |
     | def fileImpl(using Quotes): Expr[String] = {
     |   import quotes.reflect._
     |   Expr(quotes.reflect.Position.ofMacroExpansion.sourceFile.path)
     | }
     |
     | inline implicit def file: String = ${ fileImpl }
def lineImpl(using x$1: scala.quoted.Quotes): scala.quoted.Expr[Int]
def line: Int
def fileImpl(using x$1: scala.quoted.Quotes): scala.quoted.Expr[String]
def file: String

scala> {
     |
     |
     | ///MAGIC:build.sbt
     | println(file)
     | println(line)
     | def bar = ???
     | bar
     | }
build.sbt
1
scala.NotImplementedError: an implementation is missing
  at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
  at rs$line$3$.bar(rs$line$3:2)
  ... 32 elided
```
