### PR TITLE
Remove pipes from multi-line REPL prompts

### DIFF
--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -33,12 +33,12 @@ class JLineTerminal extends java.io.Closeable {
     builder.build()
   private val history = new DefaultHistory
 
-  private def purple(str: String)(using Context) =
-    if (ctx.settings.color.value != "never") Console.MAGENTA + str + Console.RESET
+  private def blue(str: String)(using Context) =
+    if (ctx.settings.color.value != "never") Console.BLUE + str + Console.RESET
     else str
-  protected def promptStr = "@"
-  private def prompt(using Context)        = purple(s"\n$promptStr ")
-  private def newLinePrompt(using Context) = purple("  ")
+  protected def promptStr = "scala"
+  private def prompt(using Context)        = blue(s"\n$promptStr> ")
+  private def newLinePrompt(using Context) = "       "
 
   /** Blockingly read line from `System.in`
    *


### PR DESCRIPTION
This makes it easier to copy-paste-autoformat REPL snippets when transferring them into your IDE for usage in Scala files