### PR TITLE
Record NotNullInfo for exceptional try-catch

### DIFF
--- a/tests/explicit-nulls/neg/i21619.scala
+++ b/tests/explicit-nulls/neg/i21619.scala
@@ -1,3 +1,5 @@
+class SomeException extends Exception
+
 def test1: String =
   var x: String | Null = null
   x = ""
@@ -248,3 +250,117 @@ def test13() =
     x.trim() // error
   }
   x.trim() // OK
+
+def test14() =
+  var x: String | Null = ""
+  x = ""
+  try {
+    try {
+    } catch {
+      case e =>
+        x = null
+        throw e
+    }
+  } catch {
+    case e =>
+      x.trim() // error
+  }
+
+
+
+def test15: String =
+  var x: String | Null = ???
+  var y: String | Null = ???
+  // ...
+  try
+    x = null
+    // ...
+    x = ""
+  catch
+    case e: SomeException =>
+      x = null
+      // situation 1: don't throw or return
+      // situation 2:
+      return ""
+  finally
+    y = x
+    // should always error on y.trim
+
+  y.trim  // error (ideally, should error if situation 1, should not error if situation 2)
+
+def test16: String =
+  var x: String | Null = ???
+  x = ""
+  try
+    // call some method that throws
+    // ...
+    x = ""
+  catch
+    case e: SomeException =>
+      x = null
+      // call some method that throws
+      // ...
+      x = "<error>"
+  finally {}
+
+  x.trim() // ok
+
+def test17: String =
+  var x: String | Null = ???
+  x = ""
+  try
+    // call some method that throws
+    // ...
+    x = ""
+  catch
+    case e: SomeException =>
+      x = null
+      // call some method that throws
+      // ...
+      x = "<error>"
+  finally
+    println(x.trim()) // error
+
+  ""
+
+def test18: String =
+  var x: String | Null = ???
+  var y: String | Null = ???
+  // ...
+  try
+    x = null
+    y = null
+    // ...
+    x = ""
+    y = ""
+  catch
+    case e: SomeException =>
+      x = null
+      return ""
+  finally {}
+
+  x.trim + y.trim
+
+
+def test19: String =
+  var x: String | Null = ???
+  try
+    x = null
+  catch
+    case e: SomeException =>
+      x = null
+      throw e
+  finally
+    throw new Exception()
+  x.trim // ok
+
+def test20: String =
+  var x: String | Null = ???
+  x = ""
+  try
+    x = ""
+  catch
+    case e: SomeException =>
+      x = ""
+  finally {}
+  x.trim // ok


### PR DESCRIPTION
Fixes #24296

This PR modifies the logic for recording notNullInfo in try-catch-finally blocks, motivated by repeated pattern from community build sconfig ([source](https://github.com/dotty-staging/sconfig/blob/7b66d352e0b75cd46198432037366c120ad19476/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImpl.scala#L86)):
```scala
def computeCachedConfig(
      loader: ClassLoader,
      key: String,
      updater: Callable[Config]
  ): Config = {
    var cache: LoaderCache = null
    try {
      cache = LoaderCacheHolder.cache
    } catch {
      case e: ExceptionInInitializerError =>
        throw ConfigImplUtil.extractInitializerError(e)
    }
    cache.getOrElseUpdate(loader, key, updater)
  }
```
Here, the cache will never be null. Because all cases of the catch block resolve exceptionally, no matter where in the try block an exception occurs, once an exception is thrown, the entire context will resolve exceptionally. Hence, we can use the notNullInfo of the try block to type what comes after the catch.

The logic of the notNullInfo is as follows (also in code):
```
/** Graphic explanation of NotNullInfo logic:
   *  Leftward exit indicates exceptional case
   *  Downward exit indicates normal case
   *
   *           ┌─────┐
   *           │ Try ├─────┬────────┬─────┐
   *           └──┬──┘     ▼        ▼     │
   *              │    ┌───────┐┌───────┐ │
   *              │    │ Catch ││ Catch ├─┤
   *              │    └───┬───┘└───┬───┘ │
   *              └─┬──────┴────────┘     │
   *                ▼                     ▼
   *           ┌─────────┐           ┌─────────┐
   *           │ Finally ├──────┐    │ Finally ├──┐
   *           └────┬────┘      │    └────┬────┘  │
   *                ▼           └─────────┴───────┴─►
   *  α = tryEffect
   *  λ = α.retracted.seq.(catchEffects.reduce.alt)
   *  β = α.alt(λ)
   *  finallyCtx = β.retracted
   *  δ = finallyEffect
   *  resultNNInfo = β.seq(δ).alt(β.retracted.seq(δ).seq(empty.terminated))
   *
   *  It is sufficient to type finally once provided that we type it in a context
   *  that considers all the paths before it that reach the finally. Since the NNinfo
   *  that we get from typing finally summarizes the effect of the finally, we can
   *  type the finally once and use the obtained NN info twice: once sequenced
   *  with β (normalNNInfo) and once sequenced with β.retractedInfo but post-sequenced
   *  by empty.terminated (to indicate that this path does not reach the code after
   *  the try-catch-finally).
   */
```