### PR TITLE
Permit new with trivial end

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -323,6 +323,8 @@ object Trees {
 
     import WithEndMarker.*
 
+    /** The span of the name in the end marker, or `NoSpan` if none.
+     */
     final def endSpan(using Context): Span =
       if hasEndMarker then
         val realName = srcName.stripModuleClassSuffix.lastPart
@@ -333,8 +335,8 @@ object Trees {
     /** The name in source code that represents this construct,
      *  and is the name that the user must write to create a valid
      *  end marker.
-     *  e.g. a constructor definition is terminated in the source
-     *  code by `end this`, so it's `srcName` should return `this`.
+     *  E.g., a constructor definition is terminated in the source
+     *  code by `end this`, so its `srcName` should return `this`.
      */
     protected def srcName(using Context): Name
 

--- a/tests/neg/i24250.scala
+++ b/tests/neg/i24250.scala
@@ -1,0 +1,7 @@
+
+class C
+val cc =
+  new C
+  end new // error
+val single =
+  new C: end new // error // error

--- a/tests/pos/i24250.scala
+++ b/tests/pos/i24250.scala
@@ -1,0 +1,28 @@
+
+trait Foo
+val foo =
+  new Foo:
+    // comment
+  end new
+val foo2 =
+  new Foo:
+  end new
+val foo3 =
+  new Foo {
+  }
+  end new
+
+class C
+val c =
+  new C:
+  end new
+val c2 =
+  new C {
+  }
+
+class D:
+end D
+val d =
+  new D:
+    def more = ???
+  end new


### PR DESCRIPTION
Fixes #24250 

Make trivial `end new` useful by supplying the empty template in parser.

This makes
```
new C {
}
```
equivalent to
```
new C:
end new
```
