### PR TITLE
[stdlib] be more conservative in what we copy from Scala 2

### DIFF
--- a/project/ScalaLibraryPlugin.scala
+++ b/project/ScalaLibraryPlugin.scala
@@ -51,7 +51,8 @@ object ScalaLibraryPlugin extends AutoPlugin {
         (files, reference) <- patches
         file <- files
         id <- file.relativeTo(reference)
-        if filesToCopy(id.toString().replace("\\", "/")) // Only Override Some Very Specific Files
+        path = id.toString().replace("\\", "/").stripSuffix(".class").stripSuffix(".sjsir")
+        if filesToCopy.exists(s => path == s || path.startsWith(s + '$')) // Only Override Some Very Specific Files
         dest = target / (id.toString)
         ref <- dest.relativeTo((LocalRootProject / baseDirectory).value)
       } {
@@ -111,7 +112,7 @@ object ScalaLibraryPlugin extends AutoPlugin {
     "scala/collection/immutable/DoubleVectorStepper",
     "scala/collection/immutable/IntVectorStepper",
     "scala/collection/immutable/LongVectorStepper",
-    "scala/collection/immutable/Range", "scala/collection/immutable/Range$",
+    "scala/collection/immutable/Range",
     "scala/jdk/DoubleAccumulator",
     "scala/jdk/IntAccumulator",
     "scala/jdk/LongAccumulator",
@@ -139,7 +140,7 @@ object ScalaLibraryPlugin extends AutoPlugin {
     "scala/jdk/FunctionWrappers$FromJavaLongUnaryOperator",
     "scala/collection/ArrayOps$ReverseIterator",
     "scala/runtime/NonLocalReturnControl",
-    "scala/util/Sorting", "scala/util/Sorting$",
-    ).flatMap(f => Seq(s"$f.class", s"$f.sjsir"))
+    "scala/util/Sorting",
+    )
 
 }


### PR DESCRIPTION
Because some of the classes we copy from stdlib contains private members and local classes, we will now copy everything (including local classes and companion classes) to the new stdlib artefact. This is a conservative approach and we don't want to go over each file we copy and check them manually.