### PR TITLE
chore: migrate GitHub macos runners

### DIFF
--- a/.github/workflows/test-launchers.yml
+++ b/.github/workflows/test-launchers.yml
@@ -45,7 +45,7 @@ jobs:
 
   mac-x86_64:
     name: Deploy and Test on Mac x64 architecture
-    runs-on: macos-13
+    runs-on: macos-15-intel
     if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
         (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
     steps:


### PR DESCRIPTION
We migrate from `macos-13` to `macOS-15-intel` since `macos-13` stopped working.

See https://github.com/actions/runner-images/issues/13046 for more details.