### PR TITLE
Don't crash when update is used as a modifier outside cc

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -301,7 +301,8 @@ object Tokens extends TokensCommon {
 
   final val closingParens = BitSet(RPAREN, RBRACKET, RBRACE)
 
-  final val softModifierNames = Set(nme.inline, nme.into, nme.opaque, nme.open, nme.transparent, nme.infix, nme.update)
+  final val softModifierNames = Set(nme.inline, nme.into, nme.opaque, nme.open, nme.transparent, nme.infix)
+    // Note: update, consume and erased are missing here since they are only modifiers under some import
 
   def showTokenDetailed(token: Int): String = debugString(token)
 

--- a/tests/neg/i24371.scala
+++ b/tests/neg/i24371.scala
@@ -1,0 +1,4 @@
+class M extends caps.Mutable:
+  update def foo = () // error // error
+
+


### PR DESCRIPTION
We now treat update like erased and consume. The error message is still not great, maybe something can be done about that.