### PR TITLE
Backport "Bump Scala CLI to v1.10.0 (was v1.9.1) and Coursier to v2.1.25-M19 (was 2.1.24)" to 3.8.0

### DIFF
--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: coursier/cache-action@v6
-      - uses: VirtusLab/scala-cli-setup@v1.9.1
+      - uses: coursier/cache-action@v7
+      - uses: VirtusLab/scala-cli-setup@v1.10.0
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ secrets.GRAPHQL_API_TOKEN }}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -149,9 +149,9 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.9.1"
+  val scalaCliLauncherVersion = "1.10.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.24"
+  val coursierJarVersion = "2.1.25-M19"
 
   object CompatMode {
     final val BinaryCompatible = 0


### PR DESCRIPTION
Backports #24362 to the 3.8.0-RC1.

PR submitted by the release tooling.
[skip ci]