### PR TITLE
Backport "Make `-usejavacp` a private setting as `-Yusejavacp`" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -194,7 +194,7 @@ class PathResolver(using c: Context) {
    */
   object Calculated {
     def scalaHome: String           = Defaults.scalaHome
-    def useJavaClassPath: Boolean   = settings.usejavacp.value || Defaults.useJavaClassPath
+    def useJavaClassPath: Boolean   = settings.Yusejavacp.value || Defaults.useJavaClassPath
     def javaBootClassPath: String   = cmdLineOrElse("javabootclasspath", Defaults.javaBootClassPath)
     def javaExtDirs: String         = cmdLineOrElse("javaextdirs", Defaults.javaExtDirs)
     def javaUserClassPath: String   = if (useJavaClassPath) Defaults.javaUserClassPath else ""

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -124,10 +124,12 @@ trait CommonScalaSettings:
 
   /* Other settings */
   val encoding: Setting[String] = StringSetting(RootSetting, "encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding, aliases = List("--encoding"))
-  val usejavacp: Setting[Boolean] = BooleanSetting(RootSetting, "usejavacp", "Utilize the java.class.path in classpath resolution.", aliases = List("--use-java-class-path"))
   val scalajs: Setting[Boolean] = BooleanSetting(RootSetting, "scalajs", "Compile in Scala.js mode (requires scalajs-library.jar on the classpath).", aliases = List("--scalajs"))
   val replInitScript: Setting[String] = StringSetting(RootSetting, "repl-init-script", "code", "The code will be run on REPL startup.", "", aliases = List("--repl-init-script"))
   val replQuitAfterInit: Setting[Boolean] = BooleanSetting(RootSetting, "repl-quit-after-init", "Quit REPL after evaluating the init script.", aliases = List("--repl-quit-after-init"))
+
+  /* YSettings shared with scaladoc */
+  val Yusejavacp: Setting[Boolean] = BooleanSetting(ForkSetting, "Yusejavacp", "Utilize the java.class.path in classpath resolution.", aliases = List("--use-java-class-path", "-usejavacp", "--usejavacp"))
 end CommonScalaSettings
 
 /** -P "plugin" settings. Various tools might support plugins. */

--- a/compiler/test/dotty/tools/dotc/classpath/MultiReleaseJarTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/MultiReleaseJarTest.scala
@@ -38,7 +38,7 @@ class MultiReleaseJarTest extends dotty.tools.backend.jvm.DottyBytecodeTest {
 
     def apiMethods(jarPath: Path, release: String): Set[String] = {
       given ctx: Context = initCtx.fresh
-      ctx.settings.usejavacp.update(true)
+      ctx.settings.Yusejavacp.update(true)
       ctx.settings.classpath.update(jarPath.toAbsolutePath.toString)
       ctx.settings.javaOutputVersion.update(release)
       ctx.initialize()
@@ -76,7 +76,7 @@ class MultiReleaseJarTest extends dotty.tools.backend.jvm.DottyBytecodeTest {
 
     def classExists(className: String, release: String): Boolean = {
       given ctx: Context = initCtx.fresh
-      ctx.settings.usejavacp.update(true)
+      ctx.settings.Yusejavacp.update(true)
       ctx.settings.javaOutputVersion.update(release)
       ctx.initialize()
       val classFile = ctx.platform.classPath.findClassFile(className)

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetCompilerTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetCompilerTest.scala
@@ -7,7 +7,7 @@ import dotty.tools.io.{AbstractFile, VirtualDirectory}
 
 class SnippetCompilerTest {
   val compiler = SnippetCompiler(
-    Seq(SnippetCompilerSetting(testContext.settings.usejavacp, true))
+    Seq(SnippetCompilerSetting(testContext.settings.Yusejavacp, true))
   )
   def wrapFn: String => WrappedSnippet = (str: String) => WrappedSnippet(
     str,

--- a/scaladoc/test/dotty/tools/scaladoc/testUtils.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/testUtils.scala
@@ -60,7 +60,7 @@ def testArgs(files: Seq[File] = Nil, dest: File = new File("notUsed")) = Scalado
 
 def testContext =
   val ctx = (new ContextBase).initialCtx.fresh.setReporter(new TestReporter)
-  ctx.setSetting(ctx.settings.usejavacp, true)
+  ctx.setSetting(ctx.settings.Yusejavacp, true)
   ctx
 
 def testDocContext(files: Seq[File] = Nil) = DocContext(testArgs(files), testContext)


### PR DESCRIPTION
Backports #24304 to the 3.8.0-RC1.

PR submitted by the release tooling.
[skip ci]