### PR TITLE
Backport "Add missing apply constructors for `Refined` and `TypeProjection` TypeTrees" to 3.8.0

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1247,6 +1247,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end TypeProjectionTypeTest
 
     object TypeProjection extends TypeProjectionModule:
+      def apply(qualifier: TypeTree, name: String): TypeProjection =
+        withDefaultPos(tpd.Select(qualifier, name.toTypeName))
       def copy(original: Tree)(qualifier: TypeTree, name: String): TypeProjection =
         tpd.cpy.Select(original)(qualifier, name.toTypeName)
       def unapply(x: TypeProjection): (TypeTree, String) =
@@ -1292,6 +1294,9 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     end RefinedTypeTest
 
     object Refined extends RefinedModule:
+      def apply(tpt: TypeTree, refinements: List[Definition], refineCls: Symbol): Refined = // Symbol of the class being refined, according to which the refinements are typed
+        assert(refineCls.isClass, "refineCls must be a class/trait/object")
+        withDefaultPos(tpd.RefinedTypeTree(tpt, refinements, refineCls.asClass).asInstanceOf[tpd.RefinedTypeTree])
       def copy(original: Tree)(tpt: TypeTree, refinements: List[Definition]): Refined =
         tpd.cpy.RefinedTypeTree(original)(tpt, refinements)
       def unapply(x: Refined): (TypeTree, List[Definition]) =

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -1974,6 +1974,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeProjection` */
     trait TypeProjectionModule { this: TypeProjection.type =>
+      def apply(qualifier: TypeTree, name: String): TypeProjection
       def copy(original: Tree)(qualifier: TypeTree, name: String): TypeProjection
       def unapply(x: TypeProjection): (TypeTree, String)
     }
@@ -2026,6 +2027,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Refined` */
     trait RefinedModule { this: Refined.type =>
+      /** Creates and types a Refined AST node.
+        * @param tpt - parent type being refined
+        * @param refinements - List of definitions represesenting refinements
+        * @param refineCls - symbol of the class of which the refinement definitions originally come from
+        * @return
+        */
+      def apply(tpt: TypeTree, refinements: List[Definition], refineCls: Symbol): Refined
       def copy(original: Tree)(tpt: TypeTree, refinements: List[Definition]): Refined
       def unapply(x: Refined): (TypeTree, List[Definition])
     }

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -141,6 +141,8 @@ object MiMaFilters {
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolModule.newClass"),
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#SymbolModule.newModule"),
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TermMethods.ensureApplied"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#RefinedModule.apply"),
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#TypeProjectionModule.apply"),
 
           // Changes to lazy vals (added static constructors)
           ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Tuple.<clinit>"),

--- a/tests/pos-macros/typedProjectionApply/Macro_1.scala
+++ b/tests/pos-macros/typedProjectionApply/Macro_1.scala
@@ -1,0 +1,19 @@
+import scala.quoted._
+class Test {type test = Int }
+object Macro:
+  inline def inlineCall(): Any = ${impl}
+  transparent inline def transparentInlineCall(): Any = ${impl}
+
+  /* Returns:
+   * val value: Test#test = 0 : Test#test
+   * value: Test#test
+   */
+  def impl(using Quotes): Expr[Any] =
+    import quotes.reflect._
+    val typeTree = TypeProjection(TypeTree.of[Test], "test")
+    val typeRepr = TypeRepr.of[Test#test]
+    val sym = Symbol.newVal(Symbol.spliceOwner, "value", typeRepr, Flags.EmptyFlags, Symbol.noSymbol)
+    Block(
+      List(ValDef(sym, Some(Typed(Literal(IntConstant(0)), typeTree)))),
+      Typed(Ref(sym), typeTree)
+    ).asExpr

--- a/tests/pos-macros/typedProjectionApply/Test_2.scala
+++ b/tests/pos-macros/typedProjectionApply/Test_2.scala
@@ -1,0 +1,4 @@
+import scala.quoted._
+def test() =
+  Macro.transparentInlineCall()
+  Macro.inlineCall()

--- a/tests/run-macros/refined-apply/Macro_1.scala
+++ b/tests/run-macros/refined-apply/Macro_1.scala
@@ -1,0 +1,30 @@
+//> using options -experimental
+import scala.quoted._
+class Foo { type test1; val test2: List[Any] = List() }
+object Macro:
+  inline def inlineCall(): Any = ${impl}
+  transparent inline def transparentInlineCall(): Any = ${impl}
+
+  def impl(using Quotes): Expr[Any] =
+    import quotes.reflect._
+    val tpt = TypeTree.of[Foo]
+
+    val typeDefSym = Symbol.newTypeAlias(Symbol.spliceOwner, "test1", Flags.EmptyFlags, TypeRepr.of[Int], Symbol.noSymbol)
+    val valDefSym = Symbol.newVal(Symbol.spliceOwner, "test2", TypeRepr.of[List[Int]], Flags.EmptyFlags, Symbol.noSymbol)
+
+    val defs = List(
+      TypeDef(typeDefSym),
+      ValDef(valDefSym, None)
+    )
+    val typeTree = Refined(tpt, defs, TypeRepr.of[Foo].typeSymbol)
+
+    // A little redundant, but we only want to see if Refined.apply() works,
+    // so we only replace the type with one we just constructed
+    val body = '{
+      new Foo { type test1 = Int; override val test2: List[Int] = List(0) }
+    }
+    val blockWithNewTypeTree = body.asTerm match
+      case Inlined(_, _, Block(cDef : ClassDef, Typed(invocation, _))) =>
+        Block(cDef, Typed(invocation, typeTree))
+
+    blockWithNewTypeTree.asExpr

--- a/tests/run-macros/refined-apply/Main_2.scala
+++ b/tests/run-macros/refined-apply/Main_2.scala
@@ -1,0 +1,9 @@
+//> using options -experimental
+
+import scala.quoted._
+def testInt(i: Int) = ()
+@main def Test(): Unit =
+  val withType = Macro.transparentInlineCall()
+  summon[withType.test1 <:< Int]
+  withType.test2.map(testInt)
+  Macro.inlineCall()


### PR DESCRIPTION
Backports #23837 to the 3.8.0-RC1.

PR submitted by the release tooling.
[skip ci]