### PR TITLE
Backport "Remove pipes from multi-line REPL prompts" to 3.8.0

### DIFF
--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -38,7 +38,7 @@ class JLineTerminal extends java.io.Closeable {
     else str
   protected def promptStr = "scala"
   private def prompt(using Context)        = blue(s"\n$promptStr> ")
-  private def newLinePrompt(using Context) = blue("     | ")
+  private def newLinePrompt(using Context) = "       "
 
   /** Blockingly read line from `System.in`
    *


### PR DESCRIPTION
Backports #24307 to the 3.8.0-RC1.

PR submitted by the release tooling.
[skip ci]