### PR TITLE
do not patch the implicit scope of `scala.Unit` in Scala.js

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -69,8 +69,6 @@ final class JSDefinitions()(using Context) {
     @threadUnsafe lazy val PseudoUnion_fromTypeConstructorR = PseudoUnionModule.requiredMethodRef("fromTypeConstructor")
     def PseudoUnion_fromTypeConstructor(using Context) = PseudoUnion_fromTypeConstructorR.symbol
 
-  @threadUnsafe lazy val UnionOpsModuleRef = requiredModuleRef("scala.scalajs.js.internal.UnitOps")
-
   @threadUnsafe lazy val JSArrayType: TypeRef = requiredClassRef("scala.scalajs.js.Array")
   def JSArrayClass(using Context) = JSArrayType.symbol.asClass
   @threadUnsafe lazy val JSDynamicType: TypeRef = requiredClassRef("scala.scalajs.js.Dynamic")

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -738,13 +738,6 @@ trait ImplicitRunInfo:
                 .suchThat(companion => companion.is(Module) && companion.owner == sym.owner)
                 .symbol)
 
-            // The companion of `js.|` defines an implicit conversions from
-            // `A | Unit` to `js.UndefOrOps[A]`. To keep this conversion in scope
-            // in Scala 3, where we re-interpret `js.|` as a real union, we inject
-            // it in the scope of `Unit`.
-            if t.isRef(defn.UnitClass) && ctx.settings.scalajs.value then
-              companions += JSDefinitions.jsdefn.UnionOpsModuleRef
-
             if sym.isClass then
               for p <- t.parents do companions ++= iscopeRefs(p)
             else

--- a/library-js/src/scala/Unit.scala
+++ b/library-js/src/scala/Unit.scala
@@ -1,0 +1,71 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc. dba Akka
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+// DO NOT EDIT, CHANGES WILL BE LOST
+// This auto-generated code can be modified in "project/GenerateAnyVals.scala".
+// Afterwards, running "sbt generateSources" regenerates this source file.
+
+package scala
+
+import scala.language.`2.13`
+import scala.scalajs.js
+import scala.annotation.nowarn
+
+/** `Unit` is a subtype of [[scala.AnyVal]]. There is only one value of type
+ *  `Unit`, `()`, and it is not represented by any object in the underlying
+ *  runtime system. A method with return type `Unit` is analogous to a Java
+ *  method which is declared `void`.
+ */
+final abstract class Unit private extends AnyVal {
+  // Provide a more specific return type for Scaladoc
+  override def getClass(): Class[Unit] = ???
+}
+
+@scala.annotation.compileTimeOnly("`Unit` companion object is not allowed in source; instead, use `()` for the unit value")
+object Unit extends AnyValCompanion {
+
+  /** Transforms a value type into a boxed reference type.
+   *
+   *  This method is not intended for use in source code.
+   *  The runtime representation of this value is platform specific.
+   *
+   *  @param  x   the Unit to be boxed
+   *  @return     a scala.runtime.BoxedUnit offering `x` as its underlying value.
+   */
+  def box(x: Unit): scala.runtime.BoxedUnit = scala.runtime.BoxedUnit.UNIT
+
+  /** Transforms a boxed type into a value type.  Note that this
+   *  method is not typesafe: it accepts any Object, but will throw
+   *  an exception if the argument is not a scala.runtime.BoxedUnit.
+   *
+   *  This method is not intended for use in source code.
+   *  The result of successfully unboxing a value is `()`.
+   *
+   *  @param  x   the scala.runtime.BoxedUnit to be unboxed.
+   *  @throws     ClassCastException  if the argument is not a scala.runtime.BoxedUnit
+   *  @return     the Unit value ()
+   */
+  def unbox(x: java.lang.Object): Unit = x.asInstanceOf[scala.runtime.BoxedUnit]
+
+  /** The String representation of the scala.Unit companion object. */
+  override def toString = "object scala.Unit"
+
+  // The companion of `js.|` defines an implicit conversions from
+  // `A | Unit` to `js.UndefOrOps[A]`. To keep this conversion in scope
+  // in Scala 3, where we re-interpret `js.|` as a real union, we inject
+  // it in the scope of `Unit`.
+  @nowarn("cat=deprecation")
+  implicit def unitOrOps[A](x: A | Unit): js.UndefOrOps[A] =
+    js.internal.UnitOps.unitOrOps[A](x)
+
+}
+

--- a/library-js/src/scala/scalajs/js/internal/UnitOps.scala
+++ b/library-js/src/scala/scalajs/js/internal/UnitOps.scala
@@ -2,7 +2,7 @@ package scala.scalajs.js.internal
 
 import scala.scalajs.js
 
-/** Under -scalajs, this object is part of the implicit scope of `scala.Unit` */
+@deprecated(message = "The implicit conversion was moved to the companion object of `scala.Unit` in Scala.js", since = "3.8.0")
 object UnitOps:
   implicit def unitOrOps[A](x: A | Unit): js.UndefOrOps[A] =
     new js.UndefOrOps(x)


### PR DESCRIPTION
Previously, we used to patch the implicit scope of `scala.Unit` to include `unitOrOps`.
In this PR, we remove that patch and instead define the implicit conversion in the source code.
Note that now the source code of `scala.Unit` has been copied in `library-js` and that it calls the old method since the constructor of `js.UndefOrOps` is package private to `js`.

This PR is part of having less magic in the compiler when it is not needed (or not needed anymore).