### PR TITLE
chore: allow to compile `scala.AnyVal` with Scala 3

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -283,13 +283,7 @@ class Definitions {
   def AnyType: TypeRef = AnyClass.typeRef
   @tu lazy val MatchableClass: ClassSymbol = completeClass(enterCompleteClassSymbol(ScalaPackageClass, tpnme.Matchable, Trait | TransparentType, AnyType :: Nil), ensureCtor = false)
   def MatchableType: TypeRef = MatchableClass.typeRef
-  @tu lazy val AnyValClass: ClassSymbol =
-    val res = completeClass(enterCompleteClassSymbol(ScalaPackageClass, tpnme.AnyVal, Abstract | TransparentType, List(AnyType, MatchableType)))
-    // Mark companion as absent, so that class does not get re-completed
-    val companion = ScalaPackageVal.info.decl(nme.AnyVal).symbol
-    companion.moduleClass.markAbsent()
-    companion.markAbsent()
-    res
+  @tu lazy val AnyValClass: ClassSymbol = requiredClass("scala.AnyVal")
 
   def AnyValType: TypeRef = AnyValClass.typeRef
 
@@ -2234,7 +2228,6 @@ class Definitions {
       orType,
       RepeatedParamClass,
       ByNameParamClass2x,
-      AnyValClass,
       NullClass,
       NothingClass,
       SingletonClass,
@@ -2537,51 +2530,6 @@ class Definitions {
     """/** The union of two types.
       | *
       | *   See [[https://docs.scala-lang.org/scala3/reference/new-types/union-types.html]].
-      | */
-    """.stripMargin)
-
-    add(AnyValClass,
-    """/** `AnyVal` is the root class of all ''value types'', which describe values
-      | *  not implemented as objects in the underlying host system. Value classes
-      | *  are specified in Scala Language Specification, section 12.2.
-      | *
-      | *  The standard implementation includes nine `AnyVal` subtypes:
-      | *
-      | *  [[scala.Double]], [[scala.Float]], [[scala.Long]], [[scala.Int]], [[scala.Char]],
-      | *  [[scala.Short]], and [[scala.Byte]] are the ''numeric value types''.
-      | *
-      | *  [[scala.Unit]] and [[scala.Boolean]] are the ''non-numeric value types''.
-      | *
-      | *  Other groupings:
-      | *
-      | *   - The ''subrange types'' are [[scala.Byte]], [[scala.Short]], and [[scala.Char]].
-      | *   - The ''integer types'' include the subrange types as well as [[scala.Int]] and [[scala.Long]].
-      | *   - The ''floating point types'' are [[scala.Float]] and [[scala.Double]].
-      | *
-      | * Prior to Scala 2.10, `AnyVal` was a sealed trait. Beginning with Scala 2.10,
-      | * however, it is possible to define a subclass of `AnyVal` called a ''user-defined value class''
-      | * which is treated specially by the compiler. Properly-defined user value classes provide a way
-      | * to improve performance on user-defined types by avoiding object allocation at runtime, and by
-      | * replacing virtual method invocations with static method invocations.
-      | *
-      | * User-defined value classes which avoid object allocation...
-      | *
-      | *   - must have a single `val` parameter that is the underlying runtime representation.
-      | *   - can define `def`s, but no `val`s, `var`s, or nested `traits`s, `class`es or `object`s.
-      | *   - typically extend no other trait apart from `AnyVal`.
-      | *   - cannot be used in type tests or pattern matching.
-      | *   - may not override `equals` or `hashCode` methods.
-      | *
-      | * A minimal example:
-      | * {{{
-      | *     class Wrapper(val underlying: Int) extends AnyVal {
-      | *       def foo: Wrapper = new Wrapper(underlying * 19)
-      | *     }
-      | * }}}
-      | *
-      | * It's important to note that user-defined value classes are limited, and in some circumstances,
-      | * still must allocate a value class instance at runtime. These limitations and circumstances are
-      | * explained in greater detail in the [[https://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]].
       | */
     """.stripMargin)
 

--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -187,6 +187,7 @@ class Erasure extends Phase with DenotTransformer {
       tp.typeSymbol == cls && ctx.compilationUnit.source.file.name == sourceName
     assert(
       isErasedType(tp)
+      || isAllowed(defn.AnyValClass, "AnyVal.scala")
       || isAllowed(defn.ArrayClass, "Array.scala")
       || isAllowed(defn.TupleClass, "Tuple.scala")
       || isAllowed(defn.NonEmptyTupleClass, "Tuple.scala")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3465,13 +3465,14 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
   /** Turn a parent type into a constructor call where needed. This is the case where
    *   - we are in a Scala class or module (not a Java class, nor a trait), and
+   *     - the symbol is not `scala.AnyVal` (must extend `scala.Any` which doesn't have a constructor)
    *     - the parent symbol is a non-trait class, or
    *     - the parent symbol is a trait that takes at least one (explicit or implicit) parameter
    *       and the parent symbol is directly extended by the current class (i.e. not
    *       extended by the superclass).
    */
   def ensureConstrCall(cls: ClassSymbol, parent: Tree, psym: Symbol)(using Context): Tree =
-    if parent.isType && !cls.is(Trait) && !cls.is(JavaDefined) && psym.isClass
+    if parent.isType && !cls.is(Trait) && !cls.is(JavaDefined) && psym.isClass && cls != defn.AnyValClass
         // Annotations are represented as traits with constructors, but should
         // never be called as such outside of annotation trees.
         && !psym.is(JavaAnnotation)

--- a/library/src-bootstrapped/scala/AnyVal.scala
+++ b/library/src-bootstrapped/scala/AnyVal.scala
@@ -55,6 +55,6 @@ import scala.language.`2.13`
  * still must allocate a value class instance at runtime. These limitations and circumstances are
  * explained in greater detail in the [[https://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]].
  */
-transparent abstract class AnyVal extends Any {
-  def getClass(): Class[_ <: AnyVal] = null
+transparent abstract class AnyVal extends Any, Matchable {
+  def getClass(): Class[? <: AnyVal] = null.asInstanceOf[Class[? <: AnyVal]]
 }

--- a/tests/neg/i1688.scala
+++ b/tests/neg/i1688.scala
@@ -2,5 +2,3 @@ package scala
 sealed trait Null  // error
 
 object Null  // error
-
-class AnyVal // error


### PR DESCRIPTION
Less magic, allow the compiler to compile `scala.AnyVal` :)