### PR TITLE
Enhance constant-folding during inlining

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -17,7 +17,7 @@ import collection.mutable
 /** A utility class offering methods for rewriting inlined code */
 class InlineReducer(inliner: Inliner)(using Context):
   import tpd.*
-  import Inliner.{isElideableExpr, DefBuffer}
+  import Inliner.{isElideableExpr, DefBuffer, inlinedConstToLiteral}
   import inliner.{call, newSym, tryInlineArg, paramBindingDef}
 
   extension (tp: Type)
@@ -202,7 +202,7 @@ class InlineReducer(inliner: Inliner)(using Context):
         val copied = sym.copy(info = rhs.tpe.widenInlineScrutinee, coord = sym.coord,
           flags = sym.flags &~ Case).asTerm
         adjustErased(copied, rhs)
-        caseBindingMap += ((sym, ValDef(copied, constToLiteral(rhs)).withSpan(sym.span)))
+        caseBindingMap += ((sym, ValDef(copied, inlinedConstToLiteral(rhs)).withSpan(sym.span)))
 
       def newTypeBinding(sym: TypeSymbol, alias: Type): Unit = {
         val copied = sym.copy(info = TypeAlias(alias), coord = sym.coord).asType
@@ -322,7 +322,7 @@ class InlineReducer(inliner: Inliner)(using Context):
                 case (pat :: pats1, selector :: selectors1) =>
                   val elem = newSym(InlineBinderName.fresh(), Synthetic, selector.tpe.widenInlineScrutinee).asTerm
                   adjustErased(elem, selector)
-                  val rhs = constToLiteral(selector)
+                  val rhs = inlinedConstToLiteral(selector)
                   elem.defTree = rhs
                   caseBindingMap += ((NoSymbol, ValDef(elem, rhs).withSpan(elem.span)))
                   reducePattern(caseBindingMap, elem.termRef, pat) &&
@@ -338,7 +338,7 @@ class InlineReducer(inliner: Inliner)(using Context):
                   else paramCls.asClass.paramAccessors
                 val selectors =
                   for (accessor <- caseAccessors)
-                  yield constToLiteral(reduceProjection(ref(scrut).select(accessor).ensureApplied))
+                  yield inlinedConstToLiteral(reduceProjection(ref(scrut).select(accessor).ensureApplied))
                 caseAccessors.length == pats.length && reduceSubPatterns(pats, selectors)
               }
               else false

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -187,6 +187,27 @@ object Inliner:
 
   end OpaqueProxy
 
+  /** A more powerful version of [[constToLiteral]] that also can "see through"
+   *  [[Block]], [[Inlined]] and [[Typed]] trees that are elidable (see
+   *  [[isElideableExpr]]).
+   */
+  def inlinedConstToLiteral(rootTree: Tree)(using Context): Tree =
+    def rec(tree: Tree): Tree =
+      inline def recChild(subTree: Tree): Tree =
+        val res = rec(subTree)
+        if res eq subTree then tree else res
+
+      tree match
+        case Typed(expr, _) => recChild(expr)
+        case Inlined(_, _, expr) => recChild(expr)
+        case Block(_, expr) => recChild(expr)
+        case _ => constToLiteral(tree)
+
+    if isElideableExpr(rootTree) then
+      rec(rootTree)
+    else
+      constToLiteral(rootTree)
+
   private[inlines] def newSym(name: Name, flags: FlagSet, info: Type, span: Span)(using Context): Symbol =
     newSymbol(ctx.owner, name, flags, info, coord = span)
 end Inliner
@@ -901,7 +922,7 @@ class Inliner(val call: tpd.Tree)(using Context):
         //if the projection leads to a typed tree then we stop reduction
         resNoReduce
       else
-        val res = constToLiteral(reducedProjection)
+        val res = inlinedConstToLiteral(reducedProjection)
         if resNoReduce ne res then
           typed(res, pt) // redo typecheck if reduction changed something
         else if res.symbol.isInlineMethod then
@@ -932,7 +953,7 @@ class Inliner(val call: tpd.Tree)(using Context):
     override def typedValDef(vdef: untpd.ValDef, sym: Symbol)(using Context): Tree =
       val vdef1 =
         if sym.is(Inline) then
-          val rhs = typed(vdef.rhs)
+          val rhs = inlinedConstToLiteral(typed(vdef.rhs))
           sym.info = rhs.tpe
           untpd.cpy.ValDef(vdef)(vdef.name, untpd.TypeTree(rhs.tpe), untpd.TypedSplice(rhs))
         else vdef
@@ -940,14 +961,14 @@ class Inliner(val call: tpd.Tree)(using Context):
 
     override def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree =
       val locked = ctx.typerState.ownedVars
-      specializeEq(inlineIfNeeded(constToLiteral(BetaReduce(super.typedApply(tree, pt))), pt, locked))
+      specializeEq(inlineIfNeeded(inlinedConstToLiteral(BetaReduce(super.typedApply(tree, pt))), pt, locked))
 
     override def isAcceptedSpuriousApply(fun: Tree, args: List[untpd.Tree])(using Context): Boolean =
       tpd.isSpuriousApply(fun, args)
 
     override def typedTypeApply(tree: untpd.TypeApply, pt: Type)(using Context): Tree =
       val locked = ctx.typerState.ownedVars
-      val tree1 = inlineIfNeeded(constToLiteral(BetaReduce(super.typedTypeApply(tree, pt))), pt, locked)
+      val tree1 = inlineIfNeeded(inlinedConstToLiteral(BetaReduce(super.typedTypeApply(tree, pt))), pt, locked)
       if tree1.symbol == defn.QuotedTypeModule_of then
         ctx.compilationUnit.needsStaging = true
       tree1
@@ -1032,8 +1053,8 @@ class Inliner(val call: tpd.Tree)(using Context):
                   case _ => rhs0
                 }
                 val rhs2 = rhs1 match {
-                  case Typed(expr, tpt) if rhs1.span.isSynthetic => constToLiteral(expr)
-                  case _ => constToLiteral(rhs1)
+                  case Typed(expr, tpt) if rhs1.span.isSynthetic => inlinedConstToLiteral(expr)
+                  case _ => inlinedConstToLiteral(rhs1)
                 }
                 val (usedBindings, rhs3) = dropUnusedDefs(caseBindings, rhs2)
                 val rhs = seq(usedBindings, rhs3)
@@ -1067,7 +1088,7 @@ class Inliner(val call: tpd.Tree)(using Context):
       val meth = tree.symbol
       if meth.isAllOf(DeferredInline) then
         errorTree(tree, em"Deferred inline ${meth.showLocated} cannot be invoked")
-      else if Inlines.needsInlining(tree) then Inlines.inlineCall(simplify(tree, pt, locked))
+      else if Inlines.needsInlining(tree) then inlinedConstToLiteral(Inlines.inlineCall(simplify(tree, pt, locked)))
       else tree
 
     override def typedUnadapted(tree: untpd.Tree, pt: Type, locked: TypeVars)(using Context): Tree =

--- a/docs/_docs/reference/metaprogramming/inline.md
+++ b/docs/_docs/reference/metaprogramming/inline.md
@@ -247,8 +247,19 @@ trait InlineConstants:
   inline val myShort: Short
 
 object Constants extends InlineConstants:
-  inline val myShort/*: Short(4)*/ = 4
+  inline val myShort/*: (4 : Short)*/ = 4
 ```
+<!-- Test case: tests/pos/inline-val-short.scala -->
+
+Inline values that are inside inline methods are only required to be constant _after inlining_. Therefore, the following is valid:
+
+```scala
+inline def double(inline x: Int): Int = x * 2
+inline def eight: Int =
+  inline val res = double(4)
+  res
+```
+<!-- Test case: tests/pos/inline-val-in-inline-method.scala -->
 
 ## Transparent Inline Methods
 

--- a/tests/pos/i24412.scala
+++ b/tests/pos/i24412.scala
@@ -1,0 +1,13 @@
+object test {
+  import scala.compiletime.erasedValue
+
+  inline def contains[T <: Tuple, E]: Boolean = inline erasedValue[T] match {
+    case _: EmptyTuple => false
+    case _: (_ *: tail) => contains[tail, E]
+  }
+  inline def check[T <: Tuple]: Unit = {
+    inline if contains[T, Long] && false then ???
+  }
+
+  check[(String, Double)]
+}

--- a/tests/pos/inline-constant-folding.scala
+++ b/tests/pos/inline-constant-folding.scala
@@ -1,0 +1,19 @@
+
+
+inline def f1() =
+  inline if 2 + 2 == 4 then true else false
+
+inline def f2() =
+  inline if {2 + 2 == 4} then true else false
+
+inline def f3() =
+  inline if {2 + (2: Int) == 4} then true else false
+
+inline def f4() =
+  inline if {2 + (2: Byte) == 4} then true else false
+
+@main def Test =
+  f1()
+  f2()
+  f3()
+  f4()

--- a/tests/pos/inline-val-in-inline-method.scala
+++ b/tests/pos/inline-val-in-inline-method.scala
@@ -1,0 +1,6 @@
+// Example in docs/_docs/reference/metaprogramming/inline.md
+
+inline def double(inline x: Int): Int = x * 2
+inline def eight: Int =
+  inline val res = double(4)
+  res

--- a/tests/pos/inline-val-short.scala
+++ b/tests/pos/inline-val-short.scala
@@ -1,0 +1,7 @@
+// Example in docs/_docs/reference/metaprogramming/inline.md
+
+trait InlineConstants:
+  inline val myShort: Short
+
+object Constants extends InlineConstants:
+  inline val myShort/*: (4 : Short)*/ = 4

--- a/tests/run/i24420-inline-local-ref.scala
+++ b/tests/run/i24420-inline-local-ref.scala
@@ -1,0 +1,12 @@
+inline def f(): Long =
+  1L
+
+inline def g(): Long =
+  inline val x = f()
+  x
+
+inline def h(): Long =
+  inline if g() > 0L then 1L else 0L
+
+@main def Test: Unit =
+  assert(h() == 1L)

--- a/tests/run/i24420-inline-val.scala
+++ b/tests/run/i24420-inline-val.scala
@@ -1,0 +1,25 @@
+inline def f1(): Long =
+  1L
+
+inline def f2(): Long =
+  inline val x = f1() + 1L
+  x
+
+inline def f3(): Long =
+  inline val x = f1()
+  x
+
+inline def g1(): Boolean =
+  true
+
+inline def g2(): Long =
+  inline if g1() then 1L else 2L
+
+inline def g3(): Long =
+  inline if f1() > 0L then 1L else 2L
+
+@main def Test: Unit =
+  assert(f2() == 2L)
+  assert(f3() == 1L)
+  assert(g2() == 1L)
+  assert(g3() == 1L)

--- a/tests/run/i24420-transparent-inline-local-ref.scala
+++ b/tests/run/i24420-transparent-inline-local-ref.scala
@@ -1,0 +1,12 @@
+transparent inline def f(): Long =
+  1L
+
+transparent inline def g(): Long =
+  inline val x = f()
+  x
+
+transparent inline def h(): Long =
+  inline if g() > 0L then 1L else 0L
+
+@main def Test: Unit =
+  assert(h() == 1L)


### PR DESCRIPTION
Fixes #24420 (see https://github.com/scala/scala3/issues/24420#issuecomment-3539228280 for some context) and fixes #24412.

Expressions can be constant-folded during inlining, but it isn't easy to determine which expressions qualify. For example, this works:

```scala
inline def g1(): Boolean =
  true

inline def g2(): Long =
  inline if g1() then 1L else 2L

@main def Test: Unit =
  assert(g2() == 1L)
```

And this works:

```scala
inline def f1(): Long =
  1L

inline def f2(): Long =
  inline val x = f1() + 1L
  x

@main def Test: Unit =
  assert(f2() == 2L)
```

But if we change the right‐hand side of `x` to just be `f1()`, then we get an error:

```scala
inline def f1(): Long =
  1L

inline def f3(): Long =
  inline val x = f1()
  x

@main def Test: Unit =
  assert(f3() == 1L)
```

```
$ scala -S 3.7.4 test3.scala
Compiling project (Scala 3.7.4, JVM (17))
[error] ./test3.scala:9:10
[error] inline value must have a literal constant type
[error]   assert(f3() == 1L)
[error]          ^^^^
Compilation failed
```

The first two examples work because they rely on `ConstantValue`, which always strips `Typed`:
https://github.com/scala/scala3/blob/96b1b83ff166be70cd8c5b1e2774580e52af4a3a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala#L1217-L1220

This PR makes the third example work too by:

1. Making constant-folding during inlining more permissive. In particular we now allow unwrapping `Typed` trees in more places (it was already done in `ConstantValue`, but not `constToLiteral`). This is implemented via a new `inlinedConstToLiteral` function — a stronger version of `constToLiteral` — that it is called in critical places in the `Inliner` where a constant is required.

2. Applying this function in two additional locations during inlining: on the result of inlined calls, and on the right-hand side of inline values.

This PR does not affect constant folding outside inlining (see #24432 for that discussion). It also keeps the existing semantics of `inline val`; it merely documents and strengthens the behavior already present.