### PR TITLE
allow to run the repl with the stdlib in the classpath

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1888,6 +1888,15 @@ object Build {
           s"-Ddotty.tools.dotc.semanticdb.test=${(ThisBuild / baseDirectory).value/"tests"/"semanticdb"}",
         )
       },
+      run / fork := true,
+      excludeDependencies += "org.scala-lang" %% "scala3-library",
+      excludeDependencies += "org.scala-lang" % "scala-library",
+      Compile / run := {
+        //val classpath = s"-classpath ${(`scala-library-bootstrapped` / Compile / packageBin).value}"
+        // TODO: We should use the val above instead of `-usejavacp` below. SBT crashes we we have a val and we call toTask
+        // with it as a parameter. THIS IS NOT A LEGIT USE CASE OF THE `-usejavacp` FLAG.
+        (Compile / run).toTask(" -usejavacp").value
+      },
     )
 
   // ==============================================================================================


### PR DESCRIPTION
Note that there is an issue in sbt that prevents me from getting the path to the stdlib and pass it to the `Compile/run` task. Otherwise, with this PR, we are now able to call `scala3-repl/run` and start the REPL. It also forks the JVM since the REPL classloading is a bit weird... 