### PR TITLE
update `StringBuilder.toString` to have an empty parameter list

### DIFF
--- a/library/src/scala/collection/mutable/StringBuilder.scala
+++ b/library/src/scala/collection/mutable/StringBuilder.scala
@@ -109,7 +109,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   def result() = underlying.toString
 
-  override def toString: String = result()
+  override def toString(): String = result()
 
   override def toArray[B >: Char](implicit ct: scala.reflect.ClassTag[B]) =
     ct.runtimeClass match {

--- a/tests/pos/i19616.scala
+++ b/tests/pos/i19616.scala
@@ -1,0 +1,6 @@
+def test: Unit =
+  val sb = new StringBuilder
+  var key = ""
+  var map = Map.empty[String, String]
+  map += key -> sb.toString()
+  map += key -> sb.toString


### PR DESCRIPTION
This change is both source compatible and binary compatible. This might only break macros but they should be able to call `ensureApplied` now in `3.8.0` (#24160).

This used to be working in `3.7.4`.

Closes #19616