### PR TITLE
Better integrations with the IDE

### DIFF
--- a/staging/src/scala/quoted/staging/QuoteCompiler.scala
+++ b/staging/src/scala/quoted/staging/QuoteCompiler.scala
@@ -25,6 +25,7 @@ import dotty.tools.io.{Path, VirtualFile}
 import scala.quoted.runtime.impl._
 
 import scala.annotation.tailrec
+import scala.compiletime.uninitialized
 import scala.concurrent.Promise
 import scala.quoted.{Expr, Quotes, Type}
 
@@ -34,7 +35,7 @@ import scala.quoted.{Expr, Quotes, Type}
 private class QuoteCompiler extends Compiler:
 
   /** Either `Left` with name of the classfile generated or `Right` with the value contained in the expression */
-  private var result: Either[String, Any] = null
+  private var result: Either[String, Any] = uninitialized
 
   override protected def frontendPhases: List[List[Phase]] =
     List(List(new QuotedFrontend))


### PR DESCRIPTION
- Disable BSP in the bootstrapped projects
- Move the `scalacOptions` to be the same globally
- Make all the projects compile with explicit nulls
- Enable semanticdb back