### PR TITLE
revert: Add back an option to enable bsp in the presentation compiler

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -448,6 +448,11 @@ object Build {
     ) ++ extMap
   }
 
+  val enableBspAllProjects = sys.env.get("ENABLE_BSP_ALL_PROJECTS").map(_.toBoolean).getOrElse{
+    val enableBspAllProjectsFile = file(".enable_bsp_all_projects")
+    enableBspAllProjectsFile.exists()
+  }
+
   // Setups up doc / scalaInstance to use in the bootstrapped projects instead of the default one
   lazy val scaladocDerivedInstanceSettings = Def.settings(
     // We cannot include scaladoc in the regular `scalaInstance` task because
@@ -1377,7 +1382,7 @@ object Build {
       keepSJSIR := false,
       // Generate Scala 3 runtime properties overlay
       Compile / resourceGenerators += generateLibraryProperties.taskValue,
-      bspEnabled := false,
+      bspEnabled := enableBspAllProjects,
     )
 
   /* Configuration of the org.scala-lang:scala3-library_3:*.**.**-bootstrapped project */
@@ -1421,7 +1426,7 @@ object Build {
       publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-library-bootstrapped",
-      bspEnabled := false,
+      bspEnabled := enableBspAllProjects,
     )
 
   /* Configuration of the org.scala-js:scalajs-scalalib_2.13:*.**.**-bootstrapped project */
@@ -2018,7 +2023,7 @@ object Build {
           s"-Ddotty.tools.dotc.semanticdb.test=${(ThisBuild / baseDirectory).value/"tests"/"semanticdb"}",
         )
       },
-      bspEnabled := false,
+      bspEnabled := enableBspAllProjects,
     )
 
   // ==============================================================================================
@@ -2095,7 +2100,7 @@ object Build {
       scalaCompilerBridgeBinaryJar := {
         Some((`scala3-sbt-bridge-nonbootstrapped` / Compile / packageBin).value)
       },
-      bspEnabled := false,
+      bspEnabled := enableBspAllProjects,
     )
 
   lazy val `scala3-presentation-compiler` = project.in(file("presentation-compiler"))
@@ -2166,13 +2171,16 @@ object Build {
           mtagsSharedSources
         } (Set(mtagsSharedSourceJar)).toSeq
       }.taskValue,
-      bspEnabled := false,
+      bspEnabled := enableBspAllProjects,
     )
   }
 
   lazy val `scala3-presentation-compiler-testcases` = project.in(file("presentation-compiler-testcases"))
     .dependsOn(`scala3-compiler-bootstrapped-new`)
-    .settings(commonBootstrappedSettings)
+    .settings(
+      commonBootstrappedSettings,
+      bspEnabled := enableBspAllProjects,
+    )
 
   lazy val `scala3-language-server` = project.in(file("language-server")).
     dependsOn(`scala3-compiler-bootstrapped-new`, `scala3-repl`).


### PR DESCRIPTION
I don't see a reason why it was removed, please let me know next time when there is some changes to this part.