### PR TITLE
add jspecify NonNull annotation to NotNullAnnots list

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1152,7 +1152,8 @@ class Definitions {
     "lombok.NonNull" ::
     "reactor.util.annotation.NonNull" ::
     "reactor.util.annotation.NonNullApi" ::
-    "io.reactivex.annotations.NonNull" :: Nil)
+    "io.reactivex.annotations.NonNull" ::
+    "org.jspecify.annotations.NonNull" :: Nil)
 
   // convenient one-parameter method types
   def methOfAny(tp: Type): MethodType = MethodType(List(AnyType), tp)


### PR DESCRIPTION
This pull request adds the [JSpecify](https://jspecify.dev/) annotation to the list of NotNull annotations for explicit nulls.

JSpecify is a standard initiative [led by Google](https://jspecify.dev/about/#what-is-our-governance) that offers a unified and vendor-neutral way to [increase interoperability](https://jspecify.dev/docs/start-here/#what-is-this) with Java tooling and the growing ecosystem of static nullness checkers (e.g., tools in IntelliJ, Error Prone, NullAway).