### PR TITLE
Remove TODO in `MatchReducer`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3594,7 +3594,11 @@ object MatchReducer:
       case Stuck              => "Stuck"
       case NoInstance(fails)  => "NoInstance(" ~ Text(fails.map(p.toText(_) ~ p.toText(_)), ", ") ~ ")"
 
-/** A type comparer for reducing match types. */
+/** A [[TypeComparer]] for reducing match types.
+ *
+ *  This needs to be a [[TypeComparer]] because it mutates the `caseLambda`
+ *  field defined in [[ConstraintHandling]]. See #24488 for more details.
+ */
 class MatchReducer(initctx: Context) extends TypeComparer(initctx) {
   import MatchReducer.*
 


### PR DESCRIPTION
Closes #24120: remove the TODO comment.

The TODO comment left by @odersky regarding `MatchReducer` was:

https://github.com/scala/scala3/blob/c9309e730b6a261ea9ccc0ba86ca7de59ef3bd59/compiler/src/dotty/tools/dotc/core/TypeComparer.scala#L3597-L3601

###  Keep `MatchReducer` as a `TypeComparer`

In the end, we _do_ need `MatchReducer` to be a `TypeComparer`. The refactoring to composition over inheritance was not possible because `MatchReducer` requires modifying the mutable protected field `caseLambda` of its superclass, `ConstraintHandling` (which is a superclass of `TypeComparer`), before invoking inherited methods that depends it.

Mutable protected field `caseLambda`:

https://github.com/scala/scala3/blob/c9309e730b6a261ea9ccc0ba86ca7de59ef3bd59/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala#L44-L47

`MatchReducer` modifies `caseLambda` variable of the superclass, and this modification is later needed when invoking methods of TypeComparer:

https://github.com/scala/scala3/blob/c9309e730b6a261ea9ccc0ba86ca7de59ef3bd59/compiler/src/dotty/tools/dotc/core/TypeComparer.scala#L3879-L3881

Maybe we could revisit this if we get rid of `matchLegacyPatMat` one day.

### Keep `MatchReducer` in the same file

Moving `MatchReducer` to its own file creates significant issues with Git history tracking:

- [.git-blame-ignore-revs](https://github.com/scala/scala3/blob/main/.git-blame-ignore-revs) Limitation: This mechanism only works for in-place refactorings. When a file is moved, Git looks at the file state immediately before the commit. Since `MatchReducer.scala` didn't exist before, Git cannot trace the history back to `TypeComparer.scala`.
- GitHub UI Limitation: GitHub's web interface does not support `git blame -C` (copy detection), so the GitHub UI would incorrectly show the person who moved the file as the author of all lines, losing attribution to the original authors.
- Loss of Context: Keeping `MatchReducer` in the same file as `TypeComparer` makes it easier to understand their tight coupling and why inheritance is necessary.
 - Local Workaround Required: Users would need to run `git blame -C` locally to see the correct history, which is not ideal for most contributors:

    ```bash
    git blame -C compiler/src/dotty/tools/dotc/core/MatchReducer.scala
    ```