### PR TITLE
Don't absolutize sources outside of the sourceroot in TASTy

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -295,7 +295,7 @@ object SourceFile {
         val path = refPath.relativize(sourcePath)
         path.iterator.asScala.mkString("/")
       else
-        sourcePath.toString
+        jpath.toString
   }
 
   /** Return true if file is a script:


### PR DESCRIPTION
Fixes #24212 

With inlining and standard library patching, it's inevitable that, when writing TASTy files, we'll encounter sources outside the sourceroot. However, we shouldn't write those sources as absolute paths because that's non-reproducible and can cause determinism issues. Instead, we should write the paths as-is.

While these sorts of paths aren't correct when written relatively, they weren't correct to begin with because they don't actually exist on the filesystem.