### PR TITLE
Single line case lambda gets a region

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3232,6 +3232,9 @@ object Parsers {
       val body = tok match
         case ARROW => atSpan(in.skipToken()):
           if exprOnly then
+            if in.token == ENDlambda then
+              in.token = NEWLINE
+              in.observeIndented()
             if in.indentSyntax && in.isAfterLineEnd && in.token != INDENT then
               warning(em"""Misleading indentation: this expression forms part of the preceding case.
                           |If this is intended, it should be indented for clarity.

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -596,7 +596,7 @@ object Scanners {
           lastWidth = r.width
           newlineIsSeparating = lastWidth <= nextWidth || r.isOutermost
           indentPrefix = r.prefix
-        case _: InString => ()
+        case _: InString | _: SingleLineLambda => ()
         case r =>
           indentIsSignificant = indentSyntax
           r.proposeKnownWidth(nextWidth, lastToken)

--- a/tests/neg/i24496.scala
+++ b/tests/neg/i24496.scala
@@ -5,8 +5,8 @@ import scala.language.experimental.relaxedLambdaSyntax
 
   val three = list
         .collect: case x =>
-          (x, x + 1) // error not a member of tuple
-        .toMap
+        (x, x + 1)
+        .toMap // error value toMap is not a member of (Int, Int)
 
   val huh = list
         .collect: x => case y => (y, y + 1) // error expecting case at x

--- a/tests/pos/i24496.scala
+++ b/tests/pos/i24496.scala
@@ -3,6 +3,12 @@ import scala.language.experimental.relaxedLambdaSyntax
 @main def Test =
   val list = List(1, 2, 3)
 
+  val three = list
+        .collect: case x =>
+          val y = x + 1
+          (x, y)
+        .toMap
+
   val two = list
         .collect: x => (x, x + 1)
         .toMap
@@ -10,6 +16,3 @@ import scala.language.experimental.relaxedLambdaSyntax
   val one = list
         .collect: case x => (x, x + 1)
         .toMap
-
-  //val huh = list
-  //      .collect: x => case y => (y, y + 1) correctly errors expecting case at x


### PR DESCRIPTION
Fixes #24496 

Relaxed case lambda uses `SingleLineLambda` region for EOL handling. If `ExprCaseClause` sees `ENDlambda` after `=>`, permit an indented region. `SingleLineLambda` preserves indent width.