### PR TITLE
fix: allow to pass inputs to `scala3-repl/run`

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1174,7 +1174,7 @@ object Build {
         //val classpath = s"-classpath ${(`scala-library-bootstrapped` / Compile / packageBin).value}"
         // TODO: We should use the val above instead of `-usejavacp` below. SBT crashes we we have a val and we call toTask
         // with it as a parameter. THIS IS NOT A LEGIT USE CASE OF THE `-usejavacp` FLAG.
-        (Compile / run).toTask(" -usejavacp").value
+        (Compile / run).partialInput(" -usejavacp").evaluated
       },
       bspEnabled := false,
     )


### PR DESCRIPTION
When running the REPL, we would like to pass some flags, say `scala3-repl/run --help`. Before this PR, that was not possible since the defined task didn't take inputs. In this PR, we change this behavior by allowing it to take inputs while at the same time preserving the already provided ones.