### PR TITLE
Add missing language experimental settings

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -70,6 +70,9 @@ object Feature:
     (into, "Allow into modifier on parameter types"),
     (modularity, "Enable experimental modularity features"),
     (packageObjectValues, "Enable experimental package objects as values"),
+    (multiSpreads, "Enable experimental varargs with multi-spreads"),
+    (subCases, "Enable experimental match expressions with sub-cases"),
+    (relaxedLambdaSyntax, "Enable experimental relaxed lambda syntax"),
   )
 
   // legacy language features from Scala 2 that are no longer supported.


### PR DESCRIPTION
Add missing language experimental settings for multipleStead, subCases and relaxedLambdaSyntax 

These were omitted and not made available as setting `-language:` settings