### PR TITLE
fix: update the correct unit when building a new unit

### DIFF
--- a/tests/pos/i24519.scala
+++ b/tests/pos/i24519.scala
@@ -1,0 +1,7 @@
+import scala.language.experimental.captureChecking
+
+trait File extends caps.SharedCapability
+
+class Foo:
+  def f(file: File^): Iterator[File]^{file} = 
+    Iterator.from(List(file))


### PR DESCRIPTION
When we force a tree, we should also update the compilation unit so that the language import processing updates the right unit.

Closes #24519