### PR TITLE
Backport "Upgrade ASM to 9.9 for JDK 26 support" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BackendUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BackendUtils.scala
@@ -186,6 +186,7 @@ object BackendUtils {
     22 -> asm.Opcodes.V22,
     23 -> asm.Opcodes.V23,
     24 -> asm.Opcodes.V24,
-    25 -> asm.Opcodes.V25
+    25 -> asm.Opcodes.V25,
+    26 -> asm.Opcodes.V26,
   )
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -784,7 +784,7 @@ object Build {
 
       // get libraries onboard
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" % "scala-asm" % "9.8.0-scala-1", // used by the backend
+        "org.scala-lang.modules" % "scala-asm" % "9.9.0-scala-1", // used by the backend
         Dependencies.compilerInterface,
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
@@ -2489,7 +2489,7 @@ object Build {
       // All the dependencies needed by the compiler
       libraryDependencies ++= Seq(
         "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-        "org.scala-lang.modules" % "scala-asm" % "9.8.0-scala-1",
+        "org.scala-lang.modules" % "scala-asm" % "9.9.0-scala-1",
         Dependencies.compilerInterface,
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
@@ -2638,7 +2638,7 @@ object Build {
       Test / unmanagedResourceDirectories += baseDirectory.value / "test-resources",
       // All the dependencies needed by the compiler
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" % "scala-asm" % "9.8.0-scala-1",
+        "org.scala-lang.modules" % "scala-asm" % "9.9.0-scala-1",
         Dependencies.compilerInterface,
         "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),


### PR DESCRIPTION
Backports #24430 to the 3.8.0-RC2.

PR submitted by the release tooling.
[skip ci]