### PR TITLE
Backport "Bump Scala CLI to 1.10.1 (was 1.10.0)" to 3.8.0

### DIFF
--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v7
-      - uses: VirtusLab/scala-cli-setup@v1.10.0
+      - uses: VirtusLab/scala-cli-setup@v1.10.1
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ secrets.GRAPHQL_API_TOKEN }}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -150,7 +150,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.10.0"
+  val scalaCliLauncherVersion = "1.10.1"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M19"
 


### PR DESCRIPTION
Backports #24448 to the 3.8.0-RC2.

PR submitted by the release tooling.
[skip ci]