### PR TITLE
Backport "[build] Add missing mapSourceURI for `scala-library-sjs` project" to 3.8.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2192,6 +2192,16 @@ object Build {
       Compile / scalacOptions += "-Yno-stdlib-patches",
       Compile / scalacOptions += "-Yexplicit-nulls",
       Compile / scalacOptions += "-scalajs",
+      // Configure the source maps to point to GitHub for releases
+      Compile / scalacOptions ++= {
+        if (isRelease) {
+          val baseURI = (LocalRootProject / baseDirectory).value.toURI
+          val dottyVersion = version.value
+          Seq(s"-scalajs-mapSourceURI:$baseURI->$dottyGithubRawUserContentUrl/$dottyVersion/")
+        } else {
+          Nil
+        }
+      },
       // Packaging configuration of the stdlib
       Compile / packageBin / publishArtifact := true,
       Compile / packageDoc / publishArtifact := true,


### PR DESCRIPTION
Backports #24450 to the 3.8.0-RC2.

PR submitted by the release tooling.
[skip ci]