### PR TITLE
Backport "CheckUnused examines type of Apply" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -122,7 +122,8 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
     case Apply(Select(left, nme.Equals | nme.NotEquals), right :: Nil) =>
       val caneq = defn.CanEqualClass.typeRef.appliedTo(left.tpe.widen :: right.tpe.widen :: Nil)
       resolveScoped(caneq)
-    case _ =>
+    case tree =>
+      refUsage(tree.tpe.typeSymbol)
     tree
 
   override def transformTypeApply(tree: TypeApply)(using Context): tree.type =

--- a/tests/warn/i24457.scala
+++ b/tests/warn/i24457.scala
@@ -1,0 +1,14 @@
+//> using options -Werror -Wunused:all
+///> using scala 3.8.0-RC1
+
+object test {
+  private case class Impl()
+  inline def makeImpl(): Any = Impl() // inline is not germane
+
+  def seth =
+    case class Loop()
+    println(Loop())
+}
+
+@main def main = println:
+  test.makeImpl()

--- a/tests/warn/i24459.scala
+++ b/tests/warn/i24459.scala
@@ -1,0 +1,17 @@
+//> using options -Werror -Wunused:all
+///> using scala 3.8.0-RC1
+
+trait Suite {
+  inline def test(body: => Any): Any = body
+}
+
+object Test {
+  private case class I()
+}
+
+class Test extends Suite {
+  test {
+    val i = Test.I()
+    i.hashCode
+  }
+}


### PR DESCRIPTION
Backports #24465 to the 3.8.0-RC2.

PR submitted by the release tooling.
[skip ci]