### PR TITLE
Backport "Add missing language experimental settings" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -70,6 +70,9 @@ object Feature:
     (into, "Allow into modifier on parameter types"),
     (modularity, "Enable experimental modularity features"),
     (packageObjectValues, "Enable experimental package objects as values"),
+    (multiSpreads, "Enable experimental varargs with multi-spreads"),
+    (subCases, "Enable experimental match expressions with sub-cases"),
+    (relaxedLambdaSyntax, "Enable experimental relaxed lambda syntax"),
   )
 
   // legacy language features from Scala 2 that are no longer supported.


### PR DESCRIPTION
Backports #24513 to the 3.8.0-RC2.

PR submitted by the release tooling.
[skip ci]