### PR TITLE
Backport "Fix #24456: Cleanup the info of a Bind symbol in posttyper" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -624,8 +624,11 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
               case _ =>
           processMemberDef(super.transform(scala2LibPatch(tree)))
         case tree: Bind =>
-          if tree.symbol.isType && !tree.symbol.name.is(WildcardParamName) then
-            Checking.checkGoodBounds(tree.symbol)
+          val sym = tree.symbol
+          if sym.isType && !sym.name.is(WildcardParamName) then
+            Checking.checkGoodBounds(sym)
+          // Cleanup retains from the info of the Bind symbol
+          sym.copySymDenotation(info = transformAnnotsIn(CleanupRetains()(sym.info))).installAfter(thisPhase)
           super.transform(tree)
         case tree: New if isCheckable(tree) =>
           Checking.checkInstantiable(tree.tpe, tree.tpe, tree.srcPos)

--- a/tests/pos-custom-args/captures/i24456.scala
+++ b/tests/pos-custom-args/captures/i24456.scala
@@ -1,0 +1,14 @@
+// Similar to i24207
+
+class Generator:
+  private def generateTable(table: Table) =
+    val (ownRelations, unusedTerm) = calculateOwnRelations(table)
+    None
+
+  private def calculateOwnRelations(table: Table) =
+    val ownRelations = table.relations.filter(_.association.isDefined)
+    (ownRelations, Nil)
+
+case class Table(relations: Seq[TableRelation])
+case class TableRelation(association: Option[Association])
+trait Association

--- a/tests/pos/i24456.scala
+++ b/tests/pos/i24456.scala
@@ -1,0 +1,14 @@
+// Similar to i24207
+
+class Generator:
+  private def generateTable(table: Table) =
+    val (ownRelations, unusedTerm) = calculateOwnRelations(table)
+    None
+
+  private def calculateOwnRelations(table: Table) =
+    val ownRelations = table.relations.filter(_.association.isDefined)
+    (ownRelations, Nil)
+
+case class Table(relations: Seq[TableRelation])
+case class TableRelation(association: Option[Association])
+trait Association


### PR DESCRIPTION
Backports #24490 to the 3.8.0-RC2.

PR submitted by the release tooling.