### PR TITLE
fix: do not add `scala.util.Properties` as the Main-Class in the Manifest

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1262,7 +1262,8 @@ object Build {
       // Should we also patch .sjsir files
       keepSJSIR := false,
       // Generate library.properties, used by scala.util.Properties
-      Compile / resourceGenerators += generateLibraryProperties.taskValue
+      Compile / resourceGenerators += generateLibraryProperties.taskValue,
+      mainClass := None,
     )
 
   /* Configuration of the org.scala-lang:scala3-library_3:*.**.**-nonbootstrapped project */
@@ -1304,6 +1305,7 @@ object Build {
       publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-library-nonbootstrapped",
+      mainClass := None,
     )
 
   /* Configuration of the org.scala-lang:scala-library:*.**.**-bootstrapped project */
@@ -1383,6 +1385,7 @@ object Build {
       // Generate Scala 3 runtime properties overlay
       Compile / resourceGenerators += generateLibraryProperties.taskValue,
       bspEnabled := enableBspAllProjects,
+      mainClass := None,
     )
 
   /* Configuration of the org.scala-lang:scala3-library_3:*.**.**-bootstrapped project */
@@ -1427,6 +1430,7 @@ object Build {
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-library-bootstrapped",
       bspEnabled := enableBspAllProjects,
+      mainClass := None,
     )
 
   /* Configuration of the org.scala-js:scalajs-scalalib_2.13:*.**.**-bootstrapped project */
@@ -1557,6 +1561,7 @@ object Build {
       // Should we also patch .sjsir files
       keepSJSIR := true,
       bspEnabled := false,
+      mainClass := None,
     )
 
   /* Configuration of the org.scala-lang:scala3-library_sjs1_3:*.**.**-bootstrapped project */
@@ -1599,6 +1604,7 @@ object Build {
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-library",
       bspEnabled := false,
+      mainClass := None,
     )
 
   // ==============================================================================================


### PR DESCRIPTION
When checking the `MANIFEST.MF` file of the stdlib 3.8.0-RC1, I observed that we list `Main-Class: scala.util.Properties`

```
Manifest-Version: 1.0
Specification-Title: scala-library-bootstrapped
Specification-Version: 3.8.0-RC1
Specification-Vendor: LAMP/EPFL
Implementation-Title: scala-library-bootstrapped
Implementation-Version: 3.8.0-RC1
Implementation-Vendor: LAMP/EPFL
Implementation-Vendor-Id: org.scala-lang
Implementation-URL: https://scala-lang.org/
Main-Class: scala.util.Properties
```

In this PR, we make sure to not list any `Main-Class` for the stdlib since it is a library, not an application.