### PR TITLE
Fix spurious unused import warnings when import of export is used in creator application 

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -351,6 +351,8 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
           || nm.isTypeName && alt.symbol.isAliasType && alt.info.dealias.typeSymbol == sym
         sameSym && alt.symbol.isAccessibleFrom(qtpe)
       def hasAltMemberNamed(nm: Name) = qtpe.member(nm).hasAltWith(_.symbol.isAccessibleFrom(qtpe))
+      def hasTypeAlias(nm: Name) = nm.isTypeName && qtpe.member(nm).hasAltWith: alt =>
+        alt.symbol.isAliasType && alt.info.dealias.typeSymbol == sym && alt.symbol.isAccessibleFrom(qtpe)
 
       def loop(sels: List[ImportSelector]): ImportSelector | Null = sels match
         case sel :: sels =>
@@ -379,7 +381,7 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
               false
             else
                  !name.exists(_.toTermName != sel.rename) // if there is an explicit name, it must match
-              && (prefix.eq(NoPrefix) || qtpe =:= prefix)
+              && (prefix.eq(NoPrefix) || qtpe =:= prefix || hasTypeAlias(sel.name.toTypeName))
               && (hasAltMember(sel.name) || hasAltMember(sel.name.toTypeName))
           if matches then sel else loop(sels)
         case nil => null


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/24562

Tested manually on release-3.8.0, seems to make the spurious warning go away. Haven't tested on `main` since `bin/scalac` seems to be broken but the code looks about the same so hopefully it works as well