### PR TITLE
fix: look at the underlying of a TermRef for a getter

### DIFF
--- a/tests/run/i24553.check
+++ b/tests/run/i24553.check
@@ -1,0 +1,11 @@
+public boolean java.lang.Object.equals(java.lang.Object)
+public final native java.lang.Class<?> java.lang.Object.getClass()
+public native int java.lang.Object.hashCode()
+public int Foo.hello()
+public final native void java.lang.Object.notify()
+public final native void java.lang.Object.notifyAll()
+public java.lang.String java.lang.Object.toString()
+public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException
+public final void java.lang.Object.wait() throws java.lang.InterruptedException
+public final native void java.lang.Object.wait(long) throws java.lang.InterruptedException
+public int Foo.x()

--- a/tests/run/i24553.scala
+++ b/tests/run/i24553.scala
@@ -1,0 +1,8 @@
+// scalajs: --skip
+class Foo:
+    val hello = 1337
+    val x: hello.type = ???
+
+@main def Test =
+    val mtds = classOf[Foo].getMethods().sortBy(_.getName())
+    for mtd <- mtds do println(mtd.toGenericString())


### PR DESCRIPTION
If the type of a `val` is a `TermRef`, generating the generic signature  based on the underlying type will produce the type `scala.Function0<underlying>`. The reason behind this is that during the `getters` phase, the same symbol will now refer to the getter where the type will be `=> <underlying>`. Since the `TermRef` originally intended to capture the underlying type of a `val`, we recover that information by directly checking the resultType of the getter.

Closes #24553