### PR TITLE
change `Designator` to be an alias

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -20,17 +20,15 @@ object Names {
    */
   type PreName = Name | String
 
-  /** A common superclass of Name and Symbol. After bootstrap, this should be
-   *  just the type alias Name | Symbol
-   */
-  abstract class Designator
+  /** A common type of Name and Symbol */
+  type Designator = Name | Symbols.Symbol
 
   /** A name is either a term name or a type name. Term names can be simple
    *  or derived. A simple term name is essentially an interned string stored
    *  in a name table. A derived term name adds a tag, and possibly a number
    *  or a further simple name to some other name.
    */
-  abstract class Name extends Designator, Showable derives CanEqual {
+  abstract class Name extends Showable derives CanEqual {
 
     /** A type for names of the same kind as this name */
     type ThisName <: Name

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -45,7 +45,7 @@ object Symbols extends SymUtils {
    *  @param id     A unique identifier of the symbol (unique per ContextBase)
    */
   class Symbol private[Symbols] (private var myCoord: Coord, val id: Int, val nestingLevel: Int)
-    extends Designator, ParamInfo, SrcPos, printing.Showable {
+    extends ParamInfo, SrcPos, printing.Showable {
 
     type ThisName <: Name
 


### PR DESCRIPTION
As per the comment in the source code, we change `Designator` to now be an alias instead of an abstract class.