### PR TITLE
Fix generic signatures for mixin forwarders conflicting type parameter names

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.excludelist
+++ b/compiler/test/dotc/pos-test-pickling.excludelist
@@ -33,6 +33,7 @@ i17186b.scala
 i11982a.scala
 i17255
 i17735.scala
+i24134
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/tests/pos/i24134/JavaPartialFunction.scala
+++ b/tests/pos/i24134/JavaPartialFunction.scala
@@ -1,0 +1,20 @@
+final class Flow[In, Out]:
+  def collect[T](pf: PartialFunction[Out, T]): Flow[In, T] = ???
+
+object Flow:
+  def create[T](): Flow[T, T] = ???
+
+
+abstract class Message:
+  def asTextMessage: TextMessage
+
+abstract class TextMessage extends Message
+
+abstract class JavaPartialFunction[A, B] extends PartialFunction[A, B]:
+  @throws(classOf[Exception]) // required, compiles without annotation
+  def apply(x: A, isCheck: Boolean): B
+
+  final def isDefinedAt(x: A): Boolean = ???
+  final override def apply(x: A): B = ???
+  final override def applyOrElse[A1 <: A, B1 >: B](x: A1, default: A1 => B1): B1 = ???
+

--- a/tests/pos/i24134/JavaTestServer.java
+++ b/tests/pos/i24134/JavaTestServer.java
@@ -1,0 +1,18 @@
+public class JavaTestServer {
+  public static Flow<Message, Message> greeter() {
+    return Flow.<Message>create()
+        .collect(
+            new JavaPartialFunction<Message, Message>() {
+              @Override
+              public Message apply(Message msg, boolean isCheck) throws Exception {
+                if (isCheck)  throw new RuntimeException(); 
+                else return handleTextMessage(msg.asTextMessage());
+              }
+            });
+  }
+
+  public static TextMessage handleTextMessage(TextMessage msg) {
+    return null;
+  }
+}
+


### PR DESCRIPTION

Fixes #24134

https://github.com/scala/scala3/commit/f99dba239f9f876ab62cd8d870e3e56e1ed7a5d7 started emitting Java generic signature for mixin forwarders.

However, when generating Java generic signatures for mixin forwarders, method-level type parameters could shadow class-level type parameters with the same name.

For example, when `JavaPartialFunction[A, B]` implements `PartialFunction1[A, B]`,

```scala
trait Function1[-T1, +R]:
  def compose[A](g: A => T1): A => R = ???

trait PartialFunction[-A, +B] extends Function1[A, B]:
  def compose[R](k: PartialFunction[R, A]): PartialFunction[R, B] = ???

abstract class JavaPartialFunction[A, B] extends PartialFunction[A, B]
```

the generated mixin forwarder for `compose` in Function1 was like:

```java
public abstract class JavaPartialFunction<A, B> implements scala.PartialFunction<A, B> {
  public <A> scala.Function1<A, B> compose(scala.Function1<A, A>);
```

which is obviously incorrect, the type parameter `A` of `compose[A]` is shadowed by the `A` in `JavaPartialFunction<A, B>`.

The `compose`'s type parameter should use an unique name like:

```java
public abstract class JavaPartialFunction<A, B> implements scala.PartialFunction<A, B> {
  public <T> scala.Function1<T, B> compose(scala.Function1<T, A>);
```

This commit fix the problem by
- Tracks class-level type parameter names when generating method signatures
- Renames conflicting method-level type parameters (A → A1, A2, etc.)