### PR TITLE
fix: allow to generate the documentation of the stdlib

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -722,3 +722,25 @@ jobs:
       - name: Run Community Build C
         run: |
           ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestC"
+
+  #################################################################################################
+  ######################################## GENERATE DOCS ##########################################
+  #################################################################################################
+
+  scala-library-docs:
+    runs-on: ubuntu-latest
+    needs  : [scala-library-bootstrapped, scaladoc]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Generate Documentation of the Standard Library
+        run: ./project/scripts/sbt scala-library-bootstrapped/doc

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1239,8 +1239,8 @@ object Build {
       // Add the source directories for the stdlib (non-boostrapped)
       Compile / unmanagedSourceDirectories := Seq(baseDirectory.value / "src"),
       Compile / unmanagedSourceDirectories += baseDirectory.value / "src-non-bootstrapped",
-      Compile / scalacOptions += "-Yno-stdlib-patches",
-      Compile / scalacOptions ++= Seq(
+      Compile / compile / scalacOptions += "-Yno-stdlib-patches",
+      Compile / compile / scalacOptions ++= Seq(
         // Needed so that the library sources are visible when `dotty.tools.dotc.core.Definitions#init` is called
         "-sourcepath", (Compile / sourceDirectories).value.map(_.getCanonicalPath).distinct.mkString(File.pathSeparator),
       ),
@@ -1312,7 +1312,6 @@ object Build {
   lazy val `scala-library-bootstrapped` = project.in(file("library"))
     .enablePlugins(ScalaLibraryPlugin)
     .settings(publishSettings)
-    .settings(disableDocSetting) // TODO now produces empty JAR to satisfy Sonatype, see https://github.com/scala/scala3/issues/24434
     .settings(
       name          := "scala-library-bootstrapped",
       moduleName    := "scala-library",
@@ -1331,8 +1330,8 @@ object Build {
       // Add the source directories for the stdlib (non-boostrapped)
       Compile / unmanagedSourceDirectories := Seq(baseDirectory.value / "src"),
       Compile / unmanagedSourceDirectories += baseDirectory.value / "src-bootstrapped",
-      Compile / scalacOptions += "-Yno-stdlib-patches",
-      Compile / scalacOptions ++= Seq(
+      Compile / compile / scalacOptions += "-Yno-stdlib-patches",
+      Compile / compile / scalacOptions ++= Seq(
         // Needed so that the library sources are visible when `dotty.tools.dotc.core.Definitions#init` is called
         "-sourcepath", (Compile / sourceDirectories).value.map(_.getCanonicalPath).distinct.mkString(File.pathSeparator),
       ),
@@ -1465,9 +1464,9 @@ object Build {
       Compile / unmanagedSourceDirectories := Seq(baseDirectory.value / "src"),
       Compile / unmanagedSourceDirectories ++=
         (`scala-library-bootstrapped` / Compile / unmanagedSourceDirectories).value,
-      Compile / scalacOptions += "-Yno-stdlib-patches",
+      Compile / compile / scalacOptions += "-Yno-stdlib-patches",
       // Configure the source maps to point to GitHub for releases
-      Compile / scalacOptions ++= {
+      Compile / compile / scalacOptions ++= {
         if (isRelease) {
           val baseURI = (LocalRootProject / baseDirectory).value.toURI
           val dottyVersion = version.value


### PR DESCRIPTION
Based on @bracevac remarks here https://github.com/scala/scala3/issues/24434#issuecomment-3588708705

We do not need to add `-sourcepath` when generating the scaladoc since compiling with `-from-tasty` (what scaladoc does) will put the TASTy in the classpath. This means that the compiler will be happy and will find the symbols.

Closes #24434
Supersedes #24569, #24510.

Thanks Oliver for taking the time to analyze the issue in depth.