### PR TITLE
chore: deprecate the content of the `scala.runtime.stdLibPatches` package

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -3,9 +3,12 @@ package scala.runtime.stdLibPatches
 import scala.language.experimental.captureChecking
 
 import scala.annotation.experimental
+import scala.annotation.publicInBinary
 import scala.annotation.internal.RuntimeChecked
 
-object Predef:
+@publicInBinary
+@deprecated(message = "Patches are not applied to the stdlib anymore", since = "3.8.0")
+private[scala] object Predef:
   import compiletime.summonFrom
 
   transparent inline def assert(inline assertion: Boolean, inline message: => Any): Unit =

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -3,10 +3,12 @@ package scala.runtime.stdLibPatches
 import scala.language.experimental.captureChecking
 
 import scala.annotation.compileTimeOnly
+import scala.annotation.publicInBinary
 
-/** Scala 3 additions and replacements to the `scala.language` object.
- */
-object language:
+/** Scala 3 additions and replacements to the `scala.language` object. */
+@publicInBinary
+@deprecated(message = "Patches are not applied to the stdlib anymore", since = "3.8.0")
+private[scala] object language:
 
   /** The experimental object contains features that have been recently added but have not
    *  been thoroughly tested in production yet.

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
@@ -136,8 +136,6 @@ class CompletionDocSuite extends BaseCompletionSuite:
       s"""
          |> Found documentation for scala/Predef.
          |Predef scala
-         |> Found documentation for scala/runtime/stdLibPatches/Predef.
-         |Predef - scala.runtime.stdLibPatches
          |""".stripMargin,
       includeDocs = true
     )


### PR DESCRIPTION
Since I'm blocked by a bug in #24477, lets at least deprecate the objects not allow access to them anymore for 3.8.0.