### PR TITLE
Fix #24599: Remove `| Null` from implicit BigDecimal conversion similar to BigInt

### DIFF
--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -22,6 +22,7 @@ import java.math.{
   RoundingMode => JRM,
 }
 import scala.collection.immutable.NumericRange
+import scala.runtime.ScalaRunTime.mapNull
 
 object BigDecimal {
   private final val maximumHashScale = 4934           // Quit maintaining hash identity with BigInt beyond this scale
@@ -304,8 +305,13 @@ object BigDecimal {
   /** Implicit conversion from `Double` to `BigDecimal`. */
   implicit def double2bigDecimal(d: Double): BigDecimal = decimal(d)
 
+  // For the following function, both the parameter and the return type are non-nullable.
+  // However, if a null reference is passed explicitly, this method will still return null.
+  // We intentionally keep this signature to discourage passing nulls implicitly while
+  // preserving the previous behavior for backward compatibility.
+
   /** Implicit conversion from `java.math.BigDecimal` to `scala.BigDecimal`. */
-  implicit def javaBigDecimal2bigDecimal(x: BigDec | Null): BigDecimal | Null = if (x == null) null else apply(x)
+  implicit def javaBigDecimal2bigDecimal(x: BigDec): BigDecimal = mapNull(x, apply(x))
 }
 
 /**

--- a/tests/explicit-nulls/pos/i24599.scala
+++ b/tests/explicit-nulls/pos/i24599.scala
@@ -1,0 +1,10 @@
+import java.math.{BigDecimal => JBigDecimal}
+import java.math.{BigInteger => JBigInteger}
+
+opaque type CurrencyValue = BigDecimal
+
+extension (value: CurrencyValue)
+  def negate: CurrencyValue = value.bigDecimal.negate().nn
+
+def testBigDecimalConversion(jbd: JBigDecimal): BigDecimal = jbd
+def testBigIntConversion(jbi: JBigInteger): BigInt = jbi


### PR DESCRIPTION
Fix #24599

We remove `| Null` from implicit BigDecimal conversion similar to BigInt.

```scala
// For the following function, both the parameter and the return type are non-nullable.
// However, if a null reference is passed explicitly, this method will still return null.
// We intentionally keep this signature to discourage passing nulls implicitly while
// preserving the previous behavior for backward compatibility.

/** Implicit conversion from `java.math.BigDecimal` to `scala.BigDecimal`. */
implicit def javaBigDecimal2bigDecimal(x: BigDec): BigDecimal = mapNull(x, apply(x))

/** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`. */
implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = mapNull(x, apply(x))
```

I have double-checked all other implicit functions in stdlib, and there is no nullable signature left anymore.