### PR TITLE
Make `compilationUnitInfo` of `TastyLoader` lazy

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
+++ b/compiler/src/dotty/tools/dotc/core/CompilationUnitInfo.scala
@@ -3,20 +3,25 @@ package dotty.tools.dotc.core
 import dotty.tools.io.AbstractFile
 import dotty.tools.tasty.TastyVersion
 
-/** Information about the compilation unit of a class symbol.
-  *
-  * @param associatedFile The source or class file from which this class or
-  *                       the class containing this symbol was generated,
-  *                       null if not applicable.
-  * @param tastyInfo      Information about the TASTy from which this class was loaded.
-  *                       None if not loaded from TASTy,
-  */
-case class CompilationUnitInfo(
+/** Information about the compilation unit of a class symbol. */
+trait CompilationUnitInfo:
+  /** The source or class file from which this class or the class containing
+   *  this symbol was generated, null if not applicable. */
+  def associatedFile: AbstractFile
+
+  /** Information about the TASTy from which this class was loaded.
+   *  [[None]] if not loaded from TASTy. */
+  def tastyInfo: Option[TastyInfo]
+
+private case class ConcreteCompilationUnitInfo(
   associatedFile: AbstractFile,
-  tastyInfo: Option[TastyInfo],
-)
+  tastyInfo: Option[TastyInfo]
+) extends CompilationUnitInfo
 
 object CompilationUnitInfo:
   def apply(assocFile: AbstractFile | Null): CompilationUnitInfo | Null =
     if assocFile == null then null
-    else new CompilationUnitInfo(assocFile, tastyInfo = None)
+    else ConcreteCompilationUnitInfo(assocFile, tastyInfo = None)
+
+  def apply(assocFile: AbstractFile, tastyInfo: Option[TastyInfo]): CompilationUnitInfo =
+    ConcreteCompilationUnitInfo(assocFile, tastyInfo)

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -473,12 +473,17 @@ class ClassfileLoader(val classfile: AbstractFile) extends SymbolLoader {
 
 class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
   val isBestEffortTasty = tastyFile.hasBetastyExtension
-  private val unpickler: tasty.DottyUnpickler =
+
+  lazy val tastyBytes = tastyFile.toByteArray
+
+  private lazy val unpickler: tasty.DottyUnpickler =
     handleUnpicklingExceptions:
-      val tastyBytes = tastyFile.toByteArray
       new tasty.DottyUnpickler(tastyFile, tastyBytes, isBestEffortTasty) // reads header and name table
 
-  val compilationUnitInfo: CompilationUnitInfo | Null = unpickler.compilationUnitInfo
+  val compilationUnitInfo: CompilationUnitInfo =
+    new CompilationUnitInfo:
+      def associatedFile: AbstractFile = tastyFile
+      def tastyInfo: Option[TastyInfo] = unpickler.compilationUnitInfo.tastyInfo
 
   def description(using Context): String =
     if isBestEffortTasty then "Best Effort TASTy file " + tastyFile.toString
@@ -488,7 +493,6 @@ class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
     handleUnpicklingExceptions:
       val (classRoot, moduleRoot) = rootDenots(root.asClass)
       if (!isBestEffortTasty || ctx.withBestEffortTasty) then
-        val tastyBytes = tastyFile.toByteArray
         unpickler.enter(roots = Set(classRoot, moduleRoot, moduleRoot.sourceModule))(using ctx.withSource(util.NoSource))
         if mayLoadTreesFromTasty || isBestEffortTasty then
           classRoot.classSymbol.rootTreeOrProvider = unpickler

--- a/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/DottyUnpickler.scala
@@ -73,7 +73,7 @@ class DottyUnpickler(
     import unpickler.header.{majorVersion, minorVersion, experimentalVersion}
     val tastyVersion = TastyVersion(majorVersion, minorVersion, experimentalVersion)
     val tastyInfo = TastyInfo(tastyVersion, tastyAttributes)
-    new CompilationUnitInfo(tastyFile, Some(tastyInfo))
+    CompilationUnitInfo(tastyFile, Some(tastyInfo))
 
   private val posUnpicklerOpt = unpickler.unpickle(new PositionsSectionUnpickler)
   private val commentUnpicklerOpt = unpickler.unpickle(new CommentsSectionUnpickler)


### PR DESCRIPTION
This PR addresses a performance regression recently found between Scala 3.7.4 and 3.8.0. The root cause is that we unzip many Tasty files that we don’t actually need, because `TastyLoader` reads files eagerly, whereas `ClassfileLoader` does so lazily. The issue became visible with the new standard library compiled by Scala 3, which now generates Tasty files.

By logging `Abstract.toByteArray` calls, I measured that we loaded 641 Tasty files (4.49 MB) to compile hello-world before this PR, whereas we now load only 100 Tasty files (0.80 MB) afterward.

