### PR TITLE
Backport "Strip CC annotations in TypeMap when CC is not enabled" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6262,12 +6262,12 @@ object Types extends TypeUtils {
 
   end BiTypeMap
 
-  /** A typemap that follows aliases and keeps their transformed results if
-  *  there is a change.
-  */
+  /** A typemap that follows non-opaque aliases and keeps their transformed
+   *  results if there is a change.
+   */
   trait FollowAliasesMap(using Context) extends TypeMap:
     def mapFollowingAliases(t: Type): Type =
-      val t1 = t.dealiasKeepAnnots
+      val t1 = t.dealiasKeepAnnotsAndOpaques
       if t1 ne t then
         val t2 = apply(t1)
         if t2 ne t1 then t2


### PR DESCRIPTION
Backports #24556 to the 3.8.0-RC3.

PR submitted by the release tooling.
[skip ci]