### PR TITLE
Backport "fix: look at the underlying of a TermRef for a getter" to 3.8.0

### DIFF
--- a/tests/run/i24553.check
+++ b/tests/run/i24553.check
@@ -1,0 +1,11 @@
+public boolean java.lang.Object.equals(java.lang.Object)
+public final native java.lang.Class<?> java.lang.Object.getClass()
+public native int java.lang.Object.hashCode()
+public int Foo.hello()
+public final native void java.lang.Object.notify()
+public final native void java.lang.Object.notifyAll()
+public java.lang.String java.lang.Object.toString()
+public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException
+public final void java.lang.Object.wait() throws java.lang.InterruptedException
+public final native void java.lang.Object.wait(long) throws java.lang.InterruptedException
+public int Foo.x()

--- a/tests/run/i24553.scala
+++ b/tests/run/i24553.scala
@@ -1,0 +1,8 @@
+// scalajs: --skip
+class Foo:
+    val hello = 1337
+    val x: hello.type = ???
+
+@main def Test =
+    val mtds = classOf[Foo].getMethods().sortBy(_.getName())
+    for mtd <- mtds do println(mtd.toGenericString())


### PR DESCRIPTION
Backports #24565 to the 3.8.0-RC3.

PR submitted by the release tooling.
[skip ci]