### PR TITLE
Backport "Fix generic signatures for mixin forwarders conflicting type parameter names" to 3.8.0

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.excludelist
+++ b/compiler/test/dotc/pos-test-pickling.excludelist
@@ -33,6 +33,7 @@ i17186b.scala
 i11982a.scala
 i17255
 i17735.scala
+i24134
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/tests/pos/i24134/JavaPartialFunction.scala
+++ b/tests/pos/i24134/JavaPartialFunction.scala
@@ -1,0 +1,20 @@
+final class Flow[In, Out]:
+  def collect[T](pf: PartialFunction[Out, T]): Flow[In, T] = ???
+
+object Flow:
+  def create[T](): Flow[T, T] = ???
+
+
+abstract class Message:
+  def asTextMessage: TextMessage
+
+abstract class TextMessage extends Message
+
+abstract class JavaPartialFunction[A, B] extends PartialFunction[A, B]:
+  @throws(classOf[Exception]) // required, compiles without annotation
+  def apply(x: A, isCheck: Boolean): B
+
+  final def isDefinedAt(x: A): Boolean = ???
+  final override def apply(x: A): B = ???
+  final override def applyOrElse[A1 <: A, B1 >: B](x: A1, default: A1 => B1): B1 = ???
+

--- a/tests/pos/i24134/JavaTestServer.java
+++ b/tests/pos/i24134/JavaTestServer.java
@@ -1,0 +1,18 @@
+public class JavaTestServer {
+  public static Flow<Message, Message> greeter() {
+    return Flow.<Message>create()
+        .collect(
+            new JavaPartialFunction<Message, Message>() {
+              @Override
+              public Message apply(Message msg, boolean isCheck) throws Exception {
+                if (isCheck)  throw new RuntimeException(); 
+                else return handleTextMessage(msg.asTextMessage());
+              }
+            });
+  }
+
+  public static TextMessage handleTextMessage(TextMessage msg) {
+    return null;
+  }
+}
+


### PR DESCRIPTION
Backports #24567 to the 3.8.0-RC3.

PR submitted by the release tooling.