### PR TITLE
Parameter name can be masked in import

### DIFF
--- a/tests/warn/i24633.scala
+++ b/tests/warn/i24633.scala
@@ -1,0 +1,20 @@
+//> using options -Werror -Wunused:imports
+
+object foo {
+  val min = 0
+  val max = 1
+}
+
+def test(max: Int) = {
+  import foo.{max as _, *}
+  s"$min - $max"
+}
+
+def local =
+  val max = 42
+  import foo.{max as _, *}
+  s"$min - $max"
+
+class Limit(max: Int):
+  import foo.{max as _, *}
+  def test = s"$min - $max"


### PR DESCRIPTION
Fixes #24633 

Consider import for masking before short circuiting lookup of parameter.
Locals can't be imported, but their names can be masked in an import.