### PR TITLE
Backport "Avoid blowup of compute times for ill-formed retains" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -30,7 +30,6 @@ import Hashable.*
 import Uniques.*
 import collection.mutable
 import config.Config
-import config.Feature
 import config.Feature.sourceVersion
 import config.SourceVersion
 import annotation.{tailrec, constructorOnly}
@@ -5887,8 +5886,9 @@ object Types extends TypeUtils {
 
     override def underlying(using Context): Type = parent
 
-    def derivedAnnotatedType(parent: Type, annot: Annotation)(using Context): AnnotatedType =
+    def derivedAnnotatedType(parent: Type, annot: Annotation)(using Context): Type =
       if ((parent eq this.parent) && (annot eq this.annot)) this
+      else if annot == EmptyAnnotation then parent
       else AnnotatedType(parent, annot)
 
     override def stripTypeVar(using Context): Type =
@@ -6466,13 +6466,7 @@ object Types extends TypeUtils {
           mapCapturingType(tp, parent, refs, variance)
 
         case tp @ AnnotatedType(underlying, annot) =>
-          if annot.symbol.isRetainsLike && !Feature.ccEnabledSomewhere then
-            this(underlying) // strip retains like annotations unless capture checking is enabled
-          else
-            val underlying1 = this(underlying)
-            val annot1 = annot.mapWith(this)
-            if annot1 eq EmptyAnnotation then underlying1
-            else derivedAnnotatedType(tp, underlying1, annot1)
+          derivedAnnotatedType(tp, this(underlying), annot.mapWith(this))
 
         case _: ThisType
           | _: BoundType

--- a/tests/pos-custom-args/captures/i24556.scala
+++ b/tests/pos-custom-args/captures/i24556.scala
@@ -1,0 +1,35 @@
+import language.experimental.captureChecking
+
+trait Item
+
+trait ItOps[+T, +CC[_], +C]:
+  def ++[B >: T](other: It[B]^): CC[B]^{this, other}
+
+trait It[+T] extends ItOps[T, It, It[T]]
+
+trait Sq[+T] extends It[T] with ItOps[T, Seq, Seq[T]]
+
+def items: Sq[Item] = ???
+
+@main def main(): It[Item] =
+  items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items

--- a/tests/pos-custom-args/captures/i24556a.scala
+++ b/tests/pos-custom-args/captures/i24556a.scala
@@ -1,0 +1,27 @@
+import language.experimental.captureChecking
+
+trait Item
+def items : Seq[Item] = ???
+
+@main def main() =
+  items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items
+  ++ items


### PR DESCRIPTION
Backports #24564 to the 3.8.0-RC3.

PR submitted by the release tooling.
[skip ci]