### PR TITLE
Cache `AbstractFile.toByteArray`

### DIFF
--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -169,7 +169,9 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   /** Returns contents of file (if applicable) in a byte array.
    */
   @throws(classOf[IOException])
-  def toByteArray: Array[Byte] = {
+  def toByteArray: Array[Byte] = _toByteArray
+
+  private lazy val _toByteArray: Array[Byte] = {
     val in = input
     sizeOption match {
       case Some(size) =>


### PR DESCRIPTION
Follow-up on #24630. Attempts to avoid ready and unzipping TASTy files over and over again.