### PR TITLE
[build] Ensure to publish javadoc for scala3-library artifacts -

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1419,7 +1419,7 @@ object Build {
       Compile / classDirectory := (`scala-library-bootstrapped` / Compile / classDirectory).value,
       // Packaging configuration of the stdlib
       Compile / packageBin / publishArtifact := true,
-      Compile / packageDoc / publishArtifact := false,
+      Compile / packageDoc / publishArtifact := true,
       Compile / packageSrc / publishArtifact := true,
       // Only publish compilation artifacts, no test artifacts
       Test    / publishArtifact := false,
@@ -1592,7 +1592,7 @@ object Build {
       Test / run     := (`scala-library-sjs` / Test / run).evaluated,
       // Packaging configuration of the stdlib
       Compile / packageBin / publishArtifact := true,
-      Compile / packageDoc / publishArtifact := false,
+      Compile / packageDoc / publishArtifact := true,
       Compile / packageSrc / publishArtifact := true,
       // Only publish compilation artifacts, no test artifacts
       Test    / publishArtifact := false,


### PR DESCRIPTION
Mavne requires all published artifacts to include JavaDoc artifact - see [failed publish job](https://github.com/scala/scala3/actions/runs/19905250615/job/57059665654) 

Adds missing `packageDoc` for `scala3-library-bootstrapped` and `scala3-library-sjs` artifacts - both are effectively empty, but we still need to include valid javadoc to satisfy validation. 