### PR TITLE
chore: add regression test for #13889

### DIFF
--- a/tests/pos/i13889.scala
+++ b/tests/pos/i13889.scala
@@ -1,0 +1,17 @@
+class DiscordRecord(fields: Map[String, Any]) extends Selectable {
+  def selectDynamic(name: String): Any = fields(name)
+}
+
+type IdentifyScope = DiscordRecord {
+  val username: String
+}
+
+type IncludeIf[Stated <: String, Requirement <: String, IfMatch] = Seq[Stated] match {
+  case Seq[Requirement] => IfMatch
+  case _ => Any
+}
+
+type RawUser[Scopes <: String] = DiscordRecord & IncludeIf[Scopes, "identify", IdentifyScope]
+
+val obj: RawUser["identify"] = ???
+val _ = obj.username


### PR DESCRIPTION
- Code is legit and should compile
- It indeed was an error in 3.1.0. When tested locally, I got the following stack trace (different from the one in the issue):
```scala
hamzaremmal@macbook scala3 % scalac test.scala -d out -Xprint:typer
exception occurred while typechecking test.scala
exception occurred while compiling test.scala
java.lang.AssertionError: NoDenotation.owner while compiling test.scala
Exception in thread "main" java.lang.AssertionError: NoDenotation.owner
        at dotty.tools.dotc.core.SymDenotations$NoDenotation$.owner(SymDenotations.scala:2503)
        at dotty.tools.dotc.typer.Nullables$.usedOutOfOrder(Nullables.scala:260)
        at dotty.tools.dotc.typer.Nullables$.isTracked(Nullables.scala:161)
        at dotty.tools.dotc.typer.Nullables$TrackedRef$.unapply(Nullables.scala:127)
        at dotty.tools.dotc.typer.Nullables$.caseContext(Nullables.scala:179)
        at dotty.tools.dotc.typer.Typer.typedCase(Typer.scala:1653)
        at dotty.tools.dotc.typer.Typer.typedCases$$anonfun$1(Typer.scala:1583)
        at dotty.tools.dotc.core.Decorators$ListDecorator$.loop$1(Decorators.scala:92)
        at dotty.tools.dotc.core.Decorators$ListDecorator$.mapconserve$extension(Decorators.scala:108)
        at dotty.tools.dotc.typer.Typer.typedCases(Typer.scala:1585)
        at dotty.tools.dotc.typer.Typer.$anonfun$20(Typer.scala:1575)
        at dotty.tools.dotc.typer.Applications.harmonic(Applications.scala:2190)
        at dotty.tools.dotc.typer.Applications.harmonic$(Applications.scala:317)
```

Closes #13889