### PR TITLE
chore: add a regression test for #15786

### DIFF
--- a/tests/pos/i15786.scala
+++ b/tests/pos/i15786.scala
@@ -1,0 +1,15 @@
+class A(val f: () => Int) {
+  def mA(p: Int = 0): Int = p
+}
+
+trait B {
+  def mB(p1: Int): Unit
+}
+
+class C[T](val f1: B, val f2: T)
+
+val f = new A(() => {
+  val x: B = null
+  C[Int](x, 0).f1.mB(1);
+  1
+}).mA()


### PR DESCRIPTION
- Code is legit and should work.
- The error was indeed present in `3.1.3` and not present anymore:
```scala
exception occurred while compiling test.scala
java.lang.AssertionError: assertion failed: method $anonfun while compiling test.scala
Exception in thread "main" java.lang.AssertionError: assertion failed: method $anonfun
        at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleDef(TreePickler.scala:324)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:559)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree$$anonfun$9$$anonfun$1(TreePickler.scala:468)
```

Closes #15786