### PR TITLE
chore: drop `toOption` (deadcode)

### DIFF
--- a/compiler/src/dotty/tools/package.scala
+++ b/compiler/src/dotty/tools/package.scala
@@ -16,8 +16,6 @@ package object tools {
      */
     transparent inline def uncheckedNN: T = x.asInstanceOf[T]
 
-    inline def toOption: Option[T] =
-      if x == null then None else Some(x.asInstanceOf[T])
   end extension
 
   object resultWrapper {

--- a/compiler/test/dotty/tools/dotc/sbt/ProgressCallbackTest.scala
+++ b/compiler/test/dotty/tools/dotc/sbt/ProgressCallbackTest.scala
@@ -7,7 +7,6 @@ import dotty.tools.dotc.sbt.ProgressCallbackTest.*
 import org.junit.Assert.*
 import org.junit.Test
 
-import dotty.tools.toOption
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Contexts.ctx
 import dotty.tools.dotc.CompilationUnit

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
@@ -11,7 +11,6 @@ import scala.meta.internal.pc.CompletionFuzzy
 import scala.meta.pc.PresentationCompilerConfig
 import scala.meta.pc.SymbolSearch
 
-import dotty.tools.toOption
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.Contexts.Context
@@ -135,7 +134,7 @@ object CaseKeywordCompletion:
                 ),
                 Nil,
                 range = Some(completionPos.toEditRange),
-                command = config.parameterHintsCommand().toOption.flatMap(_.asScala),
+                command = Option(config.parameterHintsCommand()).flatMap(_.asScala),
               )
             )
           else Nil


### PR DESCRIPTION
More deadcode removal :)
Also, this is basically using `Option.apply` now (since #24238)