### PR TITLE
chore: add regression test for #4528

### DIFF
--- a/tests/run/i4528.scala
+++ b/tests/run/i4528.scala
@@ -1,0 +1,9 @@
+import scala.reflect.Selectable.reflectiveSelectable
+
+type T = {val a: Int; def a_=(x: Int): Unit}
+
+@main def Test() =
+  val x: T = (new { var a = 10 }).asInstanceOf[T]
+  assert(x.a == 10)
+  x.a = 11
+  assert(x.a == 11)


### PR DESCRIPTION
The issue was fixed by me in #18928.

To answer @sjrd's comment in https://github.com/scala/scala3/issues/4528#issuecomment-389118815, there is no `updateDynamic` in `scala.reflect.Selectable`.

Closes #4528