### PR TITLE
Add time quota in checking global objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -427,7 +427,7 @@ class Objects(using Context @constructorOnly):
           try
             init(tpl, obj, classSym)
           catch case _: OutOfQuotaException =>
-            report.warning("Giving up checking initializatino of " + classSym + " due to exhausted budget", classSym.sourcePos)
+            report.warning("Giving up checking initialization of " + classSym + " due to exhausted budget", classSym.sourcePos)
             data.addQuotaExhausted(obj)
             data.addChecked(obj)
             data.popChecking()
@@ -445,7 +445,7 @@ class Objects(using Context @constructorOnly):
             iterate()
           else
             if !BestEffort then
-              report.warning("Giving up checking initializatino of " + classSym + " due to iteration > = " + count, classSym.sourcePos)
+              report.warning("Giving up checking initialization of " + classSym + " due to iteration > = " + count, classSym.sourcePos)
             data.addChecked(obj)
             obj
         else


### PR DESCRIPTION
Make global object checker default to best-effort mode

- In best-effort mode, the checker tries to be fast, useful and unobtrusive.
- In the aggressive mode, the checker tries to be sound by spending more check time and produce more verbose warnings.

In both modes, there will be a worst-case performance guarantee based on a quota on the number of method calls in initializing a global object.