### PR TITLE
Work around `sbt#8376` and re-enable shapeless-3 community build

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -93,7 +93,7 @@ class CommunityBuildTestC:
   @Test def scalaz = projects.scalaz.run()
   @Test def scas = projects.scas.run()
   @Test def sconfig = projects.sconfig.run()
-  //@Test def shapeless3 = projects.shapeless3.run()
+  @Test def shapeless3 = projects.shapeless3.run()
   @Test def sourcecode = projects.sourcecode.run()
   @Test def specs2 = projects.specs2.run()
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2968,7 +2968,7 @@ object Build {
     publishConfiguration ~= (_.withOverwrite(true)),
     publishLocalConfiguration ~= (_.withOverwrite(true)),
     projectID ~= {id =>
-      val line = "scala.versionLine" -> versionLine
+      val line = "info.scala.versionLine" -> versionLine
       id.withExtraAttributes(id.extraAttributes + line)
     },
     Test / publishArtifact := false,


### PR DESCRIPTION
- works around https://github.com/sbt/sbt/issues/8376 / https://github.com/coursier/coursier/issues/3520
- kudos to @eed3si9n for suggesting this, as per https://github.com/coursier/coursier/issues/3520#issuecomment-3630791062
- re-enables tests disabled in https://github.com/scala/scala3/pull/24477#discussion_r2583852505