### PR TITLE
Improve multi-line code message rendering

### DIFF
--- a/tests/neg-custom-args/captures/boundary-homebrew.check
+++ b/tests/neg-custom-args/captures/boundary-homebrew.check
@@ -10,6 +10,7 @@
    |where:    ?=> refers to a fresh root capability created in anonymous function of type (using l1²: boundary.Label[boundary.Label[Int]^]^): boundary.Label[Int]^ when checking argument to parameter body of method apply
    |          ^   refers to the universal root capability
    |          cap is a fresh root capability created in anonymous function of type (using l2: boundary.Label[Int]^'s2): Int of parameter parameter l2² of method $anonfun
+   |
 20 |      boundary.break(l2)(using l1)
 21 |      15
    |

--- a/tests/neg-custom-args/captures/boundary.check
+++ b/tests/neg-custom-args/captures/boundary.check
@@ -10,6 +10,7 @@
    |
    |  where:    ^ and cap refer to the universal root capability
    |            ^²        refers to a fresh root capability classified as Control in the type of value local
+   |
  6 |      boundary[Unit]: l2 ?=>
  7 |        boundary.break(l2)(using l1) // error
  8 |      ???
@@ -47,6 +48,7 @@
    |
    |  where:    ^ and cap² refer to the universal root capability
    |            ^² and cap refer to a fresh root capability created in package <empty>
+   |
  6 |      boundary[Unit]: l2 ?=>
  7 |        boundary.break(l2)(using l1) // error
  8 |      ???

--- a/tests/neg-custom-args/captures/capt1.check
+++ b/tests/neg-custom-args/captures/capt1.check
@@ -41,6 +41,7 @@
    |  Required: A
    |
    |  Note that capability x is not included in capture set {}.
+   |
 28 |    def m() = if x == null then y else y
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/check-inferred.check
+++ b/tests/neg-custom-args/captures/check-inferred.check
@@ -6,6 +6,7 @@
    |
    |              Inferred type          : () ->{Counter.this.count} Unit
    |              Externally visible type: () -> Unit
+   |
 19 |    count.put(count.get + 1)
 -- Error: tests/neg-custom-args/captures/check-inferred.scala:20:13 ----------------------------------------------------
 20 |  val decr = () => // error
@@ -15,6 +16,7 @@
    |
    |              Inferred type          : () ->{Counter.this.count} Unit
    |              Externally visible type: () -> Unit
+   |
 21 |    count.put(count.get - 1)
 -- Error: tests/neg-custom-args/captures/check-inferred.scala:24:14 ----------------------------------------------------
 24 |  val count = Ref(): Object^ // error // error

--- a/tests/neg-custom-args/captures/class-caps.check
+++ b/tests/neg-custom-args/captures/class-caps.check
@@ -5,6 +5,7 @@
    |                                       Required: (Int, Int) -> Int
    |
    |                                       Note that capability Test.this.console is not included in capture set {}.
+   |
 19 |    log(s"adding a ($a) to b ($b)")(using console)
 20 |    a + b
    |
@@ -16,6 +17,7 @@
    |                                      Required: (Int, Int) -> Int
    |
    |                                      Note that capability Test1.this.console is not included in capture set {}.
+   |
 29 |    log(s"adding a ($a) to b ($b)")(using console)
 30 |    a + b
    |

--- a/tests/neg-custom-args/captures/classifiers-secondclass.check
+++ b/tests/neg-custom-args/captures/classifiers-secondclass.check
@@ -7,6 +7,7 @@
    |Note that capability f.write is not included in capture set {cap.only[Read]}.
    |
    |where:    cap is a fresh root capability created in anonymous function of type (f²: Levels.File^): Unit when checking argument to parameter op of method parReduce
+   |
 42 |        f.write(42)         // the error stems from here
 43 |        a + b + f.read()    // ok
    |
@@ -20,6 +21,7 @@
    |Note that capability f.write is not included in capture set {cap.only[Read]}.
    |
    |where:    cap is a fresh root capability created in anonymous function of type (g²: Levels.File^): Unit when checking argument to parameter op of method parReduce
+   |
 54 |          f.write(42)         // the error stems from here
 55 |          a + b + f.read() + g.read() // ok
    |
@@ -33,6 +35,7 @@
    |Note that capability g.write is not included in capture set {cap.only[Read]}.
    |
    |where:    cap is a fresh root capability created in anonymous function of type (g²: Levels.File^): Unit when checking argument to parameter op of method parReduce
+   |
 57 |          g.write(42)         // the error stems from here
 58 |          0
    |

--- a/tests/neg-custom-args/captures/delayedRunops.check
+++ b/tests/neg-custom-args/captures/delayedRunops.check
@@ -5,6 +5,7 @@
    |    Required: () -> Unit
    |
    |    Note that capability ops* is not included in capture set {}.
+   |
 13 |      val ops1 = ops
 14 |      runOps(ops1)
    |
@@ -16,6 +17,7 @@
    |    Required: () -> Unit
    |
    |    Note that capability ops* is not included in capture set {}.
+   |
 25 |      val ops1: List[() ->{ops*} Unit] = ops
 26 |      runOps(ops1)
    |

--- a/tests/neg-custom-args/captures/effect-swaps-explicit.check
+++ b/tests/neg-custom-args/captures/effect-swaps-explicit.check
@@ -6,6 +6,7 @@
    |      Required: Result[Future[T], Nothing]
    |
    |      Note that capability fr is not included in capture set {}.
+   |
 65 |          fr.await.ok
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
@@ -27,6 +28,7 @@
    |
    |where:    ?=> refers to a fresh root capability created in method fail4 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
+   |
 70 |            fr.await.ok
    |
    | longer explanation available when compiling with `-explain`
@@ -40,6 +42,7 @@
    |
    |where:    ?=> refers to a fresh root capability created in method fail5 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
+   |
 74 |          Future: fut ?=>
 75 |            fr.await.ok
    |

--- a/tests/neg-custom-args/captures/effect-swaps.check
+++ b/tests/neg-custom-args/captures/effect-swaps.check
@@ -6,6 +6,7 @@
    |      Required: Result[Future[T], Nothing]
    |
    |      Note that capability fr is not included in capture set {}.
+   |
 65 |          fr.await.ok
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
@@ -27,6 +28,7 @@
    |
    |where:    ?=> refers to a fresh root capability created in method fail4 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
+   |
 70 |            fr.await.ok
    |
    | longer explanation available when compiling with `-explain`
@@ -40,6 +42,7 @@
    |
    |where:    ?=> refers to a fresh root capability created in method fail5 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
+   |
 74 |          Future: fut ?=>
 75 |            fr.await.ok
    |

--- a/tests/neg-custom-args/captures/filevar.check
+++ b/tests/neg-custom-args/captures/filevar.check
@@ -11,6 +11,7 @@
    |          ^  refers to the universal root capability
    |          l  is a reference to a value parameter
    |          l² is a reference to a value parameter
+   |
 16 |    val o = Service()
 17 |    o.file = f
 18 |    o.log

--- a/tests/neg-custom-args/captures/heal-tparam-cs.check
+++ b/tests/neg-custom-args/captures/heal-tparam-cs.check
@@ -9,6 +9,7 @@
    |
    |where:    => refers to a fresh root capability created in value test1 when checking argument to parameter op of method localCap
    |          ^  refers to the universal root capability
+   |
 11 |    () => { c.use() }
    |
    | longer explanation available when compiling with `-explain`
@@ -24,6 +25,7 @@
    |where:    =>        refers to a root capability associated with the result type of (c: Capp^): () => Unit
    |          =>² and ^ refer to the universal root capability
    |          cap       is a root capability associated with the result type of (x$0: Capp^'s4): () ->{x$0} Unit
+   |
 16 |      (c1: Capp^) => () => { c1.use() }
 17 |    }
    |
@@ -35,6 +37,7 @@
    |    Required: (c: Capp^{io}) -> () ->{net} Unit
    |
    |    Note that capability x$0 is not included in capture set {net}.
+   |
 26 |      (c1: Capp^{io}) => () => { c1.use() }
 27 |    }
    |

--- a/tests/neg-custom-args/captures/i16114.check
+++ b/tests/neg-custom-args/captures/i16114.check
@@ -5,9 +5,9 @@
    |                                Required: Unit ->{io} Unit
    |
    |                                Note that capability fs is not included in capture set {io}.
+   |
 18 |      expect[Cap^] {
-19 |        io.use()
-20 |        fs
+19 |...
 21 |      }
    |
    | longer explanation available when compiling with `-explain`
@@ -18,9 +18,9 @@
    |                                Required: Unit ->{fs} Unit
    |
    |                                Note that capability io is not included in capture set {fs}.
+   |
 24 |      expect[Cap^] {
-25 |        fs.use()
-26 |        io
+25 |...
 27 |      }
    |
    | longer explanation available when compiling with `-explain`
@@ -31,6 +31,7 @@
    |                              Required: Unit -> Unit
    |
    |                              Note that capability io is not included in capture set {}.
+   |
 36 |      expect[Cap^](io)
    |
    | longer explanation available when compiling with `-explain`
@@ -41,9 +42,9 @@
    |                           Required: Unit -> Unit
    |
    |                           Note that capability io is not included in capture set {}.
+   |
 39 |      expect[Cap^] {
-40 |        io.use()
-41 |        io
+40 |...
 42 |      }
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21347.check
+++ b/tests/neg-custom-args/captures/i21347.check
@@ -12,4 +12,5 @@
    |               ^
    |               Local reach capability ops* leaks into capture scope of method runOpsAlt.
    |               You could try to abstract the capabilities referred to by ops* in a capset variable.
+   |
 12 |    op()

--- a/tests/neg-custom-args/captures/i23431.check
+++ b/tests/neg-custom-args/captures/i23431.check
@@ -37,6 +37,7 @@
    |          ^    refers to the universal root capability
    |          cap  is a fresh root capability created in anonymous function of type (io3: IO^'s1): Unit of parameter parameter io3² of method $anonfun
    |          cap² is a fresh root capability in the type of variable myIO
+   |
 13 |      myIO = io3
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i23582.check
+++ b/tests/neg-custom-args/captures/i23582.check
@@ -7,6 +7,7 @@
    |Note that capability write is not included in capture set {cap.only[Read]}.
    |
    |where:    cap is a fresh root capability created in method test when checking argument to parameter op of method parReduce
+   |
 28 |      write(x)
 29 |      x + y + read()
    |

--- a/tests/neg-custom-args/captures/i24309-region-orig.check
+++ b/tests/neg-custom-args/captures/i24309-region-orig.check
@@ -3,7 +3,7 @@
    |            ^
    |            Local reach capability r1.R leaks into capture scope of an enclosing function.
    |            You could try to abstract the capabilities referred to by r1.R in a capset variable.
+   |
 18 |      var a: Ref^{r1.R} = r1.alloc(0)
-19 |      var b: Ref^{r2.R} = r2.alloc(0)
-20 |      val c: Ref^{r1.R} = b
+19 |...
 21 |      a

--- a/tests/neg-custom-args/captures/lazylists-exceptions.check
+++ b/tests/neg-custom-args/captures/lazylists-exceptions.check
@@ -7,6 +7,7 @@
    |
    |    Found:    LazyList[Int]^{canThrow$1}
    |    Required: LazyList[Int]^'s1
+   |
 38 |      if i > 9 then throw Ex1()
 39 |      i * i
 40 |    }

--- a/tests/neg-custom-args/captures/lazylists2.check
+++ b/tests/neg-custom-args/captures/lazylists2.check
@@ -37,6 +37,7 @@
 60 |    class Mapped2 extends Mapped:  // error
    |    ^
    |    references {f, xs} are not all included in the allowed capture set {} of the self type of class Mapped2
+   |
 61 |      this: Mapped =>
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylists2.scala:62:4 ------------------------------------
 62 |    new Mapped2 // error

--- a/tests/neg-custom-args/captures/lazyvals3.check
+++ b/tests/neg-custom-args/captures/lazyvals3.check
@@ -5,10 +5,9 @@
    |                                           Required: Int ->{ev1, console} Boolean
    |
    |                                           Note that capability c is not included in capture set {ev1, console}.
+   |
 25 |        if n == 1 then
-26 |          console.println("CONSOLE: 1")
-27 |          true
-28 |        else
+26 |...
 29 |          ev1(n - 1)
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/leaking-iterators.check
+++ b/tests/neg-custom-args/captures/leaking-iterators.check
@@ -9,6 +9,7 @@
    |
    |where:    => refers to a fresh root capability created in method test when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
+   |
 57 |    xs.iterator.map: x =>
 58 |      log.write(x)
 59 |      x * x

--- a/tests/neg-custom-args/captures/mut-iterator4.check
+++ b/tests/neg-custom-args/captures/mut-iterator4.check
@@ -14,6 +14,7 @@
    |Note that capability cap is not included in capture set {it, f}.
    |
    |where:    cap is a fresh root capability created in method mappedIterator when constructing instance Object with (Iterator[U]^{cap².rd}) {...}
+   |
 22 |  def hasNext = it.hasNext
 23 |  update def next() = f(it.next())
    |

--- a/tests/neg-custom-args/captures/nicolas1.check
+++ b/tests/neg-custom-args/captures/nicolas1.check
@@ -7,6 +7,7 @@
    |  Note that capability tail* is not included in capture set {head}.
    |
    |  where:    ^ refers to the universal root capability
+   |
 11 |  all(nextInt(all.length))
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/reaches.check
+++ b/tests/neg-custom-args/captures/reaches.check
@@ -9,6 +9,7 @@
    |where:    =>  refers to a fresh root capability created in method runAll0 when checking argument to parameter f of method usingFile
    |          ^   refers to the universal root capability
    |          cap is a fresh root capability created in anonymous function of type (f: File^'s1): Unit of parameter parameter f² of method $anonfun
+   |
 21 |    cur = (() => f.write()) :: Nil
    |
    | longer explanation available when compiling with `-explain`
@@ -23,6 +24,7 @@
    |where:    =>  refers to a fresh root capability created in method runAll1 when checking argument to parameter f of method usingFile
    |          ^   refers to the universal root capability
    |          cap is a fresh root capability created in anonymous function of type (f: File^'s3): Unit of parameter parameter f² of method $anonfun
+   |
 31 |    cur.set:
 32 |      (() => f.write()) :: Nil
    |
@@ -106,6 +108,7 @@
    |        Local cap created in type of parameter x leaks into capture scope of an enclosing function
    |
    |        where:    cap is a fresh root capability created in value id of parameter parameter x of method $anonfun
+   |
 61 |    val f1: File^{id*} = id(f)
 62 |    f1
 -- Error: tests/neg-custom-args/captures/reaches.scala:42:9 ------------------------------------------------------------

--- a/tests/neg-custom-args/captures/real-try.check
+++ b/tests/neg-custom-args/captures/real-try.check
@@ -12,9 +12,9 @@
    |  This is often caused by a locally generated exception capability leaking as part of its result.
    |
    |  where:    => refers to a fresh root capability classified as Control in the type of given instance canThrow$1
+   |
 15 |    () => foo(1)
-16 |  catch
-17 |    case _: Ex1 => ???
+16 |...
 18 |    case _: Ex2 => ???
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/real-try.scala:21:4 --------------------------------------
 21 |    () => foo(1) // error

--- a/tests/neg-custom-args/captures/ref-with-file.check
+++ b/tests/neg-custom-args/captures/ref-with-file.check
@@ -10,6 +10,7 @@
    |          ^   refers to a fresh root capability classified as Unscoped in the type of value r
    |          ^²  refers to the universal root capability
    |          cap is a fresh root capability created in anonymous function of type (f: File^'s1): Ref[File^'s3]^ of parameter parameter f² of method $anonfun
+   |
 19 |    val r = Ref(f)
 20 |    r
    |
@@ -25,6 +26,7 @@
    |where:    =>  refers to a fresh root capability created in method Test when checking argument to parameter op of method withFile
    |          ^   refers to the universal root capability
    |          cap is a fresh root capability created in anonymous function of type (f: File^'s6): (??? : -> Nothing) of parameter parameter f² of method $anonfun
+   |
 22 |    val r = Ref(f)
 23 |    ???
    |
@@ -40,6 +42,7 @@
    |
    |where:    =>        refers to a fresh root capability created in method Test when checking argument to parameter op of method withFileAndRef
    |          ^ and cap refer to the universal root capability
+   |
 26 |    r.put(f.read())
 27 |    r
    |

--- a/tests/neg-custom-args/captures/reference-cc.check
+++ b/tests/neg-custom-args/captures/reference-cc.check
@@ -22,6 +22,7 @@
    |
    |where:    => refers to a fresh root capability created in value xs when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
+   |
 48 |    LzyList(1, 2, 3).map { x => f.write(x); x * x }
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/scope-extrusions.check
+++ b/tests/neg-custom-args/captures/scope-extrusions.check
@@ -130,6 +130,7 @@
    |
    |where:    => refers to a fresh root capability created in method test when checking argument to parameter op of method withFile
    |          ^  refers to the universal root capability
+   |
 29 |    () => println(io)
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/try.check
+++ b/tests/neg-custom-args/captures/try.check
@@ -35,6 +35,7 @@
    |
    |where:    => refers to a fresh root capability created in value xx when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
+   |
 37 |      () =>
 38 |        raise(new Exception)(using x)
 39 |        22
@@ -51,6 +52,7 @@
    |
    |where:    => refers to a fresh root capability created in value global when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
+   |
 49 |    () =>
 50 |      raise(new Exception)(using x)
 51 |      22

--- a/tests/neg-custom-args/captures/vars.check
+++ b/tests/neg-custom-args/captures/vars.check
@@ -37,6 +37,7 @@
    |      where:    ^     refers to the universal root capability
    |                cap3  is a reference to a value parameter
    |                cap3² is a parameter in an anonymous function in method test
+   |
 37 |    def g(x: String): String = if cap3 == cap3 then "" else "a"
 38 |    g
    |

--- a/tests/neg-macros/annot-error-annot.check
+++ b/tests/neg-macros/annot-error-annot.check
@@ -33,12 +33,14 @@
 32 |  given gMember2: Num[Int] with // error
    |  ^
    |  MACRO ERROR
+   |
 33 |    def zero = 0
 -- Error: tests/neg-macros/annot-error-annot/Test_2.scala:35:8 ---------------------------------------------------------
 34 |  @error
 35 |  given gMember3(using DummyImplicit): Num[Int] with // error
    |  ^
    |  MACRO ERROR
+   |
 36 |    def zero = 0
 -- Error: tests/neg-macros/annot-error-annot/Test_2.scala:39:8 ---------------------------------------------------------
 38 |  @error
@@ -75,12 +77,14 @@
 54 |    given gLocal2: Num[Int] with // error
    |    ^
    |    MACRO ERROR
+   |
 55 |      def zero = 0
 -- Error: tests/neg-macros/annot-error-annot/Test_2.scala:57:10 --------------------------------------------------------
 56 |    @error
 57 |    given gLocal3(using DummyImplicit): Num[Int] with // error
    |    ^
    |    MACRO ERROR
+   |
 58 |      def zero = 0
 -- Error: tests/neg-macros/annot-error-annot/Test_2.scala:61:10 --------------------------------------------------------
 60 |    @error
@@ -117,10 +121,12 @@
 10 |given gGlobal2: Num[Int] with // error
    |^
    |MACRO ERROR
+   |
 11 |  def zero = 0
 -- Error: tests/neg-macros/annot-error-annot/Test_2.scala:13:6 ---------------------------------------------------------
 12 |@error
 13 |given gGlobal3(using DummyImplicit): Num[Int] with // error
    |^
    |MACRO ERROR
+   |
 14 |  def zero = 0

--- a/tests/neg-scalajs/js-enums.check
+++ b/tests/neg-scalajs/js-enums.check
@@ -2,6 +2,7 @@
 4 |enum MyEnum extends js.Object: // error
   |^
   |MyEnum extends scala.reflect.Enum which does not extend js.Any.
+  |
 5 |  case Foo
 -- Error: tests/neg-scalajs/js-enums.scala:9:5 -------------------------------------------------------------------------
  7 |@js.native
@@ -9,11 +10,13 @@
  9 |enum MyEnumNative extends js.Object: // error
    |^
    |MyEnumNative extends scala.reflect.Enum which does not extend js.Any.
+   |
 10 |  case Bar
 -- Error: tests/neg-scalajs/js-enums.scala:12:5 ------------------------------------------------------------------------
 12 |enum MyEnumAny extends js.Any: // error
    |^
    |Non-native JS classes and objects cannot directly extend AnyRef. They must extend a JS class (native or not).
+   |
 13 |  case Foo
 -- Error: tests/neg-scalajs/js-enums.scala:17:5 ------------------------------------------------------------------------
 15 |@js.native
@@ -21,4 +24,5 @@
 17 |enum MyEnumNativeAny extends js.Any: // error
    |^
    |MyEnumNativeAny extends scala.reflect.Enum which does not extend js.Any.
+   |
 18 |  case Bar

--- a/tests/neg/deferred-givens-2.check
+++ b/tests/neg/deferred-givens-2.check
@@ -2,11 +2,13 @@
 17 |class SortedIntWrong1 extends Sorted: // error
    |^
    |No given instance of type Ord{type Self = SortedIntWrong1.this.Element} was found for inferring the implementation of the deferred given instance given_Ord_Element in trait Sorted
+   |
 18 |  type Element = Int
 19 |  override given (Element is Ord)()
 -- [E172] Type Error: tests/neg/deferred-givens-2.scala:21:6 -----------------------------------------------------------
 21 |class SortedIntWrong2 extends Sorted: // error
    |^
    |No given instance of type Ord{type Self = SortedIntWrong2.this.Element} was found for inferring the implementation of the deferred given instance given_Ord_Element in trait Sorted
+   |
 22 |  type Element = Int
 23 |  override given (Int is Ord)()

--- a/tests/neg/i22193.check
+++ b/tests/neg/i22193.check
@@ -22,6 +22,7 @@
 28 |  fn3( // error missing argument list for value of type (=> Unit) => Unit
    |  ^
    |  missing argument list for value of type (=> Unit) => Unit
+   |
 29 |    arg = "blue sleeps faster than tuesday",
 30 |    arg2 = "the quick brown fox jumped over the lazy dog"):
    |

--- a/tests/neg/i22670.check
+++ b/tests/neg/i22670.check
@@ -2,10 +2,9 @@
  4 |package xy // error named package required for warning
    |^
    |The package name `i22670-macro$package` will be encoded on the classpath, and can lead to undefined behaviour.
+   |
  5 |import scala.quoted.*
- 6 |transparent inline def foo =
- 7 |  ${ fooImpl }
- 8 |def fooImpl(using Quotes): Expr[Any] =
+ 6 |...
  9 |  Expr("hello")
    |--------------------------------------------------------------------------------------------------------------------
    | Explanation (enabled by `-explain`)

--- a/tests/neg/illegal-match-types.check
+++ b/tests/neg/illegal-match-types.check
@@ -5,6 +5,7 @@
   |                         case Inv[Cov[t]] => t
   |                     The pattern contains an unaccounted type parameter `t`.
   |                     (this error can be ignored for now with `-source:3.3`)
+  |
 8 |  case Inv[Cov[t]] => t
 -- [E191] Type Error: tests/neg/illegal-match-types.scala:10:26 --------------------------------------------------------
 10 |type ContraNesting[X] = X match // error
@@ -13,6 +14,7 @@
    |                            case Contra[Cov[t]] => t
    |                        The pattern contains an unaccounted type parameter `t`.
    |                        (this error can be ignored for now with `-source:3.3`)
+   |
 11 |  case Contra[Cov[t]] => t
 -- [E191] Type Error: tests/neg/illegal-match-types.scala:15:22 --------------------------------------------------------
 15 |type AndTypeMT[X] = X match // error
@@ -21,6 +23,7 @@
    |                        case t & Seq[Any] => t
    |                    The pattern contains an unaccounted type parameter `t`.
    |                    (this error can be ignored for now with `-source:3.3`)
+   |
 16 |  case t & Seq[Any] => t
 -- [E191] Type Error: tests/neg/illegal-match-types.scala:22:33 --------------------------------------------------------
 22 |type TypeAliasWithBoundMT[X] = X match // error
@@ -29,6 +32,7 @@
    |                                   case IsSeq[t] => t
    |                               The pattern contains a type alias `IsSeq`.
    |                               (this error can be ignored for now with `-source:3.3`)
+   |
 23 |  case IsSeq[t] => t
 -- [E191] Type Error: tests/neg/illegal-match-types.scala:29:34 --------------------------------------------------------
 29 |type TypeMemberExtractorMT[X] = X match // error
@@ -37,6 +41,7 @@
    |              case TypeMemberAux[t] => t
    |          The pattern contains an abstract type member `TypeMember` that does not refine a member in its parent.
    |          (this error can be ignored for now with `-source:3.3`)
+   |
 30 |  case TypeMemberAux[t] => t
 -- [E191] Type Error: tests/neg/illegal-match-types.scala:40:35 --------------------------------------------------------
 40 |type TypeMemberExtractorMT2[X] = X match // error
@@ -45,4 +50,5 @@
    |                       case TypeMemberAux2[t] => t
    |                   The pattern contains an abstract type member `TypeMember` with bounds that need verification.
    |                   (this error can be ignored for now with `-source:3.3`)
+   |
 41 |  case TypeMemberAux2[t] => t

--- a/tests/neg/singleton-ctx-bound.check
+++ b/tests/neg/singleton-ctx-bound.check
@@ -31,4 +31,5 @@
 33 |class D extends A:  // error
    |^
    |No given instance of type Singleton{type Self = D.this.Elem} was found for inferring the implementation of the deferred given instance given_Singleton_Elem in trait A. Failed to synthesize an instance of type Singleton{type Self = D.this.Elem}: D.this.Elem is not a singleton
+   |
 34 |  type Elem = Int

--- a/tests/neg/unroll-clause-interleaving.check
+++ b/tests/neg/unroll-clause-interleaving.check
@@ -2,6 +2,7 @@
 6 |  final def foo(@unroll x: Int = 0)[T](// error
   |  ^
   |  Cannot have multiple parameter lists containing `@unroll` annotation
+  |
 7 |    s: T,
 8 |    @unroll y: Boolean = true,
 9 |  ): String = "" + x + s + y

--- a/tests/warn/i21258.check
+++ b/tests/warn/i21258.check
@@ -2,5 +2,6 @@
 4 |  type MT[X] = X match { // warn
   |               ^
   |               Match type upper bound inferred as String, where previously it was defaulted to Any
+  |
 5 |    case Int => String
 6 |  }

--- a/tests/warn/nonunit-statement.check
+++ b/tests/warn/nonunit-statement.check
@@ -56,12 +56,9 @@
  96 |    if (b) {          // warn, at least one branch looks interesting
     |    ^
     |    unused value of type Int
+    |
  97 |      println("true")
- 98 |      i
- 99 |    }
-100 |    else {
-101 |      println("false")
-102 |      j
+ 98 |...
 103 |    }
 -- [E176] Potential Issue Warning: tests/warn/nonunit-statement.scala:116:4 --------------------------------------------
 116 |    set += a     // warn because cannot know whether the `set` was supposed to be consumed or assigned


### PR DESCRIPTION
Improve rendering of messages with multi-line code positions, in two ways:

 - Add a blank line between the error message proper and the code lines that follow it.
 - If there are more than 3 code lines following it, summarize them by printing the first and last line and a `...` in between.