### PR TITLE
Try to fix callee type inference in typedFunctionValue

### DIFF
--- a/tests/pos/i24689b.scala
+++ b/tests/pos/i24689b.scala
@@ -9,11 +9,10 @@ object Test1:
     foo(transfer(_))
   def transfer(in: B): Unit = ???
 
-// TODO: need to fix callee type in typedFunctionValue
-// object Test2:
-//   def foo[T <: (B => Unit)](f: T) = ???
-//   def transfer(in: A): Unit =
-//     foo(in => transfer(in))
-//     foo(transfer)
-//     foo(transfer(_))
-//   def transfer(in: B): Unit = ???
+object Test2:
+  def foo[T <: (B => Unit)](f: T) = ???
+  def transfer(in: A): Unit =
+    foo(in => transfer(in))
+    foo(transfer)
+    foo(transfer(_))
+  def transfer(in: B): Unit = ???


### PR DESCRIPTION
The callee part is separated from #24697 for further investigation 

When typing a function literal's expression to infer the callee type, we now create placeholder tree for each argument, and make sure the function part does not refer to any parameter. This ensures that references in the expression won't incorrectly resolve to outer scope variables with the same names as the parameters.

Fix the following test:
```scala
def foo[T <: (B => Unit)](f: T) = ???
def transfer(in: A): Unit =
  foo(in => transfer(in)) // error: Found: (in : B) Required: A
def transfer(in: B): Unit = ???