### PR TITLE
Fix inconsistent `typeSize` calculation for `TupleN` vs recursive pair encodings

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -7125,6 +7125,8 @@ object Types extends TypeUtils {
     var seen = util.HashSet[Type](initialCapacity = 8)
     def apply(n: Int, tp: Type): Int =
       tp match {
+        case tp: AppliedType if defn.isTupleNType(tp) =>
+          foldOver(n + 1, tp.toNestedPairs)
         case tp: AppliedType =>
           val tpNorm = tp.tryNormalize
           if tpNorm.exists then apply(n, tpNorm)

--- a/compiler/test/dotty/tools/dotc/core/TypesTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/TypesTest.scala
@@ -1,0 +1,18 @@
+package dotty.tools.dotc.core
+
+import dotty.tools.DottyTest
+import dotty.tools.dotc.core.Symbols.defn
+import dotty.tools.dotc.core.TypeOps
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class TypesTest extends DottyTest:
+
+  @Test def tuple3TypeSize =
+    val tpe = defn.TupleType(3).nn.appliedTo(List(defn.IntType, defn.BooleanType, defn.DoubleType))
+    assertEquals(3, tpe.typeSize)
+
+  @Test def tuple3ConsTypeSize =
+    val tpe = TypeOps.nestedPairs(List(defn.IntType, defn.BooleanType, defn.DoubleType))
+    assertEquals(3, tpe.typeSize)

--- a/compiler/test/dotty/tools/dotc/typer/DivergenceChecker.scala
+++ b/compiler/test/dotty/tools/dotc/typer/DivergenceChecker.scala
@@ -50,8 +50,8 @@ class DivergenceCheckerTests extends DottyTest {
           1,
           1,
           1,
-          3,
-          5
+          4,
+          6
         )
 
         tpes.lazyZip(expectedSizes).lazyZip(expectedCoveringSets).foreach {


### PR DESCRIPTION
Currently, `typeSize` reports inconsistent values for standard tuple types (e.g., `(A, B)`) compared to their semantically equivalent recursive pair encodings (e.g., `A *: B *: EmptyTuple`).

This discrepancy arises because `TupleN` is represented as a flat `AppliedType`, whereas the nested encoding forms a deeper tree structure. As `typeSize` is often used as a heuristic for complexity or optimization limits, this inconsistency can lead to divergent behavior in the compiler depending on how a tuple is represented syntactically.

This PR modifies `TypeSizeAccumulator` to canonicalize `TupleN` types into their recursive `*:` representation before calculating their size. This ensures that the size metric is consistent regardless of whether the tuple is represented as a flat `AppliedType` or a nested structural type.

I have added a new unit test in `TypesTest` that asserts `Tuple3[Int, Boolean, Double]` and `Int *: Boolean *: Double *: EmptyTuple` both yield identical `typeSize` equal to 3.

Thanks to @mbovel for providing the unit test that effectively reproduces this issue and validates the fix.

Fixes #24730