### PR TITLE
Make style-only changes to doc comments for the standard library.

### DIFF
--- a/library-js/src/scala/Array.scala
+++ b/library-js/src/scala/Array.scala
@@ -61,7 +61,7 @@ object Array {
     val emptyObjectArray  = new Array[Object](0)
   }
 
-  /** Provides an implicit conversion from the Array object to a collection Factory */
+  /** Provides an implicit conversion from the Array object to a collection Factory. */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
   private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
@@ -109,7 +109,7 @@ object Array {
     }
   }
 
-  /** Copy one array to another.
+  /** Copies one array to another.
    *  Equivalent to Java's
    *    `System.arraycopy(src, srcPos, dest, destPos, length)`,
    *  except that this also works for polymorphic and boxed arrays.
@@ -132,7 +132,7 @@ object Array {
       slowcopy(src, srcPos, dest, destPos, length)
   }
 
-  /** Copy one array to another, truncating or padding with default values (if
+  /** Copies one array to another, truncating or padding with default values (if
     * necessary) so the copy has the specified length.
     *
     * Equivalent to Java's
@@ -154,7 +154,7 @@ object Array {
     case x: Array[Boolean]    => java.util.Arrays.copyOf(x, newLength)
   }).asInstanceOf[Array[A]]
 
-  /** Copy one array to another, truncating or padding with default values (if
+  /** Copies one array to another, truncating or padding with default values (if
     * necessary) so the copy has the specified length. The new array can have
     * a different type than the original one as long as the values are
     * assignment-compatible. When copying between primitive and object arrays,
@@ -192,7 +192,7 @@ object Array {
     result
   }
 
-  /** Returns an array of length 0 */
+  /** Returns an array of length 0. */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
   /** Creates an array with given elements.
@@ -212,7 +212,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Boolean` objects */
+  /** Creates an array of `Boolean` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
     val array = new Array[Boolean](xs.length + 1)
@@ -225,7 +225,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Byte` objects */
+  /** Creates an array of `Byte` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
     val array = new Array[Byte](xs.length + 1)
@@ -238,7 +238,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Short` objects */
+  /** Creates an array of `Short` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
     val array = new Array[Short](xs.length + 1)
@@ -251,7 +251,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Char` objects */
+  /** Creates an array of `Char` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
     val array = new Array[Char](xs.length + 1)
@@ -264,7 +264,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Int` objects */
+  /** Creates an array of `Int` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
     val array = new Array[Int](xs.length + 1)
@@ -277,7 +277,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Long` objects */
+  /** Creates an array of `Long` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
     val array = new Array[Long](xs.length + 1)
@@ -290,7 +290,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Float` objects */
+  /** Creates an array of `Float` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
     val array = new Array[Float](xs.length + 1)
@@ -303,7 +303,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Double` objects */
+  /** Creates an array of `Double` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
     val array = new Array[Double](xs.length + 1)
@@ -316,7 +316,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Unit` objects */
+  /** Creates an array of `Unit` objects. */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
     array(0) = x
@@ -328,23 +328,23 @@ object Array {
     array
   }
 
-  /** Creates array with given dimensions */
+  /** Creates array with given dimensions. */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
-  /** Creates a 2-dimensional array */
+  /** Creates a 2-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
     for (i <- 0 until n1) arr(i) = new Array[T](n2)
     arr
     // tabulate(n1)(_ => ofDim[T](n2))
   }
-  /** Creates a 3-dimensional array */
+  /** Creates a 3-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
-  /** Creates a 4-dimensional array */
+  /** Creates a 4-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
-  /** Creates a 5-dimensional array */
+  /** Creates a 5-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
 
@@ -662,7 +662,7 @@ object Array {
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self =>
 
-  /** The length of the array */
+  /** The length of the array. */
   def length: Int = throw new Error()
 
   /** The element at given index.
@@ -676,7 +676,7 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
    */
   def apply(i: Int): T = throw new Error()
 
-  /** Update the element at given index.
+  /** Updates the element at given index.
    *
    *  Indices start at `0`; `xs.update(i, x)` replaces the i^th^ element in the array.
    *  Note the syntax `xs(i) = x` is a shorthand for `xs.update(i, x)`.
@@ -687,7 +687,7 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
    */
   def update(i: Int, x: T): Unit = { throw new Error() }
 
-  /** Clone the Array.
+  /** Clones the Array.
    *
    *  @return A clone of the Array.
    */

--- a/library-js/src/scala/Console.scala
+++ b/library-js/src/scala/Console.scala
@@ -138,15 +138,15 @@ object Console extends AnsiColor {
   protected def setErrDirect(err: PrintStream): Unit  = errVar.value = err
   protected def setInDirect(in: BufferedReader): Unit = inVar.value = in
 
-  /** The default output, can be overridden by `withOut`
+  /** The default output, can be overridden by `withOut`.
    *  @group io-default
    */
   def out = outVar.value
-  /** The default error, can be overridden by `withErr`
+  /** The default error, can be overridden by `withErr`.
    *  @group io-default
    */
   def err = errVar.value
-  /** The default input, can be overridden by `withIn`
+  /** The default input, can be overridden by `withIn`.
    *  @group io-default
    */
   def in = inVar.value
@@ -181,7 +181,7 @@ object Console extends AnsiColor {
   def withOut[T](out: OutputStream)(thunk: =>T): T =
     withOut(new PrintStream(out))(thunk)
 
-  /** Set the default error stream for the duration
+  /** Sets the default error stream for the duration
    *  of execution of one thunk.
    *  @example {{{
    *  withErr(Console.out) { err.println("This goes to default _out_") }

--- a/library-js/src/scala/Enumeration.scala
+++ b/library-js/src/scala/Enumeration.scala
@@ -149,7 +149,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
    */
   final def apply(x: Int): Value = vmap(x)
 
-  /** Return a `Value` from this `Enumeration` whose name matches
+  /** Returns a `Value` from this `Enumeration` whose name matches
    *  the argument `s`.  The names are determined automatically via reflection.
    *
    * @param  s an `Enumeration` name
@@ -207,9 +207,9 @@ abstract class Enumeration (initial: Int) extends Serializable {
   /** The type of the enumerated values. */
   @SerialVersionUID(7091335633555234129L)
   abstract class Value extends Ordered[Value] with Serializable {
-    /** the id and bit location of this enumeration value */
+    /** The id and bit location of this enumeration value. */
     def id: Int
-    /** a marker so we can tell whose values belong to whom come reflective-naming time */
+    /** A marker so we can tell whose values belong to whom come reflective-naming time. */
     private[Enumeration] val outerEnum = thisenum
 
     override def compare(that: Value): Int =
@@ -222,7 +222,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
     override def hashCode: Int = id.##
 
-    /** Create a ValueSet which contains this value and another one */
+    /** Creates a ValueSet which contains this value and another one. */
     def + (v: Value) = ValueSet(this, v)
   }
 
@@ -255,7 +255,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
   }
 
-  /** An ordering by id for values of this set */
+  /** An ordering by id for values of this set. */
   implicit object ValueOrdering extends Ordering[Value] {
     def compare(x: Value, y: Value): Int = x compare y
   }
@@ -308,18 +308,18 @@ abstract class Enumeration (initial: Int) extends Serializable {
       super[SortedSet].collect[B](pf)
   }
 
-  /** A factory object for value sets */
+  /** A factory object for value sets. */
   @SerialVersionUID(3L)
   object ValueSet extends SpecificIterableFactory[Value, ValueSet] {
     private final val ordMsg = "No implicit Ordering[${B}] found to build a SortedSet[${B}]. You may want to upcast to a Set[Value] first by calling `unsorted`."
     private final val zipOrdMsg = "No implicit Ordering[${B}] found to build a SortedSet[(Value, ${B})]. You may want to upcast to a Set[Value] first by calling `unsorted`."
 
-    /** The empty value set */
+    /** The empty value set. */
     val empty = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
-     *  corresponding to the bits in an array */
+     *  corresponding to the bits in an array. */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
-    /** A builder object for value sets */
+    /** A builder object for value sets. */
     def newBuilder: mutable.Builder[Value, ValueSet] = new mutable.Builder[Value, ValueSet] {
       private[this] val b = new mutable.BitSet
       def addOne (x: Value) = { b += (x.id - bottomId); this }

--- a/library-js/src/scala/collection/immutable/NumericRange.scala
+++ b/library-js/src/scala/collection/immutable/NumericRange.scala
@@ -93,13 +93,13 @@ sealed class NumericRange[T](
     else if(isInclusive) new NumericRange.Inclusive(start + step, end, step)
     else new NumericRange.Exclusive(start + step, end, step)
 
-  /** Create a new range with the start and end values of this range and
+  /** Creates a new range with the start and end values of this range and
     *  a new `step`.
     */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
 
-  /** Create a copy of this range.
+  /** Creates a copy of this range.
     */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)

--- a/library-js/src/scala/collection/immutable/Range.scala
+++ b/library-js/src/scala/collection/immutable/Range.scala
@@ -157,7 +157,7 @@ sealed abstract class Range(
   final protected def copy(start: Int = start, end: Int = end, step: Int = step, isInclusive: Boolean = isInclusive): Range =
     if(isInclusive) new Range.Inclusive(start, end, step) else new Range.Exclusive(start, end, step)
 
-  /** Create a new range with the `start` and `end` values of this range and
+  /** Creates a new range with the `start` and `end` values of this range and
     *  a new `step`.
     *
     *  @return a new range with a different step
@@ -364,7 +364,7 @@ sealed abstract class Range(
     if (isEmpty) this
     else new Range.Inclusive(last, start, -step)
 
-  /** Make range inclusive.
+  /** Makes range inclusive.
     */
   final def inclusive: Range =
     if (isInclusive) this
@@ -566,21 +566,21 @@ object Range {
   def count(start: Int, end: Int, step: Int): Int =
     count(start, end, step, isInclusive = false)
 
-  /** Make a range from `start` until `end` (exclusive) with given step value.
+  /** Makes a range from `start` until `end` (exclusive) with given step value.
     * @note step != 0
     */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
-  /** Make a range from `start` until `end` (exclusive) with step value 1.
+  /** Makes a range from `start` until `end` (exclusive) with step value 1.
     */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
-  /** Make an inclusive range from `start` to `end` with given step value.
+  /** Makes an inclusive range from `start` to `end` with given step value.
     * @note step != 0
     */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
-  /** Make an inclusive range from `start` to `end` with step value 1.
+  /** Makes an inclusive range from `start` to `end` with step value 1.
     */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 

--- a/library-js/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library-js/src/scala/collection/mutable/ArrayBuilder.scala
@@ -54,10 +54,10 @@ sealed abstract class ArrayBuilder[T]
 
   protected[this] def resize(size: Int): Unit
 
-  /** Add all elements of an array */
+  /** Adds all elements of an array. */
   def addAll(xs: Array[_ <: T]): this.type = addAll(xs, 0, xs.length)
 
-  /** Add a slice of an array */
+  /** Adds a slice of an array. */
   def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
     ensureSize(this.size + length)
     Array.copy(xs, offset, elems.nn, this.size, length)
@@ -146,7 +146,7 @@ object ArrayBuilder {
       this
     }
 
-    /** Add a slice of an array */
+    /** Adds a slice of an array. */
     override def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
       val end = offset + length
       var i = offset

--- a/library-js/src/scala/collection/mutable/Buffer.scala
+++ b/library-js/src/scala/collection/mutable/Buffer.scala
@@ -52,7 +52,7 @@ trait Buffer[A]
   @`inline` final def appendAll(xs: IterableOnce[A]): this.type = addAll(xs)
 
 
-  /** Alias for `prepend` */
+  /** Alias for `prepend`. */
   @`inline` final def +=: (elem: A): this.type = prepend(elem)
 
   def prependAll(elems: IterableOnce[A]): this.type = { insertAll(0, elems); this }
@@ -60,7 +60,7 @@ trait Buffer[A]
   @deprecated("Use prependAll instead", "2.13.0")
   @`inline` final def prepend(elems: A*): this.type = prependAll(elems)
 
-  /** Alias for `prependAll` */
+  /** Alias for `prependAll`. */
   @inline final def ++=:(elems: IterableOnce[A]): this.type = prependAll(elems)
 
   /** Inserts a new element at a given index into this buffer.

--- a/library-js/src/scala/reflect/ClassTag.scala
+++ b/library-js/src/scala/reflect/ClassTag.scala
@@ -61,10 +61,10 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
    */
   def runtimeClass: jClass[_]
 
-  /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]` */
+  /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]`. */
   def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
 
-  /** Produces a new array with element type `T` and length `len` */
+  /** Produces a new array with element type `T` and length `len`. */
   def newArray(len: Int): Array[T] =
     java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
 

--- a/library-js/src/scala/runtime/ScalaRunTime.scala
+++ b/library-js/src/scala/runtime/ScalaRunTime.scala
@@ -39,7 +39,7 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Return the class object representing an array with element class `clazz`.
+  /** Returns the class object representing an array with element class `clazz`.
    */
   def arrayClass(clazz: jClass[_]): jClass[_] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
@@ -47,14 +47,14 @@ object ScalaRunTime {
     else java.lang.reflect.Array.newInstance(clazz, 0).getClass
   }
 
-  /** Return the class object representing an unboxed value type,
+  /** Returns the class object representing an unboxed value type,
    *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
    *  rewrites expressions like 5.getClass to come here.
    */
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
-  /** Retrieve generic array element */
+  /** Retrieves generic array element. */
   def array_apply(xs: AnyRef, idx: Int): Any = {
     xs match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
@@ -70,7 +70,7 @@ object ScalaRunTime {
     }
   }
 
-  /** update generic array element */
+  /** Updates generic array element. */
   def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
     xs match {
       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
@@ -86,7 +86,7 @@ object ScalaRunTime {
     }
   }
 
-  /** Get generic array length */
+  /** Gets generic array length. */
   @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
@@ -104,7 +104,7 @@ object ScalaRunTime {
     case null => throw new NullPointerException
   }
 
-  /** Convert an array to an object array.
+  /** Converts an array to an object array.
    *  Needed to deal with vararg arguments of primitive types that are passed
    *  to a generic Java vararg parameter T ...
    */

--- a/library-js/src/scala/scalajs/js/internal/UnitOps.scala
+++ b/library-js/src/scala/scalajs/js/internal/UnitOps.scala
@@ -2,7 +2,7 @@ package scala.scalajs.js.internal
 
 import scala.scalajs.js
 
-/** Under -scalajs, this object is part of the implicit scope of `scala.Unit` */
+/** Under -scalajs, this object is part of the implicit scope of `scala.Unit`. */
 object UnitOps:
   implicit def unitOrOps[A](x: A | Unit): js.UndefOrOps[A] =
     new js.UndefOrOps(x)

--- a/library-js/src/scala/util/DynamicVariable.scala
+++ b/library-js/src/scala/util/DynamicVariable.scala
@@ -50,10 +50,10 @@ class DynamicVariable[T](init: T) {
    */
   private[this] var v = init
 
-  /** Retrieve the current value */
+  /** Retrieves the current value. */
   def value: T = v
 
-  /** Set the value of the variable while executing the specified
+  /** Sets the value of the variable while executing the specified
     * thunk.
     *
     * @param newval The value to which to set the variable
@@ -67,7 +67,7 @@ class DynamicVariable[T](init: T) {
     finally v = oldval
   }
 
-  /** Change the currently bound value, discarding the old value.
+  /** Changes the currently bound value, discarding the old value.
     * Usually withValue() gives better semantics.
     */
   def value_=(newval: T) = v = newval

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -46,7 +46,7 @@ object Array {
   val emptyShortArray   = new Array[Short](0)
   val emptyObjectArray  = new Array[Object](0)
 
-  /** Provides an implicit conversion from the Array object to a collection Factory */
+  /** Provides an implicit conversion from the Array object to a collection Factory. */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
   private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
@@ -59,7 +59,7 @@ object Array {
    */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
-  /** Build an array from the iterable collection.
+  /** Builds an array from the iterable collection.
    *
    *  {{{
    *  scala> val a = Array.from(Seq(1, 5))
@@ -92,7 +92,7 @@ object Array {
     }
   }
 
-  /** Copy one array to another.
+  /** Copies one array to another.
    *  Equivalent to Java's
    *    `System.arraycopy(src, srcPos, dest, destPos, length)`,
    *  except that this also works for polymorphic and boxed arrays.
@@ -117,7 +117,7 @@ object Array {
       slowcopy(src, srcPos, dest, destPos, length)
   }
 
-  /** Copy one array to another, truncating or padding with default values (if
+  /** Copies one array to another, truncating or padding with default values (if
     * necessary) so the copy has the specified length.
     *
     * Equivalent to Java's
@@ -139,7 +139,7 @@ object Array {
     case original: Array[Boolean]    => java.util.Arrays.copyOf(original, newLength)
   }).asInstanceOf[Array[A]]
 
-  /** Copy one array to another, truncating or padding with default values (if
+  /** Copies one array to another, truncating or padding with default values (if
     * necessary) so the copy has the specified length. The new array can have
     * a different type than the original one as long as the values are
     * assignment-compatible. When copying between primitive and object arrays,
@@ -177,7 +177,7 @@ object Array {
     result
   }
 
-  /** Returns an array of length 0 */
+  /** Returns an array of length 0. */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
   /** Creates an array with given elements.
@@ -207,7 +207,7 @@ object Array {
     }
   }
 
-  /** Creates an array of `Boolean` objects */
+  /** Creates an array of `Boolean` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
     val array = new Array[Boolean](xs.length + 1)
@@ -220,7 +220,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Byte` objects */
+  /** Creates an array of `Byte` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
     val array = new Array[Byte](xs.length + 1)
@@ -233,7 +233,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Short` objects */
+  /** Creates an array of `Short` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
     val array = new Array[Short](xs.length + 1)
@@ -246,7 +246,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Char` objects */
+  /** Creates an array of `Char` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
     val array = new Array[Char](xs.length + 1)
@@ -259,7 +259,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Int` objects */
+  /** Creates an array of `Int` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
     val array = new Array[Int](xs.length + 1)
@@ -272,7 +272,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Long` objects */
+  /** Creates an array of `Long` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
     val array = new Array[Long](xs.length + 1)
@@ -285,7 +285,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Float` objects */
+  /** Creates an array of `Float` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
     val array = new Array[Float](xs.length + 1)
@@ -298,7 +298,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Double` objects */
+  /** Creates an array of `Double` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
     val array = new Array[Double](xs.length + 1)
@@ -311,7 +311,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Unit` objects */
+  /** Creates an array of `Unit` objects. */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
     array(0) = x
@@ -323,23 +323,23 @@ object Array {
     array
   }
 
-  /** Creates array with given dimensions */
+  /** Creates array with given dimensions. */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
-  /** Creates a 2-dimensional array */
+  /** Creates a 2-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
     for (i <- 0 until n1) arr(i) = new Array[T](n2)
     arr
     // tabulate(n1)(_ => ofDim[T](n2))
   }
-  /** Creates a 3-dimensional array */
+  /** Creates a 3-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
-  /** Creates a 4-dimensional array */
+  /** Creates a 4-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
-  /** Creates a 5-dimensional array */
+  /** Creates a 5-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
 
@@ -551,7 +551,7 @@ object Array {
     }
   }
 
-  /** Compare two arrays per element.
+  /** Compares two arrays per element.
    *
    *  A more efficient version of `xs.sameElements(ys)`.
    *
@@ -662,7 +662,7 @@ object Array {
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self: Array[T] =>
 
-  /** The length of the array */
+  /** The length of the array. */
   def length: Int = throw new Error()
 
   /** The element at given index.
@@ -676,7 +676,7 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
    */
   def apply(i: Int): T = throw new Error()
 
-  /** Update the element at given index.
+  /** Updates the element at given index.
    *
    *  Indices start at `0`; `xs.update(i, x)` replaces the i^th^ element in the array.
    *  Note the syntax `xs(i) = x` is a shorthand for `xs.update(i, x)`.
@@ -687,7 +687,7 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
    */
   def update(i: Int, x: T): Unit = { throw new Error() }
 
-  /** Clone the Array.
+  /** Clones the Array.
    *
    *  @return A clone of the Array.
    */

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -476,9 +476,9 @@ object Byte extends AnyValCompanion {
    */
   def unbox(x: java.lang.Object): Byte = ???
 
-  /** The String representation of the scala.Byte companion object. */
+  /** The `String` representation of the `scala.Byte` companion object. */
   override def toString() = "object scala.Byte"
-  /** Language mandated coercions from Byte to "wider" types. */
+  /** Language mandated coercions from `Byte` to "wider" types. */
   import scala.language.implicitConversions
   implicit def byte2short(x: Byte): Short = x.toShort
   implicit def byte2int(x: Byte): Int = x.toInt

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -476,9 +476,9 @@ object Char extends AnyValCompanion {
    */
   def unbox(x: java.lang.Object): Char = ???
 
-  /** The String representation of the scala.Char companion object. */
+  /** The `String` representation of the `scala.Char` companion object. */
   override def toString() = "object scala.Char"
-  /** Language mandated coercions from Char to "wider" types. */
+  /** Language mandated coercions from `Char` to "wider" types. */
   import scala.language.implicitConversions
   implicit def char2int(x: Char): Int = x.toInt
   implicit def char2long(x: Char): Long = x.toLong

--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -135,15 +135,15 @@ object Console extends AnsiColor {
   protected def setErrDirect(err: PrintStream): Unit  = errVar.value = err
   protected def setInDirect(in: BufferedReader): Unit = inVar.value = in
 
-  /** The default output, can be overridden by `withOut`
+  /** The default output, can be overridden by `withOut`.
    *  @group io-default
    */
   def out: PrintStream = outVar.value
-  /** The default error, can be overridden by `withErr`
+  /** The default error, can be overridden by `withErr`.
    *  @group io-default
    */
   def err: PrintStream = errVar.value
-  /** The default input, can be overridden by `withIn`
+  /** The default input, can be overridden by `withIn`.
    *  @group io-default
    */
   def in: BufferedReader = inVar.value
@@ -178,7 +178,7 @@ object Console extends AnsiColor {
   def withOut[T](out: OutputStream)(thunk: => T): T =
     withOut(new PrintStream(out))(thunk)
 
-  /** Set the default error stream for the duration
+  /** Sets the default error stream for the duration
    *  of execution of one thunk.
    *  @example {{{
    *  withErr(Console.out) { err.println("This goes to default _out_") }

--- a/library/src/scala/Conversion.scala
+++ b/library/src/scala/Conversion.scala
@@ -27,11 +27,11 @@ import annotation.internal.preview
 @java.lang.FunctionalInterface
 abstract class Conversion[-T, +U] extends Function1[T, U]:
   self =>
-    /** Convert value `x` of type `T` to type `U` */
+    /** Converts value `x` of type `T` to type `U`. */
     def apply(x: T): U
 
     extension (x: T)
-      /** `x.convert` converts a value `x` of type `T` to type `U` */
+      /** `x.convert` converts a value `x` of type `T` to type `U`. */
       def convert = this(x)
 
 object Conversion:
@@ -45,7 +45,7 @@ object Conversion:
   @preview
   opaque type into[+T] >: T = T
 
-  /** Unwrap an `into` */
+  /** Unwraps an `into`. */
   extension [T](x: into[T])
     @preview
     def underlying: T = x

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -251,7 +251,7 @@ object Double extends AnyValCompanion {
    */
   def unbox(x: java.lang.Object): Double = ???
 
-  /** The String representation of the scala.Double companion object. */
+  /** The `String` representation of the `scala.Double` companion object. */
   override def toString() = "object scala.Double"
 }
 

--- a/library/src/scala/Enumeration.scala
+++ b/library/src/scala/Enumeration.scala
@@ -149,11 +149,11 @@ abstract class Enumeration (initial: Int) extends Serializable {
     *  values in this enumeration. */
   final def maxId = topId
 
-  /** The value of this enumeration with given id `x`
+  /** The value of this enumeration with given id `x`.
    */
   final def apply(x: Int): Value = vmap(x)
 
-  /** Return a `Value` from this `Enumeration` whose name matches
+  /** Returns a `Value` from this `Enumeration` whose name matches
    *  the argument `s`.  The names are determined automatically via reflection.
    *
    * @param  s an `Enumeration` name
@@ -228,9 +228,9 @@ abstract class Enumeration (initial: Int) extends Serializable {
   /** The type of the enumerated values. */
   @SerialVersionUID(7091335633555234129L)
   abstract class Value extends Ordered[Value] with Serializable {
-    /** the id and bit location of this enumeration value */
+    /** The id and bit location of this enumeration value. */
     def id: Int
-    /** a marker so we can tell whose values belong to whom come reflective-naming time */
+    /** A marker so we can tell whose values belong to whom come reflective-naming time. */
     private[Enumeration] val outerEnum = thisenum
 
     override def compare(that: Value): Int =
@@ -243,7 +243,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
     override def hashCode(): Int = id.##
 
-    /** Create a ValueSet which contains this value and another one */
+    /** Creates a ValueSet which contains this value and another one. */
     def + (v: Value): ValueSet = ValueSet(this, v)
   }
 
@@ -276,7 +276,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
   }
 
-  /** An ordering by id for values of this set */
+  /** An ordering by id for values of this set. */
   implicit object ValueOrdering extends Ordering[Value] {
     def compare(x: Value, y: Value): Int = x compare y
   }
@@ -332,18 +332,18 @@ abstract class Enumeration (initial: Int) extends Serializable {
     @transient private[Enumeration] lazy val byName: Map[String, Value] = iterator.map( v => v.toString -> v).toMap
   }
 
-  /** A factory object for value sets */
+  /** A factory object for value sets. */
   @SerialVersionUID(3L)
   object ValueSet extends SpecificIterableFactory[Value, ValueSet] {
     private final val ordMsg = "No implicit Ordering[${B}] found to build a SortedSet[${B}]. You may want to upcast to a Set[Value] first by calling `unsorted`."
     private final val zipOrdMsg = "No implicit Ordering[${B}] found to build a SortedSet[(Value, ${B})]. You may want to upcast to a Set[Value] first by calling `unsorted`."
 
-    /** The empty value set */
+    /** The empty value set. */
     val empty: ValueSet = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
      *  corresponding to the bits in an array */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
-    /** A builder object for value sets */
+    /** A builder object for value sets. */
     def newBuilder: mutable.Builder[Value, ValueSet] = new mutable.Builder[Value, ValueSet] {
       private val b = new mutable.BitSet
       def addOne (x: Value) = { b += (x.id - bottomId); this }

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -251,9 +251,9 @@ object Float extends AnyValCompanion {
    */
   def unbox(x: java.lang.Object): Float = ???
 
-  /** The String representation of the scala.Float companion object. */
+  /** The `String` representation of the `scala.Float` companion object. */
   override def toString() = "object scala.Float"
-  /** Language mandated coercions from Float to "wider" types. */
+  /** Language mandated coercions from `Float` to "wider" types. */
   import scala.language.implicitConversions
   implicit def float2double(x: Float): Double = x.toDouble
 }

--- a/library/src/scala/Function.scala
+++ b/library/src/scala/Function.scala
@@ -24,7 +24,7 @@ object Function {
    */
   def chain[T](fs: scala.collection.Seq[T => T]): T => T = { x => fs.foldLeft(x)((x, f) => f(x)) }
 
-  /** The constant function */
+  /** The constant function. */
   def const[T, U](x: T)(y: U): T = x
 
   /** Turns a function `A => Option[B]` into a `PartialFunction[A, B]`.

--- a/library/src/scala/Function0.scala
+++ b/library/src/scala/Function0.scala
@@ -37,7 +37,7 @@ import scala.language.`2.13`
  *  }}}
  */
 trait Function0[@specialized(Specializable.Primitives) +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(): R

--- a/library/src/scala/Function1.scala
+++ b/library/src/scala/Function1.scala
@@ -66,7 +66,7 @@ object Function1 {
  */
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
 trait Function1[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends AnyRef {
-  /** Apply the body of this function to the argument.
+  /** Applies the body of this function to the argument.
    *  @return   the result of function application.
    */
   def apply(v1: T1): R

--- a/library/src/scala/Function10.scala
+++ b/library/src/scala/Function10.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10): R

--- a/library/src/scala/Function11.scala
+++ b/library/src/scala/Function11.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11): R

--- a/library/src/scala/Function12.scala
+++ b/library/src/scala/Function12.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12): R

--- a/library/src/scala/Function13.scala
+++ b/library/src/scala/Function13.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13): R

--- a/library/src/scala/Function14.scala
+++ b/library/src/scala/Function14.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14): R

--- a/library/src/scala/Function15.scala
+++ b/library/src/scala/Function15.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15): R

--- a/library/src/scala/Function16.scala
+++ b/library/src/scala/Function16.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16): R

--- a/library/src/scala/Function17.scala
+++ b/library/src/scala/Function17.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17): R

--- a/library/src/scala/Function18.scala
+++ b/library/src/scala/Function18.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18): R

--- a/library/src/scala/Function19.scala
+++ b/library/src/scala/Function19.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19): R

--- a/library/src/scala/Function2.scala
+++ b/library/src/scala/Function2.scala
@@ -35,7 +35,7 @@ import scala.language.`2.13`
  *  }}}
  */
 trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable.Args) -T2, @specialized(Specializable.Return) +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2): R

--- a/library/src/scala/Function20.scala
+++ b/library/src/scala/Function20.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20): R

--- a/library/src/scala/Function21.scala
+++ b/library/src/scala/Function21.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21): R

--- a/library/src/scala/Function22.scala
+++ b/library/src/scala/Function22.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, -T22, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21, v22: T22): R

--- a/library/src/scala/Function3.scala
+++ b/library/src/scala/Function3.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function3[-T1, -T2, -T3, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3): R

--- a/library/src/scala/Function4.scala
+++ b/library/src/scala/Function4.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function4[-T1, -T2, -T3, -T4, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4): R

--- a/library/src/scala/Function5.scala
+++ b/library/src/scala/Function5.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function5[-T1, -T2, -T3, -T4, -T5, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): R

--- a/library/src/scala/Function6.scala
+++ b/library/src/scala/Function6.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function6[-T1, -T2, -T3, -T4, -T5, -T6, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): R

--- a/library/src/scala/Function7.scala
+++ b/library/src/scala/Function7.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7): R

--- a/library/src/scala/Function8.scala
+++ b/library/src/scala/Function8.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8): R

--- a/library/src/scala/Function9.scala
+++ b/library/src/scala/Function9.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  */
 trait Function9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends AnyRef {
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9): R

--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -30,7 +30,7 @@ object IArray:
   extension [T <: Object](arr: IArray[T]) def apply (n: Int): T = arr.asInstanceOf[Array[T]].apply(n)
   extension [T](arr: IArray[T]) def apply (n: Int): T = arr.asInstanceOf[Array[T]].apply(n)
 
-  /** The number of elements in an immutable array
+  /** The number of elements in an immutable array.
     *  @param arr  the immutable array
     */
   extension (arr: IArray[Byte]) def length: Int = arr.asInstanceOf[Array[Byte]].length
@@ -48,19 +48,19 @@ object IArray:
   extension [T](arr: IArray[T]) def contains(elem: T): Boolean =
     genericArrayOps(arr).contains(elem.asInstanceOf)
 
-  /** Copy elements of this array to another array. */
+  /** Copies elements of this array to another array. */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U]): Int =
     genericArrayOps(arr).copyToArray(xs)
 
-  /** Copy elements of this array to another array. */
+  /** Copies elements of this array to another array. */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U], start: Int): Int =
     genericArrayOps(arr).copyToArray(xs, start)
 
-  /** Copy elements of this array to another array. */
+  /** Copies elements of this array to another array. */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U], start: Int, len: Int): Int =
     genericArrayOps(arr).copyToArray(xs, start, len)
 
-  /** Counts the number of elements in this array which satisfy a predicate */
+  /** Counts the number of elements in this array which satisfy a predicate. */
   extension [T](arr: IArray[T]) def count(p: T => Boolean): Int =
     genericArrayOps(arr).count(p)
 
@@ -120,7 +120,7 @@ object IArray:
   extension [T](arr: IArray[T]) def forall(p: T => Boolean): Boolean =
     genericArrayOps(arr).forall(p)
 
-  /** Apply `f` to each element for its side effects. */
+  /** Applies `f` to each element for its side effects. */
   extension [T](arr: IArray[T]) def foreach[U](f: T => U): Unit =
     genericArrayOps(arr).foreach(f)
 
@@ -341,11 +341,11 @@ object IArray:
   // We intentionally keep this signature to discourage passing nulls implicitly while
   // preserving the previous behavior for backward compatibility.
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def genericWrapArray[T](arr: IArray[T]): ArraySeq[T] =
     mapNull(arr, ArraySeq.unsafeWrapArray(arr))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapRefArray[T <: AnyRef | Null](arr: IArray[T]): ArraySeq.ofRef[T] =
     // Since the JVM thinks arrays are covariant, one 0-length Array[AnyRef | Null]
     // is as good as another for all T <: AnyRef | Null.  Instead of creating 100,000,000
@@ -355,43 +355,43 @@ object IArray:
       else ArraySeq.ofRef(arr.asInstanceOf[Array[T]])
     )
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapIntArray(arr: IArray[Int]): ArraySeq.ofInt =
     mapNull(arr, new ArraySeq.ofInt(arr.asInstanceOf[Array[Int]]))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapDoubleIArray(arr: IArray[Double]): ArraySeq.ofDouble =
     mapNull(arr, new ArraySeq.ofDouble(arr.asInstanceOf[Array[Double]]))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapLongIArray(arr: IArray[Long]): ArraySeq.ofLong =
     mapNull(arr, new ArraySeq.ofLong(arr.asInstanceOf[Array[Long]]))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapFloatIArray(arr: IArray[Float]): ArraySeq.ofFloat =
     mapNull(arr, new ArraySeq.ofFloat(arr.asInstanceOf[Array[Float]]))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapCharIArray(arr: IArray[Char]): ArraySeq.ofChar =
     mapNull(arr, new ArraySeq.ofChar(arr.asInstanceOf[Array[Char]]))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapByteIArray(arr: IArray[Byte]): ArraySeq.ofByte =
     mapNull(arr, new ArraySeq.ofByte(arr.asInstanceOf[Array[Byte]]))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapShortIArray(arr: IArray[Short]): ArraySeq.ofShort =
     mapNull(arr, new ArraySeq.ofShort(arr.asInstanceOf[Array[Short]]))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapBooleanIArray(arr: IArray[Boolean]): ArraySeq.ofBoolean =
     mapNull(arr, new ArraySeq.ofBoolean(arr.asInstanceOf[Array[Boolean]]))
 
-  /** Conversion from IArray to immutable.ArraySeq */
+  /** Conversion from IArray to immutable.ArraySeq. */
   implicit def wrapUnitIArray(arr: IArray[Unit]): ArraySeq.ofUnit =
     mapNull(arr, new ArraySeq.ofUnit(arr.asInstanceOf[Array[Unit]]))
 
-  /** Convert an array into an immutable array without copying, the original array
+  /** Converts an array into an immutable array without copying, the original array
    *   must _not_ be mutated after this or the guaranteed immutablity of IArray will
    *   be violated.
    */
@@ -440,7 +440,7 @@ object IArray:
   /** An immutable array with given elements. */
   def apply(x: Unit, xs: Unit*): IArray[Unit] = Array(x, xs*)
 
-  /** Build an array from the iterable collection.
+  /** Builds an array from the iterable collection.
    *
    *  {{{
    *  scala> val a = IArray.from(Seq(1, 5))
@@ -607,7 +607,7 @@ object IArray:
    */
   def iterate[T: ClassTag](start: T, len: Int)(f: T => T): IArray[T] = Array.iterate(start, len)(f)
 
-  /** Compare two arrays per element.
+  /** Compares two arrays per element.
    *
    *  A more efficient version of `xs.sameElements(ys)`.
    *
@@ -630,7 +630,7 @@ object IArray:
   /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
   class WithFilter[T](p: T => Boolean, xs: IArray[T]):
 
-    /** Apply `f` to each element for its side effects.
+    /** Applies `f` to each element for its side effects.
       * Note: [U] parameter needed to help scalac's type inference.
       */
     def foreach[U](f: T => U): Unit = {

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -476,9 +476,9 @@ object Int extends AnyValCompanion {
    */
   def unbox(x: java.lang.Object): Int = ???
 
-  /** The String representation of the scala.Int companion object. */
+  /** The `String` representation of the `scala.Int` companion object. */
   override def toString() = "object scala.Int"
-  /** Language mandated coercions from Int to "wider" types. */
+  /** Language mandated coercions from `Int` to "wider" types. */
   import scala.language.implicitConversions
   @deprecated("Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.", "2.13.1")
   implicit def int2float(x: Int): Float = x.toFloat

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -446,10 +446,10 @@ final abstract class Long private extends AnyVal {
 }
 
 object Long extends AnyValCompanion {
-  /** The smallest value representable as a Long. */
+  /** The smallest value representable as a `Long`. */
   final val MinValue = java.lang.Long.MIN_VALUE
 
-  /** The largest value representable as a Long. */
+  /** The largest value representable as a `Long`. */
   final val MaxValue = java.lang.Long.MAX_VALUE
 
   /** Transforms a value type into a boxed reference type.
@@ -473,9 +473,9 @@ object Long extends AnyValCompanion {
    */
   def unbox(x: java.lang.Object): Long = ???
 
-  /** The String representation of the scala.Long companion object. */
+  /** The `String` representation of the `scala.Long` companion object. */
   override def toString() = "object scala.Long"
-  /** Language mandated coercions from Long to "wider" types. */
+  /** Language mandated coercions from `Long` to "wider" types. */
   import scala.language.implicitConversions
   @deprecated("Implicit conversion from Long to Float is dangerous because it loses precision. Write `.toFloat` instead.", "2.13.1")
   implicit def long2float(x: Long): Float = x.toFloat

--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -13,7 +13,7 @@ object NamedTuple:
    */
   opaque type NamedTuple[N <: Tuple, +V <: Tuple] >: V <: AnyNamedTuple = V
 
-  /** A type which is a supertype of all named tuples */
+  /** A type which is a supertype of all named tuples. */
   opaque type AnyNamedTuple = Any
 
   def apply[N <: Tuple, V <: Tuple](x: V): NamedTuple[N, V] = x
@@ -37,7 +37,7 @@ object NamedTuple:
   extension [N <: Tuple, V <: Tuple](x: NamedTuple[N, V])
 
     // ALL METHODS DEPENDING ON `toTuple` MUST BE EXPORTED FROM `NamedTupleDecomposition`
-    /** The underlying tuple without the names */
+    /** The underlying tuple without the names. */
     inline def toTuple: V = x
 
     // This intentionally works for empty named tuples as well. I think NonEmptyTuple is a dead end
@@ -49,22 +49,22 @@ object NamedTuple:
 
   end extension
 
-  /** The size of a named tuple, represented as a literal constant subtype of Int */
+  /** The size of a named tuple, represented as a literal constant subtype of `Int`. */
   type Size[X <: AnyNamedTuple] = Tuple.Size[DropNames[X]]
 
-  /** The type of the element value at position N in the named tuple X */
+  /** The type of the element value at position N in the named tuple X. */
   type Elem[X <: AnyNamedTuple, N <: Int] = Tuple.Elem[DropNames[X], N]
 
-  /** The type of the first element value of a named tuple */
+  /** The type of the first element value of a named tuple. */
   type Head[X <: AnyNamedTuple] = Elem[X, 0]
 
-  /** The type of the last element value of a named tuple */
+  /** The type of the last element value of a named tuple. */
   type Last[X <: AnyNamedTuple] = Tuple.Last[DropNames[X]]
 
-  /** The type of a named tuple consisting of all elements of named tuple X except the first one */
+  /** The type of a named tuple consisting of all elements of named tuple X except the first one. */
   type Tail[X <: AnyNamedTuple] = Drop[X, 1]
 
-  /** The type of the initial part of a named tuple without its last element */
+  /** The type of the initial part of a named tuple without its last element. */
   type Init[X <: AnyNamedTuple] =
     NamedTuple[Tuple.Init[Names[X]], Tuple.Init[DropNames[X]]]
 
@@ -83,7 +83,7 @@ object NamedTuple:
   /** The pair type `(Take(X, N), Drop[X, N]). */
   type Split[X <: AnyNamedTuple, N <: Int] = (Take[X, N], Drop[X, N])
 
-  /** Type of the concatenation of two tuples `X` and `Y` */
+  /** The type of the concatenation of two tuples `X` and `Y`. */
   type Concat[X <: AnyNamedTuple, Y <: AnyNamedTuple] =
     NamedTuple[Tuple.Concat[Names[X], Names[Y]], Tuple.Concat[DropNames[X], DropNames[Y]]]
 
@@ -93,7 +93,7 @@ object NamedTuple:
   type Map[X <: AnyNamedTuple, F[_ <: Tuple.Union[DropNames[X]]]] =
     NamedTuple[Names[X], Tuple.Map[DropNames[X], F]]
 
-  /** A named tuple with the elements of tuple `X` in reversed order */
+  /** A named tuple with the elements of tuple `X` in reversed order. */
   type Reverse[X <: AnyNamedTuple] =
     NamedTuple[Tuple.Reverse[Names[X]], Tuple.Reverse[DropNames[X]]]
 
@@ -125,13 +125,13 @@ object NamedTuple:
    */
   type From[T] <: AnyNamedTuple
 
-  /** The type of the empty named tuple */
+  /** The type of the empty named tuple. */
   type Empty = NamedTuple[EmptyTuple, EmptyTuple]
 
-  /** The empty named tuple */
+  /** The empty named tuple. */
   val Empty: Empty = EmptyTuple
 
-  /** The ordering instance for named tuples */
+  /** The ordering instance for named tuples. */
   given namedTupleOrdering: [N <: Tuple, V <: Tuple] => (ord: Ordering[V]) => Ordering[NamedTuple[N, V]]:
     def compare(x: NamedTuple[N, V], y: NamedTuple[N, V]): Int =
       ord.compare(x.toTuple, y.toTuple)
@@ -141,24 +141,24 @@ end NamedTuple
 object NamedTupleDecomposition:
   import NamedTuple.*
   extension [N <: Tuple, V <: Tuple](x: NamedTuple[N, V])
-      /** The value (without the name) at index `n` of this tuple */
+      /** The value (without the name) at index `n` of this tuple. */
     inline def apply(n: Int): Elem[NamedTuple[N, V], n.type] =
       x.toTuple.apply(n).asInstanceOf[Elem[NamedTuple[N, V], n.type]]
 
-    /** The number of elements in this tuple */
+    /** The number of elements in this tuple. */
     inline def size: Size[NamedTuple[N, V]] = x.toTuple.size
 
-    /** The first element value of this tuple */
+    /** The first element value of this tuple. */
     inline def head: Head[NamedTuple[N, V]] = apply(0)
 
-    /** The last element value of this tuple */
+    /** The last element value of this tuple. */
     inline def last: Last[NamedTuple[N, V]] = apply(size - 1).asInstanceOf[Last[NamedTuple[N, V]]]
 
-    /** The tuple consisting of all elements of this tuple except the last one */
+    /** The tuple consisting of all elements of this tuple except the last one. */
     inline def init: Init[NamedTuple[N, V]] =
       x.take(size - 1).asInstanceOf[Init[NamedTuple[N, V]]]
 
-    /** The tuple consisting of all elements of this tuple except the first one */
+    /** The tuple consisting of all elements of this tuple except the first one. */
     inline def tail: Tail[NamedTuple[N, V]] = x.toTuple.drop(1)
 
     /** The tuple consisting of the first `n` elements of this tuple, or all
@@ -171,7 +171,7 @@ object NamedTupleDecomposition:
      */
     inline def drop(n: Int): Drop[NamedTuple[N, V], n.type] = x.toTuple.drop(n)
 
-    /** The tuple `(x.take(n), x.drop(n))` */
+    /** The tuple `(x.take(n), x.drop(n))`. */
     inline def splitAt(n: Int): Split[NamedTuple[N, V], n.type] = x.toTuple.splitAt(n)
 
     /** The tuple consisting of all elements of this tuple followed by all elements
@@ -188,7 +188,7 @@ object NamedTupleDecomposition:
     inline def map[F[_]](f: [t] => t => F[t]): Map[NamedTuple[N, V], F] =
       x.toTuple.map[F](f)
 
-    /** The named tuple consisting of all elements of this tuple in reverse */
+    /** The named tuple consisting of all elements of this tuple in reverse. */
     inline def reverse: Reverse[NamedTuple[N, V]] = x.toTuple.reverse
 
     /** The named tuple consisting of all element values of this tuple zipped
@@ -201,13 +201,13 @@ object NamedTupleDecomposition:
     inline def zip[V2 <: Tuple](that: NamedTuple[N, V2]): Zip[NamedTuple[N, V], NamedTuple[N, V2]] =
       x.toTuple.zip(that.toTuple)
 
-    /** A list consisting of all element values */
+    /** A list consisting of all element values. */
     inline def toList: List[Tuple.Union[V]] = x.toTuple.toList
 
-    /** An array consisting of all element values */
+    /** An array consisting of all element values. */
     inline def toArray: Array[Object] = x.toTuple.toArray
 
-    /** An immutable array consisting of all element values */
+    /** An immutable array consisting of all element values. */
     inline def toIArray: IArray[Object] = x.toTuple.toIArray
 
     /** An immutable map consisting of all element values preserving the order of fields.

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -18,7 +18,7 @@ object Option {
 
   import scala.language.implicitConversions
 
-  /** An implicit conversion that converts an option to an iterable value */
+  /** An implicit conversion that converts an option to an iterable value. */
   implicit def option2Iterable[A](xo: Option[A]): Iterable[A] =
     if (xo.isEmpty) Iterable.empty else Iterable.single(xo.get)
 
@@ -36,14 +36,14 @@ object Option {
   def empty[A] : Option[A] = None
 
   /** When a given condition is true, evaluates the `a` argument and returns
-   *  Some(a). When the condition is false, `a` is not evaluated and None is
+   *  `Some(a)`. When the condition is false, `a` is not evaluated and `None` is
    *  returned.
    */
   def when[A](cond: Boolean)(a: => A): Option[A] =
     if (cond) Some(a) else None
 
   /** Unless a given condition is true, this will evaluate the `a` argument and
-   *  return Some(a). Otherwise, `a` is not evaluated and None is returned.
+   *  return `Some(a)`. Otherwise, `a` is not evaluated and `None` is returned.
    */
   @inline def unless[A](cond: Boolean)(a: => A): Option[A] =
     when(!cond)(a)
@@ -421,7 +421,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    */
   @inline final def forall(p: A => Boolean): Boolean = isEmpty || p(this.get)
 
-  /** Apply the given procedure $f to the option's value,
+  /** Applies the given procedure $f to the option's value,
    *  if it is nonempty. Otherwise, do nothing.
    *
    * This is equivalent to:

--- a/library/src/scala/PartialFunction.scala
+++ b/library/src/scala/PartialFunction.scala
@@ -405,8 +405,8 @@ object PartialFunction {
    */
   def cond[A](x: A)(pf: PartialFunction[A, Boolean]^): Boolean = pf.applyOrElse(x, constFalse)
 
-  /** Apply the function to the given value if defined, and return the result
-   *  in a `Some`; otherwise, return `None`.
+  /** Applies the function to the given value if defined, and returns the result
+   *  in a `Some`; otherwise, returns `None`.
    *
    *  @param  x     the value to test
    *  @param  pf    the PartialFunction[T, U]

--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -107,7 +107,7 @@ import scala.runtime.ScalaRunTime.mapNull
  */
 object Predef extends LowPriorityImplicits {
   /**
-   * Retrieve the runtime representation of a class type. `classOf[T]` is equivalent to
+   * Retrieves the runtime representation of a class type. `classOf[T]` is equivalent to
    * the class literal `T.class` in Java.
    *
    * @example {{{
@@ -124,7 +124,7 @@ object Predef extends LowPriorityImplicits {
   def classOf[T]: Class[T] = null.asInstanceOf[Class[T]] // This is a stub method. The actual implementation is filled in by the compiler.
 
   /**
-   * Retrieve the single value of a type with a unique inhabitant.
+   * Retrieves the single value of a type with a unique inhabitant.
    *
    * @example {{{
    * object Foo
@@ -139,7 +139,7 @@ object Predef extends LowPriorityImplicits {
   @inline def valueOf[T](implicit vt: ValueOf[T]): T = vt.value
 
   /**
-   * Retrieve the single value of a type with a unique inhabitant.
+   * Retrieves the single value of a type with a unique inhabitant.
    *
    * @example {{{
    * object Foo

--- a/library/src/scala/ScalaReflectionException.scala
+++ b/library/src/scala/ScalaReflectionException.scala
@@ -2,7 +2,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** An exception that indicates an error during Scala reflection */
+/** An exception that indicates an error during Scala reflection. */
 case class ScalaReflectionException(msg: String) extends Exception(msg)
 
 object ScalaReflectionException extends scala.runtime.AbstractFunction1[String, ScalaReflectionException]:

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -476,9 +476,9 @@ object Short extends AnyValCompanion {
    */
   def unbox(x: java.lang.Object): Short = ???
 
-  /** The String representation of the scala.Short companion object. */
+  /** The `String` representation of the `scala.Short` companion object. */
   override def toString() = "object scala.Short"
-  /** Language mandated coercions from Short to "wider" types. */
+  /** Language mandated coercions from `Short` to "wider" types. */
   import scala.language.implicitConversions
   implicit def short2int(x: Short): Int = x.toInt
   implicit def short2long(x: Short): Long = x.toLong

--- a/library/src/scala/StringContext.scala
+++ b/library/src/scala/StringContext.scala
@@ -205,7 +205,7 @@ object StringContext {
     * @param patternChunks The non-wildcard portions of the input pattern,
     *                      separated by wildcards
     * @param input The input you wish to match against
-    * @return None if there is no match, Some containing the sequence of matched
+    * @return `None` if there is no match, `Some` containing the sequence of matched
     *         wildcard strings if there is a match 
     */
   def glob(patternChunks: Seq[String], input: String): Option[Seq[String]] = {

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -5,64 +5,64 @@ import annotation.showAsInfix
 import compiletime.*
 import compiletime.ops.int.*
 
-/** Tuple of arbitrary arity */
+/** Tuple of arbitrary arity. */
 sealed trait Tuple extends Product {
   import Tuple.*
 
-  /** Create a copy of this tuple as an Array */
+  /** Creates a copy of this tuple as an Array. */
   inline def toArray: Array[Object] =
     runtime.Tuples.toArray(this)
 
-  /** Create a copy of this tuple as a List */
+  /** Creates a copy of this tuple as a List. */
   inline def toList: List[Union[this.type]] =
     this.productIterator.toList
       .asInstanceOf[List[Union[this.type]]]
 
-  /** Create a copy of this tuple as an IArray */
+  /** Creates a copy of this tuple as an IArray. */
   inline def toIArray: IArray[Object] =
     runtime.Tuples.toIArray(this)
 
-  /** Return a copy of `this` tuple with an element appended */
+  /** Returns a copy of `this` tuple with an element appended. */
   inline def :* [This >: this.type <: Tuple, L] (x: L): This :* L =
     runtime.Tuples.append(x, this).asInstanceOf[This :* L]
 
-  /** Return a new tuple by prepending the element to `this` tuple.
+  /** Returns a new tuple by prepending the element to `this` tuple.
    *  This operation is O(this.size)
    */
   inline def *: [H, This >: this.type <: Tuple] (x: H): H *: This =
     runtime.Tuples.cons(x, this).asInstanceOf[H *: This]
 
-  /** Get the i-th element of this tuple.
+  /** Gets the i-th element of this tuple.
    *  Equivalent to productElement but with a precise return type.
    */
   inline def apply[This >: this.type <: Tuple](n: Int): Elem[This, n.type] =
     runtime.Tuples.apply(this, n).asInstanceOf[Elem[This, n.type]]
 
-  /** Get the head of this tuple */
+  /** Gets the head of this tuple. */
   inline def head[This >: this.type <: Tuple]: Head[This] =
     runtime.Tuples.apply(this, 0).asInstanceOf[Head[This]]
 
-  /** Get the initial part of the tuple without its last element */
+  /** Gets the initial part of the tuple without its last element. */
   inline def init[This >: this.type <: Tuple]: Init[This] =
     runtime.Tuples.init(this).asInstanceOf[Init[This]]
 
-  /** Get the last of this tuple */
+  /** Gets the last of this tuple. */
   inline def last[This >: this.type <: Tuple]: Last[This] =
     runtime.Tuples.last(this).asInstanceOf[Last[This]]
 
-  /** Get the tail of this tuple.
+  /** Gets the tail of this tuple.
    *  This operation is O(this.size)
    */
   inline def tail[This >: this.type <: Tuple]: Tail[This] =
     runtime.Tuples.tail(this).asInstanceOf[Tail[This]]
 
-  /** Return a new tuple by concatenating `this` tuple with `that` tuple.
+  /** Returns a new tuple by concatenating `this` tuple with `that` tuple.
    *  This operation is O(this.size + that.size)
    */
   inline def ++ [This >: this.type <: Tuple](that: Tuple): This ++ that.type =
     runtime.Tuples.concat(this, that).asInstanceOf[This ++ that.type]
 
-  /** Return the size (or arity) of the tuple */
+  /** Returns the size (or arity) of the tuple. */
   inline def size[This >: this.type <: Tuple]: Size[This] =
     runtime.Tuples.size(this).asInstanceOf[Size[This]]
 
@@ -113,48 +113,48 @@ sealed trait Tuple extends Product {
 
 object Tuple {
 
-  /** Type of a tuple with an element appended */
+  /** Type of a tuple with an element appended. */
   type Append[X <: Tuple, Y] <: NonEmptyTuple = X match {
     case EmptyTuple => Y *: EmptyTuple
     case x *: xs => x *: Append[xs, Y]
   }
 
-  /** An infix shorthand for `Append[X, Y]` */
+  /** An infix shorthand for `Append[X, Y]`. */
   infix type :*[X <: Tuple, Y] = Append[X, Y]
 
-  /** Type of the head of a tuple */
+  /** Type of the head of a tuple. */
   type Head[X <: Tuple] = X match {
     case x *: _ => x
   }
 
-  /** Type of the initial part of the tuple without its last element */
+  /** Type of the initial part of the tuple without its last element. */
   type Init[X <: Tuple] <: Tuple = X match {
     case _ *: EmptyTuple => EmptyTuple
     case x *: xs =>
       x *: Init[xs]
   }
 
-  /** Type of the tail of a tuple */
+  /** Type of the tail of a tuple. */
   type Tail[X <: Tuple] <: Tuple = X match {
     case _ *: xs => xs
   }
 
-  /** Type of the last element of a tuple */
+  /** Type of the last element of a tuple. */
   type Last[X <: Tuple] = X match {
     case x *: EmptyTuple => x
     case _ *: xs => Last[xs]
   }
 
-  /** Type of the concatenation of two tuples */
+  /** Type of the concatenation of two tuples. */
   type Concat[X <: Tuple, +Y <: Tuple] <: Tuple = X match {
     case EmptyTuple => Y
     case x1 *: xs1 => x1 *: Concat[xs1, Y]
   }
 
-  /** An infix shorthand for `Concat[X, Y]` */
+  /** An infix shorthand for `Concat[X, Y]`. */
   infix type ++[X <: Tuple, +Y <: Tuple] = Concat[X, Y]
 
-  /** Type of the element at position N in the tuple X */
+  /** Type of the element at position N in the tuple X. */
   type Elem[X <: Tuple, N <: Int] = X match {
     case x *: xs =>
       N match {
@@ -163,24 +163,24 @@ object Tuple {
       }
   }
 
-  /** Literal constant Int size of a tuple */
+  /** Literal constant Int size of a tuple. */
   type Size[X <: Tuple] <: Int = X match {
     case EmptyTuple => 0
     case x *: xs => S[Size[xs]]
   }
 
-  /** Fold a tuple `(T1, ..., Tn)` into `F[T1, F[... F[Tn, Z]...]]]` */
+  /** Folds a tuple `(T1, ..., Tn)` into `F[T1, F[... F[Tn, Z]...]]]`. */
   type Fold[Tup <: Tuple, Z, F[_, _]] = Tup match
     case EmptyTuple => Z
     case h *: t => F[h, Fold[t, Z, F]]
 
-  /** Converts a tuple `(T1, ..., Tn)` to `(F[T1], ..., F[Tn])` */
+  /** Converts a tuple `(T1, ..., Tn)` to `(F[T1], ..., F[Tn])`. */
   type Map[Tup <: Tuple, F[_ <: Union[Tup]]] <: Tuple = Tup match {
     case EmptyTuple => EmptyTuple
     case h *: t => F[h] *: Map[t, F]
   }
 
-  /** Converts a tuple `(T1, ..., Tn)` to a flattened `(..F[T1], ..., ..F[Tn])` */
+  /** Converts a tuple `(T1, ..., Tn)` to a flattened `(..F[T1], ..., ..F[Tn])`. */
   type FlatMap[Tup <: Tuple, F[_ <: Union[Tup]] <: Tuple] <: Tuple = Tup match {
     case EmptyTuple => EmptyTuple
     case h *: t => Concat[F[h], FlatMap[t, F]]
@@ -214,7 +214,7 @@ object Tuple {
     case _ => EmptyTuple
   }
 
-  /** Converts a tuple `(F[T1], ..., F[Tn])` to `(T1,  ... Tn)` */
+  /** Converts a tuple `(F[T1], ..., F[Tn])` to `(T1,  ... Tn)`. */
   type InverseMap[X <: Tuple, F[_]] <: Tuple = X match {
     case F[x] *: t => x *: InverseMap[t, F]
     case EmptyTuple => EmptyTuple
@@ -227,10 +227,10 @@ object Tuple {
    */
   type IsMappedBy[F[_]] = [X <: Tuple] =>> X =:= Map[InverseMap[X, F], F]
 
-  /** Type of the reversed tuple */
+  /** Type of the reversed tuple. */
   type Reverse[X <: Tuple] = ReverseOnto[X, EmptyTuple]
 
-  /** Prepends all elements of a tuple in reverse order onto the other tuple */
+  /** Prepends all elements of a tuple in reverse order onto the other tuple. */
   type ReverseOnto[From <: Tuple, +To <: Tuple] <: Tuple = From match
     case x *: xs => ReverseOnto[xs, x *: To]
     case EmptyTuple => To
@@ -282,16 +282,16 @@ object Tuple {
       case false => Disjoint[xs, Y]
     case EmptyTuple => true
 
-  /** Empty tuple */
+  /** Empty tuple. */
   def apply(): EmptyTuple = EmptyTuple
 
-  /** Tuple with one element */
+  /** Tuple with one element. */
   def apply[T](x: T): T *: EmptyTuple = Tuple1(x)
 
   /** Matches an empty tuple. */
   def unapply(x: EmptyTuple): true = true
 
-  /** Convert an array into a tuple of unknown arity and types */
+  /** Converts an array into a tuple of unknown arity and types. */
   def fromArray[T](xs: Array[T]): Tuple = {
     val xs2 = xs match {
       case xs: Array[Object] => xs
@@ -300,7 +300,7 @@ object Tuple {
     runtime.Tuples.fromArray(xs2)
   }
 
-  /** Convert an immutable array into a tuple of unknown arity and types */
+  /** Converts an immutable array into a tuple of unknown arity and types. */
   def fromIArray[T](xs: IArray[T]): Tuple = {
     val xs2: IArray[Object] = xs match {
       case xs: IArray[Object] @unchecked => xs
@@ -310,7 +310,7 @@ object Tuple {
     runtime.Tuples.fromIArray(xs2)
   }
 
-  /** Convert a Product into a tuple of unknown arity and types */
+  /** Converts a Product into a tuple of unknown arity and types. */
   def fromProduct(product: Product): Tuple =
     runtime.Tuples.fromProduct(product)
 
@@ -323,7 +323,7 @@ object Tuple {
   ): CanEqual[H1 *: T1, H2 *: T2] = CanEqual.derived
 }
 
-/** A tuple of 0 elements */
+/** A tuple of 0 elements. */
 type EmptyTuple = EmptyTuple.type
 
 /** A tuple of 0 elements. */
@@ -331,7 +331,7 @@ case object EmptyTuple extends Tuple {
   override def toString(): String = "()"
 }
 
-/** Tuple of arbitrary non-zero arity */
+/** Tuple of arbitrary non-zero arity. */
 sealed trait NonEmptyTuple extends Tuple
 
 @showAsInfix

--- a/library/src/scala/Unit.scala
+++ b/library/src/scala/Unit.scala
@@ -54,7 +54,7 @@ object Unit extends AnyValCompanion {
    */
   def unbox(x: java.lang.Object): Unit = x.asInstanceOf[scala.runtime.BoxedUnit]
 
-  /** The String representation of the scala.Unit companion object. */
+  /** The `String` representation of the `scala.Unit` companion object. */
   override def toString() = "object scala.Unit"
 }
 

--- a/library/src/scala/annotation/MacroAnnotation.scala
+++ b/library/src/scala/annotation/MacroAnnotation.scala
@@ -16,7 +16,7 @@ import scala.quoted.*
 @experimental
 trait MacroAnnotation extends StaticAnnotation:
 
-  /** Transform the `tree` definition and add new definitions
+  /** Transforms the `tree` definition and adds new definitions
    *
    *  This method takes as argument the annotated definition.
    *  It returns a non-empty list containing the modified version of the annotated definition.

--- a/library/src/scala/annotation/internal/AnnotationDefault.scala
+++ b/library/src/scala/annotation/internal/AnnotationDefault.scala
@@ -4,7 +4,7 @@ import language.experimental.captureChecking
 
 import scala.annotation.Annotation
 
-/** An annotation to tag Java annotation default values */
+/** An annotation to tag Java annotation default values. */
 class AnnotationDefault extends Annotation {
 
 }

--- a/library/src/scala/annotation/internal/ErasedParam.scala
+++ b/library/src/scala/annotation/internal/ErasedParam.scala
@@ -3,5 +3,5 @@ package internal
 
 import language.experimental.captureChecking
 
-/** An annotation produced by Namer to indicate an erased parameter */
+/** An annotation produced by Namer to indicate an erased parameter. */
 final class ErasedParam() extends Annotation

--- a/library/src/scala/annotation/internal/InlineParam.scala
+++ b/library/src/scala/annotation/internal/InlineParam.scala
@@ -4,5 +4,5 @@ import language.experimental.captureChecking
 
 import scala.annotation.Annotation
 
-/** An annotation produced by Namer to indicate an inline parameter */
+/** An annotation produced by Namer to indicate an inline parameter. */
 final class InlineParam() extends Annotation

--- a/library/src/scala/annotation/internal/ProvisionalSuperClass.scala
+++ b/library/src/scala/annotation/internal/ProvisionalSuperClass.scala
@@ -3,6 +3,6 @@ package internal
 
 import language.experimental.captureChecking
 
-/** An annotation to record a provisional super class */
+/** An annotation to record a provisional super class. */
 class ProvisionalSuperClass extends StaticAnnotation
 

--- a/library/src/scala/caps/package.scala
+++ b/library/src/scala/caps/package.scala
@@ -98,13 +98,13 @@ trait Unscoped extends Stateful, Classifier
 @experimental
 trait Mutable extends Stateful, Separate, Unscoped
 
-/** Marker trait for classes with reader methods, typically extended by Mutable classes */
+/** Marker trait for classes with reader methods, typically extended by Mutable classes. */
 @experimental
 @deprecated
 trait Read extends Mutable
 
 
-/** Carrier trait for capture set type parameters */
+/** Carrier trait for capture set type parameters. */
 @experimental
 trait CapSet extends Any
 
@@ -233,7 +233,7 @@ object unsafe:
    */
   def unsafeAssumeSeparate(op: Any): op.type = op
 
-  /** A wrapper around code for which uses go unrecorded */
+  /** A wrapper around code for which uses go unrecorded. */
   def unsafeDiscardUses(op: Any): op.type = op
 
   /** An unsafe variant of erasedValue that can be used as an escape hatch. Unlike the

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -66,7 +66,7 @@ object ArrayOps {
   /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
   class WithFilter[A](p: A => Boolean, xs: Array[A]) {
 
-    /** Apply `f` to each element for its side effects.
+    /** Applies `f` to each element for its side effects.
       * Note: [U] parameter needed to help scalac's type inference.
       */
     def foreach[U](f: A => U): Unit = {
@@ -1317,7 +1317,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     }
   }
 
-  /** Apply `f` to each element for its side effects.
+  /** Applies `f` to each element for its side effects.
     * Note: [U] parameter needed to help scalac's type inference.
     */
   def foreach[U](f: A => U): Unit = {
@@ -1440,7 +1440,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   def toIndexedSeq: immutable.IndexedSeq[A] =
     immutable.ArraySeq.unsafeWrapArray(Array.copyOf(xs, xs.length))
 
-  /** Copy elements of this array to another array.
+  /** Copies elements of this array to another array.
     *  Fills the given array `xs` starting at index 0.
     *  Copying will stop once either all the elements of this array have been copied,
     *  or the end of the array is reached.
@@ -1450,7 +1450,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     */
   def copyToArray[B >: A](xs: Array[B]): Int = copyToArray(xs, 0)
 
-  /** Copy elements of this array to another array.
+  /** Copies elements of this array to another array.
     *  Fills the given array `xs` starting at index `start`.
     *  Copying will stop once either all the elements of this array have been copied,
     *  or the end of the array is reached.
@@ -1461,7 +1461,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     */
   def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray(xs, start, Int.MaxValue)
 
-  /** Copy elements of this array to another array.
+  /** Copies elements of this array to another array.
     *  Fills the given array `xs` starting at index `start` with at most `len` values.
     *  Copying will stop once either all the elements of this array have been copied,
     *  or the end of the array is reached, or `len` elements have been copied.
@@ -1479,7 +1479,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     copied
   }
 
-  /** Create a copy of this array with the specified element type. */
+  /** Creates a copy of this array with the specified element type. */
   def toArray[B >: A: ClassTag]: Array[B] = {
     val destination = new Array[B](xs.length)
     @annotation.unused val copied = copyToArray(destination, 0)
@@ -1487,7 +1487,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     destination
   }
 
-  /** Counts the number of elements in this array which satisfy a predicate */
+  /** Counts the number of elements in this array which satisfy a predicate. */
   def count(p: A => Boolean): Int = {
     var i, res = 0
     val len = xs.length

--- a/library/src/scala/collection/BitSet.scala
+++ b/library/src/scala/collection/BitSet.scala
@@ -84,7 +84,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   }
 }
 
-/** Base implementation type of bitsets */
+/** Base implementation type of bitsets. */
 transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] { self =>
   import BitSetOps._
@@ -95,7 +95,7 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
 
   final def ordering: Ordering[Int] = Ordering.Int
 
-  /** The number of words (each with 64 bits) making up the set */
+  /** The number of words (each with 64 bits) making up the set. */
   protected[collection] def nwords: Int
 
   /** The words at index `idx`, or 0L if outside the range of the set
@@ -293,7 +293,7 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
   @`inline` final def ^ (other: BitSet): C = xor(other)
 
   /**
-    * Builds a new bitset by applying a function to all elements of this bitset
+    * Builds a new bitset by applying a function to all elements of this bitset.
     * @param f the function to apply to each element.
     * @return a new bitset resulting from applying the given function ''f'' to
     *         each element of this bitset and collecting the results

--- a/library/src/scala/collection/BuildFrom.scala
+++ b/library/src/scala/collection/BuildFrom.scala
@@ -31,14 +31,14 @@ import scala.reflect.ClassTag
 trait BuildFrom[-From, -A, +C] extends Any { self =>
   def fromSpecific(from: From)(it: IterableOnce[A]^): C^{it}
 
-  /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
+  /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
     * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
   def newBuilder(from: From): Builder[A, C]
 
   @deprecated("Use newBuilder() instead of apply()", "2.13.0")
   @`inline` def apply(from: From): Builder[A, C] = newBuilder(from)
 
-  /** Partially apply a BuildFrom to a Factory */
+  /** Partially apply a BuildFrom to a Factory. */
   def toFactory(from: From): Factory[A, C] = new Factory[A, C] {
     def fromSpecific(it: IterableOnce[A]^): C^{it} = self.fromSpecific(from)(it)
     def newBuilder: Builder[A, C] = self.newBuilder(from)
@@ -47,14 +47,14 @@ trait BuildFrom[-From, -A, +C] extends Any { self =>
 
 object BuildFrom extends BuildFromLowPriority1 {
 
-  /** Build the source collection type from a MapOps */
+  /** Builds the source collection type from a MapOps. */
   implicit def buildFromMapOps[CC[X, Y] <: Map[X, Y] & MapOps[X, Y, CC, ?], K0, V0, K, V]: BuildFrom[CC[K0, V0] & Map[K0, V0], (K, V), CC[K, V] & Map[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
     //TODO: Reuse a prototype instance
     def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = (from: MapOps[K0, V0, CC, ?]).mapFactory.newBuilder[K, V]
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]^): CC[K, V] = (from: MapOps[K0, V0, CC, ?]).mapFactory.from(it)
   }
 
-  /** Build the source collection type from a SortedMapOps */
+  /** Builds the source collection type from a SortedMapOps. */
   implicit def buildFromSortedMapOps[CC[X, Y] <: SortedMap[X, Y] & SortedMapOps[X, Y, CC, ?], K0, V0, K : Ordering, V]: BuildFrom[CC[K0, V0] & SortedMap[K0, V0], (K, V), CC[K, V] & SortedMap[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
     def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = (from: SortedMapOps[K0, V0, CC, ?]).sortedMapFactory.newBuilder[K, V]
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]^): CC[K, V] = (from: SortedMapOps[K0, V0, CC, ?]).sortedMapFactory.from(it)
@@ -94,7 +94,7 @@ object BuildFrom extends BuildFromLowPriority1 {
 
 trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 
-  /** Build the source collection type from an Iterable with SortedOps */
+  /** Builds the source collection type from an Iterable with SortedOps. */
   // Restating the upper bound of CC in the result type seems redundant, but it serves to prune the
   // implicit search space for faster compilation and reduced change of divergence. See the compilation
   // test in test/junit/scala/collection/BuildFromTest.scala and discussion in https://github.com/scala/scala/pull/10209
@@ -111,7 +111,7 @@ trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 }
 
 trait BuildFromLowPriority2 {
-  /** Build the source collection type from an IterableOps */
+  /** Builds the source collection type from an IterableOps. */
   implicit def buildFromIterableOps[CC[X] <: Iterable[X] & IterableOps[X, CC, ?], A0, A]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
     //TODO: Reuse a prototype instance
     def newBuilder(from: CC[A0]): Builder[A, CC[A]] = (from: IterableOps[A0, CC, ?]).iterableFactory.newBuilder[A]

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -41,7 +41,7 @@ trait Factory[-A, +C] extends Any { self =>
     */
   def fromSpecific(it: IterableOnce[A]^): C^{it}
 
-  /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
+  /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
     * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
   def newBuilder: Builder[A, C]
 }
@@ -93,7 +93,7 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     */
   def from[A](source: IterableOnce[A]^): CC[A]^{source}
 
-  /** An empty $coll
+  /** An empty $coll.
     * @tparam A      the type of the ${coll}'s elements
     */
   def empty[A]: CC[A]
@@ -263,7 +263,7 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 object IterableFactory {
 
   /**
-    * Fixes the element type of `factory` to `A`
+    * Fixes the element type of `factory` to `A`.
     * @param factory The factory to fix the element type
     * @tparam A Type of elements
     * @tparam CC Collection type constructor of the factory (e.g. `Seq`, `List`)
@@ -387,7 +387,7 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
 trait MapFactory[+CC[_, _]] extends Serializable { self =>
 
   /**
-   * An empty Map
+   * An empty Map.
    */
   def empty[K, V]: CC[K, V]
 
@@ -415,7 +415,7 @@ trait MapFactory[+CC[_, _]] extends Serializable { self =>
 object MapFactory {
 
   /**
-    * Fixes the key and value types of `factory` to `K` and `V`, respectively
+    * Fixes the key and value types of `factory` to `K` and `V`, respectively.
     * @param factory The factory to fix the key and value types
     * @tparam K Type of keys
     * @tparam V Type of values
@@ -508,7 +508,7 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
 object EvidenceIterableFactory {
 
   /**
-    * Fixes the element type of `factory` to `A`
+    * Fixes the element type of `factory` to `A`.
     * @param factory The factory to fix the element type
     * @tparam A Type of elements
     * @tparam CC Collection type constructor of the factory (e.g. `TreeSet`)

--- a/library/src/scala/collection/IndexedSeq.scala
+++ b/library/src/scala/collection/IndexedSeq.scala
@@ -21,7 +21,7 @@ import scala.collection.Searching.{Found, InsertionPoint, SearchResult}
 import scala.collection.Stepper.EfficientSplit
 import scala.math.Ordering
 
-/** Base trait for indexed sequences that have efficient `apply` and `length` */
+/** Base trait for indexed sequences that have efficient `apply` and `length`. */
 trait IndexedSeq[+A] extends Seq[A]
   with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
   with IterableFactoryDefaults[A, IndexedSeq] {
@@ -34,7 +34,7 @@ trait IndexedSeq[+A] extends Seq[A]
 @SerialVersionUID(3L)
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](immutable.IndexedSeq)
 
-/** Base trait for indexed Seq operations */
+/** Base trait for indexed Seq operations. */
 transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self: IndexedSeqOps[A, CC, C]^ =>
 
   def iterator: Iterator[A]^{this} = view.iterator

--- a/library/src/scala/collection/IndexedSeqView.scala
+++ b/library/src/scala/collection/IndexedSeqView.scala
@@ -19,7 +19,7 @@ import language.experimental.captureChecking
 import scala.annotation.nowarn
 
 
-/** View defined in terms of indexing a range */
+/** View defined in terms of indexing a range. */
 trait IndexedSeqView[+A] extends IndexedSeqOps[A, View, View[A]] with SeqView[A] {
 
   override def view: IndexedSeqView[A]^{this} = this
@@ -120,7 +120,7 @@ object IndexedSeqView {
     }
   }
 
-  /** An `IndexedSeqOps` whose collection type and collection type constructor are unknown */
+  /** An `IndexedSeqOps` whose collection type and collection type constructor are unknown. */
   type SomeIndexedSeqOps[A] = IndexedSeqOps[A, AnyConstr, ?]
 
   @SerialVersionUID(3L)

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -735,7 +735,7 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     }
   }
 
-  /** Alias for `concat` */
+  /** Alias for `concat`. */
   @inline final def ++ [B >: A](suffix: IterableOnce[B]^): CC[B]^{this, suffix} = concat(suffix)
 
   /** Returns a $ccoll formed from this $coll and another iterable collection

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -59,11 +59,11 @@ trait IterableOnce[+A] extends Any { this: IterableOnce[A]^ =>
 
   /** Returns a [[scala.collection.Stepper]] for the elements of this collection.
     *
-    * The Stepper enables creating a Java stream to operate on the collection, see
-    * [[scala.jdk.StreamConverters]]. For collections holding primitive values, the Stepper can be
+    * The `Stepper` enables creating a Java stream to operate on the collection, see
+    * [[scala.jdk.StreamConverters]]. For collections holding primitive values, the `Stepper` can be
     * used as an iterator which doesn't box the elements.
     *
-    * The implicit [[scala.collection.StepperShape]] parameter defines the resulting Stepper type according to the
+    * The implicit [[scala.collection.StepperShape]] parameter defines the resulting `Stepper` type according to the
     * element type of this collection.
     *
     *   - For collections of `Int`, `Short`, `Byte` or `Char`, an [[scala.collection.IntStepper]] is returned
@@ -72,9 +72,9 @@ trait IterableOnce[+A] extends Any { this: IterableOnce[A]^ =>
     *   - For any other element type, an [[scala.collection.AnyStepper]] is returned
     *
     * Note that this method is overridden in subclasses and the return type is refined to
-    * `S with EfficientSplit`, for example [[scala.collection.IndexedSeqOps.stepper]]. For Steppers marked with
+    * `S with EfficientSplit`, for example [[scala.collection.IndexedSeqOps.stepper]]. For `Stepper`s marked with
     * [[scala.collection.Stepper.EfficientSplit]], the converters in [[scala.jdk.StreamConverters]]
-    * allow creating parallel streams, whereas bare Steppers can be converted only to sequential
+    * allow creating parallel streams, whereas bare `Stepper`s can be converted only to sequential
     * streams.
     */
   def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S^{this} = {

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -78,7 +78,7 @@ import caps.unsafe.untrackedCaptures
 trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Iterator[A]] {
   self: Iterator[A]^ =>
 
-  /** Check if there is a next element available.
+  /** Checks if there is a next element available.
     *
     * @return `true` if there is a next element, `false` otherwise
     * @note   Reuse: $preservesIterator
@@ -88,7 +88,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   @deprecated("hasDefiniteSize on Iterator is the same as isEmpty", "2.13.0")
   @`inline` override final def hasDefiniteSize = isEmpty
 
-  /** Return the next element and advance the iterator.
+  /** Returns the next element and advance the iterator.
     *
     * @throws NoSuchElementException if there is no next element.
     * @return the next element.
@@ -218,11 +218,11 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
       this
     }
 
-    /** Eagerly fetch `size` elements to buffer.
+    /** Eagerly fetches `size` elements to buffer.
      *
      *  If buffer is dirty and stepping, copy prefix.
      *  If skipping, skip ahead.
-     *  Fetch remaining elements.
+     *  Fetches remaining elements.
      *  If unable to deliver size, then pad if padding enabled, otherwise drop segment.
      *  Returns true if successful in delivering `count` elements,
      *  or padded segment, or partial segment.
@@ -602,7 +602,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 
   def flatMap[B](f: A => IterableOnce[B]^): Iterator[B]^{this, f} = new AbstractIterator[B] {
     private var cur: Iterator[B]^{f} = Iterator.empty
-    /** Trillium logic boolean: -1 = unknown, 0 = false, 1 = true */
+    /** Trillium logic boolean: -1 = unknown, 0 = false, 1 = true. */
     private var _hasNext: Int = -1
 
     def nextCur(): Unit = {
@@ -1138,7 +1138,7 @@ object Iterator extends IterableFactory[Iterator] {
     *             the end of the collection)
     * @tparam A   Type of the elements
     * @tparam S   Type of the internal state
-    * @return an Iterator that produces elements using `f` until `f` returns `None`
+    * @return an `Iterator` that produces elements using `f` until `f` returns `None`
     */
   override def unfold[A, S](init: S)(f: S => Option[(A, S)]): Iterator[A]^{f} = new UnfoldIterator(init)(f)
 

--- a/library/src/scala/collection/JavaConverters.scala
+++ b/library/src/scala/collection/JavaConverters.scala
@@ -306,33 +306,33 @@ object JavaConverters extends AsJavaConverters with AsScalaConverters {
     new AsScala(propertiesAsScalaMap(p))
 
 
-  /** Generic class containing the `asJava` converter method */
+  /** Generic class containing the `asJava` converter method. */
   class AsJava[A](op: => A) {
-    /** Converts a Scala collection to the corresponding Java collection */
+    /** Converts a Scala collection to the corresponding Java collection. */
     def asJava: A = op
   }
 
-  /** Generic class containing the `asScala` converter method */
+  /** Generic class containing the `asScala` converter method. */
   class AsScala[A](op: => A) {
-    /** Converts a Java collection to the corresponding Scala collection */
+    /** Converts a Java collection to the corresponding Scala collection. */
     def asScala: A = op
   }
 
-  /** Generic class containing the `asJavaCollection` converter method */
+  /** Generic class containing the `asJavaCollection` converter method. */
   class AsJavaCollection[A](i: Iterable[A]) {
-    /** Converts a Scala `Iterable` to a Java `Collection` */
+    /** Converts a Scala `Iterable` to a Java `Collection`. */
     def asJavaCollection: ju.Collection[A] = JavaConverters.asJavaCollection(i)
   }
 
-  /** Generic class containing the `asJavaEnumeration` converter method */
+  /** Generic class containing the `asJavaEnumeration` converter method. */
   class AsJavaEnumeration[A](i: Iterator[A]) {
-    /** Converts a Scala `Iterator` to a Java `Enumeration` */
+    /** Converts a Scala `Iterator` to a Java `Enumeration`. */
     def asJavaEnumeration: ju.Enumeration[A] = JavaConverters.asJavaEnumeration(i)
   }
 
-  /** Generic class containing the `asJavaDictionary` converter method */
+  /** Generic class containing the `asJavaDictionary` converter method. */
   class AsJavaDictionary[K, V](m : mutable.Map[K, V]) {
-    /** Converts a Scala `Map` to a Java `Dictionary` */
+    /** Converts a Scala `Map` to a Java `Dictionary`. */
     def asJavaDictionary: ju.Dictionary[K, V] = JavaConverters.asJavaDictionary(m)
   }
 }

--- a/library/src/scala/collection/LinearSeq.scala
+++ b/library/src/scala/collection/LinearSeq.scala
@@ -34,7 +34,7 @@ trait LinearSeq[+A] extends Seq[A]
 @SerialVersionUID(3L)
 object LinearSeq extends SeqFactory.Delegate[LinearSeq](immutable.LinearSeq)
 
-/** Base trait for linear Seq operations */
+/** Base trait for linear Seq operations. */
 transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & LinearSeqOps[A, CC, C]] extends Any with SeqOps[A, CC, C] with caps.Pure { self =>
 
   /** @inheritdoc

--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -21,7 +21,7 @@ import scala.collection.generic.DefaultSerializable
 import scala.collection.mutable.StringBuilder
 import scala.util.hashing.MurmurHash3
 
-/** Base Map type */
+/** Base Map type. */
 trait Map[K, +V]
   extends Iterable[(K, V)]
     with MapOps[K, V, Map, Map[K, V]]
@@ -268,7 +268,7 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
     def next() = iter.next()._2
   }
 
-  /** Apply `f` to each key/value pair for its side effects
+  /** Applies `f` to each key/value pair for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.
    */
   def foreachEntry[U](f: (K, V) => U): Unit = {
@@ -370,7 +370,7 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
 
   // Not final because subclasses refine the result type, e.g. in SortedMap, the result type is
   // SortedMap's CC, while Map's CC is fixed to Map
-  /** Alias for `concat` */
+  /** Alias for `concat`. */
   /*@`inline` final*/ def ++ [V2 >: V](xs: collection.IterableOnce[(K, V2)]^): CC[K, V2]^{this, xs} = concat(xs)
 
   override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type =

--- a/library/src/scala/collection/MapView.scala
+++ b/library/src/scala/collection/MapView.scala
@@ -76,9 +76,9 @@ trait MapView[K, +V]
 
 object MapView extends MapViewFactory {
 
-  /** An `IterableOps` whose collection type and collection type constructor are unknown */
+  /** An `IterableOps` whose collection type and collection type constructor are unknown. */
   type SomeIterableConstr[X, Y] = IterableOps[?, AnyConstr, ?]
-  /** A `MapOps` whose collection type and collection type constructor are (mostly) unknown */
+  /** A `MapOps` whose collection type and collection type constructor are (mostly) unknown. */
   type SomeMapOps[K, +V] = MapOps[K, V, SomeIterableConstr, ?]
 
   @SerialVersionUID(3L)

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -1129,7 +1129,7 @@ object SeqOps {
     }
   }
 
-  /** Make sure a target sequence has fast, correctly-ordered indexing for KMP.
+  /** Makes sure a target sequence has fast, correctly-ordered indexing for KMP.
    *
    *  @param  W    The target sequence
    *  @param  n0   The first element in the target sequence that we should use
@@ -1167,7 +1167,7 @@ object SeqOps {
       }
   }
 
- /** Make a jump table for KMP search.
+ /** Makes a jump table for KMP search.
    *
    *  @param  Wopt The target sequence
    *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized

--- a/library/src/scala/collection/SeqView.scala
+++ b/library/src/scala/collection/SeqView.scala
@@ -46,10 +46,10 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
 
 object SeqView {
 
-  /** A `SeqOps` whose collection type and collection type constructor are unknown */
+  /** A `SeqOps` whose collection type and collection type constructor are unknown. */
   private type SomeSeqOps[+A] = SeqOps[A, AnyConstr, ?]
 
-  /** A view that doesn’t apply any transformation to an underlying sequence */
+  /** A view that doesn't apply any transformation to an underlying sequence. */
   @SerialVersionUID(3L)
   class Id[+A](underlying: SomeSeqOps[A]^) extends AbstractSeqView[A] {
     def apply(idx: Int): A = underlying.apply(idx)

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -189,7 +189,7 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     */
   def intersect(that: Set[A]): C = this.filter(that)
 
-  /** Alias for `intersect` */
+  /** Alias for `intersect`. */
   @`inline` final def & (that: Set[A]): C = intersect(that)
 
   /** Computes the difference of this set and another set.
@@ -200,7 +200,7 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     */
   def diff(that: Set[A]): C
 
-  /** Alias for `diff` */
+  /** Alias for `diff`. */
   @`inline` final def &~ (that: Set[A]): C = this diff that
 
   @deprecated("Consider requiring an immutable Set", "2.13.0")
@@ -245,7 +245,7 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   def + (elem1: A, elem2: A, elems: A*): C = fromSpecific(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
 
-  /** Alias for `concat` */
+  /** Alias for `concat`. */
   @`inline` final def ++ (that: collection.IterableOnce[A]^): C = concat(that)
 
   /** Computes the union between of set and another set.
@@ -256,7 +256,7 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     */
   @`inline` final def union(that: Set[A]): C = concat(that)
 
-  /** Alias for `union` */
+  /** Alias for `union`. */
   @`inline` final def | (that: Set[A]): C = concat(that)
 }
 

--- a/library/src/scala/collection/SortedMap.scala
+++ b/library/src/scala/collection/SortedMap.scala
@@ -18,7 +18,7 @@ import language.experimental.captureChecking
 
 import scala.annotation.{implicitNotFound, nowarn}
 
-/** A Map whose keys are sorted according to a [[scala.math.Ordering]]*/
+/** A Map whose keys are sorted according to a [[scala.math.Ordering]]. */
 trait SortedMap[K, +V]
   extends Map[K, V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
@@ -109,13 +109,13 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
   def firstKey: K = head._1
   def lastKey: K = last._1
 
-  /** Find the element with smallest key larger than or equal to a given key.
+  /** Finds the element with smallest key larger than or equal to a given key.
     * @param key The given key.
     * @return `None` if there is no such node.
     */
   def minAfter(key: K): Option[(K, V)] = rangeFrom(key).headOption
 
-  /** Find the element with largest key less than a given key.
+  /** Finds the element with largest key less than a given key.
     * @param key The given key.
     * @return `None` if there is no such node.
     */
@@ -134,7 +134,7 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
 
   override def keySet: SortedSet[K] = new KeySortedSet
 
-  /** The implementation class of the set returned by `keySet` */
+  /** The implementation class of the set returned by `keySet`. */
   protected class KeySortedSet extends SortedSet[K] with GenKeySet with GenKeySortedSet {
     def diff(that: Set[K]): SortedSet[K] = fromSpecific(view.filterNot(that))
     def rangeImpl(from: Option[K], until: Option[K]): SortedSet[K] = {
@@ -143,7 +143,7 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
     }
   }
 
-  /** A generic trait that is reused by sorted keyset implementations */
+  /** A generic trait that is reused by sorted keyset implementations. */
   protected trait GenKeySortedSet extends GenKeySet { this: SortedSet[K] =>
     implicit def ordering: Ordering[K] = SortedMapOps.this.ordering
     def iteratorFrom(start: K): Iterator[K] = SortedMapOps.this.keysIteratorFrom(start)
@@ -185,7 +185,7 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
     case _ => iterator.concat(suffix.iterator)
   })(using ordering)
 
-  /** Alias for `concat` */
+  /** Alias for `concat`. */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]^): CC[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")

--- a/library/src/scala/collection/SortedOps.scala
+++ b/library/src/scala/collection/SortedOps.scala
@@ -15,7 +15,7 @@ package scala.collection
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base trait for sorted collections */
+/** Base trait for sorted collections. */
 transparent trait SortedOps[A, +C] {
 
   def ordering: Ordering[A]
@@ -79,13 +79,13 @@ transparent trait SortedOps[A, +C] {
    */
   def rangeUntil(until: A): C = rangeImpl(None, Some(until))
 
-  /** Create a range projection of this collection with no lower-bound.
+  /** Creates a range projection of this collection with no lower-bound.
     *  @param to The upper-bound (inclusive) of the ranged projection.
     */
   @deprecated("Use rangeTo", "2.13.0")
   final def to(to: A): C = rangeTo(to)
 
-  /** Create a range projection of this collection with no lower-bound.
+  /** Creates a range projection of this collection with no lower-bound.
     *  @param to The upper-bound (inclusive) of the ranged projection.
     */
   def rangeTo(to: A): C

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -18,7 +18,7 @@ import language.experimental.captureChecking
 import scala.annotation.{implicitNotFound, nowarn}
 import scala.annotation.unchecked.uncheckedVariance
 
-/** Base type of sorted sets */
+/** Base type of sorted sets. */
 trait SortedSet[A] extends Set[A]
     with SortedSetOps[A, SortedSet, SortedSet[A]]
     with SortedSetFactoryDefaults[A, SortedSet, Set] {
@@ -79,13 +79,13 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
   def firstKey: A = head
   def lastKey: A = last
 
-  /** Find the smallest element larger than or equal to a given key.
+  /** Finds the smallest element larger than or equal to a given key.
     * @param key The given key.
     * @return `None` if there is no such node.
     */
   def minAfter(key: A): Option[A] = rangeFrom(key).headOption
 
-  /** Find the largest element less than a given key.
+  /** Finds the largest element less than a given key.
     * @param key The given key.
     * @return `None` if there is no such node.
     */

--- a/library/src/scala/collection/Stepper.scala
+++ b/library/src/scala/collection/Stepper.scala
@@ -41,13 +41,13 @@ import scala.collection.Stepper.EfficientSplit
   * @tparam A the element type of the Stepper
   */
 trait Stepper[@specialized(Double, Int, Long) +A] {
-  /** Check if there's an element available. */
+  /** Checks if there's an element available. */
   def hasStep: Boolean
 
-  /** Return the next element and advance the stepper */
+  /** Returns the next element and advance the stepper. */
   def nextStep(): A
 
-  /** Split this stepper, if applicable. The elements of the current Stepper are split up between
+  /** Splits this stepper, if applicable. The elements of the current Stepper are split up between
     * the resulting Stepper and the current stepper.
     *
     * May return `null`, in which case the current Stepper yields the same elements as before.
@@ -184,7 +184,7 @@ object Stepper {
   }
 }
 
-/** A Stepper for arbitrary element types. See [[Stepper]]. */
+/** A `Stepper` for arbitrary element types. See [[Stepper]]. */
 trait AnyStepper[+A] extends Stepper[A] {
   def trySplit(): AnyStepper[A]^{this} | Null
 
@@ -254,7 +254,7 @@ object AnyStepper {
   }
 }
 
-/** A Stepper for Ints. See [[Stepper]]. */
+/** A `Stepper` for `Int`s. See [[Stepper]]. */
 trait IntStepper extends Stepper[Int] {
   def trySplit(): IntStepper^{this} | Null
 
@@ -292,7 +292,7 @@ object IntStepper {
   }
 }
 
-/** A Stepper for Doubles. See [[Stepper]]. */
+/** A `Stepper` for `Double`s. See [[Stepper]]. */
 trait DoubleStepper extends Stepper[Double] {
   def trySplit(): DoubleStepper^{this} | Null
 
@@ -331,7 +331,7 @@ object DoubleStepper {
   }
 }
 
-/** A Stepper for Longs. See [[Stepper]]. */
+/** A `Stepper` for `Long`s. See [[Stepper]]. */
 trait LongStepper extends Stepper[Long] {
   def trySplit(): LongStepper^{this} | Null
 

--- a/library/src/scala/collection/StepperShape.scala
+++ b/library/src/scala/collection/StepperShape.scala
@@ -23,14 +23,14 @@ import scala.collection.Stepper.EfficientSplit
   * specialized Stepper `S` according to the element type `T`.
   */
 sealed trait StepperShape[-T, S <: Stepper[?]] { self =>
-  /** Return the Int constant (as defined in the `StepperShape` companion object) for this `StepperShape`. */
+  /** Returns the Int constant (as defined in the `StepperShape` companion object) for this `StepperShape`. */
   def shape: StepperShape.Shape
 
-  /** Create an unboxing primitive sequential Stepper from a boxed `AnyStepper`.
+  /** Creates an unboxing primitive sequential Stepper from a boxed `AnyStepper`.
    * This is an identity operation for reference shapes. */
   def seqUnbox(st: AnyStepper[T]^): S^{st}
 
-  /** Create an unboxing primitive parallel (i.e. `with EfficientSplit`) Stepper from a boxed `AnyStepper`.
+  /** Creates an unboxing primitive parallel (i.e. `with EfficientSplit`) Stepper from a boxed `AnyStepper`.
    * This is an identity operation for reference shapes. */
   def parUnbox(st: (AnyStepper[T] & EfficientSplit)^): (S & EfficientSplit)^{st}
 }

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -67,7 +67,7 @@ object StringOps {
   /** A lazy filtered string. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
   class WithFilter(p: Char => Boolean, s: String) {
 
-    /** Apply `f` to each element for its side effects.
+    /** Applies `f` to each element for its side effects.
       * Note: [U] parameter needed to help scalac's type inference.
       */
     def foreach[U](f: Char => U): Unit = {
@@ -187,7 +187,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   @inline def knownSize: Int = s.length
 
-  /** Get the char at the specified index. */
+  /** Gets the char at the specified index. */
   @inline def apply(i: Int): Char = s.charAt(i)
 
   def sizeCompare(otherSize: Int): Int = Integer.compare(s.length, otherSize)
@@ -347,13 +347,13 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     */
   @inline def concat(suffix: String): String = s + suffix
 
-  /** Alias for `concat` */
+  /** Alias for `concat`. */
   @inline def ++[B >: Char](suffix: Iterable[B]^): immutable.IndexedSeq[B] = concat(suffix)
 
-  /** Alias for `concat` */
+  /** Alias for `concat`. */
   @inline def ++(suffix: IterableOnce[Char]^): String = concat(suffix)
 
-  /** Alias for `concat` */
+  /** Alias for `concat`. */
   def ++(xs: String): String = concat(xs)
 
   /** Returns a collection with an element appended until a given target length is reached.
@@ -397,7 +397,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     }
   }
 
-  /** A copy of the string with an element prepended */
+  /** A copy of the string with an element prepended. */
   def prepended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     b.sizeHint(s.length + 1)
@@ -406,17 +406,17 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     b.result()
   }
 
-  /** Alias for `prepended` */
+  /** Alias for `prepended`. */
   @inline def +: [B >: Char] (elem: B): immutable.IndexedSeq[B] = prepended(elem)
 
-  /** A copy of the string with an char prepended */
+  /** A copy of the string with an char prepended. */
   def prepended(c: Char): String =
     new JStringBuilder(s.length + 1).append(c).append(s).toString
 
-  /** Alias for `prepended` */
+  /** Alias for `prepended`. */
   @inline def +: (c: Char): String = prepended(c)
 
-  /** A copy of the string with all elements from a collection prepended */
+  /** A copy of the string with all elements from a collection prepended. */
   def prependedAll[B >: Char](prefix: IterableOnce[B]^): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     val k = prefix.knownSize
@@ -426,16 +426,16 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     b.result()
   }
 
-  /** Alias for `prependedAll` */
+  /** Alias for `prependedAll`. */
   @inline def ++: [B >: Char] (prefix: IterableOnce[B]^): immutable.IndexedSeq[B] = prependedAll(prefix)
 
-  /** A copy of the string with another string prepended */
+  /** A copy of the string with another string prepended. */
   def prependedAll(prefix: String): String = prefix + s
 
-  /** Alias for `prependedAll` */
+  /** Alias for `prependedAll`. */
   @inline def ++: (prefix: String): String = prependedAll(prefix)
 
-  /** A copy of the string with an element appended */
+  /** A copy of the string with an element appended. */
   def appended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     b.sizeHint(s.length + 1)
@@ -444,28 +444,28 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     b.result()
   }
 
-  /** Alias for `appended` */
+  /** Alias for `appended`. */
   @inline def :+ [B >: Char](elem: B): immutable.IndexedSeq[B] = appended(elem)
 
-  /** A copy of the string with an element appended */
+  /** A copy of the string with an element appended. */
   def appended(c: Char): String =
     new JStringBuilder(s.length + 1).append(s).append(c).toString
 
-  /** Alias for `appended` */
+  /** Alias for `appended`. */
   @inline def :+ (c: Char): String = appended(c)
 
-  /** A copy of the string with all elements from a collection appended */
+  /** A copy of the string with all elements from a collection appended. */
   @inline def appendedAll[B >: Char](suffix: IterableOnce[B]^): immutable.IndexedSeq[B] =
     concat(suffix)
 
-  /** Alias for `appendedAll` */
+  /** Alias for `appendedAll`. */
   @inline def :++ [B >: Char](suffix: IterableOnce[B]^): immutable.IndexedSeq[B] =
     concat(suffix)
 
-  /** A copy of the string with another string appended */
+  /** A copy of the string with another string appended. */
   @inline def appendedAll(suffix: String): String = s + suffix
 
-  /** Alias for `appendedAll` */
+  /** Alias for `appendedAll`. */
   @inline def :++ (suffix: String): String = s + suffix
 
   /** Produces a new collection where a slice of characters in this string is replaced by another collection.
@@ -585,7 +585,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     if (sep.isEmpty || s.length < 2) s
     else mkString("", sep, "")
 
-  /** Returns this string */
+  /** Returns this string. */
   @inline final def mkString: String = s
 
   /** Appends this string to a string builder. */
@@ -639,7 +639,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   // Note: String.repeat is added in JDK 11.
-  /** Return the current string concatenated `n` times.
+  /** Returns the current string concatenated `n` times.
    */
   def *(n: Int): String =
     if (n <= 0) {
@@ -672,7 +672,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
       }
     }
 
-  /** Return an iterator of all lines embedded in this string,
+  /** Returns an iterator of all lines embedded in this string,
    *  including trailing line separator characters.
    *
    *  The empty string yields an empty iterator.
@@ -707,7 +707,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     }
   }
 
-  /** Return all lines in this string in an iterator, excluding trailing line
+  /** Returns all lines in this string in an iterator, excluding trailing line
     *  end characters; i.e., apply `.stripLineEnd` to all lines
     *  returned by `linesWithSeparators`.
     */
@@ -736,7 +736,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     if (s.endsWith(suffix)) s.substring(0, s.length - suffix.length)
     else s
 
-  /** Replace all literal occurrences of `literal` with the literal string `replacement`.
+  /** Replaces all literal occurrences of `literal` with the literal string `replacement`.
     * This method is equivalent to [[java.lang.String#replace(CharSequence,CharSequence)]].
     *
     * @param    literal     the string which should be replaced everywhere it occurs
@@ -778,7 +778,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
       (ch >= '0' && ch <= '9')) ch.toString
   else "\\" + ch
 
-  /** Split this string around the separator character
+  /** Splits this string around the separator character
     *
     * If this string is the empty string, returns an array of strings
     * that contains a single empty string.
@@ -863,7 +863,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   def toBoolean: Boolean               = toBooleanImpl(s)
 
   /**
-   * Try to parse as a `Boolean`
+   * Tries to parse as a `Boolean`.
    * @return `Some(true)` if the string is "true" case insensitive,
    * `Some(false)` if the string is "false" case insensitive,
    * and `None` if the string is anything else
@@ -872,80 +872,80 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   def toBooleanOption: Option[Boolean] = StringParsers.parseBool(s)
 
   /**
-    * Parse as a `Byte` (string must contain only decimal digits and optional leading `-` or `+`).
+    * Parses as a `Byte` (string must contain only decimal digits and optional leading `-` or `+`).
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Byte`.
     */
   def toByte: Byte                     = java.lang.Byte.parseByte(s)
 
   /**
-   * Try to parse as a `Byte`
+   * Tries to parse as a `Byte`.
    * @return `Some(value)` if the string contains a valid byte value, otherwise `None`
    * @throws java.lang.NullPointerException if the string is `null`
    */
   def toByteOption: Option[Byte]       = StringParsers.parseByte(s)
 
   /**
-    * Parse as a `Short` (string must contain only decimal digits and optional leading `-` or `+`).
+    * Parses as a `Short` (string must contain only decimal digits and optional leading `-` or `+`).
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Short`.
     */
   def toShort: Short                   = java.lang.Short.parseShort(s)
 
   /**
-   * Try to parse as a `Short`
+   * Tries to parse as a `Short`.
    * @return `Some(value)` if the string contains a valid short value, otherwise `None`
    * @throws java.lang.NullPointerException if the string is `null`
    */
   def toShortOption: Option[Short]     = StringParsers.parseShort(s)
 
   /**
-    * Parse as an `Int` (string must contain only decimal digits and optional leading `-` or `+`).
+    * Parses as an `Int` (string must contain only decimal digits and optional leading `-` or `+`).
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Int`.
     */
   def toInt: Int                       = java.lang.Integer.parseInt(s)
 
   /**
-   * Try to parse as an `Int`
+   * Tries to parse as an `Int`.
    * @return `Some(value)` if the string contains a valid Int value, otherwise `None`
    * @throws java.lang.NullPointerException if the string is `null`
    */
   def toIntOption: Option[Int]         = StringParsers.parseInt(s)
 
   /**
-    * Parse as a `Long` (string must contain only decimal digits and optional leading `-` or `+`).
+    * Parses as a `Long` (string must contain only decimal digits and optional leading `-` or `+`).
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Long`.
     */
   def toLong: Long                     = java.lang.Long.parseLong(s)
 
   /**
-   * Try to parse as a `Long`
+   * Tries to parse as a `Long`.
    * @return `Some(value)` if the string contains a valid long value, otherwise `None`
    * @throws java.lang.NullPointerException if the string is `null`
    */
   def toLongOption: Option[Long]       = StringParsers.parseLong(s)
 
   /**
-    * Parse as a `Float` (surrounding whitespace is removed with a `trim`).
+    * Parses as a `Float` (surrounding whitespace is removed with a `trim`).
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Float`.
     * @throws java.lang.NullPointerException  If the string is null.
     */
   def toFloat: Float                   = java.lang.Float.parseFloat(s)
 
   /**
-   * Try to parse as a `Float`
+   * Tries to parse as a `Float`.
    * @return `Some(value)` if the string is a parsable `Float`, `None` otherwise
    * @throws java.lang.NullPointerException If the string is null
    */
   def toFloatOption: Option[Float]     = StringParsers.parseFloat(s)
 
   /**
-    * Parse as a `Double` (surrounding whitespace is removed with a `trim`).
+    * Parses as a `Double` (surrounding whitespace is removed with a `trim`).
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Double`.
     * @throws java.lang.NullPointerException  If the string is null.
     */
   def toDouble: Double                 = java.lang.Double.parseDouble(s)
 
   /**
-   * Try to parse as a `Double`
+   * Tries to parse as a `Double`.
    * @return `Some(value)` if the string is a parsable `Double`, `None` otherwise
    * @throws java.lang.NullPointerException If the string is null
    */
@@ -1002,7 +1002,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   def compare(that: String): Int = s.compareTo(that)
 
-  /** Returns true if `this` is less than `that` */
+  /** Returns true if `this` is less than `that`. */
   def < (that: String): Boolean = compare(that) <  0
 
   /** Returns true if `this` is greater than `that`. */
@@ -1014,7 +1014,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Returns true if `this` is greater than or equal to `that`. */
   def >= (that: String): Boolean = compare(that) >= 0
 
-  /** Counts the number of chars in this string which satisfy a predicate */
+  /** Counts the number of chars in this string which satisfy a predicate. */
   def count(p: (Char) => Boolean): Int = {
     var i, res = 0
     val len = s.length
@@ -1025,7 +1025,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     res
   }
 
-  /** Apply `f` to each element for its side effects.
+  /** Applies `f` to each element for its side effects.
     * Note: [U] parameter needed to help scalac's type inference.
     */
   def foreach[U](f: Char => U): Unit = {
@@ -1146,7 +1146,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     */
   def indices: Range = Range(0, s.length)
 
-  /** Iterator can be used only once */
+  /** Iterator can be used only once. */
   def iterator: Iterator[Char] = new StringIterator(s)
 
   /** Stepper can be used with Java 8 Streams. This method is equivalent to a call to
@@ -1264,7 +1264,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Selects all chars of this string which do not satisfy a predicate. */
   @inline def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
 
-  /** Copy chars of this string to an array.
+  /** Copies chars of this string to an array.
     * Fills the given array `xs` starting at index 0.
     * Copying will stop once either the entire string has been copied
     * or the end of the array is reached
@@ -1274,7 +1274,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   @inline def copyToArray(xs: Array[Char]): Int =
     copyToArray(xs, 0, Int.MaxValue)
 
-  /** Copy chars of this string to an array.
+  /** Copies chars of this string to an array.
     * Fills the given array `xs` starting at index `start`.
     * Copying will stop once either the entire string has been copied
     * or the end of the array is reached
@@ -1285,7 +1285,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   @inline def copyToArray(xs: Array[Char], start: Int): Int =
     copyToArray(xs, start, Int.MaxValue)
 
-  /** Copy chars of this string to an array.
+  /** Copies chars of this string to an array.
     * Fills the given array `xs` starting at index `start` with at most `len` chars.
     * Copying will stop once either the entire string has been copied,
     * or the end of the array is reached or `len` chars have been copied.

--- a/library/src/scala/collection/View.scala
+++ b/library/src/scala/collection/View.scala
@@ -84,7 +84,7 @@ object View extends IterableFactory[View] {
 
   override def apply[A](xs: A*): View[A] = new Elems(xs*)
 
-  /** The empty view */
+  /** The empty view. */
   @SerialVersionUID(3L)
   case object Empty extends AbstractView[Nothing] {
     def iterator = Iterator.empty
@@ -92,7 +92,7 @@ object View extends IterableFactory[View] {
     override def isEmpty: Boolean = true
   }
 
-  /** A view with exactly one element */
+  /** A view with exactly one element. */
   @SerialVersionUID(3L)
   class Single[A](a: A) extends AbstractView[A] {
     def iterator: Iterator[A] = Iterator.single(a)
@@ -100,7 +100,7 @@ object View extends IterableFactory[View] {
     override def isEmpty: Boolean = false
   }
 
-  /** A view with given elements */
+  /** A view with given elements. */
   @SerialVersionUID(3L)
   class Elems[A](xs: A*) extends AbstractView[A] {
     def iterator = xs.iterator
@@ -124,7 +124,7 @@ object View extends IterableFactory[View] {
     override def isEmpty: Boolean = n <= 0
   }
 
-  /** A view containing repeated applications of a function to a start value */
+  /** A view containing repeated applications of a function to a start value. */
   @SerialVersionUID(3L)
   class Iterate[A](start: A, len: Int)(f: A => A) extends AbstractView[A] {
     def iterator: Iterator[A]^{f} = Iterator.iterate(start)(f).take(len)
@@ -140,7 +140,7 @@ object View extends IterableFactory[View] {
     def iterator: Iterator[A]^{f} = Iterator.unfold(initial)(f)
   }
 
-  /** An `IterableOps` whose collection type and collection type constructor are unknown */
+  /** An `IterableOps` whose collection type and collection type constructor are unknown. */
   type SomeIterableOps[A] = IterableOps[A, AnyConstr, ?]
 
   /** A view that filters an underlying collection. */
@@ -163,7 +163,7 @@ object View extends IterableFactory[View] {
       }
   }
 
-  /** A view that removes the duplicated elements as determined by the transformation function `f` */
+  /** A view that removes the duplicated elements as determined by the transformation function `f`. */
   @SerialVersionUID(3L)
   class DistinctBy[A, B](underlying: SomeIterableOps[A]^, f: A -> B) extends AbstractView[A] {
     def iterator: Iterator[A]^{underlying} = underlying.iterator.distinctBy(f)
@@ -370,7 +370,7 @@ object View extends IterableFactory[View] {
     override def isEmpty: Boolean = underlying.isEmpty && other.isEmpty
   }
 
-  /** A view that appends an element to its elements */
+  /** A view that appends an element to its elements. */
   @SerialVersionUID(3L)
   class Appended[+A](underlying: SomeIterableOps[A]^, elem: A) extends AbstractView[A] {
     def iterator = new Concat(underlying, new View.Single(elem)).iterator
@@ -381,7 +381,7 @@ object View extends IterableFactory[View] {
     override def isEmpty: Boolean = false
   }
 
-  /** A view that prepends an element to its elements */
+  /** A view that prepends an element to its elements. */
   @SerialVersionUID(3L)
   class Prepended[+A](elem: A, underlying: SomeIterableOps[A]^) extends AbstractView[A] {
     def iterator = new Concat(new View.Single(elem), underlying).iterator

--- a/library/src/scala/collection/concurrent/Map.scala
+++ b/library/src/scala/collection/concurrent/Map.scala
@@ -141,7 +141,7 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
   private[collection] def replaceRefEq(k: K, oldValue: V, newValue: V): Boolean = replace(k, oldValue, newValue)
 
   /**
-   * Update a mapping for the specified key and its current optionally mapped value
+   * Updates a mapping for the specified key and its current optionally mapped value
    * (`Some` if there is current mapping, `None` if not).
    *
    * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
@@ -151,7 +151,7 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
    * If the map is updated by another concurrent access, the remapping function will be retried until successfully updated.
    *
    * @param key the key value
-   * @param remappingFunction a function that receives current optionally mapped value and return a new mapping
+   * @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
    * @return the new value associated with the specified key
    */
   override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = updateWithAux(key)(remappingFunction)

--- a/library/src/scala/collection/concurrent/TrieMap.scala
+++ b/library/src/scala/collection/concurrent/TrieMap.scala
@@ -829,7 +829,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     * @param v the value compare with the value found associated with the key
     * @param removalPolicy policy deciding whether to remove `k` based on `v` and the
    *                       current value associated with `k` (Always, FullEquals, or ReferenceEq)
-    * @return an Option[V] indicating the previous value
+    * @return an `Option[V]` indicating the previous value
     */
   @tailrec private def removehc(k: K, v: V, removalPolicy: Int, hc: Int): Option[V] = {
     val r = RDCSS_READ_ROOT()

--- a/library/src/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/library/src/scala/collection/convert/JavaCollectionWrappers.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 import scala.util.chaining._
 import scala.util.control.ControlThrowable
 
-/** Wrappers for exposing Scala collections as Java collections and vice-versa */
+/** Wrappers for exposing Scala collections as Java collections and vice-versa. */
 @SerialVersionUID(3L)
 // not private[convert] because `WeakHashMap` uses JMapWrapper
 private[collection] object JavaCollectionWrappers extends Serializable {

--- a/library/src/scala/collection/convert/StreamExtensions.scala
+++ b/library/src/scala/collection/convert/StreamExtensions.scala
@@ -34,7 +34,7 @@ trait StreamExtensions {
   // collections
 
   implicit class IterableHasSeqStream[A](cc: IterableOnce[A]) {
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for this collection. If the
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this collection. If the
       * collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -48,7 +48,7 @@ trait StreamExtensions {
       def stepper[S <: Stepper[?]](implicit shape : StepperShape[A, S]) : S & EfficientSplit
     }
 
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for this collection. If the
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this collection. If the
       * collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -63,14 +63,14 @@ trait StreamExtensions {
   // maps
 
   implicit class MapHasSeqKeyValueStream[K, V, CC[X, Y] <: collection.MapOps[X, Y, collection.Map, ?]](cc: CC[K, V]) {
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for the keys of this map. If
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of this map. If
       * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
     def asJavaSeqKeyStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[K, S, St], st: StepperShape[K, St]): S =
       s.fromStepper(cc.keyStepper, par = false)
 
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for the values of this map. If
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of this map. If
       * the values are primitives, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -78,7 +78,7 @@ trait StreamExtensions {
       s.fromStepper(cc.valueStepper, par = false)
 
     // The asJavaSeqStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
       * this map.
       */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[(K, V), S, St], st: StepperShape[(K, V), St]): S =
@@ -91,7 +91,7 @@ trait StreamExtensions {
     private type MapOpsWithEfficientValueStepper = collection.MapOps[K, V, collection.Map, ?] { def valueStepper[S <: Stepper[?]](implicit shape : StepperShape[V, S]) : S & EfficientSplit }
     private type MapOpsWithEfficientStepper = collection.MapOps[K, V, collection.Map, ?] { def stepper[S <: Stepper[?]](implicit shape : StepperShape[(K, V), S]) : S & EfficientSplit }
 
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
       * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -102,7 +102,7 @@ trait StreamExtensions {
         isEfficient: CC[K, V] <:< MapOpsWithEfficientKeyStepper): S =
       s.fromStepper(cc.keyStepper, par = true)
 
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for the values of this map. If
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of this map. If
       * the values are primitives, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -114,7 +114,7 @@ trait StreamExtensions {
       s.fromStepper(cc.valueStepper, par = true)
 
     // The asJavaParStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
       * this map.
       */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
@@ -128,7 +128,7 @@ trait StreamExtensions {
   // steppers
 
   implicit class StepperHasSeqStream[A](stepper: Stepper[A]) {
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for this stepper. If the
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this stepper. If the
       * stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -142,7 +142,7 @@ trait StreamExtensions {
   }
 
   implicit class StepperHasParStream[A](stepper: Stepper[A] & EfficientSplit) {
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for this stepper. If the
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this stepper. If the
       * stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -162,58 +162,58 @@ trait StreamExtensions {
   // JDK spliterators only for double/int/long/reference.
 
   implicit class DoubleArrayHasSeqParStream(a: Array[Double]) {
-    /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
     def asJavaSeqStream: DoubleStream = java.util.Arrays.stream(a)
-    /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
     def asJavaParStream: DoubleStream = asJavaSeqStream.parallel
   }
 
   implicit class IntArrayHasSeqParStream(a: Array[Int]) {
-    /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaSeqStream: IntStream = java.util.Arrays.stream(a)
-    /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaParStream: IntStream = asJavaSeqStream.parallel
   }
 
   implicit class LongArrayHasSeqParStream(a: Array[Long]) {
-    /** Create a sequential [[java.util.stream.LongStream Java LongStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for this array. */
     def asJavaSeqStream: LongStream = java.util.Arrays.stream(a)
-    /** Create a parallel [[java.util.stream.LongStream Java LongStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.LongStream Java LongStream]] for this array. */
     def asJavaParStream: LongStream = asJavaSeqStream.parallel
   }
 
   implicit class AnyArrayHasSeqParStream[A <: AnyRef](a: Array[A]) {
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for this array. */
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this array. */
     def asJavaSeqStream: Stream[A] = java.util.Arrays.stream(a)
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for this array. */
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this array. */
     def asJavaParStream: Stream[A] = asJavaSeqStream.parallel
   }
 
   implicit class ByteArrayHasSeqParStream(a: Array[Byte]) {
-    /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaSeqStream: IntStream = a.stepper.asJavaSeqStream
-    /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaParStream: IntStream = a.stepper.asJavaParStream
   }
 
   implicit class ShortArrayHasSeqParStream(a: Array[Short]) {
-    /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaSeqStream: IntStream = a.stepper.asJavaSeqStream
-    /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaParStream: IntStream = a.stepper.asJavaParStream
   }
 
   implicit class CharArrayHasSeqParStream(a: Array[Char]) {
-    /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaSeqStream: IntStream = a.stepper.asJavaSeqStream
-    /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaParStream: IntStream = a.stepper.asJavaParStream
   }
 
   implicit class FloatArrayHasSeqParStream(a: Array[Float]) {
-    /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
     def asJavaSeqStream: DoubleStream = a.stepper.asJavaSeqStream
-    /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
     def asJavaParStream: DoubleStream = a.stepper.asJavaParStream
   }
 
@@ -248,7 +248,7 @@ trait StreamExtensions {
 
   implicit class StreamHasToScala[A](stream: Stream[A]) {
     /**
-     * Copy the elements of this stream into a Scala collection.
+     * Copies the elements of this stream into a Scala collection.
      *
      * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
      * builds the result in parallel.
@@ -275,7 +275,7 @@ trait StreamExtensions {
       else factory.fromSpecific(stream.iterator.asScala)
     }
 
-    /** Convert a generic Java Stream wrapping a primitive type to a corresponding primitive
+    /** Converts a generic Java Stream wrapping a primitive type to a corresponding primitive
       * Stream.
       */
     def asJavaPrimitiveStream[S](implicit unboxer: StreamUnboxer[A, S]): S = unboxer(stream)
@@ -283,7 +283,7 @@ trait StreamExtensions {
 
   implicit class IntStreamHasToScala(stream: IntStream) {
     /**
-     * Copy the elements of this stream into a Scala collection.
+     * Copies the elements of this stream into a Scala collection.
      *
      * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
      * builds the result in parallel.
@@ -310,7 +310,7 @@ trait StreamExtensions {
 
   implicit class LongStreamHasToScala(stream: LongStream) {
     /**
-     * Copy the elements of this stream into a Scala collection.
+     * Copies the elements of this stream into a Scala collection.
      *
      * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
      * builds the result in parallel.
@@ -337,7 +337,7 @@ trait StreamExtensions {
 
   implicit class DoubleStreamHasToScala(stream: DoubleStream) {
     /**
-     * Copy the elements of this stream into a Scala collection.
+     * Copies the elements of this stream into a Scala collection.
      *
      * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
      * builds the result in parallel.

--- a/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
@@ -25,7 +25,7 @@ import scala.collection.Stepper.EfficientSplit
   */
 private[convert] abstract class InOrderStepperBase[Sub, Semi <: Sub](protected var i0: Int, protected var iN: Int)
 extends EfficientSplit {
-  /** Set `true` if the element at `i0` is known to be there.  `false` if either not known or is a gap.
+  /** Sets `true` if the element at `i0` is known to be there.  `false` if either not known or is a gap.
     */
   protected def found: Boolean
 

--- a/library/src/scala/collection/convert/impl/IndexedStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/IndexedStepperBase.scala
@@ -18,7 +18,7 @@ import java.util.Spliterator
 
 import scala.collection.Stepper.EfficientSplit
 
-/** Abstracts all the generic operations of stepping over an indexable collection */
+/** Abstracts all the generic operations of stepping over an indexable collection. */
 private[convert] abstract class IndexedStepperBase[Sub, Semi <: Sub](protected var i0: Int, protected var iN: Int)
   extends EfficientSplit {
   protected def semiclone(half: Int): Semi

--- a/library/src/scala/collection/generic/CommonErrors.scala
+++ b/library/src/scala/collection/generic/CommonErrors.scala
@@ -19,7 +19,7 @@ import language.experimental.captureChecking
 /** Some precomputed common errors to reduce the generated code size.
   */
 private[collection] object CommonErrors {
-  /** IndexOutOfBounds exception with a known max index */
+  /** IndexOutOfBounds exception with a known max index. */
   @noinline
   def indexOutOfBounds(index: Int, max: Int): IndexOutOfBoundsException = 
     new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${max})")

--- a/library/src/scala/collection/generic/IsIterable.scala
+++ b/library/src/scala/collection/generic/IsIterable.scala
@@ -127,7 +127,7 @@ transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
   @untrackedCaptures
   override val conversion: Repr => IterableOps[A, Iterable, C] = apply(_)
 
-  /** A conversion from the type `Repr` to `IterableOps[A, Iterable, C]` */
+  /** A conversion from the type `Repr` to `IterableOps[A, Iterable, C]`. */
   def apply(coll: Repr): IterableOps[A, Iterable, C]
 
 }

--- a/library/src/scala/collection/generic/IsMap.scala
+++ b/library/src/scala/collection/generic/IsMap.scala
@@ -31,10 +31,10 @@ import scala.collection.immutable.{IntMap, LongMap}
   */
 transparent trait IsMap[Repr] extends IsIterable[Repr] {
 
-  /** The type of keys */
+  /** The type of keys. */
   type K
 
-  /** The type of values */
+  /** The type of values. */
   type V
 
   type A = (K, V)

--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -301,7 +301,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
   }
 
   /**
-   * Wrap an existing `Array` into an `ArraySeq` of the proper primitive specialization type
+   * Wraps an existing `Array` into an `ArraySeq` of the proper primitive specialization type
    * without copying. Any changes to wrapped array will break the expected immutability.
    *
    * Note that an array containing boxed primitives can be wrapped in an `ArraySeq` without

--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -65,7 +65,7 @@ sealed abstract class BitSet
     } else this
   }
 
-  /** Update word at index `idx`; enlarge set if `idx` outside range of set.
+  /** Updates word at index `idx`; enlarges set if `idx` outside range of set.
     */
   protected def updateWord(idx: Int, w: Long): BitSet
 
@@ -110,7 +110,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   private def createSmall(a: Long, b: Long): BitSet = if (b == 0L) new BitSet1(a) else new BitSet2(a, b)
 
-  /** A bitset containing all the bits in an array */
+  /** A bitset containing all the bits in an array. */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
     if (len == 0) empty

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -273,7 +273,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
 
   override def foreachEntry[U](f: (K, V) => U): Unit = rootNode.foreachEntry(f)
 
-  /** Applies a function to each key, value, and **original** hash value in this Map */
+  /** Applies a function to each key, value, and **original** hash value in this Map. */
   @inline private[collection] def foreachWithHash(f: (K, V, Int) => Unit): Unit = rootNode.foreachWithHash(f)
 
   override def equals(that: Any): Boolean =
@@ -615,7 +615,7 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
     */
   def getTuple(key: K, originalHash: Int, hash: Int, shift: Int): (K, V)
 
-  /** Adds all key-value pairs to a builder */
+  /** Adds all key-value pairs to a builder. */
   def buildTo[V1 >: V](builder: HashMapBuilder[K, V1]): Unit
 }
 
@@ -874,7 +874,7 @@ private final class BitmapIndexedMapNode[K, +V](
       if (key0 == key) {
         if (this.payloadArity == 2 && this.nodeArity == 0) {
           /*
-           * Create new node with remaining pair. The new node will a) either become the new root
+           * Creates new node with remaining pair. The new node will a) either become the new root
            * returned, or b) unwrapped and inlined during returning.
            */
           val newDataMap = if (shift == 0) (dataMap ^ bitpos) else bitposFrom(maskFrom(keyHash, 0))
@@ -2170,9 +2170,9 @@ private final class MapKeyValueTupleHashIterator[K, V](rootNode: MapNode[K, V])
   }
 }
 
-/** Used in HashMap[K, V]#removeAll(HashSet[K]) */
+/** Used in HashMap[K, V]#removeAll(HashSet[K]). */
 private final class MapNodeRemoveAllSetNodeIterator[K](rootSetNode: SetNode[K]) extends ChampBaseIterator[K, SetNode[K]](rootSetNode) {
-  /** Returns the result of immutably removing all keys in `rootSetNode` from `rootMapNode` */
+  /** Returns the result of immutably removing all keys in `rootSetNode` from `rootMapNode`. */
   def removeAll[V](rootMapNode: BitmapIndexedMapNode[K, V]): BitmapIndexedMapNode[K, V] = {
     var curr = rootMapNode
     while (curr.size > 0 && hasNext) {
@@ -2212,14 +2212,14 @@ object HashMap extends MapFactory[HashMap] {
       case _ => (newBuilder[K, V] ++= source).result()
     }
 
-  /** Create a new Builder which can be reused after calling `result()` without an
+  /** Creates a new Builder which can be reused after calling `result()` without an
     * intermediate call to `clear()` in order to build multiple related results.
     */
   def newBuilder[K, V]: ReusableBuilder[(K, V), HashMap[K, V]] = new HashMapBuilder[K, V]
 }
 
 
-/** A Builder for a HashMap.
+/** A `Builder` for a `HashMap`.
   * $multipleResults
   */
 private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, V), HashMap[K, V]] {
@@ -2246,7 +2246,7 @@ private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, 
       rootNode.getOrElse(key, originalHash, improve(originalHash), 0, value)
     }
 
-  /** Inserts element `elem` into array `as` at index `ix`, shifting right the trailing elems */
+  /** Inserts element `elem` into array `as` at index `ix`, shifting right the trailing elems. */
   private def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException
     if (ix > as.length) throw new ArrayIndexOutOfBoundsException
@@ -2257,7 +2257,7 @@ private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, 
     result
   }
 
-  /** Inserts key-value into the bitmapIndexMapNode. Requires that this is a new key-value pair */
+  /** Inserts key-value into the bitmapIndexMapNode. Requires that this is a new key-value pair. */
   private def insertValue[V1 >: V](bm: BitmapIndexedMapNode[K, V],bitpos: Int, key: K, originalHash: Int, keyHash: Int, value: V1): Unit = {
     val dataIx = bm.dataIndex(bitpos)
     val idx = TupleLength * dataIx
@@ -2280,7 +2280,7 @@ private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, 
     bm.cachedJavaKeySetHashCode += keyHash
   }
 
-  /** Upserts a key/value pair into mapNode, mutably */
+  /** Upserts a key/value pair into mapNode, mutably. */
   private[immutable] def update(mapNode: MapNode[K, V], key: K, value: V, originalHash: Int, keyHash: Int, shift: Int): Unit = {
     mapNode match {
       case bm: BitmapIndexedMapNode[K, V] =>
@@ -2324,13 +2324,13 @@ private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, 
     }
   }
 
-  /** If currently referencing aliased structure, copy elements to new mutable structure */
+  /** If currently referencing aliased structure, copy elements to new mutable structure. */
   private def ensureUnaliased() = {
     if (isAliased) copyElems()
     aliased = null
   }
 
-  /** Copy elements to new mutable structure */
+  /** Copies elements to new mutable structure. */
   private def copyElems(): Unit = {
     rootNode = rootNode.copy()
   }

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -186,7 +186,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
 
   override def foreach[U](f: A => U): Unit = rootNode.foreach(f)
 
-  /** Applies a function f to each element, and its corresponding **original** hash, in this Set */
+  /** Applies a function f to each element, and its corresponding **original** hash, in this Set. */
   @`inline` private[collection] def foreachWithHash(f: (A, Int) => Unit): Unit = rootNode.foreachWithHash(f)
 
   /** Applies a function f to each element, and its corresponding **original** hash, in this Set
@@ -1755,7 +1755,7 @@ private final class HashCollisionSetNode[A](val originalHash: Int, val hash: Int
     }
 
   /**
-    * Remove an element from the hash collision node.
+    * Removes an element from the hash collision node.
     *
     * When after deletion only one element remains, we return a bit-mapped indexed node with a
     * singleton element and a hash-prefix for trie level 0. This node will be then a) either become
@@ -1946,7 +1946,7 @@ object HashSet extends IterableFactory[HashSet] {
       case _ => (newBuilder[A] ++= source).result()
     }
 
-  /** Create a new Builder which can be reused after calling `result()` without an
+  /** Creates a new Builder which can be reused after calling `result()` without an
     * intermediate call to `clear()` in order to build multiple related results.
     */
   def newBuilder[A]: ReusableBuilder[A, HashSet[A]] = new HashSetBuilder
@@ -1972,7 +1972,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
   /** The root node of the partially built hashmap. */
   private var rootNode: BitmapIndexedSetNode[A] = newEmptyRootNode
 
-  /** Inserts element `elem` into array `as` at index `ix`, shifting right the trailing elems */
+  /** Inserts element `elem` into array `as` at index `ix`, shifting right the trailing elems. */
   private def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException
     if (ix > as.length) throw new ArrayIndexOutOfBoundsException
@@ -1983,7 +1983,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
     result
   }
 
-  /** Inserts key-value into the bitmapIndexMapNode. Requires that this is a new key-value pair */
+  /** Inserts key-value into the bitmapIndexMapNode. Requires that this is a new key-value pair. */
   private def insertValue[A1 >: A](bm: BitmapIndexedSetNode[A], bitpos: Int, key: A, originalHash: Int, keyHash: Int): Unit = {
     val dataIx = bm.dataIndex(bitpos)
     val idx = TupleLength * dataIx
@@ -2005,7 +2005,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
     bm.cachedJavaKeySetHashCode += keyHash
   }
 
-  /** Mutates `bm` to replace inline data at bit position `bitpos` with updated key/value */
+  /** Mutates `bm` to replace inline data at bit position `bitpos` with updated key/value. */
   private def setValue[A1 >: A](bm: BitmapIndexedSetNode[A], bitpos: Int, elem: A): Unit = {
     val dataIx = bm.dataIndex(bitpos)
     val idx = TupleLength * dataIx
@@ -2050,13 +2050,13 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
         }
     }
 
-  /** If currently referencing aliased structure, copy elements to new mutable structure */
+  /** If currently referencing aliased structure, copy elements to new mutable structure. */
   private def ensureUnaliased():Unit = {
     if (isAliased) copyElems()
     aliased = null
   }
 
-  /** Copy elements to new mutable structure */
+  /** Copies elements to new mutable structure. */
   private def copyElems(): Unit = {
     rootNode = rootNode.copy()
   }

--- a/library/src/scala/collection/immutable/LazyList.scala
+++ b/library/src/scala/collection/immutable/LazyList.scala
@@ -406,7 +406,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     if (knownIsEmpty) Iterator.empty
     else new LazyIterator(this)
 
-  /** Apply the given function `f` to each element of this linear sequence
+  /** Applies the given function `f` to each element of this linear sequence
     * (while respecting the order of the elements).
     *
     *  @param f The treatment to apply to each element.
@@ -1193,25 +1193,25 @@ object LazyList extends SeqFactory[LazyList] {
   /** An alternative way of building and matching lazy lists using LazyList.cons(hd, tl).
     */
   object cons {
-    /** A lazy list consisting of a given first element and remaining elements
+    /** A lazy list consisting of a given first element and remaining elements.
       *  @param hd   The first element of the result lazy list
       *  @param tl   The remaining elements of the result lazy list
       */
     def apply[A](hd: => A, tl: => LazyList[A]): LazyList[A] = newLL(eagerCons(hd, newLL(tl)))
 
-    /** Maps a lazy list to its head and tail */
+    /** Maps a lazy list to its head and tail. */
     def unapply[A](xs: LazyList[A]): Option[(A, LazyList[A])] = #::.unapply(xs)
   }
 
   implicit def toDeferrer[A](l: => LazyList[A]): Deferrer[A] = new Deferrer[A](() => l)
 
   final class Deferrer[A] private[LazyList] (private val l: () => LazyList[A]) extends AnyVal {
-    /** Construct a LazyList consisting of a given first element followed by elements
-      *  from another LazyList.
+    /** Constructs a `LazyList` consisting of a given first element followed by elements
+      *  from another `LazyList`.
       */
     def #:: [B >: A](elem: => B): LazyList[B] = newLL(eagerCons(elem, newLL(l())))
-    /** Construct a LazyList consisting of the concatenation of the given LazyList and
-      *  another LazyList.
+    /** Constructs a `LazyList` consisting of the concatenation of the given `LazyList` and
+      *  another `LazyList`.
       */
     def #:::[B >: A](prefix: LazyList[B]): LazyList[B] = prefix lazyAppendedAll l()
   }
@@ -1262,7 +1262,7 @@ object LazyList extends SeqFactory[LazyList] {
     }
 
   /**
-    * Create an infinite LazyList starting at `start` and incrementing by
+    * Creates an infinite LazyList starting at `start` and incrementing by
     * step `step`.
     *
     * @param start the start value of the LazyList
@@ -1273,7 +1273,7 @@ object LazyList extends SeqFactory[LazyList] {
     newLL(eagerCons(start, from(start + step, step)))
 
   /**
-    * Create an infinite LazyList starting at `start` and incrementing by `1`.
+    * Creates an infinite LazyList starting at `start` and incrementing by `1`.
     *
     * @param start the start value of the LazyList
     * @return the LazyList starting at value `start`.
@@ -1281,7 +1281,7 @@ object LazyList extends SeqFactory[LazyList] {
   def from(start: Int): LazyList[Int] = from(start, 1)
 
   /**
-    * Create an infinite LazyList containing the given element expression (which
+    * Creates an infinite LazyList containing the given element expression (which
     * is computed for each occurrence).
     *
     * @param elem the element composing the resulting LazyList

--- a/library/src/scala/collection/immutable/LazyListIterable.scala
+++ b/library/src/scala/collection/immutable/LazyListIterable.scala
@@ -427,7 +427,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
     if (knownIsEmpty) Iterator.empty
     else new LazyIterator(this)
 
-  /** Apply the given function `f` to each element of this linear sequence
+  /** Applies the given function `f` to each element of this linear sequence
     * (while respecting the order of the elements).
     *
     *  @param f The treatment to apply to each element.
@@ -1216,25 +1216,25 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   /** An alternative way of building and matching lazy lists using LazyListIterable.cons(hd, tl).
     */
   object cons {
-    /** A lazy list consisting of a given first element and remaining elements
+    /** A lazy list consisting of a given first element and remaining elements.
       *  @param hd   The first element of the result lazy list
       *  @param tl   The remaining elements of the result lazy list
       */
     def apply[A](hd: => A, tl: => LazyListIterable[A]): LazyListIterable[A]^{hd, tl} = newLL(eagerCons(hd, newLL(tl)))
 
-    /** Maps a lazy list to its head and tail */
+    /** Maps a lazy list to its head and tail. */
     def unapply[A](xs: LazyListIterable[A]^): Option[(A, LazyListIterable[A]^{xs})] = #::.unapply(xs)
   }
 
   implicit def toDeferrer[A](l: => LazyListIterable[A]^): Deferrer[A]^{l} = new Deferrer[A](() => l)
 
   final class Deferrer[A] private[LazyListIterable] (private val l: () => LazyListIterable[A]^) extends AnyVal { self: Deferrer[A]^ =>
-    /** Construct a LazyListIterable consisting of a given first element followed by elements
-      *  from another LazyListIterable.
+    /** Constructs a `LazyListIterable` consisting of a given first element followed by elements
+      *  from another `LazyListIterable`.
       */
     def #:: [B >: A](elem: => B): LazyListIterable[B]^{this, elem} = newLL(eagerCons(elem, newLL(l())))
-    /** Construct a LazyListIterable consisting of the concatenation of the given LazyListIterable and
-      *  another LazyListIterable.
+    /** Constructs a `LazyListIterable` consisting of the concatenation of the given `LazyListIterable` and
+      *  another `LazyListIterable`.
       */
     def #:::[B >: A](prefix: LazyListIterable[B]^): LazyListIterable[B]^{this, prefix} = prefix lazyAppendedAll l()
   }
@@ -1298,7 +1298,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
     }
 
   /**
-    * Create an infinite LazyListIterable starting at `start` and incrementing by
+    * Creates an infinite LazyListIterable starting at `start` and incrementing by
     * step `step`.
     *
     * @param start the start value of the LazyListIterable
@@ -1309,7 +1309,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
     newLL(eagerCons(start, from(start + step, step)))
 
   /**
-    * Create an infinite LazyListIterable starting at `start` and incrementing by `1`.
+    * Creates an infinite LazyListIterable starting at `start` and incrementing by `1`.
     *
     * @param start the start value of the LazyListIterable
     * @return the LazyListIterable starting at value `start`.
@@ -1317,7 +1317,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   def from(start: Int): LazyListIterable[Int] = from(start, 1)
 
   /**
-    * Create an infinite LazyListIterable containing the given element expression (which
+    * Creates an infinite LazyListIterable containing the given element expression (which
     * is computed for each occurrence).
     *
     * @param elem the element composing the resulting LazyListIterable

--- a/library/src/scala/collection/immutable/Map.scala
+++ b/library/src/scala/collection/immutable/Map.scala
@@ -23,7 +23,7 @@ import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.{Builder, ReusableBuilder}
 import SeqMap.{SeqMap1, SeqMap2, SeqMap3, SeqMap4}
 
-/** Base type of immutable Maps */
+/** Base type of immutable Maps. */
 trait Map[K, +V]
   extends Iterable[(K, V)]
      with collection.Map[K, V]
@@ -76,7 +76,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
     */
   def removed(key: K): C
 
-  /** Alias for `removed` */
+  /** Alias for `removed`. */
   @`inline` final def - (key: K): C = removed(key)
 
   @deprecated("Use -- with an explicit collection", "2.13.0")
@@ -93,7 +93,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
     */
   def removedAll(keys: IterableOnce[K]^): C = keys.iterator.foldLeft[C](coll)(_ - _)
 
-  /** Alias for `removedAll` */
+  /** Alias for `removedAll`. */
   @`inline` final override def -- (keys: IterableOnce[K]^): C = removedAll(keys)
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
@@ -105,7 +105,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
   def updated[V1 >: V](key: K, value: V1): CC[K, V1]
 
   /**
-   * Update a mapping for the specified key and its current optionally mapped value
+   * Updates a mapping for the specified key and its current optionally mapped value
    * (`Some` if there is current mapping, `None` if not).
    *
    * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
@@ -113,7 +113,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    * If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
    *
    * @param key the key value
-   * @param remappingFunction a function that receives current optionally mapped value and return a new mapping
+   * @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
    * @return A new map with the updated mapping with the key
    */
   def updatedWith[V1 >: V](key: K)(remappingFunction: Option[V] => Option[V1]): CC[K,V1] = {
@@ -145,7 +145,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
 
   override def keySet: Set[K] = new ImmutableKeySet
 
-  /** The implementation class of the set returned by `keySet` */
+  /** The implementation class of the set returned by `keySet`. */
   protected[immutable] class ImmutableKeySet extends AbstractSet[K] with GenKeySet with DefaultSerializable {
     def incl(elem: K): Set[K] = if (this(elem)) this else empty ++ this + elem
     def excl(elem: K): Set[K] = if (this(elem)) empty ++ this - elem else this

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -95,13 +95,13 @@ sealed class NumericRange[T](
     else if(isInclusive) new NumericRange.Inclusive(start + step, end, step)
     else new NumericRange.Exclusive(start + step, end, step)
 
-  /** Create a new range with the start and end values of this range and
+  /** Creates a new range with the start and end values of this range and
     *  a new `step`.
     */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
 
-  /** Create a copy of this range.
+  /** Creates a copy of this range.
     */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -219,7 +219,7 @@ sealed abstract class Range(
   final protected def copy(start: Int = start, end: Int = end, step: Int = step, isInclusive: Boolean = isInclusive): Range =
     if(isInclusive) new Range.Inclusive(start, end, step) else new Range.Exclusive(start, end, step)
 
-  /** Create a new range with the `start` and `end` values of this range and
+  /** Creates a new range with the `start` and `end` values of this range and
     *  a new `step`.
     *
     *  @return a new range with a different step
@@ -418,7 +418,7 @@ sealed abstract class Range(
     if (isEmpty) this
     else new Range.Inclusive(last, start, -step)
 
-  /** Make range inclusive.
+  /** Makes range inclusive.
     */
   final def inclusive: Range =
     if (isInclusive) this
@@ -617,21 +617,21 @@ object Range {
   def count(start: Int, end: Int, step: Int): Int =
     count(start, end, step, isInclusive = false)
 
-  /** Make a range from `start` until `end` (exclusive) with given step value.
+  /** Makes a range from `start` until `end` (exclusive) with given step value.
     * @note step != 0
     */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
-  /** Make a range from `start` until `end` (exclusive) with step value 1.
+  /** Makes a range from `start` until `end` (exclusive) with step value 1.
     */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
-  /** Make an inclusive range from `start` to `end` with given step value.
+  /** Makes an inclusive range from `start` to `end` with given step value.
     * @note step != 0
     */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
-  /** Make an inclusive range from `start` to `end` with step value 1.
+  /** Makes an inclusive range from `start` to `end` with step value 1.
     */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -69,7 +69,7 @@ private[collection] object RedBlackTree {
         res
       } else tree.black
     }
-    /** Create a new balanced tree where `newLeft` replaces `tree.left`.
+    /** Creates a new balanced tree where `newLeft` replaces `tree.left`.
      * tree and newLeft are never null */
     protected final def mutableBalanceLeft[A1, B, B1 >: B](tree: Tree[A1, B], newLeft: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -112,7 +112,7 @@ private[collection] object RedBlackTree {
         tree.mutableWithLeft(newLeft)
       }
     }
-    /** Create a new balanced tree where `newRight` replaces `tree.right`.
+    /** Creates a new balanced tree where `newRight` replaces `tree.right`.
      * tree and newRight are never null */
     protected final def mutableBalanceRight[A1, B, B1 >: B](tree: Tree[A1, B], newRight: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -340,7 +340,7 @@ private[collection] object RedBlackTree {
     new Tree(key, value.asInstanceOf[AnyRef], left, right, sizeAndColour)
   }
 
-  /** Create a new balanced tree where `newLeft` replaces `tree.left`. */
+  /** Creates a new balanced tree where `newLeft` replaces `tree.left`. */
   private def balanceLeft[A, B1](tree: Tree[A, B1], newLeft: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
     //            tree              |                   newLeft
@@ -381,7 +381,7 @@ private[collection] object RedBlackTree {
       }
     }
   }
-  /** Create a new balanced tree where `newRight` replaces `tree.right`. */
+  /** Creates a new balanced tree where `newRight` replaces `tree.right`. */
   private def balanceRight[A, B1](tree: Tree[A, B1], newRight: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
     //            tree                |                             newRight
@@ -785,8 +785,8 @@ private[collection] object RedBlackTree {
   @`inline` private[RedBlackTree] def mutableRedTree[A, B](key: A, value: B, left: Tree[A, B] | Null, right: Tree[A, B] | Null) = new Tree[A,B](key, value.asInstanceOf[AnyRef], left, right, initialRedCount)
   @`inline` private[RedBlackTree] def mutableBlackTree[A, B](key: A, value: B, left: Tree[A, B] | Null, right: Tree[A, B] | Null) = new Tree[A,B](key, value.asInstanceOf[AnyRef], left, right, initialBlackCount)
 
-  /** create a new immutable red tree.
-   * left and right may be null
+  /** Creates a new immutable red tree.
+   * left and right may be null.
    */
   private[immutable] def RedTree[A, B](key: A, value: B, left: Tree[A, B] | Null, right: Tree[A, B] | Null): Tree[A, B] = {
     //assertNotMutable(left)
@@ -856,7 +856,7 @@ private[collection] object RedBlackTree {
     protected var lookahead: Tree[A, B] | Null = if (start.isDefined) startFrom(start.get) else findLeftMostOrPopOnEmpty(root)
 
     /**
-      * Find the leftmost subtree whose key is equal to the given key, or if no such thing,
+      * Finds the leftmost subtree whose key is equal to the given key, or if no such thing,
       * the leftmost subtree with the key that would be "next" after it according
       * to the ordering. Along the way build up the iterator's path stack so that "next"
       * functionality works.
@@ -939,7 +939,7 @@ private[collection] object RedBlackTree {
     override def nextResult(tree: Tree[A, B]) = tree.value
   }
 
-  /** Build a Tree suitable for a TreeSet from an ordered sequence of keys */
+  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys. */
   def fromOrderedKeys[A](xs: Iterator[A]^, size: Int): Tree[A, Null] | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Tree[A, Null] | Null = size match {
@@ -955,7 +955,7 @@ private[collection] object RedBlackTree {
     f(1, size)
   }
 
-  /** Build a Tree suitable for a TreeMap from an ordered sequence of key/value pairs */
+  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs. */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)]^, size: Int): Tree[A, B] | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Tree[A, B] | Null = size match {
@@ -1092,7 +1092,7 @@ private[collection] object RedBlackTree {
          tl.nn.right.nn.redWithLeftRight(balance(tl.nn, tl.nn.left.nn.red, tl.nn.right.nn.left), tree.blackWithLeftRight(tl.nn.right.nn.right, tr))
     else sys.error("Defect: invariance violation")
 
-  /** `append` is similar to `join2` but requires that both subtrees have the same black height */
+  /** `append` is similar to `join2` but requires that both subtrees have the same black height. */
   private def append[A, B](tl: Tree[A, B] | Null, tr: Tree[A, B] | Null): Tree[A, B] | Null = {
     if (tl eq null) tr
     else if (tr eq null) tl
@@ -1132,7 +1132,7 @@ private[collection] object RedBlackTree {
   def difference[A, B](t1: Tree[A, B] | Null, t2: Tree[A, ?] | Null)(implicit ordering: Ordering[A]): Tree[A, B] | Null =
     blacken(_difference(t1, t2.asInstanceOf[Tree[A, B]]))
 
-  /** Compute the rank from a tree and its black height */
+  /** Computes the rank from a tree and its black height. */
   @`inline` private def rank(t: Tree[?, ?] | Null, bh: Int): Int = {
     if(t eq null) 0
     else if(t.isBlack) 2*(bh-1)

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -46,7 +46,7 @@ object Seq extends SeqFactory.Delegate[Seq](List) {
   }
 }
 
-/** Base trait for immutable indexed sequences that have efficient `apply` and `length` */
+/** Base trait for immutable indexed sequences that have efficient `apply` and `length`. */
 trait IndexedSeq[+A] extends Seq[A]
                         with collection.IndexedSeq[A]
                         with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
@@ -119,7 +119,7 @@ object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector) {
   }
 }
 
-/** Base trait for immutable indexed Seq operations */
+/** Base trait for immutable indexed `Seq` operations. */
 transparent trait IndexedSeqOps[+A, +CC[B] <: caps.Pure, +C]
   extends SeqOps[A, CC, C]
     with collection.IndexedSeqOps[A, CC, C] {
@@ -132,7 +132,7 @@ transparent trait IndexedSeqOps[+A, +CC[B] <: caps.Pure, +C]
 
 }
 
-/** Base trait for immutable linear sequences that have efficient `head` and `tail` */
+/** Base trait for immutable linear sequences that have efficient `head` and `tail`. */
 trait LinearSeq[+A]
   extends Seq[A]
     with collection.LinearSeq[A]

--- a/library/src/scala/collection/immutable/Set.scala
+++ b/library/src/scala/collection/immutable/Set.scala
@@ -20,7 +20,7 @@ import language.experimental.captureChecking
 import scala.collection.immutable.Set.Set4
 import scala.collection.mutable.{Builder, ReusableBuilder}
 
-/** Base trait for immutable set collections */
+/** Base trait for immutable set collections. */
 trait Set[A] extends Iterable[A]
     with collection.Set[A]
     with SetOps[A, Set, Set[A]]
@@ -45,7 +45,7 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     */
   def incl(elem: A): C
 
-  /** Alias for `incl` */
+  /** Alias for `incl`. */
   override final def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
@@ -56,7 +56,7 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     */
   def excl(elem: A): C
 
-  /** Alias for `excl` */
+  /** Alias for `excl`. */
   @`inline` final override def - (elem: A): C = excl(elem)
 
   def diff(that: collection.Set[A]): C =
@@ -70,7 +70,7 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     */
   def removedAll(that: IterableOnce[A]^): C = that.iterator.foldLeft[C](coll)(_ - _)
 
-  /** Alias for removedAll */
+  /** Alias for removedAll. */
   override final def -- (that: IterableOnce[A]^): C = removedAll(that)
 }
 
@@ -118,7 +118,7 @@ object Set extends IterableFactory[Set] {
 
   def newBuilder[A]: Builder[A, Set[A]] = new SetBuilderImpl[A]
 
-  /** An optimized representation for immutable empty sets */
+  /** An optimized representation for immutable empty sets. */
   @SerialVersionUID(3L)
   private object EmptySet extends AbstractSet[Any] with Serializable {
     override def size: Int = 0
@@ -163,7 +163,7 @@ object Set extends IterableFactory[Set] {
     }
   }
 
-  /** An optimized representation for immutable sets of size 1 */
+  /** An optimized representation for immutable sets of size 1. */
   @SerialVersionUID(3L)
   final class Set1[A] private[collection] (elem1: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] with Serializable {
     override def size: Int = 1
@@ -190,7 +190,7 @@ object Set extends IterableFactory[Set] {
     override def tail: Set[A] = Set.empty
   }
 
-  /** An optimized representation for immutable sets of size 2 */
+  /** An optimized representation for immutable sets of size 2. */
   @SerialVersionUID(3L)
   final class Set2[A] private[collection] (elem1: A, elem2: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] with Serializable {
     override def size: Int = 2
@@ -239,7 +239,7 @@ object Set extends IterableFactory[Set] {
     override def tail: Set[A] = new Set1(elem2)
   }
 
-  /** An optimized representation for immutable sets of size 3 */
+  /** An optimized representation for immutable sets of size 3. */
   @SerialVersionUID(3L)
   final class Set3[A] private[collection] (elem1: A, elem2: A, elem3: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] with Serializable {
     override def size: Int = 3
@@ -293,7 +293,7 @@ object Set extends IterableFactory[Set] {
     override def tail: Set[A] = new Set2(elem2, elem3)
   }
 
-  /** An optimized representation for immutable sets of size 4 */
+  /** An optimized representation for immutable sets of size 4. */
   @SerialVersionUID(3L)
   final class Set4[A] private[collection] (elem1: A, elem2: A, elem3: A, elem4: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] with Serializable {
     override def size: Int = 4

--- a/library/src/scala/collection/immutable/SortedMap.scala
+++ b/library/src/scala/collection/immutable/SortedMap.scala
@@ -95,7 +95,7 @@ transparent trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] & SortedMapOps[X, 
 
   override def keySet: SortedSet[K] = new ImmutableKeySortedSet
 
-  /** The implementation class of the set returned by `keySet` */
+  /** The implementation class of the set returned by `keySet`. */
   protected class ImmutableKeySortedSet extends AbstractSet[K] with SortedSet[K] with GenKeySet with GenKeySortedSet {
     def rangeImpl(from: Option[K], until: Option[K]): SortedSet[K] = {
       val map = self.rangeImpl(from, until)

--- a/library/src/scala/collection/immutable/SortedSet.scala
+++ b/library/src/scala/collection/immutable/SortedSet.scala
@@ -17,7 +17,7 @@ package immutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base trait for sorted sets */
+/** Base trait for sorted sets. */
 trait SortedSet[A]
   extends Set[A]
      with collection.SortedSet[A]

--- a/library/src/scala/collection/immutable/Stream.scala
+++ b/library/src/scala/collection/immutable/Stream.scala
@@ -49,7 +49,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
 
   override protected def className: String = "Stream"
 
-  /** Apply the given function `f` to each element of this linear sequence
+  /** Applies the given function `f` to each element of this linear sequence
     * (while respecting the order of the elements).
     *
     *  @param f The treatment to apply to each element.
@@ -163,7 +163,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     else iterableFactory.empty
   }
 
-  /** A `collection.WithFilter` which allows GC of the head of stream during processing */
+  /** A `collection.WithFilter` which allows GC of the head of stream during processing. */
   override final def withFilter(p: A => Boolean): collection.WithFilter[A, Stream] =
     Stream.withFilter(coll, p)
 
@@ -363,13 +363,13 @@ object Stream extends SeqFactory[Stream] {
   /** An alternative way of building and matching Streams using Stream.cons(hd, tl).
     */
   object cons {
-    /** A stream consisting of a given first element and remaining elements
+    /** A stream consisting of a given first element and remaining elements.
       *  @param hd   The first element of the result stream
       *  @param tl   The remaining elements of the result stream
       */
     def apply[A](hd: A, tl: => Stream[A]): Stream[A] = new Cons(hd, tl)
 
-    /** Maps a stream to its head and tail */
+    /** Maps a stream to its head and tail. */
     def unapply[A](xs: Stream[A]): Option[(A, Stream[A])] = #::.unapply(xs)
   }
 
@@ -438,12 +438,12 @@ object Stream extends SeqFactory[Stream] {
   implicit def toDeferrer[A](l: => Stream[A]): Deferrer[A] = new Deferrer[A](() => l)
 
   final class Deferrer[A] private[Stream] (private val l: () => Stream[A]) extends AnyVal {
-    /** Construct a Stream consisting of a given first element followed by elements
-      *  from another Stream.
+    /** Constructs a `Stream` consisting of a given first element followed by elements
+      *  from another `Stream`.
       */
     def #:: [B >: A](elem: B): Stream[B] = new Cons(elem, l())
-    /** Construct a Stream consisting of the concatenation of the given Stream and
-      *  another Stream.
+    /** Constructs a `Stream` consisting of the concatenation of the given `Stream` and
+      *  another `Stream`.
       */
     def #:::[B >: A](prefix: Stream[B]): Stream[B] = prefix lazyAppendedAll l()
   }
@@ -498,7 +498,7 @@ object Stream extends SeqFactory[Stream] {
   }
 
   /**
-    * Create an infinite Stream starting at `start` and incrementing by
+    * Creates an infinite Stream starting at `start` and incrementing by
     * step `step`.
     *
     * @param start the start value of the Stream
@@ -509,7 +509,7 @@ object Stream extends SeqFactory[Stream] {
     cons(start, from(start + step, step))
 
   /**
-    * Create an infinite Stream starting at `start` and incrementing by `1`.
+    * Creates an infinite Stream starting at `start` and incrementing by `1`.
     *
     * @param start the start value of the Stream
     * @return the Stream starting at value `start`.
@@ -517,7 +517,7 @@ object Stream extends SeqFactory[Stream] {
   def from(start: Int): Stream[Int] = from(start, 1)
 
   /**
-    * Create an infinite Stream containing the given element expression (which
+    * Creates an infinite Stream containing the given element expression (which
     * is computed for each occurrence).
     *
     * @param elem the element composing the resulting Stream

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -67,7 +67,7 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
 
   def newBuilder[A]: ReusableBuilder[A, Vector[A]] = new VectorBuilder[A]
 
-  /** Create a Vector with the same element at each index.
+  /** Creates a Vector with the same element at each index.
     *
     * Unlike `fill`, which takes a by-name argument for the value and can thereby
     * compute different values for each index, this method guarantees that all
@@ -259,14 +259,14 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   override def tail: Vector[A] = slice(1, length)
   override def init: Vector[A] = slice(0, length-1)
 
-  /** Like slice but parameters must be 0 <= lo < hi < length */
+  /** Like slice but parameters must be 0 <= lo < hi < length. */
   protected def slice0(lo: Int, hi: Int): Vector[A]
 
-  /** Number of slices */
+  /** Number of slices. */
   protected[immutable] def vectorSliceCount: Int
-  /** Slice at index */
+  /** Slices at index. */
   protected[immutable] def vectorSlice(idx: Int): Array[? <: AnyRef | Null]
-  /** Length of all slices up to and including index */
+  /** Length of all slices up to and including index. */
   protected[immutable] def vectorSlicePrefixLength(idx: Int): Int
 
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = iterator.copyToArray(xs, start, len)
@@ -317,7 +317,7 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
 }
 
 
-/** This class only exists because we cannot override `slice` in `Vector` in a binary-compatible way */
+/** This class only exists because we cannot override `slice` in `Vector` in a binary-compatible way. */
 private sealed abstract class VectorImpl[+A](_prefix1: Arr1) extends Vector[A](_prefix1) {
 
   override final def slice(from: Int, until: Int): Vector[A] = {
@@ -330,7 +330,7 @@ private sealed abstract class VectorImpl[+A](_prefix1: Arr1) extends Vector[A](_
 }
 
 
-/** Vector with suffix and length fields; all Vector subclasses except Vector1 extend this */
+/** Vector with suffix and length fields; all Vector subclasses except Vector1 extend this. */
 private sealed abstract class BigVector[+A](_prefix1: Arr1, private[immutable] val suffix1: Arr1, private[immutable] val length0: Int) extends VectorImpl[A](_prefix1) {
 
   protected[immutable] final def foreachRest[U](f: A => U): Unit = {
@@ -344,7 +344,7 @@ private sealed abstract class BigVector[+A](_prefix1: Arr1, private[immutable] v
 }
 
 
-/** Empty vector */
+/** Empty vector. */
 private object Vector0 extends BigVector[Nothing](empty1, empty1, 0) {
 
   def apply(index: Int): Nothing = throw ioob(index)
@@ -385,7 +385,7 @@ private object Vector0 extends BigVector[Nothing](empty1, empty1, 0) {
     new IndexOutOfBoundsException(s"$index is out of bounds (empty vector)")
 }
 
-/** Flat ArraySeq-like structure */
+/** Flat ArraySeq-like structure. */
 private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
 
   @inline def apply(index: Int): A = {
@@ -443,7 +443,7 @@ private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
 }
 
 
-/** 2-dimensional radix-balanced finger tree */
+/** 2-dimensional radix-balanced finger tree. */
 private final class Vector2[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val data2: Arr2,
                                  _suffix1: Arr1,
@@ -543,7 +543,7 @@ private final class Vector2[+A](_prefix1: Arr1, private[immutable] val len1: Int
 }
 
 
-/** 3-dimensional radix-balanced finger tree */
+/** 3-dimensional radix-balanced finger tree. */
 private final class Vector3[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
                                  private[immutable] val data3: Arr3,
@@ -666,7 +666,7 @@ private final class Vector3[+A](_prefix1: Arr1, private[immutable] val len1: Int
 }
 
 
-/** 4-dimensional radix-balanced finger tree */
+/** 4-dimensional radix-balanced finger tree. */
 private final class Vector4[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
                                  private[immutable] val prefix3: Arr3, private[immutable] val len123: Int,
@@ -810,7 +810,7 @@ private final class Vector4[+A](_prefix1: Arr1, private[immutable] val len1: Int
 }
 
 
-/** 5-dimensional radix-balanced finger tree */
+/** 5-dimensional radix-balanced finger tree. */
 private final class Vector5[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
                                  private[immutable] val prefix3: Arr3, private[immutable] val len123: Int,
@@ -975,7 +975,7 @@ private final class Vector5[+A](_prefix1: Arr1, private[immutable] val len1: Int
 }
 
 
-/** 6-dimensional radix-balanced finger tree */
+/** 6-dimensional radix-balanced finger tree. */
 private final class Vector6[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
                                  private[immutable] val prefix3: Arr3, private[immutable] val len123: Int,
@@ -1348,7 +1348,7 @@ private final class VectorSliceBuilder(lo: Int, hi: Int) {
     }
   }
 
-  /** Ensure prefix is not empty */
+  /** Ensures prefix is not empty. */
   private def balancePrefix(n: Int): Unit = {
     if(slices(prefixIdx(n)) eq null) {
       if(n == maxDim) {
@@ -1369,7 +1369,7 @@ private final class VectorSliceBuilder(lo: Int, hi: Int) {
     }
   }
 
-  /** Ensure suffix is not empty */
+  /** Ensures suffix is not empty. */
   private def balanceSuffix(n: Int): Unit = {
     if(slices(suffixIdx(n)) eq null) {
       if(n == maxDim) {
@@ -2016,7 +2016,7 @@ private[immutable] object VectorInline {
   type Arr5 = Array[Array[Array[Array[Array[AnyRef]]]]]
   type Arr6 = Array[Array[Array[Array[Array[Array[AnyRef]]]]]]
 
-  /** Dimension of the slice at index */
+  /** Dimension of the slice at index. */
   @inline def vectorSliceDim(count: Int, idx: Int): Int = {
     val c = count/2
     c+1-abs(idx-c)

--- a/library/src/scala/collection/mutable/AnyRefMap.scala
+++ b/library/src/scala/collection/mutable/AnyRefMap.scala
@@ -570,7 +570,7 @@ object AnyRefMap {
   /** Creates a new empty `AnyRefMap`. */
   def empty[K <: AnyRef, V]: AnyRefMap[K, V] = new AnyRefMap[K, V]
 
-  /** Creates a new empty `AnyRefMap` with the supplied default */
+  /** Creates a new empty `AnyRefMap` with the supplied default. */
   def withDefault[K <: AnyRef, V](default: K -> V): AnyRefMap[K, V] = new AnyRefMap[K, V](default)
 
   /** Creates a new `AnyRefMap` from an existing source collection. A source collection

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -65,7 +65,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
-  /** Ensure that the internal array has at least `n` cells. */
+  /** Ensures that the internal array has at least `n` cells. */
   protected def ensureSize(n: Int): Unit = {
     array = ArrayBuffer.ensureSize(array, size0, n)
   }
@@ -77,7 +77,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   def sizeHint(size: Int): Unit =
     if(size > length && size >= 1) ensureSize(size)
 
-  /** Reduce length to `n`, nulling out all dropped elements */
+  /** Reduces length to `n`, nulling out all dropped elements. */
   private def reduceToSize(n: Int): Unit = {
     mutationCount += 1
     Arrays.fill(array, n, size0, null)

--- a/library/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library/src/scala/collection/mutable/ArrayBuilder.scala
@@ -47,10 +47,10 @@ sealed abstract class ArrayBuilder[T]
 
   protected def resize(size: Int): Unit
 
-  /** Add all elements of an array. */
+  /** Adds all elements of an array. */
   def addAll(xs: Array[? <: T]): this.type = addAll(xs, 0, xs.length)
 
-  /** Add a slice of an array. */
+  /** Adds a slice of an array. */
   def addAll(xs: Array[? <: T], offset: Int, length: Int): this.type = {
     val offset1 = offset.max(0)
     val length1 = length.max(0)

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -342,7 +342,7 @@ class ArrayDeque[A] protected (
   }
 
   /**
-    * Remove all elements from this collection and return the elements while emptying this data structure
+    * Removes all elements from this collection and returns the elements while emptying this data structure.
     * @return
     */
   def removeAll(): scala.collection.immutable.Seq[A] = {
@@ -355,7 +355,7 @@ class ArrayDeque[A] protected (
   }
 
   /**
-    * Remove all elements from this collection and return the elements in reverse while emptying this data structure
+    * Removes all elements from this collection and returns the elements in reverse while emptying this data structure.
     * @return
     */
   def removeAllReverse(): scala.collection.immutable.Seq[A] = {

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -58,7 +58,7 @@ sealed abstract class ArraySeq[T]
     * or subtype of the element type. */
   def elemTag: ClassTag[?]
 
-  /** Update element at given index */
+  /** Updates element at given index. */
   def update(@deprecatedName("idx", "2.13.0") index: Int, elem: T): Unit
 
   /** The underlying array. Its element type does not have to be equal to the element type of this ArraySeq. A primitive
@@ -112,7 +112,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
   def newBuilder[A : ClassTag]: Builder[A, ArraySeq[A]] = ArrayBuilder.make[A].mapResult(make)
 
   /**
-   * Wrap an existing `Array` into a `ArraySeq` of the proper primitive specialization type
+   * Wraps an existing `Array` into a `ArraySeq` of the proper primitive specialization type
    * without copying.
    *
    * Note that an array containing boxed primitives can be converted to a `ArraySeq` without

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -369,7 +369,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   def newBuilder: Builder[Int, BitSet] = new GrowableBuilder(empty)
 
-  /** A bitset containing all the bits in an array */
+  /** A bitset containing all the bits in an array. */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
     if (len == 0) empty

--- a/library/src/scala/collection/mutable/Buffer.scala
+++ b/library/src/scala/collection/mutable/Buffer.scala
@@ -58,7 +58,7 @@ trait Buffer[A]
    */
   @`inline` final def appendAll(@deprecatedName("xs") elems: IterableOnce[A]^): this.type = addAll(elems)
 
-  /** Alias for `prepend` */
+  /** Alias for `prepend`. */
   @`inline` final def +=: (elem: A): this.type = prepend(elem)
 
   /** Prepends the elements contained in a iterable object to this buffer.
@@ -70,7 +70,7 @@ trait Buffer[A]
   @deprecated("Use prependAll instead", "2.13.0")
   @`inline` final def prepend(elems: A*): this.type = prependAll(elems)
 
-  /** Alias for `prependAll` */
+  /** Alias for `prependAll`. */
   @inline final def ++=:(elems: IterableOnce[A]^): this.type = prependAll(elems)
 
   /** Inserts a new element at a given index into this buffer.
@@ -236,7 +236,7 @@ trait Buffer[A]
     if (idx < 0) this else takeInPlace(idx)
   }
 
-  /** Append the given element to this $coll until a target length is reached.
+  /** Appends the given element to this $coll until a target length is reached.
    *
    *  @param   len   the target length
    *  @param   elem  the padding value
@@ -258,7 +258,7 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
 
   override def iterableFactory: SeqFactory[IndexedBuffer] = IndexedBuffer
 
-  /** Replace the contents of this $coll with the flatmapped result.
+  /** Replaces the contents of this $coll with the flatmapped result.
    *
    *  @param f the mapping function
    *  @return this $coll
@@ -275,7 +275,7 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
     this
   }
 
-  /** Replace the contents of this $coll with the filtered result.
+  /** Replaces the contents of this $coll with the filtered result.
    *
    *  @param f the filtering function
    *  @return this $coll

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -450,7 +450,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     case _ => iterator.concat(suffix.iterator)
   })
 
-  /** Alias for `concat` */
+  /** Alias for `concat`. */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]^): CollisionProofHashMap[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
@@ -761,10 +761,10 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
       override def sizeHint(size: Int) = elems.sizeHint(size)
     }
 
-  /** The default load factor for the hash table */
+  /** The default load factor for the hash table. */
   final def defaultLoadFactor: Double = 0.75
 
-  /** The default initial capacity for the hash table */
+  /** The default initial capacity for the hash table. */
   final def defaultInitialCapacity: Int = 16
 
   @SerialVersionUID(3L)

--- a/library/src/scala/collection/mutable/Growable.scala
+++ b/library/src/scala/collection/mutable/Growable.scala
@@ -35,7 +35,7 @@ trait Growable[-A] extends Clearable {
    */
   def addOne(elem: A): this.type
 
-  /** Alias for `addOne` */
+  /** Alias for `addOne`. */
   @inline final def += (elem: A): this.type = addOne(elem)
 
   //TODO This causes a conflict in StringBuilder; looks like a compiler bug
@@ -68,7 +68,7 @@ trait Growable[-A] extends Clearable {
     this
   }
 
-  /** Alias for `addAll` */
+  /** Alias for `addAll`. */
   @inline final def ++= (@deprecatedName("xs") elems: IterableOnce[A]^): this.type = addAll(elems)
 
   /** The number of elements in the collection under construction, if it can be cheaply computed, -1 otherwise.
@@ -81,7 +81,7 @@ trait Growable[-A] extends Clearable {
 object Growable {
 
   /**
-    * Fills a `Growable` instance with the elements of a given iterable
+    * Fills a `Growable` instance with the elements of a given iterable.
     * @param empty Instance to fill
     * @param it Elements to add
     * @tparam A Element type

--- a/library/src/scala/collection/mutable/HashMap.scala
+++ b/library/src/scala/collection/mutable/HashMap.scala
@@ -43,7 +43,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     with MapFactoryDefaults[K, V, HashMap, Iterable]
     with Serializable {
 
-  /* The HashMap class holds the following invariant:
+  /* The `HashMap` class holds the following invariant:
    * - For each i between  0 and table.length, the bucket at table(i) only contains keys whose hash-index is i.
    * - Every bucket is sorted in ascendent hash order
    * - The sum of the lengths of all buckets is equal to contentSize.
@@ -62,7 +62,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   override def size: Int = contentSize
 
-  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash*/
+  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash. */
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
   /** Computes the improved hash of an original (`any.##`) hash. */
@@ -77,7 +77,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     originalHash ^ (originalHash >>> 16)
   }
 
-  /** Computes the improved hash of this key */
+  /** Computes the improved hash of this key. */
   @`inline` private def computeHash(o: K): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
@@ -345,7 +345,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
 
 
-  /** Returns an iterator over the nodes stored in this HashMap */
+  /** Returns an iterator over the nodes stored in this HashMap. */
   private[collection] def nodeIterator: Iterator[Node[K, V]] =
     if(size == 0) Iterator.empty
     else new HashMapIterator[Node[K, V]] {
@@ -617,10 +617,10 @@ object HashMap extends MapFactory[HashMap] {
       override def sizeHint(size: Int) = elems.sizeHint(size)
     }
 
-  /** The default load factor for the hash table */
+  /** The default load factor for the hash table. */
   final def defaultLoadFactor: Double = 0.75
 
-  /** The default initial capacity for the hash table */
+  /** The default initial capacity for the hash table. */
   final def defaultInitialCapacity: Int = 16
 
   @SerialVersionUID(3L)

--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -42,7 +42,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   import HashSet.Node
 
-  /* The Hashset class holds the following invariant:
+  /* The `HashSet` class holds the following invariant:
    * - For each i between  0 and table.length, the bucket at table(i) only contains elements whose hash-index is i.
    * - Every bucket is sorted in ascendent hash order
    * - The sum of the lengths of all buckets is equal to contentSize.
@@ -57,7 +57,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   override def size: Int = contentSize
 
-  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash*/
+  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash. */
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
   /** Computes the improved hash of an original (`any.##`) hash. */
@@ -68,7 +68,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     originalHash ^ (originalHash >>> 16)
   }
 
-  /** Computes the improved hash of this element */
+  /** Computes the improved hash of this element. */
   @`inline` private def computeHash(o: A): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
@@ -149,7 +149,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     }
   }
 
-  /** Adds an element to this set
+  /** Adds an element to this set.
     * @param elem element to add
     * @param hash the **improved** hash of `elem` (see computeHash)
     */
@@ -235,7 +235,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     override protected def extract(nd: Node[A]): A = nd.key
   }
 
-  /** Returns an iterator over the nodes stored in this HashSet */
+  /** Returns an iterator over the nodes stored in this HashSet. */
   private[collection] def nodeIterator: Iterator[Node[A]] = new HashSetIterator[Node[A]] {
     override protected def extract(nd: Node[A]): Node[A] = nd
   }
@@ -424,10 +424,10 @@ object HashSet extends IterableFactory[HashSet] {
       override def sizeHint(size: Int) = elems.sizeHint(size)
     }
 
-  /** The default load factor for the hash table */
+  /** The default load factor for the hash table. */
   final def defaultLoadFactor: Double = 0.75
 
-  /** The default initial capacity for the hash table */
+  /** The default initial capacity for the hash table. */
   final def defaultInitialCapacity: Int = 16
 
   @SerialVersionUID(3L)

--- a/library/src/scala/collection/mutable/HashTable.scala
+++ b/library/src/scala/collection/mutable/HashTable.scala
@@ -131,7 +131,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
     foreachEntry(writeEntry)
   }
 
-  /** Find entry with given key in table, null if not found.
+  /** Finds entry with given key in table, null if not found.
    */
   final def findEntry(key: A): Entry | Null =
     findEntry0(key, index(elemHashCode(key)))
@@ -142,7 +142,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
     e
   }
 
-  /** Add entry to table
+  /** Adds entry to table
    *  pre: no entry with same key exists
    */
   protected[collection] final def addEntry(e: Entry): Unit = {
@@ -158,7 +158,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
       resize(2 * table.length)
   }
 
-  /** Find entry with given key in table, or add new one if not found.
+  /** Finds entry with given key in table, or adds new one if not found.
    *  May be somewhat faster then `findEntry`/`addEntry` pair as it
    *  computes entry's hash index only once.
    *  Returns entry found in table or null.
@@ -176,12 +176,12 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
    */
   def createNewEntry(key: A, value: B): Entry
 
-  /** Remove entry from table if present.
+  /** Removes entry from table if present.
    */
   final def removeEntry(key: A) : Entry | Null = {
     removeEntry0(key, index(elemHashCode(key)))
   }
-  /** Remove entry from table if present.
+  /** Removes entry from table if present.
    */
   private[collection] final def removeEntry0(key: A, h: Int) : Entry | Null = {
     var e = table(h).asInstanceOf[Entry | Null]
@@ -247,7 +247,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
     }
   }
 
-  /** Remove all entries from table
+  /** Removes all entries from table
    */
   def clearTable(): Unit = {
     var i = table.length - 1

--- a/library/src/scala/collection/mutable/LinkedHashMap.scala
+++ b/library/src/scala/collection/mutable/LinkedHashMap.scala
@@ -196,7 +196,7 @@ class LinkedHashMap[K, V]
   }
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of this key */
+  /** Computes the improved hash of this key. */
   @`inline` private def computeHash(o: K): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
@@ -361,7 +361,7 @@ class LinkedHashMap[K, V]
     e
   }
 
-  /** Delete the entry from the LinkedHashMap, set the `earlier` and `later` pointers correctly */
+  /** Deletes the entry from the LinkedHashMap, set the `earlier` and `later` pointers correctly. */
   private def deleteEntry(e: Entry): Unit = {
     if (e.earlier eq null) firstEntry = e.later
     else e.earlier.nn.later = e.later
@@ -505,9 +505,9 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
       else next.nn.findEntry(k, h)
   }
 
-  /** The default load factor for the hash table */
+  /** The default load factor for the hash table. */
   private[collection] final def defaultLoadFactor: Double = 0.75
 
-  /** The default initial capacity for the hash table */
+  /** The default initial capacity for the hash table. */
   private[collection] final def defaultinitialSize: Int = 16
 }

--- a/library/src/scala/collection/mutable/LinkedHashSet.scala
+++ b/library/src/scala/collection/mutable/LinkedHashSet.scala
@@ -152,7 +152,7 @@ class LinkedHashSet[A]
 
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of this key */
+  /** Computes the improved hash of this key. */
   @`inline` private def computeHash(o: A): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
@@ -180,7 +180,7 @@ class LinkedHashSet[A]
     e
   }
 
-  /** Delete the entry from the LinkedHashSet, set the `earlier` and `later` pointers correctly */
+  /** Deletes the entry from the LinkedHashSet, set the `earlier` and `later` pointers correctly. */
   private def deleteEntry(e: Entry): Unit = {
     if (e.earlier eq null) firstEntry = e.later
     else e.earlier.later = e.later
@@ -343,9 +343,9 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
       else next.findEntry(k, h)
   }
 
-  /** The default load factor for the hash table */
+  /** The default load factor for the hash table. */
   private[collection] final def defaultLoadFactor: Double = 0.75
 
-  /** The default initial capacity for the hash table */
+  /** The default initial capacity for the hash table. */
   private[collection] final def defaultinitialSize: Int = 16
 }

--- a/library/src/scala/collection/mutable/ListBuffer.scala
+++ b/library/src/scala/collection/mutable/ListBuffer.scala
@@ -180,7 +180,7 @@ class ListBuffer[A]
     this
   }
 
-  /** Reduce the length of the buffer, and null out last0
+  /** Reduces the length of the buffer, and nulls out last0
     *  if this reduces the length to 0.
     */
   private def reduceLengthBy(num: Int): Unit = {
@@ -301,7 +301,7 @@ class ListBuffer[A]
     len -= n
   }
 
-  /** Replace the contents of this $coll with the mapped result.
+  /** Replaces the contents of this $coll with the mapped result.
    *
    *  @param f the mapping function
    *  @return this $coll
@@ -316,7 +316,7 @@ class ListBuffer[A]
     this
   }
 
-  /** Replace the contents of this $coll with the flatmapped result.
+  /** Replaces the contents of this $coll with the flatmapped result.
    *
    *  @param f the mapping function
    *  @return this $coll
@@ -342,7 +342,7 @@ class ListBuffer[A]
     this
   }
 
-  /** Replace the contents of this $coll with the filtered result.
+  /** Replaces the contents of this $coll with the filtered result.
    *
    *  @param p the filtering predicate
    *  @return this $coll

--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -626,7 +626,7 @@ object LongMap {
   /** Creates a new empty `LongMap`. */
   def empty[V]: LongMap[V] = new LongMap[V]
 
-  /** Creates a new empty `LongMap` with the supplied default */
+  /** Creates a new empty `LongMap` with the supplied default. */
   def withDefault[V](default: Long -> V): LongMap[V] = new LongMap[V](default)
 
   /** Creates a new `LongMap` from an existing source collection. A source collection

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -18,7 +18,7 @@ import language.experimental.captureChecking
 
 import scala.language.`2.13`
 
-/** Base type of mutable Maps */
+/** Base type of mutable Maps. */
 trait Map[K, V]
   extends Iterable[(K, V)]
     with collection.Map[K, V]
@@ -109,7 +109,7 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
   def update(key: K, value: V): Unit = { coll += ((key, value)) }
 
   /**
-   * Update a mapping for the specified key and its current optionally mapped value
+   * Updates a mapping for the specified key and its current optionally mapped value
    * (`Some` if there is current mapping, `None` if not).
    *
    * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
@@ -117,7 +117,7 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
    * If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
    *
    * @param key the key value
-   * @param remappingFunction a function that receives current optionally mapped value and return a new mapping
+   * @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
    * @return the new value associated with the specified key
    */
   def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {

--- a/library/src/scala/collection/mutable/OpenHashMap.scala
+++ b/library/src/scala/collection/mutable/OpenHashMap.scala
@@ -109,8 +109,8 @@ class OpenHashMap[Key, Value](initialSize : Int)
     h ^ (h >>> 7) ^ (h >>> 4)
   }
 
-  /** Increase the size of the table.
-    * Copy only the occupied slots, effectively eliminating the deleted slots.
+  /** Increases the size of the table.
+    * Copies only the occupied slots, effectively eliminating the deleted slots.
     */
   private def growTable() = {
     val oldSize = mask + 1
@@ -124,7 +124,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
     deleted = 0
   }
 
-  /** Return the index of the first slot in the hash table (in probe order)
+  /** Returns the index of the first slot in the hash table (in probe order)
     * that is, in order of preference, either occupied by the given key, deleted, or empty.
     *
     * @param hash hash value for `key`
@@ -187,7 +187,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
     }
   }
 
-  /** Delete the hash table slot contained in the given entry. */
+  /** Deletes the hash table slot contained in the given entry. */
   @`inline`
   private def deleteSlot(entry: Entry) = {
     entry.key = null.asInstanceOf[Key]
@@ -267,7 +267,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
     it
   }
 
-  /** Loop over the key, value mappings of this map.
+  /** Loops over the key, value mappings of this map.
     *
     *  The behaviour of modifying the map during an iteration is as follows:
     *  - Deleting a mapping is always permitted.

--- a/library/src/scala/collection/mutable/PriorityQueue.scala
+++ b/library/src/scala/collection/mutable/PriorityQueue.scala
@@ -117,7 +117,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   override protected def newSpecificBuilder: Builder[A, PriorityQueue[A]] = PriorityQueue.newBuilder
   override def empty: PriorityQueue[A] = PriorityQueue.empty
 
-  /** Replace the contents of this $coll with the mapped result.
+  /** Replaces the contents of this $coll with the mapped result.
    *
    *  @param f the mapping function
    *  @return this $coll

--- a/library/src/scala/collection/mutable/Queue.scala
+++ b/library/src/scala/collection/mutable/Queue.scala
@@ -47,7 +47,7 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   override protected def stringPrefix = "Queue"
 
   /**
-    * Add elements to the end of this queue
+    * Adds elements to the end of this queue
     *
     * @param elem
     * @return this
@@ -71,7 +71,7 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   def enqueueAll(elems: scala.collection.IterableOnce[A]^): this.type = this ++= elems
 
   /**
-    * Removes the first element from this queue and returns it
+    * Removes the first element from this queue and returns it.
     *
     * @return
     * @throws NoSuchElementException when queue is empty
@@ -98,7 +98,7 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
     removeAll(p)
 
   /**
-    * Returns and dequeues all elements from the queue which satisfy the given predicate
+    * Returns and dequeues all elements from the queue which satisfy the given predicate.
     *
     *  @param f   the predicate used for choosing elements
     *  @return The removed elements

--- a/library/src/scala/collection/mutable/RedBlackTree.scala
+++ b/library/src/scala/collection/mutable/RedBlackTree.scala
@@ -613,7 +613,7 @@ private[collection] object RedBlackTree {
 
   // building
 
-  /** Build a Tree suitable for a TreeSet from an ordered sequence of keys */
+  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys. */
   def fromOrderedKeys[A](xs: Iterator[A]^, size: Int): Tree[A, Null] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Node[A, Null] | Null = size match {
@@ -632,7 +632,7 @@ private[collection] object RedBlackTree {
     new Tree(f(1, size), size)
   }
 
-  /** Build a Tree suitable for a TreeMap from an ordered sequence of key/value pairs */
+  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs. */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)]^, size: Int): Tree[A, B] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Node[A, B] | Null = size match {

--- a/library/src/scala/collection/mutable/Set.scala
+++ b/library/src/scala/collection/mutable/Set.scala
@@ -16,7 +16,7 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 import scala.collection.{IterableFactory, IterableFactoryDefaults, IterableOps}
 
-/** Base trait for mutable sets */
+/** Base trait for mutable sets. */
 trait Set[A]
   extends Iterable[A]
     with collection.Set[A]
@@ -40,7 +40,7 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
 
   def result(): C = coll
 
-  /** Check whether the set contains the given element, and add it if not.
+  /** Checks whether the set contains the given element, and adds it if not.
    *
    *  @param elem  the element to be added
    *  @return true if the element was added

--- a/library/src/scala/collection/mutable/Shrinkable.scala
+++ b/library/src/scala/collection/mutable/Shrinkable.scala
@@ -32,7 +32,7 @@ trait Shrinkable[-A] {
    */
   def subtractOne(elem: A): this.type
 
-  /** Alias for `subtractOne` */
+  /** Alias for `subtractOne`. */
   @`inline` final def -= (elem: A): this.type = subtractOne(elem)
 
   /** Removes two or more elements from this $coll.
@@ -75,7 +75,7 @@ trait Shrinkable[-A] {
     this
   }
 
-  /** Alias for `subtractAll` */
+  /** Alias for `subtractAll`. */
   @`inline` final def --= (xs: collection.IterableOnce[A]^): this.type = subtractAll(xs)
 
 }

--- a/library/src/scala/collection/mutable/Stack.scala
+++ b/library/src/scala/collection/mutable/Stack.scala
@@ -53,14 +53,14 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   override protected def stringPrefix = "Stack"
 
   /**
-    * Add elements to the top of this stack
+    * Adds elements to the top of this stack
     *
     * @param elem
     * @return
     */
   def push(elem: A): this.type = prepend(elem)
 
-  /** Push two or more elements onto the stack. The last element
+  /** Pushes two or more elements onto the stack. The last element
     *  of the sequence will be on top of the new stack.
     *
     *  @param   elems      the element sequence.
@@ -72,7 +72,7 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
     prepend(elem1).prepend(elem2).pushAll(elems)
   }
 
-  /** Push all elements in the given iterable object onto the stack. The
+  /** Pushes all elements in the given iterable object onto the stack. The
     *  last element in the iterable object will be on top of the new stack.
     *
     *  @param elems the iterable object.
@@ -85,7 +85,7 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
     })
 
   /**
-    * Removes the top element from this stack and return it
+    * Removes the top element from this stack and returns it
     *
     * @return
     * @throws NoSuchElementException when stack is empty
@@ -100,7 +100,7 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   def popAll(): scala.collection.Seq[A] = removeAll()
 
   /**
-    * Returns and removes all elements from the top of this stack which satisfy the given predicate
+    * Returns and removes all elements from the top of this stack which satisfy the given predicate.
     *
     *  @param f   the predicate used for choosing elements
     *  @return The removed elements

--- a/library/src/scala/collection/mutable/StringBuilder.scala
+++ b/library/src/scala/collection/mutable/StringBuilder.scala
@@ -101,10 +101,10 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   def clear(): Unit = underlying.setLength(0)
 
-  /** Overloaded version of `addAll` that takes a string */
+  /** Overloaded version of `addAll` that takes a string. */
   def addAll(s: String): this.type = { underlying.append(s); this }
 
-  /** Alias for `addAll` */
+  /** Alias for `addAll`. */
   def ++= (s: String): this.type = addAll(s)
 
   def result() = underlying.toString
@@ -225,7 +225,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Append the String representation of the given primitive type
+  /** Appends the String representation of the given primitive type
     *  to this sequence.  The argument is converted to a String with
     *  String.valueOf.
     *
@@ -241,7 +241,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   def append(x: Double): this.type = { underlying.append(x) ; this }
   def append(x: Char): this.type = { underlying.append(x) ; this }
 
-  /** Remove a subsequence of Chars from this sequence, starting at the
+  /** Removes a subsequence of Chars from this sequence, starting at the
     *  given start index (inclusive) and extending to the end index (exclusive)
     *  or to the end of the String, whichever comes first.
     *
@@ -308,21 +308,21 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Inserts the given Seq[Char] into this sequence at the given index.
+  /** Inserts the given `Seq[Char]` into this sequence at the given index.
     *
     *  @param  index the index at which to insert.
-    *  @param  xs    the Seq[Char].
-    *  @return       this StringBuilder.
+    *  @param  xs    the `Seq[Char]`.
+    *  @return       this `StringBuilder`.
     *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
     */
   def insertAll(index: Int, xs: IterableOnce[Char]^): this.type =
     insertAll(index, (ArrayBuilder.make[Char] ++= xs).result())
 
-  /** Inserts the given Array[Char] into this sequence at the given index.
+  /** Inserts the given `Array[Char]` into this sequence at the given index.
     *
     *  @param  index the index at which to insert.
-    *  @param  xs    the Array[Char].
-    *  @return       this StringBuilder.
+    *  @param  xs    the `Array[Char]`.
+    *  @return       this `StringBuilder`.
     *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
     */
   def insertAll(index: Int, xs: Array[Char]): this.type = {
@@ -382,7 +382,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    */
   def capacity: Int = underlying.capacity
 
-  /** Ensure that the capacity is at least the given argument.
+  /** Ensures that the capacity is at least the given argument.
    *  If the argument is greater than the current capacity, new
    *  storage will be allocated with size equal to the given
    *  argument or to `(2 * capacity + 2)`, whichever is larger.
@@ -411,7 +411,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Update the sequence at the given index to hold the specified Char.
+  /** Updates the sequence at the given index to hold the specified Char.
    *
    *  @param  index   the index to modify.
    *  @param  ch      the new Char.

--- a/library/src/scala/collection/mutable/UnrolledBuffer.scala
+++ b/library/src/scala/collection/mutable/UnrolledBuffer.scala
@@ -166,7 +166,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     if (idx >= 0 && idx < sz) headptr(idx) = newelem
     else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
-  /** Replace the contents of this $coll with the mapped result.
+  /** Replaces the contents of this $coll with the mapped result.
    *
    *  @param f the mapping function
    *  @return this $coll

--- a/library/src/scala/compat/Platform.scala
+++ b/library/src/scala/compat/Platform.scala
@@ -141,7 +141,7 @@ object Platform {
   @deprecated("Use `java.lang.System#gc` instead.", since = "2.13.0")
   def collectGarbage(): Unit = System.gc()
 
-  /** The name of the default character set encoding as a string */
+  /** The name of the default character set encoding as a string. */
   @inline
   @deprecated("Use `java.nio.charset.Charset.defaultCharset#name` instead.", since = "2.13.0")
   def defaultCharsetName: String = java.nio.charset.Charset.defaultCharset.name

--- a/library/src/scala/compiletime/testing/ErrorKind.scala
+++ b/library/src/scala/compiletime/testing/ErrorKind.scala
@@ -2,7 +2,7 @@ package scala.compiletime.testing
 
 import language.experimental.captureChecking
 
-/** An error can be either a parse-time or a typecheck-time */
+/** An error can be either a parse-time or a typecheck-time. */
 sealed trait ErrorKind // This should be an enum but currently, Dotty lib fails to
                        // compile with an obscure error.
 object ErrorKind:

--- a/library/src/scala/compiletime/testing/package.scala
+++ b/library/src/scala/compiletime/testing/package.scala
@@ -9,7 +9,7 @@ import language.experimental.captureChecking
  *
  *  @param code The code to be type checked
  *
- *  @return false if the code has syntax error or type error in the current context, otherwise returns true.
+ *  @return `false` if the code has syntax error or type error in the current context, `true` otherwise.
  *
  *  The code should be a sequence of expressions or statements that may appear in a block.
  */

--- a/library/src/scala/concurrent/Channel.scala
+++ b/library/src/scala/concurrent/Channel.scala
@@ -29,7 +29,7 @@ class Channel[A] {
   private var lastWritten = written       // aliasing of a linked list
   private var nreaders = 0
 
-  /** Append a value to the FIFO queue to be read by `read`.
+  /** Appends a value to the FIFO queue to be read by `read`.
    *  This operation is nonblocking and can be executed by any thread.
    *
    * @param x object to enqueue to this channel
@@ -41,7 +41,7 @@ class Channel[A] {
     if (nreaders > 0) notify()
   }
 
-  /** Retrieve the next waiting object from the FIFO queue,
+  /** Retrieves the next waiting object from the FIFO queue,
    *  blocking if necessary until an object is available.
    *
    * @return next object dequeued from this channel

--- a/library/src/scala/concurrent/Future.scala
+++ b/library/src/scala/concurrent/Future.scala
@@ -102,7 +102,7 @@ import scala.concurrent.impl.Promise.DefaultPromise
  * thread. That is, the implementation may run multiple callbacks
  * in a batch within a single `execute()` and it may run
  * `execute()` either immediately or asynchronously.
- * Completion of the Future must *happen-before* the invocation of the callback.
+ * Completion of the `Future` must *happen-before* the invocation of the callback.
  */
 trait Future[+T] extends Awaitable[T] {
 

--- a/library/src/scala/concurrent/SyncVar.scala
+++ b/library/src/scala/concurrent/SyncVar.scala
@@ -48,8 +48,8 @@ class SyncVar[A] {
     if (elapsed < 0) 0 else TimeUnit.NANOSECONDS.toMillis(elapsed)
   }
 
-  /** Wait at least `timeout` milliseconds (possibly more) for this `SyncVar`
-   *  to become defined and then get its value.
+  /** Waits at least `timeout` milliseconds (possibly more) for this `SyncVar`
+   *  to become defined and then gets its value.
    *
    *  @param timeout     time in milliseconds to wait
    *  @return            `None` if variable is undefined after `timeout`, `Some(value)` otherwise
@@ -78,8 +78,8 @@ class SyncVar[A] {
     finally unsetVal()
   }
 
-  /** Wait at least `timeout` milliseconds (possibly more) for this `SyncVar`
-   *  to become defined and then get the stored value, unsetting it
+  /** Waits at least `timeout` milliseconds (possibly more) for this `SyncVar`
+   *  to become defined and then gets the stored value, unsetting it
    *  as a side effect.
    *
    *  @param timeout     the amount of milliseconds to wait
@@ -98,7 +98,7 @@ class SyncVar[A] {
     setVal(x)
   }
 
-  /** Check whether a value is stored in the synchronized variable. */
+  /** Checks whether a value is stored in the synchronized variable. */
   def isSet: Boolean = synchronized {
     isDefined
   }

--- a/library/src/scala/concurrent/duration/Deadline.scala
+++ b/library/src/scala/concurrent/duration/Deadline.scala
@@ -31,36 +31,36 @@ import scala.language.`2.13`
  */
 case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
   /**
-   * Return a deadline advanced (i.e., moved into the future) by the given duration.
+   * Returns a deadline advanced (i.e., moved into the future) by the given duration.
    */
   def +(other: FiniteDuration): Deadline = copy(time = time + other)
   /**
-   * Return a deadline moved backwards (i.e., towards the past) by the given duration.
+   * Returns a deadline moved backwards (i.e., towards the past) by the given duration.
    */
   def -(other: FiniteDuration): Deadline = copy(time = time - other)
   /**
-   * Calculate time difference between this and the other deadline, where the result is directed (i.e., may be negative).
+   * Calculates time difference between this and the other deadline, where the result is directed (i.e., may be negative).
    */
   def -(other: Deadline): FiniteDuration = time - other.time
   /**
-   * Calculate time difference between this duration and now; the result is negative if the deadline has passed.
+   * Calculates time difference between this duration and now; the result is negative if the deadline has passed.
    *
    * '''''Note that on some systems this operation is costly because it entails a system call.'''''
-   * Check `System.nanoTime` for your platform.
+   * Checks `System.nanoTime` for your platform.
    */
   def timeLeft: FiniteDuration = this - Deadline.now
   /**
    * Determine whether the deadline still lies in the future at the point where this method is called.
    *
    * '''''Note that on some systems this operation is costly because it entails a system call.'''''
-   * Check `System.nanoTime` for your platform.
+   * Checks `System.nanoTime` for your platform.
    */
   def hasTimeLeft(): Boolean = !isOverdue()
   /**
    * Determine whether the deadline lies in the past at the point where this method is called.
    *
    * '''''Note that on some systems this operation is costly because it entails a system call.'''''
-   * Check `System.nanoTime` for your platform.
+   * Checks `System.nanoTime` for your platform.
    */
   def isOverdue(): Boolean = (time.toNanos - System.nanoTime()) < 0
   /**
@@ -71,7 +71,7 @@ case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
 
 object Deadline {
   /**
-   * Construct a deadline due exactly at the point where this method is called. Useful for then
+   * Constructs a deadline due exactly at the point where this method is called. Useful for then
    * advancing it to obtain a future deadline, or for sampling the current time exactly once and
    * then comparing it to multiple deadlines (using subtraction).
    */

--- a/library/src/scala/concurrent/duration/Duration.scala
+++ b/library/src/scala/concurrent/duration/Duration.scala
@@ -19,7 +19,7 @@ import scala.collection.StringParsers
 object Duration {
 
   /**
-   * Construct a Duration from the given length and unit. Observe that nanosecond precision may be lost if
+   * Constructs a Duration from the given length and unit. Observe that nanosecond precision may be lost if
    *
    *  - the unit is NANOSECONDS
    *  - and the length has an absolute value greater than `2^53`
@@ -31,13 +31,13 @@ object Duration {
   def apply(length: Double, unit: TimeUnit): Duration     = fromNanos(unit.toNanos(1) * length)
 
   /**
-   * Construct a finite duration from the given length and time unit. The unit given is retained
+   * Constructs a finite duration from the given length and time unit. The unit given is retained
    * throughout calculations as long as possible, so that it can be retrieved later.
    */
   def apply(length: Long, unit: TimeUnit): FiniteDuration = new FiniteDuration(length, unit)
 
   /**
-   * Construct a finite duration from the given length and time unit, where the latter is
+   * Constructs a finite duration from the given length and time unit, where the latter is
    * looked up in a list of string representation. Valid choices are:
    *
    * `d, day, h, hr, hour, m, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
@@ -49,7 +49,7 @@ object Duration {
   // private final val maxPreciseDouble = 9007199254740992d // not used after https://github.com/scala/scala/pull/9233
 
   /**
-   * Parse String into Duration.  Format is `"<length><unit>"`, where
+   * Parses String into Duration.  Format is `"<length><unit>"`, where
    * whitespace is allowed before, between and after the parts. Infinities are
    * designated by `"Inf"`, `"PlusInf"`, `"+Inf"`, `"Duration.Inf"` and `"-Inf"`, `"MinusInf"` or `"Duration.MinusInf"`.
    * Undefined is designated by `"Duration.Undefined"`.
@@ -99,20 +99,20 @@ object Duration {
     timeUnitLabels.flatMap{ case (unit, names) => expandLabels(names) map (_ -> unit) }.toMap
 
   /**
-   * Extract length and time unit out of a string, where the format must match the description for [[Duration$.apply(s:String)* apply(String)]].
+   * Extracts length and time unit out of a string, where the format must match the description for [[Duration$.apply(s:String)* apply(String)]].
    * The extractor will not match for malformed strings or non-finite durations.
    */
   def unapply(s: String): Option[(Long, TimeUnit)] =
     ( try Some(apply(s)) catch { case _: RuntimeException => None } ) flatMap unapply
 
   /**
-   * Extract length and time unit out of a duration, if it is finite.
+   * Extracts length and time unit out of a duration, if it is finite.
    */
   def unapply(d: Duration): Option[(Long, TimeUnit)] =
     if (d.isFinite) Some((d.length, d.unit)) else None
 
   /**
-   * Construct a possibly infinite or undefined Duration from the given number of nanoseconds.
+   * Constructs a possibly infinite or undefined Duration from the given number of nanoseconds.
    *
    *  - `Double.PositiveInfinity` is mapped to [[Duration.Inf]]
    *  - `Double.NegativeInfinity` is mapped to [[Duration.MinusInf]]
@@ -143,7 +143,7 @@ object Duration {
   private final val ns_per_d   = ns_per_h   * 24
 
   /**
-   * Construct a finite duration from the given number of nanoseconds. The
+   * Constructs a finite duration from the given number of nanoseconds. The
    * result will have the coarsest possible time unit which can exactly express
    * this duration.
    *
@@ -264,12 +264,12 @@ object Duration {
   // Java Factories
 
   /**
-   * Construct a finite duration from the given length and time unit. The unit given is retained
+   * Constructs a finite duration from the given length and time unit. The unit given is retained
    * throughout calculations as long as possible, so that it can be retrieved later.
    */
   def create(length: Long, unit: TimeUnit): FiniteDuration = apply(length, unit)
   /**
-   * Construct a Duration from the given length and unit. Observe that nanosecond precision may be lost if
+   * Constructs a Duration from the given length and unit. Observe that nanosecond precision may be lost if
    *
    *  - the unit is NANOSECONDS
    *  - and the length has an absolute value greater than `2^53`
@@ -280,7 +280,7 @@ object Duration {
    */
   def create(length: Double, unit: TimeUnit): Duration     = apply(length, unit)
   /**
-   * Construct a finite duration from the given length and time unit, where the latter is
+   * Constructs a finite duration from the given length and time unit, where the latter is
    * looked up in a list of string representation. Valid choices are:
    *
    * `d, day, h, hour, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
@@ -288,7 +288,7 @@ object Duration {
    */
   def create(length: Long, unit: String): FiniteDuration   = apply(length, unit)
   /**
-   * Parse String into Duration.  Format is `"<length><unit>"`, where
+   * Parses String into Duration.  Format is `"<length><unit>"`, where
    * whitespace is allowed before, between and after the parts. Infinities are
    * designated by `"Inf"`, `"PlusInf"`, `"+Inf"` and `"-Inf"` or `"MinusInf"`.
    *
@@ -373,61 +373,61 @@ object Duration {
  */
 sealed abstract class Duration extends Serializable with Ordered[Duration] {
   /**
-   * Obtain the length of this Duration measured in the unit obtained by the `unit` method.
+   * Obtains the length of this Duration measured in the unit obtained by the `unit` method.
    *
    * $exc
    */
   def length: Long
   /**
-   * Obtain the time unit in which the length of this duration is measured.
+   * Obtains the time unit in which the length of this duration is measured.
    *
    * $exc
    */
   def unit: TimeUnit
   /**
-   * Return the length of this duration measured in whole nanoseconds, rounding towards zero.
+   * Returns the length of this duration measured in whole nanoseconds, rounding towards zero.
    *
    * $exc
    */
   def toNanos: Long
   /**
-   * Return the length of this duration measured in whole microseconds, rounding towards zero.
+   * Returns the length of this duration measured in whole microseconds, rounding towards zero.
    *
    * $exc
    */
   def toMicros: Long
   /**
-   * Return the length of this duration measured in whole milliseconds, rounding towards zero.
+   * Returns the length of this duration measured in whole milliseconds, rounding towards zero.
    *
    * $exc
    */
   def toMillis: Long
   /**
-   * Return the length of this duration measured in whole seconds, rounding towards zero.
+   * Returns the length of this duration measured in whole seconds, rounding towards zero.
    *
    * $exc
    */
   def toSeconds: Long
   /**
-   * Return the length of this duration measured in whole minutes, rounding towards zero.
+   * Returns the length of this duration measured in whole minutes, rounding towards zero.
    *
    * $exc
    */
   def toMinutes: Long
   /**
-   * Return the length of this duration measured in whole hours, rounding towards zero.
+   * Returns the length of this duration measured in whole hours, rounding towards zero.
    *
    * $exc
    */
   def toHours: Long
   /**
-   * Return the length of this duration measured in whole days, rounding towards zero.
+   * Returns the length of this duration measured in whole days, rounding towards zero.
    *
    * $exc
    */
   def toDays: Long
   /**
-   * Return the number of nanoseconds as floating point number, scaled down to the given unit.
+   * Returns the number of nanoseconds as floating point number, scaled down to the given unit.
    * The result may not precisely represent this duration due to the Double datatype's inherent
    * limitations (mantissa size effectively 53 bits). Non-finite durations are represented as
    *  - [[Duration.Undefined]] is mapped to Double.NaN
@@ -437,35 +437,35 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
   def toUnit(unit: TimeUnit): Double
 
   /**
-   * Return the sum of that duration and this. When involving non-finite summands the semantics match those
+   * Returns the sum of that duration and this. When involving non-finite summands the semantics match those
    * of Double.
    *
    * $ovf
    */
   def +(other: Duration): Duration
   /**
-   * Return the difference of that duration and this. When involving non-finite summands the semantics match those
+   * Returns the difference of that duration and this. When involving non-finite summands the semantics match those
    * of Double.
    *
    * $ovf
    */
   def -(other: Duration): Duration
   /**
-   * Return this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
+   * Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
    * of Double.
    *
    * $ovf
    */
   def *(factor: Double): Duration
   /**
-   * Return this duration divided by the scalar factor. When involving non-finite factors the semantics match those
+   * Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
    * of Double.
    *
    * $ovf
    */
   def /(divisor: Double): Duration
   /**
-   * Return the quotient of this and that duration as floating-point number. The semantics are
+   * Returns the quotient of this and that duration as floating-point number. The semantics are
    * determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
    */
   def /(divisor: Duration): Double
@@ -479,25 +479,25 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    */
   def isFinite: Boolean
   /**
-   * Return the smaller of this and that duration as determined by the natural ordering.
+   * Returns the smaller of this and that duration as determined by the natural ordering.
    */
   def min(other: Duration): Duration = if (this < other) this else other
   /**
-   * Return the larger of this and that duration as determined by the natural ordering.
+   * Returns the larger of this and that duration as determined by the natural ordering.
    */
   def max(other: Duration): Duration = if (this > other) this else other
 
   // Java API
 
   /**
-   * Return this duration divided by the scalar factor. When involving non-finite factors the semantics match those
+   * Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
    * of Double.
    *
    * $ovf
    */
   def div(divisor: Double): Duration = this / divisor
   /**
-   * Return the quotient of this and that duration as floating-point number. The semantics are
+   * Returns the quotient of this and that duration as floating-point number. The semantics are
    * determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
    */
   def div(other: Duration): Double   = this / other
@@ -506,14 +506,14 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
   def lt(other: Duration): Boolean   = this < other
   def lteq(other: Duration): Boolean = this <= other
   /**
-   * Return the difference of that duration and this. When involving non-finite summands the semantics match those
+   * Returns the difference of that duration and this. When involving non-finite summands the semantics match those
    * of Double.
    *
    * $ovf
    */
   def minus(other: Duration): Duration = this - other
   /**
-   * Return this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
+   * Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
    * of Double.
    *
    * $ovf
@@ -524,14 +524,14 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    */
   def neg(): Duration                  = -this
   /**
-   * Return the sum of that duration and this. When involving non-finite summands the semantics match those
+   * Returns the sum of that duration and this. When involving non-finite summands the semantics match those
    * of Double.
    *
    * $ovf
    */
   def plus(other: Duration): Duration  = this + other
   /**
-   * Return duration which is equal to this duration but with a coarsest Unit, or self in case it is already the coarsest Unit
+   * Returns duration which is equal to this duration but with a coarsest Unit, or self in case it is already the coarsest Unit
    * <p/>
    * Examples:
    * {{{
@@ -599,7 +599,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   def toUnit(u: TimeUnit): Double = toNanos.toDouble / NANOSECONDS.convert(1, u)
 
   /**
-   * Construct a [[Deadline]] from this duration by adding it to the current instant `Deadline.now`.
+   * Constructs a [[Deadline]] from this duration by adding it to the current instant `Deadline.now`.
    */
   def fromNow: Deadline = Deadline.now + this
 
@@ -662,14 +662,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   // overloaded methods taking Long so that you can calculate while statically staying finite
 
   /**
-   * Return the quotient of this duration and the given integer factor.
+   * Returns the quotient of this duration and the given integer factor.
    *
    * @throws java.lang.ArithmeticException if the factor is 0
    */
   def /(divisor: Long): FiniteDuration = fromNanos(toNanos / divisor)
 
   /**
-   * Return the product of this duration and the given integer factor.
+   * Returns the product of this duration and the given integer factor.
    *
    * @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */
@@ -696,14 +696,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   }
 
   /**
-   * Return the quotient of this duration and the given integer factor.
+   * Returns the quotient of this duration and the given integer factor.
    *
    * @throws java.lang.ArithmeticException if the factor is 0
    */
   def div(divisor: Long): FiniteDuration = this / divisor
 
   /**
-   * Return the product of this duration and the given integer factor.
+   * Returns the product of this duration and the given integer factor.
    *
    * @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */

--- a/library/src/scala/deriving/Mirror.scala
+++ b/library/src/scala/deriving/Mirror.scala
@@ -6,28 +6,28 @@ package scala.deriving
  */
 sealed trait Mirror {
 
-  /** The mirrored *-type */
+  /** The mirrored *-type. */
   type MirroredMonoType
 
-  /** The name of the type */
+  /** The name of the type. */
   type MirroredLabel <: String
 
-  /** The names of the product elements */
+  /** The names of the product elements. */
   type MirroredElemLabels <: Tuple
 }
 
 object Mirror {
 
-  /** The Mirror for a sum type */
+  /** The `Mirror` for a sum type. */
   trait Sum extends Mirror { self =>
-    /** The ordinal number of the case class of `x`. For enums, `ordinal(x) == x.ordinal` */
+    /** The ordinal number of the case class of `x`. For enums, `ordinal(x) == x.ordinal`. */
     def ordinal(x: MirroredMonoType): Int
   }
 
-  /** The Mirror for a product type */
+  /** The `Mirror` for a product type. */
   trait Product extends Mirror { self =>
 
-    /** Create a new instance of type `T` with elements taken from product `p`. */
+    /** Creates a new instance of type `T` with elements taken from product `p`. */
     def fromProduct(p: scala.Product): MirroredMonoType
   }
 
@@ -39,7 +39,7 @@ object Mirror {
     def fromProduct(p: scala.Product): MirroredMonoType = this
   }
 
-  /** A proxy for Scala 2 singletons, which do not inherit `Singleton` directly */
+  /** A proxy for Scala 2 singletons, which do not inherit `Singleton` directly. */
   class SingletonProxy(val value: AnyRef) extends Product {
     type MirroredMonoType = value.type
     type MirroredType = value.type
@@ -53,11 +53,11 @@ object Mirror {
   type SumOf[T] = Mirror.Sum { type MirroredType = T; type MirroredMonoType = T; type MirroredElemTypes <: Tuple }
 
   extension [T](p: ProductOf[T])
-    /** Create a new instance of type `T` with elements taken from product `a`. */
+    /** Creates a new instance of type `T` with elements taken from product `a`. */
     def fromProductTyped[A <: scala.Product, Elems <: p.MirroredElemTypes](a: A)(using ProductOf[A] { type MirroredElemTypes = Elems }): T =
       p.fromProduct(a)
 
-    /** Create a new instance of type `T` with elements taken from tuple `t`. */
+    /** Creates a new instance of type `T` with elements taken from tuple `t`. */
     def fromTuple(t: p.MirroredElemTypes): T =
       p.fromProduct(t)
 }

--- a/library/src/scala/io/Position.scala
+++ b/library/src/scala/io/Position.scala
@@ -45,13 +45,13 @@ private[scala] abstract class Position {
    */
   def checkInput(line: Int, column: Int): Unit
 
-  /** Number of bits used to encode the line number */
+  /** Number of bits used to encode the line number. */
   final val LINE_BITS   = 20
-  /** Number of bits used to encode the column number */
+  /** Number of bits used to encode the column number. */
   final val COLUMN_BITS = 31 - LINE_BITS // no negatives => 31
-  /** Mask to decode the line number */
+  /** Mask to decode the line number. */
   final val LINE_MASK   = (1 << LINE_BITS) - 1
-  /** Mask to decode the column number */
+  /** Mask to decode the column number. */
   final val COLUMN_MASK = (1 << COLUMN_BITS) - 1
 
   /** Encodes a position into a single integer. */

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -102,7 +102,7 @@ object Source {
     )(using codec) withDescription s"file:${file.getAbsolutePath}"
   }
 
-  /** Create a `Source` from array of bytes, decoding
+  /** Creates a `Source` from array of bytes, decoding
    *  the bytes according to codec.
    *
    *  @return      the created `Source` instance.
@@ -113,7 +113,7 @@ object Source {
   def fromBytes(bytes: Array[Byte], enc: String): Source =
     fromBytes(bytes)(using Codec(enc))
 
-  /** Create a `Source` from array of bytes, assuming
+  /** Creates a `Source` from array of bytes, assuming
    *  one byte per character (ISO-8859-1 encoding.)
    */
   @deprecated("Use `fromBytes` and specify an encoding", since="2.13.9")
@@ -204,12 +204,12 @@ object Source {
  *
  */
 abstract class Source extends Iterator[Char] with Closeable {
-  /** the actual iterator */
+  /** The actual iterator. */
   protected val iter: Iterator[Char]
 
   // ------ public values
 
-  /** description of this source, default empty */
+  /** Description of this source, default empty. */
   var descr: String = ""
   var nerrors = 0
   var nwarnings = 0
@@ -263,14 +263,14 @@ abstract class Source extends Iterator[Char] with Closeable {
     /** the last character returned by next. */
     var ch: Char = compiletime.uninitialized
 
-    /** position of last character returned by next */
+    /** Position of last character returned by next. */
     var pos = 0
 
-    /** current line and column */
+    /** Current line and column. */
     var cline = 1
     var ccol = 1
 
-    /** default col increment for tabs '\t', set to 4 initially */
+    /** Default col increment for tabs '\t', set to 4 initially. */
     var tabinc = 4
 
     def next(): Char = {

--- a/library/src/scala/io/StdIn.scala
+++ b/library/src/scala/io/StdIn.scala
@@ -23,14 +23,14 @@ import java.text.MessageFormat
 private[scala] trait StdIn {
   import scala.Console._
 
-  /** Read a full line from the default input.  Returns `null` if the end of the
+  /** Reads a full line from the default input.  Returns `null` if the end of the
    * input stream has been reached.
    *
    * @return the string read from the terminal or null if the end of stream was reached.
    */
   def readLine(): String = in.readLine()
 
-  /** Print and flush formatted text to the default output, and read a full line from the default input.
+  /** Prints and flushes formatted text to the default output, and reads a full line from the default input.
    *  Returns `null` if the end of the input stream has been reached.
    *
    *  @param text the format of the text to print out, as in `printf`.

--- a/library/src/scala/jdk/Accumulator.scala
+++ b/library/src/scala/jdk/Accumulator.scala
@@ -122,10 +122,10 @@ abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.
 
   final override def knownSize: Int = if (sizeLong < Int.MaxValue) size else -1
 
-  /** Size of the accumulated collection, as a `Long` */
+  /** Size of the accumulated collection, as a `Long`. */
   final def sizeLong: Long = totalSize
 
-  /** Remove all accumulated elements from this accumulator. */
+  /** Removes all accumulated elements from this accumulator. */
   def clear(): Unit = {
     index = 0
     hIndex = 0
@@ -183,7 +183,7 @@ object Accumulator {
   def from[A, C](source: IterableOnce[A])(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     source.iterator.to(canAccumulate.factory)
 
-  /** An empty collection
+  /** An empty collection.
     * @tparam A      the type of the ${coll}'s elements
     */
   def empty[A, C](implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =

--- a/library/src/scala/jdk/AnyAccumulator.scala
+++ b/library/src/scala/jdk/AnyAccumulator.scala
@@ -21,7 +21,7 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, Factory, IterableFactoryDefaults, SeqFactory, Stepper, StepperShape, mutable}
 import scala.reflect.ClassTag
 
-/** An Accumulator for arbitrary element types, see [[Accumulator]]. */
+/** An `Accumulator` for arbitrary element types, see [[Accumulator]]. */
 final class AnyAccumulator[A]
   extends Accumulator[A, AnyAccumulator, AnyAccumulator[A]]
     with mutable.SeqOps[A, AnyAccumulator, AnyAccumulator[A]]
@@ -160,7 +160,7 @@ final class AnyAccumulator[A]
     r
   }
 
-  /** Copy the elements in this `AnyAccumulator` into an `Array` */
+  /** Copies the elements in this `AnyAccumulator` into an `Array`. */
   override def toArray[B >: A : ClassTag]: Array[B] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
     val a = new Array[B](totalSize.toInt)
@@ -188,7 +188,7 @@ final class AnyAccumulator[A]
     a
   }
 
-  /** Copies the elements in this `AnyAccumulator` to a `List` */
+  /** Copies the elements in this `AnyAccumulator` to a `List`. */
   override def toList: List[A] = {
     var ans: List[A] = Nil
     var i = index - 1
@@ -210,7 +210,7 @@ final class AnyAccumulator[A]
   }
 
   /**
-   * Copy the elements in this `AnyAccumulator` to a specified collection. Example use:
+   * Copies the elements in this `AnyAccumulator` to a specified collection. Example use:
    * `acc.to(Vector)`.
    */
   override def to[C1](factory: Factory[A, C1]): C1 = {

--- a/library/src/scala/jdk/DoubleAccumulator.scala
+++ b/library/src/scala/jdk/DoubleAccumulator.scala
@@ -237,7 +237,7 @@ final class DoubleAccumulator
     r
   }
 
-  /** Copies the elements in this `DoubleAccumulator` into an `Array[Double]` */
+  /** Copies the elements in this `DoubleAccumulator` into an `Array[Double]`. */
   @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Double] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
@@ -259,7 +259,7 @@ final class DoubleAccumulator
     a
   }
 
-  /** Copies the elements in this `DoubleAccumulator` to a `List` */
+  /** Copies the elements in this `DoubleAccumulator` to a `List`. */
   override def toList: List[Double] = {
     var ans: List[Double] = Nil
     var i = index - 1
@@ -281,7 +281,7 @@ final class DoubleAccumulator
   }
 
   /**
-   * Copy the elements in this `DoubleAccumulator` to a specified collection.
+   * Copies the elements in this `DoubleAccumulator` to a specified collection.
    * Note that the target collection is not specialized.
    * Usage example: `acc.to(Vector)`
    */

--- a/library/src/scala/jdk/DurationConverters.scala
+++ b/library/src/scala/jdk/DurationConverters.scala
@@ -24,12 +24,12 @@ import scala.concurrent.duration.FiniteDuration
   */
 object DurationConverters {
   implicit class JavaDurationOps(private val duration: JDuration) extends AnyVal {
-    /** Convert a Java duration to a Scala duration, see [[javaapi.DurationConverters.toScala]]. */
+    /** Converts a Java duration to a Scala duration, see [[javaapi.DurationConverters.toScala]]. */
     def toScala: FiniteDuration = javaapi.DurationConverters.toScala(duration)
   }
 
   implicit final class ScalaDurationOps(private val duration: FiniteDuration) extends AnyVal {
-    /** Convert a Scala duration to a Java duration, see [[javaapi.DurationConverters.toJava]]. */
+    /** Converts a Scala duration to a Java duration, see [[javaapi.DurationConverters.toJava]]. */
     def toJava: JDuration = javaapi.DurationConverters.toJava(duration)
   }
 }

--- a/library/src/scala/jdk/FutureConverters.scala
+++ b/library/src/scala/jdk/FutureConverters.scala
@@ -33,12 +33,12 @@ import scala.concurrent.Future
   */
 object FutureConverters {
   implicit class FutureOps[T](private val f: Future[T]) extends AnyVal {
-    /** Convert a Scala Future to a Java CompletionStage, see [[javaapi.FutureConverters.asJava]]. */
+    /** Converts a Scala Future to a Java CompletionStage, see [[javaapi.FutureConverters.asJava]]. */
     def asJava: CompletionStage[T] = javaapi.FutureConverters.asJava(f)
   }
 
   implicit class CompletionStageOps[T](private val cs: CompletionStage[T]) extends AnyVal {
-    /** Convert a Java CompletionStage to a Scala Future, see [[javaapi.FutureConverters.asScala]]. */
+    /** Converts a Java CompletionStage to a Scala Future, see [[javaapi.FutureConverters.asScala]]. */
     def asScala: Future[T] = javaapi.FutureConverters.asScala(cs)
   }
 }

--- a/library/src/scala/jdk/IntAccumulator.scala
+++ b/library/src/scala/jdk/IntAccumulator.scala
@@ -243,7 +243,7 @@ final class IntAccumulator
     r
   }
 
-  /** Copies the elements in this `IntAccumulator` into an `Array[Int]` */
+  /** Copies the elements in this `IntAccumulator` into an `Array[Int]`. */
   @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Int] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
@@ -265,7 +265,7 @@ final class IntAccumulator
     a
   }
 
-  /** Copies the elements in this `IntAccumulator` to a `List` */
+  /** Copies the elements in this `IntAccumulator` to a `List`. */
   override def toList: List[Int] = {
     var ans: List[Int] = Nil
     var i = index - 1
@@ -287,7 +287,7 @@ final class IntAccumulator
   }
 
   /**
-   * Copy the elements in this `IntAccumulator` to a specified collection.
+   * Copies the elements in this `IntAccumulator` to a specified collection.
    * Note that the target collection is not specialized.
    * Usage example: `acc.to(Vector)`
    */

--- a/library/src/scala/jdk/LongAccumulator.scala
+++ b/library/src/scala/jdk/LongAccumulator.scala
@@ -238,7 +238,7 @@ final class LongAccumulator
     r
   }
 
-  /** Copies the elements in this `LongAccumulator` into an `Array[Long]` */
+  /** Copies the elements in this `LongAccumulator` into an `Array[Long]`. */
   @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Long] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
@@ -260,7 +260,7 @@ final class LongAccumulator
     a
   }
 
-  /** Copies the elements in this `LongAccumulator` to a `List` */
+  /** Copies the elements in this `LongAccumulator` to a `List`. */
   override def toList: List[Long] = {
     var ans: List[Long] = Nil
     var i = index - 1
@@ -282,7 +282,7 @@ final class LongAccumulator
   }
 
   /**
-   * Copy the elements in this `LongAccumulator` to a specified collection.
+   * Copies the elements in this `LongAccumulator` to a specified collection.
    * Note that the target collection is not specialized.
    * Usage example: `acc.to(Vector)`
    */

--- a/library/src/scala/jdk/OptionConverters.scala
+++ b/library/src/scala/jdk/OptionConverters.scala
@@ -45,68 +45,68 @@ import java.util.{Optional, OptionalDouble, OptionalInt, OptionalLong}
   * }}}
   */
 object OptionConverters {
-  /** Provides conversions from Java `Optional` to Scala `Option` and specialized `Optional` types */
+  /** Provides conversions from Java `Optional` to Scala `Option` and specialized `Optional` types. */
   implicit class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
-    /** Convert a Java `Optional` to a Scala `Option` */
+    /** Converts a Java `Optional` to a Scala `Option`. */
     def toScala: Option[A] = if (o.isPresent) Some(o.get) else None
 
-    /** Convert a Java `Optional` to a Scala `Option` */
+    /** Converts a Java `Optional` to a Scala `Option`. */
     @deprecated("Use `toScala` instead", "2.13.0")
     def asScala: Option[A] = if (o.isPresent) Some(o.get) else None
 
-    /** Convert a generic Java `Optional` to a specialized variant */
+    /** Converts a generic Java `Optional` to a specialized variant. */
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O = shape.fromJava(o)
   }
 
-  /** Provides conversions from Scala `Option` to Java `Optional` types */
+  /** Provides conversions from Scala `Option` to Java `Optional` types. */
   implicit class RichOption[A](private val o: Option[A]) extends AnyVal {
-    /** Convert a Scala `Option` to a generic Java `Optional` */
+    /** Converts a Scala `Option` to a generic Java `Optional`. */
     def toJava: Optional[A] = o match { case Some(a) => Optional.ofNullable(a); case _ => Optional.empty[A] }
 
-    /** Convert a Scala `Option` to a generic Java `Optional` */
+    /** Converts a Scala `Option` to a generic Java `Optional`. */
     @deprecated("Use `toJava` instead", "2.13.0")
     def asJava: Optional[A] = o match { case Some(a) => Optional.ofNullable(a); case _ => Optional.empty[A] }
 
-    /** Convert a Scala `Option` to a specialized Java `Optional` */
+    /** Converts a Scala `Option` to a specialized Java `Optional`. */
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O = shape.fromScala(o)
   }
 
-  /** Provides conversions from `OptionalDouble` to Scala `Option` and the generic `Optional` */
+  /** Provides conversions from `OptionalDouble` to Scala `Option` and the generic `Optional`. */
   implicit class RichOptionalDouble(private val o: OptionalDouble) extends AnyVal {
-    /** Convert a Java `OptionalDouble` to a Scala `Option` */
+    /** Converts a Java `OptionalDouble` to a Scala `Option`. */
     def toScala: Option[Double] = if (o.isPresent) Some(o.getAsDouble) else None
 
-    /** Convert a Java `OptionalDouble` to a Scala `Option` */
+    /** Converts a Java `OptionalDouble` to a Scala `Option`. */
     @deprecated("Use `toScala` instead", "2.13.0")
     def asScala: Option[Double] = if (o.isPresent) Some(o.getAsDouble) else None
 
-    /** Convert a Java `OptionalDouble` to a generic Java `Optional` */
+    /** Converts a Java `OptionalDouble` to a generic Java `Optional`. */
     def toJavaGeneric: Optional[Double] = if (o.isPresent) Optional.of(o.getAsDouble) else Optional.empty[Double]
   }
 
-  /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional` */
+  /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional`. */
   implicit class RichOptionalInt(private val o: OptionalInt) extends AnyVal {
-    /** Convert a Java `OptionalInt` to a Scala `Option` */
+    /** Converts a Java `OptionalInt` to a Scala `Option`. */
     def toScala: Option[Int] = if (o.isPresent) Some(o.getAsInt) else None
 
-    /** Convert a Java `OptionalInt` to a Scala `Option` */
+    /** Converts a Java `OptionalInt` to a Scala `Option`. */
     @deprecated("Use `toScala` instead", "2.13.0")
     def asScala: Option[Int] = if (o.isPresent) Some(o.getAsInt) else None
 
-    /** Convert a Java `OptionalInt` to a generic Java `Optional` */
+    /** Converts a Java `OptionalInt` to a generic Java `Optional`. */
     def toJavaGeneric: Optional[Int] = if (o.isPresent) Optional.of(o.getAsInt) else Optional.empty[Int]
   }
 
-  /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional` */
+  /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional`. */
   implicit class RichOptionalLong(private val o: OptionalLong) extends AnyVal {
-    /** Convert a Java `OptionalLong` to a Scala `Option` */
+    /** Converts a Java `OptionalLong` to a Scala `Option`. */
     def toScala: Option[Long] = if (o.isPresent) Some(o.getAsLong) else None
 
-    /** Convert a Java `OptionalLong` to a Scala `Option` */
+    /** Converts a Java `OptionalLong` to a Scala `Option`. */
     @deprecated("Use `toScala` instead", "2.13.0")
     def asScala: Option[Long] = if (o.isPresent) Some(o.getAsLong) else None
 
-    /** Convert a Java `OptionalLong` to a generic Java `Optional` */
+    /** Converts a Java `OptionalLong` to a generic Java `Optional`. */
     def toJavaGeneric: Optional[Long] = if (o.isPresent) Optional.of(o.getAsLong) else Optional.empty[Long]
   }
 }

--- a/library/src/scala/jdk/OptionShape.scala
+++ b/library/src/scala/jdk/OptionShape.scala
@@ -26,9 +26,9 @@ import scala.annotation.implicitNotFound
   */
 @implicitNotFound("No specialized Optional type exists for elements of type ${A}")
 sealed abstract class OptionShape[A, O] {
-  /** Converts from `Optional` to the specialized variant `O` */
+  /** Converts from `Optional` to the specialized variant `O`. */
   def fromJava(o: Optional[A]): O
-  /** Converts from `Option` to the specialized variant `O` */
+  /** Converts from `Option` to the specialized variant `O`. */
   def fromScala(o: Option[A]): O
 }
 

--- a/library/src/scala/jdk/javaapi/DurationConverters.scala
+++ b/library/src/scala/jdk/javaapi/DurationConverters.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
   * code, it is recommended to use the extension methods defined in [[scala.jdk.DurationConverters]].
   */
 object  DurationConverters {
-  /** Convert a Java duration to a Scala duration. If the nanosecond part of the Java duration is
+  /** Converts a Java duration to a Scala duration. If the nanosecond part of the Java duration is
     * zero, the returned duration will have a time unit of seconds. If there is a nanoseconds part,
     * the Scala duration will have a time unit of nanoseconds.
     *
@@ -55,7 +55,7 @@ object  DurationConverters {
     }
   }
 
-  /** Convert a Scala `FiniteDuration` to a Java duration. Note that the Scala duration keeps the
+  /** Converts a Scala `FiniteDuration` to a Java duration. Note that the Scala duration keeps the
     * time unit it was created with, while a Java duration always is a pair of seconds and nanos,
     * so the unit it lost.
     */

--- a/library/src/scala/jdk/javaapi/OptionConverters.scala
+++ b/library/src/scala/jdk/javaapi/OptionConverters.scala
@@ -29,13 +29,13 @@ import java.{lang => jl}
   *                       extension methods instead.
   */
 object OptionConverters {
-  /** Convert a Scala `Option` to a Java `Optional` */
+  /** Converts a Scala `Option` to a Java `Optional`. */
   def toJava[A](o: Option[A]): Optional[A] = o match {
     case Some(a) => Optional.ofNullable(a)
     case _ => Optional.empty[A]
   }
 
-  /** Convert a Scala `Option[java.lang.Double]` to a Java `OptionalDouble`
+  /** Converts a Scala `Option[java.lang.Double]` to a Java `OptionalDouble`.
     *
     * $primitiveNote
     */
@@ -44,7 +44,7 @@ object OptionConverters {
     case _ => OptionalDouble.empty
   }
 
-  /** Convert a Scala `Option[java.lang.Integer]` to a Java `OptionalInt`
+  /** Converts a Scala `Option[java.lang.Integer]` to a Java `OptionalInt`.
     *
     * $primitiveNote
     */
@@ -53,7 +53,7 @@ object OptionConverters {
     case _ => OptionalInt.empty
   }
 
-  /** Convert a Scala `Option[java.lang.Long]` to a Java `OptionalLong`
+  /** Converts a Scala `Option[java.lang.Long]` to a Java `OptionalLong`.
     *
     * $primitiveNote
     */
@@ -62,22 +62,22 @@ object OptionConverters {
     case _ => OptionalLong.empty
   }
 
-  /** Convert a Java `Optional` to a Scala `Option` */
+  /** Converts a Java `Optional` to a Scala `Option`. */
   def toScala[A](o: Optional[A]): Option[A] = if (o.isPresent) Some(o.get) else None
 
-  /** Convert a Java `OptionalDouble` to a Scala `Option[java.lang.Double]`
+  /** Converts a Java `OptionalDouble` to a Scala `Option[java.lang.Double]`.
     *
     * $primitiveNote
     */
   def toScala(o: OptionalDouble): Option[jl.Double] = if (o.isPresent) Some(o.getAsDouble) else None
 
-  /** Convert a Java `OptionalInt` to a Scala `Option[java.lang.Integer]`
+  /** Converts a Java `OptionalInt` to a Scala `Option[java.lang.Integer]`.
     *
     * $primitiveNote
     */
   def toScala(o: OptionalInt): Option[jl.Integer] = if (o.isPresent) Some(o.getAsInt) else None
 
-  /** Convert a Java `OptionalLong` to a Scala `Option[java.lang.Long]`
+  /** Converts a Java `OptionalLong` to a Scala `Option[java.lang.Long]`.
     *
     * $primitiveNote
     */

--- a/library/src/scala/jdk/javaapi/StreamConverters.scala
+++ b/library/src/scala/jdk/javaapi/StreamConverters.scala
@@ -45,42 +45,42 @@ object StreamConverters {
   // sequential streams for collections
   /////////////////////////////////////
 
-  /** Create a sequential [[java.util.stream.Stream Java Stream]] for a Scala collection. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for a Scala collection. */
   def asJavaSeqStream[A](cc: IterableOnce[A]): Stream[A] = StreamSupport.stream(cc.stepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
     *
     * $primitiveNote
     */
   def asJavaSeqIntStream         (cc: IterableOnce[jl.Integer]):   IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
     *
     * $primitiveNote
     */
   def asJavaSeqIntStreamFromByte (cc: IterableOnce[jl.Byte]):      IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
     *
     * $primitiveNote
     */
   def asJavaSeqIntStreamFromShort(cc: IterableOnce[jl.Short]):     IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
     *
     * $primitiveNote
     */
   def asJavaSeqIntStreamFromChar (cc: IterableOnce[jl.Character]): IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
     *
     * $primitiveNote
     */
   def asJavaSeqDoubleStream         (cc: IterableOnce[jl.Double]): DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
     *
     * $primitiveNote
     */
   def asJavaSeqDoubleStreamFromFloat(cc: IterableOnce[jl.Float]):  DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.LongStream Java LongStream]] for a Scala collection.
+  /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for a Scala collection.
     *
     * $primitiveNote
     */
@@ -88,42 +88,42 @@ object StreamConverters {
 
   // Map Key Streams
 
-  /** Create a sequential [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map. */
   def asJavaSeqKeyStream[K, V](m: collection.Map[K, V]): Stream[K] = StreamSupport.stream(m.keyStepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
     *
     * $primitiveNote
     */
   def asJavaSeqKeyIntStream         [V](m: collection.Map[jl.Integer, V]):   IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
     *
     * $primitiveNote
     */
   def asJavaSeqKeyIntStreamFromByte [V](m: collection.Map[jl.Byte, V]):      IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
     *
     * $primitiveNote
     */
   def asJavaSeqKeyIntStreamFromShort[V](m: collection.Map[jl.Short, V]):     IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
     *
     * $primitiveNote
     */
   def asJavaSeqKeyIntStreamFromChar [V](m: collection.Map[jl.Character, V]): IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
     *
     * $primitiveNote
     */
   def asJavaSeqKeyDoubleStream         [V](m: collection.Map[jl.Double, V]): DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
     *
     * $primitiveNote
     */
   def asJavaSeqKeyDoubleStreamFromFloat[V](m: collection.Map[jl.Float, V]):  DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.LongStream Java LongStream]] for the keys of a Scala Map.
+  /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the keys of a Scala Map.
     *
     * $primitiveNote
     */
@@ -131,42 +131,42 @@ object StreamConverters {
 
   // Map Value Streams
 
-  /** Create a sequential [[java.util.stream.Stream Java Stream]] for the values of a Scala Map. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of a Scala Map. */
   def asJavaSeqValueStream[K, V](m: collection.Map[K, V]): Stream[V] = StreamSupport.stream(m.valueStepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
     *
     * $primitiveNote
     */
   def asJavaSeqValueIntStream         [K](m: collection.Map[K, jl.Integer]):   IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
     *
     * $primitiveNote
     */
   def asJavaSeqValueIntStreamFromByte [K](m: collection.Map[K, jl.Byte]):      IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
     *
     * $primitiveNote
     */
   def asJavaSeqValueIntStreamFromShort[K](m: collection.Map[K, jl.Short]):     IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
     *
     * $primitiveNote
     */
   def asJavaSeqValueIntStreamFromChar [K](m: collection.Map[K, jl.Character]): IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
     *
     * $primitiveNote
     */
   def asJavaSeqValueDoubleStream         [K](m: collection.Map[K, jl.Double]): DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, false)
-  /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
     *
     * $primitiveNote
     */
   def asJavaSeqValueDoubleStreamFromFloat[K](m: collection.Map[K, jl.Float]):  DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, false)
 
-  /** Create a sequential [[java.util.stream.LongStream Java LongStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the values of a
     *
     * $primitiveNote
     */
@@ -176,34 +176,34 @@ object StreamConverters {
   // parallel streams for collections
   ///////////////////////////////////
 
-  /** Create a parallel [[java.util.stream.Stream Java Stream]] for a Scala collection.
+  /** Creates a parallel [[java.util.stream.Stream Java Stream]] for a Scala collection.
     *
     * $parNote
     */
   def asJavaParStream[A](cc: IterableOnce[A]): Stream[A] = StreamSupport.stream(cc.stepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParIntStream         (cc: IterableOnce[jl.Integer]):   IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParIntStreamFromByte (cc: IterableOnce[jl.Byte]):      IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParIntStreamFromShort(cc: IterableOnce[jl.Short]):     IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
     *
     * $parNote
     *
@@ -211,14 +211,14 @@ object StreamConverters {
     */
   def asJavaParIntStreamFromChar (cc: IterableOnce[jl.Character]): IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
+  /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParDoubleStream         (cc: IterableOnce[jl.Double]): DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
+  /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
     *
     * $parNote
     *
@@ -226,7 +226,7 @@ object StreamConverters {
     */
   def asJavaParDoubleStreamFromFloat(cc: IterableOnce[jl.Float]):  DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.LongStream Java LongStream]] for a Scala collection.
+  /** Creates a parallel [[java.util.stream.LongStream Java LongStream]] for a Scala collection.
     *
     * $parNote
     *
@@ -237,34 +237,34 @@ object StreamConverters {
 
   // Map Key Streams
 
-  /** Create a parallel [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map.
+  /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map.
     *
     * $parNote
     */
   def asJavaParKeyStream[K, V](m: collection.Map[K, V]): Stream[K] = StreamSupport.stream(m.keyStepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParKeyIntStream         [V](m: collection.Map[jl.Integer, V]):   IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParKeyIntStreamFromByte [V](m: collection.Map[jl.Byte, V]):      IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParKeyIntStreamFromShort[V](m: collection.Map[jl.Short, V]):     IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
     *
     * $parNote
     *
@@ -272,14 +272,14 @@ object StreamConverters {
     */
   def asJavaParKeyIntStreamFromChar [V](m: collection.Map[jl.Character, V]): IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
+  /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParKeyDoubleStream         [V](m: collection.Map[jl.Double, V]): DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
+  /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
     *
     * $parNote
     *
@@ -287,7 +287,7 @@ object StreamConverters {
     */
   def asJavaParKeyDoubleStreamFromFloat[V](m: collection.Map[jl.Float, V]):  DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.LongStream Java LongStream]] for the keys of a Scala Map.
+  /** Creates a parallel [[java.util.stream.LongStream Java LongStream]] for the keys of a Scala Map.
     *
     * $parNote
     *
@@ -297,34 +297,34 @@ object StreamConverters {
 
   // Map Value Streams
 
-  /** Create a parallel [[java.util.stream.Stream Java Stream]] for the values of a Scala Map.
+  /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of a Scala Map.
     *
     * $parNote
     */
   def asJavaParValueStream[K, V](m: collection.Map[K, V]): Stream[V] = StreamSupport.stream(m.valueStepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParValueIntStream         [K](m: collection.Map[K, jl.Integer]):   IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParValueIntStreamFromByte [K](m: collection.Map[K, jl.Byte]):      IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParValueIntStreamFromShort[K](m: collection.Map[K, jl.Short]):     IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
+  /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
     *
     * $parNote
     *
@@ -332,14 +332,14 @@ object StreamConverters {
     */
   def asJavaParValueIntStreamFromChar [K](m: collection.Map[K, jl.Character]): IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
+  /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
     *
     * $parNote
     *
     * $primitiveNote
     */
   def asJavaParValueDoubleStream         [K](m: collection.Map[K, jl.Double]): DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, true)
-  /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
+  /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
     *
     * $parNote
     *
@@ -347,7 +347,7 @@ object StreamConverters {
     */
   def asJavaParValueDoubleStreamFromFloat[K](m: collection.Map[K, jl.Float]):  DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, true)
 
-  /** Create a parallel [[java.util.stream.LongStream Java LongStream]] for the values of a Scala Map.
+  /** Creates a parallel [[java.util.stream.LongStream Java LongStream]] for the values of a Scala Map.
     *
     * $parNote
     *

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -447,27 +447,27 @@ object language {
   @compileTimeOnly("`future-migration` can only be used at compile time in import statements")
   object `future-migration`
 
-  /** Set source version to 2.13. Effectively, this doesn't change the source language,
+  /** Sets source version to 2.13. Effectively, this doesn't change the source language,
    * but rather adapts the generated code as if it was compiled with Scala 2.13
    */
   @compileTimeOnly("`2.13` can only be used at compile time in import statements")
   private[scala] object `2.13`
 
-  /** Set source version to 3.0-migration.
+  /** Sets source version to 3.0-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.0-migration` can only be used at compile time in import statements")
   object `3.0-migration`
 
-  /** Set source version to 3.0.
+  /** Sets source version to 3.0.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.0` can only be used at compile time in import statements")
   object `3.0`
 
-  /** Set source version to 3.1-migration.
+  /** Sets source version to 3.1-migration.
     *
     * This is a no-op, and should not be used. A syntax error will be reported upon import.
     *
@@ -477,119 +477,119 @@ object language {
   @deprecated("`3.1-migration` is not valid, use `3.1` instead", since = "3.2")
   object `3.1-migration`
 
-  /** Set source version to 3.1
+  /** Sets source version to 3.1
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.1` can only be used at compile time in import statements")
   object `3.1`
 
-  /** Set source version to 3.2-migration.
+  /** Sets source version to 3.2-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.2-migration` can only be used at compile time in import statements")
   object `3.2-migration`
 
-  /** Set source version to 3.2
+  /** Sets source version to 3.2
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.2` can only be used at compile time in import statements")
   object `3.2`
 
-  /** Set source version to 3.3-migration.
+  /** Sets source version to 3.3-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.3-migration` can only be used at compile time in import statements")
   object `3.3-migration`
 
-  /** Set source version to 3.3
+  /** Sets source version to 3.3
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.3` can only be used at compile time in import statements")
   object `3.3`
 
-  /** Set source version to 3.4-migration.
+  /** Sets source version to 3.4-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.4-migration` can only be used at compile time in import statements")
   object `3.4-migration`
 
-  /** Set source version to 3.4
+  /** Sets source version to 3.4
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.4` can only be used at compile time in import statements")
   object `3.4`
 
-  /** Set source version to 3.5-migration.
+  /** Sets source version to 3.5-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.5-migration` can only be used at compile time in import statements")
   object `3.5-migration`
 
-  /** Set source version to 3.5
+  /** Sets source version to 3.5
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.5` can only be used at compile time in import statements")
   object `3.5`
 
-  /** Set source version to 3.6-migration.
+  /** Sets source version to 3.6-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.6-migration` can only be used at compile time in import statements")
   object `3.6-migration`
 
-  /** Set source version to 3.6
+  /** Sets source version to 3.6
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.6` can only be used at compile time in import statements")
   object `3.6`
 
-  /** Set source version to 3.7-migration.
+  /** Sets source version to 3.7-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.7-migration` can only be used at compile time in import statements")
   object `3.7-migration`
 
-  /** Set source version to 3.7
+  /** Sets source version to 3.7
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.7` can only be used at compile time in import statements")
   object `3.7`
 
-    /** Set source version to 3.8-migration.
+    /** Sets source version to 3.8-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.8-migration` can only be used at compile time in import statements")
   object `3.8-migration`
 
-  /** Set source version to 3.8
+  /** Sets source version to 3.8
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.8` can only be used at compile time in import statements")
   object `3.8`
 
-  /** Set source version to 3.9-migration.
+  /** Sets source version to 3.9-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.9-migration` can only be used at compile time in import statements")
   object `3.9-migration`
 
-  /** Set source version to 3.9
+  /** Sets source version to 3.9
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */

--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -573,7 +573,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     if (r eq bigDecimal) this else new BigDecimal(r, this.mc)
   }
 
-  /** Returns a `BigDecimal` rounded according to its own `MathContext` */
+  /** Returns a `BigDecimal` rounded according to its own `MathContext`. */
   def rounded: BigDecimal = {
     val r = bigDecimal.round(mc)
     if (r eq bigDecimal) this else new BigDecimal(r, mc)

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -616,7 +616,7 @@ final class BigInt private (
     if (isValidLong && (-(1L << 53) <= _long && _long <= (1L << 53))) _long.toDouble
     else this.bigInteger.doubleValue
 
-  /** Create a `NumericRange[BigInt]` in range `[start;end)`
+  /** Creates a `NumericRange[BigInt]` in range `[start;end)`
    *  with the specified step, where start is the target BigInt.
    *
    *  @param end    the end value of the range (exclusive)

--- a/library/src/scala/math/Ordered.scala
+++ b/library/src/scala/math/Ordered.scala
@@ -96,7 +96,7 @@ trait Ordered[A] extends Any with java.lang.Comparable[A] {
 }
 
 object Ordered {
-  /** Lens from `Ordering[T]` to `Ordered[T]` */
+  /** Lens from `Ordering[T]` to `Ordered[T]`. */
   implicit def orderingToOrdered[T](x: T)(implicit ord: Ordering[T]): Ordered[T] =
     new Ordered[T] { def compare(that: T): Int = ord.compare(x, that) }
 }

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -88,28 +88,28 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    */
   def compare(x: T, y: T): Int
 
-  /** Return true if `x` <= `y` in the ordering. */
+  /** Returns true if `x` <= `y` in the ordering. */
   override def lteq(x: T, y: T): Boolean = compare(x, y) <= 0
 
-  /** Return true if `x` >= `y` in the ordering. */
+  /** Returns true if `x` >= `y` in the ordering. */
   override def gteq(x: T, y: T): Boolean = compare(x, y) >= 0
 
-  /** Return true if `x` < `y` in the ordering. */
+  /** Returns true if `x` < `y` in the ordering. */
   override def lt(x: T, y: T): Boolean = compare(x, y) < 0
 
-  /** Return true if `x` > `y` in the ordering. */
+  /** Returns true if `x` > `y` in the ordering. */
   override def gt(x: T, y: T): Boolean = compare(x, y) > 0
 
-  /** Return true if `x` == `y` in the ordering. */
+  /** Returns true if `x` == `y` in the ordering. */
   override def equiv(x: T, y: T): Boolean = compare(x, y) == 0
 
-  /** Return `x` if `x` >= `y`, otherwise `y`. */
+  /** Returns `x` if `x` >= `y`, otherwise `y`. */
   def max[U <: T](x: U, y: U): U = if (gteq(x, y)) x else y
 
-  /** Return `x` if `x` <= `y`, otherwise `y`. */
+  /** Returns `x` if `x` <= `y`, otherwise `y`. */
   def min[U <: T](x: U, y: U): U = if (lteq(x, y)) x else y
 
-  /** Return the opposite ordering of this one.
+  /** Returns the opposite ordering of this one.
     *
     * Implementations overriding this method MUST override [[isReverseOf]]
     * as well if they change the behavior at all (for example, caching does
@@ -243,7 +243,7 @@ object Ordering extends LowPriorityOrderingImplicits {
     override final def isReverseOf(other: Ordering[?]): Boolean = other eq _reverse
   }
 
-  /** A reverse ordering */
+  /** A reverse ordering. */
   private final class Reverse[T](private[Ordering] val outer: Ordering[T]) extends Ordering[T] {
     override def reverse: Ordering[T]                   = outer
     override def isReverseOf(other: Ordering[?]): Boolean = other == outer
@@ -311,7 +311,7 @@ object Ordering extends LowPriorityOrderingImplicits {
   /** An object containing implicits which are not in the default scope. */
   object Implicits extends ExtraImplicits { }
 
-  /** Construct an Ordering[T] given a function `lt`. */
+  /** Constructs an Ordering[T] given a function `lt`. */
   def fromLessThan[T](cmp: (T, T) => Boolean): Ordering[T] = new Ordering[T] {
     def compare(x: T, y: T) = if (cmp(x, y)) -1 else if (cmp(y, x)) 1 else 0
     // overrides to avoid multiple comparisons

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -8,7 +8,7 @@ import language.experimental.captureChecking
  */
 abstract class Expr[+T] private[scala] ()
 
-/** Constructors for expressions */
+/** Constructors for expressions. */
 object Expr {
 
   /** `e.betaReduce` returns an expression that is functionally equivalent to `e`,
@@ -67,11 +67,11 @@ object Expr {
     Block(statements.map(asTerm), expr.asTerm).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Creates an expression that will construct the value `x` */
+  /** Creates an expression that will construct the value `x`. */
   def apply[T](x: T)(using ToExpr[T])(using Quotes): Expr[T] =
     scala.Predef.summon[ToExpr[T]].apply(x)
 
-  /** Get `Some` of a copy of the value if the expression contains a literal constant or constructor of `T`.
+  /** Gets `Some` of a copy of the value if the expression contains a literal constant or constructor of `T`.
    *  Otherwise returns `None`.
    *
    *  Usage:
@@ -268,8 +268,8 @@ object Expr {
     ofTupleFromSeq(elems).asExprOf[Tuple.InverseMap[T, Expr]]
   }
 
-  /** Find a given instance of type `T` in the current scope.
-   *  Return `Some` containing the expression of the implicit or
+  /** Finds a given instance of type `T` in the current scope.
+   *  Returns `Some` containing the expression of the implicit or
    * `None` if implicit resolution failed.
    *
    *  @tparam T type of the implicit parameter
@@ -282,9 +282,9 @@ object Expr {
     }
   }
 
-  /** Find a given instance of type `T` in the current scope,
+  /** Finds a given instance of type `T` in the current scope,
    *  while excluding certain symbols from the initial implicit search.
-   *  Return `Some` containing the expression of the implicit or
+   *  Returns `Some` containing the expression of the implicit or
    * `None` if implicit resolution failed.
    *
    *  @tparam T type of the implicit parameter

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -4,10 +4,10 @@ import language.experimental.captureChecking
 
 trait ExprMap:
 
-  /** Map an expression `e` with a type `T` */
+  /** Maps an expression `e` with a type `T`. */
   def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T]
 
-  /** Map sub-expressions an expression `e` with a type `T` */
+  /** Maps sub-expressions an expression `e` with a type `T`. */
   def transformChildren[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] = {
     import quotes.reflect.*
     final class MapChildren() {

--- a/library/src/scala/quoted/Exprs.scala
+++ b/library/src/scala/quoted/Exprs.scala
@@ -4,7 +4,7 @@ import language.experimental.captureChecking
 
 object Exprs:
 
-  /** Matches literal sequence of literal constant value expressions and return a sequence of values.
+  /** Matches literal sequence of literal constant value expressions and returns a sequence of values.
    *
    *  Usage:
    *  ```scala

--- a/library/src/scala/quoted/FromExpr.scala
+++ b/library/src/scala/quoted/FromExpr.scala
@@ -14,7 +14,7 @@ import language.experimental.captureChecking
  */
 trait FromExpr[T] {
 
-  /** Return the value of the expression.
+  /** Returns the value of the expression.
    *
    *  Returns `None` if the expression does not represent a value or possibly contains side effects.
    *  Otherwise returns the `Some` of the value.
@@ -23,7 +23,7 @@ trait FromExpr[T] {
 
 }
 
-/** Default given instances of `FromExpr` */
+/** Default given instances of `FromExpr`. */
 object FromExpr {
 
   /** Default implementation of `FromExpr[Boolean]`
@@ -81,7 +81,7 @@ object FromExpr {
    */
   given StringFromExpr[T <: String]: FromExpr[T] = new PrimitiveFromExpr
 
-  /** Lift a quoted primitive value `'{ x }` into `x` */
+  /** Lift a quoted primitive value `'{ x }` into `x`. */
   private class PrimitiveFromExpr[T <: Boolean | Byte | Short | Int | Long | Float | Double | Char | String] extends FromExpr[T] {
     def unapply(expr: Expr[T])(using Quotes) =
       import quotes.reflect.*

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -46,7 +46,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
   // Extension methods for `Expr[T]`
   extension [T](self: Expr[T])
-    /** Show a source code like representation of this expression */
+    /** Shows a source code like representation of this expression. */
     def show: String
 
     /** Pattern matches `this` against `that`. Effectively performing a deep equality check.
@@ -59,7 +59,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     */
     def matches(that: Expr[Any]): Boolean
 
-    /** Return the value of this expression.
+    /** Returns the value of this expression.
      *
      *  Returns `None` if the expression does not represent a value or possibly contains side effects.
      *  Otherwise returns the `Some` of the value.
@@ -68,7 +68,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       given Quotes = Quotes.this
       summon[FromExpr[T]].unapply(self)
 
-    /** Return the value of this expression.
+    /** Returns the value of this expression.
      *
      *  Emits an error and throws if the expression does not represent a value or possibly contains side effects.
      *  Otherwise returns the value.
@@ -82,7 +82,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       given Quotes = Quotes.this
       fromExpr.unapply(self).getOrElse(reportError)
 
-    /** Return the value of this expression.
+    /** Returns the value of this expression.
      *
      *  Emits an error and aborts if the expression does not represent a value or possibly contains side effects.
      *  Otherwise returns the value.
@@ -93,10 +93,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
   // Extension methods for `Expr[Any]` that take another explicit type parameter
   extension (self: Expr[Any])
-    /** Checks is the `quoted.Expr[?]` is valid expression of type `X` */
+    /** Checks is the `quoted.Expr[?]` is valid expression of type `X`. */
     def isExprOf[X](using Type[X]): Boolean
 
-    /** Convert this to an `quoted.Expr[X]` if this expression is a valid expression of type `X` or throws */
+    /** Converts this to an `quoted.Expr[X]` if this expression is a valid expression of type `X` or throws. */
     def asExprOf[X](using Type[X]): Expr[X]
   end extension
 
@@ -250,10 +250,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    */
   trait reflectModule { self: reflect.type =>
 
-    /** Module object of `type CompilationInfo`  */
+    /** Module object of `type CompilationInfo`. */
     val CompilationInfo: CompilationInfoModule
 
-    /** Methods of the module object `val CompilationInfo` */
+    /** Methods of the module object `val CompilationInfo`. */
     trait CompilationInfoModule { this: CompilationInfo.type =>
       /** Are we expanding a `inline` macro while typing the program?
        *
@@ -272,7 +272,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     }
 
 
-    /** Returns the `Term` representation this expression */
+    /** Returns the `Term` representation this expression. */
     extension (expr: Expr[Any])
       def asTerm: Term
 
@@ -280,44 +280,44 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     //   TREES   //
     ///////////////
 
-    /** Tree representing code written in the source */
+    /** Tree representing code written in the source. */
     type Tree <: AnyRef
 
-    /** Module object of `type Tree`  */
+    /** Module object of `type Tree`. */
     val Tree: TreeModule
 
-    /** Methods of the module object `val Tree` */
+    /** Methods of the module object `val Tree`. */
     trait TreeModule { this: Tree.type => }
 
-    /** Makes extension methods on `Tree` available without any imports */
+    /** Makes extension methods on `Tree` available without any imports. */
     given TreeMethods: TreeMethods
 
-    /** Extension methods of `Tree` */
+    /** Extension methods of `Tree`. */
     trait TreeMethods {
 
       extension (self: Tree)
-        /** Position in the source code */
+        /** Position in the source code. */
         def pos: Position
 
-        /** Symbol of defined or referred by this tree */
+        /** Symbol of defined or referred by this tree. */
         def symbol: Symbol
 
-        /** Shows the tree as String */
+        /** Shows the tree as String. */
         def show(using Printer[Tree]): String
 
         /** Does this tree represent a valid expression? */
         def isExpr: Boolean
 
-        /** Convert this tree to an `quoted.Expr[Any]` if the tree is a valid expression or throws */
+        /** Converts this tree to an `quoted.Expr[Any]` if the tree is a valid expression or throws. */
         def asExpr: Expr[Any]
       end extension
 
-      /** Convert this tree to an `quoted.Expr[T]` if the tree is a valid expression or throws */
+      /** Converts this tree to an `quoted.Expr[T]` if the tree is a valid expression or throws. */
       extension (self: Tree)
         def asExprOf[T](using Type[T]): Expr[T]
 
       extension [ThisTree <: Tree](self: ThisTree)
-        /** Changes the owner of the symbols in the tree */
+        /** Changes the owner of the symbols in the tree. */
         def changeOwner(newOwner: Symbol): ThisTree
       end extension
 
@@ -340,31 +340,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type PackageClause <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `PackageClause` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `PackageClause`. */
     given PackageClauseTypeTest: TypeTest[Tree, PackageClause]
 
-    /** Module object of `type PackageClause`  */
+    /** Module object of `type PackageClause`. */
     val PackageClause: PackageClauseModule
 
-    /** Methods of the module object `val PackageClause` */
+    /** Methods of the module object `val PackageClause`. */
     trait PackageClauseModule { this: PackageClause.type =>
-      /** Create a package clause `package pid { stats }` */
+      /** Creates a package clause `package pid { stats }`. */
       def apply(pid: Ref, stats: List[Tree]): PackageClause
-      /** Copy a package clause `package pid { stats }` */
+      /** Copies a package clause `package pid { stats }`. */
       def copy(original: Tree)(pid: Ref, stats: List[Tree]): PackageClause
-      /** Matches a package clause `package pid { stats }` and extracts the `pid` and `stats` */
+      /** Matches a package clause `package pid { stats }` and extracts the `pid` and `stats`. */
       def unapply(tree: PackageClause): (Ref, List[Tree])
     }
 
-    /** Makes extension methods on `PackageClause` available without any imports */
+    /** Makes extension methods on `PackageClause` available without any imports. */
     given PackageClauseMethods: PackageClauseMethods
 
-    /** Extension methods of `PackageClause` */
+    /** Extension methods of `PackageClause`. */
     trait PackageClauseMethods:
       extension (self: PackageClause)
-        /** Tree containing the package name */
+        /** Tree containing the package name. */
         def pid: Ref
-        /** Definitions, imports or exports within the package */
+        /** Definitions, imports or exports within the package. */
         def stats: List[Tree]
       end extension
     end PackageClauseMethods
@@ -375,29 +375,29 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type Import <: Statement
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Import` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Import`. */
     given ImportTypeTest: TypeTest[Tree, Import]
 
-    /** Module object of `type Import`  */
+    /** Module object of `type Import`. */
     val Import: ImportModule
 
-    /** Methods of the module object `val Import` */
+    /** Methods of the module object `val Import`. */
     trait ImportModule { this: Import.type =>
-      /** Create an `Import` with the given qualifier and selectors */
+      /** Creates an `Import` with the given qualifier and selectors. */
       def apply(expr: Term, selectors: List[Selector]): Import
-      /** Copy an `Import` with the given qualifier and selectors */
+      /** Copies an `Import` with the given qualifier and selectors. */
       def copy(original: Tree)(expr: Term, selectors: List[Selector]): Import
-      /** Matches an `Import` and extracts the qualifier and selectors */
+      /** Matches an `Import` and extracts the qualifier and selectors. */
       def unapply(tree: Import): (Term, List[Selector])
     }
 
-    /** Makes extension methods on `Import` available without any imports */
+    /** Makes extension methods on `Import` available without any imports. */
     given ImportMethods: ImportMethods
 
-    /** Extension methods of `Import` */
+    /** Extension methods of `Import`. */
     trait ImportMethods:
       extension (self: Import)
-        /** Qualifier of the import */
+        /** Qualifier of the import. */
         def expr: Term
         /** List selectors of the import
          *
@@ -412,25 +412,25 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type Export <: Statement
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Export` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Export`. */
     given ExportTypeTest: TypeTest[Tree, Export]
 
-    /** Module object of `type Export`  */
+    /** Module object of `type Export`. */
     val Export: ExportModule
 
-    /** Methods of the module object `val Export` */
+    /** Methods of the module object `val Export`. */
     trait ExportModule { this: Export.type =>
-      /** Matches an `Export` and extracts the qualifier and selectors */
+      /** Matches an `Export` and extracts the qualifier and selectors. */
       def unapply(tree: Export): (Term, List[Selector])
     }
 
-    /** Makes extension methods on `Export` available without any imports */
+    /** Makes extension methods on `Export` available without any imports. */
     given ExportMethods: ExportMethods
 
-    /** Extension methods of `Export` */
+    /** Extension methods of `Export`. */
     trait ExportMethods:
       extension (self: Export)
-        /** Qualifier of the export */
+        /** Qualifier of the export. */
         def expr: Term
         /** List selectors of the export
          *
@@ -440,51 +440,51 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end ExportMethods
 
-    /** Tree representing a statement in the source code */
+    /** Tree representing a statement in the source code. */
     type Statement <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Statement` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Statement`. */
     given StatementTypeTest: TypeTest[Tree, Statement]
 
     // ----- Definitions ----------------------------------------------
 
-    /** Tree representing a definition in the source code. It can be `ClassDef`, `TypeDef`, `DefDef` or `ValDef` */
+    /** Tree representing a definition in the source code. It can be `ClassDef`, `TypeDef`, `DefDef` or `ValDef`. */
     type Definition <: Statement
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Definition` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Definition`. */
     given DefinitionTypeTest: TypeTest[Tree, Definition]
 
-    /** Module object of `type Definition`  */
+    /** Module object of `type Definition`. */
     val Definition: DefinitionModule
 
-    /** Methods of the module object `val Definition` */
+    /** Methods of the module object `val Definition`. */
     trait DefinitionModule { this: Definition.type => }
 
-    /** Makes extension methods on `Definition` available without any imports */
+    /** Makes extension methods on `Definition` available without any imports. */
     given DefinitionMethods: DefinitionMethods
 
-    /** Extension methods of `Definition` */
+    /** Extension methods of `Definition`. */
     trait DefinitionMethods:
       extension (self: Definition)
-        /** Name of the definition */
+        /** Name of the definition. */
         def name: String
       end extension
     end DefinitionMethods
 
     // ClassDef
 
-    /** Tree representing a class definition. This includes anonymous class definitions and the class of a module object */
+    /** Tree representing a class definition. This includes anonymous class definitions and the class of a module object. */
     type ClassDef <: Definition
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `ClassDef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `ClassDef`. */
     given ClassDefTypeTest: TypeTest[Tree, ClassDef]
 
-    /** Module object of `type ClassDef`  */
+    /** Module object of `type ClassDef`. */
     val ClassDef: ClassDefModule
 
-    /** Methods of the module object `val ClassDef` */
+    /** Methods of the module object `val ClassDef`. */
     trait ClassDefModule { this: ClassDef.type =>
-      /** Create a class definition tree
+      /** Creates a class definition tree
        *
        *  @param cls The class symbol. A new class symbol can be created using `Symbol.newClass`.
        *  @param parents The parents trees class. The trees must align with the parent types of `cls`.
@@ -499,7 +499,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def unapply(cdef: ClassDef): (String, DefDef, List[Tree /* Term | TypeTree */], Option[ValDef], List[Statement])
 
 
-      /** Create the ValDef and ClassDef of a module (equivalent to an `object` declaration in source code).
+      /** Creates the ValDef and ClassDef of a module (equivalent to an `object` declaration in source code).
        *
        *  Equivalent to
        *  ```
@@ -523,13 +523,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def module(module: Symbol, parents: List[Tree /* Term | TypeTree */], body: List[Statement]): (ValDef, ClassDef)
     }
 
-    /** Makes extension methods on `ClassDef` available without any imports */
+    /** Makes extension methods on `ClassDef` available without any imports. */
     given ClassDefMethods: ClassDefMethods
 
-    /** Extension methods of `ClassDef` */
+    /** Extension methods of `ClassDef`. */
     trait ClassDefMethods:
       extension (self: ClassDef)
-        /** The primary constructor of this class */
+        /** The primary constructor of this class. */
         def constructor: DefDef
         /** List of extended parent classes or traits.
          *  The first parent is always a class.
@@ -566,36 +566,36 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type ValOrDefDef <: Definition
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `ValOrDefDef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `ValOrDefDef`. */
     given ValOrDefDefTypeTest: TypeTest[Tree, ValOrDefDef]
 
-    /** Makes extension methods on `ValOrDefDef` available without any imports */
+    /** Makes extension methods on `ValOrDefDef` available without any imports. */
     given ValOrDefDefMethods: ValOrDefDefMethods
 
-    /** Extension methods of `ValOrDefDef` */
+    /** Extension methods of `ValOrDefDef`. */
     trait ValOrDefDefMethods:
       extension (self: ValOrDefDef)
-        /** The type tree of this `val` or `def` definition */
+        /** The type tree of this `val` or `def` definition. */
         def tpt: TypeTree
-        /** The right-hand side of this `val` or `def` definition */
+        /** The right-hand side of this `val` or `def` definition. */
         def rhs: Option[Term]
       end extension
     end ValOrDefDefMethods
 
     // DefDef
 
-    /** Tree representing a method definition in the source code */
+    /** Tree representing a method definition in the source code. */
     type DefDef <: ValOrDefDef
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `DefDef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `DefDef`. */
     given DefDefTypeTest: TypeTest[Tree, DefDef]
 
-    /** Module object of `type DefDef`  */
+    /** Module object of `type DefDef`. */
     val DefDef: DefDefModule
 
-    /** Methods of the module object `val DefDef` */
+    /** Methods of the module object `val DefDef`. */
     trait DefDefModule { this: DefDef.type =>
-      /** Create a method definition `def f[..](...)` with the signature defined in the symbol.
+      /** Creates a method definition `def f[..](...)` with the signature defined in the symbol.
        *
        *  The `rhsFn` is a function that receives references to its parameters, and should return
        *  `Some` containing the implementation of the method, or `None` if the method has no implementation.
@@ -610,13 +610,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def unapply(ddef: DefDef): (String, List[ParamClause], TypeTree, Option[Term])
     }
 
-    /** Makes extension methods on `DefDef` available without any imports */
+    /** Makes extension methods on `DefDef` available without any imports. */
     given DefDefMethods: DefDefMethods
 
-    /** Extension methods of `DefDef` */
+    /** Extension methods of `DefDef`. */
     trait DefDefMethods:
       extension (self: DefDef)
-        /** List of type and term parameter clauses */
+        /** List of type and term parameter clauses. */
         def paramss: List[ParamClause]
 
         /** List of leading type parameters or Nil if the method does not have leading type parameters.
@@ -633,7 +633,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def leadingTypeParams: List[TypeDef]
 
         /** List of parameter clauses following the leading type parameters or all clauses.
-         *  Return all parameter clauses if there are no leading type parameters.
+         *  Returns all parameter clauses if there are no leading type parameters.
          *
          *  Non leading type parameters can be found in extension methods such as
          *  ```scala
@@ -646,10 +646,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          */
         def trailingParamss: List[ParamClause]
 
-        /** List of term parameter clauses */
+        /** List of term parameter clauses. */
         def termParamss: List[TermParamClause]
 
-        /** The tree of the return type of this `def` definition */
+        /** The tree of the return type of this `def` definition. */
         def returnTpt: TypeTree
 
         /** The tree of the implementation of the method.
@@ -664,15 +664,15 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Tree representing a value definition in the source code. This includes `val`, `lazy val`, `var`, `object` and parameter definitions. */
     type ValDef <: ValOrDefDef
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `ValDef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `ValDef`. */
     given ValDefTypeTest: TypeTest[Tree, ValDef]
 
-    /** Module object of `type ValDef`  */
+    /** Module object of `type ValDef`. */
     val ValDef: ValDefModule
 
-    /** Methods of the module object `val ValDef` */
+    /** Methods of the module object `val ValDef`. */
     trait ValDefModule { this: ValDef.type =>
-      /** Create a value definition `val x`, `var x` or `lazy val x` with the signature defined in the symbol.
+      /** Creates a value definition `val x`, `var x` or `lazy val x` with the signature defined in the symbol.
        *
        *  The `rhs` should return `Some` containing the implementation of the method,
        *  or `None` if the method has no implementation.
@@ -741,44 +741,44 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def let(owner: Symbol, terms: List[Term])(body: List[Ref] => Term): Term
     }
 
-    /** Makes extension methods on `ValDef` available without any imports */
+    /** Makes extension methods on `ValDef` available without any imports. */
     given ValDefMethods: ValDefMethods
 
-    /** Extension methods of `ValDef` */
+    /** Extension methods of `ValDef`. */
     trait ValDefMethods:
       extension (self: ValDef)
-        /** The type tree of this `val` definition */
+        /** The type tree of this `val` definition. */
         def tpt: TypeTree
-        /** The right-hand side of this `val` definition */
+        /** The right-hand side of this `val` definition. */
         def rhs: Option[Term]
       end extension
     end ValDefMethods
 
     // TypeDef
 
-    /** Tree representing a type (parameter or member) definition in the source code */
+    /** Tree representing a type (parameter or member) definition in the source code. */
     type TypeDef <: Definition
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeDef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeDef`. */
     given TypeDefTypeTest: TypeTest[Tree, TypeDef]
 
-    /** Module object of `type TypeDef`  */
+    /** Module object of `type TypeDef`. */
     val TypeDef: TypeDefModule
 
-    /** Methods of the module object `val TypeDef` */
+    /** Methods of the module object `val TypeDef`. */
     trait TypeDefModule { this: TypeDef.type =>
       def apply(symbol: Symbol): TypeDef
       def copy(original: Tree)(name: String, rhs: Tree): TypeDef
       def unapply(tdef: TypeDef): (String, Tree)
     }
 
-    /** Makes extension methods on `TypeDef` available without any imports */
+    /** Makes extension methods on `TypeDef` available without any imports. */
     given TypeDefMethods: TypeDefMethods
 
-    /** Extension methods of `TypeDef` */
+    /** Extension methods of `TypeDef`. */
     trait TypeDefMethods:
       extension (self: TypeDef)
-        /** The type bounds on the right-hand side of this `type` definition */
+        /** The type bounds on the right-hand side of this `type` definition. */
         def rhs: Tree
       end extension
     end TypeDefMethods
@@ -786,16 +786,16 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     // ----- Terms ----------------------------------------------------
 
-    /** Tree representing an expression in the source code */
+    /** Tree representing an expression in the source code. */
     type Term <: Statement
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Term` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Term`. */
     given TermTypeTest: TypeTest[Tree, Term]
 
-    /** Module object of `type Term`  */
+    /** Module object of `type Term`. */
     val Term: TermModule
 
-    /** Methods of the module object `val Term` */
+    /** Methods of the module object `val Term`. */
     trait TermModule { this: Term.type =>
 
      /** Returns a term that is functionally equivalent to `t`,
@@ -844,17 +844,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     }
 
-    /** Makes extension methods on `Term` available without any imports */
+    /** Makes extension methods on `Term` available without any imports. */
     given TermMethods: TermMethods
 
-    /** Extension methods of `Term` */
+    /** Extension methods of `Term`. */
     trait TermMethods {
       extension (self: Term)
 
-        /** TypeRepr of this term */
+        /** TypeRepr of this term. */
         def tpe: TypeRepr
 
-        /** Replace Inlined nodes and InlineProxy references to underlying arguments.
+        /** Replaces Inlined nodes and InlineProxy references to underlying arguments.
          *  The resulting tree is useful for inspection of the value or content of a non-inline argument.
          *
          *  Warning: This tree may contain references that are out of scope and should not be used in the generated code.
@@ -862,7 +862,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          */
         def underlyingArgument: Term
 
-        /** Replace Ident nodes references to the underlying tree that defined them.
+        /** Replaces Ident nodes references to the underlying tree that defined them.
          *  The resulting tree is useful for inspection of the definition of some bindings.
          *
          *  Warning: This tree may contain references that are out of scope and should not be used in the generated code.
@@ -870,16 +870,16 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          */
         def underlying: Term
 
-        /** Converts a partially applied term into a lambda expression */
+        /** Converts a partially applied term into a lambda expression. */
         def etaExpand(owner: Symbol): Term
 
-        /** A unary apply node with given argument: `tree(arg)` */
+        /** A unary apply node with given argument: `tree(arg)`. */
         def appliedTo(arg: Term): Term
 
-        /** An apply node with given arguments: `tree(arg, args0, ..., argsN)` */
+        /** An apply node with given arguments: `tree(arg, args0, ..., argsN)`. */
         def appliedTo(arg: Term, args: Term*): Term
 
-        /** An apply node with given argument list `tree(args(0), ..., args(args.length - 1))` */
+        /** An apply node with given argument list `tree(args(0), ..., args(args.length - 1))`. */
         def appliedToArgs(args: List[Term]): Apply
 
         /** The current tree applied to given argument lists:
@@ -887,19 +887,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         */
         def appliedToArgss(argss: List[List[Term]]): Term
 
-        /** The current tree applied to (): `tree()` */
+        /** The current tree applied to (): `tree()`. */
         def appliedToNone: Apply
 
-        /** The current tree applied to `()` unless the tree's widened type is parameterless or expects type parameters */
+        /** The current tree applied to `()` unless the tree's widened type is parameterless or expects type parameters. */
         def ensureApplied: Term
 
-        /** The current tree applied to given type argument: `tree[targ]` */
+        /** The current tree applied to given type argument: `tree[targ]`. */
         def appliedToType(targ: TypeRepr): Term
 
-        /** The current tree applied to given type arguments: `tree[targ0, ..., targN]` */
+        /** The current tree applied to given type arguments: `tree[targ0, ..., targN]`. */
         def appliedToTypes(targs: List[TypeRepr]): Term
 
-        /** The current tree applied to given type argument list: `tree[targs(0), ..., targs(targs.length - 1)]` */
+        /** The current tree applied to given type argument list: `tree[targs(0), ..., targs(targs.length - 1)]`. */
         def appliedToTypeTrees(targs: List[TypeTree]): Term
 
         /** A select node that selects the given symbol. */
@@ -909,22 +909,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     }
 
-    /** Tree representing a reference to definition */
+    /** Tree representing a reference to definition. */
     type Ref <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Ref` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Ref`. */
     given RefTypeTest: TypeTest[Tree, Ref]
 
-    /** Module object of `type Ref`  */
+    /** Module object of `type Ref`. */
     val Ref: RefModule
 
-    /** Methods of the module object `val Ref` */
+    /** Methods of the module object `val Ref`. */
     trait RefModule { this: Ref.type =>
 
-      /** A tree representing the same reference as the given type */
+      /** A tree representing the same reference as the given type. */
       def term(tp: TermRef): Ref
 
-      /** Create a reference tree from a symbol
+      /** Creates a reference tree from a symbol
       *
       *  If `sym` refers to a class member `foo` in class `C`,
       *  returns a tree representing `C.this.foo`.
@@ -945,32 +945,32 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def apply(sym: Symbol): Ref
     }
 
-    /** Tree representing a reference to definition with a given name */
+    /** Tree representing a reference to definition with a given name. */
     type Ident <: Ref
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Ident` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Ident`. */
     given IdentTypeTest: TypeTest[Tree, Ident]
 
-    /** Module object of `type Ident`  */
+    /** Module object of `type Ident`. */
     val Ident: IdentModule
 
-    /** Methods of the module object `val Ident` */
+    /** Methods of the module object `val Ident`. */
     trait IdentModule { this: Ident.type =>
       def apply(tmref: TermRef): Term
 
       def copy(original: Tree)(name: String): Ident
 
-      /** Matches a term identifier and returns its name */
+      /** Matches a term identifier and returns its name. */
       def unapply(tree: Ident): Some[String]
     }
 
-    /** Makes extension methods on `Ident` available without any imports */
+    /** Makes extension methods on `Ident` available without any imports. */
     given IdentMethods: IdentMethods
 
-    /** Extension methods of `Ident` */
+    /** Extension methods of `Ident`. */
     trait IdentMethods:
       extension (self: Ident)
-        /** Name of this `Ident` */
+        /** Name of this `Ident`. */
         def name: String
       end extension
     end IdentMethods
@@ -978,35 +978,35 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Pattern representing a `_` wildcard. */
     type Wildcard <: Ident
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Wildcard` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Wildcard`. */
     given WildcardTypeTest: TypeTest[Tree, Wildcard]
 
-    /** Module object of `type Wildcard`  */
+    /** Module object of `type Wildcard`. */
     val Wildcard: WildcardModule
 
-    /** Methods of the module object `val Wildcard` */
+    /** Methods of the module object `val Wildcard`. */
     trait WildcardModule { this: Wildcard.type =>
-      /** Create a tree representing a `_` wildcard. */
+      /** Creates a tree representing a `_` wildcard. */
       def apply(): Wildcard
-      /** Match a tree representing a `_` wildcard. */
+      /** Matches a tree representing a `_` wildcard. */
       def unapply(wildcard: Wildcard): true
     }
 
-    /** Tree representing a selection of definition with a given name on a given prefix */
+    /** Tree representing a selection of definition with a given name on a given prefix. */
     type Select <: Ref
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Select` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Select`. */
     given SelectTypeTest: TypeTest[Tree, Select]
 
-    /** Module object of `type Select`  */
+    /** Module object of `type Select`. */
     val Select: SelectModule
 
-    /** Methods of the module object `val Select` */
+    /** Methods of the module object `val Select`. */
     trait SelectModule { this: Select.type =>
-      /** Select a term member by symbol */
+      /** Selects a term member by symbol. */
       def apply(qualifier: Term, symbol: Symbol): Select
 
-      /** Select a field or a non-overloaded method by name
+      /** Selects a field or a non-overloaded method by name
       *
       *  @note The method will produce an assertion error if the selected
       *        method is overloaded. The method `overloaded` should be used
@@ -1014,90 +1014,90 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       */
       def unique(qualifier: Term, name: String): Select
 
-      /** Call an overloaded method with the given type and term parameters */
+      /** Calls an overloaded method with the given type and term parameters. */
       def overloaded(qualifier: Term, name: String, targs: List[TypeRepr], args: List[Term]): Term
 
-      /** Call an overloaded method with the given type and term parameters */
+      /** Calls an overloaded method with the given type and term parameters. */
       def overloaded(qualifier: Term, name: String, targs: List[TypeRepr], args: List[Term], returnType: TypeRepr): Term
 
       def copy(original: Tree)(qualifier: Term, name: String): Select
 
-      /** Matches `<qualifier: Term>.<name: String>` */
+      /** Matches `<qualifier: Term>.<name: String>`. */
       def unapply(x: Select): (Term, String)
     }
 
-    /** Makes extension methods on `Select` available without any imports */
+    /** Makes extension methods on `Select` available without any imports. */
     given SelectMethods: SelectMethods
 
-    /** Extension methods of `Select` */
+    /** Extension methods of `Select`. */
     trait SelectMethods:
       extension (self: Select)
-        /** Qualifier of the `qualifier.name` */
+        /** Qualifier of the `qualifier.name`. */
         def qualifier: Term
-        /** Name of this `Select` */
+        /** Name of this `Select`. */
         def name: String
-        /** Signature of this method */
+        /** Signature of this method. */
         def signature: Option[Signature]
       end extension
     end SelectMethods
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Literal` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Literal`. */
     given LiteralTypeTest: TypeTest[Tree, Literal]
 
-    /** Tree representing a literal value in the source code */
+    /** Tree representing a literal value in the source code. */
     type Literal <: Term
 
-    /** Module object of `type Literal`  */
+    /** Module object of `type Literal`. */
     val Literal: LiteralModule
 
-    /** Methods of the module object `val Literal` */
+    /** Methods of the module object `val Literal`. */
     trait LiteralModule { this: Literal.type =>
 
-      /** Create a literal constant */
+      /** Creates a literal constant. */
       def apply(constant: Constant): Literal
 
       def copy(original: Tree)(constant: Constant): Literal
 
-      /** Matches a literal constant */
+      /** Matches a literal constant. */
       def unapply(x: Literal): Some[Constant]
     }
 
-    /** Makes extension methods on `Literal` available without any imports */
+    /** Makes extension methods on `Literal` available without any imports. */
     given LiteralMethods: LiteralMethods
 
-    /** Extension methods of `Literal` */
+    /** Extension methods of `Literal`. */
     trait LiteralMethods:
       extension (self: Literal)
-        /** Value of this literal */
+        /** Value of this literal. */
         def constant: Constant
       end extension
     end LiteralMethods
 
-    /** Tree representing `this` or `C.this` in the source code */
+    /** Tree representing `this` or `C.this` in the source code. */
     type This <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `This` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `This`. */
     given ThisTypeTest: TypeTest[Tree, This]
 
-    /** Module object of `type This`  */
+    /** Module object of `type This`. */
     val This: ThisModule
 
-    /** Methods of the module object `val This` */
+    /** Methods of the module object `val This`. */
     trait ThisModule { this: This.type =>
 
-      /** Create a `C.this` for `C` pointing to `cls` */
+      /** Creates a `C.this` for `C` pointing to `cls`. */
       def apply(cls: Symbol): This
 
       def copy(original: Tree)(qual: Option[String]): This
 
-      /** Matches `this` or `qual.this` and returns the name of `qual` */
+      /** Matches `this` or `qual.this` and returns the name of `qual`. */
       def unapply(x: This): Some[Option[String]]
     }
 
-    /** Makes extension methods on `This` available without any imports */
+    /** Makes extension methods on `This` available without any imports. */
     given ThisMethods: ThisMethods
 
-    /** Extension methods of `This` */
+    /** Extension methods of `This`. */
     trait ThisMethods:
       extension (self: This)
         /** Returns `C` if the underlying tree is of the form `C.this`
@@ -1108,68 +1108,68 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end ThisMethods
 
-    /** Tree representing `new` in the source code */
+    /** Tree representing `new` in the source code. */
     type New <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `New` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `New`. */
     given NewTypeTest: TypeTest[Tree, New]
 
-    /** Module object of `type New`  */
+    /** Module object of `type New`. */
     val New: NewModule
 
-    /** Methods of the module object `val New` */
+    /** Methods of the module object `val New`. */
     trait NewModule { this: New.type =>
 
-      /** Create a `new <tpt: TypeTree>` */
+      /** Creates a `new <tpt: TypeTree>`. */
       def apply(tpt: TypeTree): New
 
       def copy(original: Tree)(tpt: TypeTree): New
 
-      /** Matches `new <tpt: TypeTree>` */
+      /** Matches `new <tpt: TypeTree>`. */
       def unapply(x: New): Some[TypeTree]
     }
 
-    /** Makes extension methods on `New` available without any imports */
+    /** Makes extension methods on `New` available without any imports. */
     given NewMethods: NewMethods
 
-    /** Extension methods of `New` */
+    /** Extension methods of `New`. */
     trait NewMethods:
       extension (self: New)
-        /** Returns the type tree of this `new` */
+        /** Returns the type tree of this `new`. */
         def tpt: TypeTree
       end extension
     end NewMethods
 
-    /** Tree representing an argument passed with an explicit name. Such as `arg1 = x` in `foo(arg1 = x)` */
+    /** Tree representing an argument passed with an explicit name. Such as `arg1 = x` in `foo(arg1 = x)`. */
     type NamedArg <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `NamedArg` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `NamedArg`. */
     given NamedArgTypeTest: TypeTest[Tree, NamedArg]
 
-    /** Module object of `type NamedArg`  */
+    /** Module object of `type NamedArg`. */
     val NamedArg: NamedArgModule
 
-    /** Methods of the module object `val NamedArg` */
+    /** Methods of the module object `val NamedArg`. */
     trait NamedArgModule { this: NamedArg.type =>
 
-      /** Create a named argument `<name: String> = <value: Term>` */
+      /** Creates a named argument `<name: String> = <value: Term>`. */
       def apply(name: String, arg: Term): NamedArg
 
       def copy(original: Tree)(name: String, arg: Term): NamedArg
 
-      /** Matches a named argument `<name: String> = <value: Term>` */
+      /** Matches a named argument `<name: String> = <value: Term>`. */
       def unapply(x: NamedArg): (String, Term)
     }
 
-    /** Makes extension methods on `NamedArg` available without any imports */
+    /** Makes extension methods on `NamedArg` available without any imports. */
     given NamedArgMethods: NamedArgMethods
 
-    /** Extension methods of `NamedArg` */
+    /** Extension methods of `NamedArg`. */
     trait NamedArgMethods:
       extension (self: NamedArg)
-        /** The name part of `name = arg` */
+        /** The name part of `name = arg`. */
         def name: String
-        /** The argument part of `name = arg` */
+        /** The argument part of `name = arg`. */
         def value: Term
       end extension
     end NamedArgMethods
@@ -1179,28 +1179,28 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type Apply <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Apply` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Apply`. */
     given ApplyTypeTest: TypeTest[Tree, Apply]
 
-    /** Module object of `type Apply`  */
+    /** Module object of `type Apply`. */
     val Apply: ApplyModule
 
-    /** Methods of the module object `val Apply` */
+    /** Methods of the module object `val Apply`. */
     trait ApplyModule { this: Apply.type =>
 
-      /** Create a function application `<fun: Term>(<args: List[Term]>)` */
+      /** Creates a function application `<fun: Term>(<args: List[Term]>)`. */
       def apply(fun: Term, args: List[Term]): Apply
 
       def copy(original: Tree)(fun: Term, args: List[Term]): Apply
 
-      /** Matches a function application `<fun: Term>(<args: List[Term]>)` */
+      /** Matches a function application `<fun: Term>(<args: List[Term]>)`. */
       def unapply(x: Apply): (Term, List[Term])
     }
 
-    /** Makes extension methods on `Apply` available without any imports */
+    /** Makes extension methods on `Apply` available without any imports. */
     given ApplyMethods: ApplyMethods
 
-    /** Extension methods of `Apply` */
+    /** Extension methods of `Apply`. */
     trait ApplyMethods:
       extension (self: Apply)
         /** The `fun` part of an (implicit) application like `fun(args)`
@@ -1228,31 +1228,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end ApplyMethods
 
-    /** Tree representing an application of type arguments */
+    /** Tree representing an application of type arguments. */
     type TypeApply <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeApply` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeApply`. */
     given TypeApplyTypeTest: TypeTest[Tree, TypeApply]
 
-    /** Module object of `type TypeApply`  */
+    /** Module object of `type TypeApply`. */
     val TypeApply: TypeApplyModule
 
-    /** Methods of the module object `val TypeApply` */
+    /** Methods of the module object `val TypeApply`. */
     trait TypeApplyModule { this: TypeApply.type =>
 
-      /** Create a function type application `<fun: Term>[<args: List[TypeTree]>]` */
+      /** Creates a function type application `<fun: Term>[<args: List[TypeTree]>]`. */
       def apply(fun: Term, args: List[TypeTree]): TypeApply
 
       def copy(original: Tree)(fun: Term, args: List[TypeTree]): TypeApply
 
-      /** Matches a function type application `<fun: Term>[<args: List[TypeTree]>]` */
+      /** Matches a function type application `<fun: Term>[<args: List[TypeTree]>]`. */
       def unapply(x: TypeApply): (Term, List[TypeTree])
     }
 
-    /** Makes extension methods on `TypeApply` available without any imports */
+    /** Makes extension methods on `TypeApply` available without any imports. */
     given TypeApplyMethods: TypeApplyMethods
 
-    /** Extension methods of `TypeApply` */
+    /** Extension methods of `TypeApply`. */
     trait TypeApplyMethods:
       extension (self: TypeApply)
         /** The `fun` part of an (inferred) type application like `fun[Args]`
@@ -1294,31 +1294,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end TypeApplyMethods
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Super` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Super`. */
     given SuperTypeTest: TypeTest[Tree, Super]
 
-    /** Tree representing `super` in the source code */
+    /** Tree representing `super` in the source code. */
     type Super <: Term
 
-    /** Module object of `type Super`  */
+    /** Module object of `type Super`. */
     val Super: SuperModule
 
-    /** Methods of the module object `val Super` */
+    /** Methods of the module object `val Super`. */
     trait SuperModule { this: Super.type =>
 
-      /** Creates a `<qualifier: Term>.super[<id: Option[Id]>` */
+      /** Creates a `<qualifier: Term>.super[<id: Option[Id]>`. */
       def apply(qual: Term, mix: Option[String]): Super
 
       def copy(original: Tree)(qual: Term, mix: Option[String]): Super
 
-      /** Matches a `<qualifier: Term>.super[<id: Option[Id]>` */
+      /** Matches a `<qualifier: Term>.super[<id: Option[Id]>`. */
       def unapply(x: Super): (Term, Option[String])
     }
 
-    /** Makes extension methods on `Super` available without any imports */
+    /** Makes extension methods on `Super` available without any imports. */
     given SuperMethods: SuperMethods
 
-    /** Extension methods of `Super` */
+    /** Extension methods of `Super`. */
     trait SuperMethods:
       extension (self: Super)
         def qualifier: Term
@@ -1327,7 +1327,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end SuperMethods
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Typed` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Typed`. */
     given TypedTypeTest: TypeTest[Tree, Typed]
 
     /** Tree representing a type ascription `x: T` in the source code.
@@ -1337,25 +1337,25 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type Typed <: Term & TypedOrTest
 
-    /** Module object of `type Typed`  */
+    /** Module object of `type Typed`. */
     val Typed: TypedModule
 
-    /** Methods of the module object `val Typed` */
+    /** Methods of the module object `val Typed`. */
     trait TypedModule { this: Typed.type =>
 
-      /** Create a type ascription `<x: Term>: <tpt: TypeTree>` */
+      /** Creates a type ascription `<x: Term>: <tpt: TypeTree>`. */
       def apply(expr: Term, tpt: TypeTree): Typed
 
       def copy(original: Tree)(expr: Term, tpt: TypeTree): Typed
 
-      /** Matches `<expr: Term>: <tpt: TypeTree>` */
+      /** Matches `<expr: Term>: <tpt: TypeTree>`. */
       def unapply(x: Typed): (Term, TypeTree)
     }
 
-    /** Makes extension methods on `Typed` available without any imports */
+    /** Makes extension methods on `Typed` available without any imports. */
     given TypedMethods: TypedMethods
 
-    /** Extension methods of `Typed` */
+    /** Extension methods of `Typed`. */
     trait TypedMethods:
       extension (self: Typed)
         def expr: Term
@@ -1363,31 +1363,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end TypedMethods
 
-    /** Tree representing an assignment `x = y` in the source code */
+    /** Tree representing an assignment `x = y` in the source code. */
     type Assign <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Assign` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Assign`. */
     given AssignTypeTest: TypeTest[Tree, Assign]
 
-    /** Module object of `type Assign`  */
+    /** Module object of `type Assign`. */
     val Assign: AssignModule
 
-    /** Methods of the module object `val Assign` */
+    /** Methods of the module object `val Assign`. */
     trait AssignModule { this: Assign.type =>
 
-      /** Create an assignment `<lhs: Term> = <rhs: Term>` */
+      /** Creates an assignment `<lhs: Term> = <rhs: Term>`. */
       def apply(lhs: Term, rhs: Term): Assign
 
       def copy(original: Tree)(lhs: Term, rhs: Term): Assign
 
-      /** Matches an assignment `<lhs: Term> = <rhs: Term>` */
+      /** Matches an assignment `<lhs: Term> = <rhs: Term>`. */
       def unapply(x: Assign): (Term, Term)
     }
 
-    /** Makes extension methods on `Assign` available without any imports */
+    /** Makes extension methods on `Assign` available without any imports. */
     given AssignMethods: AssignMethods
 
-    /** Extension methods of `Assign` */
+    /** Extension methods of `Assign`. */
     trait AssignMethods:
       extension (self: Assign)
         def lhs: Term
@@ -1395,31 +1395,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end AssignMethods
 
-    /** Tree representing a block `{ ... }` in the source code */
+    /** Tree representing a block `{ ... }` in the source code. */
     type Block <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Block` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Block`. */
     given BlockTypeTest: TypeTest[Tree, Block]
 
-    /** Module object of `type Block`  */
+    /** Module object of `type Block`. */
     val Block: BlockModule
 
-    /** Methods of the module object `val Block` */
+    /** Methods of the module object `val Block`. */
     trait BlockModule { this: Block.type =>
 
-      /** Creates a block `{ <statements: List[Statement]>; <expr: Term> }` */
+      /** Creates a block `{ <statements: List[Statement]>; <expr: Term> }`. */
       def apply(stats: List[Statement], expr: Term): Block
 
       def copy(original: Tree)(stats: List[Statement], expr: Term): Block
 
-      /** Matches a block `{ <statements: List[Statement]>; <expr: Term> }` */
+      /** Matches a block `{ <statements: List[Statement]>; <expr: Term> }`. */
       def unapply(x: Block): (List[Statement], Term)
     }
 
-    /** Makes extension methods on `Block` available without any imports */
+    /** Makes extension methods on `Block` available without any imports. */
     given BlockMethods: BlockMethods
 
-    /** Extension methods of `Block` */
+    /** Extension methods of `Block`. */
     trait BlockMethods:
       extension (self: Block)
         def statements: List[Statement]
@@ -1427,7 +1427,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end BlockMethods
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Closure` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Closure`. */
     given ClosureTypeTest: TypeTest[Tree, Closure]
 
     /** A lambda `(...) => ...` in the source code is represented as
@@ -1441,10 +1441,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type Closure <: Term
 
-    /** Module object of `type Closure`  */
+    /** Module object of `type Closure`. */
     val Closure: ClosureModule
 
-    /** Methods of the module object `val Closure` */
+    /** Methods of the module object `val Closure`. */
     trait ClosureModule { this: Closure.type =>
 
       def apply(meth: Term, tpe: Option[TypeRepr]): Closure
@@ -1454,10 +1454,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def unapply(x: Closure): (Term, Option[TypeRepr])
     }
 
-    /** Makes extension methods on `Closure` available without any imports */
+    /** Makes extension methods on `Closure` available without any imports. */
     given ClosureMethods: ClosureMethods
 
-    /** Extension methods of `Closure` */
+    /** Extension methods of `Closure`. */
     trait ClosureMethods:
       extension (self: Closure)
         def meth: Term
@@ -1480,7 +1480,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     val Lambda: LambdaModule
 
-    /** Methods of the module object `val Lambda` */
+    /** Methods of the module object `val Lambda`. */
     trait LambdaModule { this: Lambda.type =>
       /** Matches a lambda definition of the form
        *  ```scala sc:nocompile
@@ -1523,31 +1523,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def apply(owner: Symbol, tpe: MethodType, rhsFn: (Symbol, List[Tree]) => Tree): Block
     }
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `If` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `If`. */
     given IfTypeTest: TypeTest[Tree, If]
 
-    /** Tree representing an if/then/else `if (...) ... else ...` in the source code */
+    /** Tree representing an if/then/else `if (...) ... else ...` in the source code. */
     type If <: Term
 
-    /** Module object of `type If` */
+    /** Module object of `type If`. */
     val If: IfModule
 
-    /** Methods of the module object `val If` */
+    /** Methods of the module object `val If`. */
     trait IfModule { this: If.type =>
 
-      /** Create an if/then/else `if (<cond: Term>) <thenp: Term> else <elsep: Term>` */
+      /** Creates an if/then/else `if (<cond: Term>) <thenp: Term> else <elsep: Term>`. */
       def apply(cond: Term, thenp: Term, elsep: Term): If
 
       def copy(original: Tree)(cond: Term, thenp: Term, elsep: Term): If
 
-      /** Matches an if/then/else `if (<cond: Term>) <thenp: Term> else <elsep: Term>` */
+      /** Matches an if/then/else `if (<cond: Term>) <thenp: Term> else <elsep: Term>`. */
       def unapply(tree: If): (Term, Term, Term)
     }
 
-    /** Makes extension methods on `If` available without any imports */
+    /** Makes extension methods on `If` available without any imports. */
     given IfMethods: IfMethods
 
-    /** Extension methods of `If` */
+    /** Extension methods of `If`. */
     trait IfMethods:
       extension (self: If)
         def cond: Term
@@ -1557,31 +1557,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end IfMethods
 
-    /** Tree representing a pattern match `x match  { ... }` in the source code */
+    /** Tree representing a pattern match `x match  { ... }` in the source code. */
     type Match <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Match` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Match`. */
     given MatchTypeTest: TypeTest[Tree, Match]
 
-    /** Module object of `type Match`  */
+    /** Module object of `type Match`. */
     val Match: MatchModule
 
-    /** Methods of the module object `val Match` */
+    /** Methods of the module object `val Match`. */
     trait MatchModule { this: Match.type =>
 
-      /** Creates a pattern match `<scrutinee: Term> match { <cases: List[CaseDef]> }` */
+      /** Creates a pattern match `<scrutinee: Term> match { <cases: List[CaseDef]> }`. */
       def apply(selector: Term, cases: List[CaseDef]): Match
 
       def copy(original: Tree)(selector: Term, cases: List[CaseDef]): Match
 
-      /** Matches a pattern match `<scrutinee: Term> match { <cases: List[CaseDef]> }` */
+      /** Matches a pattern match `<scrutinee: Term> match { <cases: List[CaseDef]> }`. */
       def unapply(x: Match): (Term, List[CaseDef])
     }
 
-    /** Makes extension methods on `Match` available without any imports */
+    /** Makes extension methods on `Match` available without any imports. */
     given MatchMethods: MatchMethods
 
-    /** Extension methods of `Match` */
+    /** Extension methods of `Match`. */
     trait MatchMethods:
       extension (self: Match)
         def scrutinee: Term
@@ -1590,62 +1590,62 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end MatchMethods
 
-    /** Tree representing a summoning match `summonFrom { ... }` in the source code */
+    /** Tree representing a summoning match `summonFrom { ... }` in the source code. */
     type SummonFrom <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `SummonFrom` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `SummonFrom`. */
     given SummonFromTypeTest: TypeTest[Tree, SummonFrom]
 
-    /** Module object of `type SummonFrom`  */
+    /** Module object of `type SummonFrom`. */
     val SummonFrom: SummonFromModule
 
-    /** Methods of the module object `val SummonFrom` */
+    /** Methods of the module object `val SummonFrom`. */
     trait SummonFromModule { this: SummonFrom.type =>
 
-      /** Creates a pattern match `given match { <cases: List[CaseDef]> }` */
+      /** Creates a pattern match `given match { <cases: List[CaseDef]> }`. */
       def apply(cases: List[CaseDef]): SummonFrom
 
       def copy(original: Tree)(cases: List[CaseDef]): SummonFrom
 
-      /** Matches a pattern match `given match { <cases: List[CaseDef]> }` */
+      /** Matches a pattern match `given match { <cases: List[CaseDef]> }`. */
       def unapply(x: SummonFrom): Some[List[CaseDef]]
     }
 
-    /** Makes extension methods on `SummonFrom` available without any imports */
+    /** Makes extension methods on `SummonFrom` available without any imports. */
     given SummonFromMethods: SummonFromMethods
 
-    /** Extension methods of `SummonFrom` */
+    /** Extension methods of `SummonFrom`. */
     trait SummonFromMethods:
       extension (self: SummonFrom)
         def cases: List[CaseDef]
       end extension
     end SummonFromMethods
 
-    /** Tree representing a try catch `try x catch { ... } finally { ... }` in the source code */
+    /** Tree representing a try catch `try x catch { ... } finally { ... }` in the source code. */
     type Try <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Try` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Try`. */
     given TryTypeTest: TypeTest[Tree, Try]
 
-    /** Module object of `type Try`  */
+    /** Module object of `type Try`. */
     val Try: TryModule
 
-    /** Methods of the module object `val Try` */
+    /** Methods of the module object `val Try`. */
     trait TryModule { this: Try.type =>
 
-      /** Create a try/catch `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>` */
+      /** Creates a try/catch `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>`. */
       def apply(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try
 
       def copy(original: Tree)(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try
 
-      /** Matches a try/catch `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>` */
+      /** Matches a try/catch `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>`. */
       def unapply(x: Try): (Term, List[CaseDef], Option[Term])
     }
 
-    /** Makes extension methods on `Try` available without any imports */
+    /** Makes extension methods on `Try` available without any imports. */
     given TryMethods: TryMethods
 
-    /** Extension methods of `Try` */
+    /** Extension methods of `Try`. */
     trait TryMethods:
       extension (self: Try)
         def body: Term
@@ -1654,31 +1654,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end TryMethods
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Return` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Return`. */
     given ReturnTypeTest: TypeTest[Tree, Return]
 
-    /** Tree representing a `return` in the source code */
+    /** Tree representing a `return` in the source code. */
     type Return <: Term
 
-    /** Module object of `type Return`  */
+    /** Module object of `type Return`. */
     val Return: ReturnModule
 
-    /** Methods of the module object `val Return` */
+    /** Methods of the module object `val Return`. */
     trait ReturnModule { this: Return.type =>
 
-      /** Creates `return <expr: Term>` */
+      /** Creates `return <expr: Term>`. */
       def apply(expr: Term, from: Symbol): Return
 
       def copy(original: Tree)(expr: Term, from: Symbol): Return
 
-      /** Matches `return <expr: Term>` and extracts the expression and symbol of the method */
+      /** Matches `return <expr: Term>` and extracts the expression and symbol of the method. */
       def unapply(x: Return): (Term, Symbol)
     }
 
-    /** Makes extension methods on `Return` available without any imports */
+    /** Makes extension methods on `Return` available without any imports. */
     given ReturnMethods: ReturnMethods
 
-    /** Extension methods of `Return` */
+    /** Extension methods of `Return`. */
     trait ReturnMethods:
       extension (self: Return)
         def expr: Term
@@ -1713,26 +1713,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type Repeated <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Repeated` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Repeated`. */
     given RepeatedTypeTest: TypeTest[Tree, Repeated]
 
-    /** Module object of `type Repeated`  */
+    /** Module object of `type Repeated`. */
     val Repeated: RepeatedModule
 
-    /** Methods of the module object `val Repeated` */
+    /** Methods of the module object `val Repeated`. */
     trait RepeatedModule { this: Repeated.type =>
-      /** Create a literal sequence of elements */
+      /** Creates a literal sequence of elements. */
       def apply(elems: List[Term], tpt: TypeTree): Repeated
-      /** Copy a literal sequence of elements */
+      /** Copies a literal sequence of elements. */
       def copy(original: Tree)(elems: List[Term], tpt: TypeTree): Repeated
-      /** Matches a literal sequence of elements */
+      /** Matches a literal sequence of elements. */
       def unapply(x: Repeated): (List[Term], TypeTree)
     }
 
-    /** Makes extension methods on `Repeated` available without any imports */
+    /** Makes extension methods on `Repeated` available without any imports. */
     given RepeatedMethods: RepeatedMethods
 
-    /** Extension methods of `Repeated` */
+    /** Extension methods of `Repeated`. */
     trait RepeatedMethods:
       extension (self: Repeated)
         def elems: List[Term]
@@ -1740,26 +1740,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end RepeatedMethods
 
-    /** Tree representing the scope of an inlined tree */
+    /** Tree representing the scope of an inlined tree. */
     type Inlined <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Inlined` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Inlined`. */
     given InlinedTypeTest: TypeTest[Tree, Inlined]
 
-    /** Module object of `type Inlined`  */
+    /** Module object of `type Inlined`. */
     val Inlined: InlinedModule
 
-    /** Methods of the module object `val Inlined` */
+    /** Methods of the module object `val Inlined`. */
     trait InlinedModule { this: Inlined.type =>
       def apply(call: Option[Tree /* Term | TypeTree */], bindings: List[Definition], expansion: Term): Inlined
       def copy(original: Tree)(call: Option[Tree /* Term | TypeTree */], bindings: List[Definition], expansion: Term): Inlined
       def unapply(x: Inlined): (Option[Tree /* Term | TypeTree */], List[Definition], Term)
     }
 
-    /** Makes extension methods on `Inlined` available without any imports */
+    /** Makes extension methods on `Inlined` available without any imports. */
     given InlinedMethods: InlinedMethods
 
-    /** Extension methods of `Inlined` */
+    /** Extension methods of `Inlined`. */
     trait InlinedMethods:
       extension (self: Inlined)
         def call: Option[Tree /* Term | TypeTree */]
@@ -1768,26 +1768,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end InlinedMethods
 
-    /** Tree representing a selection of definition with a given name on a given prefix and number of nested scopes of inlined trees */
+    /** Tree representing a selection of definition with a given name on a given prefix and number of nested scopes of inlined trees. */
     type SelectOuter <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `SelectOuter` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `SelectOuter`. */
     given SelectOuterTypeTest: TypeTest[Tree, SelectOuter]
 
-    /** Module object of `type SelectOuter`  */
+    /** Module object of `type SelectOuter`. */
     val SelectOuter: SelectOuterModule
 
-    /** Methods of the module object `val SelectOuter` */
+    /** Methods of the module object `val SelectOuter`. */
     trait SelectOuterModule { this: SelectOuter.type =>
       def apply(qualifier: Term, name: String, levels: Int): SelectOuter
       def copy(original: Tree)(qualifier: Term, name: String, levels: Int): SelectOuter
       def unapply(x: SelectOuter): (Term, String, Int)
     }
 
-    /** Makes extension methods on `SelectOuter` available without any imports */
+    /** Makes extension methods on `SelectOuter` available without any imports. */
     given SelectOuterMethods: SelectOuterMethods
 
-    /** Extension methods of `SelectOuter` */
+    /** Extension methods of `SelectOuter`. */
     trait SelectOuterMethods:
       extension (self: SelectOuter)
         def qualifier: Term
@@ -1796,31 +1796,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end SelectOuterMethods
 
-    /** Tree representing a while loop */
+    /** Tree representing a while loop. */
     type While <: Term
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `While` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `While`. */
     given WhileTypeTest: TypeTest[Tree, While]
 
-    /** Module object of `type While`  */
+    /** Module object of `type While`. */
     val While: WhileModule
 
-    /** Methods of the module object `val While` */
+    /** Methods of the module object `val While`. */
     trait WhileModule { this: While.type =>
 
-      /** Creates a while loop `while (<cond>) <body>` and returns (<cond>, <body>) */
+      /** Creates a while loop `while (<cond>) <body>` and returns (<cond>, <body>). */
       def apply(cond: Term, body: Term): While
 
       def copy(original: Tree)(cond: Term, body: Term): While
 
-      /** Extractor for while loops. Matches `while (<cond>) <body>` and returns (<cond>, <body>) */
+      /** Extractor for while loops. Matches `while (<cond>) <body>` and returns (<cond>, <body>). */
       def unapply(x: While): (Term, Term)
     }
 
-    /** Makes extension methods on `While` available without any imports */
+    /** Makes extension methods on `While` available without any imports. */
     given WhileMethods: WhileMethods
 
-    /** Extension methods of `While` */
+    /** Extension methods of `While`. */
     trait WhileMethods:
       extension (self: While)
         def cond: Term
@@ -1828,31 +1828,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end WhileMethods
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypedOrTest` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypedOrTest`. */
     given TypedOrTestTypeTest: TypeTest[Tree, TypedOrTest]
 
     /** Tree representing a type ascription or type test pattern `x: T` in the source code. */
     type TypedOrTest <: Tree
 
-    /** Module object of `type TypedOrTest`  */
+    /** Module object of `type TypedOrTest`. */
     val TypedOrTest: TypedOrTestModule
 
-    /** Methods of the module object `val TypedOrTest` */
+    /** Methods of the module object `val TypedOrTest`. */
     trait TypedOrTestModule { this: TypedOrTest.type =>
 
-      /** Create a type ascription `<x: Tree>: <tpt: TypeTree>` */
+      /** Creates a type ascription `<x: Tree>: <tpt: TypeTree>`. */
       def apply(expr: Tree, tpt: TypeTree): TypedOrTest
 
       def copy(original: Tree)(expr: Tree, tpt: TypeTree): TypedOrTest
 
-      /** Matches `<expr: Tree>: <tpt: TypeTree>` */
+      /** Matches `<expr: Tree>: <tpt: TypeTree>`. */
       def unapply(x: TypedOrTest): (Tree, TypeTree)
     }
 
-    /** Makes extension methods on `TypedOrTest` available without any imports */
+    /** Makes extension methods on `TypedOrTest` available without any imports. */
     given TypedOrTestMethods: TypedOrTestMethods
 
-    /** Extension methods of `TypedOrTest` */
+    /** Extension methods of `TypedOrTest`. */
     trait TypedOrTestMethods:
       extension (self: TypedOrTest)
         def tree: Tree
@@ -1862,18 +1862,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     // ----- TypeTrees ------------------------------------------------
 
-    /** Type tree representing a type written in the source */
+    /** Type tree representing a type written in the source. */
     type TypeTree <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeTree` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeTree`. */
     given TypeTreeTypeTest: TypeTest[Tree, TypeTree]
 
-    /** Module object of `type TypeTree`  */
+    /** Module object of `type TypeTree`. */
     val TypeTree: TypeTreeModule
 
-    /** Methods of the module object `val TypeTree` */
+    /** Methods of the module object `val TypeTree`. */
     trait TypeTreeModule { this: TypeTree.type =>
-      /** Returns the tree of type or kind (TypeTree) of T */
+      /** Returns the tree of type or kind (TypeTree) of T. */
       def of[T <: AnyKind](using Type[T]): TypeTree
 
       /** Returns a type tree reference to the symbol
@@ -1883,79 +1883,79 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def ref(typeSymbol: Symbol): TypeTree
     }
 
-    /** Makes extension methods on `TypeTree` available without any imports */
+    /** Makes extension methods on `TypeTree` available without any imports. */
     given TypeTreeMethods: TypeTreeMethods
 
-    /** Extension methods of `TypeTree` */
+    /** Extension methods of `TypeTree`. */
     trait TypeTreeMethods:
       extension (self: TypeTree)
-        /** TypeRepr of this type tree */
+        /** TypeRepr of this type tree. */
         def tpe: TypeRepr
       end extension
     end TypeTreeMethods
 
-    /** Type tree representing an inferred type */
+    /** Type tree representing an inferred type. */
     type Inferred <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Inferred` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Inferred`. */
     given InferredTypeTest: TypeTest[Tree, Inferred]
 
-    /** Module object of `type Inferred`  */
+    /** Module object of `type Inferred`. */
     val Inferred: InferredModule
 
-    /** Methods of the module object `val Inferred` */
+    /** Methods of the module object `val Inferred`. */
     trait InferredModule { this: Inferred.type =>
       def apply(tpe: TypeRepr): Inferred
-      /** Matches a TypeTree containing an inferred type */
+      /** Matches a TypeTree containing an inferred type. */
       def unapply(x: Inferred): true
     }
 
-    /** Type tree representing a reference to definition with a given name */
+    /** Type tree representing a reference to definition with a given name. */
     type TypeIdent <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeIdent` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeIdent`. */
     given TypeIdentTypeTest: TypeTest[Tree, TypeIdent]
 
-    /** Module object of `type TypeIdent`  */
+    /** Module object of `type TypeIdent`. */
     val TypeIdent: TypeIdentModule
 
-    /** Methods of the module object `val TypeIdent` */
+    /** Methods of the module object `val TypeIdent`. */
     trait TypeIdentModule { this: TypeIdent.type =>
       def apply(sym: Symbol): TypeTree
       def copy(original: Tree)(name: String): TypeIdent
       def unapply(x: TypeIdent): Some[String]
     }
 
-    /** Makes extension methods on `TypeIdent` available without any imports */
+    /** Makes extension methods on `TypeIdent` available without any imports. */
     given TypeIdentMethods: TypeIdentMethods
 
-    /** Extension methods of `TypeIdent` */
+    /** Extension methods of `TypeIdent`. */
     trait TypeIdentMethods:
       extension (self: TypeIdent)
         def name: String
       end extension
     end TypeIdentMethods
 
-    /** Type tree representing a selection of definition with a given name on a given term prefix */
+    /** Type tree representing a selection of definition with a given name on a given term prefix. */
     type TypeSelect <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeSelect` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeSelect`. */
     given TypeSelectTypeTest: TypeTest[Tree, TypeSelect]
 
-    /** Module object of `type TypeSelect`  */
+    /** Module object of `type TypeSelect`. */
     val TypeSelect: TypeSelectModule
 
-    /** Methods of the module object `val TypeSelect` */
+    /** Methods of the module object `val TypeSelect`. */
     trait TypeSelectModule { this: TypeSelect.type =>
       def apply(qualifier: Term, name: String): TypeSelect
       def copy(original: Tree)(qualifier: Term, name: String): TypeSelect
       def unapply(x: TypeSelect): (Term, String)
     }
 
-    /** Makes extension methods on `TypeSelect` available without any imports */
+    /** Makes extension methods on `TypeSelect` available without any imports. */
     given TypeSelectMethods: TypeSelectMethods
 
-    /** Extension methods of `TypeSelect` */
+    /** Extension methods of `TypeSelect`. */
     trait TypeSelectMethods:
       extension (self: TypeSelect)
         def qualifier: Term
@@ -1963,26 +1963,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end TypeSelectMethods
 
-    /** Type tree representing a selection of definition with a given name on a given type prefix */
+    /** Type tree representing a selection of definition with a given name on a given type prefix. */
     type TypeProjection <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeProjection` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeProjection`. */
     given TypeProjectionTypeTest: TypeTest[Tree, TypeProjection]
 
-    /** Module object of `type TypeProjection`  */
+    /** Module object of `type TypeProjection`. */
     val TypeProjection: TypeProjectionModule
 
-    /** Methods of the module object `val TypeProjection` */
+    /** Methods of the module object `val TypeProjection`. */
     trait TypeProjectionModule { this: TypeProjection.type =>
       def apply(qualifier: TypeTree, name: String): TypeProjection
       def copy(original: Tree)(qualifier: TypeTree, name: String): TypeProjection
       def unapply(x: TypeProjection): (TypeTree, String)
     }
 
-    /** Makes extension methods on `TypeProjection` available without any imports */
+    /** Makes extension methods on `TypeProjection` available without any imports. */
     given TypeProjectionMethods: TypeProjectionMethods
 
-    /** Extension methods of `TypeProjection` */
+    /** Extension methods of `TypeProjection`. */
     trait TypeProjectionMethods:
       extension (self: TypeProjection)
         def qualifier: TypeTree
@@ -1990,42 +1990,42 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end TypeProjectionMethods
 
-    /** Type tree representing a singleton type */
+    /** Type tree representing a singleton type. */
     type Singleton <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Singleton` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Singleton`. */
     given SingletonTypeTest: TypeTest[Tree, Singleton]
 
-    /** Module object of `type Singleton`  */
+    /** Module object of `type Singleton`. */
     val Singleton: SingletonModule
 
-    /** Methods of the module object `val Singleton` */
+    /** Methods of the module object `val Singleton`. */
     trait SingletonModule { this: Singleton.type =>
       def apply(ref: Term): Singleton
       def copy(original: Tree)(ref: Term): Singleton
       def unapply(x: Singleton): Some[Term]
     }
 
-    /** Makes extension methods on `Singleton` available without any imports */
+    /** Makes extension methods on `Singleton` available without any imports. */
     given SingletonMethods: SingletonMethods
 
-    /** Extension methods of `Singleton` */
+    /** Extension methods of `Singleton`. */
     trait SingletonMethods:
       extension (self: Singleton)
         def ref: Term
       end extension
     end SingletonMethods
 
-    /** Type tree representing a type refinement */
+    /** Type tree representing a type refinement. */
     type Refined <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Refined` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Refined`. */
     given RefinedTypeTest: TypeTest[Tree, Refined]
 
-    /** Module object of `type Refined`  */
+    /** Module object of `type Refined`. */
     val Refined: RefinedModule
 
-    /** Methods of the module object `val Refined` */
+    /** Methods of the module object `val Refined`. */
     trait RefinedModule { this: Refined.type =>
       /** Creates and types a Refined AST node.
         * @param tpt - parent type being refined
@@ -2038,10 +2038,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def unapply(x: Refined): (TypeTree, List[Definition])
     }
 
-    /** Makes extension methods on `Refined` available without any imports */
+    /** Makes extension methods on `Refined` available without any imports. */
     given RefinedMethods: RefinedMethods
 
-    /** Extension methods of `Refined` */
+    /** Extension methods of `Refined`. */
     trait RefinedMethods:
       extension (self: Refined)
         def tpt: TypeTree
@@ -2049,26 +2049,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end RefinedMethods
 
-    /** Type tree representing a type application */
+    /** Type tree representing a type application. */
     type Applied <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Applied` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Applied`. */
     given AppliedTypeTest: TypeTest[Tree, Applied]
 
-    /** Module object of `type Applied`  */
+    /** Module object of `type Applied`. */
     val Applied: AppliedModule
 
-    /** Methods of the module object `val Applied` */
+    /** Methods of the module object `val Applied`. */
     trait AppliedModule { this: Applied.type =>
       def apply(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/]): Applied
       def copy(original: Tree)(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/]): Applied
       def unapply(x: Applied): (TypeTree, List[Tree /*TypeTree | TypeBoundsTree*/])
     }
 
-    /** Makes extension methods on `Applied` available without any imports */
+    /** Makes extension methods on `Applied` available without any imports. */
     given AppliedMethods: AppliedMethods
 
-    /** Extension methods of `Applied` */
+    /** Extension methods of `Applied`. */
     trait AppliedMethods:
       extension (self: Applied)
         def tpt: TypeTree
@@ -2076,26 +2076,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end AppliedMethods
 
-    /** Type tree representing an annotated type */
+    /** Type tree representing an annotated type. */
     type Annotated <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Annotated` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Annotated`. */
     given AnnotatedTypeTest: TypeTest[Tree, Annotated]
 
-    /** Module object of `type Annotated`  */
+    /** Module object of `type Annotated`. */
     val Annotated: AnnotatedModule
 
-    /** Methods of the module object `val Annotated` */
+    /** Methods of the module object `val Annotated`. */
     trait AnnotatedModule { this: Annotated.type =>
       def apply(arg: TypeTree, annotation: Term): Annotated
       def copy(original: Tree)(arg: TypeTree, annotation: Term): Annotated
       def unapply(x: Annotated): (TypeTree, Term)
     }
 
-    /** Makes extension methods on `Annotated` available without any imports */
+    /** Makes extension methods on `Annotated` available without any imports. */
     given AnnotatedMethods: AnnotatedMethods
 
-    /** Extension methods of `Annotated` */
+    /** Extension methods of `Annotated`. */
     trait AnnotatedMethods:
       extension (self: Annotated)
         def arg: TypeTree
@@ -2103,26 +2103,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end AnnotatedMethods
 
-    /** Type tree representing a type match */
+    /** Type tree representing a type match. */
     type MatchTypeTree <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `MatchTypeTree` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `MatchTypeTree`. */
     given MatchTypeTreeTypeTest: TypeTest[Tree, MatchTypeTree]
 
-    /** Module object of `type MatchTypeTree`  */
+    /** Module object of `type MatchTypeTree`. */
     val MatchTypeTree: MatchTypeTreeModule
 
-    /** Methods of the module object `val MatchTypeTree` */
+    /** Methods of the module object `val MatchTypeTree`. */
     trait MatchTypeTreeModule { this: MatchTypeTree.type =>
       def apply(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree
       def copy(original: Tree)(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree
       def unapply(x: MatchTypeTree): (Option[TypeTree], TypeTree, List[TypeCaseDef])
     }
 
-    /** Makes extension methods on `MatchTypeTree` available without any imports */
+    /** Makes extension methods on `MatchTypeTree` available without any imports. */
     given MatchTypeTreeMethods: MatchTypeTreeMethods
 
-    /** Extension methods of `MatchTypeTree` */
+    /** Extension methods of `MatchTypeTree`. */
     trait MatchTypeTreeMethods:
       extension (self: MatchTypeTree)
         def bound: Option[TypeTree]
@@ -2131,52 +2131,52 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end MatchTypeTreeMethods
 
-    /** Type tree representing a by name parameter */
+    /** Type tree representing a by name parameter. */
     type ByName <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `ByName` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `ByName`. */
     given ByNameTypeTest: TypeTest[Tree, ByName]
 
-    /** Module object of `type ByName`  */
+    /** Module object of `type ByName`. */
     val ByName: ByNameModule
 
-    /** Methods of the module object `val ByName` */
+    /** Methods of the module object `val ByName`. */
     trait ByNameModule { this: ByName.type =>
       def apply(result: TypeTree): ByName
       def copy(original: Tree)(result: TypeTree): ByName
       def unapply(x: ByName): Some[TypeTree]
     }
 
-    /** Makes extension methods on `ByName` available without any imports */
+    /** Makes extension methods on `ByName` available without any imports. */
     given ByNameMethods: ByNameMethods
 
-    /** Extension methods of `ByName` */
+    /** Extension methods of `ByName`. */
     trait ByNameMethods:
       extension (self: ByName)
         def result: TypeTree
       end extension
     end ByNameMethods
 
-    /** Type tree representing a lambda abstraction type */
+    /** Type tree representing a lambda abstraction type. */
     type LambdaTypeTree <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `LambdaTypeTree` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `LambdaTypeTree`. */
     given LambdaTypeTreeTypeTest: TypeTest[Tree, LambdaTypeTree]
 
-    /** Module object of `type LambdaTypeTree`  */
+    /** Module object of `type LambdaTypeTree`. */
     val LambdaTypeTree: LambdaTypeTreeModule
 
-    /** Methods of the module object `val LambdaTypeTree` */
+    /** Methods of the module object `val LambdaTypeTree`. */
     trait LambdaTypeTreeModule { this: LambdaTypeTree.type =>
       def apply(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/): LambdaTypeTree
       def copy(original: Tree)(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/): LambdaTypeTree
       def unapply(tree: LambdaTypeTree): (List[TypeDef], Tree /*TypeTree | TypeBoundsTree*/)
     }
 
-    /** Makes extension methods on `LambdaTypeTree` available without any imports */
+    /** Makes extension methods on `LambdaTypeTree` available without any imports. */
     given LambdaTypeTreeMethods: LambdaTypeTreeMethods
 
-    /** Extension methods of `LambdaTypeTree` */
+    /** Extension methods of `LambdaTypeTree`. */
     trait LambdaTypeTreeMethods:
       extension (self: LambdaTypeTree)
         def tparams: List[TypeDef]
@@ -2184,25 +2184,25 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end LambdaTypeTreeMethods
 
-    /** Type tree representing a type binding */
+    /** Type tree representing a type binding. */
     type TypeBind <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeBind` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeBind`. */
     given TypeBindTypeTest: TypeTest[Tree, TypeBind]
 
-    /** Module object of `type TypeBind`  */
+    /** Module object of `type TypeBind`. */
     val TypeBind: TypeBindModule
 
-    /** Methods of the module object `val TypeBind` */
+    /** Methods of the module object `val TypeBind`. */
     trait TypeBindModule { this: TypeBind.type =>
       def copy(original: Tree)(name: String, tpt: Tree /*TypeTree | TypeBoundsTree*/): TypeBind
       def unapply(x: TypeBind): (String, Tree /*TypeTree | TypeBoundsTree*/)
     }
 
-    /** Makes extension methods on `TypeBind` available without any imports */
+    /** Makes extension methods on `TypeBind` available without any imports. */
     given TypeBindMethods: TypeBindMethods
 
-    /** Extension methods of `TypeBind` */
+    /** Extension methods of `TypeBind`. */
     trait TypeBindMethods:
       extension (self: TypeBind)
         def name: String
@@ -2210,26 +2210,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end TypeBindMethods
 
-    /** Type tree within a block with aliases `{ type U1 = ... ; T[U1, U2] }` */
+    /** Type tree within a block with aliases `{ type U1 = ... ; T[U1, U2] }`. */
     type TypeBlock <: TypeTree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeBlock` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeBlock`. */
     given TypeBlockTypeTest: TypeTest[Tree, TypeBlock]
 
-    /** Module object of `type TypeBlock`  */
+    /** Module object of `type TypeBlock`. */
     val TypeBlock: TypeBlockModule
 
-    /** Methods of the module object `val TypeBlock` */
+    /** Methods of the module object `val TypeBlock`. */
     trait TypeBlockModule { this: TypeBlock.type =>
       def apply(aliases: List[TypeDef], tpt: TypeTree): TypeBlock
       def copy(original: Tree)(aliases: List[TypeDef], tpt: TypeTree): TypeBlock
       def unapply(x: TypeBlock): (List[TypeDef], TypeTree)
     }
 
-    /** Makes extension methods on `TypeBlock` available without any imports */
+    /** Makes extension methods on `TypeBlock` available without any imports. */
     given TypeBlockMethods: TypeBlockMethods
 
-    /** Extension methods of `TypeBlock` */
+    /** Extension methods of `TypeBlock`. */
     trait TypeBlockMethods:
       extension (self: TypeBlock)
         def aliases: List[TypeDef]
@@ -2239,26 +2239,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     // ----- TypeBoundsTrees ------------------------------------------------
 
-    /** Type tree representing a type bound written in the source */
+    /** Type tree representing a type bound written in the source. */
     type TypeBoundsTree <: Tree /*TypeTree | TypeBoundsTree*/
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeBoundsTree` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeBoundsTree`. */
     given TypeBoundsTreeTypeTest: TypeTest[Tree, TypeBoundsTree]
 
-    /** Module object of `type TypeBoundsTree`  */
+    /** Module object of `type TypeBoundsTree`. */
     val TypeBoundsTree: TypeBoundsTreeModule
 
-    /** Methods of the module object `val TypeBoundsTree` */
+    /** Methods of the module object `val TypeBoundsTree`. */
     trait TypeBoundsTreeModule { this: TypeBoundsTree.type =>
       def apply(low: TypeTree, hi: TypeTree): TypeBoundsTree
       def copy(original: Tree)(low: TypeTree, hi: TypeTree): TypeBoundsTree
       def unapply(x: TypeBoundsTree): (TypeTree, TypeTree)
     }
 
-    /** Makes extension methods on `TypeBoundsTree` available without any imports */
+    /** Makes extension methods on `TypeBoundsTree` available without any imports. */
     given TypeBoundsTreeMethods: TypeBoundsTreeMethods
 
-    /** Extension methods of `TypeBoundsTree` */
+    /** Extension methods of `TypeBoundsTree`. */
     trait TypeBoundsTreeMethods:
       extension (self: TypeBoundsTree)
         def tpe: TypeBounds
@@ -2273,23 +2273,23 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     */
     type WildcardTypeTree <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `WildcardTypeTree` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `WildcardTypeTree`. */
     given WildcardTypeTreeTypeTest: TypeTest[Tree, WildcardTypeTree]
 
-    /** Module object of `type WildcardTypeTree`  */
+    /** Module object of `type WildcardTypeTree`. */
     val WildcardTypeTree: WildcardTypeTreeModule
 
-    /** Methods of the module object `val WildcardTypeTree` */
+    /** Methods of the module object `val WildcardTypeTree`. */
     trait WildcardTypeTreeModule { this: WildcardTypeTree.type =>
       def apply(tpe: TypeRepr): WildcardTypeTree
-      /** Matches a TypeBoundsTree containing wildcard type bounds */
+      /** Matches a TypeBoundsTree containing wildcard type bounds. */
       def unapply(x: WildcardTypeTree): true
     }
 
-    /** Makes extension methods on `WildcardTypeTree` available without any imports */
+    /** Makes extension methods on `WildcardTypeTree` available without any imports. */
     given WildcardTypeTreeMethods: WildcardTypeTreeMethods
 
-    /** Extension methods of `WildcardTypeTree` */
+    /** Extension methods of `WildcardTypeTree`. */
     trait WildcardTypeTreeMethods:
       extension (self: WildcardTypeTree)
         def tpe: TypeRepr
@@ -2298,26 +2298,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     // ----- CaseDefs ------------------------------------------------
 
-    /** Branch of a pattern match or catch clause */
+    /** Branch of a pattern match or catch clause. */
     type CaseDef <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `CaseDef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `CaseDef`. */
     given CaseDefTypeTest: TypeTest[Tree, CaseDef]
 
-    /** Module object of `type CaseDef`  */
+    /** Module object of `type CaseDef`. */
     val CaseDef: CaseDefModule
 
-    /** Methods of the module object `val CaseDef` */
+    /** Methods of the module object `val CaseDef`. */
     trait CaseDefModule { this: CaseDef.type =>
       def apply(pattern: Tree, guard: Option[Term], rhs: Term): CaseDef
       def copy(original: Tree)(pattern: Tree, guard: Option[Term], rhs: Term): CaseDef
       def unapply(x: CaseDef): (Tree, Option[Term], Term)
     }
 
-    /** Makes extension methods on `CaseDef` available without any imports */
+    /** Makes extension methods on `CaseDef` available without any imports. */
     given CaseDefMethods: CaseDefMethods
 
-    /** Extension methods of `CaseDef` */
+    /** Extension methods of `CaseDef`. */
     trait CaseDefMethods:
       extension (self: CaseDef)
         def pattern: Tree
@@ -2326,26 +2326,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end CaseDefMethods
 
-    /** Branch of a type pattern match */
+    /** Branch of a type pattern match. */
     type TypeCaseDef <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeCaseDef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `TypeCaseDef`. */
     given TypeCaseDefTypeTest: TypeTest[Tree, TypeCaseDef]
 
-    /** Module object of `type TypeCaseDef`  */
+    /** Module object of `type TypeCaseDef`. */
     val TypeCaseDef: TypeCaseDefModule
 
-    /** Methods of the module object `val TypeCaseDef` */
+    /** Methods of the module object `val TypeCaseDef`. */
     trait TypeCaseDefModule { this: TypeCaseDef.type =>
       def apply(pattern: TypeTree, rhs: TypeTree): TypeCaseDef
       def copy(original: Tree)(pattern: TypeTree, rhs: TypeTree): TypeCaseDef
       def unapply(tree: TypeCaseDef): (TypeTree, TypeTree)
     }
 
-    /** Makes extension methods on `TypeCaseDef` available without any imports */
+    /** Makes extension methods on `TypeCaseDef` available without any imports. */
     given TypeCaseDefMethods: TypeCaseDefMethods
 
-    /** Extension methods of `TypeCaseDef` */
+    /** Extension methods of `TypeCaseDef`. */
     trait TypeCaseDefMethods:
       extension (self: TypeCaseDef)
         def pattern: TypeTree
@@ -2358,23 +2358,23 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Pattern representing a `_ @ _` binding. */
     type Bind <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Bind` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `Bind`. */
     given BindTypeTest: TypeTest[Tree, Bind]
 
-    /** Module object of `type Bind`  */
+    /** Module object of `type Bind`. */
     val Bind: BindModule
 
-    /** Methods of the module object `val Bind` */
+    /** Methods of the module object `val Bind`. */
     trait BindModule { this: Bind.type =>
       def apply(sym: Symbol, pattern: Tree): Bind
       def copy(original: Tree)(name: String, pattern: Tree): Bind
       def unapply(pattern: Bind): (String, Tree)
     }
 
-    /** Makes extension methods on `Bind` available without any imports */
+    /** Makes extension methods on `Bind` available without any imports. */
     given BindMethods: BindMethods
 
-    /** Extension methods of `Bind` */
+    /** Extension methods of `Bind`. */
     trait BindMethods:
       extension (self: Bind)
         def name: String
@@ -2385,26 +2385,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Pattern representing a `Xyz(...)` unapply. */
     type Unapply <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Unapply` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Unapply`. */
     given UnapplyTypeTest: TypeTest[Tree, Unapply]
 
-    /** Module object of `type Unapply`  */
+    /** Module object of `type Unapply`. */
     val Unapply: UnapplyModule
 
-    /** Methods of the module object `val Unapply` */
+    /** Methods of the module object `val Unapply`. */
     trait UnapplyModule { this: Unapply.type =>
-      /** Create an `Unapply` tree representing a pattern `<fun>(<patterns*>)(using <implicits*>)` */
+      /** Creates an `Unapply` tree representing a pattern `<fun>(<patterns*>)(using <implicits*>)`. */
       def apply(fun: Term, implicits: List[Term], patterns: List[Tree]): Unapply
-      /** Copy an `Unapply` tree representing a pattern `<fun>(<patterns*>)(using <implicits*>)` */
+      /** Copies an `Unapply` tree representing a pattern `<fun>(<patterns*>)(using <implicits*>)`. */
       def copy(original: Tree)(fun: Term, implicits: List[Term], patterns: List[Tree]): Unapply
-      /** Matches an `Unapply(fun, implicits, patterns)` tree representing a pattern `<fun>(<patterns*>)(using <implicits*>)` */
+      /** Matches an `Unapply(fun, implicits, patterns)` tree representing a pattern `<fun>(<patterns*>)(using <implicits*>)`. */
       def unapply(x: Unapply): (Term, List[Term], List[Tree])
     }
 
-    /** Makes extension methods on `Unapply` available without any imports */
+    /** Makes extension methods on `Unapply` available without any imports. */
     given UnapplyMethods: UnapplyMethods
 
-    /** Extension methods of `Unapply` */
+    /** Extension methods of `Unapply`. */
     trait UnapplyMethods:
       extension (self: Unapply)
         /** The extractor function of the pattern.
@@ -2413,9 +2413,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *  partially applied tree containing type parameters and leading given parameters.
          */
         def fun: Term
-        /** Training implicit parameters of the `unapply` method */
+        /** Training implicit parameters of the `unapply` method. */
         def implicits: List[Term]
-        /** List of nested patterns */
+        /** List of nested patterns. */
         def patterns: List[Tree]
       end extension
     end UnapplyMethods
@@ -2423,23 +2423,23 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Pattern representing `X | Y | ...` alternatives. */
     type Alternatives <: Tree
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Alternatives` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is an `Alternatives`. */
     given AlternativesTypeTest: TypeTest[Tree, Alternatives]
 
-    /** Module object of `type Alternatives`  */
+    /** Module object of `type Alternatives`. */
     val Alternatives: AlternativesModule
 
-    /** Methods of the module object `val Alternatives` */
+    /** Methods of the module object `val Alternatives`. */
     trait AlternativesModule { this: Alternatives.type =>
       def apply(patterns: List[Tree]): Alternatives
       def copy(original: Tree)(patterns: List[Tree]): Alternatives
       def unapply(x: Alternatives): Some[List[Tree]]
     }
 
-    /** Makes extension methods on `Alternatives` available without any imports */
+    /** Makes extension methods on `Alternatives` available without any imports. */
     given AlternativesMethods: AlternativesMethods
 
-    /** Extension methods of `Alternatives` */
+    /** Extension methods of `Alternatives`. */
     trait AlternativesMethods:
       extension (self: Alternatives)
         def patterns: List[Tree]
@@ -2468,20 +2468,20 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type ParamClause <: AnyRef
 
-    /** Module object of `type ParamClause`  */
+    /** Module object of `type ParamClause`. */
     val ParamClause: ParamClauseModule
 
-    /** Methods of the module object `val ParamClause` */
+    /** Methods of the module object `val ParamClause`. */
     trait ParamClauseModule { this: ParamClause.type =>
     }
 
-    /** Makes extension methods on `ParamClause` available without any imports */
+    /** Makes extension methods on `ParamClause` available without any imports. */
     given ParamClauseMethods: ParamClauseMethods
 
-    /** Extension methods of `ParamClause` */
+    /** Extension methods of `ParamClause`. */
     trait ParamClauseMethods:
       extension (self: ParamClause)
-        /** List of parameters of the clause */
+        /** List of parameters of the clause. */
         def params: List[ValDef] | List[TypeDef]
     end ParamClauseMethods
 
@@ -2490,63 +2490,63 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type TermParamClause <: ParamClause
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `ParamClause` is a `TermParamClause` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `ParamClause` is a `TermParamClause`. */
     given TermParamClauseTypeTest: TypeTest[ParamClause, TermParamClause]
 
-    /** Module object of `type TermParamClause`  */
+    /** Module object of `type TermParamClause`. */
     val TermParamClause: TermParamClauseModule
 
-    /** Methods of the module object `val TermParamClause` */
+    /** Methods of the module object `val TermParamClause`. */
     trait TermParamClauseModule { this: TermParamClause.type =>
       def apply(params: List[ValDef]): TermParamClause
       def unapply(x: TermParamClause): Some[List[ValDef]]
     }
 
-    /** Makes extension methods on `TermParamClause` available without any imports */
+    /** Makes extension methods on `TermParamClause` available without any imports. */
     given TermParamClauseMethods: TermParamClauseMethods
 
-    /** Extension methods of `TermParamClause` */
+    /** Extension methods of `TermParamClause`. */
     trait TermParamClauseMethods:
       extension (self: TermParamClause)
-        /** List of parameters of the clause */
+        /** List of parameters of the clause. */
         def params: List[ValDef]
-        /** Is this an implicit parameter clause `(implicit x1: X1, ..., xn: Xn)` */
+        /** Is this an implicit parameter clause `(implicit x1: X1, ..., xn: Xn)`. */
         def isImplicit: Boolean
-        /** Is this a given parameter clause `(using X1, ..., Xn)` or `(using x1: X1, ..., xn: Xn)` */
+        /** Is this a given parameter clause `(using X1, ..., Xn)` or `(using x1: X1, ..., xn: Xn)`. */
         def isGiven: Boolean
-        /** Is this a erased parameter clause `(erased x1: X1, ..., xn: Xn)` */
+        /** Is this a erased parameter clause `(erased x1: X1, ..., xn: Xn)`. */
         @deprecated("Use `hasErasedArgs` and `erasedArgs`", "3.4")
         def isErased: Boolean
-        /** List of `erased` flags for each parameter of the clause */
+        /** List of `erased` flags for each parameter of the clause. */
         @experimental
         def erasedArgs: List[Boolean]
-        /** Whether the clause has any erased parameters */
+        /** Whether the clause has any erased parameters. */
         @experimental
         def hasErasedArgs: Boolean
     end TermParamClauseMethods
 
-    /** A type parameter clause `[X1, ..., Xn]` */
+    /** A type parameter clause `[X1, ..., Xn]`. */
     type TypeParamClause <: ParamClause
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `ParamClause` is a `TypeParamClause` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `ParamClause` is a `TypeParamClause`. */
     given TypeParamClauseTypeTest: TypeTest[ParamClause, TypeParamClause]
 
-    /** Module object of `type TypeParamClause`  */
+    /** Module object of `type TypeParamClause`. */
     val TypeParamClause: TypeParamClauseModule
 
-    /** Methods of the module object `val TypeParamClause` */
+    /** Methods of the module object `val TypeParamClause`. */
     trait TypeParamClauseModule { this: TypeParamClause.type =>
       def apply(params: List[TypeDef]): TypeParamClause
       def unapply(x: TypeParamClause): Some[List[TypeDef]]
     }
 
-    /** Makes extension methods on `TypeParamClause` available without any imports */
+    /** Makes extension methods on `TypeParamClause` available without any imports. */
     given TypeParamClauseMethods: TypeParamClauseMethods
 
-    /** Extension methods of `TypeParamClause` */
+    /** Extension methods of `TypeParamClause`. */
     trait TypeParamClauseMethods:
       extension (self: TypeParamClause)
-        /** List of parameters of the clause */
+        /** List of parameters of the clause. */
         def params: List[TypeDef]
     end TypeParamClauseMethods
 
@@ -2562,31 +2562,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type Selector <: AnyRef
 
-    /** Module object of `type Selector`  */
+    /** Module object of `type Selector`. */
     val Selector: SelectorModule
 
-    /** Methods of the module object `val Selector` */
+    /** Methods of the module object `val Selector`. */
     trait SelectorModule { this: Selector.type => }
 
-    /** Simple import/export selector: `.bar` in `import foo.bar` */
+    /** Simple import/export selector: `.bar` in `import foo.bar`. */
     type SimpleSelector <: Selector
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is a `SimpleSelector` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is a `SimpleSelector`. */
     given SimpleSelectorTypeTest: TypeTest[Selector, SimpleSelector]
 
-    /** Module object of `type SimpleSelector`  */
+    /** Module object of `type SimpleSelector`. */
     val SimpleSelector: SimpleSelectorModule
 
-    /** Methods of the module object `val SimpleSelector` */
+    /** Methods of the module object `val SimpleSelector`. */
     trait SimpleSelectorModule { this: SimpleSelector.type =>
       @experimental def apply(name: String): SimpleSelector
       def unapply(x: SimpleSelector): Some[String]
     }
 
-    /** Makes extension methods on `SimpleSelector` available without any imports */
+    /** Makes extension methods on `SimpleSelector` available without any imports. */
     given SimpleSelectorMethods: SimpleSelectorMethods
 
-    /** Extension methods of `SimpleSelector` */
+    /** Extension methods of `SimpleSelector`. */
     trait SimpleSelectorMethods:
       extension (self: SimpleSelector)
         def name: String
@@ -2594,25 +2594,25 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end SimpleSelectorMethods
 
-    /** Rename import/export selector: `.{bar => baz}` in `import foo.{bar => baz}` */
+    /** Rename import/export selector: `.{bar => baz}` in `import foo.{bar => baz}`. */
     type RenameSelector <: Selector
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is a `RenameSelector` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is a `RenameSelector`. */
     given RenameSelectorTypeTest: TypeTest[Selector, RenameSelector]
 
-    /** Module object of `type RenameSelector`  */
+    /** Module object of `type RenameSelector`. */
     val RenameSelector: RenameSelectorModule
 
-    /** Methods of the module object `val RenameSelector` */
+    /** Methods of the module object `val RenameSelector`. */
     trait RenameSelectorModule { this: RenameSelector.type =>
       @experimental def apply(fromName: String, toName: String): RenameSelector
       def unapply(x: RenameSelector): (String, String)
     }
 
-    /** Makes extension methods on `RenameSelector` available without any imports */
+    /** Makes extension methods on `RenameSelector` available without any imports. */
     given RenameSelectorMethods: RenameSelectorMethods
 
-    /** Extension methods of `RenameSelector` */
+    /** Extension methods of `RenameSelector`. */
     trait RenameSelectorMethods:
       extension (self: RenameSelector)
         def fromName: String
@@ -2622,50 +2622,50 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end RenameSelectorMethods
 
-    /** Omit import/export selector: `.{bar => _}` in `import foo.{bar => _}` */
+    /** Omit import/export selector: `.{bar => _}` in `import foo.{bar => _}`. */
     type OmitSelector <: Selector
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is an `OmitSelector` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Selector` is an `OmitSelector`. */
     given OmitSelectorTypeTest: TypeTest[Selector, OmitSelector]
 
-    /** Module object of `type OmitSelector`  */
+    /** Module object of `type OmitSelector`. */
     val OmitSelector: OmitSelectorModule
 
-    /** Methods of the module object `val OmitSelector` */
+    /** Methods of the module object `val OmitSelector`. */
     trait OmitSelectorModule { this: OmitSelector.type =>
       @experimental def apply(name: String): OmitSelector
       def unapply(x: OmitSelector): Some[String]
     }
 
-    /** Makes extension methods on `OmitSelector` available without any imports */
+    /** Makes extension methods on `OmitSelector` available without any imports. */
     given OmitSelectorMethods: OmitSelectorMethods
 
-    /** Extension methods of `OmitSelector` */
+    /** Extension methods of `OmitSelector`. */
     trait OmitSelectorMethods:
       extension (self: OmitSelector)
         def name: String
         def namePos: Position
     end OmitSelectorMethods
 
-    /** given import/export selector: `.given`/`.{given T}` in `import foo.given`/`export foo.{given T}` */
+    /** given import/export selector: `.given`/`.{given T}` in `import foo.given`/`export foo.{given T}`. */
     type GivenSelector <: Selector
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `Selector` is a `GivenSelector` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if an `Selector` is a `GivenSelector`. */
     given GivenSelectorTypeTest: TypeTest[Selector, GivenSelector]
 
-    /** Module object of `type GivenSelector`  */
+    /** Module object of `type GivenSelector`. */
     val GivenSelector: GivenSelectorModule
 
-    /** Methods of the module object `val GivenSelector` */
+    /** Methods of the module object `val GivenSelector`. */
     trait GivenSelectorModule { this: GivenSelector.type =>
       @experimental def apply(bound: Option[TypeTree]): GivenSelector
       def unapply(x: GivenSelector): Some[Option[TypeTree]]
     }
 
-    /** Makes extension methods on `GivenSelector` available without any imports */
+    /** Makes extension methods on `GivenSelector` available without any imports. */
     given GivenSelectorMethods: GivenSelectorMethods
 
-    /** Extension methods of `GivenSelector` */
+    /** Extension methods of `GivenSelector`. */
     trait GivenSelectorMethods:
       extension (self: GivenSelector)
         def bound: Option[TypeTree]
@@ -2677,32 +2677,32 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     // ----- Types ----------------------------------------------------
 
-    /** A type, type constructors, type bounds or NoPrefix */
+    /** A type, type constructors, type bounds or NoPrefix. */
     type TypeRepr <: Matchable
 
-    /** Module object of `type TypeRepr`  */
+    /** Module object of `type TypeRepr`. */
     val TypeRepr: TypeReprModule
 
-    /** Methods of the module object `val TypeRepr` */
+    /** Methods of the module object `val TypeRepr`. */
     trait TypeReprModule { this: TypeRepr.type =>
-      /** Returns the type or kind (TypeRepr) of T */
+      /** Returns the type or kind (TypeRepr) of T. */
       def of[T <: AnyKind](using Type[T]): TypeRepr
 
-      /** Returns the type constructor of the runtime (erased) class */
+      /** Returns the type constructor of the runtime (erased) class. */
       def typeConstructorOf(clazz: Class[?]): TypeRepr
     }
 
-    /** Makes extension methods on `TypeRepr` available without any imports */
+    /** Makes extension methods on `TypeRepr` available without any imports. */
     given TypeReprMethods: TypeReprMethods
 
-    /** Extension methods of `TypeRepr` */
+    /** Extension methods of `TypeRepr`. */
     trait TypeReprMethods {
       extension (self: TypeRepr)
 
-        /** Shows the type as a String */
+        /** Shows the type as a String. */
         def show(using Printer[TypeRepr]): String
 
-        /** Convert this `TypeRepr` to an `Type[?]`
+        /** Converts this `TypeRepr` to an `Type[?]`
         *
         *  Usage:
         *  ```scala
@@ -2823,60 +2823,60 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          */
         def isTupleN: Boolean
 
-        /** The type <this . sym>, reduced if possible */
+        /** The type <this . sym>, reduced if possible. */
         def select(sym: Symbol): TypeRepr
 
-        /** The current type applied to given type arguments: `this[targ]` */
+        /** The current type applied to given type arguments: `this[targ]`. */
         def appliedTo(targ: TypeRepr): TypeRepr
 
-        /** The current type applied to given type arguments: `this[targ0, ..., targN]` */
+        /** The current type applied to given type arguments: `this[targ0, ..., targN]`. */
         def appliedTo(targs: List[TypeRepr]): TypeRepr
 
-        /** Substitute all types that refer in their symbol attribute to
+        /** Substitutes all types that refer in their symbol attribute to
          *  one of the symbols in `from` by the corresponding types in `to`.
          */
         def substituteTypes(from: List[Symbol], to: List[TypeRepr]): TypeRepr
 
-        /** The applied type arguments (empty if there is no such arguments) */
+        /** The applied type arguments (empty if there is no such arguments). */
         def typeArgs: List[TypeRepr]
       end extension
     }
 
-    /** A singleton type representing a known constant value */
+    /** A singleton type representing a known constant value. */
     type ConstantType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `ConstantType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `ConstantType`. */
     given ConstantTypeTypeTest: TypeTest[TypeRepr, ConstantType]
 
-    /** Module object of `type ConstantType`  */
+    /** Module object of `type ConstantType`. */
     val ConstantType: ConstantTypeModule
 
-    /** Methods of the module object `val Type` */
+    /** Methods of the module object `val Type`. */
     trait ConstantTypeModule { this: ConstantType.type =>
       def apply(x : Constant): ConstantType
       def unapply(x: ConstantType): Some[Constant]
     }
 
-    /** Makes extension methods on `ConstantType` available without any imports */
+    /** Makes extension methods on `ConstantType` available without any imports. */
     given ConstantTypeMethods: ConstantTypeMethods
 
-    /** Extension methods of `ConstantType` */
+    /** Extension methods of `ConstantType`. */
     trait ConstantTypeMethods:
       extension (self: ConstantType)
         def constant: Constant
       end extension
     end ConstantTypeMethods
 
-    /** Type of a reference to a type or term symbol */
+    /** Type of a reference to a type or term symbol. */
     type NamedType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `NamedType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `NamedType`. */
     given NamedTypeTypeTest: TypeTest[TypeRepr, NamedType]
 
-    /** Makes extension methods on `NamedType` available without any imports */
+    /** Makes extension methods on `NamedType` available without any imports. */
     given NamedTypeMethods: NamedTypeMethods
 
-    /** Extension methods of `NamedType` */
+    /** Extension methods of `NamedType`. */
     trait NamedTypeMethods:
       extension (self: NamedType)
         def qualifier: TypeRepr
@@ -2884,39 +2884,39 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end NamedTypeMethods
 
-    /** Type of a reference to a term symbol */
+    /** Type of a reference to a term symbol. */
     type TermRef <: NamedType
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `TermRef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `TermRef`. */
     given TermRefTypeTest: TypeTest[TypeRepr, TermRef]
 
-    /** Module object of `type TermRef`  */
+    /** Module object of `type TermRef`. */
     val TermRef: TermRefModule
 
-    /** Methods of the module object `val TermRef` */
+    /** Methods of the module object `val TermRef`. */
     trait TermRefModule { this: TermRef.type =>
       def apply(qual: TypeRepr, name: String): TermRef
       def unapply(x: TermRef): (TypeRepr, String)
     }
 
-    /** Type of a reference to a type symbol */
+    /** Type of a reference to a type symbol. */
     type TypeRef <: NamedType
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `TypeRef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `TypeRef`. */
     given TypeRefTypeTest: TypeTest[TypeRepr, TypeRef]
 
-    /** Module object of `type TypeRef`  */
+    /** Module object of `type TypeRef`. */
     val TypeRef: TypeRefModule
 
-    /** Methods of the module object `val TypeRef` */
+    /** Methods of the module object `val TypeRef`. */
     trait TypeRefModule { this: TypeRef.type =>
       def unapply(x: TypeRef): (TypeRepr, String)
     }
 
-    /** Makes extension methods on `TypeRef` available without any imports */
+    /** Makes extension methods on `TypeRef` available without any imports. */
     given TypeRefMethods: TypeRefMethods
 
-    /** Extension methods of `TypeRef` */
+    /** Extension methods of `TypeRef`. */
     trait TypeRefMethods:
       extension (self: TypeRef)
         def isOpaqueAlias: Boolean
@@ -2924,25 +2924,25 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end TypeRefMethods
 
-    /** Type of a `super` reference */
+    /** Type of a `super` reference. */
     type SuperType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `SuperType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `SuperType`. */
     given SuperTypeTypeTest: TypeTest[TypeRepr, SuperType]
 
-    /** Module object of `type SuperType`  */
+    /** Module object of `type SuperType`. */
     val SuperType: SuperTypeModule
 
-    /** Methods of the module object `val SuperType` */
+    /** Methods of the module object `val SuperType`. */
     trait SuperTypeModule { this: SuperType.type =>
       def apply(thistpe: TypeRepr, supertpe: TypeRepr): SuperType
       def unapply(x: SuperType): (TypeRepr, TypeRepr)
     }
 
-    /** Makes extension methods on `SuperType` available without any imports */
+    /** Makes extension methods on `SuperType` available without any imports. */
     given SuperTypeMethods: SuperTypeMethods
 
-    /** Extension methods of `SuperType` */
+    /** Extension methods of `SuperType`. */
     trait SuperTypeMethods { this: SuperTypeMethods =>
       extension (self: SuperType)
         def thistpe: TypeRepr
@@ -2950,25 +2950,25 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     }
 
-    /** A type with a type refinement `T { type U }` */
+    /** A type with a type refinement `T { type U }`. */
     type Refinement <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `Refinement` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `Refinement`. */
     given RefinementTypeTest: TypeTest[TypeRepr, Refinement]
 
-    /** Module object of `type Refinement`  */
+    /** Module object of `type Refinement`. */
     val Refinement: RefinementModule
 
-    /** Methods of the module object `val Refinement` */
+    /** Methods of the module object `val Refinement`. */
     trait RefinementModule { this: Refinement.type =>
       def apply(parent: TypeRepr, name: String, info: TypeRepr): Refinement
       def unapply(x: Refinement): (TypeRepr, String, TypeRepr)
     }
 
-    /** Makes extension methods on `Refinement` available without any imports */
+    /** Makes extension methods on `Refinement` available without any imports. */
     given RefinementMethods: RefinementMethods
 
-    /** Extension methods of `Refinement` */
+    /** Extension methods of `Refinement`. */
     trait RefinementMethods:
       extension (self: Refinement)
         def parent: TypeRepr
@@ -2977,26 +2977,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end RefinementMethods
 
-    /** A higher kinded type applied to some types `T[U]` */
+    /** A higher kinded type applied to some types `T[U]`. */
     type AppliedType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `AppliedType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `AppliedType`. */
     given AppliedTypeTypeTest: TypeTest[TypeRepr, AppliedType]
 
-    /** Module object of `type AppliedType`  */
+    /** Module object of `type AppliedType`. */
     val AppliedType: AppliedTypeModule
 
-    /** Methods of the module object `val AppliedType` */
+    /** Methods of the module object `val AppliedType`. */
     trait AppliedTypeModule { this: AppliedType.type =>
-      /** Applied the type constructor `T` to a list of type arguments `T_1,..,T_n` to create `T[T_1,..,T_n]` */
+      /** Applied the type constructor `T` to a list of type arguments `T_1,..,T_n` to create `T[T_1,..,T_n]`. */
       def apply(tycon: TypeRepr, args: List[TypeRepr]): AppliedType
       def unapply(x: AppliedType): (TypeRepr, List[TypeRepr])
     }
 
-    /** Makes extension methods on `AppliedType` available without any imports */
+    /** Makes extension methods on `AppliedType` available without any imports. */
     given AppliedTypeMethods: AppliedTypeMethods
 
-    /** Extension methods of `AppliedType` */
+    /** Extension methods of `AppliedType`. */
     trait AppliedTypeMethods:
       extension (self: AppliedType)
         def tycon: TypeRepr
@@ -3007,22 +3007,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** A type with an annotation `T @foo` */
     type AnnotatedType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `AnnotatedType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `AnnotatedType`. */
     given AnnotatedTypeTypeTest: TypeTest[TypeRepr, AnnotatedType]
 
-    /** Module object of `type AnnotatedType`  */
+    /** Module object of `type AnnotatedType`. */
     val AnnotatedType: AnnotatedTypeModule
 
-    /** Methods of the module object `val AnnotatedType` */
+    /** Methods of the module object `val AnnotatedType`. */
     trait AnnotatedTypeModule { this: AnnotatedType.type =>
       def apply(underlying: TypeRepr, annot: Term): AnnotatedType
       def unapply(x: AnnotatedType): (TypeRepr, Term)
     }
 
-    /** Makes extension methods on `AnnotatedType` available without any imports */
+    /** Makes extension methods on `AnnotatedType` available without any imports. */
     given AnnotatedTypeMethods: AnnotatedTypeMethods
 
-    /** Extension methods of `AnnotatedType` */
+    /** Extension methods of `AnnotatedType`. */
     trait AnnotatedTypeMethods:
       extension (self: AnnotatedType)
         def underlying: TypeRepr
@@ -3031,16 +3031,16 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     end AnnotatedTypeMethods
 
 
-    /** Intersection type `T & U` or an union type `T | U` */
+    /** Intersection type `T & U` or an union type `T | U`. */
     type AndOrType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `AndOrType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `AndOrType`. */
     given AndOrTypeTypeTest: TypeTest[TypeRepr, AndOrType]
 
-    /** Makes extension methods on `AndOrType` available without any imports */
+    /** Makes extension methods on `AndOrType` available without any imports. */
     given AndOrTypeMethods: AndOrTypeMethods
 
-    /** Extension methods of `AndOrType` */
+    /** Extension methods of `AndOrType`. */
     trait AndOrTypeMethods:
       extension (self: AndOrType)
         def left: TypeRepr
@@ -3048,55 +3048,55 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end AndOrTypeMethods
 
-    /** Intersection type `T & U` */
+    /** Intersection type `T & U`. */
     type AndType <: AndOrType
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `AndType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `AndType`. */
     given AndTypeTypeTest: TypeTest[TypeRepr, AndType]
 
-    /** Module object of `type AndType`  */
+    /** Module object of `type AndType`. */
     val AndType: AndTypeModule
 
-    /** Methods of the module object `val AndType` */
+    /** Methods of the module object `val AndType`. */
     trait AndTypeModule { this: AndType.type =>
       def apply(lhs: TypeRepr, rhs: TypeRepr): AndType
       def unapply(x: AndType): (TypeRepr, TypeRepr)
     }
 
-    /** Union type `T | U` */
+    /** Union type `T | U`. */
     type OrType <: AndOrType
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `OrType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is an `OrType`. */
     given OrTypeTypeTest: TypeTest[TypeRepr, OrType]
 
-    /** Module object of `type OrType`  */
+    /** Module object of `type OrType`. */
     val OrType: OrTypeModule
 
-    /** Methods of the module object `val OrType` */
+    /** Methods of the module object `val OrType`. */
     trait OrTypeModule { this: OrType.type =>
       def apply(lhs: TypeRepr, rhs: TypeRepr): OrType
       def unapply(x: OrType): (TypeRepr, TypeRepr)
     }
 
-    /** Type match `T match { case U => ... }` */
+    /** Type match `T match { case U => ... }`. */
     type MatchType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MatchType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MatchType`. */
     given MatchTypeTypeTest: TypeTest[TypeRepr, MatchType]
 
-    /** Module object of `type MatchType`  */
+    /** Module object of `type MatchType`. */
     val MatchType: MatchTypeModule
 
-    /** Methods of the module object `val MatchType` */
+    /** Methods of the module object `val MatchType`. */
     trait MatchTypeModule { this: MatchType.type =>
       def apply(bound: TypeRepr, scrutinee: TypeRepr, cases: List[TypeRepr]): MatchType
       def unapply(x: MatchType): (TypeRepr, TypeRepr, List[TypeRepr])
     }
 
-    /** Makes extension methods on `MatchType` available without any imports */
+    /** Makes extension methods on `MatchType` available without any imports. */
     given MatchTypeMethods: MatchTypeMethods
 
-    /** Extension methods of `MatchType` */
+    /** Extension methods of `MatchType`. */
     trait MatchTypeMethods:
       extension (self: MatchType)
         def bound: TypeRepr
@@ -3122,46 +3122,46 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type ByNameType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `ByNameType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `ByNameType`. */
     given ByNameTypeTypeTest: TypeTest[TypeRepr, ByNameType]
 
-    /** Module object of `type ByNameType`  */
+    /** Module object of `type ByNameType`. */
     val ByNameType: ByNameTypeModule
 
-    /** Methods of the module object `val ByNameType` */
+    /** Methods of the module object `val ByNameType`. */
     trait ByNameTypeModule { this: ByNameType.type =>
       def apply(underlying: TypeRepr): TypeRepr
       def unapply(x: ByNameType): Some[TypeRepr]
     }
 
-    /** Makes extension methods on `ByNameType` available without any imports */
+    /** Makes extension methods on `ByNameType` available without any imports. */
     given ByNameTypeMethods: ByNameTypeMethods
 
-    /** Extension methods of `ByNameType` */
+    /** Extension methods of `ByNameType`. */
     trait ByNameTypeMethods:
       extension (self: ByNameType)
         def underlying: TypeRepr
       end extension
     end ByNameTypeMethods
 
-    /** Type of a parameter reference */
+    /** Type of a parameter reference. */
     type ParamRef <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `ParamRef` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `ParamRef`. */
     given ParamRefTypeTest: TypeTest[TypeRepr, ParamRef]
 
-    /** Module object of `type ParamRef`  */
+    /** Module object of `type ParamRef`. */
     val ParamRef: ParamRefModule
 
-    /** Methods of the module object `val ParamRef` */
+    /** Methods of the module object `val ParamRef`. */
     trait ParamRefModule { this: ParamRef.type =>
       def unapply(x: ParamRef): (TypeRepr, Int)
     }
 
-    /** Makes extension methods on `ParamRef` available without any imports */
+    /** Makes extension methods on `ParamRef` available without any imports. */
     given ParamRefMethods: ParamRefMethods
 
-    /** Extension methods of `ParamRef` */
+    /** Extension methods of `ParamRef`. */
     trait ParamRefMethods:
       extension (self: ParamRef)
         def binder: TypeRepr
@@ -3169,67 +3169,67 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end ParamRefMethods
 
-    /** Type of `this` */
+    /** Type of `this`. */
     type ThisType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `ThisType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `ThisType`. */
     given ThisTypeTypeTest: TypeTest[TypeRepr, ThisType]
 
-    /** Module object of `type ThisType`  */
+    /** Module object of `type ThisType`. */
     val ThisType: ThisTypeModule
 
-    /** Methods of the module object `val ThisType` */
+    /** Methods of the module object `val ThisType`. */
     trait ThisTypeModule { this: ThisType.type =>
       def unapply(x: ThisType): Some[TypeRepr]
     }
 
-    /** Makes extension methods on `ThisType` available without any imports */
+    /** Makes extension methods on `ThisType` available without any imports. */
     given ThisTypeMethods: ThisTypeMethods
 
-    /** Extension methods of `ThisType` */
+    /** Extension methods of `ThisType`. */
     trait ThisTypeMethods:
       extension (self: ThisType)
         def tref: TypeRepr
       end extension
     end ThisTypeMethods
 
-    /** A type that is recursively defined `this` */
+    /** A type that is recursively defined `this`. */
     type RecursiveThis <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `RecursiveThis` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `RecursiveThis`. */
     given RecursiveThisTypeTest: TypeTest[TypeRepr, RecursiveThis]
 
-    /** Module object of `type RecursiveThis`  */
+    /** Module object of `type RecursiveThis`. */
     val RecursiveThis: RecursiveThisModule
 
-    /** Methods of the module object `val RecursiveThis` */
+    /** Methods of the module object `val RecursiveThis`. */
     trait RecursiveThisModule { this: RecursiveThis.type =>
       def unapply(x: RecursiveThis): Some[RecursiveType]
     }
 
-    /** Makes extension methods on `RecursiveThis` available without any imports */
+    /** Makes extension methods on `RecursiveThis` available without any imports. */
     given RecursiveThisMethods: RecursiveThisMethods
 
-    /** Extension methods of `RecursiveThis` */
+    /** Extension methods of `RecursiveThis`. */
     trait RecursiveThisMethods:
       extension (self: RecursiveThis)
         def binder: RecursiveType
       end extension
     end RecursiveThisMethods
 
-    /** A type that is recursively defined */
+    /** A type that is recursively defined. */
     type RecursiveType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `RecursiveType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `RecursiveType`. */
     given RecursiveTypeTypeTest: TypeTest[TypeRepr, RecursiveType]
 
-    /** Module object of `type RecursiveType`  */
+    /** Module object of `type RecursiveType`. */
     val RecursiveType: RecursiveTypeModule
 
-    /** Methods of the module object `val RecursiveType` */
+    /** Methods of the module object `val RecursiveType`. */
     trait RecursiveTypeModule { this: RecursiveType.type =>
 
-      /** Create a RecType, normalizing its contents. This means:
+      /** Creates a RecType, normalizing its contents. This means:
       *
       *   1. Nested Rec types on the type's spine are merged with the outer one.
       *   2. Any refinement of the form `type T = z.T` on the spine of the type
@@ -3242,10 +3242,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def unapply(x: RecursiveType): Some[TypeRepr]
     }
 
-    /** Makes extension methods on `RecursiveType` available without any imports */
+    /** Makes extension methods on `RecursiveType` available without any imports. */
     given RecursiveTypeMethods: RecursiveTypeMethods
 
-    /** Extension methods of `RecursiveType` */
+    /** Extension methods of `RecursiveType`. */
     trait RecursiveTypeMethods:
       extension (self: RecursiveType)
         def underlying: TypeRepr
@@ -3253,16 +3253,16 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end RecursiveTypeMethods
 
-    /** Type of the definition of a method taking a single list of type or term parameters */
+    /** Type of the definition of a method taking a single list of type or term parameters. */
     type LambdaType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `LambdaType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `LambdaType`. */
     given LambdaTypeTypeTest: TypeTest[TypeRepr, LambdaType]
 
-    /** Makes extension methods on `LambdaType` available without any imports */
+    /** Makes extension methods on `LambdaType` available without any imports. */
     given LambdaTypeMethods: LambdaTypeMethods
 
-    /** Extension methods of `LambdaType` */
+    /** Extension methods of `LambdaType`. */
     trait LambdaTypeMethods:
       extension (self: LambdaType)
         def paramNames: List[String]
@@ -3271,56 +3271,56 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       end extension
     end LambdaTypeMethods
 
-    /** Type of the definition of a method taking a single list of type or term parameters */
+    /** Type of the definition of a method taking a single list of type or term parameters. */
     type MethodOrPoly <: LambdaType
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MethodOrPoly` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MethodOrPoly`. */
     given MethodOrPolyTypeTest: TypeTest[TypeRepr, MethodOrPoly]
 
     /** Type which decides on the kind of parameter list represented by `MethodType`. */
     enum MethodTypeKind:
-      /** Represents a parameter list without any implicitness of parameters, like (x1: X1, x2: X2, ...) */
+      /** Represents a parameter list without any implicitness of parameters, like (x1: X1, x2: X2, ...). */
       case Plain
-      /** Represents a parameter list with implicit parameters, like `(implicit X1, ..., Xn)`, `(using X1, ..., Xn)`, `(using x1: X1, ..., xn: Xn)` */
+      /** Represents a parameter list with implicit parameters, like `(implicit X1, ..., Xn)`, `(using X1, ..., Xn)`, `(using x1: X1, ..., xn: Xn)`. */
       case Implicit
-      /** Represents a parameter list of a contextual method, like `(using X1, ..., Xn)` or `(using x1: X1, ..., xn: Xn)` */
+      /** Represents a parameter list of a contextual method, like `(using X1, ..., Xn)` or `(using x1: X1, ..., xn: Xn)`. */
       case Contextual
 
     /** Type of the definition of a method taking a single list of parameters. It's return type may be a MethodType. */
     type MethodType <: MethodOrPoly
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MethodType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MethodType`. */
     given MethodTypeTypeTest: TypeTest[TypeRepr, MethodType]
 
-    /** Module object of `type MethodType`  */
+    /** Module object of `type MethodType`. */
     val MethodType: MethodTypeModule
 
-    /** Methods of the module object `val MethodType` */
+    /** Methods of the module object `val MethodType`. */
     trait MethodTypeModule { this: MethodType.type =>
       def apply(paramNames: List[String])(paramInfosExp: MethodType => List[TypeRepr], resultTypeExp: MethodType => TypeRepr): MethodType
       def apply(kind: MethodTypeKind)(paramNames: List[String])(paramInfosExp: MethodType => List[TypeRepr], resultTypeExp: MethodType => TypeRepr): MethodType
       def unapply(x: MethodType): (List[String], List[TypeRepr], TypeRepr)
     }
 
-    /** Makes extension methods on `MethodType` available without any imports */
+    /** Makes extension methods on `MethodType` available without any imports. */
     given MethodTypeMethods: MethodTypeMethods
 
-    /** Extension methods of `MethodType` */
+    /** Extension methods of `MethodType`. */
     trait MethodTypeMethods:
       extension (self: MethodType)
-        /** Is this the type of parameter clause like `(implicit X1, ..., Xn)`, `(using X1, ..., Xn)` or `(using x1: X1, ..., xn: Xn)` */
+        /** Is this the type of parameter clause like `(implicit X1, ..., Xn)`, `(using X1, ..., Xn)` or `(using x1: X1, ..., xn: Xn)`. */
         def isImplicit: Boolean
-        /** Is this the type of parameter clause like `(using X1, ..., Xn)` or `(using x1: X1, x2: X2, ... )` */
+        /** Is this the type of parameter clause like `(using X1, ..., Xn)` or `(using x1: X1, x2: X2, ... )`. */
         def isContextual: Boolean
         /** Returns a MethodTypeKind object representing the implicitness of the MethodType parameter clause. */
         def methodTypeKind: MethodTypeKind
-        /** Is this the type of erased parameter clause `(erased x1: X1, ..., xn: Xn)` */
+        /** Is this the type of erased parameter clause `(erased x1: X1, ..., xn: Xn)`. */
         @deprecated("Use `hasErasedParams` and `erasedParams`", "3.4")
         def isErased: Boolean
-        /** List of `erased` flags for each parameters of the clause */
+        /** List of `erased` flags for each parameters of the clause. */
         @experimental
         def erasedParams: List[Boolean]
-        /** Whether the clause has any erased parameters */
+        /** Whether the clause has any erased parameters. */
         @experimental
         def hasErasedParams: Boolean
         def param(idx: Int): TypeRepr
@@ -3330,22 +3330,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Type of the definition of a method taking a list of type parameters. It's return type may be a MethodType. */
     type PolyType <: MethodOrPoly
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `PolyType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `PolyType`. */
     given PolyTypeTypeTest: TypeTest[TypeRepr, PolyType]
 
-    /** Module object of `type PolyType`  */
+    /** Module object of `type PolyType`. */
     val PolyType: PolyTypeModule
 
-    /** Methods of the module object `val PolyType` */
+    /** Methods of the module object `val PolyType`. */
     trait PolyTypeModule { this: PolyType.type =>
       def apply(paramNames: List[String])(paramBoundsExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => TypeRepr): PolyType
       def unapply(x: PolyType): (List[String], List[TypeBounds], TypeRepr)
     }
 
-    /** Makes extension methods on `PolyType` available without any imports */
+    /** Makes extension methods on `PolyType` available without any imports. */
     given PolyTypeMethods: PolyTypeMethods
 
-    /** Extension methods of `PolyType` */
+    /** Extension methods of `PolyType`. */
     trait PolyTypeMethods:
       extension (self: PolyType)
         def param(idx: Int): TypeRepr
@@ -3356,27 +3356,27 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Type of the definition of a type lambda taking a list of type parameters. It's return type may be a TypeLambda. */
     type TypeLambda <: LambdaType
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `TypeLambda` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `TypeLambda`. */
     given TypeLambdaTypeTest: TypeTest[TypeRepr, TypeLambda]
 
-    /** Module object of `type TypeLambda`  */
+    /** Module object of `type TypeLambda`. */
     val TypeLambda: TypeLambdaModule
 
-    /** Methods of the module object `val TypeLambda` */
+    /** Methods of the module object `val TypeLambda`. */
     trait TypeLambdaModule { this: TypeLambda.type =>
       def apply(paramNames: List[String], boundsFn: TypeLambda => List[TypeBounds], bodyFn: TypeLambda => TypeRepr): TypeLambda
       def unapply(x: TypeLambda): (List[String], List[TypeBounds], TypeRepr)
     }
 
-    /** Makes extension methods on `TypeLambda` available without any imports */
+    /** Makes extension methods on `TypeLambda` available without any imports. */
     given TypeLambdaMethods: TypeLambdaMethods
 
-    /** Extension methods of `TypeLambda` */
+    /** Extension methods of `TypeLambda`. */
     trait TypeLambdaMethods:
       extension (self: TypeLambda)
-        /** Reference to the i-th parameter */
+        /** Reference to the i-th parameter. */
         def param(idx: Int) : TypeRepr
-        /** Type bounds of the i-th parameter */
+        /** Type bounds of the i-th parameter. */
         def paramBounds: List[TypeBounds]
         /** Variance flags for the i-th parameter
          *
@@ -3392,13 +3392,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     type MatchCase <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MatchCase` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `MatchCase`. */
     given MatchCaseTypeTest: TypeTest[TypeRepr, MatchCase]
 
-    /** Module object of `type MatchCase`  */
+    /** Module object of `type MatchCase`. */
     val MatchCase: MatchCaseModule
 
-    /** Methods of the module object `val MatchCase` */
+    /** Methods of the module object `val MatchCase`. */
     trait MatchCaseModule { this: MatchCase.type =>
       /* Create match type case `case <pattern> => <rhs>` */
       def apply(pattern: TypeRepr, rhs: TypeRepr): MatchCase
@@ -3406,15 +3406,15 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def unapply(x: MatchCase): (TypeRepr, TypeRepr)
     }
 
-    /** Makes extension methods on `MatchCase` available without any imports */
+    /** Makes extension methods on `MatchCase` available without any imports. */
     given MatchCaseMethods: MatchCaseMethods
 
-    /** Extension methods of `MatchCase` */
+    /** Extension methods of `MatchCase`. */
     trait MatchCaseMethods:
       extension (self: MatchCase)
-        /** Pattern `P` of `case P => R` in a `MatchType` */
+        /** Pattern `P` of `case P => R` in a `MatchType`. */
         def pattern: TypeRepr
-        /** RHS `R` of `case P => R` in a `MatchType` */
+        /** RHS `R` of `case P => R` in a `MatchType`. */
         def rhs: TypeRepr
       end extension
     end MatchCaseMethods
@@ -3422,16 +3422,16 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     // ----- TypeBounds -----------------------------------------------
 
-    /** Type bounds */
+    /** Type bounds. */
     type TypeBounds <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `TypeBounds` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `TypeBounds`. */
     given TypeBoundsTypeTest: TypeTest[TypeRepr, TypeBounds]
 
-    /** Module object of `type TypeBounds`  */
+    /** Module object of `type TypeBounds`. */
     val TypeBounds: TypeBoundsModule
 
-    /** Methods of the module object `val TypeBounds` */
+    /** Methods of the module object `val TypeBounds`. */
     trait TypeBoundsModule { this: TypeBounds.type =>
       def apply(low: TypeRepr, hi: TypeRepr): TypeBounds
       def unapply(x: TypeBounds): (TypeRepr, TypeRepr)
@@ -3440,10 +3440,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def lower(lo: TypeRepr): TypeBounds
     }
 
-    /** Makes extension methods on `TypeBounds` available without any imports */
+    /** Makes extension methods on `TypeBounds` available without any imports. */
     given TypeBoundsMethods: TypeBoundsMethods
 
-    /** Extension methods of `TypeBounds` */
+    /** Extension methods of `TypeBounds`. */
     trait TypeBoundsMethods:
       extension (self: TypeBounds)
         def low: TypeRepr
@@ -3453,41 +3453,41 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     // ----- NoPrefix -------------------------------------------------
 
-    /** NoPrefix for a type selection */
+    /** NoPrefix for a type selection. */
     type NoPrefix <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `NoPrefix` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `NoPrefix`. */
     given NoPrefixTypeTest: TypeTest[TypeRepr, NoPrefix]
 
-    /** Module object of `type NoPrefix`  */
+    /** Module object of `type NoPrefix`. */
     val NoPrefix: NoPrefixModule
 
-    /** Methods of the module object `val NoPrefix` */
+    /** Methods of the module object `val NoPrefix`. */
     trait NoPrefixModule { this: NoPrefix.type =>
       def unapply(x: NoPrefix): true
     }
 
     // ----- Flexible Type --------------------------------------------
 
-    /** Flexible types for explicit nulls */
+    /** Flexible types for explicit nulls. */
     type FlexibleType <: TypeRepr
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `FlexibleType` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `TypeRepr` is a `FlexibleType`. */
     given FlexibleTypeTypeTest: TypeTest[TypeRepr, FlexibleType]
 
-    /** Module object of `type FlexibleType`  */
+    /** Module object of `type FlexibleType`. */
     val FlexibleType: FlexibleTypeModule
 
-    /** Methods of the module object `val FlexibleType` */
+    /** Methods of the module object `val FlexibleType`. */
     trait FlexibleTypeModule { this: FlexibleType.type =>
       def apply(tp: TypeRepr): FlexibleType
       def unapply(x: FlexibleType): Option[TypeRepr]
     }
 
-    /** Makes extension methods on `FlexibleType` available without any imports */
+    /** Makes extension methods on `FlexibleType` available without any imports. */
     given FlexibleTypeMethods: FlexibleTypeMethods
 
-    /** Extension methods of `FlexibleType` */
+    /** Extension methods of `FlexibleType`. */
     trait FlexibleTypeMethods:
       extension (self: FlexibleType)
         def underlying: TypeRepr
@@ -3500,234 +3500,234 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     // CONSTANTS //
     ///////////////
 
-    /** Constant value represented as the constant itself */
+    /** Constant value represented as the constant itself. */
     type Constant <: AnyRef
 
-    /** Constant value represented as the constant itself */
+    /** Constant value represented as the constant itself. */
     val Constant: ConstantModule
 
-    /** Constant value represented as the constant itself */
+    /** Constant value represented as the constant itself. */
     trait ConstantModule { this: Constant.type => }
 
-    /** Makes extension methods on `Constant` available without any imports */
+    /** Makes extension methods on `Constant` available without any imports. */
     given ConstantMethods: ConstantMethods
 
-    /** Extension methods of `Constant` */
+    /** Extension methods of `Constant`. */
     trait ConstantMethods {
       extension (self: Constant)
-        /** Returns the value of the constant */
+        /** Returns the value of the constant. */
         def value: Any
 
-        /** Shows the constant as a String */
+        /** Shows the constant as a String. */
         def show(using Printer[Constant]): String
 
       end extension
     }
 
-    /** Constant Boolean value */
+    /** Constant Boolean value. */
     type BooleanConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `BooleanConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `BooleanConstant`. */
     given BooleanConstantTypeTest: TypeTest[Constant, BooleanConstant]
 
-    /** Module object of `type BooleanConstant` */
+    /** Module object of `type BooleanConstant`. */
     val BooleanConstant: BooleanConstantModule
 
-    /** Methods of the module object `val BooleanConstant` */
+    /** Methods of the module object `val BooleanConstant`. */
     trait BooleanConstantModule { this: BooleanConstant.type =>
-      /** Create a constant Boolean value */
+      /** Creates a constant Boolean value. */
       def apply(x: Boolean): BooleanConstant
-      /** Match Boolean value constant and extract its value */
+      /** Match Boolean value constant and extract its value. */
       def unapply(constant: BooleanConstant): Some[Boolean]
     }
 
-    /** Constant Byte value */
+    /** Constant Byte value. */
     type ByteConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `ByteConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `ByteConstant`. */
     given ByteConstantTypeTest: TypeTest[Constant, ByteConstant]
 
-    /** Module object of `type ByteConstant` */
+    /** Module object of `type ByteConstant`. */
     val ByteConstant: ByteConstantModule
 
-    /** Methods of the module object `val ByteConstant` */
+    /** Methods of the module object `val ByteConstant`. */
     trait ByteConstantModule { this: ByteConstant.type =>
-      /** Create a constant Byte value */
+      /** Creates a constant Byte value. */
       def apply(x: Byte): ByteConstant
-      /** Match Byte value constant and extract its value */
+      /** Match Byte value constant and extract its value. */
       def unapply(constant: ByteConstant): Some[Byte]
     }
 
-    /** Constant Short value */
+    /** Constant Short value. */
     type ShortConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `ShortConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `ShortConstant`. */
     given ShortConstantTypeTest: TypeTest[Constant, ShortConstant]
 
-    /** Module object of `type ShortConstant` */
+    /** Module object of `type ShortConstant`. */
     val ShortConstant: ShortConstantModule
 
-    /** Methods of the module object `val Short` */
+    /** Methods of the module object `val Short`. */
     trait ShortConstantModule { this: ShortConstant.type =>
-      /** Create a constant Short value */
+      /** Creates a constant Short value. */
       def apply(x: Short): ShortConstant
-      /** Match Short value constant and extract its value */
+      /** Match Short value constant and extract its value. */
       def unapply(constant: ShortConstant): Some[Short]
     }
 
-    /** Constant Int value */
+    /** Constant Int value. */
     type IntConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `IntConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `IntConstant`. */
     given IntConstantTypeTest: TypeTest[Constant, IntConstant]
 
-    /** Module object of `type IntConstant` */
+    /** Module object of `type IntConstant`. */
     val IntConstant: IntConstantModule
 
-    /** Methods of the module object `val IntConstant` */
+    /** Methods of the module object `val IntConstant`. */
     trait IntConstantModule { this: IntConstant.type =>
-      /** Create a constant Int value */
+      /** Creates a constant Int value. */
       def apply(x: Int): IntConstant
-      /** Match Int value constant and extract its value */
+      /** Match Int value constant and extract its value. */
       def unapply(constant: IntConstant): Some[Int]
     }
 
-    /** Constant Long value */
+    /** Constant Long value. */
     type LongConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `LongConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `LongConstant`. */
     given LongConstantTypeTest: TypeTest[Constant, LongConstant]
 
-    /** Module object of `type LongConstant` */
+    /** Module object of `type LongConstant`. */
     val LongConstant: LongConstantModule
 
-    /** Methods of the module object `val LongConstant` */
+    /** Methods of the module object `val LongConstant`. */
     trait LongConstantModule { this: LongConstant.type =>
-      /** Create a constant Long value */
+      /** Creates a constant Long value. */
       def apply(x: Long): LongConstant
-      /** Match Long value constant and extract its value */
+      /** Match Long value constant and extract its value. */
       def unapply(constant: LongConstant): Some[Long]
     }
 
-    /** Constant Float value */
+    /** Constant Float value. */
     type FloatConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `FloatConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `FloatConstant`. */
     given FloatConstantTypeTest: TypeTest[Constant, FloatConstant]
 
-    /** Module object of `type FloatConstant` */
+    /** Module object of `type FloatConstant`. */
     val FloatConstant: FloatConstantModule
 
-    /** Methods of the module object `val FloatConstant` */
+    /** Methods of the module object `val FloatConstant`. */
     trait FloatConstantModule { this: FloatConstant.type =>
-      /** Create a constant Float value */
+      /** Creates a constant Float value. */
       def apply(x: Float): FloatConstant
-      /** Match Float value constant and extract its value */
+      /** Match Float value constant and extract its value. */
       def unapply(constant: FloatConstant): Some[Float]
     }
 
-    /** Constant Double value */
+    /** Constant Double value. */
     type DoubleConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `DoubleConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `DoubleConstant`. */
     given DoubleConstantTypeTest: TypeTest[Constant, DoubleConstant]
 
-    /** Module object of `type DoubleConstant` */
+    /** Module object of `type DoubleConstant`. */
     val DoubleConstant: DoubleConstantModule
 
-    /** Methods of the module object `val DoubleConstant` */
+    /** Methods of the module object `val DoubleConstant`. */
     trait DoubleConstantModule { this: DoubleConstant.type =>
-      /** Create a constant Double value */
+      /** Creates a constant Double value. */
       def apply(x: Double): DoubleConstant
-      /** Match Double value constant and extract its value */
+      /** Match Double value constant and extract its value. */
       def unapply(constant: DoubleConstant): Some[Double]
     }
 
-    /** Constant Char value */
+    /** Constant Char value. */
     type CharConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `CharConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `CharConstant`. */
     given CharConstantTypeTest: TypeTest[Constant, CharConstant]
 
-    /** Module object of `type CharConstant` */
+    /** Module object of `type CharConstant`. */
     val CharConstant: CharConstantModule
 
-    /** Methods of the module object `val CharConstant` */
+    /** Methods of the module object `val CharConstant`. */
     trait CharConstantModule { this: CharConstant.type =>
-      /** Create a constant Char value */
+      /** Creates a constant Char value. */
       def apply(x: Char): CharConstant
-      /** Match Char value constant and extract its value */
+      /** Match Char value constant and extract its value. */
       def unapply(constant: CharConstant): Some[Char]
     }
 
-    /** Constant String value */
+    /** Constant String value. */
     type StringConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `StringConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `StringConstant`. */
     given StringConstantTypeTest: TypeTest[Constant, StringConstant]
 
-    /** Module object of `type StringConstant` */
+    /** Module object of `type StringConstant`. */
     val StringConstant: StringConstantModule
 
-    /** Methods of the module object `val StringConstant` */
+    /** Methods of the module object `val StringConstant`. */
     trait StringConstantModule { this: StringConstant.type =>
-      /** Create a constant String value
+      /** Creates a constant String value
        *
        *  @throw `IllegalArgumentException` if the argument is `null`
        */
       def apply(x: String): StringConstant
-      /** Match String value constant and extract its value */
+      /** Match String value constant and extract its value. */
       def unapply(constant: StringConstant): Some[String]
     }
 
-    /** Constant Unit value */
+    /** Constant Unit value. */
     type UnitConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `UnitConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `UnitConstant`. */
     given UnitConstantTypeTest: TypeTest[Constant, UnitConstant]
 
-    /** Module object of `type UnitConstant` */
+    /** Module object of `type UnitConstant`. */
     val UnitConstant: UnitConstantModule
 
-    /** Methods of the module object `val UnitConstant` */
+    /** Methods of the module object `val UnitConstant`. */
     trait UnitConstantModule { this: UnitConstant.type =>
-      /** Create a constant Unit value */
+      /** Creates a constant Unit value. */
       def apply(): UnitConstant
-      /** Match Unit value constant */
+      /** Match Unit value constant. */
       def unapply(constant: UnitConstant): true
     }
 
-    /** Constant null value */
+    /** Constant null value. */
     type NullConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `NullConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `NullConstant`. */
     given NullConstantTypeTest: TypeTest[Constant, NullConstant]
 
-    /** Module object of `type NullConstant` */
+    /** Module object of `type NullConstant`. */
     val NullConstant: NullConstantModule
 
-    /** Methods of the module object `val NullConstant` */
+    /** Methods of the module object `val NullConstant`. */
     trait NullConstantModule { this: NullConstant.type =>
-      /** Create a constant null value */
+      /** Creates a constant null value. */
       def apply(): NullConstant
-      /** Match null value constant */
+      /** Matches null value constant. */
       def unapply(constant: NullConstant): Boolean
     }
 
-    /** Constant class value representing a `classOf[T]` */
+    /** Constant class value representing a `classOf[T]`. */
     type ClassOfConstant <: Constant
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `ClassOfConstant` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if a `Constant` is a `ClassOfConstant`. */
     given ClassOfConstantTypeTest: TypeTest[Constant, ClassOfConstant]
 
-    /** Module object of `type ClassOfConstant` */
+    /** Module object of `type ClassOfConstant`. */
     val ClassOfConstant: ClassOfConstantModule
 
-    /** Methods of the module object `val ClassOf` */
+    /** Methods of the module object `val ClassOf`. */
     trait ClassOfConstantModule { this: ClassOfConstant.type =>
-      /** Create a constant class value representing `classOf[<tpe>]` */
+      /** Creates a constant class value representing `classOf[<tpe>]`. */
       def apply(tpe: TypeRepr): ClassOfConstant
-      /** Match a class value constant representing `classOf[<tpe>]` and extract its type */
+      /** Matches a class value constant representing `classOf[<tpe>]` and extracts its type. */
       def unapply(constant: ClassOfConstant): Option[TypeRepr]
     }
 
@@ -3735,21 +3735,21 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     // IMPLICIT SEARCH //
     /////////////////////
 
-    /** Module object of `type Implicits`  */
+    /** Module object of `type Implicits`. */
     val Implicits: ImplicitsModule
 
-    /** Methods of the module object `val Implicits` */
+    /** Methods of the module object `val Implicits`. */
     trait ImplicitsModule { self: Implicits.type =>
-      /** Find a given instance of type `T` in the current scope provided by the current enclosing splice.
-      *  Return an `ImplicitSearchResult`.
+      /** Finds a given instance of type `T` in the current scope provided by the current enclosing splice.
+      *  Returns an `ImplicitSearchResult`.
       *
       *  @param tpe type of the implicit parameter
       */
       def search(tpe: TypeRepr): ImplicitSearchResult
 
-      /** Find a given instance of type `T` in the current scope provided by the current enclosing splice,
+      /** Finds a given instance of type `T` in the current scope provided by the current enclosing splice,
       *  while excluding certain symbols from the initial implicit search.
-      *  Return an `ImplicitSearchResult`.
+      *  Returns an `ImplicitSearchResult`.
       *
       *  @param tpe type of the implicit parameter
       *  @param ignored Symbols ignored during the initial implicit search
@@ -3760,18 +3760,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def searchIgnoring(tpe: TypeRepr)(ignored: Symbol*): ImplicitSearchResult
     }
 
-    /** Result of a given instance search */
+    /** Result of a given instance search. */
     type ImplicitSearchResult <: AnyRef
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is an `ImplicitSearchSuccess` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is an `ImplicitSearchSuccess`. */
     given ImplicitSearchSuccessTypeTest: TypeTest[ImplicitSearchResult, ImplicitSearchSuccess]
 
     type ImplicitSearchSuccess <: ImplicitSearchResult
 
-    /** Makes extension methods on `ImplicitSearchSuccess` available without any imports */
+    /** Makes extension methods on `ImplicitSearchSuccess` available without any imports. */
     given ImplicitSearchSuccessMethods: ImplicitSearchSuccessMethods
 
-    /** Extension methods of `ImplicitSearchSuccess` */
+    /** Extension methods of `ImplicitSearchSuccess`. */
     trait ImplicitSearchSuccessMethods:
       extension (self: ImplicitSearchSuccess)
         def tree: Term
@@ -3780,13 +3780,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     type ImplicitSearchFailure <: ImplicitSearchResult
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is an `ImplicitSearchFailure` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is an `ImplicitSearchFailure`. */
     given ImplicitSearchFailureTypeTest: TypeTest[ImplicitSearchResult, ImplicitSearchFailure]
 
-    /** Makes extension methods on `ImplicitSearchFailure` available without any imports */
+    /** Makes extension methods on `ImplicitSearchFailure` available without any imports. */
     given ImplicitSearchFailureMethods: ImplicitSearchFailureMethods
 
-    /** Extension methods of `ImplicitSearchFailure` */
+    /** Extension methods of `ImplicitSearchFailure`. */
     trait ImplicitSearchFailureMethods:
       extension (self: ImplicitSearchFailure)
         def explanation: String
@@ -3795,17 +3795,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     type DivergingImplicit <: ImplicitSearchFailure
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is a `DivergingImplicit` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is a `DivergingImplicit`. */
     given DivergingImplicitTypeTest: TypeTest[ImplicitSearchResult, DivergingImplicit]
 
     type NoMatchingImplicits <: ImplicitSearchFailure
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is a `NoMatchingImplicits` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is a `NoMatchingImplicits`. */
     given NoMatchingImplicitsTypeTest: TypeTest[ImplicitSearchResult, NoMatchingImplicits]
 
     type AmbiguousImplicits <: ImplicitSearchFailure
 
-    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is an `AmbiguousImplicits` */
+    /** `TypeTest` that allows testing at runtime in a pattern match if an `ImplicitSearchResult` is an `AmbiguousImplicits`. */
     given AmbiguousImplicitsTypeTest: TypeTest[ImplicitSearchResult, AmbiguousImplicits]
 
     /////////////
@@ -3817,10 +3817,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     */
     type Symbol <: AnyRef
 
-    /** Module object of `type Symbol`  */
+    /** Module object of `type Symbol`. */
     val Symbol: SymbolModule
 
-    /** Methods of the module object `val Symbol` */
+    /** Methods of the module object `val Symbol`. */
     trait SymbolModule { this: Symbol.type =>
 
       /** Symbol of the definition that encloses the current splicing context.
@@ -3834,19 +3834,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def spliceOwner: Symbol
 
-      /** Get package symbol if package is either defined in current compilation run or present on classpath. */
+      /** Gets package symbol if package is either defined in current compilation run or present on classpath. */
       def requiredPackage(path: String): Symbol
 
-      /** Get class symbol if class is either defined in current compilation run or present on classpath. */
+      /** Gets class symbol if class is either defined in current compilation run or present on classpath. */
       def requiredClass(path: String): Symbol
 
-      /** Get module symbol if module is either defined in current compilation run or present on classpath. */
+      /** Gets module symbol if module is either defined in current compilation run or present on classpath. */
       def requiredModule(path: String): Symbol
 
-      /** Get method symbol if method is either defined in current compilation run or present on classpath. Throws if the method has an overload. */
+      /** Gets method symbol if method is either defined in current compilation run or present on classpath. Throws if the method has an overload. */
       def requiredMethod(path: String): Symbol
 
-      /** The class Symbol of a global class definition */
+      /** The class Symbol of a global class definition. */
       def classSymbol(fullName: String): Symbol
 
       /** Generates a new class symbol for a class with a public parameterless constructor.
@@ -4111,7 +4111,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *  @param modFlags extra flags with which the module symbol should be constructed
        *  @param clsFlags extra flags with which the module class symbol should be constructed
        *  @param parents A function that takes the symbol of the module class as input and returns the parent classes of the class. The first parent must not be a trait.
-       *  @param decls A function that takes the symbol of the module class as input and return the symbols of its declared members
+       *  @param decls A function that takes the symbol of the module class as input and returns the symbols of its declared members
        *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
        *
        *  This symbol starts without an accompanying definition.
@@ -4190,7 +4190,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       // Keep: `flags` doc aligned with QuotesImpl's `validBindFlags`
       def newBind(parent: Symbol, name: String, flags: Flags, tpe: TypeRepr): Symbol
 
-      /** Generate a new type symbol for a type alias with the given parent, name and type
+      /** Generates a new type symbol for a type alias with the given parent, name and type
         *
         *  This symbol starts without an accompanying definition.
         *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
@@ -4208,7 +4208,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       // Keep: `flags` doc aligned with QuotesImpl's `validTypeAliasFlags`
       def newTypeAlias(parent: Symbol, name: String, flags: Flags, tpe: TypeRepr, privateWithin: Symbol): Symbol
 
-      /** Generate a new type symbol for a type bounds with the given parent, name and type
+      /** Generates a new type symbol for a type bounds with the given parent, name and type
         *
         *  This symbol starts without an accompanying definition.
         *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
@@ -4226,7 +4226,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       // Keep: `flags` doc aligned with QuotesImpl's `validBoundedTypeFlags`
       def newBoundedType(parent: Symbol, name: String, flags: Flags, tpe: TypeBounds, privateWithin: Symbol): Symbol
 
-      /** Definition not available */
+      /** Definition not available. */
       def noSymbol: Symbol
 
       /** A fresh name for class or member symbol names.
@@ -4241,10 +4241,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def freshName(prefix: String): String
     }
 
-    /** Makes extension methods on `Symbol` available without any imports */
+    /** Makes extension methods on `Symbol` available without any imports. */
     given SymbolMethods: SymbolMethods
 
-    /** Extension methods of `Symbol` */
+    /** Extension methods of `Symbol`. */
     trait SymbolMethods {
       extension (self: Symbol)
 
@@ -4254,29 +4254,29 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** Owner of this symbol. The owner is the symbol in which this symbol is defined. Returns `NoSymbol` if this symbol does not have an owner. */
         def maybeOwner: Symbol
 
-        /** Flags of this symbol */
+        /** Flags of this symbol. */
         def flags: Flags
 
-        /** This symbol is private within the resulting type */
+        /** This symbol is private within the resulting type. */
         def privateWithin: Option[TypeRepr]
 
-        /** This symbol is protected within the resulting type */
+        /** This symbol is protected within the resulting type. */
         def protectedWithin: Option[TypeRepr]
 
-        /** The name of this symbol */
+        /** The name of this symbol. */
         def name: String
 
-        /** The full name of this symbol up to the root package */
+        /** The full name of this symbol up to the root package. */
         def fullName: String
 
-        /** Type of the definition */
+        /** Type of the definition. */
         @experimental
         def info: TypeRepr
 
-        /** The position of this symbol */
+        /** The position of this symbol. */
         def pos: Option[Position]
 
-        /** The documentation for this symbol, if any */
+        /** The documentation for this symbol, if any. */
         def docstring: Option[String]
 
         /** Tree of this definition
@@ -4310,10 +4310,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** Is the annotation defined with `annotSym` attached to this symbol? */
         def hasAnnotation(annotSym: Symbol): Boolean
 
-        /** Get the annotation defined with `annotSym` attached to this symbol */
+        /** Gets the annotation defined with `annotSym` attached to this symbol. */
         def getAnnotation(annotSym: Symbol): Option[Term]
 
-        /** Annotations attached to this symbol */
+        /** Annotations attached to this symbol. */
         def annotations: List[Term]
 
         /** Does this symbol come from a currently compiled source file? */
@@ -4357,7 +4357,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** Is this the definition of a ClassDef tree? */
         def isClassDef: Boolean
 
-        /** Is this the definition of a TypeDef tree */
+        /** Is this the definition of a TypeDef tree. */
         def isTypeDef: Boolean
 
         /** Is this the definition of a ValDef tree? */
@@ -4375,67 +4375,67 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** Does this symbol represent a definition? */
         def exists: Boolean
 
-        /** Field with the given name directly declared in the class */
+        /** Field with the given name directly declared in the class. */
         def declaredField(name: String): Symbol
 
-        /** Fields directly declared in the class */
+        /** Fields directly declared in the class. */
         def declaredFields: List[Symbol]
 
-        /** Get named non-private fields declared or inherited */
+        /** Gets named non-private fields declared or inherited. */
         @deprecated("Use fieldMember", "3.1.0")
         def memberField(name: String): Symbol
 
-        /** Get named non-private fields declared or inherited */
+        /** Gets named non-private fields declared or inherited. */
         def fieldMember(name: String): Symbol
 
-        /** Get all non-private fields declared or inherited */
+        /** Gets all non-private fields declared or inherited. */
         @deprecated("Use fieldMembers", "3.1.0")
         def memberFields: List[Symbol]
 
-        /** Get all non-private fields declared or inherited */
+        /** Gets all non-private fields declared or inherited. */
         def fieldMembers: List[Symbol]
 
-        /** Get non-private named methods defined directly inside the class */
+        /** Gets non-private named methods defined directly inside the class. */
         def declaredMethod(name: String): List[Symbol]
 
-        /** Get all non-private methods defined directly inside the class, excluding constructors */
+        /** Gets all non-private methods defined directly inside the class, excluding constructors. */
         def declaredMethods: List[Symbol]
 
-        /** Get named non-private methods declared or inherited */
+        /** Gets named non-private methods declared or inherited. */
         @deprecated("Use methodMember", "3.1.0")
         def memberMethod(name: String): List[Symbol]
 
-        /** Get named non-private methods declared or inherited */
+        /** Gets named non-private methods declared or inherited. */
         def methodMember(name: String): List[Symbol]
 
-        /** Get all non-private methods declared or inherited */
+        /** Gets all non-private methods declared or inherited. */
         @deprecated("Use methodMembers", "3.1.0")
         def memberMethods: List[Symbol]
 
-        /** Get all non-private methods declared or inherited */
+        /** Gets all non-private methods declared or inherited. */
         def methodMembers: List[Symbol]
 
-        /** Get non-private named type defined directly inside the class */
+        /** Gets non-private named type defined directly inside the class. */
         def declaredType(name: String): List[Symbol]
 
-        /** Get all non-private types defined directly inside the class */
+        /** Gets all non-private types defined directly inside the class. */
         def declaredTypes: List[Symbol]
 
-        /** Type member with the given name directly declared in the class */
+        /** Type member with the given name directly declared in the class. */
         @deprecated("Use declaredType or typeMember", "3.1.0")
         def memberType(name: String): Symbol
 
-        /** Type member with the given name declared or inherited in the class */
+        /** Type member with the given name declared or inherited in the class. */
         def typeMember(name: String): Symbol
 
-        /** Type member directly declared in the class */
+        /** Type member directly declared in the class. */
         @deprecated("Use declaredTypes or typeMembers", "3.1.0")
         def memberTypes: List[Symbol]
 
-        /** Type member directly declared or inherited in the class */
+        /** Type member directly declared or inherited in the class. */
         def typeMembers: List[Symbol]
 
-        /** All members directly declared in the class */
+        /** All members directly declared in the class. */
         def declarations: List[Symbol]
 
         /** The symbols of each type parameter list and value parameter list of this
@@ -4455,10 +4455,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** The primary constructor of a class or trait, `noSymbol` if not applicable. */
         def primaryConstructor: Symbol
 
-        /** Fields of a case class type -- only the ones declared in primary constructor */
+        /** Fields of a case class type -- only the ones declared in primary constructor. */
         def caseFields: List[Symbol]
 
-        /** Is this the symbol of a type parameter */
+        /** Is this the symbol of a type parameter. */
         def isTypeParam: Boolean
 
         /** Variance flags for of this type parameter.
@@ -4468,16 +4468,16 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          */
         def paramVariance: Flags
 
-        /** Signature of this definition */
+        /** Signature of this definition. */
         def signature: Signature
 
-        /** The class symbol of the companion module class */
+        /** The class symbol of the companion module class. */
         def moduleClass: Symbol
 
-        /** The symbol of the companion class */
+        /** The symbol of the companion class. */
         def companionClass: Symbol
 
-        /** The symbol of the companion module */
+        /** The symbol of the companion module. */
         def companionModule: Symbol
 
         /** Case class or case object children of a sealed trait or cases of an `enum`. */
@@ -4540,22 +4540,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     // SIGNATURES //
     ////////////////
 
-    /** The signature of a method */
+    /** The signature of a method. */
     type Signature <: AnyRef
 
-    /** Module object of `type Signature`  */
+    /** Module object of `type Signature`. */
     val Signature: SignatureModule
 
-    /** Methods of the module object `val Signature` */
+    /** Methods of the module object `val Signature`. */
     trait SignatureModule { this: Signature.type =>
       /** Matches the method signature and returns its parameters and result type. */
       def unapply(sig: Signature): (List[String | Int], String)
     }
 
-    /** Makes extension methods on `Signature` available without any imports */
+    /** Makes extension methods on `Signature` available without any imports. */
     given SignatureMethods: SignatureMethods
 
-    /** Extension methods of `Signature` */
+    /** Extension methods of `Signature`. */
     trait SignatureMethods {
       extension (self: Signature)
 
@@ -4568,7 +4568,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           */
         def paramSigs: List[String | Int]
 
-        /** The signature of the result type */
+        /** The signature of the result type. */
         def resultSig: String
 
       end extension
@@ -4578,10 +4578,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     // STANDARD DEFINITIONS //
     //////////////////////////
 
-    /** A value containing all standard definitions */
+    /** A value containing all standard definitions. */
     val defn: defnModule
 
-    /** Methods of the module object `val defn` */
+    /** Methods of the module object `val defn`. */
     trait defnModule { self: defn.type =>
 
       /** The module symbol of root package `_root_`. */
@@ -4602,7 +4602,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       /** The class symbol of core class `scala.Any`. */
       def AnyClass: Symbol
 
-      /** The class symbol of core trait `scala.Matchable` */
+      /** The class symbol of core trait `scala.Matchable`. */
       def MatchableClass: Symbol
 
       /** The class symbol of core class `scala.AnyVal`. */
@@ -4687,7 +4687,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       */
       def RepeatedParamClass: Symbol
 
-      /** The class symbol of class `scala.annotation.reflection.Repeated` */
+      /** The class symbol of class `scala.annotation.reflection.Repeated`. */
       def RepeatedAnnot: Symbol
 
       /** The class symbol of class `scala.Option`. */
@@ -4699,7 +4699,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       /** The module symbol of module `scala.Some`. */
       def SomeModule: Symbol
 
-      /** Function-like object that maps arity to symbols for classes `scala.Product` */
+      /** Function-like object that maps arity to symbols for classes `scala.Product`. */
       def ProductClass: Symbol
 
       /** Function-like object that maps arity to symbols for classes `scala.FunctionX`.
@@ -4740,7 +4740,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       */
       def TupleClass(arity: Int): Symbol
 
-      /** Returns `true` if `sym` is a `Tuple1`, `Tuple2`, ... `Tuple22` */
+      /** Returns `true` if `sym` is a `Tuple1`, `Tuple2`, ... `Tuple22`. */
       def isTupleClass(sym: Symbol): Boolean
 
       /** Contains Scala primitive value classes:
@@ -4773,16 +4773,16 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     //   FLAGS   //
     ///////////////
 
-    /** Flags of a Symbol */
+    /** Flags of a Symbol. */
     type Flags
 
-    /** Module object of `type Flags`  */
+    /** Module object of `type Flags`. */
     val Flags: FlagsModule
 
-    /** Methods of the module object `val Flags` */
+    /** Methods of the module object `val Flags`. */
     trait FlagsModule { this: Flags.type =>
 
-      /** Is this symbol `abstract` */
+      /** Is this symbol `abstract`. */
       def Abstract: Flags
 
       /** Is this an abstract override method?
@@ -4797,156 +4797,156 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def Artifact: Flags
 
-      /** Is this symbol `case` */
+      /** Is this symbol `case`. */
       def Case: Flags
 
-      /** Is this symbol a getter for case class parameter */
+      /** Is this symbol a getter for case class parameter. */
       def CaseAccessor: Flags
 
-      /** Is this symbol a type parameter marked as contravariant `-` */
+      /** Is this symbol a type parameter marked as contravariant `-`. */
       def Contravariant: Flags
 
-      /** Is this symbol a type parameter marked as covariant `+` */
+      /** Is this symbol a type parameter marked as covariant `+`. */
       def Covariant: Flags
 
-      /** Is a declared, but not defined member */
+      /** Is a declared, but not defined member. */
       def Deferred: Flags
 
-      /** The empty set of flags */
+      /** The empty set of flags. */
       def EmptyFlags: Flags
 
-      /** Is this symbol an enum */
+      /** Is this symbol an enum. */
       def Enum: Flags
 
-      /** Is this symbol `erased` */
+      /** Is this symbol `erased`. */
       def Erased: Flags
 
-      /** Is this symbol exported from provided instance */
+      /** Is this symbol exported from provided instance. */
       def Exported: Flags
 
-      /** Is this symbol a `def` defined in an `extension` */
+      /** Is this symbol a `def` defined in an `extension`. */
       def ExtensionMethod: Flags
 
-      /** Is this symbol a getter or a setter */
+      /** Is this symbol a getter or a setter. */
       def FieldAccessor: Flags
 
-      /** Is this symbol `final` */
+      /** Is this symbol `final`. */
       def Final: Flags
 
-      /** Is this symbol an inferable ("given") parameter */
+      /** Is this symbol an inferable ("given") parameter. */
       def Given: Flags
 
       /** Is this symbol a parameter with a default value? */
       def HasDefault: Flags
 
-      /** Is this symbol `implicit` */
+      /** Is this symbol `implicit`. */
       def Implicit: Flags
 
-      /** Is an infix method or type */
+      /** Is an infix method or type. */
       def Infix: Flags
 
-      /** Is this symbol `inline` */
+      /** Is this symbol `inline`. */
       def Inline: Flags
 
       /** Is this symbol invisible when typechecking? */
       def Invisible: Flags
 
-      /** Is this symbol defined in a Java class */
+      /** Is this symbol defined in a Java class. */
       def JavaDefined: Flags
 
-      /** Is implemented as a Java static */
+      /** Is implemented as a Java static. */
       def JavaStatic: Flags
 
-      /** Is this an annotation defined in Java */
+      /** Is this an annotation defined in Java. */
       def JavaAnnotation: Flags
 
-      /** Is this symbol `lazy` */
+      /** Is this symbol `lazy`. */
       def Lazy: Flags
 
-      /** Is this symbol local? Used in conjunction with private/private[T] to mean private[this] extends Modifier protected[this] */
+      /** Is this symbol local? Used in conjunction with private/private[T] to mean private[this] extends Modifier protected[this]. */
       def Local: Flags
 
-      /** Is this symbol marked as a macro. An inline method containing top level splices */
+      /** Is this symbol marked as a macro. An inline method containing top level splices. */
       def Macro: Flags
 
-      /** Is this symbol `def` */
+      /** Is this symbol `def`. */
       def Method: Flags
 
-      /** Is this symbol an object or its class (used for a ValDef or a ClassDef extends Modifier respectively) */
+      /** Is this symbol an object or its class (used for a ValDef or a ClassDef extends Modifier respectively). */
       def Module: Flags
 
-      /** Is this symbol a `var` (when used on a ValDef) */
+      /** Is this symbol a `var` (when used on a ValDef). */
       def Mutable: Flags
 
       /** Trait does not have fields or initialization code. */
       def NoInits: Flags
 
-      /** Is this symbol `opaque` */
+      /** Is this symbol `opaque`. */
       def Opaque: Flags
 
-      /** Is this symbol `open` */
+      /** Is this symbol `open`. */
       def Open: Flags
 
-      /** Is this symbol `override` */
+      /** Is this symbol `override`. */
       def Override: Flags
 
-      /** Is this symbol a package */
+      /** Is this symbol a package. */
       def Package: Flags
 
-      /** Is this symbol a parameter */
+      /** Is this symbol a parameter. */
       def Param: Flags
 
-      /** Is this symbol a parameter accessor */
+      /** Is this symbol a parameter accessor. */
       def ParamAccessor: Flags
 
-      /** Is this symbol `private` */
+      /** Is this symbol `private`. */
       def Private: Flags
 
-      /** Is this symbol labeled private[this] */
+      /** Is this symbol labeled private[this]. */
       def PrivateLocal: Flags
 
-      /** Is this symbol `protected` */
+      /** Is this symbol `protected`. */
       def Protected: Flags
 
-      /** Was this symbol imported from Scala2.x */
+      /** Was this symbol imported from Scala2.x. */
       def Scala2x: Flags
 
-      /** Is this symbol `sealed` */
+      /** Is this symbol `sealed`. */
       def Sealed: Flags
 
-      /** Is this symbol member that is assumed to be stable and realizable */
+      /** Is this symbol member that is assumed to be stable and realizable. */
       def StableRealizable: Flags
 
-      /** Is this symbol marked as static. Mapped to static Java member */
+      /** Is this symbol marked as static. Mapped to static Java member. */
       @deprecated("Use JavaStatic instead", "3.3.0") def Static: Flags
 
-      /** Is this symbol to be tagged Java Synthetic */
+      /** Is this symbol to be tagged Java Synthetic. */
       def Synthetic: Flags
 
-      /** Is this symbol a trait */
+      /** Is this symbol a trait. */
       def Trait: Flags
 
-      /** Is a transparent inline method or trait */
+      /** Is a transparent inline method or trait. */
       def Transparent: Flags
 
     }
 
-    /** Makes extension methods on `Flags` available without any imports */
+    /** Makes extension methods on `Flags` available without any imports. */
     given FlagsMethods: FlagsMethods
 
-    /** Extension methods of `Flags` */
+    /** Extension methods of `Flags`. */
     trait FlagsMethods {
       extension (self: Flags)
-        /** Is the given flag set a subset of this flag sets */
+        /** Is the given flag set a subset of this flag sets. */
         def is(that: Flags): Boolean
 
-        /** Union of the two flag sets */
+        /** Union of the two flag sets. */
         def |(that: Flags): Flags
 
-        /** Intersection of the two flag sets */
+        /** Intersection of the two flag sets. */
         def &(that: Flags): Flags
 
-        /** Shows the flags as a String */
+        /** Shows the flags as a String. */
         def show: String
 
       end extension
@@ -4958,81 +4958,81 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     ///////////////
 
 
-    /** Position in a source file */
+    /** Position in a source file. */
     type Position <: AnyRef
 
-    /** Module object of `type Position`  */
+    /** Module object of `type Position`. */
     val Position: PositionModule
 
-    /** Methods of the module object `val Position` */
+    /** Methods of the module object `val Position`. */
     trait PositionModule { this: Position.type =>
-      /** Position of the expansion site of the macro */
+      /** Position of the expansion site of the macro. */
       def ofMacroExpansion: Position
 
-      /** Create a new position in the source with the given range. The range must be contained in the file. */
+      /** Creates a new position in the source with the given range. The range must be contained in the file. */
       def apply(sourceFile: SourceFile, start: Int, end: Int): Position
     }
 
-    /** Makes extension methods on `Position` available without any imports */
+    /** Makes extension methods on `Position` available without any imports. */
     given PositionMethods: PositionMethods
 
-    /** Extension methods of `Position` */
+    /** Extension methods of `Position`. */
     trait PositionMethods {
       extension (self: Position)
 
-        /** The start offset in the source file */
+        /** The start offset in the source file. */
         def start: Int
 
-        /** The end offset in the source file */
+        /** The end offset in the source file. */
         def end: Int
 
-        /** Source file in which this position is located */
+        /** Source file in which this position is located. */
         def sourceFile: SourceFile
 
-        /** The start line in the source file */
+        /** The start line in the source file. */
         def startLine: Int
 
-        /** The end line in the source file */
+        /** The end line in the source file. */
         def endLine: Int
 
-        /** The start column in the source file */
+        /** The start column in the source file. */
         def startColumn: Int
 
-        /** The end column in the source file */
+        /** The end column in the source file. */
         def endColumn: Int
 
-        /** Source code within the position */
+        /** Source code within the position. */
         def sourceCode: Option[String]
 
       end extension
     }
 
-    /** Scala source file */
+    /** Scala source file. */
     type SourceFile <: AnyRef
 
-    /** Module object of `type SourceFile`  */
+    /** Module object of `type SourceFile`. */
     val SourceFile: SourceFileModule
 
-    /** Methods of the module object `val SourceFile` */
+    /** Methods of the module object `val SourceFile`. */
     trait SourceFileModule { this: SourceFile.type =>
       /** Returns the source file being compiled. The path is relative to the current working directory. */
       def current: SourceFile
     }
 
-    /** Makes extension methods on `SourceFile` available without any imports */
+    /** Makes extension methods on `SourceFile` available without any imports. */
     given SourceFileMethods: SourceFileMethods
 
-    /** Extension methods of `SourceFile` */
+    /** Extension methods of `SourceFile`. */
     trait SourceFileMethods {
       extension (self: SourceFile)
-        /** Path to this source file. May be `null` for virtual files such as in the REPL.  */
+        /** Path to this source file. May be `null` for virtual files such as in the REPL. */
         @deprecated("Use getJPath, name, or path instead of jpath", "3.0.2")
         def jpath: java.nio.file.Path
 
         /** Path to this source file. May be `None` for virtual files such as in the REPL. */
         def getJPath: Option[java.nio.file.Path]
 
-        /** Name of the source file */
+        /** Name of the source file. */
         def name: String
 
         /** Path of the source file.
@@ -5042,7 +5042,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          */
         def path: String
 
-        /** Content of this source file */
+        /** Content of this source file. */
         def content: Option[String]
       end extension
     }
@@ -5054,55 +5054,55 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Module containing error and warning reporting. */
     val report: reportModule
 
-    /** Methods of the module object `val report` */
+    /** Methods of the module object `val report`. */
     trait reportModule { self: report.type =>
 
-      /** Report an error at the position of the macro expansion */
+      /** Report an error at the position of the macro expansion. */
       def error(msg: String): Unit
 
-      /** Report an error at the position of `expr` */
+      /** Report an error at the position of `expr`. */
       def error(msg: String, expr: Expr[Any]): Unit
 
-      /** Report an error message at the given position */
+      /** Report an error message at the given position. */
       def error(msg: String, pos: Position): Unit
 
-      /** Report an error at the position of the macro expansion and throw a StopMacroExpansion */
+      /** Report an error at the position of the macro expansion and throw a StopMacroExpansion. */
       def errorAndAbort(msg: String): Nothing
 
-      /** Report an error at the position of `expr` and throw a StopMacroExpansion */
+      /** Report an error at the position of `expr` and throw a StopMacroExpansion. */
       def errorAndAbort(msg: String, expr: Expr[Any]): Nothing
 
-      /** Report an error message at the given position and throw a StopMacroExpansion */
+      /** Report an error message at the given position and throw a StopMacroExpansion. */
       def errorAndAbort(msg: String, pos: Position): Nothing
 
-      /** Report an error at the position of the macro expansion and throw a StopMacroExpansion */
+      /** Report an error at the position of the macro expansion and throw a StopMacroExpansion. */
       @deprecated("Use errorAndAbort", "3.1.0")
       def throwError(msg: String): Nothing
 
-      /** Report an error at the position of `expr` and throw a StopMacroExpansion */
+      /** Report an error at the position of `expr` and throw a StopMacroExpansion. */
       @deprecated("Use errorAndAbort", "3.1.0")
       def throwError(msg: String, expr: Expr[Any]): Nothing
 
-      /** Report an error message at the given position and throw a StopMacroExpansion */
+      /** Report an error message at the given position and throw a StopMacroExpansion. */
       @deprecated("Use errorAndAbort", "3.1.0")
       def throwError(msg: String, pos: Position): Nothing
 
-      /** Report a warning at the position of the macro expansion */
+      /** Report a warning at the position of the macro expansion. */
       def warning(msg: String): Unit
 
-      /** Report a warning at the position of `expr` */
+      /** Report a warning at the position of `expr`. */
       def warning(msg: String, expr: Expr[Any]): Unit
 
-      /** Report a warning message at the given position */
+      /** Report a warning message at the given position. */
       def warning(msg: String, pos: Position): Unit
 
-      /** Report an info at the position of the macro expansion */
+      /** Report an info at the position of the macro expansion. */
       def info(msg: String): Unit
 
-      /** Report an info message at the position of `expr` */
+      /** Report an info message at the position of `expr`. */
       def info(msg: String, expr: Expr[Any]): Unit
 
-      /** Report an info message at the given position */
+      /** Report an info message at the given position. */
       def info(msg: String, pos: Position): Unit
 
     }
@@ -5450,19 +5450,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     end TreeMap
 
-    /** Type class used in `show` methods to provide customizable `String` representations */
+    /** Type class used in `show` methods to provide customizable `String` representations. */
     trait Printer[T]:
-      /** Show the arguments as a `String` */
+      /** Shows the arguments as a `String`. */
       def show(x: T): String
     end Printer
 
-    /** Default pinter for `Tree` used when calling `tree.show` */
+    /** Default pinter for `Tree` used when calling `tree.show`. */
     given TreePrinter: Printer[Tree] = Printer.TreeCode
 
-    /** Default pinter for `TypeRepr` used when calling `tpe.show` */
+    /** Default pinter for `TypeRepr` used when calling `tpe.show`. */
     given TypeReprPrinter: Printer[TypeRepr] = Printer.TypeReprCode
 
-    /** Default pinter for `Constant` used when calling `const.show` */
+    /** Default pinter for `Constant` used when calling `const.show`. */
     given ConstantPrinter: Printer[Constant] = Printer.ConstantCode
 
     /** Module object of `type Printer`.
@@ -5470,7 +5470,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     val Printer: PrinterModule
 
-    /** Methods of the module object `val Printer` */
+    /** Methods of the module object `val Printer`. */
     trait PrinterModule { self: Printer.type =>
       /** Prints fully elaborated version of the source code. */
       def TreeCode: Printer[Tree]

--- a/library/src/scala/quoted/ToExpr.scala
+++ b/library/src/scala/quoted/ToExpr.scala
@@ -9,80 +9,80 @@ import scala.reflect.ClassTag
  */
 trait ToExpr[T] {
 
-  /** Lift a value into an expression containing the construction of that value */
+  /** Lift a value into an expression containing the construction of that value. */
   def apply(x: T)(using Quotes): Expr[T]
 
 }
 
-/** Default given instances of `ToExpr` */
+/** Default given instances of `ToExpr`. */
 object ToExpr {
 
   // IMPORTANT Keep in sync with tests/run-staging/liftables.scala
 
-  /** Default implementation of `ToExpr[Boolean]` */
+  /** Default implementation of `ToExpr[Boolean]`. */
   given BooleanToExpr[T <: Boolean]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(BooleanConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[Byte]` */
+  /** Default implementation of `ToExpr[Byte]`. */
   given ByteToExpr[T <: Byte]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(ByteConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[Short]` */
+  /** Default implementation of `ToExpr[Short]`. */
   given ShortToExpr[T <: Short]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(ShortConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[Int]` */
+  /** Default implementation of `ToExpr[Int]`. */
   given IntToExpr[T <: Int]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(IntConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[Long]` */
+  /** Default implementation of `ToExpr[Long]`. */
   given LongToExpr[T <: Long]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(LongConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[Float]` */
+  /** Default implementation of `ToExpr[Float]`. */
   given FloatToExpr[T <: Float]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(FloatConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[Double]` */
+  /** Default implementation of `ToExpr[Double]`. */
   given DoubleToExpr[T <: Double]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(DoubleConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[Char]` */
+  /** Default implementation of `ToExpr[Char]`. */
   given CharToExpr[T <: Char]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(CharConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[String]` */
+  /** Default implementation of `ToExpr[String]`. */
   given StringToExpr[T <: String]: ToExpr[T] with {
     def apply(x: T)(using Quotes) =
       import quotes.reflect.*
       Literal(StringConstant(x)).asExpr.asInstanceOf[Expr[T]]
   }
 
-  /** Default implementation of `ToExpr[Class[T]]` */
+  /** Default implementation of `ToExpr[Class[T]]`. */
   given ClassToExpr[T <: Class[?]]: ToExpr[T] with {
     def apply(x: T)(using Quotes) = {
       import quotes.reflect.*
@@ -90,111 +90,111 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[ClassTag[T]]` */
+  /** Default implementation of `ToExpr[ClassTag[T]]`. */
   given ClassTagToExpr[T: Type]: ToExpr[ClassTag[T]] with {
     def apply(ct: ClassTag[T])(using Quotes): Expr[ClassTag[T]] =
       '{ ClassTag[T](${Expr(ct.runtimeClass.asInstanceOf[Class[T]])}) }
   }
 
-  /** Default implementation of `ToExpr[Array[T]]` */
+  /** Default implementation of `ToExpr[Array[T]]`. */
   given ArrayToExpr[T: Type: ToExpr: ClassTag]: ToExpr[Array[T]] with {
     def apply(arr: Array[T])(using Quotes): Expr[Array[T]] =
       '{ Array[T](${Expr(arr.toSeq)}*)(using ${Expr(summon[ClassTag[T]])}) }
   }
 
-  /** Default implementation of `ToExpr[Array[Boolean]]` */
+  /** Default implementation of `ToExpr[Array[Boolean]]`. */
   given ArrayOfBooleanToExpr: ToExpr[Array[Boolean]] with {
     def apply(array: Array[Boolean])(using Quotes): Expr[Array[Boolean]] =
       if (array.length == 0) '{ Array.emptyBooleanArray }
       else '{ Array(${Expr(array(0))}, ${Expr(array.toSeq.tail)}*) }
   }
 
-  /** Default implementation of `ToExpr[Array[Byte]]` */
+  /** Default implementation of `ToExpr[Array[Byte]]`. */
   given ArrayOfByteToExpr: ToExpr[Array[Byte]] with {
     def apply(array: Array[Byte])(using Quotes): Expr[Array[Byte]] =
       if (array.length == 0) '{ Array.emptyByteArray }
       else '{ Array(${Expr(array(0))}, ${Expr(array.toSeq.tail)}*) }
   }
 
-  /** Default implementation of `ToExpr[Array[Short]]` */
+  /** Default implementation of `ToExpr[Array[Short]]`. */
   given ArrayOfShortToExpr: ToExpr[Array[Short]] with {
     def apply(array: Array[Short])(using Quotes): Expr[Array[Short]] =
       if (array.length == 0) '{ Array.emptyShortArray }
       else '{ Array(${Expr(array(0))}, ${Expr(array.toSeq.tail)}*) }
   }
 
-  /** Default implementation of `ToExpr[Array[Char]]` */
+  /** Default implementation of `ToExpr[Array[Char]]`. */
   given ArrayOfCharToExpr: ToExpr[Array[Char]] with {
     def apply(array: Array[Char])(using Quotes): Expr[Array[Char]] =
       if (array.length == 0) '{ Array.emptyCharArray }
       else '{ Array(${Expr(array(0))}, ${Expr(array.toSeq.tail)}*) }
   }
 
-  /** Default implementation of `ToExpr[Array[Int]]` */
+  /** Default implementation of `ToExpr[Array[Int]]`. */
   given ArrayOfIntToExpr: ToExpr[Array[Int]] with {
     def apply(array: Array[Int])(using Quotes): Expr[Array[Int]] =
       if (array.length == 0) '{ Array.emptyIntArray }
       else '{ Array(${Expr(array(0))}, ${Expr(array.toSeq.tail)}*) }
   }
 
-  /** Default implementation of `ToExpr[Array[Long]]` */
+  /** Default implementation of `ToExpr[Array[Long]]`. */
   given ArrayOfLongToExpr: ToExpr[Array[Long]] with {
     def apply(array: Array[Long])(using Quotes): Expr[Array[Long]] =
       if (array.length == 0) '{ Array.emptyLongArray }
       else '{ Array(${Expr(array(0))}, ${Expr(array.toSeq.tail)}*) }
   }
 
-  /** Default implementation of `ToExpr[Array[Float]]` */
+  /** Default implementation of `ToExpr[Array[Float]]`. */
   given ArrayOfFloatToExpr: ToExpr[Array[Float]] with {
     def apply(array: Array[Float])(using Quotes): Expr[Array[Float]] =
       if (array.length == 0) '{ Array.emptyFloatArray }
       else '{ Array(${Expr(array(0))}, ${Expr(array.toSeq.tail)}*) }
   }
 
-  /** Default implementation of `ToExpr[Array[Double]]` */
+  /** Default implementation of `ToExpr[Array[Double]]`. */
   given ArrayOfDoubleToExpr: ToExpr[Array[Double]] with {
     def apply(array: Array[Double])(using Quotes): Expr[Array[Double]] =
       if (array.length == 0) '{ Array.emptyDoubleArray }
       else '{ Array(${Expr(array(0))}, ${Expr(array.toSeq.tail)}*) }
   }
 
-  /** Default implementation of `ToExpr[IArray[T]]` */
+  /** Default implementation of `ToExpr[IArray[T]]`. */
   given IArrayToExpr[T: Type](using ltArray: ToExpr[Array[T]]): ToExpr[IArray[T]] with {
     def apply(iarray: IArray[T])(using Quotes): Expr[IArray[T]] =
       '{ ${ltArray.apply(iarray.asInstanceOf[Array[T]])}.asInstanceOf[IArray[T]] }
   }
 
-  /** Default implementation of `ToExpr[Seq[T]]` */
+  /** Default implementation of `ToExpr[Seq[T]]`. */
   given SeqToExpr[T: Type: ToExpr]: ToExpr[Seq[T]] with {
     def apply(xs: Seq[T])(using Quotes): Expr[Seq[T]] =
       Expr.ofSeq(xs.map(summon[ToExpr[T]].apply))
   }
 
-  /** Default implementation of `ToExpr[List[T]]` */
+  /** Default implementation of `ToExpr[List[T]]`. */
   given ListToExpr[T: Type: ToExpr]: ToExpr[List[T]] with {
     def apply(xs: List[T])(using Quotes): Expr[List[T]] =
       Expr.ofList(xs.map(summon[ToExpr[T]].apply))
   }
 
-  /** Default implementation of `ToExpr[Nil.type]` */
+  /** Default implementation of `ToExpr[Nil.type]`. */
   given NilToExpr: ToExpr[Nil.type] with {
     def apply(xs: Nil.type)(using Quotes): Expr[Nil.type] =
       '{ Nil }
   }
 
-  /** Default implementation of `ToExpr[Set[T]]` */
+  /** Default implementation of `ToExpr[Set[T]]`. */
   given SetToExpr[T: Type: ToExpr]: ToExpr[Set[T]] with {
     def apply(set: Set[T])(using Quotes): Expr[Set[T]] =
       '{ Set(${Expr(set.toSeq)}*) }
   }
 
-  /** Default implementation of `ToExpr[Map[T, U]]` */
+  /** Default implementation of `ToExpr[Map[T, U]]`. */
   given MapToExpr[T: Type: ToExpr, U: Type: ToExpr]: ToExpr[Map[T, U]] with {
     def apply(map: Map[T, U])(using Quotes): Expr[Map[T, U]] =
     '{ Map(${Expr(map.toSeq)}*) }
   }
 
-  /** Default implementation of `ToExpr[Option[T]]` */
+  /** Default implementation of `ToExpr[Option[T]]`. */
   given OptionToExpr[T: Type: ToExpr]: ToExpr[Option[T]] with {
     def apply(x: Option[T])(using Quotes): Expr[Option[T]] = x match {
       case x: Some[T] => Expr(x)
@@ -202,68 +202,68 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Some[T]]` */
+  /** Default implementation of `ToExpr[Some[T]]`. */
   given SomeToExpr[T: Type: ToExpr]: ToExpr[Some[T]] with {
     def apply(x: Some[T])(using Quotes): Expr[Some[T]] =
       '{ Some[T](${Expr(x.get)}) }
   }
 
-  /** Default implementation of `ToExpr[None.type]` */
+  /** Default implementation of `ToExpr[None.type]`. */
   given NoneToExpr: ToExpr[None.type] with {
     def apply(x: None.type)(using Quotes): Expr[None.type] =
       '{ None }
   }
 
-  /** Default implementation of `ToExpr[Either[L, R]]` */
+  /** Default implementation of `ToExpr[Either[L, R]]`. */
   given EitherToExpr[L: Type: ToExpr, R: Type: ToExpr]: ToExpr[Either[L, R]] with {
     def apply(x: Either[L, R])(using Quotes): Expr[Either[L, R]] = x match
       case x: Left[L, R] => Expr(x)
       case x: Right[L, R] => Expr(x)
   }
 
-  /** Default implementation of `ToExpr[Left[L, R]]` */
+  /** Default implementation of `ToExpr[Left[L, R]]`. */
   given LeftToExpr[L: Type: ToExpr, R: Type]: ToExpr[Left[L, R]] with {
     def apply(x: Left[L, R])(using Quotes): Expr[Left[L, R]] =
       '{ Left[L, R](${Expr(x.value)}) }
   }
 
-  /** Default implementation of `ToExpr[Right[L, R]]` */
+  /** Default implementation of `ToExpr[Right[L, R]]`. */
   given RightToExpr[L: Type, R: Type: ToExpr]: ToExpr[Right[L, R]] with {
     def apply(x: Right[L, R])(using Quotes): Expr[Right[L, R]] =
       '{ Right[L, R](${Expr(x.value)}) }
   }
 
-  /** Default implementation of `ToExpr[EmptyTuple.type]` */
+  /** Default implementation of `ToExpr[EmptyTuple.type]`. */
   given EmptyTupleToExpr: ToExpr[EmptyTuple.type] with {
     def apply(tup: EmptyTuple.type)(using Quotes) =
       '{ EmptyTuple }
   }
 
-  /** Default implementation of `ToExpr[Tuple1[T1]]` */
+  /** Default implementation of `ToExpr[Tuple1[T1]]`. */
   given Tuple1ToExpr[T1: Type: ToExpr]: ToExpr[Tuple1[T1]] with {
     def apply(tup: Tuple1[T1])(using Quotes) =
       '{ Tuple1(${Expr(tup._1)}) }
   }
 
-  /** Default implementation of `ToExpr[Tuple2[T1, T2]]` */
+  /** Default implementation of `ToExpr[Tuple2[T1, T2]]`. */
   given Tuple2ToExpr[T1: Type: ToExpr, T2: Type: ToExpr]: ToExpr[Tuple2[T1, T2]] with {
     def apply(tup: Tuple2[T1, T2])(using Quotes) =
       '{ (${Expr(tup._1)}, ${Expr(tup._2)}) }
   }
 
-  /** Default implementation of `ToExpr[Tuple3[T1, T2, T3]]` */
+  /** Default implementation of `ToExpr[Tuple3[T1, T2, T3]]`. */
   given Tuple3ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr]: ToExpr[Tuple3[T1, T2, T3]] with {
     def apply(tup: Tuple3[T1, T2, T3])(using Quotes) =
       '{ (${Expr(tup._1)}, ${Expr(tup._2)}, ${Expr(tup._3)}) }
   }
 
-  /** Default implementation of `ToExpr[Tuple4[T1, T2, T3, T4]]` */
+  /** Default implementation of `ToExpr[Tuple4[T1, T2, T3, T4]]`. */
   given Tuple4ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr]: ToExpr[Tuple4[T1, T2, T3, T4]] with {
     def apply(tup: Tuple4[T1, T2, T3, T4])(using Quotes) =
       '{ (${Expr(tup._1)}, ${Expr(tup._2)}, ${Expr(tup._3)}, ${Expr(tup._4)}) }
   }
 
-  /** Default implementation of `ToExpr[Tuple5[T1, T2, T3, T4, T5]]` */
+  /** Default implementation of `ToExpr[Tuple5[T1, T2, T3, T4, T5]]`. */
   given Tuple5ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr]: ToExpr[Tuple5[T1, T2, T3, T4, T5]] with {
     def apply(tup: Tuple5[T1, T2, T3, T4, T5])(using Quotes) = {
       val (x1, x2, x3, x4, x5) = tup
@@ -271,7 +271,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple6[T1, T2, T3, T4, T5, T6]]` */
+  /** Default implementation of `ToExpr[Tuple6[T1, T2, T3, T4, T5, T6]]`. */
   given Tuple6ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr]: ToExpr[Tuple6[T1, T2, T3, T4, T5, T6]] with {
     def apply(tup: Tuple6[T1, T2, T3, T4, T5, T6])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6) = tup
@@ -279,7 +279,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple7[T1, T2, T3, T4, T5, T6, T7]]` */
+  /** Default implementation of `ToExpr[Tuple7[T1, T2, T3, T4, T5, T6, T7]]`. */
   given Tuple7ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr]: ToExpr[Tuple7[T1, T2, T3, T4, T5, T6, T7]] with {
     def apply(tup: Tuple7[T1, T2, T3, T4, T5, T6, T7])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7) = tup
@@ -287,7 +287,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]]` */
+  /** Default implementation of `ToExpr[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]]`. */
   given Tuple8ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr]: ToExpr[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]] with {
     def apply(tup: Tuple8[T1, T2, T3, T4, T5, T6, T7, T8])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8) = tup
@@ -295,7 +295,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]` */
+  /** Default implementation of `ToExpr[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]`. */
   given Tuple9ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr]: ToExpr[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] with {
     def apply(tup: Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9) = tup
@@ -303,7 +303,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]]` */
+  /** Default implementation of `ToExpr[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]]`. */
   given Tuple10ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr]: ToExpr[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] with {
     def apply(tup: Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) = tup
@@ -311,7 +311,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]]` */
+  /** Default implementation of `ToExpr[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]]`. */
   given Tuple11ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr]: ToExpr[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] with {
     def apply(tup: Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) = tup
@@ -319,7 +319,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]]` */
+  /** Default implementation of `ToExpr[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]]`. */
   given Tuple12ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr]: ToExpr[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] with {
     def apply(tup: Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) = tup
@@ -327,7 +327,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]]` */
+  /** Default implementation of `ToExpr[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]]`. */
   given Tuple13ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr]: ToExpr[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] with {
     def apply(tup: Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) = tup
@@ -335,7 +335,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]]` */
+  /** Default implementation of `ToExpr[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]]`. */
   given Tuple14ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr]: ToExpr[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] with {
     def apply(tup: Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) = tup
@@ -343,7 +343,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]]` */
+  /** Default implementation of `ToExpr[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]]`. */
   given Tuple15ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr, T15: Type: ToExpr]: ToExpr[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] with {
     def apply(tup: Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) = tup
@@ -351,7 +351,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]]` */
+  /** Default implementation of `ToExpr[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]]`. */
   given Tuple16ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr, T15: Type: ToExpr, T16: Type: ToExpr]: ToExpr[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] with {
     def apply(tup: Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) = tup
@@ -359,7 +359,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]]` */
+  /** Default implementation of `ToExpr[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]]`. */
   given Tuple17ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr, T15: Type: ToExpr, T16: Type: ToExpr, T17: Type: ToExpr]: ToExpr[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] with {
     def apply(tup: Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17) = tup
@@ -367,7 +367,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]]` */
+  /** Default implementation of `ToExpr[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]]`. */
   given Tuple18ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr, T15: Type: ToExpr, T16: Type: ToExpr, T17: Type: ToExpr, T18: Type: ToExpr]: ToExpr[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] with {
     def apply(tup: Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18) = tup
@@ -375,7 +375,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]]` */
+  /** Default implementation of `ToExpr[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]]`. */
   given Tuple19ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr, T15: Type: ToExpr, T16: Type: ToExpr, T17: Type: ToExpr, T18: Type: ToExpr, T19: Type: ToExpr]: ToExpr[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]] with {
     def apply(tup: Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19) = tup
@@ -383,7 +383,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]]` */
+  /** Default implementation of `ToExpr[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]]`. */
   given Tuple20ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr, T15: Type: ToExpr, T16: Type: ToExpr, T17: Type: ToExpr, T18: Type: ToExpr, T19: Type: ToExpr, T20: Type: ToExpr]: ToExpr[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]] with {
     def apply(tup: Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20) = tup
@@ -391,7 +391,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]]` */
+  /** Default implementation of `ToExpr[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]]`. */
   given Tuple21ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr, T15: Type: ToExpr, T16: Type: ToExpr, T17: Type: ToExpr, T18: Type: ToExpr, T19: Type: ToExpr, T20: Type: ToExpr, T21: Type: ToExpr]: ToExpr[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]] with {
     def apply(tup: Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21) = tup
@@ -399,7 +399,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]]` */
+  /** Default implementation of `ToExpr[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]]`. */
   given Tuple22ToExpr[T1: Type: ToExpr, T2: Type: ToExpr, T3: Type: ToExpr, T4: Type: ToExpr, T5: Type: ToExpr, T6: Type: ToExpr, T7: Type: ToExpr, T8: Type: ToExpr, T9: Type: ToExpr, T10: Type: ToExpr, T11: Type: ToExpr, T12: Type: ToExpr, T13: Type: ToExpr, T14: Type: ToExpr, T15: Type: ToExpr, T16: Type: ToExpr, T17: Type: ToExpr, T18: Type: ToExpr, T19: Type: ToExpr, T20: Type: ToExpr, T21: Type: ToExpr, T22: Type: ToExpr]: ToExpr[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]] with {
     def apply(tup: Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22])(using Quotes) = {
       val (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22) = tup
@@ -407,7 +407,7 @@ object ToExpr {
     }
   }
 
-  /** Default implementation of `ToExpr[H *: T]` */
+  /** Default implementation of `ToExpr[H *: T]`. */
   given TupleConsToExpr [H: Type: ToExpr, T <: Tuple: Type: ToExpr]: ToExpr[H *: T] with {
     def apply(tup: H *: T)(using Quotes): Expr[H *: T] =
       val head = Expr[H](tup.head)
@@ -415,20 +415,20 @@ object ToExpr {
       '{ $head *: $tail }
   }
 
-  /** Default implementation of `ToExpr[BigInt]` */
+  /** Default implementation of `ToExpr[BigInt]`. */
   given BigIntToExpr: ToExpr[BigInt] with {
     def apply(x: BigInt)(using Quotes): Expr[BigInt] =
       '{ BigInt(${Expr(x.toByteArray)}) }
   }
 
-  /** Default implementation of `ToExpr[BigDecimal using the default MathContext]` */
+  /** Default implementation of `ToExpr[BigDecimal using the default MathContext]`. */
   given BigDecimalToExpr: ToExpr[BigDecimal] with {
     def apply(x: BigDecimal)(using Quotes): Expr[BigDecimal] =
       val bigDecimal: String = "" + x // workaround "method toString in class BigDecimal does not take parameters" in scaladoc/generateScalaDocumentation
       '{ BigDecimal(${Expr(bigDecimal)}) }
   }
 
-  /** Default implementation of `ToExpr[StringContext]` */
+  /** Default implementation of `ToExpr[StringContext]`. */
   given StringContextToExpr: ToExpr[StringContext] with {
     def apply(stringContext: StringContext)(using Quotes): Expr[StringContext] =
       val parts = Varargs(stringContext.parts.map(Expr(_)))

--- a/library/src/scala/quoted/Type.scala
+++ b/library/src/scala/quoted/Type.scala
@@ -4,28 +4,28 @@ import language.experimental.captureChecking
 
 import scala.annotation.{compileTimeOnly, experimental}
 
-/** Type (or type constructor) `T` needed contextually when using `T` in a quoted expression `'{... T ...}` */
+/** Type (or type constructor) `T` needed contextually when using `T` in a quoted expression `'{... T ...}`. */
 abstract class Type[T <: AnyKind] private[scala]:
-  /** The type represented by `Type` */
+  /** The type represented by `Type`. */
   type Underlying = T
 end Type
 
-/** Methods to interact with the current `Type[T]` in scope */
+/** Methods to interact with the current `Type[T]` in scope. */
 object Type:
 
-  /** Show a source code like representation of this type without syntax highlight */
+  /** Shows a source code like representation of this type without syntax highlight. */
   def show[T <: AnyKind](using Type[T])(using Quotes): String =
     import quotes.reflect.*
     TypeTree.of[T].show
 
-  /** Return a quoted.Type with the given type */
+  /** Returns a quoted.Type with the given type. */
   @compileTimeOnly("Reference to `scala.quoted.Type.of` was not handled by PickleQuotes")
   given of[T <: AnyKind](using Quotes): Type[T] = ???
 
 
   /** Extracts the value of a singleton constant type.
-   *  Returns Some of the value of the type if it is a singleton constant type.
-   *  Returns None if the type is not a singleton constant type.
+   *  Returns `Some` of the value of the type if it is a singleton constant type.
+   *  Returns `None` if the type is not a singleton constant type.
    *
    *  Example usage:
    *  ```scala
@@ -48,8 +48,8 @@ object Type:
     ValueOf.unapply(quotes.reflect.TypeRepr.of[T]).asInstanceOf[Option[T]]
 
   /** Extracts the value of a tuple of singleton constant types.
-   *  Returns Some of the tuple type if it is a tuple singleton constant types.
-   *  Returns None if the type is not a tuple singleton constant types.
+   *  Returns `Some` of the tuple type if it is a tuple singleton constant types.
+   *  Returns `None` if the type is not a tuple singleton constant types.
    *
    *  Example usage:
    *  ```scala

--- a/library/src/scala/quoted/Varargs.scala
+++ b/library/src/scala/quoted/Varargs.scala
@@ -34,7 +34,7 @@ object Varargs {
     Repeated(xs.map(_.asTerm).toList, TypeTree.of[T]).asExpr.asInstanceOf[Expr[Seq[T]]]
   }
 
-  /** Matches a literal sequence of expressions and return a sequence of expressions.
+  /** Matches a literal sequence of expressions and returns a sequence of expressions.
    *
    *  Usage:
    *  ```scala

--- a/library/src/scala/quoted/runtime/QuoteMatching.scala
+++ b/library/src/scala/quoted/runtime/QuoteMatching.scala
@@ -4,7 +4,7 @@ import language.experimental.captureChecking
 
 import scala.quoted.{Expr, Type}
 
-/** Part of the Quotes interface that needs to be implemented by the compiler but is not visible to users */
+/** Part of the `Quotes` interface that needs to be implemented by the compiler but is not visible to users. */
 trait QuoteMatching:
 
   val ExprMatch: ExprMatchModule

--- a/library/src/scala/quoted/runtime/QuoteUnpickler.scala
+++ b/library/src/scala/quoted/runtime/QuoteUnpickler.scala
@@ -4,7 +4,7 @@ import language.experimental.captureChecking
 
 import scala.quoted.{Quotes, Expr, Type}
 
-/** Part of the Quotes interface that needs to be implemented by the compiler but is not visible to users */
+/** Part of the `Quotes` interface that needs to be implemented by the compiler but is not visible to users. */
 trait QuoteUnpickler:
 
   /** Unpickle `repr` which represents a pickled `Expr` tree,

--- a/library/src/scala/quoted/runtime/StopMacroExpansion.scala
+++ b/library/src/scala/quoted/runtime/StopMacroExpansion.scala
@@ -2,7 +2,7 @@ package scala.quoted.runtime
 
 import language.experimental.captureChecking
 
-/** Throwable used to abort the expansion of a macro after an error was reported */
+/** Throwable used to abort the expansion of a macro after an error was reported. */
 class StopMacroExpansion extends Throwable:
 
   // Do not fill the stacktrace for performance.

--- a/library/src/scala/ref/Reference.scala
+++ b/library/src/scala/ref/Reference.scala
@@ -18,9 +18,9 @@ import scala.language.`2.13`
  * @see `java.lang.ref.Reference`
  */
 trait Reference[+T <: AnyRef] extends Function0[T] {
-  /** return the underlying value */
+  /** Returns the underlying value. */
   def apply(): T
-  /** return `Some` underlying if it hasn't been collected, otherwise `None` */
+  /** Returns `Some` underlying if it hasn't been collected, otherwise `None`. */
   def get: Option[T]
   override def toString(): String = get.map(_.toString).getOrElse("<deleted>")
   def clear(): Unit

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -26,10 +26,10 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T] | Null) e
  */
 object SoftReference {
 
-  /** Creates a `SoftReference` pointing to `value` */
+  /** Creates a `SoftReference` pointing to `value`. */
   def apply[T <: AnyRef](value: T): SoftReference[T] = new SoftReference(value)
 
-  /** Optionally returns the referenced value, or `None` if that value no longer exists */
+  /** Optionally returns the referenced value, or `None` if that value no longer exists. */
   def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)
 }
 

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -25,13 +25,13 @@ class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T] | Null) ext
     new WeakReferenceWithWrapper[T](value, queue, this)
 }
 
-/** An extractor for weak reference values */
+/** An extractor for weak reference values. */
 object WeakReference {
 
-  /** Creates a weak reference pointing to `value` */
+  /** Creates a weak reference pointing to `value`. */
   def apply[T <: AnyRef](value: T): WeakReference[T] = new WeakReference(value)
 
-  /** Optionally returns the referenced value, or `None` if that value no longer exists */
+  /** Optionally returns the referenced value, or `None` if that value no longer exists. */
   def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)
 }
 

--- a/library/src/scala/reflect/ClassTag.scala
+++ b/library/src/scala/reflect/ClassTag.scala
@@ -57,10 +57,10 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
    */
   def runtimeClass: jClass[?]
 
-  /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]` */
+  /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]`. */
   def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
 
-  /** Produces a new array with element type `T` and length `len` */
+  /** Produces a new array with element type `T` and length `len`. */
   def newArray(len: Int): Array[T] =
     java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
 

--- a/library/src/scala/reflect/Enum.scala
+++ b/library/src/scala/reflect/Enum.scala
@@ -2,8 +2,8 @@ package scala.reflect
 
 import language.experimental.captureChecking
 
-/** A base trait of all Scala enum definitions */
+/** A base trait of all Scala enum definitions. */
 transparent trait Enum extends Any, Product, Serializable:
 
-  /** A number uniquely identifying a case of an enum */
+  /** A number uniquely identifying a case of an enum. */
   def ordinal: Int

--- a/library/src/scala/reflect/NameTransformer.scala
+++ b/library/src/scala/reflect/NameTransformer.scala
@@ -63,7 +63,7 @@ object NameTransformer {
   enterOp('?', "$qmark")
   enterOp('@', "$at")
 
-  /** Replace operator symbols by corresponding `\$opname`.
+  /** Replaces operator symbols by corresponding `\$opname`.
    *
    *  @param name the string to encode
    *  @return     the string with all recognized opchars replaced with their encoding
@@ -97,7 +97,7 @@ object NameTransformer {
     if (buf eq null) name else buf.toString()
   }
 
-  /** Replace `\$opname` by corresponding operator symbol.
+  /** Replaces `\$opname` by corresponding operator symbol.
    *
    *  @param name0 the string to decode
    *  @return      the string with all recognized operator symbol encodings replaced with their name

--- a/library/src/scala/reflect/Selectable.scala
+++ b/library/src/scala/reflect/Selectable.scala
@@ -19,7 +19,7 @@ trait Selectable extends scala.Selectable:
   protected def selectedValue: Any = this
 
   // The Scala.js codegen relies on this method being final for correctness
-  /** Select member with given name */
+  /** Selects member with given name. */
   final def selectDynamic(name: String): Any =
     val rcls = selectedValue.getClass
     try
@@ -30,7 +30,7 @@ trait Selectable extends scala.Selectable:
       applyDynamic(name)()
 
   // The Scala.js codegen relies on this method being final for correctness
-  /** Select method and apply to arguments.
+  /** Selects method and applies to arguments.
    *  @param name       The name of the selected method
    *  @param paramTypes The class tags of the selected method's formal parameter types
    *  @param args       The arguments to pass to the selected method

--- a/library/src/scala/reflect/TypeTest.scala
+++ b/library/src/scala/reflect/TypeTest.scala
@@ -27,5 +27,5 @@ trait TypeTest[-S, T] extends Serializable:
 
 object TypeTest:
 
-  /** Trivial type test that always succeeds */
+  /** Trivial type test that always succeeds. */
   def identity[T]: TypeTest[T, T] = Some(_)

--- a/library/src/scala/reflect/package.scala
+++ b/library/src/scala/reflect/package.scala
@@ -52,7 +52,7 @@ package object reflect {
 
   def classTag[T](implicit ctag: ClassTag[T]) = ctag
 
-  /** Make a java reflection object accessible, if it is not already
+  /** Makes a java reflection object accessible, if it is not already
    *  and it is possible to do so. If a SecurityException is thrown in the
    *  attempt, it is caught and discarded.
    */

--- a/library/src/scala/runtime/Arrays.scala
+++ b/library/src/scala/runtime/Arrays.scala
@@ -20,14 +20,14 @@ object Arrays {
   def newGenericArray[T](length: Int)(implicit tag: ClassTag[T]): Array[T] =
     tag.newArray(length)
 
-  /** Convert a sequence to a Java array with element type given by `clazz`. */
+  /** Converts a sequence to a Java array with element type given by `clazz`. */
   def seqToArray[T](xs: Seq[T], clazz: Class[?]): Array[T] = {
     val arr = java.lang.reflect.Array.newInstance(clazz, xs.length).asInstanceOf[Array[T]]
     xs.copyToArray(arr)
     arr
   }
 
-  /** Create an array of a reference type T.
+  /** Creates an array of a reference type T.
    */
   def newArray[Arr](componentType: Class[?], @unused returnType: Class[Arr], dimensions: Array[Int]): Arr =
     jlr.Array.newInstance(componentType, dimensions*).asInstanceOf[Arr]

--- a/library/src/scala/runtime/FunctionXXL.scala
+++ b/library/src/scala/runtime/FunctionXXL.scala
@@ -5,7 +5,7 @@ import language.experimental.captureChecking
 /** A function with all parameters grouped in an array. */
 trait FunctionXXL {
 
-  /** Apply all parameters grouped in xs to this function. */
+  /** Applies all parameters grouped in xs to this function. */
   def apply(xs: IArray[Object]): Object
 
   override def toString() = "<functionXXL>"

--- a/library/src/scala/runtime/LambdaDeserializer.scala
+++ b/library/src/scala/runtime/LambdaDeserializer.scala
@@ -23,7 +23,7 @@ import java.lang.invoke._
  */
 object LambdaDeserializer {
   /**
-   * Deserialize a lambda by calling `LambdaMetafactory.altMetafactory` to spin up a lambda class
+   * Deserializes a lambda by calling `LambdaMetafactory.altMetafactory` to spin up a lambda class
    * and instantiating this class with the captured arguments.
    *
    * A cache may be provided to ensure that subsequent deserialization of the same lambda expression

--- a/library/src/scala/runtime/RichInt.scala
+++ b/library/src/scala/runtime/RichInt.scala
@@ -70,7 +70,7 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
     */
   def until(end: Int, step: Int): Range = Range(self, end, step)
 
-  /** like `until`, but includes the last index */
+  /** Like `until`, but includes the last index. */
   /**
     * @param end The final bound of the range to make.
     * @return A [[scala.collection.immutable.Range]] from `'''this'''` up to

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -38,7 +38,7 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Return the class object representing an array with element class `clazz`.
+  /** Returns the class object representing an array with element class `clazz`.
    */
   def arrayClass(clazz: jClass[?]): jClass[?] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
@@ -46,14 +46,14 @@ object ScalaRunTime {
     else java.lang.reflect.Array.newInstance(clazz, 0).getClass
   }
 
-  /** Return the class object representing an unboxed value type,
+  /** Returns the class object representing an unboxed value type,
    *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
    *  rewrites expressions like 5.getClass to come here.
    */
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
-  /** Retrieve generic array element */
+  /** Retrieves generic array element. */
   def array_apply(xs: AnyRef, idx: Int): Any = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
@@ -69,7 +69,7 @@ object ScalaRunTime {
     }
   }
 
-  /** update generic array element */
+  /** Updates generic array element. */
   def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
@@ -85,7 +85,7 @@ object ScalaRunTime {
     }
   }
 
-  /** Get generic array length */
+  /** Gets generic array length. */
   @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
@@ -103,7 +103,7 @@ object ScalaRunTime {
     case null => throw new NullPointerException
   }
 
-  /** Convert an array to an object array.
+  /** Converts an array to an object array.
    *  Needed to deal with vararg arguments of primitive types that are passed
    *  to a generic Java vararg parameter T ...
    */

--- a/library/src/scala/runtime/Statics.java
+++ b/library/src/scala/runtime/Statics.java
@@ -135,7 +135,7 @@ public final class Statics {
     return x.hashCode();
   }
 
-  /** Used as a marker object to return from PartialFunctions */
+  /** Used as a marker object to return from `PartialFunction`s. */
   public static final Object pfMarker = new Object();
 
   // @ForceInline would be nice here.

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -18,7 +18,7 @@ private[scala] object Predef:
     if !assertion then scala.runtime.Scala3RunTime.assertFailed()
 
   /**
-   * Retrieve the single value of a type with a unique inhabitant.
+   * Retrieves the single value of a type with a unique inhabitant.
    *
    * @example {{{
    * object Foo

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -256,27 +256,27 @@ private[scala] object language:
   @compileTimeOnly("`future-migration` can only be used at compile time in import statements")
   object `future-migration`
 
-  /** Set source version to 2.13. Effectively, this doesn't change the source language,
+  /** Sets source version to 2.13. Effectively, this doesn't change the source language,
    * but rather adapts the generated code as if it was compiled with Scala 2.13
    */
   @compileTimeOnly("`2.13` can only be used at compile time in import statements")
   private[scala] object `2.13`
 
-  /** Set source version to 3.0-migration.
+  /** Sets source version to 3.0-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.0-migration` can only be used at compile time in import statements")
   object `3.0-migration`
 
-  /** Set source version to 3.0.
+  /** Sets source version to 3.0.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.0` can only be used at compile time in import statements")
   object `3.0`
 
-  /** Set source version to 3.1-migration.
+  /** Sets source version to 3.1-migration.
     *
     * This is a no-op, and should not be used. A syntax error will be reported upon import.
     *
@@ -286,119 +286,119 @@ private[scala] object language:
   @deprecated("`3.1-migration` is not valid, use `3.1` instead", since = "3.2")
   object `3.1-migration`
 
-  /** Set source version to 3.1
+  /** Sets source version to 3.1
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.1` can only be used at compile time in import statements")
   object `3.1`
 
-  /** Set source version to 3.2-migration.
+  /** Sets source version to 3.2-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.2-migration` can only be used at compile time in import statements")
   object `3.2-migration`
 
-  /** Set source version to 3.2
+  /** Sets source version to 3.2
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.2` can only be used at compile time in import statements")
   object `3.2`
 
-  /** Set source version to 3.3-migration.
+  /** Sets source version to 3.3-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.3-migration` can only be used at compile time in import statements")
   object `3.3-migration`
 
-  /** Set source version to 3.3
+  /** Sets source version to 3.3
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.3` can only be used at compile time in import statements")
   object `3.3`
 
-  /** Set source version to 3.4-migration.
+  /** Sets source version to 3.4-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.4-migration` can only be used at compile time in import statements")
   object `3.4-migration`
 
-  /** Set source version to 3.4
+  /** Sets source version to 3.4
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.4` can only be used at compile time in import statements")
   object `3.4`
 
-  /** Set source version to 3.5-migration.
+  /** Sets source version to 3.5-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.5-migration` can only be used at compile time in import statements")
   object `3.5-migration`
 
-  /** Set source version to 3.5
+  /** Sets source version to 3.5
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.5` can only be used at compile time in import statements")
   object `3.5`
 
-  /** Set source version to 3.6-migration.
+  /** Sets source version to 3.6-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.6-migration` can only be used at compile time in import statements")
   object `3.6-migration`
 
-  /** Set source version to 3.6
+  /** Sets source version to 3.6
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.6` can only be used at compile time in import statements")
   object `3.6`
 
-  /** Set source version to 3.7-migration.
+  /** Sets source version to 3.7-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.7-migration` can only be used at compile time in import statements")
   object `3.7-migration`
 
-  /** Set source version to 3.7
+  /** Sets source version to 3.7
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.7` can only be used at compile time in import statements")
   object `3.7`
 
-  /** Set source version to 3.8-migration.
+  /** Sets source version to 3.8-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.8-migration` can only be used at compile time in import statements")
   object `3.8-migration`
 
-  /** Set source version to 3.8
+  /** Sets source version to 3.8
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.8` can only be used at compile time in import statements")
   object `3.8`
 
-  /** Set source version to 3.9-migration.
+  /** Sets source version to 3.9-migration.
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */
   @compileTimeOnly("`3.9-migration` can only be used at compile time in import statements")
   object `3.9-migration`
 
-  /** Set source version to 3.9
+  /** Sets source version to 3.9
     *
     * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
     */

--- a/library/src/scala/sys/PropImpl.scala
+++ b/library/src/scala/sys/PropImpl.scala
@@ -40,7 +40,7 @@ private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends P
   def option: Option[T] = if (isSet) Some(value) else None
   def or[T1 >: T](alt: => T1): T1 = if (isSet) value else alt
 
-  /** The underlying property map, in our case always sys.props */
+  /** The underlying property map, in our case always `sys.props`. */
   protected def underlying: mutable.Map[String, String | Null] = scala.sys.props
   protected def zero: T = null.asInstanceOf[T]
   private def getString = if (isSet) "currently: " + get else "unset"

--- a/library/src/scala/sys/package.scala
+++ b/library/src/scala/sys/package.scala
@@ -21,19 +21,19 @@ import scala.jdk.CollectionConverters._
  *  world outside of it.
  */
 package object sys {
-  /** Throw a new RuntimeException with the supplied message.
+  /** Throws a new RuntimeException with the supplied message.
    *
    *  @return   Nothing.
    */
   def error(message: String): Nothing = throw new RuntimeException(message)
 
-  /** Exit the JVM with the default status code.
+  /** Exits the JVM with the default status code.
    *
    *  @return   Nothing.
    */
   def exit(): Nothing = exit(0)
 
-  /** Exit the JVM with the given status code.
+  /** Exits the JVM with the given status code.
    *
    *  @return   Nothing.
    */
@@ -63,7 +63,7 @@ package object sys {
    *  If lookup fails, use `System.getenv(_)` for case-insensitive lookup
    *  on a certain platform. If that also fails, throw `NoSuchElementException`.
    *
-   *  @return   a Map containing the system environment variables.
+   *  @return   a `Map` containing the system environment variables.
    */
   def env: Map[String, String] = Map.from(System.getenv().asScala).withDefault { v =>
     val s = System.getenv(v)
@@ -71,7 +71,7 @@ package object sys {
     s
   }
 
-  /** Register a shutdown hook to be run when the VM exits.
+  /** Registers a shutdown hook to be run when the VM exits.
    *  The hook is automatically registered: the returned value can be ignored,
    *  but is available in case the Thread requires further modification.
    *  It can also be unregistered by calling ShutdownHookThread#remove().

--- a/library/src/scala/sys/process/BasicIO.scala
+++ b/library/src/scala/sys/process/BasicIO.scala
@@ -33,7 +33,7 @@ import scala.annotation.tailrec
   * features, but can also be used by client code.
   */
 object BasicIO {
-  /** Size of the buffer used in all the functions that copy data */
+  /** Size of the buffer used in all the functions that copy data. */
   final val BufferSize = 8192
 
   /** Used to separate lines in the `processFully` function that takes `Appendable`. */
@@ -132,7 +132,7 @@ object BasicIO {
   def apply(withIn: Boolean, buffer: Appendable, log: Option[ProcessLogger]) =
     new ProcessIO(input(withIn), processFully(buffer), getErr(log))
 
-  /** Creates a `ProcessIO` from a `ProcessLogger` . It can attach the
+  /** Creates a `ProcessIO` from a `ProcessLogger`. It can attach the
     * process input to stdin.
     *
     * @param withIn True if the process input should be attached to stdin.
@@ -161,7 +161,7 @@ object BasicIO {
   private def processErrFully(log: ProcessLogger) = processFully(log err _)
   private def processOutFully(log: ProcessLogger) = processFully(log out _)
 
-  /** Closes a `Closeable` without throwing an exception */
+  /** Closes a `Closeable` without throwing an exception. */
   def close(c: Closeable) = try c.close() catch { case _: IOException => () }
 
   /** Returns a function `InputStream => Unit` that appends all data read to the
@@ -215,7 +215,7 @@ object BasicIO {
     readFully()
   }
 
-  /** Copy contents of stdin to the `OutputStream`. */
+  /** Copies contents of stdin to the `OutputStream`. */
   def connectToIn(o: OutputStream): Unit = transferFully(Uncloseable protect stdin, o)
 
   /** Returns a function `OutputStream => Unit` that either reads the content
@@ -233,20 +233,20 @@ object BasicIO {
   /** Returns a `ProcessIO` connected to stdout and stderr, and, optionally, stdin. */
   def standard(connectInput: Boolean): ProcessIO = standard(input(connectInput))
 
-  /** Returns a `ProcessIO` connected to stdout, stderr and the provided `in` */
+  /** Returns a `ProcessIO` connected to stdout, stderr and the provided `in`. */
   def standard(in: OutputStream => Unit): ProcessIO = new ProcessIO(in, toStdOut, toStdErr)
 
-  /** Send all the input from the stream to stderr, and closes the input stream
+  /** Sends all the input from the stream to stderr, and closes the input stream
    * afterwards.
    */
   def toStdErr = (in: InputStream) => transferFully(in, stderr)
 
-  /** Send all the input from the stream to stdout, and closes the input stream
+  /** Sends all the input from the stream to stdout, and closes the input stream
    * afterwards.
    */
   def toStdOut = (in: InputStream) => transferFully(in, stdout)
 
-  /** Copy all input from the input stream to the output stream. Closes the
+  /** Copies all input from the input stream to the output stream. Closes the
     * input stream once it's all read.
     */
   def transferFully(in: InputStream, out: OutputStream): Unit =

--- a/library/src/scala/sys/process/Parser.scala
+++ b/library/src/scala/sys/process/Parser.scala
@@ -22,7 +22,7 @@ private[scala] object Parser {
   private final val SQ = '\''
   private final val EOF = -1
 
-  /** Split the line into tokens separated by whitespace or quotes.
+  /** Splits the line into tokens separated by whitespace or quotes.
    *
    *  @return either an error message or reverse list of tokens
    */

--- a/library/src/scala/sys/process/Process.scala
+++ b/library/src/scala/sys/process/Process.scala
@@ -35,7 +35,7 @@ import scala.language.implicitConversions
  *  @see [[scala.sys.process.ProcessBuilder]]
  */
 trait Process {
-  /** Returns this process alive status */
+  /** Returns this process alive status. */
   def isAlive(): Boolean
   /** Blocks until this process exits and returns the exit code.*/
   def exitValue(): Int
@@ -175,7 +175,7 @@ trait ProcessCreation {
   }
 }
 
-/** Provide implicit conversions for the factories offered by [[scala.sys.process.Process]]'s
+/** Provides implicit conversions for the factories offered by [[scala.sys.process.Process]]'s
   * companion object. These implicits can then be used to decrease the noise in a pipeline
   * of commands, making it look more shell-like. They are available through the package object
   * [[scala.sys.process]].
@@ -183,7 +183,7 @@ trait ProcessCreation {
 trait ProcessImplicits {
   import Process._
 
-  /** Return a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence
+  /** Returns a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence
     * of values for which an implicit conversion to `Source` is available.
     */
   implicit def buildersToProcess[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = applySeq(builders)

--- a/library/src/scala/sys/process/ProcessBuilder.scala
+++ b/library/src/scala/sys/process/ProcessBuilder.scala
@@ -164,160 +164,160 @@ trait ProcessBuilder extends Source with Sink {
   def !!<(log: ProcessLogger): String
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a LazyList that blocks when lines are not available but the process has not
+    * a `LazyList` that blocks when lines are not available but the process has not
     * completed.  Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the LazyList will provide all lines up to termination
+    * with a non-zero value, the `LazyList` will provide all lines up to termination
     * and then throw an exception.
     */
   def lazyLines: LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a LazyList that blocks when lines are not available but the process has not
+   * a `LazyList` that blocks when lines are not available but the process has not
    * completed.
    * The producer process will block if the given capacity of lines if filled
-   * without being consumed from the LazyList.
+   * without being consumed from the `LazyList`.
    * Standard error is sent to the console.  If the process exits
-   * with a non-zero value, the LazyList will provide all lines up to termination
+   * with a non-zero value, the `LazyList` will provide all lines up to termination
    * and then throw an exception.
    */
   def lazyLines(capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a LazyList that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided ProcessLogger.  If the
-    * process exits with a non-zero value, the LazyList will provide all lines up
+    * a `LazyList` that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided `ProcessLogger`.  If the
+    * process exits with a non-zero value, the `LazyList` will provide all lines up
     * to termination and then throw an exception.
     */
   def lazyLines(log: ProcessLogger): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a LazyList that blocks when lines are not available but the process has not
+   * a `LazyList` that blocks when lines are not available but the process has not
    * completed.
    * The producer process will block if the given capacity of lines if filled
-   * without being consumed from the LazyList.
-   * Standard error is sent to the provided ProcessLogger.  If the
-   * process exits with a non-zero value, the LazyList will provide all lines up
+   * without being consumed from the `LazyList`.
+   * Standard error is sent to the provided `ProcessLogger`.  If the
+   * process exits with a non-zero value, the `LazyList` will provide all lines up
    * to termination and then throw an exception.
    */
   def lazyLines(log: ProcessLogger, capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a LazyList that blocks when lines are not available but the process has not
+    * a `LazyList` that blocks when lines are not available but the process has not
     * completed.  Standard error is sent to the console. If the process exits
-    * with a non-zero value, the LazyList will provide all lines up to termination
+    * with a non-zero value, the `LazyList` will provide all lines up to termination
     * but will not throw an exception.
     */
   def lazyLines_! : LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a LazyList that blocks when lines are not available but the process has not
+   * a `LazyList` that blocks when lines are not available but the process has not
    * completed.
    * The producer process will block if the given capacity of lines if filled
    * without being consumed from the stream.
    * Standard error is sent to the console. If the process exits
-   * with a non-zero value, the LazyList will provide all lines up to termination
+   * with a non-zero value, the `LazyList` will provide all lines up to termination
    * but will not throw an exception.
    */
   def lazyLines_!(capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a LazyList that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided ProcessLogger. If the
-    * process exits with a non-zero value, the LazyList will provide all lines up
+    * a `LazyList` that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided `ProcessLogger`. If the
+    * process exits with a non-zero value, the `LazyList` will provide all lines up
     * to termination but will not throw an exception.
     */
   def lazyLines_!(log: ProcessLogger): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a LazyList that blocks when lines are not available but the process has not
+   * a `LazyList` that blocks when lines are not available but the process has not
    * completed.
    * The producer process will block if the given capacity of lines if filled
    * without being consumed from the stream.
-   * Standard error is sent to the provided ProcessLogger. If the
-   * process exits with a non-zero value, the LazyList will provide all lines up
+   * Standard error is sent to the provided `ProcessLogger`. If the
+   * process exits with a non-zero value, the `LazyList` will provide all lines up
    * to termination but will not throw an exception.
    */
   def lazyLines_!(log: ProcessLogger, capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.  Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the Stream will provide all lines up to termination
+    * with a non-zero value, the `Stream` will provide all lines up to termination
     * and then throw an exception.
     */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream: Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.
     * The producer process will block if the given capacity of lines if filled
     * without being consumed from the stream.
     * Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the Stream will provide all lines up to termination
+    * with a non-zero value, the `Stream` will provide all lines up to termination
     * and then throw an exception.
     */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided ProcessLogger.  If the
-    * process exits with a non-zero value, the Stream will provide all lines up
+    * a `Stream` that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided `ProcessLogger`.  If the
+    * process exits with a non-zero value, the `Stream` will provide all lines up
     * to termination and then throw an exception.
     */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(log: ProcessLogger): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.
     * The producer process will block if the given capacity of lines if filled
     * without being consumed from the stream.
-    * Standard error is sent to the provided ProcessLogger.  If the
-    * process exits with a non-zero value, the Stream will provide all lines up
+    * Standard error is sent to the provided `ProcessLogger`.  If the
+    * process exits with a non-zero value, the `Stream` will provide all lines up
     * to termination and then throw an exception.
     */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(log: ProcessLogger, capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.  Standard error is sent to the console. If the process exits
-    * with a non-zero value, the Stream will provide all lines up to termination
+    * with a non-zero value, the `Stream` will provide all lines up to termination
     * but will not throw an exception.
     */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_! : Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.
     * The producer process will block if the given capacity of lines if filled
     * without being consumed from the stream.
     * Standard error is sent to the console. If the process exits
-    * with a non-zero value, the Stream will provide all lines up to termination
+    * with a non-zero value, the `Stream` will provide all lines up to termination
     * but will not throw an exception.
     */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_!(capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided ProcessLogger. If the
-    * process exits with a non-zero value, the Stream will provide all lines up
+    * a `Stream` that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided `ProcessLogger`. If the
+    * process exits with a non-zero value, the `Stream` will provide all lines up
     * to termination but will not throw an exception.
     */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_!(log: ProcessLogger): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.
     * The producer process will block if the given capacity of lines if filled
     * without being consumed from the stream.
-    * Standard error is sent to the provided ProcessLogger. If the
-    * process exits with a non-zero value, the Stream will provide all lines up
+    * Standard error is sent to the provided `ProcessLogger`. If the
+    * process exits with a non-zero value, the `Stream` will provide all lines up
     * to termination but will not throw an exception.
     */
   @deprecated("use lazyLines_!", since = "2.13.0")
@@ -394,7 +394,7 @@ trait ProcessBuilder extends Source with Sink {
   def ### (other: ProcessBuilder): ProcessBuilder
 
 
-  /** True if this command can be the target of a pipe.  */
+  /** True if this command can be the target of a pipe. */
   def canPipeTo: Boolean
 
   /** True if this command has an exit code which should be propagated to the
@@ -417,16 +417,16 @@ object ProcessBuilder extends ProcessBuilderImpl {
     * [[scala.sys.process.ProcessBuilder.Sink]] from a file.
     */
   trait FileBuilder extends Sink with Source {
-    /** Append the contents of a `java.io.File` to this file */
+    /** Appends the contents of a `java.io.File` to this file. */
     def #<<(f: File): ProcessBuilder
 
-    /** Append the contents from a `java.net.URL` to this file */
+    /** Appends the contents from a `java.net.URL` to this file. */
     def #<<(u: URL): ProcessBuilder
 
-    /** Append the contents of a `java.io.InputStream` to this file */
+    /** Appends the contents of a `java.io.InputStream` to this file. */
     def #<<(i: => InputStream): ProcessBuilder
 
-    /** Append the contents of a [[scala.sys.process.ProcessBuilder]] to this file */
+    /** Appends the contents of a [[scala.sys.process.ProcessBuilder]] to this file. */
     def #<<(p: ProcessBuilder): ProcessBuilder
   }
 

--- a/library/src/scala/sys/process/ProcessImpl.scala
+++ b/library/src/scala/sys/process/ProcessImpl.scala
@@ -120,7 +120,7 @@ private[process] trait ProcessImpl {
       )
     }
 
-    /** Start and block until the exit value is available and then return it in Some.  Return None if destroyed (use 'run')*/
+    /** Starts and blocks until the exit value is available and then returns it in Some.  Returns None if destroyed (use 'run'). */
     protected def runAndExitValue(): Option[Int]
 
     protected def runInterruptible[T](action: => T)(destroyImpl: => Unit): Option[T] = {

--- a/library/src/scala/sys/process/package.scala
+++ b/library/src/scala/sys/process/package.scala
@@ -210,11 +210,11 @@ import scala.language.`2.13`
     */
   @annotation.nowarn("msg=package object inheritance")
   object `package` extends ProcessImplicits {
-    /** The input stream of this process */
+    /** The input stream of this process. */
     def stdin: java.io.InputStream = java.lang.System.in
-    /** The output stream of this process */
+    /** The output stream of this process. */
     def stdout: java.io.PrintStream = java.lang.System.out
-    /** The error stream of this process */
+    /** The error stream of this process. */
     def stderr: java.io.PrintStream = java.lang.System.err
   }
   // private val shell: String => Array[String] =

--- a/library/src/scala/typeConstraints.scala
+++ b/library/src/scala/typeConstraints.scala
@@ -74,7 +74,7 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
   def substituteBoth[F[-_, +_]](ftf: F[To, From]): F[From, To]
   // = substituteCo[({type G[+T] = F[From, T]})#G](substituteContra[({type G[-T] = F[T, From})#G](ftf))
   // = substituteContra[({type G[-T] = F[T, To]})#G](substituteCo[({type G[+T] = F[From, T]})#G](ftf))
-  /** Substitute the `From` in the type `F[From]`, where `F` is $coCon, for `To`.
+  /** Substitutes the `From` in the type `F[From]`, where `F` is $coCon, for `To`.
     *
     *  Equivalent in power to each of [[substituteBoth]] and [[substituteContra]].
     *
@@ -87,7 +87,7 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     substituteBoth[G](ff)
   }
   // = substituteContra[({type G[-T] = F[T] => F[To]})#G](identity)(ff)
-  /** Substitute the `To` in the type `F[To]`, where `F` is $contraCon, for `From`.
+  /** Substitutes the `To` in the type `F[To]`, where `F` is $contraCon, for `From`.
     *
     *  Equivalent in power to each of [[substituteBoth]] and [[substituteCo]].
     *
@@ -117,7 +117,7 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     type G[+T] = C => T
     substituteCo[G](r)
   }
-  /** If `From <: To` and `C <: From`, then `C <: To` (subtyping is transitive) */
+  /** If `From <: To` and `C <: From`, then `C <: To` (subtyping is transitive). */
   def compose[C](r: C <:< From): C <:< To = {
     type G[+T] = C <:< T
     substituteCo[G](r)
@@ -126,7 +126,7 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     type G[-T] = T => C
     substituteContra[G](r)
   }
-  /** If `From <: To` and `To <: C`, then `From <: C` (subtyping is transitive) */
+  /** If `From <: To` and `To <: C`, then `From <: C` (subtyping is transitive). */
   def andThen[C](r: To <:< C): From <:< C = {
     type G[-T] = T <:< C
     substituteContra[G](r)
@@ -169,7 +169,7 @@ object <:< {
   implicit def refl[A]: A =:= A = singleton.asInstanceOf[A =:= A]
   // = new =:=[A, A] { override def substituteBoth[F[_, _]](faa: F[A, A]): F[A, A] = faa }
 
-  /** If `A <: B` and `B <: A`, then `A = B` (subtyping is antisymmetric) */
+  /** If `A <: B` and `B <: A`, then `A = B` (subtyping is antisymmetric). */
   def antisymm[A, B](implicit l: A <:< B, r: B <:< A): A =:= B = singleton.asInstanceOf[A =:= B]
   // = ??? (I don't think this is possible to implement "safely")
 }
@@ -218,18 +218,18 @@ sealed abstract class =:=[From, To] extends (From <:< To) with Serializable {
 
   /** @inheritdoc */ override def apply(f: From) = super.apply(f)
 
-  /** If `From = To` then `To = From` (equality is symmetric) */
+  /** If `From = To` then `To = From` (equality is symmetric). */
   def flip: To =:= From = {
     type G[T, F] = F =:= T
     substituteBoth[G](this)
   }
 
-  /** If `From = To` and `C = From`, then `C = To` (equality is transitive) */
+  /** If `From = To` and `C = From`, then `C = To` (equality is transitive). */
   def compose[C](r: C =:= From): C =:= To = {
     type G[T] = C =:= T
     substituteCo[G](r)
   }
-  /** If `From = To` and `To = C`, then `From = C` (equality is transitive) */
+  /** If `From = To` and `To = C`, then `From = C` (equality is transitive). */
   def andThen[C](r: To =:= C): From =:= C = {
     type G[T] = T =:= C
     substituteContra[G](r)

--- a/library/src/scala/util/CommandLineParser.scala
+++ b/library/src/scala/util/CommandLineParser.scala
@@ -2,16 +2,16 @@ package scala.util
 
 import language.experimental.captureChecking
 
-/** A utility object to support command line parsing for @main methods */
+/** A utility object to support command line parsing for @main methods. */
 object CommandLineParser {
 
-  /** An exception raised for an illegal command line
+  /** An exception raised for an illegal command line.
     *  @param idx  The index of the argument that's faulty (starting from 0)
     *  @param msg  The error message
     */
   class ParseError(val idx: Int, val msg: String) extends Exception
 
-  /** Parse command line argument `s`, which has index `n`, as a value of type `T`
+  /** Parses command line argument `s`, which has index `n`, as a value of type `T`.
    *  @throws ParseError if argument cannot be converted to type `T`.
    */
   def parseString[T](str: String, n: Int)(using fs: FromString[T]^): T = {
@@ -21,21 +21,21 @@ object CommandLineParser {
     }
   }
 
-  /** Parse `n`'th argument in `args` (counting from 0) as a value of type `T`
+  /** Parses `n`'th argument in `args` (counting from 0) as a value of type `T`.
    *  @throws ParseError if argument does not exist or cannot be converted to type `T`.
    */
   def parseArgument[T](args: Array[String], n: Int)(using fs: FromString[T]^): T =
     if n < args.length then parseString(args(n), n)
     else throw ParseError(n, "more arguments expected")
 
-  /** Parse all arguments from `n`'th one (counting from 0) as a list of values of type `T`
+  /** Parses all arguments from `n`'th one (counting from 0) as a list of values of type `T`.
    *  @throws ParseError if some of the arguments cannot be converted to type `T`.
    */
   def parseRemainingArguments[T](args: Array[String], n: Int)(using fs: FromString[T]^): List[T] =
     if n < args.length then parseString(args(n), n) :: parseRemainingArguments(args, n + 1)
     else Nil
 
-  /** Print error message explaining given ParserError */
+  /** Prints error message explaining given ParserError. */
   def showError(err: ParseError): Unit = {
     val where =
       if err.idx == 0 then ""
@@ -45,7 +45,7 @@ object CommandLineParser {
   }
 
   trait FromString[T] {
-    /** Can throw java.lang.IllegalArgumentException */
+    /** Can throw java.lang.IllegalArgumentException. */
     def fromString(s: String): T
 
     def fromStringOption(s: String): Option[T] =

--- a/library/src/scala/util/DynamicVariable.scala
+++ b/library/src/scala/util/DynamicVariable.scala
@@ -44,10 +44,10 @@ class DynamicVariable[T](init: T) {
     override def initialValue: T & AnyRef = init.asInstanceOf[T & AnyRef]
   }
 
-  /** Retrieve the current value */
+  /** Retrieves the current value. */
   def value: T = tl.get.asInstanceOf[T]
 
-  /** Set the value of the variable while executing the specified
+  /** Sets the value of the variable while executing the specified
     * thunk.
     *
     * @param newval The value to which to set the variable

--- a/library/src/scala/util/FromDigits.scala
+++ b/library/src/scala/util/FromDigits.scala
@@ -9,7 +9,7 @@ import language.experimental.captureChecking
  */
 trait FromDigits[T] {
 
-  /** Convert `digits` string to value of type `T`
+  /** Converts `digits` string to value of type `T`
    *  `digits` can contain
    *  - sign `+` or `-`
    *  - sequence of digits between 0 and 9
@@ -30,7 +30,7 @@ object FromDigits {
   trait WithRadix[T] extends FromDigits[T] {
     def fromDigits(digits: String): T = fromDigits(digits, 10)
 
-    /** Convert digits string with given radix to number of type `T`.
+    /** Converts digits string with given radix to number of type `T`.
      *  E.g. if radix is 16, digits `a..f` and `A..F` are also allowed.
      */
     def fromDigits(digits: String, radix: Int): T
@@ -52,7 +52,7 @@ object FromDigits {
    */
   abstract class FromDigitsException(msg: String) extends NumberFormatException(msg)
 
-  /** Thrown if value of result does not fit into result type's range */
+  /** Thrown if value of result does not fit into result type's range. */
   class NumberTooLarge(msg: String = "number too large") extends FromDigitsException(msg)
 
   /** Thrown in case of numeric underflow (e.g. a non-zero
@@ -60,10 +60,10 @@ object FromDigits {
    */
   class NumberTooSmall(msg: String = "number too small") extends FromDigitsException(msg)
 
-  /** Thrown if digit string is not legal for the given type */
+  /** Thrown if digit string is not legal for the given type. */
   class MalformedNumber(msg: String = "malformed number literal") extends FromDigitsException(msg)
 
-  /** Convert digits and radix to integer value (either int or Long)
+  /** Converts digits and radix to integer value (either int or Long)
    *  This is tricky because of the max negative value.
    *  Note: We cannot use java.lang.Integer.valueOf or java.lang.Long.valueOf
    *  since these do not handle unsigned hex numbers greater than the maximal value
@@ -98,7 +98,7 @@ object FromDigits {
     if (negated) -value else value
   }
 
-  /** Convert digit string to Int number
+  /** Converts digit string to Int number.
    *  @param digits            The string to convert
    *  @param radix             The radix
    *  @throws NumberTooLarge   if number does not fit within Int range
@@ -109,7 +109,7 @@ object FromDigits {
   def intFromDigits(digits: String, radix: Int = 10): Int =
     integerFromDigits(digits, radix, Int.MaxValue).toInt
 
-  /** Convert digit string to Long number
+  /** Converts digit string to Long number.
    *  @param digits            The string to convert
    *  @param radix             The radix
    *  @throws NumberTooLarge   if the resulting number does not fit within Long range
@@ -122,7 +122,7 @@ object FromDigits {
 
   @sharable private val zeroFloat = raw"-?[0.]+(?:[eE][+-]?[0-9]+)?[fFdD]?".r
 
-  /** Convert digit string to Float number
+  /** Converts digit string to Float number.
    *  @param digits            The string to convert
    *  @throws NumberTooLarge   if the resulting number is infinite
    *  @throws NumberTooSmall   if the resulting number is 0.0f, yet the digits
@@ -140,12 +140,12 @@ object FromDigits {
     x
   }
 
-  /** Convert digit string to Double number
+  /** Converts digit string to Double number.
    *  @param digits            The string to convert
    *  @throws NumberTooLarge   if the resulting number is infinite
    *  @throws NumberTooSmall   if the resulting number is 0.0d, yet the digits
    *                           string contains non-zero digits before the exponent.
-   *  @throws MalformedNumber  if digits is not a legal digit string for floating point numbers..
+   *  @throws MalformedNumber  if digits is not a legal digit string for floating point numbers.
    */
   def doubleFromDigits(digits: String): Double = {
     val x: Double =

--- a/library/src/scala/util/NotGiven.scala
+++ b/library/src/scala/util/NotGiven.scala
@@ -28,7 +28,7 @@ final class NotGiven[+T] private ()
 
 trait LowPriorityNotGiven {
 
-  /** A fallback method used to emulate negation in Scala 2 */
+  /** A fallback method used to emulate negation in Scala 2. */
   given default[T]: NotGiven[T] = NotGiven.value
 }
 object NotGiven extends LowPriorityNotGiven {
@@ -41,9 +41,9 @@ object NotGiven extends LowPriorityNotGiven {
    */
   def value: NotGiven[Nothing] = cachedValue
 
-  /** One of two ambiguous methods used to emulate negation in Scala 2 */
+  /** One of two ambiguous methods used to emulate negation in Scala 2. */
   given amb1[T](using ev: T): NotGiven[T] = ???
 
-  /** One of two ambiguous methods used to emulate negation in Scala 2 */
+  /** One of two ambiguous methods used to emulate negation in Scala 2. */
   given amb2[T](using ev: T): NotGiven[T] = ???
 }

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -32,10 +32,10 @@ private[scala] trait PropertiesTrait {
   protected def propCategory: String      // specializes the remainder of the values
   protected def pickJarBasedOn: Class[?]  // props file comes from jar containing this
 
-  /** The name of the properties file */
+  /** The name of the properties file. */
   protected val propFilename = "/" + propCategory + ".properties"
 
-  /** The loaded properties */
+  /** The loaded properties. */
   protected lazy val scalaProps: java.util.Properties = {
     val props = new java.util.Properties
     val stream = pickJarBasedOn.getResourceAsStream(propFilename)
@@ -134,7 +134,7 @@ private[scala] trait PropertiesTrait {
   lazy val isWin            = osName.startsWith("Windows")
   // See https://mail.openjdk.java.net/pipermail/macosx-port-dev/2012-November/005148.html for
   // the reason why we don't follow developer.apple.com/library/mac/#technotes/tn2002/tn2110.
-  /** Returns `true` iff the underlying operating system is a version of Apple Mac OSX.  */
+  /** Returns `true` iff the underlying operating system is a version of Apple Mac OSX. */
   lazy val isMac            = osName.startsWith("Mac OS X")
   /** Returns `true` iff the underlying operating system is a Linux distribution. */
   lazy val isLinux          = osName.startsWith("Linux")
@@ -147,7 +147,7 @@ private[scala] trait PropertiesTrait {
     case s      => "" == s || "true".equalsIgnoreCase(s)
   }
 
-  /** System.console.isTerminal, or just check for null console on JDK < 22 */
+  /** System.console.isTerminal, or just check for null console on JDK < 22. */
   private[scala] lazy val consoleIsTerminal: Boolean = {
     import scala.reflect.Selectable.reflectiveSelectable
     val console = System.console

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -37,18 +37,18 @@ import scala.math.Ordering
   * other libraries that cover this use case.
   */
 object Sorting {
-  /** Sort an array of Doubles using `java.util.Arrays.sort`. */
+  /** Sorts an array of Doubles using `java.util.Arrays.sort`. */
   def quickSort(a: Array[Double]): Unit = java.util.Arrays.sort(a)
 
-  /** Sort an array of Ints using `java.util.Arrays.sort`. */
+  /** Sorts an array of Ints using `java.util.Arrays.sort`. */
   def quickSort(a: Array[Int]): Unit    = java.util.Arrays.sort(a)
 
-  /** Sort an array of Floats using `java.util.Arrays.sort`. */
+  /** Sorts an array of Floats using `java.util.Arrays.sort`. */
   def quickSort(a: Array[Float]): Unit  = java.util.Arrays.sort(a)
 
   private final val qsortThreshold = 16
 
-  /** Sort array `a` with quicksort, using the Ordering on its elements.
+  /** Sorts array `a` with quicksort, using the Ordering on its elements.
     * This algorithm sorts in place, so no additional memory is used aside from
     * what might be required to box individual elements during comparison.
     */
@@ -251,11 +251,11 @@ object Sorting {
     case null => throw new NullPointerException
   }
 
-  /** Sort array `a` using the Ordering on its elements, preserving the original ordering where possible.
+  /** Sorts array `a` using the Ordering on its elements, preserving the original ordering where possible.
     * Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, 0, a.length)`. */
   @`inline` def stableSort[K: Ordering](a: Array[K]): Unit = stableSort(a, 0, a.length)
 
-  /** Sort array `a` or a part of it using the Ordering on its elements, preserving the original ordering where possible.
+  /** Sorts array `a` or a part of it using the Ordering on its elements, preserving the original ordering where possible.
     * Uses `java.util.Arrays.sort` unless `K` is a primitive type.
     *
     * @param a The array to sort
@@ -264,12 +264,12 @@ object Sorting {
     */
   def stableSort[K: Ordering](a: Array[K], from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
 
-  /** Sort array `a` using function `f` that computes the less-than relation for each element.
+  /** Sorts array `a` using function `f` that computes the less-than relation for each element.
     * Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`. */
   @`inline` def stableSort[K](a: Array[K], f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
-  /** Sort array `a` or a part of it using function `f` that computes the less-than relation for each element.
+  /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
     * Uses `java.util.Arrays.sort` unless `K` is a primitive type.
     *
     * @param a The array to sort

--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -39,7 +39,7 @@ object boundary:
   final class Break[T] private[boundary](val label: Label[T]^{}, val value: T)
   extends RuntimeException(
     /*message*/ null, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false):
-    /** Compare the given [[Label]] to the one this [[Break]] was constructed with. */
+    /** Compares the given [[Label]] to the one this [[Break]] was constructed with. */
     def isSameLabelAs(other: Label[T]) = label eq other
 
   object Break:

--- a/library/src/scala/util/control/Exception.scala
+++ b/library/src/scala/util/control/Exception.scala
@@ -30,7 +30,7 @@ import scala.language.implicitConversions
  *
  *  === Examples ===
  *
- *  Create a `Catch` which handles specified exceptions.
+ *  Creates a `Catch` which handles specified exceptions.
  *  {{{
  *  import scala.util.control.Exception._
  *  import java.net._
@@ -52,7 +52,7 @@ import scala.language.implicitConversions
  *  val x4: URL = failAsValue(classOf[MalformedURLException])(defaultUrl)(new URL("htt/xx"))
  *  }}}
  *
- *  Create a `Catch` which logs exceptions using `handling` and `by`.
+ *  Creates a `Catch` which logs exceptions using `handling` and `by`.
  *  {{{
  *  def log(t: Throwable): Unit = t.printStackTrace
  *
@@ -219,11 +219,11 @@ object Exception {
 
     protected val name = "Catch"
 
-    /** Create a new Catch with additional exception handling logic. */
+    /** Creates a new Catch with additional exception handling logic. */
     def or[U >: T](pf2: Catcher[U]): Catch[U] = new Catch(pf orElse pf2, fin, rethrow)
     def or[U >: T](other: Catch[U]): Catch[U] = or(other.pf)
 
-    /** Apply this catch logic to the supplied body. */
+    /** Applies this catch logic to the supplied body. */
     def apply[U >: T](body: => U): U =
       try body
       catch {
@@ -232,7 +232,7 @@ object Exception {
       }
       finally fin foreach (_.invoke())
 
-    /** Create a new Catch container from this object and the supplied finally body.
+    /** Creates a new Catch container from this object and the supplied finally body.
      *  @param body The additional logic to apply after all existing finally bodies
      */
     def andFinally(body: => Unit): Catch[T] = {
@@ -240,23 +240,23 @@ object Exception {
       new Catch(pf, Some(appendedFin), rethrow)
     }
 
-    /** Apply this catch logic to the supplied body, mapping the result
+    /** Applies this catch logic to the supplied body, mapping the result
      *  into `Option[T]` - `None` if any exception was caught, `Some(T)` otherwise.
      */
     def opt[U >: T](body: => U): Option[U] = toOption(Some(body))
 
-    /** Apply this catch logic to the supplied body, mapping the result
+    /** Applies this catch logic to the supplied body, mapping the result
      *  into `Either[Throwable, T]` - `Left(exception)` if an exception was caught,
      *  `Right(T)` otherwise.
      */
     def either[U >: T](body: => U): Either[Throwable, U] = toEither(Right(body))
 
-    /** Apply this catch logic to the supplied body, mapping the result
+    /** Applies this catch logic to the supplied body, mapping the result
      * into `Try[T]` - `Failure` if an exception was caught, `Success(T)` otherwise.
      */
     def withTry[U >: T](body: => U): scala.util.Try[U] = toTry(Success(body))
 
-    /** Create a `Catch` object with the same `isDefinedAt` logic as this one,
+    /** Creates a `Catch` object with the same `isDefinedAt` logic as this one,
       * but with the supplied `apply` method replacing the current one. */
     def withApply[U](f: Throwable => U): Catch[U] = {
       val pf2 = new Catcher[U] {
@@ -366,7 +366,7 @@ object Exception {
     catching(exceptions*) withApply (x => throw unwrap(x))
   }
 
-  /** Private **/
+  /** Private. */
   private def wouldMatch(x: Throwable, classes: scala.collection.Seq[Class[?]]): Boolean =
     classes exists (_.isAssignableFrom(x.getClass))
 

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -45,7 +45,7 @@ object NonFatal {
     case _ => true
   }
   /**
-   * Returns Some(t) if NonFatal(t) == true, otherwise None
+   * Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None`
    */
   def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
 }

--- a/library/src/scala/util/control/NonLocalReturns.scala
+++ b/library/src/scala/util/control/NonLocalReturns.scala
@@ -38,7 +38,7 @@ object NonLocalReturns {
   def throwReturn[T](result: T)(using returner: ReturnThrowable[? >: T]): Nothing =
     returner.throwReturn(result)
 
-  /** Enable nonlocal returns in `op`. */
+  /** Enables nonlocal returns in `op`. */
   @deprecated("Use scala.util.boundary instead", "3.3")
   def returning[T](op: ReturnThrowable[T] ?=> T): T = {
     val returner = new ReturnThrowable[T]

--- a/library/src/scala/util/control/TailCalls.scala
+++ b/library/src/scala/util/control/TailCalls.scala
@@ -106,7 +106,7 @@ object TailCalls {
    */
   def tailcall[A](rest: => TailRec[A]): TailRec[A] = Call(() => rest)
 
-  /** Return the final result from a tailcalling computation.
+  /** Returns the final result from a tailcalling computation.
    *  @param  `result` the result value
    *  @return a `TailRec` object representing a computation which immediately
    *          returns `result`

--- a/library/src/scala/util/hashing/MurmurHash3.scala
+++ b/library/src/scala/util/hashing/MurmurHash3.scala
@@ -82,7 +82,7 @@ private[hashing] class MurmurHash3 {
     }
   }
 
-  /** See the [[MurmurHash3.caseClassHash(x:Product,caseClassName:String)]] overload */
+  /** See the [[MurmurHash3.caseClassHash(x:Product,caseClassName:String)]] overload. */
   final def caseClassHash(x: Product, seed: Int, caseClassName: String | Null): Int = {
     val arr = x.productArity
     val aye = (if (caseClassName != null) caseClassName else x.productPrefix).hashCode
@@ -100,7 +100,7 @@ private[hashing] class MurmurHash3 {
   }
 
 
-  /** Compute the hash of a string */
+  /** Computes the hash of a string. */
   final def stringHash(str: String, seed: Int): Int = {
     var h = seed
     var i = 0
@@ -113,7 +113,7 @@ private[hashing] class MurmurHash3 {
     finalizeHash(h, str.length)
   }
 
-  /** Compute a hash that is symmetric in its arguments - that is a hash
+  /** Computes a hash that is symmetric in its arguments - that is a hash
    *  where the order of appearance of elements does not matter.
    *  This is useful for hashing sets, for example.
    */
@@ -136,7 +136,7 @@ private[hashing] class MurmurHash3 {
     finalizeHash(h, n)
   }
 
-  /** Compute a hash that depends on the order of its arguments. Potential range
+  /** Computes a hash that depends on the order of its arguments. Potential range
     * hashes are recognized to produce a hash that is compatible with rangeHash.
     */
   final def orderedHash(xs: IterableOnce[Any], seed: Int): Int = {
@@ -172,7 +172,7 @@ private[hashing] class MurmurHash3 {
 
   }
 
-  /** Compute the hash of an array. Potential range hashes are recognized to produce a
+  /** Computes the hash of an array. Potential range hashes are recognized to produce a
     * hash that is compatible with rangeHash.
     */
   final def arrayHash[@specialized T](a: Array[T], seed: Int): Int = {
@@ -209,14 +209,14 @@ private[hashing] class MurmurHash3 {
     }
   }
 
-  /** Compute the hash of a Range with at least 2 elements. Ranges with fewer
+  /** Computes the hash of a Range with at least 2 elements. Ranges with fewer
     * elements need to use seqHash instead. The `last` parameter must be the
     * actual last element produced by a Range, not the nominal `end`.
     */
   final def rangeHash(start: Int, step: Int, last: Int, seed: Int): Int =
     avalanche(mix(mix(mix(seed, start), step), last))
 
-  /** Compute the hash of a byte array. Faster than arrayHash, because
+  /** Computes the hash of a byte array. Faster than arrayHash, because
    *  it hashes 4 bytes at once. Note that the result is not compatible with
    *  arrayHash!
    */
@@ -251,7 +251,7 @@ private[hashing] class MurmurHash3 {
     finalizeHash(h, data.length)
   }
 
-  /** Compute the hash of an IndexedSeq. Potential range hashes are recognized to produce a
+  /** Computes the hash of an IndexedSeq. Potential range hashes are recognized to produce a
     * hash that is compatible with rangeHash.
     */
   final def indexedSeqHash(a: scala.collection.IndexedSeq[Any], seed: Int): Int = {
@@ -288,7 +288,7 @@ private[hashing] class MurmurHash3 {
     }
   }
 
-  /** Compute the hash of a List. Potential range hashes are recognized to produce a
+  /** Computes the hash of a List. Potential range hashes are recognized to produce a
     * hash that is compatible with rangeHash.
     */
   final def listHash(xs: scala.collection.immutable.List[?], seed: Int): Int = {
@@ -368,7 +368,7 @@ object MurmurHash3 extends MurmurHash3 {
   def productHash(x: Product): Int = caseClassHash(x, productSeed, null)
 
   /**
-   * Compute the `hashCode` of a case class instance. This method returns the same value as `x.hashCode`
+   * Computes the `hashCode` of a case class instance. This method returns the same value as `x.hashCode`
    * if `x` is an instance of a case class with the default, synthetic `hashCode`.
    *
    * This method can be used to implement case classes with a cached `hashCode`:

--- a/library/src/scala/util/matching/Regex.scala
+++ b/library/src/scala/util/matching/Regex.scala
@@ -346,7 +346,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
   //  @see UnanchoredRegex
   protected def runMatcher(m: Matcher): Boolean = m.matches()
 
-  /** Return all non-overlapping matches of this `Regex` in the given character
+  /** Returns all non-overlapping matches of this `Regex` in the given character
    *  sequence as a [[scala.util.matching.Regex.MatchIterator]],
    *  which is a special [[scala.collection.Iterator]] that returns the
    *  matched strings but can also be queried for more data about the last match,
@@ -387,7 +387,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    */
   def findAllIn(source: CharSequence): MatchIterator = new Regex.MatchIterator(source, this, groupNames)
 
-  /** Return all non-overlapping matches of this regexp in given character sequence as a
+  /** Returns all non-overlapping matches of this regexp in given character sequence as a
    *  [[scala.collection.Iterator]] of [[scala.util.matching.Regex.Match]].
    *
    *  @param source The text to match against.
@@ -405,7 +405,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     }
   }
 
-  /** Return an optional first matching string of this `Regex` in the given character sequence,
+  /** Returns an optional first matching string of this `Regex` in the given character sequence,
    *  or None if there is no match.
    *
    *  @param source The text to match against.
@@ -417,23 +417,23 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     if (m.find) Some(m.group) else None
   }
 
-  /** Return an optional first match of this `Regex` in the given character sequence,
-   *  or None if it does not exist.
+  /** Returns an optional first match of this `Regex` in the given character sequence,
+   *  or `None` if it does not exist.
    *
    *  If the match is successful, the [[scala.util.matching.Regex.Match]] can be queried for
    *  more data.
    *
    *  @param source The text to match against.
    *  @return       A [[scala.Option]] of [[scala.util.matching.Regex.Match]] of the first matching string in the text.
-   *  @example      {{{("""[a-z]""".r findFirstMatchIn "A simple example.") map (_.start) // returns Some(2), the index of the first match in the text}}}
+   *  @example      {{{("""[a-z]""".r findFirstMatchIn "A simple example.") map (_.start) // returns `Some(2)`, the index of the first match in the text}}}
    */
   def findFirstMatchIn(source: CharSequence): Option[Match] = {
     val m = pattern.matcher(source)
     if (m.find) Some(new Match(source, m, groupNames)) else None
   }
 
-  /** Return an optional match of this `Regex` at the beginning of the
-   *  given character sequence, or None if it matches no prefix
+  /** Returns an optional match of this `Regex` at the beginning of the
+   *  given character sequence, or `None` if it matches no prefix
    *  of the character sequence.
    *
    *  Unlike `findFirstIn`, this method will only return a match at
@@ -441,15 +441,15 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  @param source The text to match against.
    *  @return       A [[scala.Option]] of the matched prefix.
-   *  @example      {{{"""\p{Lower}""".r findPrefixOf "A simple example." // returns None, since the text does not begin with a lowercase letter}}}
+   *  @example      {{{"""\p{Lower}""".r findPrefixOf "A simple example." // returns `None`, since the text does not begin with a lowercase letter}}}
    */
   def findPrefixOf(source: CharSequence): Option[String] = {
     val m = pattern.matcher(source)
     if (m.lookingAt) Some(m.group) else None
   }
 
-  /** Return an optional match of this `Regex` at the beginning of the
-   *  given character sequence, or None if it matches no prefix
+  /** Returns an optional match of this `Regex` at the beginning of the
+   *  given character sequence, or `None` if it matches no prefix
    *  of the character sequence.
    *
    *  Unlike `findFirstMatchIn`, this method will only return a match at
@@ -457,7 +457,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  @param source The text to match against.
    *  @return       A [[scala.Option]] of the [[scala.util.matching.Regex.Match]] of the matched string.
-   *  @example      {{{"""\w+""".r findPrefixMatchOf "A simple example." map (_.after) // returns Some(" simple example.")}}}
+   *  @example      {{{"""\w+""".r findPrefixMatchOf "A simple example." map (_.after) // returns `Some(" simple example.")`}}}
    */
   def findPrefixMatchOf(source: CharSequence): Option[Match] = {
     val m = pattern.matcher(source)
@@ -565,7 +565,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
   def split(toSplit: CharSequence): Array[String] =
     pattern.split(toSplit)
 
-  /** Create a new Regex with the same pattern, but no requirement that
+  /** Creates a new Regex with the same pattern, but no requirement that
    *  the entire String matches in extractor patterns and [[Regex#matches]].
    *
    *  Normally, matching on `date` behaves as though the pattern were
@@ -595,7 +595,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
 
   def regex: String = pattern.pattern
 
-  /** The string defining the regular expression */
+  /** The string defining the regular expression. */
   override def toString(): String = regex
 }
 
@@ -621,10 +621,10 @@ object Regex {
     /** Basically, wraps a platform Matcher. */
     protected def matcher: Matcher
 
-    /** The source from which the match originated */
+    /** The source from which the match originated. */
     val source: CharSequence
 
-    /** The names of the groups, or an empty sequence if none defined */
+    /** The names of the groups, or an empty sequence if none defined. */
     @deprecated("groupNames does not include inline group names, and should not be used anymore", "2.13.7")
     val groupNames: Seq[String]
 
@@ -633,7 +633,7 @@ object Regex {
      */
     def groupCount: Int
 
-    /** The index of the first matched character, or -1 if nothing was matched */
+    /** The index of the first matched character, or -1 if nothing was matched. */
     def start: Int
 
     /** The index of the first matched character in group `i`,
@@ -814,7 +814,7 @@ object Regex {
     // 0 = not yet matched, 1 = matched, 2 = advanced to match, 3 = no more matches
     private var nextSeen = 0
 
-    /** Return true if `next` will find a match.
+    /** Returns true if `next` will find a match.
      *  As a side effect, advance the underlying matcher if necessary;
      *  queries about the current match data pertain to the underlying matcher.
      */
@@ -867,13 +867,13 @@ object Regex {
     /** The number of subgroups. */
     def groupCount: Int = { ensure() ; matcher.groupCount }
 
-    /** Convert to an iterator that yields MatchData elements instead of Strings. */
+    /** Converts to an iterator that yields MatchData elements instead of Strings. */
     def matchData: Iterator[Match] = new AbstractIterator[Match] {
       def hasNext = self.hasNext
       def next() = { self.next(); new Match(source, matcher, _groupNames).force }
     }
 
-    /** Convert to an iterator that yields MatchData elements instead of Strings and has replacement support. */
+    /** Converts to an iterator that yields MatchData elements instead of Strings and has replacement support. */
     private[matching] def replacementData = new AbstractIterator[Match] with Replacement {
       protected def matcher = self.matcher
       def hasNext = self.hasNext


### PR DESCRIPTION
The following style changes are made in this commit:

1. Use indicative mood (Returns, Builds, ... not imperative mood (Return, Build, ...).
2. Terminate initial sentence with a period.
3. Place code artifact names (for classes, methods, etc.) in backticks so they will render in code font.

Only doc comments are changed, and only to make the above style changes.

Reasoning: Indicative mood is recommended over imperative mood by the Scaladoc Style Guide:

https://docs.scala-lang.org/style/scaladoc.html

Which says: Document what the method does do not what the method should do. In other words, say “returns the result of applying f to x” rather than “return the result of applying f to x”. Subtle, but important.

It is also what maybe 60% of Scaladoc comments in the standard library does, so this PR makes that consistent. It is also the way doc comments are written in Javadoc for the Java standard library. It is essentially writing the docoumentation as if you are explaining to a user (Returns something...) rather than an implementor (Return something...).

The terminating period is also used some of the time, but not always, in the existing doc comments for the standard library> This makes it consistent. Some phrases are not full sentences, but you can think of the subject as "implicit." "Returns true" means "This method returns true." Also if you have a bullet list where some of the items are complete sentences, and others not, the style guide (Chicago Manual of Style) I go by suggests putting periods after all items. And the Java standard library documentation seems to do this. 

A few spots are missed in this PR, which I jotted down as I reviewed *every* changed file. But it hits most of them, so I'm hoping we can merge this into main and I can do further cleanup in later PRs.