### PR TITLE
Unused lint ignores args to ctor of enclosing class

### DIFF
--- a/tests/warn/i24698.scala
+++ b/tests/warn/i24698.scala
@@ -1,0 +1,22 @@
+//> using options -Wunused:all
+
+trait TC[X] {
+  def notTrivial: Int
+}
+
+class C[T: TC]() { // warn implicit TC used only for new instance of owner
+  def mod: C[T] = new C
+}
+
+class D(val i: Int):
+  def this(s: String) = this(s.toInt) // not new
+
+class E[T](tc: TC[T]): // warn
+  def mod: E[T] = new E(tc)
+
+class F[T: TC](i: Int): // warn // warn
+  def mod: F[T] = new F(i)
+
+class G(i: Int): // warn
+  class Inner(i: Int):
+    def g = new G(i)


### PR DESCRIPTION
Fixes #24698

In `new C(x)` where `x` is a param accessor and the ctor parameter is also `x`, don't take the reference to `x` as a "usage".
