### PR TITLE
Remove old `-Yno-stdlib-patches` option

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1239,7 +1239,6 @@ object Build {
       // Add the source directories for the stdlib (non-boostrapped)
       Compile / unmanagedSourceDirectories := Seq(baseDirectory.value / "src"),
       Compile / unmanagedSourceDirectories += baseDirectory.value / "src-non-bootstrapped",
-      Compile / compile / scalacOptions += "-Yno-stdlib-patches",
       Compile / compile / scalacOptions ++= Seq(
         // Needed so that the library sources are visible when `dotty.tools.dotc.core.Definitions#init` is called
         "-sourcepath", (Compile / sourceDirectories).value.map(_.getCanonicalPath).distinct.mkString(File.pathSeparator),


### PR DESCRIPTION
This avoids the following warning:

```
[warn] bad option '-Yno-stdlib-patches' was ignored
```