### PR TITLE
Update `StringOps.*` implementation

### DIFF
--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -638,20 +638,13 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     else s.substring(start, end)
   }
 
-  // Note: String.repeat is added in JDK 11.
   /** Returns the current string concatenated `n` times.
    */
   def *(n: Int): String =
     if (n <= 0) {
       ""
     } else {
-      val sb = new JStringBuilder(s.length * n)
-      var i = 0
-      while (i < n) {
-        sb.append(s)
-        i += 1
-      }
-      sb.toString
+      s.repeat(n)
     }
 
   @inline private def isLineBreak(c: Char) = c == CR || c == LF


### PR DESCRIPTION
- https://github.com/xuwei-k/string-repeat-benchmark/commit/330544d5527beeb2cf95f6edd1919fe0012c05ee
- https://github.com/xuwei-k/string-repeat-benchmark/actions/runs/20405673816/job/58635011105#step:5:374
- https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#repeat(int)

```
[info] Benchmark     (size)   Mode  Cnt           Score        Error  Units
[info] Main.newImpl       1  thrpt   10  1606571321.905 ± 992031.056  ops/s
[info] Main.newImpl      10  thrpt   10    43216576.705 ±  29480.044  ops/s
[info] Main.newImpl     100  thrpt   10    23027077.051 ±  87609.285  ops/s
[info] Main.newImpl    1000  thrpt   10     3877430.815 ±  56856.895  ops/s
[info] Main.oldImpl       1  thrpt   10    80238683.180 ± 230581.751  ops/s
[info] Main.oldImpl      10  thrpt   10    39374657.631 ± 118702.198  ops/s
[info] Main.oldImpl     100  thrpt   10     5530021.313 ±  15677.695  ops/s
[info] Main.oldImpl    1000  thrpt   10      525098.038 ±   1315.209  ops/s
```