### PR TITLE
Backport "Parameter name can be masked in import" to 3.8.0

### DIFF
--- a/tests/warn/i24633.scala
+++ b/tests/warn/i24633.scala
@@ -1,0 +1,20 @@
+//> using options -Werror -Wunused:imports
+
+object foo {
+  val min = 0
+  val max = 1
+}
+
+def test(max: Int) = {
+  import foo.{max as _, *}
+  s"$min - $max"
+}
+
+def local =
+  val max = 42
+  import foo.{max as _, *}
+  s"$min - $max"
+
+class Limit(max: Int):
+  import foo.{max as _, *}
+  def test = s"$min - $max"


### PR DESCRIPTION
Backports #24635 to the 3.8.0-RC4.

PR submitted by the release tooling.
[skip ci]