### PR TITLE
Backport "Move into to preview in the language reference" to 3.8.0

### DIFF
--- a/docs/_docs/reference/preview/into.md
+++ b/docs/_docs/reference/preview/into.md
@@ -2,14 +2,10 @@
 layout: doc-page
 title: The `into` Type and Modifier
 redirectFrom: /docs/reference/other-new-features/into.html
-nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/into.html
+nightlyOf: https://docs.scala-lang.org/scala3/reference/preview/into.html
 ---
 
-This feature is not yet part of the Scala 3 language definition. It can be made available by a language import:
-
-```scala
-import scala.language.experimental.into
-```
+This feature is available as a preview since Scala 3.8.0.
 
 
 ## Summary

--- a/docs/_docs/reference/preview/overview.md
+++ b/docs/_docs/reference/preview/overview.md
@@ -21,4 +21,4 @@ This flag enables the use of all preview language feature in the project.
 
 ## List of available preview features
 
-Currently there are no available preview features.
+* [The `into` Type and Modifier](into.md)

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -141,6 +141,8 @@ subsection:
   - title: Preview Features
     directory: preview
     index: reference/preview/overview.md
+    subsection:
+      - page: reference/preview/into.md
   - title: Experimental Features
     directory: experimental
     index: reference/experimental/overview.md
@@ -157,7 +159,6 @@ subsection:
       - page: reference/experimental/numeric-literals.md
       - page: reference/experimental/explicit-nulls.md
       - page: reference/experimental/main-annotation.md
-      - page: reference/experimental/into.md
       - title: Capture Checking
         index: reference/experimental/capture-checking/cc.md
         subsection:


### PR DESCRIPTION
Backports #24704 to the 3.8.0-RC4.

PR submitted by the release tooling.
[skip ci]