### PR TITLE
Backport "Fix #24440: Do not check public flexible types on artifact symbols or inside anonymous classes" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1203,6 +1203,7 @@ object RefChecks {
   def checkPublicFlexibleTypes(sym: Symbol)(using Context): Unit =
     if ctx.explicitNulls && !ctx.isJava
         && sym.exists && sym.owner.isClass
+        && !sym.owner.isAnonymousClass
         && !sym.isOneOf(JavaOrPrivateOrSynthetic | InlineProxy | Param | Exported) then
       val resTp = sym.info.finalResultType
       if resTp.existsPart(_.isInstanceOf[FlexibleType], StopAt.Static) then

--- a/tests/explicit-nulls/pos/i24440.scala
+++ b/tests/explicit-nulls/pos/i24440.scala
@@ -9,3 +9,9 @@ trait AwtComponentLogging extends java.awt.Component:
   private def superPS1 = super.getPreferredSize
 
   private val superPS2 = super.getPreferredSize
+
+class Test:
+  def getCompoment: java.awt.Component =
+    new java.awt.Component {
+      override def getPreferredSize = super.getPreferredSize
+    }


### PR DESCRIPTION
Backports #24471 to the 3.8.0-RC4.

PR submitted by the release tooling.
[skip ci]