### PR TITLE
Backport "Update to new wildcard syntax in library scaladoc" to 3.8.0

### DIFF
--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -113,8 +113,8 @@ object Predef extends LowPriorityImplicits {
    * the class literal `T.class` in Java.
    *
    * @example {{{
-   * val listClass = classOf[List[_]]
-   * // listClass is java.lang.Class[List[_]] = class scala.collection.immutable.List
+   * val listClass = classOf[List[?]]
+   * // listClass is java.lang.Class[List[?]] = class scala.collection.immutable.List
    *
    * val mapIntString = classOf[Map[Int,String]]
    * // mapIntString is java.lang.Class[Map[Int,String]] = interface scala.collection.immutable.Map

--- a/library/src/scala/Selectable.scala
+++ b/library/src/scala/Selectable.scala
@@ -18,7 +18,7 @@ import language.experimental.captureChecking
  *  list of `java.lang.Class` arguments, i.e. it may alternatively have the
  *  signature
  *  {{{
- *    def applyDynamic(name: String, paramClasses: Class[_]*)(args: Any*): Any
+ *    def applyDynamic(name: String, paramClasses: Class[?]*)(args: Any*): Any
  *  }}}
  *  In this case the call will synthesize `Class` arguments for the erasure of
  *  all formal parameter types of the method in the structural type.
@@ -41,7 +41,7 @@ object Selectable:
    *  that precise parameter types are not needed for method dispatch. That is,
    *  a class inheriting from this trait and implementing
    *  {{{
-   *     def applyDynamic(name: String, paramTypes: Class[_]*)(args: Any*)
+   *     def applyDynamic(name: String, paramTypes: Class[?]*)(args: Any*)
    *  }}}
    *  should dispatch to a method with the given `name` without having to rely
    *  on the precise `paramTypes`. Subtypes of `WithoutPreciseParameterTypes`

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -167,8 +167,8 @@ object language {
    *  types of methods. If `existentials` is not enabled, those cases will trigger
    *  a warning from the compiler.
    *
-   *  Existential types with wildcard type syntax such as `List[_]`,
-   *  or `Map[String, _]` are not affected.
+   *  Existential types with wildcard type syntax such as `List[?]`,
+   *  or `Map[String, ?]` are not affected.
    *
    *  '''Why keep the feature?''' Existential types are needed to make sense of Java’s wildcard
    *  types and raw types and the erased types of run-time values.

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -2268,7 +2268,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     end TypeBoundsTreeMethods
 
     /** Type tree representing wildcard type bounds written in the source.
-    *  The wildcard type `_` (for example in in `List[_]`) will be a type tree that
+    *  The wildcard type `?` (for example in in `List[?]`) will be a type tree that
     *  represents a type but has `TypeBounds` inside.
     */
     type WildcardTypeTree <: Tree


### PR DESCRIPTION
Backports #24751 to the 3.8.0-RC4.

PR submitted by the release tooling.
[skip ci]