### PR TITLE
[build] Ensure that `scala3-library` artifacts are empty

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1538,9 +1538,10 @@ object Build {
       scalaCompilerBridgeBinaryJar := {
         val lm = dependencyResolution.value
         val log = streams.value.log
-        val retrieveDir = streams.value.cacheDirectory / "scala3-sbt-bridge" / referenceVersion
+        val version = scalaVersion.value
+        val retrieveDir = streams.value.cacheDirectory / "scala3-sbt-bridge" / version
         val comp = lm.retrieve("org.scala-lang" % "scala3-sbt-bridge" %
-          referenceVersion, scalaModuleInfo = None, retrieveDir, log)
+          version, scalaModuleInfo = None, retrieveDir, log)
           .fold(w => throw w.resolveException, identity)
         Some(comp(0))
       },


### PR DESCRIPTION


* Added task to validate that produced `.jar`, `-sources.jar`, `-javadoc.jar` are effectively empty (contain only META-INF, no .class, .tasty, .sjsir .html, etc) 
* Don't delegate `scala3-library-bootstrapepd` and `scala3-library-sjs` for `doc` tasks to `scala-library-bootstrapped` tasks -  Fixes #24807  
* Also don't delegate `scala3-library-nonboostrapped` 
* Deduplicate settings used in all of the mentioned tasks 

Piggy backed changes (small improvements unrelated directlly to the core of the PR): 
* simplifiy `fetchedScalaInstanceSettings` - always use `scalaVersion.value` 
* ensure that downloaded `sbt-scala3-bridge` uses the same version as used `scalaVersion` 