### PR TITLE
[CI] Fix broken Scaladoc workflow

### DIFF
--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -15,7 +15,6 @@ permissions:
 jobs:
   build:
     env:
-      AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     runs-on: ubuntu-latest
     if: "github.event_name == 'merge_group'


### PR DESCRIPTION
Fixes typo breaking scaladoc GH actions after https://github.com/scala/scala3/pull/24779
Also removes long time unused AZURE_STORAGE_SAS_TOKEN