### PR TITLE
Fix REPL interrupt instrumentation conditional

### DIFF
--- a/repl/src/dotty/tools/repl/AbstractFileClassLoader.scala
+++ b/repl/src/dotty/tools/repl/AbstractFileClassLoader.scala
@@ -59,7 +59,8 @@ class AbstractFileClassLoader(root: AbstractFile, parent: ClassLoader, interrupt
 
     val bytes = file.toByteArray
 
-    if !interruptInstrumentation.is(InterruptInstrumentation.Enabled) then defineClassInstrumented(name, bytes)
+
+    if interruptInstrumentation.is(InterruptInstrumentation.Enabled) then defineClassInstrumented(name, bytes)
     else defineClass(name, bytes, 0, bytes.length)
   }
 


### PR DESCRIPTION
Fixes a regression in #24514, which occurred in 3.8.0-RC3. We mixed up the double-negative when porting the conditional from a string-equality-check to the `setting.is`-check

Reproducted the problem and tested the fix manually via

```
sbt --client scala3-compiler-bootstrapped-new/publishLocalBin &&
sbt --client scala-library-bootstrapped/publishLocalBin &&
sbt --client scala3-library-bootstrapped-new/publishLocalBin &&
sbt --client tasty-core-bootstrapped-new/publishLocalBin &&
sbt --client scala3-repl/publishLocalBin &&
java -cp $(cs fetch -p org.scala-lang:scala3-repl_3:3.8.1-RC1-bin-SNAPSHOT) dotty.tools.repl.Main -cp $(cs fetch -p org.scala-lang:scala3-repl_3:3.8.1-RC1-bin-SNAPSHOT)
scala> while(true)()
^C
Attempting to interrupt running thread with `Thread.interrupt`
java.lang.ThreadDeath
  at dotty.tools.repl.StopRepl.throwIfReplStopped(StopRepl.scala:17)
  ... 30 elided                
```

CC @WojciechMazur since you're the author of the original PR, would be nice to get this into 3.8.0-RC5