### PR TITLE
Skip `module-info.class` files during REPL tab-completion

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -211,8 +211,8 @@ object SymbolLoaders {
    */
   def initializeFromClassPath(owner: Symbol, classRep: ClassRepresentation)(using Context): Unit =
     // module-info is a special class added by JPMS (Java 9+) that cannot be parsed like a normal class
-    if classRep.name == "module-info" then return
-    ((classRep.binary, classRep.source): @unchecked) match {
+    if classRep.name != "module-info" then
+      ((classRep.binary, classRep.source): @unchecked) match {
       case (Some(bin), Some(src)) if needCompile(bin, src) && !binaryOnly(owner, nameOf(classRep)) =>
         if (ctx.settings.verbose.value) report.inform("[symloader] picked up newer source file for " + src.path)
         enterToplevelsFromSource(owner, nameOf(classRep), src)


### PR DESCRIPTION
fixes https://github.com/scala/scala3/issues/20421. `module-info-class` files are weird class files that cause problems during parsing, and anyway they can't contain things that autocompletion should care about anyway, so better just to skip them

Tested manually via 

```
sbt --client scala3-compiler-bootstrapped-new/publishLocalBin &&
sbt --client scala-library-bootstrapped/publishLocalBin &&
sbt --client scala3-library-bootstrapped-new/publishLocalBin &&
sbt --client tasty-core-bootstrapped-new/publishLocalBin &&
sbt --client scala3-repl/publishLocalBin &&
java -cp $(cs fetch -p org.scala-lang:scala3-repl_3:3.8.1-RC1-bin-SNAPSHOT) dotty.tools.repl.Main -cp $(cs fetch -p org.scala-lang:scala3-repl_3:3.8.1-RC1-bin-SNAPSHOT)
```

Passing a problematic classpath to the REPL. Without this PR, the upstream issue appears. With this PR, it doesn't