### PR TITLE
Replace REPL signal handling with raw mode jline terminal to make Ctrl-C handling work when REPL is a child process

### DIFF
--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -235,27 +235,22 @@ class ReplDriver(settings: Array[String],
         // Clear the stop flag before executing new code
         ReplBytecodeInstrumentation.setStopFlag(rendering.classLoader()(using state.context), false)
 
-        val previousSignalHandler = terminal.handle(
-          org.jline.terminal.Terminal.Signal.INT,
-          (sig: org.jline.terminal.Terminal.Signal) => {
+        val newState = terminal.withMonitoringCtrlC(
+          handler = () =>
             if (!firstCtrlCEntered) {
               firstCtrlCEntered = true
               // Set the stop flag to trigger throwIfReplStopped() in instrumented code
               ReplBytecodeInstrumentation.setStopFlag(rendering.classLoader()(using state.context), true)
-              // Also interrupt the thread as a fallback for non-instrumented code
+              // Also interrupt the thread as a fallback for non-instrumented code, e.g. IO/sleeps
               thread.interrupt()
-              out.println("\nAttempting to interrupt running thread with `Thread.interrupt`")
+              out.println("\nAttempting to interrupt running REPL command")
             } else {
               out.println("\nTerminating REPL Process...")
               System.exit(130)  // Standard exit code for SIGINT
             }
-          }
-        )
-
-        val newState =
-          try interpret(res)
-          // Restore previous handler
-          finally terminal.handle(org.jline.terminal.Terminal.Signal.INT, previousSignalHandler)
+        ) {
+          interpret(res)
+        }
 
         loop(using newState)()
       }


### PR DESCRIPTION
Rather than using JVM signal handling to trap the Ctrl-C, we instead make JLine set the terminal to raw mode and handle the Ctrl-C as a standard input character. 

This is similar to what Ammonite ([link](https://github.com/com-lihaoyi/Ammonite/blob/185818d3f5efdad311d32f6ff6c926514a9415d4/terminal/src/main/scala/ammonite/terminal/Utils.scala#L126-L135)) and (I think) JShell does, and has the advantage that it works even for `stdin`/`stdout` terminals inherited from parent processes (e.g. Mill or SBT) v.s. the current signal handling that only works when the REPL process is receiving the Ctrl-C directly.

Fixes https://github.com/com-lihaoyi/mill/issues/6452 downstream in Mill

Tested the sub-process case manually by cherry picking onto `release-3.8.0`, publishing locally, and using it in Mill

```
sbt --client scala3-compiler-bootstrapped-new/publishLocalBin &&
sbt --client scala-library-bootstrapped/publishLocalBin &&
sbt --client scala3-library-bootstrapped-new/publishLocalBin &&
sbt --client tasty-core-bootstrapped-new/publishLocalBin &&
sbt --client scala3-repl/publishLocalBin &&
sbt --client scala3-interfaces/publishLocalBin &&
sbt --client scala3-sbt-bridge-bootstrapped/publishLocalBin
```

Also tested the primary-process case by running `java -cp $(cs fetch -p org.scala-lang:scala3-repl_3:3.8.1-RC1-bin-SNAPSHOT) dotty.tools.repl.Main -usejavacp` to run a standalone Scala REPL with the compiled code

