### PR TITLE
Refine `TypeErasure.samExpansionNotNeeded` to check parent traits if SAM is covered

### DIFF
--- a/tests/run/getclass.check
+++ b/tests/run/getclass.check
@@ -22,5 +22,5 @@ class [D
 class [Lscala.collection.immutable.List;
 
 Functions:
-class Test$$$Lambda/
-class Test$$$Lambda/
+class Test$$$Lambda$
+class Test$$$Lambda$

--- a/tests/run/i24553.check
+++ b/tests/run/i24553.check
@@ -5,7 +5,7 @@ public int Foo.hello()
 public final native void java.lang.Object.notify()
 public final native void java.lang.Object.notifyAll()
 public java.lang.String java.lang.Object.toString()
-public final void java.lang.Object.wait(long) throws java.lang.InterruptedException
 public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException
 public final void java.lang.Object.wait() throws java.lang.InterruptedException
+public final native void java.lang.Object.wait(long) throws java.lang.InterruptedException
 public int Foo.x()


### PR DESCRIPTION
Fixes #24826 

Starting with compilation of standard library using Scala 3.8 `scala.Function1` flags have changed which affected SAM expansion: 
```
// 3.7 - trait Function1 in package scala: <trait> abstract        <scala-2.x>           <touched>
// 3.8 - trait Function1 in package scala: <trait> <scala-2-tasty> <scala-2.x> <noinits> <touched>
``` 

This affects the `isSAM` check making `cls.directlyInheritedTraits.forall(_.is(NoInits))` fail
https://github.com/scala/scala3/blob/3654e2e027b17691ec3eef643e0ca140b01204ec/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala#L47-L57  

To workaround this problem we refine the `samExpansionNotNeeded` to check not only direct type to be implemented, but also all of directlly inherited trait and it's SAM candidates

