### PR TITLE
Also substitute symbols in case bindings symbols

### DIFF
--- a/tests/pos/i24813.scala
+++ b/tests/pos/i24813.scala
@@ -1,0 +1,8 @@
+object test {
+  class Seq[T]
+  inline def f[T]: T = scala.compiletime.summonFrom {
+    case given (Seq[t] =:= T) => new Seq[t]
+  }
+
+  f[Seq[Int]]
+}


### PR DESCRIPTION
Fixes #24813

The fix for #24813 is the also updating the symbol in the line
```
to.foreach(sym => sym.info = sym.info.substSym(from, to))
```

the other changes are more clean up so we only have to do that substitution once. Before https://github.com/scala/scala3/pull/7902 the substitution are done both inside substBindings and afterwards. But if done after it the partial substitutions inside are redundant. So this changes it so we only call `subst` one place.

It unclear if we expect `subst` to already do this replace? If we do then we should probably fix this in that implementation instead.
