### PR TITLE
Warn if reach capability in result will likely cause leakage

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -663,6 +663,8 @@ class CheckCaptures extends Recheck, SymTransformer:
           if param.isUseParam then markFree(arg.nuType.deepCaptureSet, errTree)
     end markFreeTypeArgs
 
+// ---- Check for leakages of reach capabilities ------------------------------
+
     /** If capability `c` refers to a parameter that is not implicitly or explicitly
      *  @use declared, report an error.
      */
@@ -695,13 +697,15 @@ class CheckCaptures extends Recheck, SymTransformer:
                     case tp: TermRef =>
                       report.warning(
                         em"""Reach capability $ref in function result refers to ${tp.symbol}.
-                            |To avoid errors of the form "Local reach capability $ref leaks into capture set ..."
+                            |To avoid errors of the form "Local reach capability $ref leaks into capture scope ..."
                             |you should replace the reach capability with a new capset variable in ${tree.symbol}.""",
                         tree.tpt.srcPos)
                     case _ =>
           case _ =>
         tpt.nuType.foreachPart(checkType, StopAt.Static)
       case _ =>
+
+// ---- Rechecking operations for different kinds of trees----------------------
 
     /** If `tp` (possibly after widening singletons) is an ExprType
      *  of a parameterless method, map Result instances in it to Fresh instances

--- a/tests/neg-custom-args/captures/nicolas2.check
+++ b/tests/neg-custom-args/captures/nicolas2.check
@@ -1,0 +1,11 @@
+-- Warning: tests/neg-custom-args/captures/nicolas2.scala:9:53 ---------------------------------------------------------
+9 |def oneOf[A](head: Rand ?=> A, tail: (Rand ?=> A)*): Rand ?->{head, tail*} A =
+  |                                                     ^^^^^^^^^^^^^^^^^^^^^^^
+  |                           Reach capability tail* in function result refers to parameter tail.
+  |                           To avoid errors of the form "Local reach capability tail* leaks into capture scope ..."
+  |                           you should replace the reach capability with a new capset variable in method oneOf.
+-- Error: tests/neg-custom-args/captures/nicolas2.scala:11:5 -----------------------------------------------------------
+11 |  all(nextInt(all.length))  // error
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |  Local reach capability tail* leaks into capture scope of method oneOf.
+   |  You could try to abstract the capabilities referred to by tail* in a capset variable.

--- a/tests/neg-custom-args/captures/nicolas2.scala
+++ b/tests/neg-custom-args/captures/nicolas2.scala
@@ -1,0 +1,11 @@
+import caps.*
+
+trait Rand extends SharedCapability:
+  def range(min: Int, max: Int): Int
+
+def nextInt(max: Int): Rand ?-> Int =
+  r ?=> r.range(0, max)
+
+def oneOf[A](head: Rand ?=> A, tail: (Rand ?=> A)*): Rand ?->{head, tail*} A =
+  val all: Seq[Rand ?->{head, tail*} A] = head +: tail
+  all(nextInt(all.length))  // error

--- a/tests/pos-custom-args/captures/nicolas1.scala
+++ b/tests/pos-custom-args/captures/nicolas1.scala
@@ -1,0 +1,11 @@
+import caps.*
+
+trait Rand extends SharedCapability:
+  def range(min: Int, max: Int): Int
+
+def nextInt(max: Int): Rand ?-> Int =
+  r ?=> r.range(0, max)
+
+def oneOf[A, B^](head: Rand ?=> A, tail: (Rand ?->{B} A)*): Rand ?->{head, B} A =
+  val all: Seq[Rand ?->{head, B} A] = head +: tail // error
+  all(nextInt(all.length))


### PR DESCRIPTION
An unboxed reach in a result type of a method will in almost all cases lead to use leakage error in the body of the method (except if the body is pure, and we widen to the reach without cause). Warn at this point already so that the leakage error that follows can be better understood.