### PR TITLE
Backport "[build] Ensure that `scala3-library` artifacts are empty" to 3.8.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -454,13 +454,12 @@ object Build {
 
   // Creates a scalaInstance by fetching the compiler from Maven.
   // Used by non-bootstrapped projects that need a published compiler.
-  def fetchedScalaInstanceSettings = Def.settings(
+  def fetchedScalaInstanceSettings(ver: String) = Def.settings(
     // sbt adds all the projects to scala-tool config which breaks building the scalaInstance
     // as a workaround, we build it manually by only adding the compiler
     scalaInstance := {
       val lm = dependencyResolution.value
       val log = streams.value.log
-      val ver = scalaVersion.value
       val retrieveDir = streams.value.cacheDirectory / "scala3-compiler" / ver
       val comp = lm.retrieve("org.scala-lang" % "scala3-compiler_3" %
         ver, scalaModuleInfo = None, retrieveDir, log)
@@ -839,7 +838,7 @@ object Build {
       publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-sbt-bridge-nonbootstrapped",
-      fetchedScalaInstanceSettings,
+      fetchedScalaInstanceSettings(referenceVersion),
     )
 
   // ==============================================================================================
@@ -1211,7 +1210,7 @@ object Build {
       autoScalaLibrary := false,
       // Drop all the scala tools in this project, so we can never generate any bytecode, or documentation
       managedScalaInstance := false,
-      fetchedScalaInstanceSettings,
+      fetchedScalaInstanceSettings(referenceVersion),
       // This Project only has a dependency to `org.scala-lang:scala-library:*.**.**-nonbootstrapped`
       emptyPublishedJarSettings,  // Validate JAR is empty (only META-INF)
       // Packaging configuration of the stdlib
@@ -1479,7 +1478,7 @@ object Build {
       publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "tasty-core-nonbootstrapped",
-      fetchedScalaInstanceSettings,
+      fetchedScalaInstanceSettings(referenceVersion),
       // Add configuration of the test
       Test / envVars ++= Map(
         "EXPECTED_TASTY_VERSION" -> expectedTastyVersion,
@@ -1593,11 +1592,11 @@ object Build {
       // sbt adds all the projects to scala-tool config which breaks building the scalaInstance
       // as a workaround, I build it manually by only adding the compiler
       managedScalaInstance := false,
-      fetchedScalaInstanceSettings,
+      fetchedScalaInstanceSettings(referenceVersion),
       scalaCompilerBridgeBinaryJar := {
         val lm = dependencyResolution.value
         val log = streams.value.log
-        val version = scalaVersion.value
+        val version = referenceVersion
         val retrieveDir = streams.value.cacheDirectory / "scala3-sbt-bridge" / version
         val comp = lm.retrieve("org.scala-lang" % "scala3-sbt-bridge" %
           version, scalaModuleInfo = None, retrieveDir, log)


### PR DESCRIPTION
Backports #24816 to the 3.8.0-RC5.

PR submitted by the release tooling.
[skip ci]