### PR TITLE
Backport "Add `@uncheckedOverride` annotation for definitions that may override" to 3.8.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1077,6 +1077,7 @@ class Definitions {
   @tu lazy val ThrowsAnnot: ClassSymbol = requiredClass("scala.throws")
   @tu lazy val TransientAnnot: ClassSymbol = requiredClass("scala.transient")
   @tu lazy val UncheckedAnnot: ClassSymbol = requiredClass("scala.unchecked")
+  @tu lazy val UncheckedOverrideAnnot: ClassSymbol = requiredClass("scala.annotation.unchecked.uncheckedOverride")
   @tu lazy val UncheckedStableAnnot: ClassSymbol = requiredClass("scala.annotation.unchecked.uncheckedStable")
   @tu lazy val UncheckedVarianceAnnot: ClassSymbol = requiredClass("scala.annotation.unchecked.uncheckedVariance")
   @tu lazy val UncheckedCapturesAnnot: ClassSymbol = requiredClass("scala.annotation.unchecked.uncheckedCaptures")

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -390,6 +390,8 @@ object RefChecks {
       if makeOverridingPairsChecker == null then OverridingPairsChecker(clazz, self)
       else makeOverridingPairsChecker(clazz, self)
 
+    def isMarkedOverride(sym: Symbol) = sym.isAnyOverride || sym.hasAnnotation(defn.UncheckedOverrideAnnot)
+
     /* Check that all conditions for overriding `other` by `member`
      * of class `clazz` are met.
      */
@@ -539,7 +541,7 @@ object RefChecks {
               )
             && !member.is(Deferred)
             && !other.name.is(DefaultGetterName)
-            && !member.isAnyOverride
+            && !isMarkedOverride(member)
       then
         // Exclusion for default getters, fixes SI-5178. We cannot assign the Override flag to
         // the default getter: one default getter might sometimes override, sometimes not. Example in comment on ticket.
@@ -569,9 +571,9 @@ object RefChecks {
           overrideError("needs `override` modifier")
       else if (other.is(AbsOverride) && other.isIncompleteIn(clazz) && !member.is(AbsOverride))
         overrideError("needs `abstract override` modifiers")
-      else if member.is(Override) && other.isMutableVarOrAccessor then
+      else if isMarkedOverride(member) && other.isMutableVarOrAccessor then
         overrideError("cannot override a mutable variable")
-      else if member.isAnyOverride
+      else if isMarkedOverride(member)
         && !(member.owner.thisType.baseClasses.exists(_.isSubClass(other.owner)))
         && !member.is(Deferred) && !other.is(Deferred)
         && intersectionIsEmpty(member.extendedOverriddenSymbols, other.extendedOverriddenSymbols)

--- a/library/src/scala/annotation/unchecked/uncheckedOverride.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedOverride.scala
@@ -13,6 +13,7 @@
 package scala.annotation.unchecked
 
 import scala.annotation.StaticAnnotation
+import scala.language.`2.13`
 
 /**
  * Marking a definition `@uncheckedOverride` is equivalent to the `override` keyword, except that overriding is not

--- a/tests/pos/t13127.scala
+++ b/tests/pos/t13127.scala
@@ -1,0 +1,27 @@
+import scala.annotation.unchecked.uncheckedOverride
+
+trait Hordering[T] extends java.util.Comparator[T] {
+  // overriding on java 26 and later, not overriding before
+  @uncheckedOverride def max[U <: T](x: U, y: U): U = x
+  @uncheckedOverride def min[U <: T](x: U, y: U): U = x
+}
+
+trait Base[T] {
+  def max[U <: T](x: U, y: U): U = x
+
+  def mux(x: String = "ex") = x
+}
+
+trait Sub[T] extends Base[T] {
+  @uncheckedOverride def max[U <: T](x: U, y: U): U = x // overriding ok
+  @uncheckedOverride def min[U <: T](x: U, y: U): U = x // not overriding ok
+
+  // overriding default
+  @uncheckedOverride def mux(x: String = "nox") = x
+
+  def test = mux()
+}
+
+trait OverrideOrdering[T] extends scala.math.Ordering[T] {
+  override def max[U <: T](x: U, y: U): U = x
+}


### PR DESCRIPTION
Backports #24545 to the 3.8.0-RC5.

PR submitted by the release tooling.
[skip ci]