### PR TITLE
    Retain parameter annotations in the generation of mixin phase forwarding methods -- PR choice 1

### DIFF
--- a/tests/run/i22991/Bar.scala
+++ b/tests/run/i22991/Bar.scala
@@ -1,0 +1,9 @@
+class Blah extends scala.annotation.StaticAnnotation
+
+trait Barly {
+  def bar[T](a: String, @Foo v: Int)(@Foo b: T, @Blah w: Int) = ()
+}
+
+class Bar extends Barly{
+  def bar2(@Foo v: Int) = ()
+}

--- a/tests/run/i22991/Foo.java
+++ b/tests/run/i22991/Foo.java
@@ -1,0 +1,6 @@
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Foo {
+}
+

--- a/tests/run/i22991/Test.scala
+++ b/tests/run/i22991/Test.scala
@@ -1,0 +1,17 @@
+
+//Test java runtime reflection access to @Runtime annotations on method parameters.
+object Test extends App:
+  val method: java.lang.reflect.Method = classOf[Bar].getMethod("bar", classOf[String], classOf[Int], classOf[Object], classOf[Int])
+  val annots: Array[Array[java.lang.annotation.Annotation]] = method.getParameterAnnotations()
+  assert(annots.length == 4)
+  assert(annots(0).length == 0)
+  assert(annots(1).length == 1)
+  assert(annots(1)(0).isInstanceOf[Foo])
+  assert(annots(2).length == 1)
+  assert(annots(2)(0).isInstanceOf[Foo])
+  assert(annots(3).length == 0)
+
+  val method2: java.lang.reflect.Method = classOf[Bar].getMethod("bar2", classOf[Int])
+  val annots2: Array[Array[java.lang.annotation.Annotation]] = method2.getParameterAnnotations()
+  assert(annots2.length == 1)
+  assert(annots2(0)(0).isInstanceOf[Foo])


### PR DESCRIPTION

    This PR fixes issue #22991 by retaining parameter annotations in mixin phase
    generation of forwarder methods.
    Therefore, a trait method parameter annotated with Java RetentionPolicy.RUNTIME
    annotation is retained in the subclasses .class file in same named method/parameter
    for Java reflection use.
    This restores the behavior of Scala 2 for such RUNTIME annotated paramters.

    Closes ticket #22991

Note -- This is one of two PR choices that fix the issue. Consider this one as first cut with simplest set of changes.

Fixes #22991