### PR TITLE
Actually run tests in FromTastyTests?

### DIFF
--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -22,7 +22,7 @@ class FromTastyTests {
     // > scalac -Ythrough-tasty -Ycheck:all <source>
 
     implicit val testGroup: TestGroup = TestGroup("posTestFromTasty")
-    compileTastyInDir(s"tests${JFile.separator}pos", defaultOptions,
+    compileTastyInDir(s"tests${JFile.separator}pos", defaultOptions.and("-experimental"),
       fromTastyFilter = FileFilter.exclude(TestSources.posFromTastyExcludelisted)
     ).checkCompile()
   }
@@ -34,7 +34,7 @@ class FromTastyTests {
     // > scala Test
 
     implicit val testGroup: TestGroup = TestGroup("runTestFromTasty")
-    compileTastyInDir(s"tests${JFile.separator}run", defaultOptions,
+    compileTastyInDir(s"tests${JFile.separator}run", defaultOptions.and("-experimental"),
       fromTastyFilter = FileFilter.exclude(TestSources.runFromTastyExcludelisted)
     ).checkRuns()
   }

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1574,7 +1574,9 @@ trait ParallelTesting extends RunnerOrchestration:
 
     val filteredFiles = testFilter match
       case _ :: _ => files.filter(f => testFilter.exists(f.getPath.contains))
-      case _      => Nil
+      case _      => files
+
+    assert(filteredFiles.nonEmpty)
 
     class JointCompilationSourceFromTasty(
        name: String,


### PR DESCRIPTION
Stumbled upon this while trying to add a Mill build in the Scala 3 repo. It seems the second half of each test from `FromTastyTests` doesn't do anything by default, IIUC the current code (`targets` remaining empty around the changed code in `ParallelTesting.scala`). So the second commit in this PR fixes that. It seems many test cases break when doing it. As a first workaround, the second commit also adds `-experimental` to all `FromTastyTests` test cases, that seems required for many of them.