### PR TITLE
Do not consider generated getters to be `update def`

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Mutability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Mutability.scala
@@ -55,11 +55,7 @@ object Mutability:
      */
     def isUpdateMethod(using Context): Boolean =
       sym.isAllOf(Mutable | Method)
-        && (if sym.isSetter then
-              sym.owner.derivesFrom(defn.Caps_Stateful)
-              && !sym.field.hasAnnotation(defn.UntrackedCapturesAnnot)
-            else true
-           )
+        && (!sym.is(Accessor) || (sym.isSetter && sym.owner.derivesFrom(defn.Caps_Stateful) && !sym.field.hasAnnotation(defn.UntrackedCapturesAnnot)))
       || ccConfig.strictMutability && sym.name == nme.update && sym == defn.Array_update
 
     /** A read-only member is a lazy val or a method that is not an update method. */

--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -78,4 +78,7 @@ class PrintingTest {
 
   @Test
   def transformedPrinting: Unit = testIn("tests/printing/transformed", "repeatableAnnotations")
+
+  @Test
+  def getters: Unit = testIn("tests/printing/getters", "getters")
 }

--- a/tests/printing/getters/var-should-not-be-update-def-get.check
+++ b/tests/printing/getters/var-should-not-be-update-def-get.check
@@ -1,0 +1,10 @@
+[[syntax trees at end of MegaPhase{pruneErasedDefs, uninitialized, inlinePatterns, vcInlineMethods, seqLiterals, intercepted, getters, specializeFunctions, specializeTuples, collectNullableFields, elimOuterSelect, resolveSuper, functionXXLForwarders, paramForwarding, genericTuples, letOverApply, arrayConstructors}]] // tests/printing/getters/var-should-not-be-update-def-get.scala
+package <empty> {
+  import scala.language.experimental.captureChecking
+  @SourceFile("tests/printing/getters/var-should-not-be-update-def-get.scala")
+    trait Foo() extends Object, scala.caps.Mutable {
+    def x: Int
+    update def x_=(x$1: Int): Unit
+  }
+}
+

--- a/tests/printing/getters/var-should-not-be-update-def-get.scala
+++ b/tests/printing/getters/var-should-not-be-update-def-get.scala
@@ -1,0 +1,4 @@
+import scala.language.experimental.captureChecking
+
+trait Foo extends caps.Mutable:
+  var x: Int


### PR DESCRIPTION
Fixes #24485 