### PR TITLE
Fix opaque types displayed as `Nothing & Any` in hover and signature help

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -244,7 +244,7 @@ object Signatures {
         findCurrentParamIndex(untpdArgs, span, alternativeSymbol.paramSymss(safeParamssListIndex).length - 1)
 
       val pre = treeQualifier(fun)
-      val alternativesWithTypes = alternatives.map(_.asSeenFrom(pre.tpe.widenTermRefExpr))
+      val alternativesWithTypes = alternatives.map(_.asSeenFrom(pre.tpe))
       val alternativeSignatures = alternativesWithTypes
         .flatMap(toApplySignature(_, findOutermostCurriedApply(untpdPath), safeParamssListIndex))
 

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -303,7 +303,7 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
     def seenFrom(sym: Symbol)(using Context): (Type, Symbol) =
       try
         val pre = tree.qual
-        val denot = sym.denot.asSeenFrom(pre.typeOpt.widenTermRefExpr)
+        val denot = sym.denot.asSeenFrom(pre.typeOpt)
         (denot.info, sym.withUpdatedTpe(denot.info))
       catch case NonFatal(e) => (sym.info, sym)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
@@ -284,7 +284,7 @@ class HoverDefnSuite extends BaseHoverSuite:
     check(
       """|
          |@ma@@in
-         |def example() = 
+         |def example() =
          |    println("test")
          |""".stripMargin,
       """|```scala
@@ -296,7 +296,7 @@ class HoverDefnSuite extends BaseHoverSuite:
       check(
         """|
           |@ma@@in
-          |def example() = 
+          |def example() =
           |    List("test")
           |""".stripMargin,
         """|```scala
@@ -308,7 +308,7 @@ class HoverDefnSuite extends BaseHoverSuite:
       check(
         """|
           |@ma@@in
-          |def example() = 
+          |def example() =
           |    Array("test")
           |""".stripMargin,
         """|```scala
@@ -320,10 +320,21 @@ class HoverDefnSuite extends BaseHoverSuite:
       check(
         """|
           |@ma@@in
-          |def example() = 
+          |def example() =
           |    Array(1, 2)
           |""".stripMargin,
         """|```scala
           |def this(): main
           |```""".stripMargin.hover
+      )
+
+  @Test def `opaque-type-method` =
+      check(
+        """|object History {
+           |  opaque type Builder[A] = String
+           |  def <<bui@@ld>>(b: Builder[Unit]): Int = ???
+           |}
+           |""".stripMargin,
+        """|def build(b: Builder[Unit]): Int
+           |""".stripMargin.hover
       )

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -953,3 +953,18 @@ class HoverTermSuite extends BaseHoverSuite:
          |""".stripMargin,
       "val name: String".hover
     )
+
+  @Test def `opaque-type-method-call` =
+    check(
+      """|object History {
+         |  opaque type Builder[A] = String
+         |  def emptyBuilder: Builder[Unit] = ""
+         |  def build(b: Builder[Unit]): Int = ???
+         |}
+         |object Main {
+         |  <<History.bui@@ld(History.emptyBuilder)>>
+         |}
+         |""".stripMargin,
+      """|def build(b: Builder[Unit]): Int
+         |""".stripMargin.hover
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
@@ -1577,7 +1577,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
         |""".stripMargin,
       "foo[K, V](): Unit"
     )
-  
+
   @Test def `proper-param-list-after-param-empty-list` =
     check(
       """
@@ -1627,3 +1627,17 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
     )
 
 
+  @Test def `opaque-type-parameter` =
+    check(
+      """|object History {
+         |  opaque type Builder[A] = String
+         |  def build(b: Builder[Unit]): Int = ???
+         |}
+         |object Main {
+         |  History.build(@@)
+         |}
+         |""".stripMargin,
+      """|build(b: Builder[Unit]): Int
+         |      ^^^^^^^^^^^^^^^^
+         |""".stripMargin
+    )


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8048