### PR TITLE
improvement: Try to optimize coverage phase

### DIFF
--- a/compiler/src/dotty/tools/dotc/coverage/Coverage.scala
+++ b/compiler/src/dotty/tools/dotc/coverage/Coverage.scala
@@ -19,11 +19,6 @@ class Coverage:
     if stmt.id >= _nextStatementId then _nextStatementId = stmt.id + 1
     statementsById(stmt.id) = stmt
 
-  def removeStatementsFromFile(sourcePath: Path | Null) =
-    val removedIds = statements.filter(_.location.sourcePath == sourcePath).map(_.id.toLong)
-    removedIds.foreach(statementsById.remove)
-
-
 /**
   * A statement that can be invoked, and thus counted as "covered" by code coverage tools.
   *


### PR DESCRIPTION
Main optimization is to only deserialize and serialize coverage files once. Tested it locally and it did seem to help.

Should  help with https://github.com/scala/scala3/issues/24909