### PR TITLE
Fix "Colon as operator part at beginning of line in REPL"

### DIFF
--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -155,7 +155,9 @@ case object Help extends Command {
 
 object ParseResult {
 
-  @sharable private val CommandExtract = """(:[\S]+)\s*(.*)""".r
+  // Commands must start with ":" followed by a letter (e.g. :help, :load)
+  // This ensures operators like :: or :+ are treated as Scala code, not commands
+  @sharable private val CommandExtract = """(:[a-zA-Z]\S*)\s*(.*)""".r
 
   private def parseStats(using Context): List[untpd.Tree] = {
     val parser = new Parser(ctx.source)

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -520,6 +520,28 @@ class ReplCompilerTests extends ReplTest:
   @Test def `i22844b regression colon arrow eol`: Unit = contextually:
     assertTrue(ParseResult.isIncomplete("List(42).map: x =>"))
 
+  // i24142: Colon operator at line beginning should be treated as Scala code, not REPL command
+  @Test def `i24142 cons operator`: Unit = initially:
+    run("::(1, Nil)")
+    assertEquals("val res0: ::[Int] = List(1)", storedOutput().trim)
+
+  @Test def `i24142 symbolic identifier starting with colon`: Unit = initially:
+    // Test a custom identifier starting with :
+    run("val `:test` = 42")
+    assertEquals("val :test: Int = 42", storedOutput().trim)
+
+  @Test def `i24142 colon as infix`: Unit = initially:
+    run("1 :: 2 :: Nil")
+    assertEquals("val res0: List[Int] = List(1, 2)", storedOutput().trim)
+
+  @Test def `i24142 commands still work`: Unit = initially:
+    run(":help")
+    assertTrue(storedOutput().contains("The REPL has several commands available"))
+
+  @Test def `i24142 abbreviated commands still work`: Unit = initially:
+    run(":he")
+    assertTrue(storedOutput().contains("The REPL has several commands available"))
+
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");


### PR DESCRIPTION
Attempts to fix http://github.com/scala/scala3/issues/24142, vibe coded

Seems like a straightforward regex fix that doesn't require a claude explanation