### PR TITLE
Prefer non-extension to extension

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2080,13 +2080,15 @@ trait Applications extends Compatibility {
       tp1 match
         case tp1: MethodType => // (1)
           tp1.paramInfos.isEmpty && tp2.isInstanceOf[LambdaType]
-          || {
+          || (
+            !alt1.symbol.is(ExtensionMethod) || alt2.symbol.is(ExtensionMethod)
+          ) && (
             if tp1.isVarArgsMethod then
               tp2.isVarArgsMethod
               && isApplicableMethodRef(alt2, tp1.paramInfos.map(_.repeatedToSingle), WildcardType, ArgMatch.Compatible)
             else
               isApplicableMethodRef(alt2, tp1.paramInfos, WildcardType, ArgMatch.Compatible)
-          }
+          )
         case tp1: PolyType => // (2)
           inContext(ctx.fresh.setExploreTyperState()) {
             // Fully define the PolyType parameters so that the infos of the

--- a/docs/_docs/reference/changed-features/overload-resolution.md
+++ b/docs/_docs/reference/changed-features/overload-resolution.md
@@ -46,6 +46,10 @@ This change is motivated by the new language feature
 [extension methods](../contextual/extension-methods.md), where emerges the need to do
 overload resolution based on additional argument blocks.
 
+Note that extension methods do not compete with member methods when extension syntax is used.
+Contrarily, since extension methods can be called using ordinary method call syntax,
+in the case of ambiguity, the member method will be preferred.
+
 ## Parameter Types of Function Values
 
 The handling of function values with missing parameter types has been improved. We can now

--- a/tests/neg/i24891.scala
+++ b/tests/neg/i24891.scala
@@ -1,0 +1,5 @@
+def test1: Unit = {
+  val x1 = IArray("a")
+  val x2 = x1.apply
+  val x3: IArray[IArray[String]] = x2 // error
+}

--- a/tests/pos/i24891.scala
+++ b/tests/pos/i24891.scala
@@ -1,0 +1,68 @@
+object Main {
+  def test1: Unit = {
+    val x1 = IArray("a")
+    val x2 = IArray(x1)
+    val x3: IArray[IArray[String]] = x2
+  }
+  def test2a: Unit = {
+    import lib.*
+    val x1 = MyIArray("a")
+    val x2 = MyIArray(x1)
+    val x3: MyIArray[MyIArray[String]] = x2
+  }
+  def test2b: Unit = {
+    import lib2.*
+    val x1 = MyIArray("a")
+    val x2 = MyIArray(x1)
+    val x3: MyIArray[MyIArray[String]] = x2
+  }
+  def test2c: Unit = {
+    import lib3.*
+    val x1 = MyIArray("a")
+    val x2 = x1.apply
+    val x3: MyIArray[MyIArray[String]] = x2
+  }
+  def test3: Unit = {
+    val x1 = Array("a")
+    val x2 = Array(x1)
+    val x3: Array[Array[String]] = x2
+  }
+}
+
+object lib {
+  import reflect.*
+
+  opaque type MyIArray[+T] = Array[? <: T]
+
+  object MyIArray {
+    extension [T](arr: MyIArray[T]) {
+      def apply(n: Int): T = arr.asInstanceOf[Array[T]].apply(n)
+    }
+    def apply[T](xs: T*)(using ClassTag[T]): MyIArray[T] = Array(xs*)
+  }
+}
+object lib2 {
+  import reflect.*
+
+  opaque type MyIArray[+T] = Array[? <: T]
+
+  object MyIArray {
+    extension [T](arr: MyIArray[T]) {
+      def apply(n: Int): T = arr.asInstanceOf[Array[T]].apply(n)
+    }
+    def apply[T](x: T)(using ClassTag[T]): MyIArray[T] = Array(x)
+  }
+}
+object lib3 {
+  import reflect.*
+
+  opaque type MyIArray[+T] = Array[? <: T]
+
+  object MyIArray {
+    extension [T](arr: MyIArray[T]) {
+      def apply(n: Int): T = arr.asInstanceOf[Array[T]].apply(n)
+      def apply(using ClassTag[MyIArray[T]]): MyIArray[MyIArray[T]] = Array(arr)
+    }
+    def apply[T](xs: T*)(using ClassTag[T]): MyIArray[T] = Array(xs*)
+  }
+}


### PR DESCRIPTION
Fixes #24891 

Adapting an extension selection will only look at applicable extension methods; when considering a regular application for which both extension and non-extension methods are applicable, prefer the non-extension.