### PR TITLE
Backport "Replace REPL signal handling with raw mode jline terminal to make Ctrl-C handling work when REPL is a child process" to 3.8.1

### DIFF
--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -235,27 +235,22 @@ class ReplDriver(settings: Array[String],
         // Clear the stop flag before executing new code
         ReplBytecodeInstrumentation.setStopFlag(rendering.classLoader()(using state.context), false)
 
-        val previousSignalHandler = terminal.handle(
-          org.jline.terminal.Terminal.Signal.INT,
-          (sig: org.jline.terminal.Terminal.Signal) => {
+        val newState = terminal.withMonitoringCtrlC(
+          handler = () =>
             if (!firstCtrlCEntered) {
               firstCtrlCEntered = true
               // Set the stop flag to trigger throwIfReplStopped() in instrumented code
               ReplBytecodeInstrumentation.setStopFlag(rendering.classLoader()(using state.context), true)
-              // Also interrupt the thread as a fallback for non-instrumented code
+              // Also interrupt the thread as a fallback for non-instrumented code, e.g. IO/sleeps
               thread.interrupt()
-              out.println("\nAttempting to interrupt running thread with `Thread.interrupt`")
+              out.println("\nAttempting to interrupt running REPL command")
             } else {
               out.println("\nTerminating REPL Process...")
               System.exit(130)  // Standard exit code for SIGINT
             }
-          }
-        )
-
-        val newState =
-          try interpret(res)
-          // Restore previous handler
-          finally terminal.handle(org.jline.terminal.Terminal.Signal.INT, previousSignalHandler)
+        ) {
+          interpret(res)
+        }
 
         loop(using newState)()
       }


### PR DESCRIPTION
Backports #24842 to the 3.8.1-RC1.

PR submitted by the release tooling.
[skip ci]