### PR TITLE
Backport "Refine `TypeErasure.samExpansionNotNeeded` to check parent traits if SAM is covered" to 3.8.1

### DIFF
--- a/tests/run/getclass.check
+++ b/tests/run/getclass.check
@@ -22,5 +22,5 @@ class [D
 class [Lscala.collection.immutable.List;
 
 Functions:
-class Test$$$Lambda/
-class Test$$$Lambda/
+class Test$$$Lambda$
+class Test$$$Lambda$

--- a/tests/run/i24553.check
+++ b/tests/run/i24553.check
@@ -5,7 +5,7 @@ public int Foo.hello()
 public final native void java.lang.Object.notify()
 public final native void java.lang.Object.notifyAll()
 public java.lang.String java.lang.Object.toString()
-public final void java.lang.Object.wait(long) throws java.lang.InterruptedException
 public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException
 public final void java.lang.Object.wait() throws java.lang.InterruptedException
+public final native void java.lang.Object.wait(long) throws java.lang.InterruptedException
 public int Foo.x()


### PR DESCRIPTION
Backports #24843 to the 3.8.1-RC1.

PR submitted by the release tooling.
[skip ci]