### PR TITLE
Backport "update `BackendUtils.classfileVersionMap`" to 3.8.1

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BackendUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BackendUtils.scala
@@ -169,15 +169,6 @@ class BackendUtils(val postProcessor: PostProcessor) {
 
 object BackendUtils {
   lazy val classfileVersionMap: Map[Int, Int] = Map(
-    8 -> asm.Opcodes.V1_8,
-    9 -> asm.Opcodes.V9,
-    10 -> asm.Opcodes.V10,
-    11 -> asm.Opcodes.V11,
-    12 -> asm.Opcodes.V12,
-    13 -> asm.Opcodes.V13,
-    14 -> asm.Opcodes.V14,
-    15 -> asm.Opcodes.V15,
-    16 -> asm.Opcodes.V16,
     17 -> asm.Opcodes.V17,
     18 -> asm.Opcodes.V18,
     19 -> asm.Opcodes.V19,

--- a/compiler/src/dotty/tools/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/compiler/src/dotty/tools/backend/jvm/PostProcessorFrontendAccess.scala
@@ -118,7 +118,7 @@ object PostProcessorFrontendAccess {
           case (Some(release), Some(_)) =>
             report.warning(s"The value of ${s.XuncheckedJavaOutputVersion.name} was overridden by ${ctx.settings.javaOutputVersion.name}")
             release
-          case (None, None) => "8" // least supported version by default
+          case (None, None) => "17" // least supported version by default
 
       override val debug: Boolean = ctx.debug
       override val dumpClassesDirectory: Option[String] = s.Xdumpclasses.valueSetByUser

--- a/compiler/test/dotty/tools/backend/jvm/AsmConverters.scala
+++ b/compiler/test/dotty/tools/backend/jvm/AsmConverters.scala
@@ -148,7 +148,7 @@ object ASMConverters {
 
     private def convertBsmArgs(a: Array[Object]): List[Object] = a.iterator.map({
       case h: asm.Handle => convertMethodHandle(h)
-      case _ => a // can be: Class, method Type, primitive constant
+      case x => x // can be: Class, method Type, primitive constant
     }).toList
 
     private def convertMethodHandle(h: asm.Handle): MethodHandle = MethodHandle(h.getTag, h.getOwner, h.getName, h.getDesc, h.isInterface)

--- a/compiler/test/dotty/tools/backend/jvm/StringConcatTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/StringConcatTest.scala
@@ -61,43 +61,11 @@ class StringConcatTest extends DottyBytecodeTest {
       }
 
       assertEquals(List(
-        "<init>(I)V",
-        "toString()Ljava/lang/String;",
-        "append(Ljava/lang/String;)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
-        "append(Z)Ljava/lang/StringBuilder;",
-        "append(C)Ljava/lang/StringBuilder;",
-        "append(I)Ljava/lang/StringBuilder;",
-        "append(I)Ljava/lang/StringBuilder;",
-        "append(I)Ljava/lang/StringBuilder;",
-        "append(F)Ljava/lang/StringBuilder;",
-        "append(J)Ljava/lang/StringBuilder;",
-        "append(D)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/Object;)Ljava/lang/StringBuilder;", // test that we're not using the [C overload
         "toString()Ljava/lang/String;"),
         invokeNameDesc("t1")
       )
 
       assertEquals(List(
-        "<init>(I)V",
-        "toString()Ljava/lang/String;",
-        "append(Ljava/lang/String;)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/String;)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
-        "append(Z)Ljava/lang/StringBuilder;",
-        "append(C)Ljava/lang/StringBuilder;",
-        "append(I)Ljava/lang/StringBuilder;",
-        "append(I)Ljava/lang/StringBuilder;",
-        "append(I)Ljava/lang/StringBuilder;",
-        "append(F)Ljava/lang/StringBuilder;",
-        "append(J)Ljava/lang/StringBuilder;",
-        "append(D)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;",
-        "append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
         "toString()Ljava/lang/String;"),
         invokeNameDesc("t2")
       )

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -101,9 +101,5 @@ object TestConfiguration {
   val explicitNullsOptions = defaultOptions `and` "-Yexplicit-nulls"
 
   /** Default target of the generated class files */
-  private def defaultTarget: String = {
-    import scala.util.Properties.isJavaAtLeast
-
-    if isJavaAtLeast("9") then "9" else "8"
-  }
+  private def defaultTarget: String = "17"
 }


### PR DESCRIPTION
Backports #23954 to the 3.8.1-RC1.

PR submitted by the release tooling.