### PR TITLE
Emit unchecked warnings for trait patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -108,9 +108,10 @@ object TypeTestsCasts {
         //
         // If we perform widening, we will get X = Nothing, and we don't have
         // Ident[X] <:< Ident[Int] any more.
-        TypeComparer.constrainPatternType(P1, X, forceInvariantRefinement = true)
+        val forceInvariantRefinement = !tycon.classSymbol.is(Trait)
+        TypeComparer.constrainPatternType(P1, X, forceInvariantRefinement = forceInvariantRefinement)
         debug.println(
-          TypeComparer.explained(_.constrainPatternType(P1, X, forceInvariantRefinement = true))
+          TypeComparer.explained(_.constrainPatternType(P1, X, forceInvariantRefinement = forceInvariantRefinement))
         )
       }
 

--- a/tests/warn/i24322.scala
+++ b/tests/warn/i24322.scala
@@ -1,0 +1,13 @@
+trait A[+T]:
+  def x: T
+trait B[+T] extends A[T]:
+  def y: T
+
+object Troll extends A[Int] with B[Any]:
+  def x: Int = 0
+  def y: Any = ""
+
+def f[T](a: A[T]): T = a match {
+  case b: B[T] => b.y  // warn
+  case _ => a.x
+}


### PR DESCRIPTION
closes: https://github.com/scala/scala3/issues/24322

`forceInvariantRefinement` was hardcoded to `true` during constraint calculation, which prevented correct handling of mixed-in trait patterns. This PR passes `forceInvariantRefinement` as `true` only if the type is not a trait.