### PR TITLE
Fix false exhaustivity warning for GADT pattern matching

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -245,7 +245,9 @@ object SpaceEngine {
         else a
       case (a @ Typ(tp1, _), Prod(tp2, fun, ss)) =>
         // rationale: every instance of `tp1` is covered by `tp2(_)`
-        if isSubType(tp1.stripNamedTuple, tp2) && covers(fun, tp1, ss.length) then
+        if (isSubType(tp1.stripNamedTuple, tp2)
+          || (tp1.isRef(tp2.classSymbol) && tp1.classSymbol.is(CaseClass)))
+          && covers(fun, tp1, ss.length) then
           minus(Prod(tp1, fun, signature(fun, tp1, ss.length).map(Typ(_, false))), b)
         else if canDecompose(a) then minus(Or(decompose(a)), b)
         else a

--- a/tests/pos/i24968.scala
+++ b/tests/pos/i24968.scala
@@ -1,0 +1,18 @@
+enum Type[A] {
+  case TString extends Type[String]
+  case TInt extends Type[Int]
+}
+
+enum DSL {
+  case Run[A](value: A, type0: Type[A])
+  case Noop
+}
+
+object Eval {
+  def loop(dsl: DSL) =
+    dsl match {
+      case DSL.Run(value, Type.TString) => 42
+      case DSL.Run(value, Type.TInt)    => 42
+      case DSL.Noop                     => 42
+    }
+}


### PR DESCRIPTION
closes https://github.com/scala/scala3/issues/24968

Since `Run[?]` is not a subtype of `Run[String]`, minus(`Typ(Run[?])`, `Prod(Run[String])`) returns `Typ(Run[?])`. This PR fixes false GADT exhaustivity warnings by allowing `minus` to inspect fields of the same case class, even without a subtype relationship