### PR TITLE
Revert addition of new base trait to ReturnThrowable

### DIFF
--- a/library/src/scala/util/control/NonLocalReturns.scala
+++ b/library/src/scala/util/control/NonLocalReturns.scala
@@ -24,7 +24,7 @@ import scala.compiletime.uninitialized
 @deprecated("Use scala.util.boundary instead", "3.3")
 object NonLocalReturns {
   @deprecated("Use scala.util.boundary.Break instead", "3.3")
-  class ReturnThrowable[T] extends ControlThrowable, caps.Control {
+  class ReturnThrowable[T] extends ControlThrowable {
     private var myResult: T = uninitialized
     def throwReturn(result: T): Nothing = {
       myResult = result

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -19,6 +19,7 @@ object MiMaFilters {
 
       // Breaking changes since last reference version
       Build.mimaPreviousDottyVersion -> Seq(
+        ProblemFilters.exclude[MissingTypesProblem]("scala.util.control.NonLocalReturns$ReturnThrowable")
       )
     )
   }


### PR DESCRIPTION
The deprecated class NonLocalReturns.ReturnThrowable acquired a new base type `caps.Control` in 3.8. That was a mistake. Later versions of the capture checker reject that inheritance since `ReturnThrowable` is an exception and therefore must be a pure class, whereas inheriting `caps.Control` would automatically add a capture set to that class.

It's too late to revert for 3.8, but we should revert for 3.8.1. It's technically a backwards incompatible change, but I would be extremely surprised if anyone has used ReturnThrowable as a caps.Control in the 3.8.0 window.