### PR TITLE
Fix "No check for abstract methods when Erased instances are around"

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -686,6 +686,10 @@ object RefChecks {
         clazz.nonPrivateMembersNamed(mbr.name)
           .filterWithPredicate(
             impl => isConcrete(impl.symbol)
+              // Extension methods cannot implement non-extension abstract methods (they are static
+              // methods with an extra receiver parameter, even if erased parameters make signatures
+              // appear to match). But extension methods CAN implement abstract extension methods.
+              && !(impl.symbol.is(ExtensionMethod) && !mbr.is(ExtensionMethod))
               && withMode(Mode.IgnoreCaptures)(mbrDenot.matchesLoosely(impl, alwaysCompareTypes = true)))
           .exists
 

--- a/tests/neg/i23932.scala
+++ b/tests/neg/i23932.scala
@@ -1,0 +1,108 @@
+//> using options -language:experimental.erasedDefinitions
+
+// Test for issue #23932: Missing abstract method validation with erased types
+// https://github.com/scala/scala3/issues/23932
+
+import scala.compiletime.Erased
+import scala.annotation.experimental
+import scala.annotation.targetName
+
+@experimental
+class In[T <: AnyKind] extends Erased
+
+// Case 1: Original issue - extension method with erased param should not count as implementation
+trait Semigroup:
+  type Self
+  def add(x: Self, y: Self): Self
+
+@experimental
+trait Monoid extends Semigroup:
+  def empty: Self
+  extension (in: In[Self])
+    @targetName("empty_in")
+    def empty: Self = this.empty  // extension method with same name, different target name
+
+object Semigroup:
+  @experimental
+  given badMonoid: Monoid with  // error: missing implementation of empty
+    type Self = String
+    def add(x: Self, y: Self): Self = x
+    // Missing: empty method implementation - should be detected at compile time
+
+// Case 2: Extension method should not implement abstract method even with matching signature
+trait HasMethod:
+  def foo: Int
+
+trait HasExtension extends HasMethod:
+  extension (x: String)
+    def foo: Int = 42  // extension method, should not implement abstract foo
+
+class BadImpl extends HasExtension  // error: missing implementation of foo
+
+// Case 3: Normal (non-extension) method should still work
+trait GoodBase:
+  def bar: String
+
+class GoodImpl extends GoodBase:
+  def bar: String = "ok"  // OK - proper implementation
+
+// Case 4: Extension method with params should not implement abstract method with same name
+trait HasMethodWithParam:
+  def compute(x: Int): Int
+
+trait HasExtensionWithParam extends HasMethodWithParam:
+  extension (s: String)
+    def compute(x: Int): Int = x + s.length
+
+class BadImplWithParam extends HasExtensionWithParam  // error: missing implementation of compute
+
+// Case 5: Multiple abstract methods, one provided, one with only extension
+trait TwoMethods:
+  def first: Int
+  def second: String
+
+trait MixedImpl extends TwoMethods:
+  def first: Int = 1  // OK - proper implementation
+  extension (x: Double)
+    def second: String = x.toString  // extension, should not implement abstract second
+
+class BadMixedImpl extends MixedImpl  // error: missing implementation of second
+
+// Case 6: Extension method with type parameter should not implement abstract method
+trait GenericTrait[T]:
+  def process(x: T): T
+
+trait ExtensionGeneric[T] extends GenericTrait[T]:
+  extension (s: String)
+    def process(x: T): T = x  // extension with type param
+
+class BadGenericImpl extends ExtensionGeneric[Int]  // error: missing implementation of process
+
+// ============================================================================
+// POSITIVE CASES: Extension methods CAN implement abstract extension methods
+// ============================================================================
+
+// Case 7: Extension method properly implementing abstract extension method
+trait AbstractExtension[T]:
+  extension (x: T) def show: String
+
+class ConcreteExtension extends AbstractExtension[Int]:
+  extension (x: Int) def show: String = x.toString  // OK - extension implementing abstract extension
+
+// Case 8: Type class pattern with extension methods
+trait Showable[T]:
+  extension (x: T) def display: String
+
+object IntShowable extends Showable[Int]:
+  extension (x: Int) def display: String = s"Int($x)"  // OK - proper extension implementation
+
+// Case 9: Multiple extension methods in type class
+trait Numeric[T]:
+  extension (x: T)
+    def plus(y: T): T
+    def times(y: T): T
+
+object IntNumeric extends Numeric[Int]:
+  extension (x: Int)
+    def plus(y: Int): Int = x + y  // OK
+    def times(y: Int): Int = x * y  // OK


### PR DESCRIPTION
Attempts to fix https://github.com/scala/scala3/issues/23932. Vibe coded

> Problem
>
> Extension methods with erased parameters could incorrectly be counted as implementations of non-extension abstract methods, because when erased parameters are filtered out during signature matching, the signatures could appear to match.
>
> Fix
>
> In compiler/src/dotty/tools/dotc/typer/RefChecks.scala, I added a check to the isImplemented function:
>
> && !(impl.symbol.is(ExtensionMethod) && !mbr.is(ExtensionMethod))
>
> This ensures:
> - Extension methods cannot implement non-extension abstract methods (the bug)
> - Extension methods can implement abstract extension methods (legitimate use case like type classes)
>
> Test File
>
> Created tests/neg/i23932.scala with 9 test cases:
> - Cases 1-6 (errors): Extension methods incorrectly trying to implement non-extension abstract methods
> - Cases 7-9 (OK): Extension methods properly implementing abstract extension methods
>
> Verification
>
> - The test file produces exactly 5 expected errors
> - Existing extension tests (tests/run/extension-methods.scala, tests/neg/extension-methods.scala, tests/neg/override-extension_normal-methods.scala) continue to work correctly
> - The fix is consistent with existing behavior where normal methods cannot override extension methods and vice versa