### PR TITLE
Ensure the inline match scrutinee type conforms to the recalculated type

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -355,7 +355,7 @@ class InlineReducer(inliner: Inliner)(using Context):
 
     /** The initial scrutinee binding: `val $scrutineeN = <scrutinee>` */
     val scrutineeSym = newSym(InlineScrutineeName.fresh(), Synthetic, scrutType).asTerm
-    val scrutineeBinding = normalizeBinding(ValDef(scrutineeSym, scrutinee.ensureConforms(scrutType)))
+    val scrutineeBinding = normalizeBinding(ValDef(scrutineeSym, scrutinee))
 
     // If scrutinee has embedded references to `compiletime.erasedValue` or to
     // other erased values, mark scrutineeSym as Erased. In addition, if scrutinee

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -973,13 +973,17 @@ class Inliner(val call: tpd.Tree)(using Context):
       if (!tree.isInline || ctx.owner.isInlineMethod) // don't reduce match of nested inline method yet
         super.typedMatchFinish(tree, sel, wideSelType, cases, pt)
       else {
-        def selTyped(sel: Tree): Type = sel match {
+        def selTyped(sel: Tree): Tree = sel match {
           case Typed(sel2, _) => selTyped(sel2)
-          case Block(Nil, sel2) => selTyped(sel2)
-          case Inlined(_, Nil, sel2) => selTyped(sel2)
-          case _ => sel.tpe
+          case block @ Block(Nil, sel2) => tpd.cpy.Block(block)(Nil, selTyped(sel2))
+          case inlined @ Inlined(_, Nil, sel2) => tpd.cpy.Inlined(inlined)(inlined.call, inlined.bindings, selTyped(sel2))
+          case _ => sel
         }
-        val selType = if (sel.isEmpty) wideSelType else selTyped(sel)
+        val (retypedSel, selType) =
+          if (sel.isEmpty) (sel, wideSelType)
+          else
+            val retypedSel = selTyped(sel)
+            (retypedSel, retypedSel.tpe)
 
         /** Make an Inlined that has no bindings. */
         def flattenInlineBlock(tree: Tree): Tree = {
@@ -1044,7 +1048,7 @@ class Inliner(val call: tpd.Tree)(using Context):
                         | patterns :  ${tree.cases.map(patStr).mkString("\n             ")}"""
                 errorTree(tree, msg)
             }
-        reduceInlineMatchExpr(sel)
+        reduceInlineMatchExpr(retypedSel)
       }
 
     override def newLikeThis(nestingLevel: Int): Typer = new InlineTyper(initialErrorCount, nestingLevel)


### PR DESCRIPTION
When simplifying an inline match, the compiler intentionally recalculates the type of the scrutinee by removing `Typed` nodes. However, after that recalculation, it uses that type to define a scrutinee proxy symbol, which would cause typing errors, when it would try to point to the original tree eg:
it would generate:
```scala
val b: B // B <: A
val scrutinee$: B // type recalculated from (b: A)
  = (b: A) // original tree; after this fix we add .asInstanceOf[B]
```
The reason this issue has been unnoticed before is because for the proxy symbol to appear, the scrutinee has to be used on the right hand side (directly or through an unapply pattern) which the original tests didn't have.

Fixes #24479 
Some additional context: #11291