### PR TITLE
Backport "Revert addition of new base trait to ReturnThrowable" to 3.8.1

### DIFF
--- a/library/src/scala/util/control/NonLocalReturns.scala
+++ b/library/src/scala/util/control/NonLocalReturns.scala
@@ -24,7 +24,7 @@ import scala.compiletime.uninitialized
 @deprecated("Use scala.util.boundary instead", "3.3")
 object NonLocalReturns {
   @deprecated("Use scala.util.boundary.Break instead", "3.3")
-  class ReturnThrowable[T] extends ControlThrowable, caps.Control {
+  class ReturnThrowable[T] extends ControlThrowable {
     private var myResult: T = uninitialized
     def throwReturn(result: T): Nothing = {
       myResult = result

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -509,6 +509,8 @@ object MiMaFilters {
 
           // scala/scala3#24855 - copied from Scala 2.13.16 by ScalaLibraryPlugin, to be removed when Scala 3.8.0 is released
           ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$State*"),
+          // #24975 removed inheritence of caps.Control
+          ProblemFilters.exclude[MissingTypesProblem]("scala.util.control.NonLocalReturns$ReturnThrowable"),
       )
     )
   }


### PR DESCRIPTION
Backports #24975 to the 3.8.1 (hotfix).

PR submitted by the release tooling. 

Would also be backported to 3.8.2-RC2 (successor of 3.8.1-RC1) 