### PR TITLE
[nightly docs] add contributing-to-stdlib in sidebar

### DIFF
--- a/docs/sidebar.nightly.template.yml
+++ b/docs/sidebar.nightly.template.yml
@@ -30,6 +30,7 @@ subsection:
         subsection:
           - page: contributing/procedures/release.md
           - page: contributing/procedures/vulpix.md
+          - page: contributing/procedures/contributing-to-stdlib.md
       - title: High Level Architecture
         directory: architecture
         index: contributing/architecture/index.md


### PR DESCRIPTION
should display in the website now
Edit: however i have no clue if any nightly website is being updated right now as the page is not there