### PR TITLE
fix: Instantiate type parameters for parametric extension methods in signature help

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
@@ -6,6 +6,20 @@ import org.junit.{Ignore, Test}
 
 class SignatureHelpSuite extends BaseSignatureHelpSuite:
 
+  @Test def `parametric-extension` =
+    check(
+      """
+        |object A:
+        |  extension [T](x: T)
+        |    def foo(p: T): T = x
+        |  
+        |  val _ = 1.foo(@@)
+      """.stripMargin,
+      """|foo[Int](x: Int)(p: Int): Int
+         |                   ^^^^^^
+         |""".stripMargin
+    )
+
   @Test def `method` =
     check(
       """


### PR DESCRIPTION
## Description
This PR fixes an issue where type arguments for parametric extension methods were not correctly rendered in signature help. Previously, they would appear as the generic type parameter (e.g., `p: T`) instead of the instantiated type (e.g., `p: Int`).

## Context
This issue was originally reported in the Metals repository (scalameta/metals#7911). Upon review, the maintainers indicated that the fix should be implemented upstream in the Scala 3 Presentation Compiler.

## Changes
- Modified [SignatureHelpProvider.scala](cci:7://file:///Users/rajesh/scala3/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala:0:0-0:0) to `refineSignatures` by checking the method application's instantiated types.
- Implemented a check to skip refinement if the result is too generic (`Any` or `Nothing`), preserving the original signature in unconstrained cases.
- Added a new test case `parametric-extension` to [SignatureHelpSuite.scala](cci:7://file:///Users/rajesh/scala3/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala:0:0-0:0) and updated existing test expectations to reflect more precise type information.

## Verification
- Added a regression test verifying that `extension [T](<x: T>) def foo(p: T)` correctly displays `foo(p: Int)` when invoked on an `Int`.
- Verified that all existing tests in `SignatureHelpSuite` pass.

@tgodzik 