### PR TITLE
Backport "Revert addition of new base trait to ReturnThrowable" to 3.8.2

### DIFF
--- a/library/src/scala/util/control/NonLocalReturns.scala
+++ b/library/src/scala/util/control/NonLocalReturns.scala
@@ -24,7 +24,7 @@ import scala.compiletime.uninitialized
 @deprecated("Use scala.util.boundary instead", "3.3")
 object NonLocalReturns {
   @deprecated("Use scala.util.boundary.Break instead", "3.3")
-  class ReturnThrowable[T] extends ControlThrowable, caps.Control {
+  class ReturnThrowable[T] extends ControlThrowable {
     private var myResult: T = uninitialized
     def throwReturn(result: T): Nothing = {
       myResult = result

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -19,6 +19,7 @@ object MiMaFilters {
 
       // Breaking changes since last reference version
       Build.mimaPreviousDottyVersion -> Seq(
+        ProblemFilters.exclude[MissingTypesProblem]("scala.util.control.NonLocalReturns$ReturnThrowable")
       )
     )
   }


### PR DESCRIPTION
Backports #24975 to the 3.8.2-RC1.

PR submitted by the release tooling.
[skip ci]