### PR TITLE
Backport "Fix wildcardArgOK for mixed wildcard/concrete type args" to 3.8.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -882,25 +882,66 @@ trait Applications extends Compatibility {
             case SAMType(samMeth, samParent) => argtpe <:< samMeth.toFunctionType(isJava = samParent.classSymbol.is(JavaDefined))
             case _ => false
 
-        // For overload resolution, allow wildcard upper bounds to match their bound type.
-        // For example, given:
-        //   def blub[T](a: Class[? <: T]): String = "a"
-        //   def blub[T](a: Class[T], ints: Int*): String = "b"
-        //   blub(classOf[Object])
+        // For overload resolution, allow arguments with wildcard type parameters to match
+        // formal parameters. This handles cases where isCompatible fails because the
+        // argument type has wildcards in positions where the formal type has concrete types
+        // or type variables.
         //
-        // The non-varargs overload should be preferred. While Class[? <: T] is not a
-        // subtype of Class[T] (Class is invariant), for overload resolution we consider
-        // Class[? <: T] "applicable" where Class[T] is expected by checking if the
-        // wildcard's upper bound is a subtype of the formal type parameter.
+        // In the example below, the non-varargs overload (1) should be preferred.
+        // While Class[? <: Object] is not a subtype of Class[T],
+        // for applicability we check if the wildcard's bounds are compatible with the formal.
+        //
+        // ```scala
+        // def blub[T](a: Class[? <: T]): String = "a" // (1)
+        // def blub[T](a: Class[T], ints: Int*): String = "b" (2)
+        // blub(classOf[Object])  // classOf[Object]: Class[? <: Object]
+        // ```
+        //
+        // The case where argtpe has wildcard type isn't handled by isCompatible:
+        // When (where Class is invariant): (1)
+        // - formal = Class[? <: String]
+        // - argtpe = Class[String]
+        // isCompatible returns true because Class[String] <:< Class[? <: String] (String is a valid "some T <: String").
+        // On the other hand, when (2)
+        // - formal = Class[String]
+        // - argtpe = Class[? <: String]
+        // isCompatible returns false because Class[? <: String] <:< Class[String] doesn't hold.
+        //
+        // However, for overload resolution, we want to check applicability:
+        // "could this work with some type instantiation?" (yes, if ? = String)
         def wildcardArgOK =
           argtpe match
             case at @ AppliedType(tycon1, args1) if at.hasWildcardArg =>
               formal match
                 case AppliedType(tycon2, args2)
                 if tycon1 =:= tycon2 && args1.length == args2.length =>
+                  // We need to handle all 4 cases, in addition to
+                  // `case (TypeBounds(_, hi), formal)` case where arg has wildcard, and formal is concrete:
+                  // because if argtpe has a wildcard type, and formal has concrete at the same position,
+                  // isComptible immediately returns false:
+                  // In the example below, argtpe = Codec[?, String, ? <: Format]
+                  // and formal = Codec[L, H, F <: Format].
+                  // isCompatible immediately returns false, because of the first type arguments.
+                  // wildcardArgOK needs to handle all combinations of TypeBounds on argtpe and formal.
+                  //
+                  // ```scala
+                  // trait Format
+                  // trait Codec[L, H, F <: Format]  // invariant
+                  //
+                  // def decode[L, H](codec: Codec[L, H, ? <: Format]): Int = 1
+                  // def decode[L, H](other: String): Int = 2
+                  // decode(null: Codec[?, String, ? <: Format]) // should return 1
+                  // ```
                   args1.lazyZip(args2).forall {
-                    case (TypeBounds(_, hi), formal) => hi relaxed_<:< formal
-                    case (arg, formal) => arg =:= formal
+                    case (arg: TypeBounds, formal: TypeBounds) =>
+                      (formal.lo relaxed_<:< arg.lo) &&
+                        (arg.hi relaxed_<:< formal.hi)
+                    case (TypeBounds(_, hi), formal) =>
+                      hi relaxed_<:< formal
+                    case (arg, formal: TypeBounds) =>
+                      (formal.lo relaxed_<:< arg) && (arg relaxed_<:< formal.hi)
+                    case (a, b) =>
+                      a =:= b
                   }
                 case _ => false
             case _ => false

--- a/tests/run/i25000.scala
+++ b/tests/run/i25000.scala
@@ -1,0 +1,23 @@
+// Regression test: wildcardArgOK must handle mixed wildcard/concrete type args
+// where both arg and formal have TypeBounds in the same position
+
+trait Format
+trait Codec[L, H, F <: Format]  // invariant
+
+trait Variant[O] {
+  def codec: Codec[?, O, ? <: Format]
+}
+
+object Test {
+  def decode[L, H](codec: Codec[L, H, ? <: Format]): Int = 1
+  def decode[L, H](other: String): Int = 2
+
+  def test[O](v: Variant[O]): Int = decode(v.codec)
+
+  def main(args: Array[String]): Unit = {
+    val variant = new Variant[String] {
+      def codec: Codec[?, String, ? <: Format] = null
+    }
+    assert(test(variant) == 1)
+  }
+}

--- a/tests/run/i25000b.scala
+++ b/tests/run/i25000b.scala
@@ -1,0 +1,19 @@
+trait Codec[L, H, F]  // invariant
+
+trait Variant {
+  def codec: Codec[?, String, ? <: AnyRef]
+}
+
+object Test {
+  def decode[L](codec: Codec[L, ? >: String, ? <: AnyRef]): Int = 1
+  def decode(other: Int): Int = 2
+
+  def test(v: Variant): Int = decode(v.codec)
+
+  def main(args: Array[String]): Unit = {
+    val variant = new Variant {
+      def codec: Codec[?, String, ? <: AnyRef] = null
+    }
+    assert(test(variant) == 1)
+  }
+}

--- a/tests/run/overload_repeated/A_1.java
+++ b/tests/run/overload_repeated/A_1.java
@@ -33,9 +33,20 @@ class A_1 {
   public static <V> int foo10(java.util.Map<String, ? extends V> a) { return 1; }
   public static <V> int foo10(java.util.Map<String, V> a, int... ints) { return 2; }
 
+  public static <V> int foo11(java.util.Map<? super Integer, ? extends V> a) { return 1; }
+  public static <V> int foo11(java.util.Map<? super Number, ? extends V> a, int... ints) { return 2; }
+
+  public static <V> int foo12(java.util.Map<Integer, ? super String> a) { return 1; }
+  public static <V> int foo12(java.util.Map<Integer, V> a, int... ints) { return 2; }
+
   public static boolean check() {
     // Java prefers non-varargs to varargs:
     // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2
+
+    java.util.Map<String, ? extends Object> map10 = new java.util.HashMap<String, Object>();
+    java.util.Map<Integer, ? extends Object> map11 = new java.util.HashMap<Integer, Object>();
+    java.util.Map<Integer, ? extends Object> map12 = new java.util.HashMap<Integer, Object>();
+
     return
         foo1("") == 1 &&
         foo2("") == 1 &&
@@ -46,6 +57,8 @@ class A_1 {
         foo7(Integer.class) == 1 &&
         foo8(Integer.class) == 1 &&
         foo9(Integer.class) == 1 &&
-        foo10(new java.util.HashMap<String, Object>()) == 1;
+        foo10(map10) == 1 &&
+        foo11(map11) == 1 &&
+        foo12(map12) == 2;  // returns 2 because arg's wildcard has no lower bound, fails lower bound check
   }
 }

--- a/tests/run/overload_repeated/B_2.scala
+++ b/tests/run/overload_repeated/B_2.scala
@@ -35,6 +35,12 @@ object Test {
   def bar10[V](a: java.util.Map[String, ? <: V]): Int = 1
   def bar10[V](a: java.util.Map[String, V], ints: Int*): Int = 2
 
+  def bar11[V](a: java.util.Map[? >: Int, ? <: V]): Int = 1
+  def bar11[V](a: java.util.Map[? >: Number, ? <: V], ints: Int*): Int = 2
+
+  def bar12[V](a: java.util.Map[Int, ? >: String <: V]): Int = 1
+  def bar12[V](a: java.util.Map[Int, V], ints: Int*): Int = 2
+
   def main(args: Array[String]): Unit = {
     // In Java, varargs are always less specific than non-varargs (see
     // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2),
@@ -44,24 +50,27 @@ object Test {
     assert(A_1.foo2("") == 1) // Same as in Java and Scala 2
     assert(A_1.foo3("") == 1) // Same as in Java and Scala 2
     assert(A_1.foo4("") == 1) // Same as in Java and Scala 2
-    assert(A_1.foo5(classOf[Object]) == 1) // Same as in Java and Scala 2
+    assert(A_1.foo5(classOf[Object]: Class[? <: Object]) == 1) // Same as in Java and Scala 2
     assert(A_1.foo6(classOf[Object]) == 1) // Same as in Java and Scala 2
-    assert(A_1.foo7(classOf[Integer]) == 1) // Same as in Java and Scala 2
+    assert(A_1.foo7(classOf[Integer]: Class[? <: Integer]) == 1) // Same as in Java and Scala 2
     assert(A_1.foo8(classOf[Integer]) == 1) // Same as in Java and Scala 2
     // assert(A_1.foo9(classOf[Integer]) == 1) // Works in Java, ambiguous in Scala 2 and 3
-    val javaMap: java.util.Map[String, ? <: Object] = new java.util.HashMap()
-    assert(A_1.foo10(javaMap) == 1) // Same as in Java
+    assert(A_1.foo10(new java.util.HashMap(): java.util.Map[String, ? <: Object]) == 1) // Same as in Java
+    assert(A_1.foo11(new java.util.HashMap(): java.util.Map[Integer, ? <: Object]) == 1) // Same as in Java and Scala 2
+    assert(A_1.foo12(new java.util.HashMap(): java.util.Map[Integer, ? <: Object]) == 2) // Same as in Java and Scala 2
 
     // Same with Scala varargs:
     // assert(bar1("") == 1) // Works in Java, ambiguous in Scala 2 and Dotty
     assert(bar2("") == 1) // same in Scala 2
     assert(bar3("") == 1) // same in Scala 2
     assert(bar4("") == 1) // same in Scala 2
-    assert(bar5(classOf[Object]) == 1) // same in Scala2
-    assert(bar6(classOf[Object]) == 1) // same in Scala2
-    assert(bar7(classOf[Integer]) == 1) // same in Scala2
-    assert(bar8(classOf[Integer]) == 1) // same in Scala2
+    assert(bar5(classOf[Object]: Class[? <: Object]) == 1) // same in Scala2
+    assert(bar6(classOf[Object]: Class[? <: Object]) == 1) // same in Scala2
+    assert(bar7(classOf[Integer]: Class[? <: Integer]) == 1) // same in Scala2
+    assert(bar8(classOf[Integer]: Class[? <: Integer]) == 1) // same in Scala2
     // assert(bar9(classOf[Integer]) == 1) Works in Java, ambiguous in Scala 2 and 3
-    assert(bar10(javaMap) == 1)
+    assert(bar10(new java.util.HashMap(): java.util.Map[String, ? <: Object]) == 1) // same in Scala2
+    assert(bar11(new java.util.HashMap(): java.util.Map[Int, ? <: Object]) == 1) // same in Scala2
+    assert(bar12(new java.util.HashMap(): java.util.Map[Int, ? <: Object]) == 2) // same in Scala2
   }
 }


### PR DESCRIPTION
Backports #25001 to the 3.8.2-RC1.

PR submitted by the release tooling.
[skip ci]