### PR TITLE
Backport "correct the list of files to copy from Scala 2" to 3.8.2

### DIFF
--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -9,6 +9,11 @@ object MiMaFilters {
       // Additions that require a new minor version of the library
       Build.mimaPreviousDottyVersion -> Seq(
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.caps.package#package.freeze"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.caps.package#package.cap"),
+        ProblemFilters.exclude[FinalClassProblem]("scala.Function1$UnliftOps$"),
+        ProblemFilters.exclude[FinalClassProblem]("scala.jdk.Accumulator$AccumulatorFactoryShape$"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.iterateUntilEmpty$extension"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.scala$collection$ArrayOps$$elemTag$extension"),
       ),
 
     )
@@ -19,7 +24,34 @@ object MiMaFilters {
 
       // Breaking changes since last reference version
       Build.mimaPreviousDottyVersion -> Seq(
-        ProblemFilters.exclude[MissingTypesProblem]("scala.util.control.NonLocalReturns$ReturnThrowable")
+        ProblemFilters.exclude[MissingTypesProblem]("scala.util.control.NonLocalReturns$ReturnThrowable"),
+        // THIS IS FINE, IT SHOULD HAVE BEEN THIS WAY
+        ProblemFilters.exclude[MissingTypesProblem]("scala.Function1$"),
+        ProblemFilters.exclude[MissingTypesProblem]("scala.Function1$UnliftOps$"),
+        ProblemFilters.exclude[MissingTypesProblem]("scala.Product1$"),
+        ProblemFilters.exclude[MissingTypesProblem]("scala.Product2$"),
+        ProblemFilters.exclude[MissingTypesProblem]("scala.collection.ArrayOps$"),
+        ProblemFilters.exclude[MissingTypesProblem]("scala.jdk.Accumulator$"),
+        ProblemFilters.exclude[MissingTypesProblem]("scala.jdk.Accumulator$AccumulatorFactoryShape$"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Function1#UnliftOps.equals$extension"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Function1#UnliftOps.hashCode$extension"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Function1#UnliftOps.unlift$extension"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.iterateUntilEmpty$extension"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.scala$collection$ArrayOps$$$iterateUntilEmpty$extension"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.scala$collection$ArrayOps$$$elemTag$extension"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.Accumulator#AccumulatorFactoryShape.anyAccumulatorFactoryShape"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.Accumulator#AccumulatorFactoryShape.doubleAccumulatorFactoryShape"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.Accumulator#AccumulatorFactoryShape.intAccumulatorFactoryShape"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.Accumulator#AccumulatorFactoryShape.jDoubleAccumulatorFactoryShape"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.Accumulator#AccumulatorFactoryShape.jIntegerAccumulatorFactoryShape"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.Accumulator#AccumulatorFactoryShape.jLongAccumulatorFactoryShape"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.Accumulator#AccumulatorFactoryShape.longAccumulatorFactoryShape"),
+        ProblemFilters.exclude[MissingFieldProblem]("scala.Function1.UnliftOps"),
+        ProblemFilters.exclude[MissingFieldProblem]("scala.jdk.Accumulator.AccumulatorFactoryShape"),
+        ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.++:"),
+        ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.:++"),
+        ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.concat"),
+        ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.sizeHint$default$2"),
       )
     )
   }

--- a/project/ScalaLibraryPlugin.scala
+++ b/project/ScalaLibraryPlugin.scala
@@ -358,10 +358,14 @@ object ScalaLibraryPlugin extends AutoPlugin {
   }
 
   private lazy val filesToCopy = Set(
+    "scala/Function0",
+    "scala/Function1",
+    "scala/Function2",
+    "scala/Product1",
+    "scala/Product2",
     "scala/Tuple1",
     "scala/Tuple2",
-    "scala/collection/ArrayOps$ArrayIterator",
-    "scala/collection/ArrayOps$ReverseIterator",
+    "scala/collection/ArrayOps",
     "scala/collection/Stepper",
     "scala/collection/DoubleStepper",
     "scala/collection/IntStepper",
@@ -370,6 +374,7 @@ object ScalaLibraryPlugin extends AutoPlugin {
     "scala/collection/immutable/IntVectorStepper",
     "scala/collection/immutable/LongVectorStepper",
     "scala/collection/immutable/Range",
+    "scala/jdk/Accumulator",
     "scala/jdk/DoubleAccumulator",
     "scala/jdk/IntAccumulator",
     "scala/jdk/LongAccumulator",
@@ -395,9 +400,13 @@ object ScalaLibraryPlugin extends AutoPlugin {
     "scala/jdk/FunctionWrappers$FromJavaLongToDoubleFunction",
     "scala/jdk/FunctionWrappers$FromJavaLongToIntFunction",
     "scala/jdk/FunctionWrappers$FromJavaLongUnaryOperator",
+    "scala/runtime/AbstractFunction0",
+    "scala/runtime/AbstractFunction1",
+    "scala/runtime/AbstractFunction2",
+    "scala/runtime/AbstractPartialFunction",
     "scala/runtime/NonLocalReturnControl",
-    "scala/util/hashing/MurmurHash3",
     "scala/util/Sorting",
+    "scala/util/hashing/MurmurHash3",
   )
 
   /** Extract the SourceFile attribute from class file bytecode */


### PR DESCRIPTION
Backports #25033 to the 3.8.2-RC1.

PR submitted by the release tooling.