### PR TITLE
[CI] Publish Nightly version only if given version is not yet published

### DIFF
--- a/.github/workflows/release-maven-artifacts.yml
+++ b/.github/workflows/release-maven-artifacts.yml
@@ -28,7 +28,17 @@ jobs:
           gpg_private_key: ${{ secrets.SCALA_PGP_KEY }}
           passphrase     : ${{ secrets.SCALA_PGP_PASSPHRASE }}
           fingerprint    : ${{ vars.SCALA_PGP_FINGERPRINT }}
+      - name: Get version string for this build
+        run: |
+          ver=$(./project/scripts/sbt "print scala3-compiler-bootstrapped/version" | tail -n1)
+          echo "THISBUILD_VERSION=$ver" >> $GITHUB_ENV
+      - name: Check whether not yet published
+        id: not_yet_published
+        continue-on-error: true
+        run: |
+          ! ./project/scripts/is-version-published.sh "$THISBUILD_VERSION"
       - name: Publish Artifacts to the Maven Repository
+        if: "steps.not_yet_published.outcome == 'success'"
         run : sbt scala3-bootstrapped/publishSigned
         env:
           MAVEN_REPOSITORY_USER : ${{ secrets.MAVEN_REPOSITORY_USER }}
@@ -38,6 +48,7 @@ jobs:
           MAVEN_REPOSITORY_URL  : ${{ vars.MAVEN_REPOSITORY_URL }}
           NEWNIGHTLY            : ${{ vars.NEWNIGHTLY }}
           NIGHTLYBUILD          : ${{ vars.NIGHTLYBUILD }}
+
   release-maven-lts-artifacts:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
@@ -64,8 +75,18 @@ jobs:
           echo "$PGP_SECRET" > "/home/runner/.sbt/gpg/secring.asc"
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
+      - name: Get version string for this build
+        run: |
+          ver=$(./project/scripts/sbt "print scala3-compiler-bootstrapped/version" | tail -n1)
+          echo "THISBUILD_VERSION=$ver" >> $GITHUB_ENV
+      - name: Check whether not yet published
+        id: not_yet_published
+        continue-on-error: true
+        run: |
+          ! ./project/scripts/is-version-published.sh "$THISBUILD_VERSION"
       - uses: sbt/setup-sbt@v1
       - name: Publish Artifacts to the Maven Repository
+        if: "steps.not_yet_published.outcome == 'success'"
         run : ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned"
         env:
           SONATYPE_USER         : ${{ secrets.MAVEN_REPOSITORY_USER }}

--- a/project/scripts/is-version-published.sh
+++ b/project/scripts/is-version-published.sh
@@ -30,7 +30,7 @@ binaryVersion="${ver%%.*}"
 artifactId="scala3-compiler_$binaryVersion"
 pom="$artifactId-$ver.pom"
 
-maven_url=https://repo1.maven.org/maven2/org/scala-lang/$artifactId/$ver/$pom
+maven_url=https://repo.scala-lang.org/artifactory/maven-nightlies/org/scala-lang/$artifactId/$ver/$pom
 
 echo "Checking whether $ver is published"
 echo "at $maven_url"


### PR DESCRIPTION
Fixes failures when publishing LTS nightlies - we tried to override existing artifacts 

Fixes #25019

See: https://github.com/scala/scala3/actions/runs/21234961072/job/61100818265 