### PR TITLE
Do not generate access proxies for locally defined protected defs

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -73,7 +73,7 @@ abstract class AccessProxies {
 
     /** The name of the accessor for definition with given `name` in given `site` */
     def accessorNameOf(name: TermName, site: Symbol)(using Context): TermName
-    def needsAccessor(sym: Symbol)(using Context): Boolean
+    def needsAccessor(refTree: RefTree | Apply | TypeApply)(using Context): Boolean
 
     def ifNoHost(reference: RefTree)(using Context): Tree = {
       assert(false, i"no host found for $reference with ${reference.symbol.showLocated} from ${ctx.owner}")
@@ -155,7 +155,7 @@ abstract class AccessProxies {
 
     /** Replace tree with a reference to an accessor if needed */
     def accessorIfNeeded(tree: Tree)(using Context): Tree = tree match {
-      case tree: RefTree if needsAccessor(tree.symbol) =>
+      case tree: RefTree if needsAccessor(tree) =>
         if (tree.symbol.isConstructor) {
           report.error("Cannot use private constructors in inline methods. You can use @publicInBinary to make constructor accessible in inline methods.", tree.srcPos)
           tree // TODO: create a proper accessor for the private constructor

--- a/compiler/src/dotty/tools/dotc/transform/ProtectedAccessors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ProtectedAccessors.scala
@@ -68,7 +68,7 @@ class ProtectedAccessors extends MiniPhase {
   private class Accessors extends AccessProxies {
     val insert: Insert = new Insert {
       def accessorNameOf(name: TermName, site: Symbol)(using Context): TermName = ProtectedAccessorName(name)
-      def needsAccessor(sym: Symbol)(using Context) = ProtectedAccessors.needsAccessor(sym)
+      def needsAccessor(refTree: RefTree | Apply | TypeApply)(using Context) = ProtectedAccessors.needsAccessor(refTree.symbol)
 
       override def ifNoHost(reference: RefTree)(using Context): Tree = {
         val curCls = ctx.owner.enclosingClass

--- a/tests/pos-macros/i24821/Macro_1.scala
+++ b/tests/pos-macros/i24821/Macro_1.scala
@@ -1,0 +1,57 @@
+import scala.quoted._
+
+trait Foo {
+  protected def pSelect: Int = 4
+  protected def pApply(i: Int): Int = 4 + i
+  protected def pTypeApply[T]: T = ???
+  def foo: Int
+}
+
+// base case
+inline def baseCaseMacro: Foo = ${baseCaseMacroImpl()}
+def baseCaseMacroImpl(using Quotes)(): Expr[Foo] =
+  '{
+    new Foo {
+      def foo: Int = pSelect
+    }
+  }
+
+// base case - transparent
+transparent inline def baseCaseTransparentMacro: Foo = ${baseCaseTransparentMacroImpl()}
+def baseCaseTransparentMacroImpl(using Quotes)(): Expr[Foo] =
+  '{
+    new Foo {
+      def foo: Int = pSelect
+    }
+  }
+
+// nested classes
+inline def nestedClassesMacro: Foo = ${nestedClassesMacroImpl()}
+def nestedClassesMacroImpl(using Quotes)(): Expr[Foo] =
+  '{
+    new Foo { a =>
+      def foo: Int = 0
+      def bar =
+        new Foo { b =>
+          def foo: Int = a.pSelect + pSelect + b.pSelect
+        }
+    }
+  }
+
+// apply
+inline def applyMacro: Foo = ${applyMacroImpl()}
+def applyMacroImpl(using Quotes)(): Expr[Foo] =
+  '{
+    new Foo {
+      def foo: Int = pApply(1)
+    }
+  }
+
+// type apply
+inline def typeApplyMacro: Foo = ${typeApplyMacroImpl()}
+def typeApplyMacroImpl(using Quotes)(): Expr[Foo] =
+  '{
+    new Foo {
+      def foo: Int = pTypeApply[Int]
+    }
+  }

--- a/tests/pos-macros/i24821/Test_2.scala
+++ b/tests/pos-macros/i24821/Test_2.scala
@@ -1,0 +1,6 @@
+@main def main =
+  baseCaseMacro
+  baseCaseTransparentMacro
+  nestedClassesMacro
+  applyMacro
+  typeApplyMacro


### PR DESCRIPTION
Fixes #24821

This issue caused references to the protected refs to be mapped to unnecessary access proxies (in the issue: `p$inline`) during Typer, which ultimately were not added to the classes, causing incoherent type errors or even crashes (for trees with `Apply`) In later phases.  