### PR TITLE
[CI] Ensure nightly docs are using nightly versioning instead of snapshots

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: release-nightly
     needs: release-maven-artifacts
+    env:
+      NIGHTLYBUILD: ${{ vars.NIGHTLYBUILD }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5


### PR DESCRIPTION
Nightly builds are now correctly published, but are using invalid versions: snapshot instead of nightly https://nightly.scala-lang.org/ 