### PR TITLE
Fix #24997: Avoid unnecessary CHECKCAST in untupled function parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1970,12 +1970,23 @@ object desugar {
       flags =
         if params.nonEmpty && params.head.mods.is(Given) then SyntheticTermParam | Given
         else SyntheticTermParam)
+
+    def paramIsUsed(name: Name, body: Tree): Boolean =
+      val acc = new UntypedTreeAccumulator[Boolean]:
+        def apply(x: Boolean, t: Tree)(using Context) =
+          if x then true
+          else t match
+            case Ident(id) => id == name
+            case _ => foldOver(x, t)
+      acc(false, body)
+
     def selector(n: Int) =
       if (isGenericTuple) Apply(Select(refOfDef(param), nme.apply), Literal(Constant(n)))
       else Select(refOfDef(param), nme.selectorName(n))
     val vdefs =
       params.zipWithIndex.collect {
-        case (param, idx) if param.name != nme.WILDCARD && !param.name.is(WildcardParamName) =>
+        case (param, idx) if param.name != nme.WILDCARD &&
+          (!param.name.is(WildcardParamName) || paramIsUsed(param.name, body)) =>
           ValDef(param.name, param.tpt, selector(idx))
             .withSpan(param.span)
             .withAttachment(UntupledParam, ())


### PR DESCRIPTION
## Fix unnecessary CHECKCAST in untupled function parameters (#24997)

### Summary
This PR fixes an issue where automatic parameter untupling (e.g., `(number, _) => number`) introduced unnecessary `CHECKCAST` instructions for unused wildcard parameters. 

Previously, the compiler generated `ValDef` bindings for every element of the tuple, even if they were named `_`. This forced an extraction and a type check for unused elements. By filtering out wildcard parameters during desugaring, we avoid these unnecessary operations, making the generated bytecode as efficient as explicit pattern matching (`case (number, _) => number`).

### Changes
- **Desugar.scala**: Modified `makeTupledFunction` to only generate `ValDef` bindings for parameters that are not wildcards (`nme.WILDCARD`).
- **DottyBytecodeTests.scala**: Added a new test case `i24997` to verify that automatic untupling and explicit case-based untupling produce equivalent bytecode without extra casts.

### Verification
Ran the new bytecode test:
```bash
sbt "scala3-compiler-bootstrapped/testOnly dotty.tools.backend.jvm.DottyBytecodeTests -- i24997"
```

Fixes #24997 