### PR TITLE
Fix printing references to nested objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -109,8 +109,17 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   override def toTextRef(tp: SingletonType): Text = controlled {
     tp match {
       case tp: ThisType if !printDebug =>
-        if (tp.cls.isAnonymousClass) keywordStr("this")
-        if (tp.cls.is(ModuleClass)) fullNameString(tp.cls.sourceModule)
+        val cls = tp.cls
+        if cls.isAnonymousClass then
+          keywordStr("this")
+        else if cls.is(ModuleClass) then
+          if cls.isStatic then
+            fullNameString(tp.cls.sourceModule)
+          else cls.owner.thisType match
+            case tp: SingletonType =>
+              toTextRef(tp) ~ "." ~ nameString(cls)
+            case _ => // owner is a term, just print the name
+              nameString(cls)
         else super.toTextRef(tp)
       case tp: TermRef if !printDebug =>
         if tp.symbol.is(Package) then fullNameString(tp.symbol)

--- a/tests/neg-custom-args/captures/mut-iterator.check
+++ b/tests/neg-custom-args/captures/mut-iterator.check
@@ -6,7 +6,7 @@
 -- Error: tests/neg-custom-args/captures/mut-iterator.scala:17:14 ------------------------------------------------------
 17 |      current = xs1 // error
    |      ^^^^^^^^^^^^^
-   |      Cannot assign to field current of $anon.this
+   |      Cannot assign to field current of this
    |      since the access is in method next, which is not an update method.
 -- Error: tests/neg-custom-args/captures/mut-iterator.scala:22:15 ------------------------------------------------------
 22 |  def next() = f(it.next()) // error

--- a/tests/neg-custom-args/captures/nested-objects-printing.check
+++ b/tests/neg-custom-args/captures/nested-objects-printing.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/nested-objects-printing.scala:4:19 -----------------------
+4 |      val x: Int = B.this // error, was "found: (B: A.B.type)", should be "found: (B: B.type)"
+  |                   ^^^^^^
+  |                   Found:    (B : B.type)
+  |                   Required: Int
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/nested-objects-printing.scala
+++ b/tests/neg-custom-args/captures/nested-objects-printing.scala
@@ -1,0 +1,4 @@
+object A:
+  def f =
+    object B:
+      val x: Int = B.this // error, was "found: (B: A.B.type)", should be "found: (B: B.type)"

--- a/tests/neg/22145b.check
+++ b/tests/neg/22145b.check
@@ -13,7 +13,7 @@
    |    failed with:
    |
    |        Found:    (self.base : Collection.this.Self)
-   |        Required: foo.Collection.given_is_Slice_Collection.Self²
+   |        Required: Collection.this.given_is_Slice_Collection.Self²
    |        
    |        where:    Self  is a type in trait Collection
    |                  Self² is a type in object given_is_Slice_Collection which is an alias of Collection.this.Slice
@@ -29,7 +29,7 @@
    |    failed with:
    |
    |        Found:    (self.base : Collection.this.Self)
-   |        Required: foo.Collection.given_is_Slice_Collection.Self²
+   |        Required: Collection.this.given_is_Slice_Collection.Self²
    |        
    |        where:    Self  is a type in trait Collection
    |                  Self² is a type in object given_is_Slice_Collection which is an alias of Collection.this.Slice


### PR DESCRIPTION
We printed their full-name before, but this is wrong if there is a method between the inner object and the outer object.